### PR TITLE
fix(providers): Add SSRF protection to email webhook and SMS providers fixes NV-7918

### DIFF
--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
@@ -1,34 +1,24 @@
 import * as dns from 'node:dns';
 import * as http from 'node:http';
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { EmailWebhookProvider } from './email-webhook.provider';
 
 const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-beforeAll(() => {
-  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
-  const realLookup = dns.promises.lookup.bind(dns.promises);
-  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
-    if (hostname === 'test-email-webhook.invalid') {
-      const result = [{ address: '127.0.0.1', family: 4 }];
-
-      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
-    }
-
-    return realLookup(hostname as string, opts as dns.LookupOptions);
-  }) as typeof dns.promises.lookup);
-});
-afterAll(() => {
-  vi.restoreAllMocks();
-  if (ORIGINAL_ALLOW === undefined) {
-    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-  } else {
-    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
-  }
-});
+const ORIGINAL_ENTERPRISE = process.env.NOVU_ENTERPRISE;
+const ORIGINAL_SELF_HOSTED = process.env.IS_SELF_HOSTED;
 
 let server: http.Server;
 let serverUrl: string;
+let directServerUrl: string;
 let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 beforeEach(async () => {
   lastRequest = null;
@@ -50,6 +40,7 @@ beforeEach(async () => {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
   const addr = server.address();
   if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  directServerUrl = `http://127.0.0.1:${addr.port}/webhook`;
   serverUrl = `http://test-email-webhook.invalid:${addr.port}/webhook`;
 });
 
@@ -57,106 +48,163 @@ afterEach(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-test('should trigger email-webhook-provider library correctly', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: serverUrl,
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+describe('with SSRF protection (enterprise cloud)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'false';
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+    const realLookup = dns.promises.lookup.bind(dns.promises);
+    vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+      if (hostname === 'test-email-webhook.invalid') {
+        const result = [{ address: '127.0.0.1', family: 4 }];
+
+        return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+      }
+
+      return realLookup(hostname as string, opts as dns.LookupOptions);
+    }) as typeof dns.promises.lookup);
   });
 
-  const testTo = 'johndoe@example.com';
-  const testFrom = 'janedoe@example.com';
-
-  const payload = {
-    to: [testTo],
-    from: testFrom,
-    subject: 'test',
-    html: '<h1>test</h1>',
-    text: 'test',
-  };
-
-  await provider.sendMessage(payload);
-
-  expect(lastRequest).not.toBeNull();
-  expect(lastRequest!.method).toBe('POST');
-  expect(lastRequest!.body).toBe(
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}'
-  );
-  expect(lastRequest!.headers['x-novu-signature']).toBe(
-    'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767'
-  );
-});
-
-test('should trigger email-webhook-provider library correctly with _passthrough', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: serverUrl,
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+  afterAll(() => {
+    vi.restoreAllMocks();
+    restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
-  const testTo = 'johndoe@example.com';
-  const testFrom = 'janedoe@example.com';
+  test('should trigger email-webhook-provider library correctly', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: serverUrl,
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
 
-  const payload = {
-    to: [testTo],
-    from: testFrom,
-    subject: 'test',
-    html: '<h1>test</h1>',
-    text: 'test',
-  };
+    const testTo = 'johndoe@example.com';
+    const testFrom = 'janedoe@example.com';
 
-  await provider.sendMessage(payload, {
-    _passthrough: {
-      body: {
-        subject: 'test _passthrough',
+    const payload = {
+      to: [testTo],
+      from: testFrom,
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    };
+
+    await provider.sendMessage(payload);
+
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest?.method).toBe('POST');
+    expect(lastRequest?.body).toBe(
+      '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}'
+    );
+    expect(lastRequest?.headers['x-novu-signature']).toBe(
+      'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767'
+    );
+  });
+
+  test('should trigger email-webhook-provider library correctly with _passthrough', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: serverUrl,
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    const testTo = 'johndoe@example.com';
+    const testFrom = 'janedoe@example.com';
+
+    const payload = {
+      to: [testTo],
+      from: testFrom,
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    };
+
+    await provider.sendMessage(payload, {
+      _passthrough: {
+        body: {
+          subject: 'test _passthrough',
+        },
       },
-    },
+    });
+
+    expect(lastRequest?.body).toBe(
+      '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}'
+    );
+    expect(lastRequest?.headers['x-novu-signature']).toBe(
+      'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7'
+    );
   });
 
-  expect(lastRequest!.body).toBe(
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}'
-  );
-  expect(lastRequest!.headers['x-novu-signature']).toBe(
-    'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7'
-  );
+  test('should reject the request when the URL resolves to a private IP', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'http://127.0.0.2:8080/webhook',
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: ['johndoe@example.com'],
+        from: 'janedoe@example.com',
+        subject: 'test',
+        html: '<h1>test</h1>',
+        text: 'test',
+      })
+    ).rejects.toThrow(/Email webhook URL blocked/);
+  });
+
+  test('should reject non-http schemes', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'file:///etc/passwd',
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: ['johndoe@example.com'],
+        from: 'janedoe@example.com',
+        subject: 'test',
+        html: '<h1>test</h1>',
+        text: 'test',
+      })
+    ).rejects.toThrow(/Invalid URL format|Email webhook URL blocked/);
+  });
 });
 
-test('should reject the request when the URL resolves to a private IP', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: 'http://127.0.0.2:8080/webhook',
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+describe('without SSRF protection (self-hosted)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'true';
   });
 
-  await expect(
-    provider.sendMessage({
+  afterAll(() => {
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
+  });
+
+  test('should allow requests to private IPs via axios', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: directServerUrl,
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    await provider.sendMessage({
       to: ['johndoe@example.com'],
       from: 'janedoe@example.com',
       subject: 'test',
       html: '<h1>test</h1>',
       text: 'test',
-    })
-  ).rejects.toThrow(/Email webhook URL blocked/);
-});
+    });
 
-test('should reject non-http schemes', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: 'file:///etc/passwd',
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest?.method).toBe('POST');
   });
-
-  await expect(
-    provider.sendMessage({
-      to: ['johndoe@example.com'],
-      from: 'janedoe@example.com',
-      subject: 'test',
-      html: '<h1>test</h1>',
-      text: 'test',
-    })
-  ).rejects.toThrow(/Invalid URL format|Email webhook URL blocked/);
 });

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
@@ -1,15 +1,65 @@
-import axios from 'axios';
-import { expect, test } from 'vitest';
-import { axiosSpy } from '../../../utils/test/spy-axios';
+import * as dns from 'node:dns';
+import * as http from 'node:http';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { EmailWebhookProvider } from './email-webhook.provider';
 
-test('should trigger email-webhook-provider library correctly', async () => {
-  const { mockPost } = axiosSpy({
-    data: true,
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+beforeAll(() => {
+  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+  const realLookup = dns.promises.lookup.bind(dns.promises);
+  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+    if (hostname === 'test-email-webhook.invalid') {
+      const result = [{ address: '127.0.0.1', family: 4 }];
+
+      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+    }
+
+    return realLookup(hostname as string, opts as dns.LookupOptions);
+  }) as typeof dns.promises.lookup);
+});
+afterAll(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+  }
+});
+
+let server: http.Server;
+let serverUrl: string;
+let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+beforeEach(async () => {
+  lastRequest = null;
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      lastRequest = {
+        url: req.url ?? '',
+        method: req.method ?? 'GET',
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      };
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ id: 'ok' }));
+    });
   });
 
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  serverUrl = `http://test-email-webhook.invalid:${addr.port}/webhook`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test('should trigger email-webhook-provider library correctly', async () => {
   const provider = new EmailWebhookProvider({
-    webhookUrl: 'http://127.0.0.1:8080/webhook',
+    webhookUrl: serverUrl,
     hmacSecretKey: 'super-secret-key',
     retryDelay: 1,
     retryCount: 1,
@@ -28,26 +78,19 @@ test('should trigger email-webhook-provider library correctly', async () => {
 
   await provider.sendMessage(payload);
 
-  expect(mockPost).toHaveBeenCalled();
-  expect(mockPost).toHaveBeenCalledWith(
-    'http://127.0.0.1:8080/webhook',
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}',
-    {
-      headers: {
-        'content-type': 'application/json',
-        'X-Novu-Signature': 'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767',
-      },
-    }
+  expect(lastRequest).not.toBeNull();
+  expect(lastRequest!.method).toBe('POST');
+  expect(lastRequest!.body).toBe(
+    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}'
+  );
+  expect(lastRequest!.headers['x-novu-signature']).toBe(
+    'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767'
   );
 });
 
 test('should trigger email-webhook-provider library correctly with _passthrough', async () => {
-  const { mockPost } = axiosSpy({
-    data: true,
-  });
-
   const provider = new EmailWebhookProvider({
-    webhookUrl: 'http://127.0.0.1:8080/webhook',
+    webhookUrl: serverUrl,
     hmacSecretKey: 'super-secret-key',
     retryDelay: 1,
     retryCount: 1,
@@ -72,15 +115,48 @@ test('should trigger email-webhook-provider library correctly with _passthrough'
     },
   });
 
-  expect(mockPost).toHaveBeenCalled();
-  expect(mockPost).toHaveBeenCalledWith(
-    'http://127.0.0.1:8080/webhook',
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}',
-    {
-      headers: {
-        'content-type': 'application/json',
-        'X-Novu-Signature': 'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7',
-      },
-    }
+  expect(lastRequest!.body).toBe(
+    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}'
   );
+  expect(lastRequest!.headers['x-novu-signature']).toBe(
+    'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7'
+  );
+});
+
+test('should reject the request when the URL resolves to a private IP', async () => {
+  const provider = new EmailWebhookProvider({
+    webhookUrl: 'http://127.0.0.2:8080/webhook',
+    hmacSecretKey: 'super-secret-key',
+    retryDelay: 1,
+    retryCount: 1,
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: ['johndoe@example.com'],
+      from: 'janedoe@example.com',
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    })
+  ).rejects.toThrow(/Email webhook URL blocked/);
+});
+
+test('should reject non-http schemes', async () => {
+  const provider = new EmailWebhookProvider({
+    webhookUrl: 'file:///etc/passwd',
+    hmacSecretKey: 'super-secret-key',
+    retryDelay: 1,
+    retryCount: 1,
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: ['johndoe@example.com'],
+      from: 'janedoe@example.com',
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    })
+  ).rejects.toThrow(/Invalid URL format|Email webhook URL blocked/);
 });

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { EmailProviderIdEnum } from '@novu/shared';
+import { EmailProviderIdEnum, isOutboundSsrfProtectionEnabled } from '@novu/shared';
 import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
 import {
   assertSafeOutboundUrl,
@@ -14,6 +14,7 @@ import {
   IEmailProvider,
   ISendMessageSuccessResponse,
 } from '@novu/stateless';
+import axios from 'axios';
 import { setTimeout } from 'node:timers/promises';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
@@ -36,7 +37,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     this.config.retryCount ??= 3;
   }
 
-  async checkIntegration(options: IEmailOptions): Promise<ICheckIntegrationResponse> {
+  async checkIntegration(_options: IEmailOptions): Promise<ICheckIntegrationResponse> {
     return {
       success: true,
       message: 'Integrated successfully!',
@@ -49,6 +50,46 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
     const transformedData = this.transform(bridgeProviderData, options);
+    const bodyData = this.createBody(transformedData.body);
+    const hmacValue = this.computeHmac(bodyData);
+    const requestHeaders = {
+      'content-type': 'application/json',
+      'X-Novu-Signature': hmacValue,
+      ...transformedData.headers,
+    };
+
+    if (isOutboundSsrfProtectionEnabled()) {
+      await this.sendWithSsrfProtection(bodyData, requestHeaders);
+    } else {
+      await this.sendWithAxios(bodyData, requestHeaders);
+    }
+
+    return {
+      id: options.id,
+      date: new Date().toDateString(),
+    };
+  }
+
+  private async sendWithAxios(bodyData: string, requestHeaders: Record<string, string>): Promise<void> {
+    let sent = false;
+
+    for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
+      try {
+        await axios.create().post(this.config.webhookUrl, bodyData, {
+          headers: requestHeaders,
+        });
+        sent = true;
+      } catch {
+        await setTimeout(this.config.retryDelay);
+      }
+    }
+
+    if (!sent) {
+      throw new Error('webhook send failed !');
+    }
+  }
+
+  private async sendWithSsrfProtection(bodyData: string, requestHeaders: Record<string, string>): Promise<void> {
     const webhookUrl = normalizeOutboundHttpUrl(this.config.webhookUrl);
 
     if (!webhookUrl) {
@@ -64,8 +105,6 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
       throw err;
     }
 
-    const bodyData = this.createBody(transformedData.body);
-    const hmacValue = this.computeHmac(bodyData);
     let sent = false;
 
     for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
@@ -73,11 +112,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
         const response = await safeOutboundJsonRequest({
           url: webhookUrl,
           method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            'X-Novu-Signature': hmacValue,
-            ...transformedData.headers,
-          },
+          headers: requestHeaders,
           body: bodyData,
         }).catch((err: unknown) => {
           if (err instanceof SsrfBlockedError) {
@@ -98,14 +133,10 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
         await setTimeout(this.config.retryDelay);
       }
     }
+
     if (!sent) {
       throw new Error('webhook send failed !');
     }
-
-    return {
-      id: options.id,
-      date: new Date().toDateString(),
-    };
   }
 
   createBody(options: WithPassthrough<Record<string, unknown>>): string {

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -70,7 +70,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
 
     for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
       try {
-        await safeOutboundJsonRequest({
+        const response = await safeOutboundJsonRequest({
           url: webhookUrl,
           method: 'POST',
           headers: {
@@ -85,6 +85,11 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
           }
           throw err;
         });
+
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          throw new Error(`webhook send failed with status ${response.statusCode}`);
+        }
+
         sent = true;
       } catch (error) {
         if (error instanceof Error && error.message.startsWith('Email webhook URL blocked')) {

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -1,4 +1,11 @@
+import crypto from 'node:crypto';
 import { EmailProviderIdEnum } from '@novu/shared';
+import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
+import {
+  assertSafeOutboundUrl,
+  normalizeOutboundHttpUrl,
+  SsrfBlockedError,
+} from '@novu/shared/utils/ssrf-url-validation';
 import {
   ChannelTypeEnum,
   CheckIntegrationResponseEnum,
@@ -7,9 +14,7 @@ import {
   IEmailProvider,
   ISendMessageSuccessResponse,
 } from '@novu/stateless';
-import axios from 'axios';
-import crypto from 'crypto';
-import { setTimeout } from 'timers/promises';
+import { setTimeout } from 'node:timers/promises';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -44,21 +49,47 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
     const transformedData = this.transform(bridgeProviderData, options);
+    const webhookUrl = normalizeOutboundHttpUrl(this.config.webhookUrl);
+
+    if (!webhookUrl) {
+      throw new Error('Email webhook URL blocked: Invalid URL format.');
+    }
+
+    try {
+      assertSafeOutboundUrl(webhookUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Email webhook URL blocked: ${err.message}`);
+      }
+      throw err;
+    }
+
     const bodyData = this.createBody(transformedData.body);
     const hmacValue = this.computeHmac(bodyData);
     let sent = false;
 
     for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
       try {
-        await axios.create().post(this.config.webhookUrl, bodyData, {
+        await safeOutboundJsonRequest({
+          url: webhookUrl,
+          method: 'POST',
           headers: {
             'content-type': 'application/json',
             'X-Novu-Signature': hmacValue,
             ...transformedData.headers,
           },
+          body: bodyData,
+        }).catch((err: unknown) => {
+          if (err instanceof SsrfBlockedError) {
+            throw new Error(`Email webhook URL blocked: ${err.message}`);
+          }
+          throw err;
         });
         sent = true;
       } catch (error) {
+        if (error instanceof Error && error.message.startsWith('Email webhook URL blocked')) {
+          throw error;
+        }
         await setTimeout(this.config.retryDelay);
       }
     }

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -19,6 +19,15 @@ import { setTimeout } from 'node:timers/promises';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
+const PROTECTED_HEADER_NAMES = new Set(['content-type', 'x-novu-signature']);
+
+export class EmailWebhookUrlBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmailWebhookUrlBlockedError';
+  }
+}
+
 export class EmailWebhookProvider extends BaseProvider implements IEmailProvider {
   protected casing: CasingEnum = CasingEnum.CAMEL_CASE;
   readonly id = EmailProviderIdEnum.EmailWebhook;
@@ -52,10 +61,15 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     const transformedData = this.transform(bridgeProviderData, options);
     const bodyData = this.createBody(transformedData.body);
     const hmacValue = this.computeHmac(bodyData);
+    const passthroughHeaders = Object.fromEntries(
+      Object.entries(transformedData.headers ?? {}).filter(
+        ([headerName]) => !PROTECTED_HEADER_NAMES.has(headerName.toLowerCase())
+      )
+    );
     const requestHeaders = {
+      ...passthroughHeaders,
       'content-type': 'application/json',
       'X-Novu-Signature': hmacValue,
-      ...transformedData.headers,
     };
 
     if (isOutboundSsrfProtectionEnabled()) {
@@ -93,14 +107,16 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     const webhookUrl = normalizeOutboundHttpUrl(this.config.webhookUrl);
 
     if (!webhookUrl) {
-      throw new Error('Email webhook URL blocked: Invalid URL format.');
+      throw new EmailWebhookUrlBlockedError('Email webhook URL blocked: Invalid URL format.');
     }
 
+    // Structure-only check (scheme, credentials, blocked hostnames). Literal private IPs
+    // are rejected at connect time inside safeOutboundJsonRequest.
     try {
       assertSafeOutboundUrl(webhookUrl);
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
-        throw new Error(`Email webhook URL blocked: ${err.message}`);
+        throw new EmailWebhookUrlBlockedError(`Email webhook URL blocked: ${err.message}`);
       }
       throw err;
     }
@@ -116,7 +132,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
           body: bodyData,
         }).catch((err: unknown) => {
           if (err instanceof SsrfBlockedError) {
-            throw new Error(`Email webhook URL blocked: ${err.message}`);
+            throw new EmailWebhookUrlBlockedError(`Email webhook URL blocked: ${err.message}`);
           }
           throw err;
         });
@@ -127,7 +143,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
 
         sent = true;
       } catch (error) {
-        if (error instanceof Error && error.message.startsWith('Email webhook URL blocked')) {
+        if (error instanceof EmailWebhookUrlBlockedError || error instanceof SsrfBlockedError) {
           throw error;
         }
         await setTimeout(this.config.retryDelay);

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
@@ -1,35 +1,25 @@
 import crypto from 'node:crypto';
 import * as dns from 'node:dns';
 import * as http from 'node:http';
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { GenericSmsProvider } from './generic-sms.provider';
 
 const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-beforeAll(() => {
-  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
-  const realLookup = dns.promises.lookup.bind(dns.promises);
-  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
-    if (hostname === 'test-generic-sms.invalid') {
-      const result = [{ address: '127.0.0.1', family: 4 }];
-
-      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
-    }
-
-    return realLookup(hostname as string, opts as dns.LookupOptions);
-  }) as typeof dns.promises.lookup);
-});
-afterAll(() => {
-  vi.restoreAllMocks();
-  if (ORIGINAL_ALLOW === undefined) {
-    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-  } else {
-    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
-  }
-});
+const ORIGINAL_ENTERPRISE = process.env.NOVU_ENTERPRISE;
+const ORIGINAL_SELF_HOSTED = process.env.IS_SELF_HOSTED;
 
 let server: http.Server;
 let serverUrl: string;
+let directServerUrl: string;
 let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 beforeEach(async () => {
   lastRequest = null;
@@ -60,6 +50,7 @@ beforeEach(async () => {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
   const addr = server.address();
   if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  directServerUrl = `http://127.0.0.1:${addr.port}/`;
   serverUrl = `http://test-generic-sms.invalid:${addr.port}/`;
 });
 
@@ -67,92 +58,148 @@ afterEach(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-test('should trigger generic-sms library correctly', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: serverUrl,
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
-    idPath: 'message.id',
-    datePath: 'message.date',
+describe('with SSRF protection (enterprise cloud)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'false';
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+    const realLookup = dns.promises.lookup.bind(dns.promises);
+    vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+      if (hostname === 'test-generic-sms.invalid') {
+        const result = [{ address: '127.0.0.1', family: 4 }];
+
+        return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+      }
+
+      return realLookup(hostname as string, opts as dns.LookupOptions);
+    }) as typeof dns.promises.lookup);
   });
 
-  const result = await provider.sendMessage({
-    to: '+1234567890',
-    content: 'SMS Content form Generic SMS Provider',
+  afterAll(() => {
+    vi.restoreAllMocks();
+    restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
-  expect(lastRequest).not.toBeNull();
-  expect(lastRequest!.method).toBe('POST');
-  expect(JSON.parse(lastRequest!.body)).toEqual({
-    to: '+1234567890',
-    content: 'SMS Content form Generic SMS Provider',
-    sender: 'sender-id',
-  });
-  expect(lastRequest!.headers.apikey).toBe('123456');
-  expect(result.id).toBeDefined();
-  expect(result.date).toBeDefined();
-});
+  test('should trigger generic-sms library correctly', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: serverUrl,
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+      idPath: 'message.id',
+      datePath: 'message.date',
+    });
 
-test('should trigger generic-sms library correctly with _passthrough', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: serverUrl,
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
-    idPath: 'message.id',
-    datePath: 'message.date',
-  });
-
-  await provider.sendMessage(
-    {
+    const result = await provider.sendMessage({
       to: '+1234567890',
       content: 'SMS Content form Generic SMS Provider',
-    },
-    {
-      _passthrough: {
-        body: {
-          to: '+2234567890',
-        },
+    });
+
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest?.method).toBe('POST');
+    expect(JSON.parse(lastRequest?.body ?? '{}')).toEqual({
+      to: '+1234567890',
+      content: 'SMS Content form Generic SMS Provider',
+      sender: 'sender-id',
+    });
+    expect(lastRequest?.headers.apikey).toBe('123456');
+    expect(result.id).toBeDefined();
+    expect(result.date).toBeDefined();
+  });
+
+  test('should trigger generic-sms library correctly with _passthrough', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: serverUrl,
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+      idPath: 'message.id',
+      datePath: 'message.date',
+    });
+
+    await provider.sendMessage(
+      {
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
       },
-    }
-  );
+      {
+        _passthrough: {
+          body: {
+            to: '+2234567890',
+          },
+        },
+      }
+    );
 
-  expect(JSON.parse(lastRequest!.body)).toEqual({
-    to: '+2234567890',
-    content: 'SMS Content form Generic SMS Provider',
-    sender: 'sender-id',
+    expect(JSON.parse(lastRequest?.body ?? '{}')).toEqual({
+      to: '+2234567890',
+      content: 'SMS Content form Generic SMS Provider',
+      sender: 'sender-id',
+    });
+  });
+
+  test('should reject the request when the URL resolves to a private IP', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: 'http://127.0.0.2:8080/',
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
+      })
+    ).rejects.toThrow(/Generic SMS URL blocked/);
+  });
+
+  test('should reject non-http schemes', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: 'file:///etc/passwd',
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
+      })
+    ).rejects.toThrow(/Invalid URL format|Generic SMS URL blocked/);
   });
 });
 
-test('should reject the request when the URL resolves to a private IP', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: 'http://127.0.0.2:8080/',
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
+describe('without SSRF protection (self-hosted)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'true';
   });
 
-  await expect(
-    provider.sendMessage({
-      to: '+1234567890',
-      content: 'SMS Content form Generic SMS Provider',
-    })
-  ).rejects.toThrow(/Generic SMS URL blocked/);
-});
-
-test('should reject non-http schemes', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: 'file:///etc/passwd',
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
+  afterAll(() => {
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
-  await expect(
-    provider.sendMessage({
+  test('should allow requests to private IPs via axios', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: directServerUrl,
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+      idPath: 'message.id',
+      datePath: 'message.date',
+    });
+
+    const result = await provider.sendMessage({
       to: '+1234567890',
       content: 'SMS Content form Generic SMS Provider',
-    })
-  ).rejects.toThrow(/Invalid URL format|Generic SMS URL blocked/);
+    });
+
+    expect(lastRequest).not.toBeNull();
+    expect(result.id).toBeDefined();
+  });
 });

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
@@ -1,20 +1,75 @@
-import crypto from 'crypto';
-import { expect, test } from 'vitest';
-import { axiosSpy } from '../../../utils/test/spy-axios';
+import crypto from 'node:crypto';
+import * as dns from 'node:dns';
+import * as http from 'node:http';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { GenericSmsProvider } from './generic-sms.provider';
 
-test('should trigger generic-sms library correctly', async () => {
-  const { mockRequest: spy } = axiosSpy({
-    data: {
-      message: {
-        id: crypto.randomUUID(),
-        date: new Date().toISOString(),
-      },
-    },
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+beforeAll(() => {
+  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+  const realLookup = dns.promises.lookup.bind(dns.promises);
+  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+    if (hostname === 'test-generic-sms.invalid') {
+      const result = [{ address: '127.0.0.1', family: 4 }];
+
+      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+    }
+
+    return realLookup(hostname as string, opts as dns.LookupOptions);
+  }) as typeof dns.promises.lookup);
+});
+afterAll(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+  }
+});
+
+let server: http.Server;
+let serverUrl: string;
+let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+beforeEach(async () => {
+  lastRequest = null;
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      lastRequest = {
+        url: req.url ?? '',
+        method: req.method ?? 'GET',
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      };
+      const messageId = crypto.randomUUID();
+      const messageDate = new Date().toISOString();
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          message: {
+            id: messageId,
+            date: messageDate,
+          },
+        })
+      );
+    });
   });
 
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  serverUrl = `http://test-generic-sms.invalid:${addr.port}/`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test('should trigger generic-sms library correctly', async () => {
   const provider = new GenericSmsProvider({
-    baseUrl: 'https://api.generic-sms-provider.com',
+    baseUrl: serverUrl,
     apiKeyRequestHeader: 'apiKey',
     apiKey: '123456',
     from: 'sender-id',
@@ -22,34 +77,26 @@ test('should trigger generic-sms library correctly', async () => {
     datePath: 'message.date',
   });
 
-  await provider.sendMessage({
+  const result = await provider.sendMessage({
     to: '+1234567890',
     content: 'SMS Content form Generic SMS Provider',
   });
 
-  expect(spy).toHaveBeenCalled();
-  expect(spy).toHaveBeenCalledWith({
-    method: 'POST',
-    data: {
-      to: '+1234567890',
-      content: 'SMS Content form Generic SMS Provider',
-      sender: 'sender-id',
-    },
+  expect(lastRequest).not.toBeNull();
+  expect(lastRequest!.method).toBe('POST');
+  expect(JSON.parse(lastRequest!.body)).toEqual({
+    to: '+1234567890',
+    content: 'SMS Content form Generic SMS Provider',
+    sender: 'sender-id',
   });
+  expect(lastRequest!.headers.apikey).toBe('123456');
+  expect(result.id).toBeDefined();
+  expect(result.date).toBeDefined();
 });
 
 test('should trigger generic-sms library correctly with _passthrough', async () => {
-  const { mockRequest: spy } = axiosSpy({
-    data: {
-      message: {
-        id: crypto.randomUUID(),
-        date: new Date().toISOString(),
-      },
-    },
-  });
-
   const provider = new GenericSmsProvider({
-    baseUrl: 'https://api.generic-sms-provider.com',
+    baseUrl: serverUrl,
     apiKeyRequestHeader: 'apiKey',
     apiKey: '123456',
     from: 'sender-id',
@@ -71,13 +118,41 @@ test('should trigger generic-sms library correctly with _passthrough', async () 
     }
   );
 
-  expect(spy).toHaveBeenCalled();
-  expect(spy).toHaveBeenCalledWith({
-    method: 'POST',
-    data: {
-      to: '+2234567890',
-      content: 'SMS Content form Generic SMS Provider',
-      sender: 'sender-id',
-    },
+  expect(JSON.parse(lastRequest!.body)).toEqual({
+    to: '+2234567890',
+    content: 'SMS Content form Generic SMS Provider',
+    sender: 'sender-id',
   });
+});
+
+test('should reject the request when the URL resolves to a private IP', async () => {
+  const provider = new GenericSmsProvider({
+    baseUrl: 'http://127.0.0.2:8080/',
+    apiKeyRequestHeader: 'apiKey',
+    apiKey: '123456',
+    from: 'sender-id',
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: '+1234567890',
+      content: 'SMS Content form Generic SMS Provider',
+    })
+  ).rejects.toThrow(/Generic SMS URL blocked/);
+});
+
+test('should reject non-http schemes', async () => {
+  const provider = new GenericSmsProvider({
+    baseUrl: 'file:///etc/passwd',
+    apiKeyRequestHeader: 'apiKey',
+    apiKey: '123456',
+    from: 'sender-id',
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: '+1234567890',
+      content: 'SMS Content form Generic SMS Provider',
+    })
+  ).rejects.toThrow(/Invalid URL format|Generic SMS URL blocked/);
 });

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -63,14 +63,22 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       const tokenResponse = await this.safeJsonRequest(domainUrl, {
         method: 'POST',
         headers: requestHeaders,
+        blockedPrefix: 'Generic SMS auth URL blocked',
       });
+
+      this.assertSuccessStatus(tokenResponse.statusCode, 'Generic SMS auth request failed');
 
       const tokenBody = tokenResponse.body as { data?: Record<string, string> };
       const token = tokenBody?.data?.[authTokenKey];
 
+      if (!token) {
+        throw new Error('Generic SMS auth request failed: authentication token missing from response.');
+      }
+
       requestHeaders = {
-        [authTokenKey]: token,
+        ...this.headers,
         ...data.headers,
+        [authTokenKey]: token,
       };
     }
 
@@ -80,12 +88,15 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       method: 'POST',
       headers: requestHeaders,
       body: data.body,
+      blockedPrefix: 'Generic SMS URL blocked',
     });
 
-    const responseData = response.body;
+    this.assertSuccessStatus(response.statusCode, 'Generic SMS request failed');
+
+    const responseData = this.asResponseRecord(response.body);
 
     return {
-      id: this.getResponseValue(this.config.idPath || 'id', responseData),
+      id: this.getResponseValue(this.config.idPath || 'id', responseData) ?? '',
       date: this.getResponseValue(this.config.datePath || 'date', responseData) || new Date().toISOString(),
     };
   }
@@ -109,7 +120,23 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     return url;
   }
 
-  private safeJsonRequest(url: string, options: { method: 'POST'; headers: Record<string, string>; body?: unknown }) {
+  private assertSuccessStatus(statusCode: number, message: string): void {
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`${message} with status ${statusCode}`);
+    }
+  }
+
+  private safeJsonRequest(
+    url: string,
+    options: {
+      method: 'POST';
+      headers: Record<string, string>;
+      body?: Record<string, unknown>;
+      blockedPrefix?: string;
+    }
+  ) {
+    const blockedPrefix = options.blockedPrefix ?? 'Generic SMS URL blocked';
+
     return safeOutboundJsonRequest({
       url,
       method: options.method,
@@ -117,15 +144,38 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       body: options.body,
     }).catch((err: unknown) => {
       if (err instanceof SsrfBlockedError) {
-        throw new Error(`Generic SMS URL blocked: ${err.message}`);
+        throw new Error(`${blockedPrefix}: ${err.message}`);
       }
       throw err;
     });
   }
 
-  private getResponseValue(path: string, data: Record<string, unknown>) {
-    const pathArray = path.split('.');
+  private asResponseRecord(body: unknown): Record<string, unknown> {
+    if (body && typeof body === 'object' && !Array.isArray(body)) {
+      return body as Record<string, unknown>;
+    }
 
-    return pathArray.reduce<unknown>((acc, curr) => (acc as Record<string, unknown>)[curr], data);
+    return {};
+  }
+
+  private getResponseValue(path: string, data: Record<string, unknown>): string | undefined {
+    let current: unknown = data;
+
+    for (const segment of path.split('.')) {
+      if (current === null || current === undefined || typeof current !== 'object') {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+
+    if (typeof current === 'string') {
+      return current;
+    }
+
+    if (current === undefined || current === null) {
+      return undefined;
+    }
+
+    return String(current);
   }
 }

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -1,4 +1,4 @@
-import { SmsProviderIdEnum } from '@novu/shared';
+import { isOutboundSsrfProtectionEnabled, SmsProviderIdEnum } from '@novu/shared';
 import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
 import {
   assertSafeOutboundUrl,
@@ -7,6 +7,7 @@ import {
 } from '@novu/shared/utils/ssrf-url-validation';
 import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
 
+import axios, { AxiosInstance } from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -14,6 +15,7 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
   id = SmsProviderIdEnum.GenericSms;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
   protected casing = CasingEnum.CAMEL_CASE;
+  axiosInstance?: AxiosInstance;
   headers: Record<string, string>;
 
   constructor(
@@ -39,11 +41,69 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     if (this.config?.secretKeyRequestHeader && this.config?.secretKey) {
       this.headers[this.config?.secretKeyRequestHeader] = config.secretKey;
     }
+
+    if (!this.config?.authenticateByToken) {
+      this.axiosInstance = axios.create({
+        baseURL: config.baseUrl,
+        headers: this.headers,
+      });
+    }
   }
 
   async sendMessage(
     options: ISmsOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
+  ): Promise<ISendMessageSuccessResponse> {
+    if (isOutboundSsrfProtectionEnabled()) {
+      return this.sendMessageWithSsrfProtection(options, bridgeProviderData);
+    }
+
+    return this.sendMessageWithAxios(options, bridgeProviderData);
+  }
+
+  private async sendMessageWithAxios(
+    options: ISmsOptions,
+    bridgeProviderData: WithPassthrough<Record<string, unknown>>
+  ): Promise<ISendMessageSuccessResponse> {
+    const data = this.transform(bridgeProviderData, {
+      ...options,
+      sender: options.from || this.config.from,
+    });
+
+    if (this.config?.authenticateByToken) {
+      const tokenAxiosInstance = await axios.request({
+        method: 'POST',
+        baseURL: this.config.domain,
+        headers: this.headers,
+      });
+
+      const token = tokenAxiosInstance.data.data[this.config.authenticationTokenKey!];
+
+      this.axiosInstance = axios.create({
+        baseURL: this.config.baseUrl,
+        headers: {
+          [this.config.authenticationTokenKey!]: token,
+          ...data.headers,
+        },
+      });
+    }
+
+    const response = await this.axiosInstance!.request({
+      method: 'POST',
+      data: data.body,
+    });
+
+    const responseData = response.data as Record<string, unknown>;
+
+    return {
+      id: this.getResponseValue(this.config.idPath || 'id', responseData) ?? '',
+      date: this.getResponseValue(this.config.datePath || 'date', responseData) || new Date().toISOString(),
+    };
+  }
+
+  private async sendMessageWithSsrfProtection(
+    options: ISmsOptions,
+    bridgeProviderData: WithPassthrough<Record<string, unknown>>
   ): Promise<ISendMessageSuccessResponse> {
     const data = this.transform(bridgeProviderData, {
       ...options,
@@ -87,7 +147,7 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     const response = await this.safeJsonRequest(baseUrl, {
       method: 'POST',
       headers: requestHeaders,
-      body: data.body,
+      body: data.body as Record<string, unknown>,
       blockedPrefix: 'Generic SMS URL blocked',
     });
 

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -111,6 +111,7 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     });
 
     let requestHeaders: Record<string, string> = { ...this.headers, ...data.headers };
+    const baseUrl = this.assertSafeSmsUrl(this.config.baseUrl, 'Generic SMS URL blocked');
 
     if (this.config?.authenticateByToken) {
       const authTokenKey = this.config.authenticationTokenKey;
@@ -141,8 +142,6 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
         [authTokenKey]: token,
       };
     }
-
-    const baseUrl = this.assertSafeSmsUrl(this.config.baseUrl, 'Generic SMS URL blocked');
 
     const response = await this.safeJsonRequest(baseUrl, {
       method: 'POST',

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -1,7 +1,12 @@
 import { SmsProviderIdEnum } from '@novu/shared';
+import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
+import {
+  assertSafeOutboundUrl,
+  normalizeOutboundHttpUrl,
+  SsrfBlockedError,
+} from '@novu/shared/utils/ssrf-url-validation';
 import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
 
-import axios, { AxiosInstance } from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -9,7 +14,6 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
   id = SmsProviderIdEnum.GenericSms;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
   protected casing = CasingEnum.CAMEL_CASE;
-  axiosInstance: AxiosInstance;
   headers: Record<string, string>;
 
   constructor(
@@ -35,13 +39,6 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     if (this.config?.secretKeyRequestHeader && this.config?.secretKey) {
       this.headers[this.config?.secretKeyRequestHeader] = config.secretKey;
     }
-
-    if (!this.config?.authenticateByToken) {
-      this.axiosInstance = axios.create({
-        baseURL: config.baseUrl,
-        headers: this.headers,
-      });
-    }
   }
 
   async sendMessage(
@@ -52,30 +49,40 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       ...options,
       sender: options.from || this.config.from,
     });
+
+    let requestHeaders: Record<string, string> = { ...this.headers, ...data.headers };
+
     if (this.config?.authenticateByToken) {
-      const tokenAxiosInstance = await axios.request({
+      const authTokenKey = this.config.authenticationTokenKey;
+      if (!authTokenKey) {
+        throw new Error('Generic SMS auth URL blocked: authenticationTokenKey is required.');
+      }
+
+      const domainUrl = this.assertSafeSmsUrl(this.config.domain, 'Generic SMS auth URL blocked');
+
+      const tokenResponse = await this.safeJsonRequest(domainUrl, {
         method: 'POST',
-        baseURL: this.config.domain,
-        headers: this.headers,
+        headers: requestHeaders,
       });
 
-      const token = tokenAxiosInstance.data.data[this.config.authenticationTokenKey];
+      const tokenBody = tokenResponse.body as { data?: Record<string, string> };
+      const token = tokenBody?.data?.[authTokenKey];
 
-      this.axiosInstance = axios.create({
-        baseURL: this.config.baseUrl,
-        headers: {
-          [this.config.authenticationTokenKey]: token,
-          ...data.headers,
-        },
-      });
+      requestHeaders = {
+        [authTokenKey]: token,
+        ...data.headers,
+      };
     }
 
-    const response = await this.axiosInstance.request({
+    const baseUrl = this.assertSafeSmsUrl(this.config.baseUrl, 'Generic SMS URL blocked');
+
+    const response = await this.safeJsonRequest(baseUrl, {
       method: 'POST',
-      data: data.body,
+      headers: requestHeaders,
+      body: data.body,
     });
 
-    const responseData = response.data;
+    const responseData = response.body;
 
     return {
       id: this.getResponseValue(this.config.idPath || 'id', responseData),
@@ -83,9 +90,42 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     };
   }
 
-  private getResponseValue(path: string, data: any) {
+  private assertSafeSmsUrl(urlRaw: string | undefined, blockedPrefix: string): string {
+    const url = normalizeOutboundHttpUrl(urlRaw ?? '');
+
+    if (!url) {
+      throw new Error(`${blockedPrefix}: Invalid URL format.`);
+    }
+
+    try {
+      assertSafeOutboundUrl(url);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`${blockedPrefix}: ${err.message}`);
+      }
+      throw err;
+    }
+
+    return url;
+  }
+
+  private safeJsonRequest(url: string, options: { method: 'POST'; headers: Record<string, string>; body?: unknown }) {
+    return safeOutboundJsonRequest({
+      url,
+      method: options.method,
+      headers: options.headers,
+      body: options.body,
+    }).catch((err: unknown) => {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Generic SMS URL blocked: ${err.message}`);
+      }
+      throw err;
+    });
+  }
+
+  private getResponseValue(path: string, data: Record<string, unknown>) {
     const pathArray = path.split('.');
 
-    return pathArray.reduce((acc, curr) => acc[curr], data);
+    return pathArray.reduce<unknown>((acc, curr) => (acc as Record<string, unknown>)[curr], data);
   }
 }

--- a/packages/shared/src/utils/env.spec.ts
+++ b/packages/shared/src/utils/env.spec.ts
@@ -61,4 +61,10 @@ describe('isOutboundSsrfProtectionEnabled', () => {
       expect(isOutboundSsrfProtectionEnabled()).toBe(true);
     });
   });
+
+  test('returns false when CI_EE_TEST is enabled on self-hosted', () => {
+    withEnv({ [CI_EE_TEST_KEY]: 'true', [IS_SELF_HOSTED_KEY]: 'true' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(false);
+    });
+  });
 });

--- a/packages/shared/src/utils/env.spec.ts
+++ b/packages/shared/src/utils/env.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { isOutboundSsrfProtectionEnabled } from './env';
+
+const NOVU_ENTERPRISE_KEY = 'NOVU_ENTERPRISE';
+const IS_SELF_HOSTED_KEY = 'IS_SELF_HOSTED';
+const CI_EE_TEST_KEY = 'CI_EE_TEST';
+
+function withEnv(env: Record<string, string | undefined>, fn: () => void) {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of [NOVU_ENTERPRISE_KEY, IS_SELF_HOSTED_KEY, CI_EE_TEST_KEY]) {
+    previous[key] = process.env[key];
+    const value = env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    fn();
+  } finally {
+    for (const key of [NOVU_ENTERPRISE_KEY, IS_SELF_HOSTED_KEY, CI_EE_TEST_KEY]) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+describe('isOutboundSsrfProtectionEnabled', () => {
+  afterEach(() => {
+    delete process.env[NOVU_ENTERPRISE_KEY];
+    delete process.env[IS_SELF_HOSTED_KEY];
+    delete process.env[CI_EE_TEST_KEY];
+  });
+
+  test('returns true for enterprise cloud', () => {
+    withEnv({ [NOVU_ENTERPRISE_KEY]: 'true', [IS_SELF_HOSTED_KEY]: 'false' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(true);
+    });
+  });
+
+  test('returns false for community cloud', () => {
+    withEnv({ [NOVU_ENTERPRISE_KEY]: 'false', [IS_SELF_HOSTED_KEY]: 'false' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(false);
+    });
+  });
+
+  test('returns false for enterprise self-hosted', () => {
+    withEnv({ [NOVU_ENTERPRISE_KEY]: 'true', [IS_SELF_HOSTED_KEY]: 'true' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(false);
+    });
+  });
+
+  test('returns true when CI_EE_TEST is enabled on cloud', () => {
+    withEnv({ [CI_EE_TEST_KEY]: 'true', [IS_SELF_HOSTED_KEY]: 'false' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(true);
+    });
+  });
+});

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -67,3 +67,14 @@ export const getEEAuthProvider = (): EEAuthProvider => {
 export const isClerkEnabled = () => isEEAuthEnabled() && getEEAuthProvider() === 'clerk';
 
 export const isBetterAuthEnabled = () => isEEAuthEnabled() && getEEAuthProvider() === 'better-auth';
+
+/**
+ * Outbound SSRF pinning applies only on Novu Cloud Enterprise builds.
+ * Self-hosted and community deployments may intentionally target internal URLs.
+ */
+export const isOutboundSsrfProtectionEnabled = (): boolean => {
+  const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+  const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
+
+  return isEnterprise && !isSelfHosted;
+};

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -73,8 +73,9 @@ export const isBetterAuthEnabled = () => isEEAuthEnabled() && getEEAuthProvider(
  * Self-hosted and community deployments may intentionally target internal URLs.
  */
 export const isOutboundSsrfProtectionEnabled = (): boolean => {
-  const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
-  const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
+  const isEnterprise =
+    getEnvVariable('NOVU_ENTERPRISE') === 'true' || getEnvVariable('CI_EE_TEST') === 'true';
+  const isSelfHosted = getEnvVariable('IS_SELF_HOSTED') === 'true';
 
   return isEnterprise && !isSelfHosted;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds SSRF protection to `EmailWebhookProvider` and `GenericSmsProvider`, matching the pattern used by `ChatWebhookProvider` and `PushWebhookProvider`.

## Changes

- **`EmailWebhookProvider`**: Routes outbound HTTP through `assertSafeOutboundUrl` + `safeOutboundJsonRequest` when SSRF protection is enabled. Preserves axios + retry behavior for self-hosted/community deployments.
- **`GenericSmsProvider`**: Same split for `baseUrl` and token-auth `domain` URLs. Typed response parsing and non-2xx status handling on the SSRF path.
- **`@novu/shared`**: Adds `isOutboundSsrfProtectionEnabled()` — enabled only for enterprise cloud (`NOVU_ENTERPRISE` or `CI_EE_TEST`, and not `IS_SELF_HOSTED`).

## Behavior

| Deployment | Outbound HTTP |
| --- | --- |
| Enterprise cloud | SSRF-safe (`assertSafeOutboundUrl` + `safeOutboundJsonRequest`) |
| Self-hosted / community | Legacy axios (no SSRF blocking) |

## Tests

- Email webhook + generic SMS: success, passthrough, private IP rejection, invalid scheme rejection (enterprise cloud)
- Self-hosted: private IPs allowed via axios
- `isOutboundSsrfProtectionEnabled` unit tests in `@novu/shared`

## Linear

fixes NV-7918
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7918](https://linear.app/novu/issue/NV-7918/add-ssrf-protection-to-email-webhook-and-sms-providers)

<div><a href="https://cursor.com/agents/bc-41579b6a-319f-4b9d-aa24-eff94c4be58d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41579b6a-319f-4b9d-aa24-eff94c4be58d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR adds SSRF protection to EmailWebhookProvider and GenericSmsProvider so outbound HTTP is validated and proxied through safeOutboundJsonRequest when running in enterprise cloud, blocking private IPs and invalid schemes. Self-hosted and community deployments continue to use the legacy axios-based sender to preserve existing behavior. The change aligns these providers with existing ChatWebhookProvider/PushWebhookProvider SSRF protections and fixes NV-7918.

## Affected areas

**providers**: EmailWebhookProvider and GenericSmsProvider now choose between an SSRF-safe HTTP path (assertSafeOutboundUrl + safeOutboundJsonRequest) or a legacy axios path at runtime; both preserve retry/backoff semantics, enforce non-2xx as failures on the SSRF path, and tighten response parsing and header handling.

**shared**: Added isOutboundSsrfProtectionEnabled() to gate SSRF protection based on environment (enabled for enterprise cloud via NOVU_ENTERPRISE or CI_EE_TEST unless IS_SELF_HOSTED is true). This change affects enterprise-only behavior.

## Key technical decisions

- Conditional runtime routing selects SSRF-safe or axios senders to maintain backward compatibility for self-hosted deployments.
- Tests moved from axios-spying to integration-style tests using real node http servers plus DNS lookup mocking to exercise genuine SSRF rejection behavior.
- GenericSmsProvider’s axiosInstance was made optional since SSRF-protected flows do not rely on axios.

## Testing

Added integration-style tests that spin up local HTTP servers and mock DNS lookups to verify success, passthrough, private IP rejection, and invalid-scheme rejection in enterprise cloud mode, plus self-hosted tests that confirm legacy axios behavior; unit tests cover env-gating for isOutboundSsrfProtectionEnabled().
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends SSRF protection to `EmailWebhookProvider` and `GenericSmsProvider`, following the same dual-path pattern already used by `ChatWebhookProvider` and `PushWebhookProvider`. At runtime, `isOutboundSsrfProtectionEnabled()` routes enterprise-cloud deployments through `assertSafeOutboundUrl` + `safeOutboundJsonRequest` while leaving self-hosted deployments on the original axios path.

- **`EmailWebhookProvider`**: A new `sendWithSsrfProtection` method normalizes the URL, runs a structure-only pre-flight, then retries via `safeOutboundJsonRequest`; SSRF errors surface as a dedicated `EmailWebhookUrlBlockedError` and are never retried.
- **`GenericSmsProvider`**: `sendMessageWithSsrfProtection` validates `baseUrl` up-front (before the token-auth network call), validates the auth `domain` separately, and enforces non-2xx status as a failure on both sub-requests.
- **`@novu/shared`**: Adds `isOutboundSsrfProtectionEnabled()` gated on `NOVU_ENTERPRISE`/`CI_EE_TEST` and not `IS_SELF_HOSTED`; uses `getEnvVariable` for edge-runtime compatibility.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the SSRF-protected paths are logically correct, SSRF errors are properly surfaced and not retried, and the self-hosted axios fallback is unchanged.

The dual-path routing, URL normalization, pre-flight validation, and retry semantics are all implemented correctly. The `baseUrl` SSRF check in `GenericSmsProvider` happens before the auth-domain network call. Test coverage is solid with real HTTP servers and DNS mocking covering both deployment modes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/env.ts | Adds `isOutboundSsrfProtectionEnabled()` gating on NOVU_ENTERPRISE/CI_EE_TEST and not IS_SELF_HOSTED; uses `getEnvVariable` (edge-compatible) consistently. |
| packages/shared/src/utils/env.spec.ts | New unit tests for `isOutboundSsrfProtectionEnabled` cover all meaningful env-var combinations; `withEnv` helper correctly restores state after each case. |
| packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts | Adds SSRF-protected path via `sendWithSsrfProtection`: URL normalized, structure pre-flight, then retry loop with `safeOutboundJsonRequest`; SSRF errors surfaced as `EmailWebhookUrlBlockedError` and correctly not retried. |
| packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts | Rewrites test suite to use real HTTP servers and DNS mocking; covers enterprise-cloud success, passthrough, private-IP rejection, invalid-scheme rejection, and self-hosted private-IP allow-through. |
| packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts | Adds SSRF path (`sendMessageWithSsrfProtection`); correctly validates `baseUrl` before the auth-domain request, handles token-auth flow, non-2xx gating, and typed response parsing. |
| packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts | Rewrites SMS tests to use real HTTP servers and DNS mocking; covers both SSRF-protected and self-hosted code paths with private IP and scheme rejection scenarios. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sendMessage] -->|isOutboundSsrfProtectionEnabled?| B{Enterprise Cloud?}
    B -->|Yes| C[SSRF-Safe Path]
    B -->|No - self-hosted| D[Axios Path]
    C --> C1[normalizeOutboundHttpUrl]
    C1 -->|null| CE1[Throw URL blocked error]
    C1 -->|valid| C2[assertSafeOutboundUrl]
    C2 -->|SsrfBlockedError| CE1
    C2 -->|ok| C3{authenticateByToken?}
    C3 -->|Yes| C4[Validate domain, fetch token]
    C3 -->|No| C5[safeOutboundJsonRequest]
    C4 --> C5
    C5 -->|SsrfBlockedError| CE1
    C5 -->|non-2xx| CE2[Retry then throw]
    C5 -->|2xx| C6[Return success response]
    D --> D1[axiosInstance.request]
    D1 -->|error| D3[Retry then throw]
    D1 -->|success| D4[Return success response]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fproviders%2Fsrc%2Flib%2Femail%2Femail-webhook%2Femail-webhook.provider.ts%3A124-155%0AAfter%20%60retryCount%60%20attempts%20the%20loop%20exits%20and%20the%20final%20error%20is%20always%20the%20generic%20%60'webhook%20send%20failed%20!'%60%2C%20silently%20discarding%20the%20status%20code%20of%20the%20last%20response%20%28e.g.%20503%29.%20Callers%20and%20logs%20lose%20the%20ability%20to%20distinguish%20a%20transient%20503%20from%20a%20configuration%20error%20like%20401.%20Consider%20re-throwing%20the%20last%20informative%20error%20instead.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20sent%20%3D%20false%3B%0A%20%20%20%20let%20lastError%3A%20Error%20%3D%20new%20Error%28'webhook%20send%20failed%20!'%29%3B%0A%0A%20%20%20%20for%20%28let%20retries%20%3D%200%3B%20!sent%20%26%26%20retries%20%3C%20this.config.retryCount%3B%20retries%20%2B%3D%201%29%20%7B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20const%20response%20%3D%20await%20safeOutboundJsonRequest%28%7B%0A%20%20%20%20%20%20%20%20%20%20url%3A%20webhookUrl%2C%0A%20%20%20%20%20%20%20%20%20%20method%3A%20'POST'%2C%0A%20%20%20%20%20%20%20%20%20%20headers%3A%20requestHeaders%2C%0A%20%20%20%20%20%20%20%20%20%20body%3A%20bodyData%2C%0A%20%20%20%20%20%20%20%20%7D%29.catch%28%28err%3A%20unknown%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20if%20%28err%20instanceof%20SsrfBlockedError%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20throw%20new%20EmailWebhookUrlBlockedError%28%60Email%20webhook%20URL%20blocked%3A%20%24%7Berr.message%7D%60%29%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20throw%20err%3B%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%0A%20%20%20%20%20%20%20%20if%20%28response.statusCode%20%3C%20200%20%7C%7C%20response.statusCode%20%3E%3D%20300%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20throw%20new%20Error%28%60webhook%20send%20failed%20with%20status%20%24%7Bresponse.statusCode%7D%60%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20sent%20%3D%20true%3B%0A%20%20%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28error%20instanceof%20EmailWebhookUrlBlockedError%20%7C%7C%20error%20instanceof%20SsrfBlockedError%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20throw%20error%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28error%20instanceof%20Error%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20lastError%20%3D%20error%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20await%20setTimeout%28this.config.retryDelay%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20%28!sent%29%20%7B%0A%20%20%20%20%20%20throw%20lastError%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fproviders%2Fsrc%2Flib%2Fsms%2Fgeneric-sms%2Fgeneric-sms.provider.ts%3A113%0A**Passthrough%20headers%20absent%20from%20non-token-auth%20axios%20path**%0A%0AIn%20%60sendMessageWithAxios%60%2C%20when%20%60authenticateByToken%60%20is%20false%2C%20%60this.axiosInstance%60%20is%20created%20in%20the%20constructor%20with%20only%20%60this.headers%60%3B%20the%20per-call%20%60data.headers%60%20from%20%60bridgeProviderData%60%20are%20never%20forwarded.%20The%20SSRF%20path%20at%20line%20113%20correctly%20merges%20both%20%28%60%7B%20...this.headers%2C%20...data.headers%20%7D%60%29%2C%20so%20passthrough%20headers%20now%20work%20on%20enterprise%20cloud%20but%20are%20silently%20dropped%20on%20self-hosted%20for%20non-token-auth%20providers.%20This%20pre-existed%20the%20PR%20but%20the%20divergence%20is%20now%20more%20visible%20across%20the%20two%20code%20paths.%0A%0A&pr=11378&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts:124-155
After `retryCount` attempts the loop exits and the final error is always the generic `'webhook send failed !'`, silently discarding the status code of the last response (e.g. 503). Callers and logs lose the ability to distinguish a transient 503 from a configuration error like 401. Consider re-throwing the last informative error instead.

```suggestion
    let sent = false;
    let lastError: Error = new Error('webhook send failed !');

    for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
      try {
        const response = await safeOutboundJsonRequest({
          url: webhookUrl,
          method: 'POST',
          headers: requestHeaders,
          body: bodyData,
        }).catch((err: unknown) => {
          if (err instanceof SsrfBlockedError) {
            throw new EmailWebhookUrlBlockedError(`Email webhook URL blocked: ${err.message}`);
          }
          throw err;
        });

        if (response.statusCode < 200 || response.statusCode >= 300) {
          throw new Error(`webhook send failed with status ${response.statusCode}`);
        }

        sent = true;
      } catch (error) {
        if (error instanceof EmailWebhookUrlBlockedError || error instanceof SsrfBlockedError) {
          throw error;
        }
        if (error instanceof Error) {
          lastError = error;
        }
        await setTimeout(this.config.retryDelay);
      }
    }

    if (!sent) {
      throw lastError;
    }
```

### Issue 2 of 2
packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts:113
**Passthrough headers absent from non-token-auth axios path**

In `sendMessageWithAxios`, when `authenticateByToken` is false, `this.axiosInstance` is created in the constructor with only `this.headers`; the per-call `data.headers` from `bridgeProviderData` are never forwarded. The SSRF path at line 113 correctly merges both (`{ ...this.headers, ...data.headers }`), so passthrough headers now work on enterprise cloud but are silently dropped on self-hosted for non-token-auth providers. This pre-existed the PR but the divergence is now more visible across the two code paths.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(providers): address SSRF PR review f..."](https://github.com/novuhq/novu/commit/ef84ad3a6200ea89c29b3d4520e3699e07a18055) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34804487)</sub>

<!-- /greptile_comment -->