### PR TITLE
refactor(api-service): replace Close this tab button with static hint fixes NV-7928

### DIFF
--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -56,7 +56,7 @@ export class AgentsMcpOAuthController {
     );
 
     // Render a self-contained "flow complete" page instead of redirecting to the
-    // dashboard. The shared renderer already shows a "Close this tab" action,
+    // dashboard. The shared renderer tells the user they can close the tab.
     // so the message stays short and avoids repeating it. Openers detect the
     // outcome via popup-close detection / status polling, not from this page.
     const isConnected = result.status === 'connected';

--- a/apps/api/src/app/shared/html/connection-result-page.spec.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.spec.ts
@@ -67,7 +67,7 @@ describe('connection-result-page', () => {
         message: 'Your workspace is connected and ready to use.',
       });
 
-      expect(html).to.include('You can close this tab manually.');
+      expect(html).to.include('You can close this tab.');
       expect(html).to.include('class="close-hint"');
       expect(html).to.not.include('Close this tab</a>');
       expect(html).to.not.include('onclick=');

--- a/apps/api/src/app/shared/html/connection-result-page.spec.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.spec.ts
@@ -6,15 +6,12 @@ import {
 
 describe('connection-result-page', () => {
   describe('CONNECTION_RESULT_CSP', () => {
-    // Anchor the directive name to a `^`/`;` boundary so neither assertion can
-    // pass via `script-src-attr` / `style-src-elem` if the bare directive ever
-    // regresses.
     it('allows inline styles so the embedded <style> block is not blocked', () => {
       expect(CONNECTION_RESULT_CSP).to.match(/(?:^|;\s*)style-src\s+[^;]*'unsafe-inline'/);
     });
 
-    it('allows inline scripts so the close-tab onclick handler is not blocked', () => {
-      expect(CONNECTION_RESULT_CSP).to.match(/(?:^|;\s*)script-src\s+[^;]*'unsafe-inline'/);
+    it("does not allow inline scripts — the page is style-only", () => {
+      expect(CONNECTION_RESULT_CSP).to.not.match(/(?:^|;\s*)script-src\s+[^;]*'unsafe-inline'/);
     });
 
     it("keeps default-src locked down to 'self'", () => {
@@ -62,7 +59,22 @@ describe('connection-result-page', () => {
       expect(html).to.include('&quot;footer&quot; &amp; &lt;note&gt;');
     });
 
-    it('does not emit a window.opener.postMessage shim', () => {
+    it('shows a static close-tab hint instead of an interactive button', () => {
+      const html = renderConnectionResultPage({
+        status: 'success',
+        title: 'Connection complete',
+        heading: "You're all set",
+        message: 'Your workspace is connected and ready to use.',
+      });
+
+      expect(html).to.include('You can close this tab manually.');
+      expect(html).to.include('class="close-hint"');
+      expect(html).to.not.include('Close this tab</a>');
+      expect(html).to.not.include('onclick=');
+      expect(html).to.not.include('javascript:void');
+    });
+
+    it('does not emit scripts or postMessage shims', () => {
       const html = renderConnectionResultPage({
         status: 'success',
         title: 't',

--- a/apps/api/src/app/shared/html/connection-result-page.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.ts
@@ -152,7 +152,7 @@ const SUCCESS_ICON = `<div class="check">
 
 const ERROR_ICON = `<div class="info-icon" aria-hidden="true">!</div>`;
 
-const CLOSE_HINT = `<p class="close-hint">You can close this tab manually.</p>`;
+const CLOSE_HINT = `<p class="close-hint">You can close this tab.</p>`;
 
 export function renderConnectionResultPage(options: ConnectionResultPageOptions): string {
   const { status, title, heading, message, footerNote } = options;

--- a/apps/api/src/app/shared/html/connection-result-page.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.ts
@@ -17,13 +17,10 @@ export type ConnectionResultStatus = 'success' | 'error';
 
 /**
  * CSP header value that matches what {@link renderConnectionResultPage} emits:
- * the page ships an inline `<style>` block and an `onclick` handler on the
- * close-tab link. `script-src 'unsafe-inline'` covers the event handler via
- * the CSP3 `script-src-attr` fallback; `style-src 'unsafe-inline'` covers the
- * inline stylesheet. `default-src 'self'` keeps everything else locked down.
+ * the page ships an inline `<style>` block only. `style-src 'unsafe-inline'`
+ * covers the stylesheet; `default-src 'self'` keeps everything else locked down.
  */
-export const CONNECTION_RESULT_CSP =
-  "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
+export const CONNECTION_RESULT_CSP = "default-src 'self'; style-src 'self' 'unsafe-inline'";
 
 export interface ConnectionResultPageOptions {
   status: ConnectionResultStatus;
@@ -73,24 +70,7 @@ const PAGE_STYLES = `
   }
   h1.message-heading { margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #18181b; }
   p.intro { margin: 0 0 8px; color: #52525b; font-size: 14px; line-height: 1.5; }
-  a.secondary,
-  button.secondary {
-    appearance: none;
-    border: 0;
-    background: transparent;
-    cursor: pointer;
-    color: #71717a;
-    font-size: 13px;
-    font-weight: 500;
-    margin-top: 14px;
-    padding: 4px 8px;
-    text-decoration: none;
-    display: inline-block;
-    border-radius: 6px;
-    transition: color 120ms ease, background 120ms ease;
-    font-family: inherit;
-  }
-  a.secondary:hover, button.secondary:hover { color: #18181b; background: #f4f4f5; }
+  p.close-hint { margin: 14px 0 0; font-size: 13px; color: #71717a; }
   .footer {
     margin-top: 24px;
     padding-top: 16px;
@@ -133,12 +113,6 @@ const PAGE_STYLES = `
     align-items: center;
     justify-content: center;
   }
-  .cancel-hint {
-    display: none;
-    margin-top: 12px;
-    font-size: 12px;
-    color: #71717a;
-  }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
   @keyframes pop { 0% { transform: scale(0.6); opacity: 0; } 60% { transform: scale(1.06); opacity: 1; } 100% { transform: scale(1); opacity: 1; } }
   @keyframes stroke { to { stroke-dashoffset: 0; } }
@@ -148,13 +122,11 @@ const PAGE_STYLES = `
     .card { background: #18181b; border-color: #27272a; box-shadow: 0 1px 2px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.4); }
     h1.message-heading { color: #fafafa; }
     p.intro { color: #a1a1aa; }
-    a.secondary, button.secondary { color: #a1a1aa; }
-    a.secondary:hover, button.secondary:hover { color: #fafafa; background: #27272a; }
+    p.close-hint { color: #a1a1aa; }
     .footer { color: #71717a; border-top-color: #27272a; }
     .check { background: #052e16; }
     .check svg path { stroke: #34d399; }
     .info-icon { background: #450a0a; color: #fca5a5; }
-    .cancel-hint { color: #a1a1aa; }
   }
 `;
 
@@ -180,14 +152,7 @@ const SUCCESS_ICON = `<div class="check">
 
 const ERROR_ICON = `<div class="info-icon" aria-hidden="true">!</div>`;
 
-/**
- * Inline close-tab link. `window.close()` only works on tabs opened by script, so
- * we attempt it and, if the tab is still here a moment later, reveal a manual hint.
- * The handler is inlined so it works even when the markup is injected without
- * executing `<script>` blocks.
- */
-const CLOSE_LINK = `<a class="secondary" href="javascript:void(0)" onclick="try{window.close();}catch(e){}var h=this.nextElementSibling;setTimeout(function(){if(!document.hidden&&h){h.style.display='block';}},150);return false;">Close this tab</a>
-  <div class="cancel-hint">You can close this tab manually.</div>`;
+const CLOSE_HINT = `<p class="close-hint">You can close this tab manually.</p>`;
 
 export function renderConnectionResultPage(options: ConnectionResultPageOptions): string {
   const { status, title, heading, message, footerNote } = options;
@@ -199,7 +164,7 @@ export function renderConnectionResultPage(options: ConnectionResultPageOptions)
   ${icon}
   <h1 class="message-heading">${escapeHtml(heading)}</h1>
   <p class="intro">${escapeHtml(message)}</p>
-  ${CLOSE_LINK}
+  ${CLOSE_HINT}
   ${footer}
 </div>`;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Replaced the interactive "Close this tab" link (which attempted window.close() and revealed a fallback hint) with a static message: "You can close this tab manually." Tightened the connection-result page Content Security Policy to disallow inline scripts since the page no longer runs any JavaScript.

## Affected areas

**api**: The shared connection-result HTML was simplified — removed the interactive close link, its onclick/timeout reveal logic, and the CLOSE_LINK constant; added a static CLOSE_HINT and corresponding CSS. CONNECTION_RESULT_CSP was tightened from allowing inline scripts to a style-only policy (`default-src 'self'; style-src 'self' 'unsafe-inline'`). Controller comment updated and unit tests expanded to assert the static hint and absence of onclick handlers, javascript: URIs, window.opener/postMessage usage, or <script> tags.

## Key technical decisions

- CSP narrowed to style-only to reflect the page’s zero-JavaScript design.  
- Removed client-side close-attempt/fallback logic in favor of a deterministic static hint.

## Testing

Updated unit tests (connection-result-page.spec.ts) — ~8 specs run locally — to assert the static hint is rendered and that no inline scripts, onclick attributes, javascript: URIs, or <script> tags are emitted; no additional e2e or backend tests were required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Follow-up to #11376 / NV-7926. The connection-result page still rendered an interactive **Close this tab** link with an inline `onclick` handler that called `window.close()` and conditionally revealed a hidden hint. That added `script-src 'unsafe-inline'` to the CSP and button/hover CSS that no longer served a useful purpose — `window.close()` only works on script-opened tabs, and most OAuth callbacks land in the same tab anyway.

**Changes:**

- Replace the close link + hidden reveal with static copy: *You can close this tab manually.*
- Remove `.secondary` button styles, `.cancel-hint` hidden/reveal logic, and the `CLOSE_LINK` constant.
- Tighten `CONNECTION_RESULT_CSP` to style-only: `default-src 'self'; style-src 'self' 'unsafe-inline'` (no `script-src 'unsafe-inline'`).
- Update specs to assert the static hint and that no `onclick` / `javascript:void` / `<script>` is emitted.

### Screenshots

No visual regression expected — the card still shows the checkmark, heading, message, and close hint; only the clickable link is gone.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- 8 specs in `connection-result-page.spec.ts`, all passing locally.
- Unrelated endpoints (`subscribersV1`, Azure Quick Setup popup) keep their existing CSP — they don't use `CONNECTION_RESULT_CSP`.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12402d1e-70d4-4141-95dc-a15429c867f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12402d1e-70d4-4141-95dc-a15429c867f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the interactive "Close this tab" link (which invoked `window.close()` and conditionally revealed a hidden div) with a simple static `<p class="close-hint">You can close this tab.</p>`, and tightens the `CONNECTION_RESULT_CSP` by dropping `script-src 'unsafe-inline'` since no inline JavaScript is executed on the page anymore.

- **CSP hardened**: `CONNECTION_RESULT_CSP` now restricts to `default-src 'self'; style-src 'self' 'unsafe-inline'`, removing the previously required `script-src 'unsafe-inline'`. This is correct because `window.close()` only works on script-opened tabs and the onClick handler is now gone.
- **Unused CSS cleaned up**: `.secondary`, `.cancel-hint`, and their dark-mode overrides are removed alongside the `CLOSE_LINK` constant.
- **Test coverage updated**: Eight spec cases now assert the static hint is present, `onclick` / `javascript:void` / `<script>` are absent, and CSP no longer permits inline scripts. The shared `CONNECTION_RESULT_CSP` constant is also used by the `integrations.controller.ts` OAuth callback path, so the tightened policy applies there as well.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes dead JavaScript, tightens the CSP, and leaves all consumers of the shared renderer and CSP constant working correctly.

The refactor is narrow and self-contained: it removes an inline onclick handler that was already unreliable (window.close() only works on script-opened tabs), replaces it with a static paragraph, and aligns the CSP to match. All callers — the MCP OAuth controller and the integrations Slack/MSTeams callback path — share the same renderer and CSP constant, and neither caller added any inline scripts of its own, so the stricter policy is correct for both. Tests cover the key assertions: static hint present, no onclick or script-src unsafe-inline, and CSP locked to style-only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/html/connection-result-page.ts | Replaces the interactive CLOSE_LINK (with inline onclick and hidden reveal) with a static CLOSE_HINT paragraph; trims CSP to style-only by removing script-src 'unsafe-inline'. Changes are internally consistent. |
| apps/api/src/app/shared/html/connection-result-page.spec.ts | Tests updated to assert static hint is rendered, no onclick/javascript URIs emitted, and script-src unsafe-inline is absent from CSP. Coverage is thorough. |
| apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts | Comment-only update to reflect that the page now tells the user to close the tab rather than offering an interactive link. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant API as API Controller
    participant Renderer as renderConnectionResultPage

    Browser->>API: GET /oauth/callback
    API->>Renderer: renderConnectionResultPage(options)
    Renderer-->>API: HTML with static close-hint paragraph
    API-->>Browser: "200 text/html, CSP: style-only"
    Note over Browser: Shows card with static hint<br/>"You can close this tab."<br/>No onclick or inline scripts
```

<sub>Reviews (2): Last reviewed commit: ["chore(api-service): shorten connection-r..."](https://github.com/novuhq/novu/commit/2228196797254d603f7f8814eb9a25c165b920b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34814735)</sub>

<!-- /greptile_comment -->