### PR TITLE
feat(root): update readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 <a href="https://www.recent.dev">Recent.dev</a>
 </p>
 
-Software is becoming more conversational, and user expectations are rising with it. People no longer want static, irrelevant notifications they glance at and forget — they want to engage, ask questions, and go deeper. Instead of a one-way report dropped in their inbox, they expect a thread they can explore: follow up on a metric, drill into an anomaly, or continue a conversation right where they left off. That shift — from broadcast to dialogue — is what Novu's communication infrastructure is built for.
+Software is becoming more conversational, and user expectations are rising with it. People no longer want static, irrelevant notifications they glance at and forget, they want to engage, ask questions, and go deeper. Instead of a one-way report dropped in their inbox, they expect a thread they can explore: follow up on a metric, drill into an anomaly, or continue a conversation right where they left off. That shift, from broadcast to meaningful dialog is what Novu's communication infrastructure is built for.
 
 ## ⭐️ Why Novu?
  

--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@
   ·
   <a href="https://go.novu.co/contact?utm_source=github&utm_medium=readme&utm_campaign=contact-us-link" target="_blank" rel="noopener noreferrer"
 >Contact us</a>
-.
-<a href="https://www.recent.dev">Recent.dev</a>
-</p>
 
 Software is becoming more conversational, and user expectations are rising with it. People no longer want static, irrelevant notifications they glance at and forget, they want to engage, ask questions, and go deeper. Instead of a one-way report dropped in their inbox, they expect a thread they can explore: follow up on a metric, drill into an anomaly, or continue a conversation right where they left off. That shift, from broadcast to meaningful dialog is what Novu's communication infrastructure is built for.
 
@@ -113,6 +110,14 @@ Novu handles the plumbing in both directions: it receives inbound messages from 
 - **Bring your own agent** — works with whatever you've built, whether that's Claude Managed Agents, AI SDK, LangGraph, or a custom stack; Novu doesn't constrain your agent logic
 - **Best practices built in** — conversation threading, reactions, channel-aware formatting, actions and a single integration surface
 Novu connects the agent to the world, it is not the agent itself.
+
+### Want to see ACI in action?
+We have built [Novu Connect](https://novu.co/connect) to showcase the power of ACI, build on integrate an existing Claude Managed Agent as a teammate in Slack, Telegram, or Email in less than 2 minutes. 
+
+Try it now:
+```
+npx novu@latest connect
+```
 
 ## Embeddable Inbox component
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 </p>
 
 <h1 align="center">
- The &lt;Inbox /&gt; infrastructure for modern products
+ The open-source communication infrastructure for agents and products
 </h1>
 
 <div align="center">
-  The notification platform that turns complex multi-channel delivery into a single component. Built for developers, designed for growth, powered by open source.
+  One API and one unified conversation model to connect your <strong>products</strong> and your <strong>agents</strong> to every channel your users live on — Inbox, Email, SMS, Push, Chat, Slack, Microsoft Teams, Telegram, and more.
 </div>
 
 <p align="center">
@@ -73,16 +73,6 @@ There are two ways to build with Novu, and they share the same foundation: a sin
 
 > **Novu isn't the brain of your agent.** You bring the intelligence, Novu is the connective layer between your agent and the people it talks to.
 
-## ✨ Features
-
-- Embeddable Inbox component with real-time support
-- Single API for all messaging providers (Inbox/In-App, Email, SMS, Push, Chat)
-- Digest Engine to combine multiple notification in to a single E-mail
-- No-Code Block Editor for Email
-- Notification Workflow Engine
-- Embeddable user preferences component gives your subscribers control over their notifications
-- Community-driven
-
 ## 🚀 Getting Started
 
 [Create a free account](https://go.novu.co/dashboard?utm_source=github&utm_medium=readme&utm_campaign=create-free-account-link) and follow the instructions on the dashboard.
@@ -92,14 +82,9 @@ There are two ways to build with Novu, and they share the same foundation: a sin
 - [Why Novu?](#️-why-novu)
 - [Communication infrastructure for products](#-communication-infrastructure-for-products)
 - [Agent Communication Infrastructure (ACI)](#-agent-communication-infrastructure-aci)
-- [Features](#-features)
 - [Getting Started](#-getting-started)
 - [Embeddable Inbox and Preferences](#embeddable-inbox-component)
 - [Providers](#providers)
-- [Need Help?](#need-help)
-- [Links](#links)
-- [License](#license)
-
 
 ## 📬 Communication infrastructure for products
  

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ There are two ways to build with Novu, and they share the same foundation: a sin
 - **Communication infrastructure for products** — Send notifications across Inbox/In-App, Email, SMS, Push, and Chat through one API, with workflows, digests, and an embeddable `<Inbox />` component.
 - **Agent Communication Infrastructure (ACI)** — Connect any agent you've already built to any communication channel: Slack, Microsoft Teams, Telegram, WhatsApp, email through one conversation model.
 
-> **Novu isn't the brain of your agent.** You bring the intelligence, Novu is the connective layer between your agent and the people it talks to.
-
 ## 🚀 Getting Started
 
 [Create a free account](https://go.novu.co/dashboard?utm_source=github&utm_medium=readme&utm_campaign=create-free-account-link) and follow the instructions on the dashboard.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,15 @@
 </p>
 
 ## ⭐️ Why Novu?
+ 
+Every product and every agent eventually needs to talk to people, across the channels those people already use. Novu is the open-source layer that handles that communication for you, so you don't rebuild Inbox feeds, provider integrations, and channel webhooks from scratch every time.
+ 
+There are two ways to build with Novu, and they share the same foundation: a single API and a unified conversation model.
+ 
+- **Communication infrastructure for products** — Send notifications across Inbox/In-App, Email, SMS, Push, and Chat through one API, with workflows, digests, and an embeddable `<Inbox />` component.
+- **Agent Communication Infrastructure (ACI)** — Connect any agent you've already built to any communication channel: Slack, Microsoft Teams, Telegram, WhatsApp, email through one conversation model.
 
-Novu provides a unified API that makes it simple to send notifications through multiple channels, including Inbox/In-App, Push, Email, SMS, and Chat.
-With Novu, you can create custom workflows and define conditions for each channel, ensuring that your notifications are delivered in the most effective way possible.
+> **Novu isn't the brain of your agent.** You bring the intelligence, Novu is the connective layer between your agent and the people it talks to.
 
 ## ✨ Features
 
@@ -82,13 +88,46 @@ With Novu, you can create custom workflows and define conditions for each channe
 [Create a free account](https://go.novu.co/dashboard?utm_source=github&utm_medium=readme&utm_campaign=create-free-account-link) and follow the instructions on the dashboard.
 
 ## 📚 Table of contents
+ 
+- [Why Novu?](#️-why-novu)
+- [Communication infrastructure for products](#-communication-infrastructure-for-products)
+- [Agent Communication Infrastructure (ACI)](#-agent-communication-infrastructure-aci)
+- [Features](#-features)
+- [Getting Started](#-getting-started)
+- [Embeddable Inbox and Preferences](#embeddable-inbox-component)
+- [Providers](#providers)
+- [Need Help?](#need-help)
+- [Links](#links)
+- [License](#license)
 
-- [Getting Started](https://github.com/novuhq/novu#-getting-started)
-- [Embeddable Inbox and Preferences](https://github.com/novuhq/novu#embeddable-notification-center)
-- [Providers](https://github.com/novuhq/novu#providers)
-- [Need Help?](https://github.com/novuhq/novu#-need-help)
-- [Links](https://github.com/novuhq/novu#-links)
-- [License](https://github.com/novuhq/novu#%EF%B8%8F-license)
+
+## 📬 Communication infrastructure for products
+ 
+The notification platform that turns complex multi-channel delivery into a single component. Built for developers, designed for growth, powered by open source.
+ 
+Novu provides a unified API to send notifications through multiple channels — **Inbox/In-App, Push, Email, SMS, and Chat**. Create custom workflows, define per-channel conditions, and let Novu deliver each notification in the most effective way, without stitching together a provider for every channel yourself.
+ 
+- One API for all messaging providers
+- Embeddable, real-time `<Inbox />` component
+- Notification workflow engine with branching and conditions
+- Digest engine to batch multiple notifications into a single message
+- No-code email editor
+- Embeddable preferences component so users control their own notifications
+
+## 🤖 Agent Communication Infrastructure (ACI)
+ 
+> **You build the agent. Novu gives it a voice.**
+ 
+ACI is a complete suite for companies already building agents that need to talk to users on real communication channels. It connects your agent to any channel and abstracts away the quirks of each platform behind a single, unified conversation model.
+ 
+Novu handles the plumbing in both directions: it receives inbound messages from each channel, normalizes them into one consistent shape, routes them to your agent, and sends your agent's responses back out, so you integrate once instead of building and maintaining a webhook handler per platform.
+ 
+- **Unified conversation model** — one consistent model across every channel, instead of per-platform message formats and webhook quirks
+- **Bidirectional messaging** — receive user messages and send agent replies through the same layer
+- **Channel integrations** — Slack, Microsoft Teams, Telegram, WhatsApp, Email, and an In-App Inbox for agents
+- **Bring your own agent** — works with whatever you've built, whether that's Claude Managed Agents, AI SDK, LangGraph, or a custom stack; Novu doesn't constrain your agent logic
+- **Best practices built in** — conversation threading, reactions, channel-aware formatting, actions and a single integration surface
+Novu connects the agent to the world, it is not the agent itself.
 
 ## Embeddable Inbox component
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@
 <a href="https://www.recent.dev">Recent.dev</a>
 </p>
 
+Software is becoming more conversational, and user expectations are rising with it. People no longer want static, irrelevant notifications they glance at and forget — they want to engage, ask questions, and go deeper. Instead of a one-way report dropped in their inbox, they expect a thread they can explore: follow up on a metric, drill into an anomaly, or continue a conversation right where they left off. That shift — from broadcast to dialogue — is what Novu's communication infrastructure is built for.
+
 ## ⭐️ Why Novu?
  
 Every product and every agent eventually needs to talk to people, across the channels those people already use. Novu is the open-source layer that handles that communication for you, so you don't rebuild Inbox feeds, provider integrations, and channel webhooks from scratch every time.


### PR DESCRIPTION
Expanded the 'Why Novu?' section to clarify the communication infrastructure and agent communication capabilities. Added details on the unified API and features for both product and agent communication.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed?
The README was rewritten to reposition Novu as a unified communication layer supporting two use cases—product notification infrastructure and Agent Communication Infrastructure (ACI). The hero tagline, intro narrative, and the “Why Novu?” content were replaced with explicit sections and bullet-driven value propositions for product notifications and ACI; a new Table of Contents (moved after Getting Started) with relative anchors was added, and placeholders for links, screenshots, enterprise PR, and reviewer notes were included to support docs and marketing updates. This is a documentation-only change to clarify positioning and developer guidance.

## Affected areas
**Documentation (README.md)** — Full prose rewrite: new hero tagline/subtitle, replaced “Why Novu?” with separate “Communication infrastructure for products” and “Agent Communication Infrastructure (ACI)” sections (with feature bullets), moved and updated the Table of Contents to use relative anchors placed after Getting Started, and added placeholders for links/screenshots/reviewer notes; no source code, configs, API contracts, schemas, packages, or runtime behavior were changed.

## Key technical decisions
None — documentation-only; no architectural, dependency, API contract, or schema changes.

## Testing
No automated tests added or required; verification is manual by reviewing the rendered README. Note: a Greptile review flagged a broken TOC anchor caused by a stray U+FE0F variation-selector on the “Why Novu?” link (it won’t navigate on GitHub) and the TOC’s moved position may reduce discoverability—these should be fixed during review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites the `README.md` to reposition Novu as a unified communication layer for both product notifications and Agent Communication Infrastructure (ACI), adding two new feature sections and updating the hero tagline, ToC, and intro narrative.

- The removal of the old \"Recent.dev\" link also removed the `</p>` that closed the `<p align=\"center\">` block, causing the new intro paragraph to render centered on GitHub.
- The ToC anchor for \"Why Novu?\" is missing the `⭐` codepoint, so the link won't jump to that section on GitHub.
- The ACI demo sentence contains the phrase \"build on integrate\" which is a copy-edit artifact.

<h3>Confidence Score: 4/5</h3>

Documentation-only change; no source code, APIs, or configs are touched, but two rendering defects in the README need fixing before merge.

The missing </p> tag will cause the new intro paragraph to render centered inside the hero link block on GitHub, and the broken ToC anchor for "Why Novu?" will silently fail to navigate. Both are visible defects in the primary file being changed.

README.md — the unclosed <p align="center"> and the malformed ToC anchor both need correction.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Full prose rewrite repositioning Novu; introduces a missing </p> closing tag that will center unintended text, a broken TOC anchor for "Why Novu?", and a grammatical error in the ACI demo sentence. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 86-104 ([link](https://github.com/novuhq/novu/blob/0afb4fe970d1bef19ae5978b44ff31c70d447f30/README.md#L86-L104)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The Table of Contents is placed after the "Getting Started" section, meaning readers must scroll past three sections before finding navigation links. A ToC is most useful near the top of the document so users can jump to any section without reading sequentially first.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: README.md
   Line: 86-104

   Comment:
   The Table of Contents is placed after the "Getting Started" section, meaning readers must scroll past three sections before finding navigation links. A ToC is most useful near the top of the document so users can jump to any section without reading sequentially first.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%2086-104%0A%0AComment%3A%0AThe%20Table%20of%20Contents%20is%20placed%20after%20the%20%22Getting%20Started%22%20section%2C%20meaning%20readers%20must%20scroll%20past%20three%20sections%20before%20finding%20navigation%20links.%20A%20ToC%20is%20most%20useful%20near%20the%20top%20of%20the%20document%20so%20users%20can%20jump%20to%20any%20section%20without%20reading%20sequentially%20first.%0A%0A%60%60%60suggestion%0A%23%23%20%F0%9F%93%9A%20Table%20of%20contents%0A%20%0A-%20%5BWhy%20Novu%3F%5D%28%23%EF%B8%8F-why-novu%29%0A-%20%5BCommunication%20infrastructure%20for%20products%5D%28%23-communication-infrastructure-for-products%29%0A-%20%5BAgent%20Communication%20Infrastructure%20%28ACI%29%5D%28%23-agent-communication-infrastructure-aci%29%0A-%20%5BFeatures%5D%28%23-features%29%0A-%20%5BGetting%20Started%5D%28%23-getting-started%29%0A-%20%5BEmbeddable%20Inbox%20and%20Preferences%5D%28%23embeddable-inbox-component%29%0A-%20%5BProviders%5D%28%23providers%29%0A-%20%5BNeed%20Help%3F%5D%28%23need-help%29%0A-%20%5BLinks%5D%28%23links%29%0A-%20%5BLicense%5D%28%23license%29%0A%0A%23%23%20%F0%9F%9A%80%20Getting%20Started%0A%0A%5BCreate%20a%20free%20account%5D%28https%3A%2F%2Fgo.novu.co%2Fdashboard%3Futm_source%3Dgithub%26utm_medium%3Dreadme%26utm_campaign%3Dcreate-free-account-link%29%20and%20follow%20the%20instructions%20on%20the%20dashboard.%0A%0A%23%23%20%F0%9F%93%AC%20Communication%20infrastructure%20for%20products%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A59-62%0A**Missing%20%60%3C%2Fp%3E%60%20closing%20tag**%0A%0AThe%20%60%3Cp%20align%3D%22center%22%3E%60%20opened%20at%20line%2032%20previously%20closed%20with%20%60%3C%2Fp%3E%60%20right%20after%20the%20%22Contact%20us%22%20link.%20That%20closing%20tag%20was%20removed%20along%20with%20the%20old%20%22Recent.dev%22%20link.%20Without%20it%2C%20the%20plain-text%20paragraph%20starting%20with%20%22Software%20is%20becoming%20more%20conversational%E2%80%A6%22%20on%20line%2062%20sits%20inside%20the%20unclosed%20centered%20%60%3Cp%3E%60%20block%20and%20will%20render%20centered%20on%20GitHub%20instead%20of%20left-aligned.%0A%0A%23%23%23%20Issue%202%20of%203%0AREADME.md%3A79%0AThe%20TOC%20anchor%20%60%23%EF%B8%8F-why-novu%60%20strips%20the%20%60%E2%AD%90%60%20codepoint%20%28U%2B2B50%29%20and%20retains%20only%20the%20variation-selector%20%28U%2BFE0F%29%2C%20so%20the%20link%20won't%20navigate%20to%20%60%23%23%20%E2%AD%90%EF%B8%8F%20Why%20Novu%3F%60%20on%20GitHub.%20GitHub%20derives%20the%20anchor%20from%20the%20full%20heading%20text%2C%20including%20the%20%60%E2%AD%90%60%20character%2C%20making%20the%20correct%20anchor%20%60%23%E2%AD%90%EF%B8%8F-why-novu%60.%0A%0A%60%60%60suggestion%0A-%20%5BWhy%20Novu%3F%5D%28%23%E2%AD%90%EF%B8%8F-why-novu%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0AREADME.md%3A115%0AThe%20phrase%20%22build%20on%20integrate%22%20appears%20to%20be%20a%20copy-edit%20artifact%20%E2%80%94%20likely%20%22to%20integrate%22%20was%20the%20intended%20wording.%0A%0A%60%60%60suggestion%0AWe%20have%20built%20%5BNovu%20Connect%5D%28https%3A%2F%2Fnovu.co%2Fconnect%29%20to%20showcase%20the%20power%20of%20ACI%2C%20to%20integrate%20an%20existing%20Claude%20Managed%20Agent%20as%20a%20teammate%20in%20Slack%2C%20Telegram%2C%20or%20Email%20in%20less%20than%202%20minutes.%0A%60%60%60%0A%0A&pr=11383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
README.md:59-62
**Missing `</p>` closing tag**

The `<p align="center">` opened at line 32 previously closed with `</p>` right after the "Contact us" link. That closing tag was removed along with the old "Recent.dev" link. Without it, the plain-text paragraph starting with "Software is becoming more conversational…" on line 62 sits inside the unclosed centered `<p>` block and will render centered on GitHub instead of left-aligned.

### Issue 2 of 3
README.md:79
The TOC anchor `#️-why-novu` strips the `⭐` codepoint (U+2B50) and retains only the variation-selector (U+FE0F), so the link won't navigate to `## ⭐️ Why Novu?` on GitHub. GitHub derives the anchor from the full heading text, including the `⭐` character, making the correct anchor `#⭐️-why-novu`.

```suggestion
- [Why Novu?](#⭐️-why-novu)
```

### Issue 3 of 3
README.md:115
The phrase "build on integrate" appears to be a copy-edit artifact — likely "to integrate" was the intended wording.

```suggestion
We have built [Novu Connect](https://novu.co/connect) to showcase the power of ACI, to integrate an existing Claude Managed Agent as a teammate in Slack, Telegram, or Email in less than 2 minutes.
```


`````

</details>

<sub>Reviews (6): Last reviewed commit: ["Update README.md"](https://github.com/novuhq/novu/commit/b44b421cf49cc024702d8de10f1f350cb5cf8f19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34856561)</sub>

<!-- /greptile_comment -->