### PR TITLE
feat(dashboard): add BETA labels for Novu Connect and Agents fixes NV-7932

### DIFF
--- a/apps/dashboard/src/components/confirmation-modal.tsx
+++ b/apps/dashboard/src/components/confirmation-modal.tsx
@@ -18,7 +18,7 @@ type ConfirmationModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
-  title: string;
+  title: ReactNode;
   description: ReactNode;
   confirmButtonText: string;
   confirmTrailingIcon?: IconType;

--- a/apps/dashboard/src/components/dashboard-shell/app-rail.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/app-rail.tsx
@@ -23,6 +23,7 @@ type BrandConfig = {
   tooltip: string;
   subtitle: string;
   features: string[];
+  showBeta?: boolean;
 };
 
 const PLATFORM_BRAND: BrandConfig = {
@@ -50,6 +51,7 @@ const CONNECT_BRAND: BrandConfig = {
     'Connect your agent to where you work.',
     'Connect the tools your team works on.',
   ],
+  showBeta: true,
 };
 
 type BrandTileProps = {
@@ -79,7 +81,7 @@ type SwitcherTileProps = {
 };
 
 function SwitcherTile({ brand, to, isExternal, openInNewTab = false }: SwitcherTileProps) {
-  const { Icon, label, tooltip, subtitle, features } = brand;
+  const { Icon, label, tooltip, subtitle, features, showBeta } = brand;
   const { isModalOpen, setIsModalOpen, handleSwitcherClick, handleConfirm, showConnectSwitchModal } =
     useConnectSwitchConfirmation({
       targetAppId: brand.id,
@@ -137,7 +139,7 @@ function SwitcherTile({ brand, to, isExternal, openInNewTab = false }: SwitcherT
           size="lg"
           className="border-stroke-weak w-auto overflow-hidden rounded-lg border p-0 shadow-md"
         >
-          <AppSwitcherTooltipContent label={label} subtitle={subtitle} features={features} />
+          <AppSwitcherTooltipContent label={label} subtitle={subtitle} features={features} showBeta={showBeta} />
         </TooltipContent>
       </Tooltip>
       {showConnectSwitchModal ? (

--- a/apps/dashboard/src/components/dashboard-shell/app-switcher-tooltip-content.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/app-switcher-tooltip-content.tsx
@@ -1,17 +1,22 @@
 import { RiArrowRightUpLine, RiCheckLine } from 'react-icons/ri';
+import { BetaBadge } from '@/components/primitives/beta-badge';
 
 type AppSwitcherTooltipContentProps = {
   label: string;
   subtitle: string;
   features: string[];
+  showBeta?: boolean;
 };
 
-export function AppSwitcherTooltipContent({ label, subtitle, features }: AppSwitcherTooltipContentProps) {
+export function AppSwitcherTooltipContent({ label, subtitle, features, showBeta }: AppSwitcherTooltipContentProps) {
   return (
     <div className="flex w-[305px] flex-col overflow-hidden">
       <div className="border-stroke-weak bg-bg-weak flex items-start gap-1.5 border-b px-3 py-2">
         <div className="flex min-w-0 flex-1 flex-col justify-center">
-          <p className="text-text-sub text-label-sm font-medium leading-5">{label}</p>
+          <p className="text-text-sub text-label-sm flex items-center gap-1 font-medium leading-5">
+            {label}
+            {showBeta ? <BetaBadge className="shrink-0" /> : null}
+          </p>
           <p className="text-text-soft text-label-xs font-medium leading-4">{subtitle}</p>
         </div>
         <RiArrowRightUpLine className="text-text-soft size-3.5 shrink-0" aria-hidden />

--- a/apps/dashboard/src/components/dashboard-shell/connect-switch-confirmation-modal.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/connect-switch-confirmation-modal.tsx
@@ -1,5 +1,6 @@
 import { RiArrowRightUpLine, RiCheckLine } from 'react-icons/ri';
 import { ConfirmationModal } from '@/components/confirmation-modal';
+import { BetaBadge } from '@/components/primitives/beta-badge';
 
 type ConnectSwitchConfirmationModalProps = {
   open: boolean;
@@ -17,7 +18,12 @@ export function ConnectSwitchConfirmationModal({
       open={open}
       onOpenChange={onOpenChange}
       onConfirm={onConfirm}
-      title="Switch to Novu Connect?"
+      title={
+        <span className="flex items-center gap-1.5">
+          Switch to Novu Connect?
+          <BetaBadge className="shrink-0" />
+        </span>
+      }
       description={
         <div className="flex flex-col gap-3">
           <p>

--- a/apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx
@@ -27,6 +27,7 @@ import {
   BreadcrumbSeparator,
 } from '../primitives/breadcrumb';
 import { Button } from '../primitives/button';
+import { BetaBadge } from '../primitives/beta-badge';
 import { Kbd } from '../primitives/kbd';
 import { AppRail } from './app-rail';
 import { useConnectBreadcrumbLeaf } from './use-connect-breadcrumb';
@@ -66,7 +67,32 @@ type ConnectBreadcrumbEntry = {
   label: string;
   icon?: ReactNode;
   to?: string;
+  showBeta?: boolean;
 };
+
+function shouldShowConnectBreadcrumbBeta(
+  itemKey: string,
+  connectSection: ConnectSectionId,
+  isLast: boolean
+): boolean {
+  if (itemKey === 'root') {
+    return true;
+  }
+
+  if (connectSection !== 'agents') {
+    return false;
+  }
+
+  if (itemKey === 'section') {
+    return isLast;
+  }
+
+  if (itemKey === 'leaf') {
+    return isLast;
+  }
+
+  return false;
+}
 
 export function DashboardShell({
   children,
@@ -132,6 +158,7 @@ export function DashboardShell({
             <BreadcrumbList>
               {connectBreadcrumbItems.map((item, index) => {
                 const isLast = index === connectLastIndex;
+                const showBeta = shouldShowConnectBreadcrumbBeta(item.key, connectSection, isLast);
 
                 return (
                   <Fragment key={item.key}>
@@ -141,11 +168,13 @@ export function DashboardShell({
                         <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
                           {item.icon}
                           <span className="truncate">{item.label}</span>
+                          {showBeta ? <BetaBadge className="shrink-0" /> : null}
                         </BreadcrumbPage>
                       ) : (
                         <BreadcrumbLink to={item.to ?? '#'} className="flex min-w-0 items-center gap-1.5 text-text-sub">
                           {item.icon}
                           <span className="truncate">{item.label}</span>
+                          {showBeta ? <BetaBadge className="shrink-0" /> : null}
                         </BreadcrumbLink>
                       )}
                     </BreadcrumbItem>

--- a/apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx
@@ -67,7 +67,6 @@ type ConnectBreadcrumbEntry = {
   label: string;
   icon?: ReactNode;
   to?: string;
-  showBeta?: boolean;
 };
 
 function shouldShowConnectBreadcrumbBeta(
@@ -83,11 +82,7 @@ function shouldShowConnectBreadcrumbBeta(
     return false;
   }
 
-  if (itemKey === 'section') {
-    return isLast;
-  }
-
-  if (itemKey === 'leaf') {
+  if (itemKey === 'section' || itemKey === 'leaf') {
     return isLast;
   }
 

--- a/apps/dashboard/src/components/primitives/beta-badge.tsx
+++ b/apps/dashboard/src/components/primitives/beta-badge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/primitives/badge';
+import { cn } from '@/utils/ui';
+
+type BetaBadgeProps = {
+  variant?: 'nav' | 'header';
+  className?: string;
+};
+
+export function BetaBadge({ variant = 'header', className }: BetaBadgeProps) {
+  if (variant === 'nav') {
+    return (
+      <Badge variant="lighter" className={cn('text-xs', className)}>
+        BETA
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge color="gray" size="sm" variant="lighter" className={className}>
+      BETA
+    </Badge>
+  );
+}

--- a/apps/dashboard/src/components/side-navigation/connect-side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/connect-side-navigation.tsx
@@ -1,4 +1,5 @@
 import { RiDashboardLine, RiDiscussLine, RiRobot2Line, RiSettings4Line } from 'react-icons/ri';
+import { BetaBadge } from '@/components/primitives/beta-badge';
 import { SidebarContent } from '@/components/side-navigation/sidebar';
 import { useEnvironment } from '@/context/environment/hooks';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -28,7 +29,9 @@ export const ConnectSideNavigation = () => {
             <NavigationGroup label="Manage">
               <NavigationLink to={buildEnvRoute(ROUTES.CONNECT_AGENTS)}>
                 <RiRobot2Line className="size-4" />
-                <span>Agents</span>
+                <span>
+                  Agents <BetaBadge variant="nav" />
+                </span>
               </NavigationLink>
             </NavigationGroup>
             <NavigationGroup label="Monitor">

--- a/apps/dashboard/src/components/side-navigation/mobile-side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/mobile-side-navigation.tsx
@@ -7,6 +7,7 @@ import { ConnectSwitchConfirmationModal } from '@/components/dashboard-shell/con
 import { CrossAppLink } from '@/components/dashboard-shell/cross-app-link';
 import { ConnectLogo } from '@/components/icons/connect-logo';
 import { LogoCircle } from '@/components/icons/logo-circle';
+import { BetaBadge } from '@/components/primitives/beta-badge';
 import { Sheet, SheetContent, SheetTitle } from '@/components/primitives/sheet';
 import { IS_HOSTNAME_SPLIT_ENABLED } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
@@ -21,6 +22,7 @@ type MobileBrand = {
   id: AppId;
   Icon: ComponentType<{ className?: string }>;
   label: string;
+  showBeta?: boolean;
 };
 
 const PLATFORM_BRAND: MobileBrand = {
@@ -33,6 +35,7 @@ const CONNECT_BRAND: MobileBrand = {
   id: APP_IDS.CONNECT,
   Icon: ConnectLogo,
   label: 'Novu Connect',
+  showBeta: true,
 };
 
 function MobileAppSwitcher() {
@@ -67,7 +70,10 @@ function MobileAppSwitcher() {
         className="bg-bg-weak border-stroke-weak flex items-center gap-2 rounded-md border px-2 py-1.5"
       >
         <CurrentIcon className="size-4" aria-hidden />
-        <span className="text-foreground-950 text-sm font-medium">{currentBrand.label}</span>
+        <span className="text-foreground-950 flex items-center gap-1 text-sm font-medium">
+          {currentBrand.label}
+          {currentBrand.showBeta ? <BetaBadge className="shrink-0" /> : null}
+        </span>
       </span>
 
       {otherHref ? (
@@ -80,7 +86,10 @@ function MobileAppSwitcher() {
             aria-label={`Open ${otherBrand.label}`}
           >
             <OtherIcon className="size-4" aria-hidden />
-            <span>{otherBrand.label}</span>
+            <span className="flex items-center gap-1">
+              {otherBrand.label}
+              {otherBrand.showBeta ? <BetaBadge className="shrink-0" /> : null}
+            </span>
             {IS_HOSTNAME_SPLIT_ENABLED && <RiArrowRightUpLine className="text-foreground-400 size-3.5" aria-hidden />}
           </CrossAppLink>
           {showConnectSwitchModal ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Novu Connect and Agents are in public beta. This PR adds consistent **BETA** badges so users can see that status across Connect product surfaces and Connect-specific Agents navigation.

## Changes

- Added shared `BetaBadge` component with `nav` and `header` variants matching existing dashboard patterns
- **Novu Connect product surfaces:**
  - App switcher tooltip (desktop app rail)
  - Mobile app switcher (current brand + switch link)
  - Connect breadcrumb root (`Connect`)
  - Switch-to-Connect confirmation modal title
- **Agents (Connect gaps):**
  - Connect sidebar Agents nav link
  - Connect breadcrumb for Agents list and agent detail pages
- Extended `ConfirmationModal` title prop to accept `ReactNode` for badge support

Platform Agents already had BETA labels in sidebar, page header, and detail breadcrumb — no changes needed there.

## Verification

- Dashboard TypeScript check passes (`pnpm exec tsc --noEmit`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed656047-f011-4a1e-82fd-47b64ce33256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed656047-f011-4a1e-82fd-47b64ce33256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR adds visual BETA indicators across Novu Connect and Agents product surfaces in the dashboard. A new reusable `BetaBadge` component was introduced with nav and header variants to enable consistent beta labeling. The badge now appears in the app switcher (desktop and mobile), Connect breadcrumb navigation, switch-to-Connect confirmation modal, and Agents navigation link.

## Affected areas

**dashboard**: Added new `BetaBadge` component with `nav` and `header` variants. Updated app rail to show beta badge for Connect brand in desktop app switcher tooltip. Enhanced mobile switcher to conditionally display beta badge next to app labels. Modified Connect breadcrumb logic to conditionally render beta badges for section headers and agent-related pages. Updated Agents navigation link in Connect sidebar to include a nav-variant beta badge. Extended `ConfirmationModal` title prop from `string` to `ReactNode` to support badge composition.

## Key technical decisions

- Created reusable `BetaBadge` component with configurable variants to reduce duplication across surfaces and maintain consistent styling.
- Extended `ConfirmationModal` title prop to `ReactNode` to allow badge composition without breaking existing implementations.
- Introduced `shouldShowConnectBreadcrumbBeta()` helper function to centralize beta display logic based on breadcrumb item position and context (special-casing agents).
- Added optional `showBeta` flag to `BrandConfig` and `MobileBrand` types to control beta badge visibility per brand.

## Testing

Dashboard TypeScript check passes. Manual verification completed as noted in PR verification section. No additional unit or integration tests were added, as this is a UI-only feature with straightforward component integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `BetaBadge` component and places it consistently across all Novu Connect product surfaces: the desktop app-rail tooltip, mobile app switcher, Connect breadcrumb root, the switch-confirmation modal title, and the Connect sidebar Agents link.

- `BetaBadge` provides two variants (`nav` / `header`) backed by the existing `Badge` primitive; `ConfirmationModal.title` is widened from `string` to `ReactNode` to support the badge in the modal title.
- `shouldShowConnectBreadcrumbBeta` in `dashboard-shell.tsx` drives badge visibility per breadcrumb item: root always shows it, and in the agents section the deepest visible crumb also shows it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive UI badges with no logic, data, or API surface impact.

All changes are purely presentational: a new badge component is threaded into existing UI slots. The breadcrumb logic is straightforward and correct. Widening title to ReactNode is backwards-compatible. No business logic, data flow, or auth paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/primitives/beta-badge.tsx | New shared BetaBadge component with nav and header variants; clean implementation. |
| apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx | Adds shouldShowConnectBreadcrumbBeta helper and renders BetaBadge in both BreadcrumbPage and BreadcrumbLink; logic is correct for root-always and agents-deepest-item cases. |
| apps/dashboard/src/components/confirmation-modal.tsx | title prop widened from string to ReactNode; backwards-compatible and passes through to DialogTitle correctly. |
| apps/dashboard/src/components/side-navigation/connect-side-navigation.tsx | BetaBadge added to Agents nav link using a text space for separation rather than flex+gap used elsewhere in the PR. |
| apps/dashboard/src/components/dashboard-shell/connect-switch-confirmation-modal.tsx | Title now renders a flex span with BetaBadge, leveraging the widened ReactNode title prop. |
| apps/dashboard/src/components/dashboard-shell/app-rail.tsx | showBeta added to BrandConfig and CONNECT_BRAND, threaded through SwitcherTile to AppSwitcherTooltipContent. |
| apps/dashboard/src/components/side-navigation/mobile-side-navigation.tsx | showBeta added to MobileBrand; renders BetaBadge for both current and target brand in the mobile switcher. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    BB["BetaBadge\n(nav | header)"]
    BB --> AST["AppSwitcherTooltipContent\n(desktop rail tooltip)"]
    BB --> MSN["MobileSideNavigation\n(current + switch link)"]
    BB --> CSCM["ConnectSwitchConfirmationModal\ntitle"]
    BB --> CSN["ConnectSideNavigation\nAgents nav link"]
    BB --> DS["DashboardShell\nConnect breadcrumb"]
    DS --> ROOT["root crumb: always beta"]
    DS --> AGENTS{"connectSection\n=== 'agents'?"}
    AGENTS -- yes --> LAST["section/leaf crumb\nif isLast → beta"]
    AGENTS -- no --> NONE["no extra badge"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx`, line 65-71 ([link](https://github.com/novuhq/novu/blob/bd3c901ed9eff333c506edaf73e0ac81b1a59cb3/apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx#L65-L71)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `showBeta` field added to `ConnectBreadcrumbEntry` is never assigned when constructing `connectBreadcrumbItems` — all items are created without it, and badge visibility is computed entirely by `shouldShowConnectBreadcrumbBeta`. The field is dead code that could mislead future maintainers into thinking it drives the badge display.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx
   Line: 65-71

   Comment:
   The `showBeta` field added to `ConnectBreadcrumbEntry` is never assigned when constructing `connectBreadcrumbItems` — all items are created without it, and badge visibility is computed entirely by `shouldShowConnectBreadcrumbBeta`. The field is dead code that could mislead future maintainers into thinking it drives the badge display.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fcomponents%2Fdashboard-shell%2Fdashboard-shell.tsx%0ALine%3A%2065-71%0A%0AComment%3A%0AThe%20%60showBeta%60%20field%20added%20to%20%60ConnectBreadcrumbEntry%60%20is%20never%20assigned%20when%20constructing%20%60connectBreadcrumbItems%60%20%E2%80%94%20all%20items%20are%20created%20without%20it%2C%20and%20badge%20visibility%20is%20computed%20entirely%20by%20%60shouldShowConnectBreadcrumbBeta%60.%20The%20field%20is%20dead%20code%20that%20could%20mislead%20future%20maintainers%20into%20thinking%20it%20drives%20the%20badge%20display.%0A%0A%60%60%60suggestion%0Atype%20ConnectBreadcrumbEntry%20%3D%20%7B%0A%20%20key%3A%20string%3B%0A%20%20label%3A%20string%3B%0A%20%20icon%3F%3A%20ReactNode%3B%0A%20%20to%3F%3A%20string%3B%0A%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11385&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fside-navigation%2Fconnect-side-navigation.tsx%3A32-34%0AThe%20badge%20is%20placed%20after%20a%20literal%20text%20space%20character%20inside%20a%20non-flex%20%60%3Cspan%3E%60%2C%20while%20every%20other%20badge%20placement%20in%20this%20PR%20wraps%20the%20label%20in%20a%20flex%20container%20with%20%60gap-1%60.%20The%20literal%20space%20renders%20as%20a%20normal%20text%20node%2C%20so%20the%20gap%20between%20%22Agents%22%20and%20the%20badge%20will%20be%20glyph-width%20rather%20than%20a%20consistent%20layout%20gap%2C%20and%20could%20collapse%20under%20certain%20text-overflow%20conditions.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cspan%20className%3D%22flex%20items-center%20gap-1%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Agents%20%3CBetaBadge%20variant%3D%22nav%22%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2Fspan%3E%0A%60%60%60%0A%0A&pr=11385&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/side-navigation/connect-side-navigation.tsx:32-34
The badge is placed after a literal text space character inside a non-flex `<span>`, while every other badge placement in this PR wraps the label in a flex container with `gap-1`. The literal space renders as a normal text node, so the gap between "Agents" and the badge will be glyph-width rather than a consistent layout gap, and could collapse under certain text-overflow conditions.

```suggestion
                <span className="flex items-center gap-1">
                  Agents <BetaBadge variant="nav" />
                </span>
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(dashboard): address Greptile re..."](https://github.com/novuhq/novu/commit/ce67cb7bc27493a58f4c4a41acf11b9c0730593d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34860578)</sub>

<!-- /greptile_comment -->