### PR TITLE
chore(ci): update Docker build workflow to support multi-architecture  builds for stable releases

### DIFF
--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -138,6 +138,14 @@ jobs:
           echo "REGISTRY_OWNER=novuhq" >> $GITHUB_ENV
           echo "This is the service name: $SERVICE_NAME and release version: $LATEST_VERSION"
 
+          # Only build multi-arch (amd64 + arm64) for stable/latest releases (tag pushes).
+          # All other releases (nightly, manual dispatch) build amd64 only to save CI time.
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "DOCKER_PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_ENV
+          else
+            echo "DOCKER_PLATFORMS=linux/amd64" >> $GITHUB_ENV
+          fi
+
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
@@ -164,14 +172,14 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           image: tonistiigi/binfmt:qemu-v8.0.4
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver-opts: "image=moby/buildkit:v0.15.0"
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.DOCKER_PLATFORMS }}
 
       - uses: ./.github/actions/free-space
         name: Extend space in Action Container
@@ -189,7 +197,7 @@ jobs:
           DOCKER_BUILD_ARGUMENTS: >
             --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/cache:build-cache-${{ env.SERVICE_NAME }}-community
             --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/cache:build-cache-${{ env.SERVICE_NAME }}-community,mode=max
-            --platform=linux/amd64,linux/arm64 --provenance=false
+            --platform=${{ env.DOCKER_PLATFORMS }} --provenance=false
             --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.SERVICE_NAME }},push-by-digest=true,name-canonical=true
         run: |
           cp scripts/dotenvcreate.mjs apps/$SERVICE_COMMON_NAME/src/dotenvcreate.mjs
@@ -256,14 +264,14 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Sync release to Linear
-        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}
           name: v${{ env.RELEASE_VERSION }}
           version: ${{ env.RELEASE_VERSION }}
 
       - name: Complete release in Linear
-        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}
           command: complete

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -138,12 +138,14 @@ jobs:
           echo "REGISTRY_OWNER=novuhq" >> $GITHUB_ENV
           echo "This is the service name: $SERVICE_NAME and release version: $LATEST_VERSION"
 
-          # Only build multi-arch (amd64 + arm64) for stable/latest releases (tag pushes).
-          # All other releases (nightly, manual dispatch) build amd64 only to save CI time.
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "DOCKER_PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_ENV
-          else
+          # Build multi-arch (amd64 + arm64) for any release that publishes :latest,
+          # i.e. every non-nightly build (tag pushes and non-nightly manual dispatches).
+          # Building amd64 only here would clobber the multi-arch :latest manifest.
+          # Nightly builds publish :nightly only, so they stay amd64 to save CI time.
+          if [ "$IS_NIGHTLY" == "true" ]; then
             echo "DOCKER_PLATFORMS=linux/amd64" >> $GITHUB_ENV
+          else
+            echo "DOCKER_PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_ENV
           fi
 
       - name: Install pnpm


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The CI Docker build workflow now chooses build platforms dynamically: stable releases (tag pushes / non-nightly releases) produce multi-architecture images for linux/amd64 and linux/arm64, while nightly and manual-dispatch builds are limited to linux/amd64. This reduces CI time and resource usage for non-stable runs while preserving multi-arch production artifacts. The Linear release steps were also made consistent by pinning the same action reference for both sync and complete phases.

## Affected areas

- GitHub Actions CI/CD — The prepare-self-hosted-release.yml workflow sets a DOCKER_PLATFORMS variable and passes it to QEMU setup, Docker Buildx, and the docker build command (--platform), replacing the previous hardcoded platform configuration. The Linear release action steps now reference the same pinned linear/linear-release-action commit.

## Key technical decisions

- Conditional multi-arch builds: Only stable/tag-triggered releases build both amd64 and arm64 to balance build time and artifact coverage.

## Testing

No application tests were added; this is a CI configuration change. Validation is done by observing workflow runs (manual dispatch and tag-triggered CI) to confirm platform selection and successful multi-arch image creation for stable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
