### PR TITLE
feat(inbound-mail): write request log row early to avoid loss on worker crash fixes NV-7936

### DIFF
--- a/apps/inbound-mail/package.json
+++ b/apps/inbound-mail/package.json
@@ -22,6 +22,7 @@
     "@aws-sdk/client-secrets-manager": "^3.1037.0",
     "@aws-sdk/s3-request-presigner": "^3.996.0",
     "@novu/application-generic": "workspace:*",
+    "@novu/dal": "workspace:*",
     "@novu/shared": "workspace:*",
     "@sentry/browser": "^8.33.1",
     "@sentry/hub": "^7.114.0",

--- a/apps/inbound-mail/src/server/inbound-mail.service.ts
+++ b/apps/inbound-mail/src/server/inbound-mail.service.ts
@@ -1,8 +1,36 @@
-import { InboundParseQueueService, WorkflowInMemoryProviderService } from '@novu/application-generic';
+import {
+  ClickHouseService,
+  FeatureFlagsService,
+  InboundMailRequestLogger,
+  InboundMailTenantResolver,
+  InboundParseQueueService,
+  PinoLogger,
+  RequestLogRepository,
+  TraceLogRepository,
+  WorkflowInMemoryProviderService,
+} from '@novu/application-generic';
+import { DalService, DomainRepository } from '@novu/dal';
+import logger from './logger';
 
+/**
+ * Long-lived dependencies for the inbound-mail SMTP server.
+ *
+ * In addition to the BullMQ queue producer, we now also wire ClickHouse +
+ * MongoDB clients so the server can write the canonical `requests` row (plus
+ * `request_received`/`request_queued` traces) before the message is enqueued.
+ * Both stores are best-effort: failures during analytics writes never block
+ * SMTP acceptance, and the analytics path can be turned off entirely via the
+ * `IS_ANALYTICS_LOGS_ENABLED` / `IS_INBOUND_ANALYTICS_LOGS_ENABLED` env vars.
+ */
 export class InboundMailService {
   public inboundParseQueueService: InboundParseQueueService;
+  public requestLogger?: InboundMailRequestLogger;
+  public tenantResolver?: InboundMailTenantResolver;
+
   private workflowInMemoryProviderService: WorkflowInMemoryProviderService;
+  private dalService?: DalService;
+  private clickHouseService?: ClickHouseService;
+
   constructor() {
     this.workflowInMemoryProviderService = new WorkflowInMemoryProviderService();
     this.inboundParseQueueService = new InboundParseQueueService(this.workflowInMemoryProviderService);
@@ -10,5 +38,60 @@ export class InboundMailService {
 
   async start() {
     await this.workflowInMemoryProviderService.initialize();
+    await this.initializeAnalytics();
+  }
+
+  /**
+   * Optional initialization for the inbound-mail request analytics pipeline.
+   * The server still works without it — request logging is gated behind two
+   * env vars and silently disables itself when ClickHouse or MongoDB cannot
+   * be reached.
+   */
+  private async initializeAnalytics(): Promise<void> {
+    if (process.env.IS_ANALYTICS_LOGS_ENABLED !== 'true' || process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED !== 'true') {
+      logger.info(
+        { context: 'InboundMailService' },
+        'Inbound mail request analytics is disabled — skipping ClickHouse / DAL initialization'
+      );
+
+      return;
+    }
+
+    try {
+      const pinoLogger = new PinoLogger({ pinoHttp: { logger } });
+
+      this.clickHouseService = new ClickHouseService();
+      await this.clickHouseService.init();
+
+      const featureFlagsService = new FeatureFlagsService();
+      await featureFlagsService.initialize();
+
+      const requestLogRepository = new RequestLogRepository(this.clickHouseService, pinoLogger, featureFlagsService);
+      const traceLogRepository = new TraceLogRepository(this.clickHouseService, pinoLogger, featureFlagsService);
+
+      let domainRepository: DomainRepository | undefined;
+      if (process.env.MONGO_URL) {
+        this.dalService = new DalService();
+        await this.dalService.connect(process.env.MONGO_URL);
+        domainRepository = new DomainRepository();
+      } else {
+        logger.warn(
+          { context: 'InboundMailService' },
+          'MONGO_URL is not set — inbound mail tenant resolution will be limited to reply-to addresses'
+        );
+      }
+
+      this.tenantResolver = new InboundMailTenantResolver(domainRepository, pinoLogger);
+      this.requestLogger = new InboundMailRequestLogger(requestLogRepository, traceLogRepository, pinoLogger);
+
+      logger.info({ context: 'InboundMailService' }, 'Inbound mail request analytics initialized');
+    } catch (error) {
+      logger.error(
+        { err: error, context: 'InboundMailService' },
+        'Failed to initialize inbound mail request analytics — continuing without it'
+      );
+      this.requestLogger = undefined;
+      this.tenantResolver = undefined;
+    }
   }
 }

--- a/apps/inbound-mail/src/server/index.early-logging.spec.ts
+++ b/apps/inbound-mail/src/server/index.early-logging.spec.ts
@@ -1,0 +1,196 @@
+import {
+  InboundMailRequestLogger,
+  InboundMailTenantResolver,
+  InboundParseQueueService,
+} from '@novu/application-generic';
+import { expect } from 'chai';
+import net from 'node:net';
+import sinon from 'sinon';
+
+import mailinServer, { __testInboundMailService } from './index';
+
+/*
+ * Validates that the inbound-mail SMTP pipeline writes the early `requests`
+ * row in apps/inbound-mail (before BullMQ enqueue) and threads the resulting
+ * `requestLogId` through the queue payload so the worker can later append
+ * the terminal completion trace.
+ *
+ * Analytics initialization in `InboundMailService.initializeAnalytics` is
+ * skipped in this test because the feature-flag env vars are unset. Instead
+ * we stub `requestLogger` / `tenantResolver` directly on the
+ * `InboundMailService` instance imported by the SMTP server.
+ */
+describe('Mailin SMTP DATA handler — early request logging', () => {
+  const SMTP_HOST = '127.0.0.1';
+  const SMTP_PORT = Number(process.env.PORT || 2525);
+
+  let logReceivedStub: sinon.SinonStub;
+  let logQueuedStub: sinon.SinonStub;
+  let logQueueFailedStub: sinon.SinonStub;
+  let resolveStub: sinon.SinonStub;
+  let queueAddStub: sinon.SinonStub;
+
+  function sendInboundMessage(): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+      const socket = net.connect(SMTP_PORT, SMTP_HOST);
+      const transcript: string[] = [];
+      let buffer = '';
+
+      const dataLines = [
+        'From: <sender@example.com>',
+        'To: <support@customer.com>',
+        'Subject: Test inbound mail',
+        'Message-ID: <log-test-message-id@example.com>',
+        '',
+        'Hello world',
+        '.',
+      ].join('\r\n');
+
+      const script = [
+        'EHLO test.local',
+        'MAIL FROM:<sender@example.com>',
+        'RCPT TO:<support@customer.com>',
+        'DATA',
+        dataLines,
+        'QUIT',
+      ];
+      let step = 0;
+
+      socket.setEncoding('utf8');
+      socket.setTimeout(15_000, () => {
+        socket.destroy(new Error('SMTP transaction timed out'));
+      });
+
+      socket.on('data', (chunk: string) => {
+        buffer += chunk;
+        const parts = buffer.split('\r\n');
+        buffer = parts.pop() ?? '';
+        for (const line of parts) {
+          if (!line) continue;
+          transcript.push(line);
+          if (/^\d{3} /.test(line)) {
+            const next = script[step++];
+            if (next != null) {
+              socket.write(`${next}\r\n`);
+            }
+          }
+        }
+      });
+
+      socket.on('error', reject);
+      socket.on('close', () => resolve(transcript));
+    });
+  }
+
+  before(async function before() {
+    this.timeout(30_000);
+    const deadline = Date.now() + 25_000;
+    while (Date.now() < deadline) {
+      const smtp = (mailinServer as unknown as { _smtp: unknown })._smtp;
+      if (smtp) {
+        try {
+          await new Promise<void>((resolve, reject) => {
+            const probe = net.connect(SMTP_PORT, SMTP_HOST);
+            probe.once('connect', () => {
+              probe.end();
+              resolve();
+            });
+            probe.once('error', reject);
+            probe.setTimeout(1000, () => probe.destroy(new Error('probe timeout')));
+          });
+
+          return;
+        } catch {
+          // not ready yet
+        }
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    this.skip();
+  });
+
+  let originalRequestLogger: typeof __testInboundMailService.requestLogger;
+  let originalTenantResolver: typeof __testInboundMailService.tenantResolver;
+
+  beforeEach(() => {
+    logReceivedStub = sinon.stub().resolves('req_test_123');
+    logQueuedStub = sinon.stub().resolves();
+    logQueueFailedStub = sinon.stub().resolves();
+    resolveStub = sinon.stub().resolves({
+      organizationId: 'org_test',
+      environmentId: 'env_test',
+      transactionId: 'log-test-message-id@example.com',
+    });
+
+    originalRequestLogger = __testInboundMailService.requestLogger;
+    originalTenantResolver = __testInboundMailService.tenantResolver;
+    __testInboundMailService.requestLogger = {
+      logReceived: logReceivedStub,
+      logQueued: logQueuedStub,
+      logQueueFailed: logQueueFailedStub,
+    } as unknown as InboundMailRequestLogger;
+    __testInboundMailService.tenantResolver = {
+      resolve: resolveStub,
+    } as unknown as InboundMailTenantResolver;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    __testInboundMailService.requestLogger = originalRequestLogger;
+    __testInboundMailService.tenantResolver = originalTenantResolver;
+  });
+
+  it('writes the early request log row, attaches requestLogId to the queue payload, and traces request_queued on success', async () => {
+    queueAddStub = sinon.stub(InboundParseQueueService.prototype, 'add').resolves(undefined as never);
+
+    const transcript = await sendInboundMessage();
+    const acceptedReply = transcript.find((line) => line.startsWith('250 ') && line.toLowerCase().includes('queued'));
+    expect(acceptedReply, `expected 250 OK on success, transcript: ${transcript.join(' | ')}`).to.exist;
+
+    // Give the post-queue trace promise a beat to flush after SMTP returns.
+    await new Promise((r) => setTimeout(r, 250));
+
+    sinon.assert.calledOnce(resolveStub);
+    sinon.assert.calledOnce(logReceivedStub);
+    sinon.assert.calledOnce(queueAddStub);
+
+    const enqueueCallArg = queueAddStub.getCall(0).args[0];
+    expect(enqueueCallArg.data.requestLogId).to.equal('req_test_123');
+    expect(enqueueCallArg.data.subject).to.equal('Test inbound mail');
+
+    sinon.assert.calledOnce(logQueuedStub);
+    const queuedContext = logQueuedStub.getCall(0).args[0];
+    expect(queuedContext.requestLogId).to.equal('req_test_123');
+    expect(queuedContext.environmentId).to.equal('env_test');
+
+    sinon.assert.notCalled(logQueueFailedStub);
+  });
+
+  it('writes a request_failed trace when the queue insert fails', async () => {
+    queueAddStub = sinon.stub(InboundParseQueueService.prototype, 'add').rejects(new Error('Simulated queue failure'));
+
+    await sendInboundMessage();
+    await new Promise((r) => setTimeout(r, 250));
+
+    sinon.assert.calledOnce(logReceivedStub);
+    sinon.assert.calledOnce(logQueueFailedStub);
+    const failedContext = logQueueFailedStub.getCall(0).args[0];
+    expect(failedContext.requestLogId).to.equal('req_test_123');
+    expect(failedContext.message).to.contain('Simulated queue failure');
+    sinon.assert.notCalled(logQueuedStub);
+  });
+
+  it('continues processing when the request logger throws', async () => {
+    logReceivedStub.rejects(new Error('clickhouse down'));
+    queueAddStub = sinon.stub(InboundParseQueueService.prototype, 'add').resolves(undefined as never);
+
+    const transcript = await sendInboundMessage();
+    const acceptedReply = transcript.find((line) => line.startsWith('250 ') && line.toLowerCase().includes('queued'));
+    expect(acceptedReply, `expected 250 OK even when analytics fail, transcript: ${transcript.join(' | ')}`).to.exist;
+
+    sinon.assert.calledOnce(queueAddStub);
+    const enqueueCallArg = queueAddStub.getCall(0).args[0];
+    // requestLogId is not propagated when logReceived throws or returns null
+    expect(enqueueCallArg.data.requestLogId).to.be.undefined;
+  });
+});

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -28,6 +28,13 @@ const mailUtilities = Promise.promisifyAll(require('./mailUtilities'));
 const inboundMailService = new InboundMailService();
 BullMqService.haveProInstalled();
 
+/**
+ * Exposed for tests so they can inject mock `requestLogger` / `tenantResolver`
+ * without standing up real ClickHouse / MongoDB. Production code should not
+ * read from this export.
+ */
+export const __testInboundMailService = inboundMailService;
+
 class Mailin extends events.EventEmitter {
   public configuration: IConfiguration;
 

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -330,6 +330,7 @@ class Mailin extends events.EventEmitter {
                   return finalizedMessage;
                 })
               )
+              .then(logInboundMailReceived.bind(null, connection))
               .then(postQueue.bind(null, connection))
               .then(
                 () => unlinkFile(connection).then(() => resolve()),
@@ -543,6 +544,49 @@ class Mailin extends events.EventEmitter {
       return parsedEmail;
     }
 
+    function logInboundMailReceived(connection, finalizedMessage) {
+      return nr.startSegment('inbound-mail/log-received', true, async () => {
+        const requestLogger = inboundMailService.requestLogger;
+        const tenantResolver = inboundMailService.tenantResolver;
+
+        if (!requestLogger || !tenantResolver) {
+          return finalizedMessage;
+        }
+
+        const toAddress = getAddressTo(finalizedMessage);
+
+        try {
+          const tenant = await tenantResolver.resolve(toAddress, finalizedMessage.messageId);
+          const durationMs = connection.startTimeMs ? Date.now() - connection.startTimeMs : 0;
+
+          const requestLogId = await requestLogger.logReceived({
+            source: finalizedMessage,
+            toAddress,
+            tenant,
+            durationMs,
+          });
+
+          if (requestLogId) {
+            finalizedMessage.requestLogId = requestLogId;
+            connection.requestLogContext = {
+              requestLogId,
+              organizationId: tenant.organizationId,
+              environmentId: tenant.environmentId,
+              transactionId: tenant.transactionId,
+            };
+          }
+        } catch (error) {
+          // Observability writes must never block the SMTP pipeline.
+          logger.warn(
+            { err: error, context: LOG_CONTEXT, connectionId: connection.id },
+            `${connection.id} Failed to write inbound-mail request log — continuing`
+          );
+        }
+
+        return finalizedMessage;
+      });
+    }
+
     function postQueue(connection, finalizedMessage) {
       return nr.startSegment(
         'inbound-mail/post-queue',
@@ -594,16 +638,45 @@ class Mailin extends events.EventEmitter {
                 data: finalizedMessage,
                 groupId,
               })
-              .then(() => resolve())
+              .then(() => {
+                emitQueueLifecycleTrace(connection, 'queued');
+                resolve();
+              })
               .catch((error) => {
                 logger.error(
                   { err: error, context: LOG_CONTEXT, connectionId: connection.id },
                   `${connection.id} Failed to add inbound mail to queue`
                 );
+                emitQueueLifecycleTrace(
+                  connection,
+                  'queue-failed',
+                  error instanceof Error ? error.message : 'Failed to enqueue inbound mail'
+                );
                 reject(error);
               });
           })
       );
+    }
+
+    function emitQueueLifecycleTrace(connection, phase: 'queued' | 'queue-failed', message?: string) {
+      const requestLogger = inboundMailService.requestLogger;
+      const context = connection.requestLogContext;
+
+      if (!requestLogger || !context) {
+        return;
+      }
+
+      const promise = phase === 'queued'
+        ? requestLogger.logQueued(context)
+        : requestLogger.logQueueFailed({ ...context, message });
+
+      promise.catch((traceError) => {
+        // Trace writes are best-effort; never fail the SMTP pipeline on them.
+        logger.warn(
+          { err: traceError, context: LOG_CONTEXT, connectionId: connection.id, phase },
+          `${connection.id} Failed to write inbound-mail ${phase} trace`
+        );
+      });
     }
     /*
      * Best-effort cleanup of the raw email temp file. Used on both success and
@@ -653,6 +726,7 @@ class Mailin extends events.EventEmitter {
           `${connection.id} Receiving message from ${connection.envelope.mailFrom.address}`
         );
 
+        connection.startTimeMs = Date.now();
         _this.emit('startMessage', connection);
 
         stream.pipe(fs.createWriteStream(mailPath));

--- a/apps/worker/src/app/shared/shared.module.ts
+++ b/apps/worker/src/app/shared/shared.module.ts
@@ -21,6 +21,7 @@ import {
   GetDecryptedSecretKey,
   GetTenant,
   HttpClientService,
+  InboundMailRequestLogger,
   InMemoryLRUCacheService,
   InvalidateCacheService,
   LoggerModule,
@@ -109,6 +110,10 @@ const ANALYTICS_PROVIDERS = [
   clickHouseService,
   clickHouseBatchService,
   WorkflowRunService,
+
+  // Inbound mail logging (shared with apps/inbound-mail; worker only writes
+  // terminal completion traces so the tenant resolver is not needed here).
+  InboundMailRequestLogger,
 ];
 
 const PROVIDERS = [

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.command.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.command.ts
@@ -123,4 +123,8 @@ export class InboundEmailParseCommand extends BaseCommand implements IInboundPar
 
   @IsDefined()
   envelopeTo: IEnvelopeTo[];
+
+  @IsOptional()
+  @IsString()
+  requestLogId?: string;
 }

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
@@ -1,11 +1,35 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import { InboundEmailParseCommand } from './inbound-email-parse.command';
-import { InboundParseProcessingError } from './inbound-parse-outcome';
+import { InboundParseDroppedError, InboundParseProcessingError } from './inbound-parse-outcome';
 import { LogInboundEmailRequest } from './log-inbound-email-request.usecase';
 import { DomainRouteStrategy } from './strategies/domain-route.strategy';
 import { ReplyToStrategy } from './strategies/reply-to.strategy';
 
+/**
+ * Worker entry point for inbound email parsing.
+ *
+ * Lifecycle ownership:
+ * - The early `requests` row + `request_received` + `request_queued` traces are
+ *   written by `apps/inbound-mail` before the BullMQ job is enqueued.
+ * - This use case only writes the worker-side terminal trace
+ *   (`request_delivered` / `request_failed`) linked via `command.requestLogId`.
+ * - `LogInboundEmailRequest` no-ops when `requestLogId` is missing, so legacy
+ *   jobs queued before the early-logging rollout drain cleanly without
+ *   producing orphan rows.
+ *
+ * Terminal-trace policy:
+ * - Strategy returns an outcome → trace `request_delivered` (200) or
+ *   `request_failed` (4xx/5xx).
+ * - Strategy throws `InboundParseProcessingError` with an outcome → trace
+ *   `request_failed` from the carried outcome.
+ * - Strategy throws `BadRequestException` (malformed address / unknown
+ *   domain) → trace `request_failed` with `warning` severity (non-retriable).
+ * - Strategy throws `InboundParseDroppedError` (silent shared-agent drop) →
+ *   trace `request_failed` with `warning` severity (non-retriable).
+ * - Any other throw → re-thrown so BullMQ retries; the per-job final-failure
+ *   trace is written by the `failed` handler on `InboundParseWorker`.
+ */
 @Injectable()
 export class InboundEmailParse {
   constructor(
@@ -22,34 +46,57 @@ export class InboundEmailParse {
 
     this.logger.info({ toAddress }, 'Received new email to parse');
 
-    const start = Date.now();
-
     try {
       const outcome = this.isReplyToAddress(toAddress)
         ? await this.replyToStrategy.execute(command)
         : await this.domainRouteStrategy.execute(command);
 
-      // Outcomes are only produced once the recipient resolves to a tenant.
-      // Mail dropped before resolution has no org/env to scope a request log to.
       if (outcome) {
-        await this.logInboundEmailRequest.execute({ command, outcome, durationMs: Date.now() - start });
-      }
-    } catch (error) {
-      if (error instanceof InboundParseProcessingError && error.outcome) {
-        try {
-          await this.logInboundEmailRequest.execute({
-            command,
-            outcome: error.outcome,
-            durationMs: Date.now() - start,
-          });
-        } catch (logError) {
-          this.logger.warn(
-            { err: logError, transactionId: error.outcome.transactionId },
-            'Failed to write inbound-email failure request log'
-          );
-        }
+        await this.logInboundEmailRequest.execute({ command, outcome });
+
+        return;
       }
 
+      // Strategy returned `undefined` without throwing — historically used by
+      // the shared agent-inbox path for "drop silently after logging". That
+      // contract still works for callers we haven't migrated, but the parsed
+      // mail now becomes invisible in the request detail view too. Emit a
+      // warning trace so operators can still see why nothing was delivered.
+      await this.logInboundEmailRequest.logUnresolvedFailure({
+        requestLogId: command.requestLogId ?? '',
+        message: 'Inbound mail dropped — no matching route or recipient',
+        severity: 'warning',
+      });
+    } catch (error) {
+      if (error instanceof InboundParseProcessingError && error.outcome) {
+        await this.logInboundEmailRequest.execute({ command, outcome: error.outcome });
+        throw error;
+      }
+
+      if (error instanceof InboundParseDroppedError) {
+        await this.logInboundEmailRequest.logUnresolvedFailure({
+          requestLogId: command.requestLogId ?? '',
+          message: error.reason,
+          organizationId: error.tenant?.organizationId,
+          environmentId: error.tenant?.environmentId,
+          transactionId: error.tenant?.transactionId,
+          severity: 'warning',
+        });
+
+        return;
+      }
+
+      if (error instanceof BadRequestException) {
+        await this.logInboundEmailRequest.logUnresolvedFailure({
+          requestLogId: command.requestLogId ?? '',
+          message: extractMessage(error),
+          severity: 'warning',
+        });
+      }
+
+      // For all other throws (DB error, unhandled exception, etc.) we let
+      // BullMQ retry. The terminal trace for retries that exhaust comes from
+      // the `failed` handler on the worker process.
       throw error;
     }
   }
@@ -57,4 +104,12 @@ export class InboundEmailParse {
   private isReplyToAddress(address: string): boolean {
     return address.includes('-nv-e=');
   }
+}
+
+function extractMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return typeof error === 'string' ? error : 'Inbound email processing failed';
 }

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-parse-outcome.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-parse-outcome.ts
@@ -1,5 +1,4 @@
 import { generateObjectId } from '@novu/application-generic';
-import { InboundEmailParseCommand } from './inbound-email-parse.command';
 
 /**
  * Which inbound-email resolution path produced the request log row. Maps to the
@@ -44,6 +43,23 @@ export class InboundParseProcessingError extends Error {
 }
 
 /**
+ * Thrown when the inbound mail server cannot route a message to any tenant
+ * (e.g. shared agent inbox: unknown routing key, inactive agent, missing
+ * integration link). Carries an optional reason for the trace `message`. The
+ * worker's safety-net handler converts these into a terminal `request_failed`
+ * trace using `command.requestLogId`. Non-retriable.
+ */
+export class InboundParseDroppedError extends Error {
+  constructor(
+    public readonly reason: string,
+    public readonly tenant?: { organizationId?: string; environmentId?: string; transactionId?: string }
+  ) {
+    super(reason);
+    this.name = 'InboundParseDroppedError';
+  }
+}
+
+/**
  * Inbound emails arriving through the domain-route / agent paths have no native
  * Novu transaction id. We derive a deterministic id from the RFC 5322
  * Message-ID so retries of the same email collapse onto one logical request.
@@ -52,29 +68,4 @@ export function inboundTransactionIdFromMessageId(messageId: string | undefined)
   const cleaned = messageId?.replace(/[<>]/g, '').trim();
 
   return cleaned || `inbound_${generateObjectId()}`;
-}
-
-/**
- * Metadata snapshot of an inbound email for the `request_body` column.
- * Excludes raw `html`/`text` bodies (same boundary as inbound-mail APM). Includes
- * routing fields (`from`, `to`, `subject`) so tenant-scoped Requests debugging works;
- * retention follows the `requests` table TTL policy.
- */
-export function buildInboundRequestMetadata(command: InboundEmailParseCommand): string {
-  const metadata = {
-    subject: command.subject,
-    messageId: command.messageId,
-    from: command.from?.map((sender) => sender.address),
-    to: command.to?.map((recipient) => recipient.address),
-    dkim: command.dkim,
-    spf: command.spf,
-    spamScore: command.spamScore,
-    attachments: command.attachments?.map((attachment) => ({
-      filename: attachment.filename,
-      contentType: attachment.contentType,
-      size: attachment.size,
-    })),
-  };
-
-  return JSON.stringify(metadata);
 }

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/log-inbound-email-request.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/log-inbound-email-request.usecase.spec.ts
@@ -1,14 +1,11 @@
-import { PinoLogger, RequestLogRepository, TraceLogRepository } from '@novu/application-generic';
+import { InboundMailRequestLogger, PinoLogger } from '@novu/application-generic';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { InboundEmailParseCommand } from './inbound-email-parse.command';
 import { InboundParseOutcome } from './inbound-parse-outcome';
 import { LogInboundEmailRequest } from './log-inbound-email-request.usecase';
 
-const ORIGINAL_ANALYTICS = process.env.IS_ANALYTICS_LOGS_ENABLED;
-const ORIGINAL_INBOUND = process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED;
-
-function buildCommand(): InboundEmailParseCommand {
+function buildCommand(overrides: Partial<InboundEmailParseCommand> = {}): InboundEmailParseCommand {
   return {
     html: '<b>secret body</b>',
     text: 'secret body',
@@ -21,34 +18,29 @@ function buildCommand(): InboundEmailParseCommand {
     spamScore: 1,
     attachments: [{ filename: 'a.pdf', contentType: 'application/pdf', size: 10 }],
     connection: { remoteAddress: '203.0.113.5', clientHostname: 'mta.example.com' },
+    requestLogId: 'req_abc',
+    ...overrides,
   } as unknown as InboundEmailParseCommand;
 }
 
 describe('LogInboundEmailRequest', () => {
   let sandbox: sinon.SinonSandbox;
-  let requestLogRepository: sinon.SinonStubbedInstance<RequestLogRepository>;
-  let traceLogRepository: sinon.SinonStubbedInstance<TraceLogRepository>;
+  let inboundMailRequestLogger: sinon.SinonStubbedInstance<InboundMailRequestLogger>;
   let usecase: LogInboundEmailRequest;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    requestLogRepository = sandbox.createStubInstance(RequestLogRepository);
-    traceLogRepository = sandbox.createStubInstance(TraceLogRepository);
-    (requestLogRepository as any).identifierPrefix = 'req_';
-    requestLogRepository.create.resolves();
-    traceLogRepository.createRequest.resolves();
+    inboundMailRequestLogger = sandbox.createStubInstance(InboundMailRequestLogger);
+    inboundMailRequestLogger.logCompleted.resolves();
 
     usecase = new LogInboundEmailRequest(
-      requestLogRepository as unknown as RequestLogRepository,
-      traceLogRepository as unknown as TraceLogRepository,
+      inboundMailRequestLogger as unknown as InboundMailRequestLogger,
       sandbox.createStubInstance(PinoLogger) as unknown as PinoLogger
     );
   });
 
   afterEach(() => {
     sandbox.restore();
-    process.env.IS_ANALYTICS_LOGS_ENABLED = ORIGINAL_ANALYTICS;
-    process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = ORIGINAL_INBOUND;
   });
 
   const successOutcome: InboundParseOutcome = {
@@ -59,79 +51,86 @@ describe('LogInboundEmailRequest', () => {
     status: 200,
   };
 
-  it('writes nothing when the feature flags are disabled', async () => {
-    process.env.IS_ANALYTICS_LOGS_ENABLED = 'false';
-    process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'false';
+  it('no-ops when requestLogId is missing (legacy jobs queued pre-rollout)', async () => {
+    await usecase.execute({
+      command: buildCommand({ requestLogId: undefined }),
+      outcome: successOutcome,
+    });
 
-    await usecase.execute({ command: buildCommand(), outcome: successOutcome, durationMs: 5 });
-
-    sinon.assert.notCalled(requestLogRepository.create);
-    sinon.assert.notCalled(traceLogRepository.createRequest);
+    sinon.assert.notCalled(inboundMailRequestLogger.logCompleted);
   });
 
-  it('writes nothing when only the shared analytics flag is enabled', async () => {
-    process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
-    process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'false';
+  it('emits request_delivered for a 200 outcome', async () => {
+    await usecase.execute({ command: buildCommand(), outcome: successOutcome });
 
-    await usecase.execute({ command: buildCommand(), outcome: successOutcome, durationMs: 5 });
-
-    sinon.assert.notCalled(requestLogRepository.create);
+    sinon.assert.calledOnce(inboundMailRequestLogger.logCompleted);
+    const arg = inboundMailRequestLogger.logCompleted.getCall(0).args[0];
+    expect(arg.delivered).to.equal(true);
+    expect(arg.severity).to.equal('success');
+    expect(arg.requestLogId).to.equal('req_abc');
+    expect(arg.organizationId).to.equal('org_1');
+    expect(arg.environmentId).to.equal('env_1');
+    expect(arg.transactionId).to.equal('txn_1');
   });
 
-  it('writes a source=inbound_email row and lifecycle traces on success', async () => {
-    process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
-    process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+  it('emits request_failed with warning severity for 422 outcomes (non-retriable)', async () => {
+    await usecase.execute({
+      command: buildCommand(),
+      outcome: { ...successOutcome, status: 422, message: 'No matching route' },
+    });
 
-    await usecase.execute({ command: buildCommand(), outcome: successOutcome, durationMs: 42 });
-
-    sinon.assert.calledOnce(requestLogRepository.create);
-    const [row, context] = requestLogRepository.create.getCall(0).args;
-    expect(row.source).to.equal('inbound_email');
-    expect(row.method).to.equal('INBOUND');
-    expect(row.status_code).to.equal(200);
-    expect(row.path).to.equal('/inbound-mail/domain-route');
-    expect(row.transaction_id).to.equal('txn_1');
-    expect(row.ip).to.equal('203.0.113.5');
-    expect(row.hostname).to.equal('mta.example.com');
-    expect(row.duration_ms).to.equal(42);
-    expect(row.organization_id).to.equal('org_1');
-    expect(row.environment_id).to.equal('env_1');
-    expect(context).to.deep.equal({ organizationId: 'org_1', environmentId: 'env_1' });
-
-    // request_body carries metadata only; never the raw html/text bodies (PII).
-    expect(row.request_body).to.not.contain('secret body');
-    const metadata = JSON.parse(row.request_body);
-    expect(metadata.subject).to.equal('Hello there');
-    expect(metadata.from).to.deep.equal(['sender@example.com']);
-    expect(metadata.attachments).to.deep.equal([{ filename: 'a.pdf', contentType: 'application/pdf', size: 10 }]);
-    expect(metadata.html).to.be.undefined;
-    expect(metadata.text).to.be.undefined;
-
-    sinon.assert.calledOnce(traceLogRepository.createRequest);
-    const traces = traceLogRepository.createRequest.getCall(0).args[0];
-    expect(traces).to.have.length(2);
-    expect(traces[0].event_type).to.equal('request_received');
-    expect(traces[0].entity_id).to.equal(row.id);
-    expect(traces[1].event_type).to.equal('request_queued');
-    expect(traces[1].status).to.equal('success');
+    const arg = inboundMailRequestLogger.logCompleted.getCall(0).args[0];
+    expect(arg.delivered).to.equal(false);
+    expect(arg.severity).to.equal('warning');
+    expect(arg.message).to.equal('No matching route');
   });
 
-  it('emits a request_failed trace for failure outcomes', async () => {
-    process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
-    process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
-
+  it('emits request_failed with error severity for 502 outcomes (downstream failure)', async () => {
     await usecase.execute({
       command: buildCommand(),
       outcome: { ...successOutcome, status: 502, message: 'Inbound delivery failed' },
-      durationMs: 10,
     });
 
-    const row = requestLogRepository.create.getCall(0).args[0];
-    expect(row.status_code).to.equal(502);
+    const arg = inboundMailRequestLogger.logCompleted.getCall(0).args[0];
+    expect(arg.delivered).to.equal(false);
+    expect(arg.severity).to.equal('error');
+    expect(arg.message).to.equal('Inbound delivery failed');
+  });
 
-    const traces = traceLogRepository.createRequest.getCall(0).args[0];
-    expect(traces[1].event_type).to.equal('request_failed');
-    expect(traces[1].status).to.equal('error');
-    expect(traces[1].message).to.equal('Inbound delivery failed');
+  describe('logUnresolvedFailure', () => {
+    it('skips when no requestLogId is provided (legacy job safety net)', async () => {
+      await usecase.logUnresolvedFailure({ requestLogId: '', message: 'malformed address' });
+
+      sinon.assert.notCalled(inboundMailRequestLogger.logCompleted);
+    });
+
+    it('emits a warning trace for non-retriable drops', async () => {
+      await usecase.logUnresolvedFailure({
+        requestLogId: 'req_abc',
+        message: 'Shared agent inbox: integration is inactive',
+        severity: 'warning',
+        environmentId: 'env_2',
+      });
+
+      const arg = inboundMailRequestLogger.logCompleted.getCall(0).args[0];
+      expect(arg.requestLogId).to.equal('req_abc');
+      expect(arg.delivered).to.equal(false);
+      expect(arg.severity).to.equal('warning');
+      expect(arg.environmentId).to.equal('env_2');
+      expect(arg.message).to.equal('Shared agent inbox: integration is inactive');
+    });
+
+    it('defaults severity to error when not provided', async () => {
+      await usecase.logUnresolvedFailure({ requestLogId: 'req_abc', message: 'Unexpected throw' });
+
+      const arg = inboundMailRequestLogger.logCompleted.getCall(0).args[0];
+      expect(arg.severity).to.equal('error');
+    });
+  });
+
+  it('swallows write failures so the worker can continue', async () => {
+    inboundMailRequestLogger.logCompleted.rejects(new Error('clickhouse down'));
+
+    await usecase.execute({ command: buildCommand(), outcome: successOutcome });
   });
 });

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/log-inbound-email-request.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/log-inbound-email-request.usecase.ts
@@ -1,153 +1,116 @@
 import { Injectable } from '@nestjs/common';
 import {
-  generateObjectId,
-  LogRepository,
-  mapEventTypeToTitle,
+  InboundMailRequestLogger,
   PinoLogger,
-  RequestLog,
-  RequestLogRepository,
-  RequestLogSourceEnum,
-  RequestTraceInput,
-  TraceLogRepository,
+  TraceStatus,
 } from '@novu/application-generic';
 import { InboundEmailParseCommand } from './inbound-email-parse.command';
-import { buildInboundRequestMetadata, InboundParseOutcome } from './inbound-parse-outcome';
+import { InboundParseOutcome } from './inbound-parse-outcome';
 
-const INBOUND_METHOD = 'INBOUND';
-
-export interface LogInboundEmailRequestCommand {
+export interface LogInboundEmailCompletedCommand {
   command: InboundEmailParseCommand;
   outcome: InboundParseOutcome;
-  durationMs: number;
 }
 
 /**
- * Centralized writer that mirrors an inbound email into the analytics `requests`
- * table (with `source = inbound_email`) plus the matching lifecycle traces, so
- * inbound mail shows up in the dashboard "Requests" view alongside HTTP triggers.
+ * Writes the worker-side terminal trace for an inbound email — either
+ * `request_delivered` (status 200) or `request_failed` (any other status).
  *
- * Writes are gated by two env vars: the shared analytics switch
- * (`IS_ANALYTICS_LOGS_ENABLED`) and a dedicated inbound kill-switch
- * (`IS_INBOUND_ANALYTICS_LOGS_ENABLED`), both default off. Failures here never
- * propagate — observability must not break inbound mail processing.
+ * The early `requests` row, the `request_received` trace, and the
+ * `request_queued` trace are all written in `apps/inbound-mail` before the
+ * BullMQ job is enqueued. The worker links its terminal trace to that row
+ * via `command.requestLogId`.
+ *
+ * Failures here never propagate — observability must not break inbound mail
+ * processing — and we silently no-op when no `requestLogId` is present so
+ * jobs queued before the early-logging rollout still drain cleanly.
  */
 @Injectable()
 export class LogInboundEmailRequest {
   constructor(
-    private requestLogRepository: RequestLogRepository,
-    private traceLogRepository: TraceLogRepository,
-    private logger: PinoLogger
+    private readonly inboundMailRequestLogger: InboundMailRequestLogger,
+    private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
   }
 
-  private isEnabled(): boolean {
-    return process.env.IS_ANALYTICS_LOGS_ENABLED === 'true' && process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED === 'true';
-  }
-
-  async execute({ command, outcome, durationMs }: LogInboundEmailRequestCommand): Promise<void> {
-    if (!this.isEnabled()) {
+  async execute({ command, outcome }: LogInboundEmailCompletedCommand): Promise<void> {
+    if (!command.requestLogId) {
       return;
     }
 
     try {
-      const requestId = `${this.requestLogRepository.identifierPrefix}${generateObjectId()}`;
-      const context = {
+      await this.inboundMailRequestLogger.logCompleted({
+        requestLogId: command.requestLogId,
         organizationId: outcome.organizationId,
         environmentId: outcome.environmentId,
-      };
-      const isFailure = outcome.status >= 400;
-
-      try {
-        await this.requestLogRepository.create(this.buildRequestLog(requestId, command, outcome, durationMs), context);
-      } catch (error) {
-        this.logger.warn(
-          { err: error, transactionId: outcome.transactionId, strategy: outcome.strategy },
-          'Failed to write inbound-email request log'
-        );
-
-        return;
-      }
-
-      try {
-        await this.traceLogRepository.createRequest(this.buildTraces(requestId, outcome, isFailure));
-      } catch (error) {
-        this.logger.warn(
-          { err: error, requestId, transactionId: outcome.transactionId },
-          'Failed to write inbound-email request traces'
-        );
-      }
+        transactionId: outcome.transactionId,
+        delivered: outcome.status >= 200 && outcome.status < 300,
+        severity: severityFromStatus(outcome.status),
+        message: outcome.message,
+      });
     } catch (error) {
       this.logger.warn(
         { err: error, transactionId: outcome.transactionId, strategy: outcome.strategy },
-        'Unexpected error while writing inbound-email request log'
+        'Failed to write inbound-email completion trace'
       );
     }
   }
 
-  private buildRequestLog(
-    requestId: string,
-    command: InboundEmailParseCommand,
-    outcome: InboundParseOutcome,
-    durationMs: number
-  ): Omit<RequestLog, 'expires_at'> {
-    const path = `/inbound-mail/${outcome.strategy}`;
+  /**
+   * Append a `request_failed` trace for a job that we cannot resolve to a
+   * terminal `InboundParseOutcome` — e.g. silent shared-agent drops, malformed
+   * addresses caught pre-resolution, or unhandled exceptions on the final
+   * BullMQ retry. Tenant context is best-effort: callers pass whatever they
+   * managed to resolve before the failure.
+   */
+  async logUnresolvedFailure(params: {
+    requestLogId: string;
+    message: string;
+    organizationId?: string;
+    environmentId?: string;
+    transactionId?: string;
+    severity?: TraceStatus;
+  }): Promise<void> {
+    if (!params.requestLogId) {
+      return;
+    }
 
-    return {
-      id: requestId,
-      created_at: LogRepository.formatDateTime64(new Date()),
-      path,
-      url: path,
-      url_pattern: path,
-      hostname: command.connection?.clientHostname || '',
-      status_code: outcome.status,
-      method: INBOUND_METHOD,
-      transaction_id: outcome.transactionId,
-      ip: command.connection?.remoteAddress || '',
-      user_agent: '',
-      request_body: buildInboundRequestMetadata(command),
-      response_body: '',
-      user_id: '',
-      organization_id: outcome.organizationId,
-      environment_id: outcome.environmentId,
-      auth_type: '',
-      duration_ms: durationMs,
-      source: RequestLogSourceEnum.INBOUND_EMAIL,
-    };
+    try {
+      await this.inboundMailRequestLogger.logCompleted({
+        requestLogId: params.requestLogId,
+        organizationId: params.organizationId ?? '',
+        environmentId: params.environmentId ?? '',
+        transactionId: params.transactionId ?? '',
+        delivered: false,
+        severity: params.severity ?? 'error',
+        message: params.message,
+      });
+    } catch (error) {
+      this.logger.warn(
+        { err: error, requestLogId: params.requestLogId },
+        'Failed to write inbound-email unresolved-failure trace'
+      );
+    }
+  }
+}
+
+/**
+ * Map our overloaded inbound-mail status codes onto the `traces.status` column.
+ *
+ * - `2xx` → `success`
+ * - `4xx` → `warning` (resolved but the customer cannot deliver — bad route,
+ *   misconfigured webhook, SSRF policy block, etc. — non-retriable)
+ * - `5xx` → `error` (downstream system failure — retriable; the worker only
+ *   emits a trace once retries are exhausted)
+ */
+function severityFromStatus(status: number): TraceStatus {
+  if (status >= 200 && status < 300) {
+    return 'success';
+  }
+  if (status >= 400 && status < 500) {
+    return 'warning';
   }
 
-  private buildTraces(requestId: string, outcome: InboundParseOutcome, isFailure: boolean): RequestTraceInput[] {
-    const baseTrace: Omit<RequestTraceInput, 'event_type' | 'title' | 'status' | 'message'> = {
-      created_at: LogRepository.formatDateTime64(new Date()),
-      organization_id: outcome.organizationId,
-      environment_id: outcome.environmentId,
-      user_id: '',
-      subscriber_id: '',
-      external_subscriber_id: '',
-      raw_data: '',
-      entity_id: requestId,
-      workflow_run_identifier: '',
-      workflow_id: '',
-      provider_id: '',
-    };
-
-    const receivedTrace: RequestTraceInput = {
-      ...baseTrace,
-      event_type: 'request_received',
-      title: mapEventTypeToTitle('request_received'),
-      status: 'success',
-      message: '',
-    };
-
-    const terminalEventType = isFailure ? 'request_failed' : 'request_queued';
-    const terminalTrace: RequestTraceInput = {
-      ...baseTrace,
-      event_type: terminalEventType,
-      title: mapEventTypeToTitle(terminalEventType),
-      status: isFailure ? 'error' : 'success',
-      message: outcome.message || '',
-    };
-
-    return [receivedTrace, terminalTrace];
-  }
+  return 'error';
 }

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/log-inbound-email-request.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/log-inbound-email-request.usecase.ts
@@ -1,9 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  InboundMailRequestLogger,
-  PinoLogger,
-  TraceStatus,
-} from '@novu/application-generic';
+import { InboundMailRequestLogger, PinoLogger, TraceStatus } from '@novu/application-generic';
 import { InboundEmailParseCommand } from './inbound-email-parse.command';
 import { InboundParseOutcome } from './inbound-parse-outcome';
 

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
@@ -16,6 +16,7 @@ import {
 import { DomainRouteTypeEnum, DomainStatusEnum } from '@novu/shared';
 import { InboundEmailParseCommand } from '../inbound-email-parse.command';
 import {
+  InboundParseDroppedError,
   InboundParseOutcome,
   InboundParseProcessingError,
   InboundParseStrategy,
@@ -141,7 +142,7 @@ export class DomainRouteStrategy {
       return { ...resolved, status: 200 };
     }
 
-    return undefined;
+    return { ...baseResolved, strategy: 'domain-route', status: 422, message: `Unsupported route type: ${route.type}` };
   }
 
   private fail(resolved: ResolvedDomainRouteContext, status: number, message: string): never {
@@ -175,8 +176,7 @@ export class DomainRouteStrategy {
   ): Promise<InboundParseOutcome | undefined> {
     if (!localPart) {
       this.logger.info({ toAddress }, 'Shared agent domain: missing local part - dropping');
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: missing local part');
     }
 
     const parsed = parseAgentSharedInboxLocalPart(localPart);
@@ -185,8 +185,7 @@ export class DomainRouteStrategy {
         { toAddress, localPart },
         'Shared agent domain: local part did not match {slug}-{inboxRoutingKey} - dropping'
       );
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: local part did not match expected pattern');
     }
 
     const integration = await this.integrationRepository.findAgentInboundByInboxRoutingKey(parsed.inboxRoutingKey);
@@ -195,8 +194,7 @@ export class DomainRouteStrategy {
         { toAddress, inboxRoutingKey: parsed.inboxRoutingKey },
         'Shared agent domain: no integration found for routing key - dropping'
       );
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: no integration found for routing key');
     }
 
     if (integration.active === false) {
@@ -204,8 +202,10 @@ export class DomainRouteStrategy {
         { toAddress, integrationId: integration._id },
         'Shared agent domain: integration is inactive - dropping'
       );
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: integration is inactive', {
+        organizationId: integration._organizationId,
+        environmentId: integration._environmentId,
+      });
     }
 
     if (integration.credentials?.sharedInboxDisabled) {
@@ -213,8 +213,10 @@ export class DomainRouteStrategy {
         { toAddress, integrationId: integration._id },
         'Shared agent domain: shared inbox disabled for this agent - dropping'
       );
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: shared inbox disabled for this agent', {
+        organizationId: integration._organizationId,
+        environmentId: integration._environmentId,
+      });
     }
 
     const link = await this.agentIntegrationRepository.findOne(
@@ -230,8 +232,10 @@ export class DomainRouteStrategy {
         { toAddress, integrationId: integration._id },
         'Shared agent domain: no agent link found for integration - dropping'
       );
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: no agent link found for integration', {
+        organizationId: integration._organizationId,
+        environmentId: integration._environmentId,
+      });
     }
 
     const agent = await this.agentRepository.findByIdForWebhook(link._agentId);
@@ -240,14 +244,18 @@ export class DomainRouteStrategy {
         { toAddress, agentId: link._agentId },
         'Shared agent domain: no agent found for link - dropping'
       );
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: no agent found for link', {
+        organizationId: integration._organizationId,
+        environmentId: integration._environmentId,
+      });
     }
 
     if (agent.active === false) {
       this.logger.info({ toAddress, agentId: agent._id }, 'Shared agent domain: agent is inactive - dropping');
-
-      return undefined;
+      throw new InboundParseDroppedError('Shared agent domain: agent is inactive', {
+        organizationId: agent._organizationId,
+        environmentId: agent._environmentId,
+      });
     }
 
     const resolved: ResolvedDomainRouteContext = {

--- a/apps/worker/src/app/workflow/workers/inbound-parse.worker.service.ts
+++ b/apps/worker/src/app/workflow/workers/inbound-parse.worker.service.ts
@@ -3,6 +3,7 @@ import {
   BullMqService,
   getInboundParseMailWorkerOptions,
   IInboundParseDataDto,
+  InboundMailRequestLogger,
   WorkerBaseService,
   WorkerOptions,
   WorkflowInMemoryProviderService,
@@ -21,11 +22,13 @@ export class InboundParseWorker extends WorkerBaseService {
    */
   constructor(
     private inboundEmailParseUsecase: InboundEmailParse,
+    private inboundMailRequestLogger: InboundMailRequestLogger,
     public workflowInMemoryProviderService: WorkflowInMemoryProviderService
   ) {
     super(JobTopicNameEnum.INBOUND_PARSE_MAIL, new BullMqService(workflowInMemoryProviderService));
 
     this.initWorker(this.getWorkerProcessor(), this.getWorkerOptions());
+    this.registerFailedSafetyNet();
   }
 
   private getWorkerOptions(): WorkerOptions {
@@ -37,5 +40,61 @@ export class InboundParseWorker extends WorkerBaseService {
       Logger.verbose({ data }, 'Processing the inbound parsed email', LOG_CONTEXT);
       await this.inboundEmailParseUsecase.execute(InboundEmailParseCommand.create({ ...data }));
     };
+  }
+
+  /**
+   * Safety net: BullMQ's `failed` event fires after every failed attempt. We
+   * only emit a terminal `request_failed` trace once BullMQ has exhausted all
+   * configured retries — intermediate 5xx retries do not get duplicate traces
+   * on the request, only the final outcome does. Handles unhandled exceptions
+   * that bypass `InboundEmailParse.execute()`'s own catch block (e.g.
+   * unexpected throws during DB access, OOM, etc.).
+   */
+  private registerFailedSafetyNet(): void {
+    const worker = this.bullMqWorker;
+
+    if (!worker) {
+      return;
+    }
+
+    worker.on('failed', (job, error) => {
+      if (!job) {
+        return;
+      }
+
+      const attemptsMade = job.attemptsMade ?? 0;
+      const maxAttempts = job.opts?.attempts ?? 1;
+
+      // Wait until the final attempt before recording the terminal trace, so
+      // retries don't generate noise. Strategies still write terminal traces
+      // for resolved failures via `InboundEmailParse` — this handler only
+      // catches unhandled exceptions and exhausted retries.
+      if (attemptsMade < maxAttempts) {
+        return;
+      }
+
+      const data = job.data as IInboundParseDataDto | undefined;
+      if (!data?.requestLogId) {
+        return;
+      }
+
+      this.inboundMailRequestLogger
+        .logCompleted({
+          requestLogId: data.requestLogId,
+          organizationId: '',
+          environmentId: '',
+          transactionId: data.messageId ?? '',
+          delivered: false,
+          severity: 'error',
+          message: error instanceof Error ? error.message : 'Inbound mail processing failed after exhausted retries',
+        })
+        .catch((traceError) => {
+          Logger.warn(
+            { err: traceError, jobId: job.id, requestLogId: data.requestLogId },
+            'Failed to write inbound-email exhausted-retries trace',
+            LOG_CONTEXT
+          );
+        });
+    });
   }
 }

--- a/libs/application-generic/src/dtos/inbound-parse-job.dto.ts
+++ b/libs/application-generic/src/dtos/inbound-parse-job.dto.ts
@@ -58,6 +58,17 @@ export interface IInboundParseDataDto {
   connection: IConnection;
   envelopeFrom: IEnvelopeFrom;
   envelopeTo: IEnvelopeTo[];
+  /**
+   * Identifier of the early ClickHouse `requests` row written by the
+   * inbound-mail server before this job was enqueued. The worker links its
+   * terminal completion trace (`request_delivered` / `request_failed`) to
+   * this id so the request detail view shows the full lifecycle.
+   *
+   * Optional for backward compatibility with jobs queued before early logging
+   * was deployed; missing id means the worker should fall back to writing the
+   * full row itself (legacy path).
+   */
+  requestLogId?: string;
 }
 
 export interface IHeaders {

--- a/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.repository.ts
+++ b/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.repository.ts
@@ -562,6 +562,8 @@ export function mapEventTypeToTitle(eventType: EventType): string {
       return 'Request received';
     case 'request_queued':
       return 'Request queued';
+    case 'request_delivered':
+      return 'Request delivered';
     case 'request_failed':
       return 'Request failed';
     case 'request_organization_not_found':

--- a/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.schema.ts
+++ b/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.schema.ts
@@ -183,6 +183,7 @@ export type EventType =
   | 'step_canceled'
   | 'request_received'
   | 'request_queued'
+  | 'request_delivered'
   | 'request_failed'
   | 'request_organization_not_found'
   | 'request_environment_not_found'

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-request-logger.spec.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-request-logger.spec.ts
@@ -1,0 +1,241 @@
+import { PinoLogger } from 'nestjs-pino';
+import { RequestLogRepository, TraceLogRepository } from '../analytic-logs';
+import { InboundMailRequestLogger } from './inbound-mail-request-logger';
+import { InboundRequestSource } from './inbound-request-metadata';
+
+const ORIGINAL_ANALYTICS = process.env.IS_ANALYTICS_LOGS_ENABLED;
+const ORIGINAL_INBOUND = process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED;
+
+function buildSource(): InboundRequestSource {
+  return {
+    subject: 'Hello there',
+    messageId: 'abc-123@example.com',
+    from: [{ address: 'sender@example.com', name: 'Sender' }],
+    to: [{ address: 'parse@inbound.example.com', name: '' }],
+    dkim: 'pass',
+    spf: 'pass',
+    spamScore: 1,
+    attachments: [{ filename: 'a.pdf', contentType: 'application/pdf', size: 10 }],
+    connection: { remoteAddress: '203.0.113.5', clientHostname: 'mta.example.com' } as any,
+  };
+}
+
+describe('InboundMailRequestLogger', () => {
+  let requestLogRepository: jest.Mocked<Pick<RequestLogRepository, 'create' | 'identifierPrefix'>>;
+  let traceLogRepository: jest.Mocked<Pick<TraceLogRepository, 'createRequest'>>;
+  let logger: InboundMailRequestLogger;
+  let pinoLogger: jest.Mocked<PinoLogger>;
+
+  beforeEach(() => {
+    requestLogRepository = {
+      create: jest.fn().mockResolvedValue(undefined),
+      identifierPrefix: 'req_',
+    } as any;
+    traceLogRepository = {
+      createRequest: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    pinoLogger = {
+      setContext: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as any;
+
+    logger = new InboundMailRequestLogger(
+      requestLogRepository as unknown as RequestLogRepository,
+      traceLogRepository as unknown as TraceLogRepository,
+      pinoLogger
+    );
+  });
+
+  afterEach(() => {
+    process.env.IS_ANALYTICS_LOGS_ENABLED = ORIGINAL_ANALYTICS;
+    process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = ORIGINAL_INBOUND;
+  });
+
+  describe('logReceived', () => {
+    it('returns null when feature flags are disabled', async () => {
+      process.env.IS_ANALYTICS_LOGS_ENABLED = 'false';
+      process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+
+      const result = await logger.logReceived({
+        source: buildSource(),
+        toAddress: 'foo@example.com',
+        tenant: { organizationId: 'org_1', environmentId: 'env_1', transactionId: 'txn_1' },
+        durationMs: 5,
+      });
+
+      expect(result).toBeNull();
+      expect(requestLogRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('writes an early row with status_code 202 and a request_received trace', async () => {
+      process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+      process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+
+      const requestLogId = await logger.logReceived({
+        source: buildSource(),
+        toAddress: 'support@customer.com',
+        tenant: { organizationId: 'org_1', environmentId: 'env_1', transactionId: 'txn_1' },
+        durationMs: 42,
+      });
+
+      expect(requestLogId).toMatch(/^req_/);
+      expect(requestLogRepository.create).toHaveBeenCalledTimes(1);
+      const [row, context] = requestLogRepository.create.mock.calls[0];
+      expect(row.source).toBe('inbound_email');
+      expect(row.method).toBe('INBOUND');
+      expect(row.status_code).toBe(202);
+      expect(row.path).toBe('/inbound-mail/domain-route');
+      expect(row.transaction_id).toBe('txn_1');
+      expect(row.duration_ms).toBe(42);
+      expect(context).toEqual({ organizationId: 'org_1', environmentId: 'env_1' });
+
+      // request_body carries metadata only; never the raw html/text bodies (PII).
+      const metadata = JSON.parse(row.request_body);
+      expect(metadata.subject).toBe('Hello there');
+      expect(metadata.html).toBeUndefined();
+      expect(metadata.text).toBeUndefined();
+
+      expect(traceLogRepository.createRequest).toHaveBeenCalledTimes(1);
+      const [traces] = traceLogRepository.createRequest.mock.calls[0];
+      expect(traces).toHaveLength(1);
+      expect(traces[0].event_type).toBe('request_received');
+      expect(traces[0].entity_id).toBe(requestLogId);
+      expect(traces[0].status).toBe('success');
+    });
+
+    it('infers reply-to strategy for legacy reply-to addresses', async () => {
+      process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+      process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+
+      await logger.logReceived({
+        source: buildSource(),
+        toAddress: 'parse+txn-nv-e=env_1@reply.novu.co',
+        tenant: { organizationId: '', environmentId: 'env_1', transactionId: 'txn' },
+        durationMs: 1,
+      });
+
+      const [row] = requestLogRepository.create.mock.calls[0];
+      expect(row.path).toBe('/inbound-mail/reply-to');
+    });
+
+    it('returns null when the row write fails', async () => {
+      process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+      process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+      requestLogRepository.create.mockRejectedValueOnce(new Error('clickhouse down'));
+
+      const result = await logger.logReceived({
+        source: buildSource(),
+        toAddress: 'foo@example.com',
+        tenant: { organizationId: 'org_1', environmentId: 'env_1', transactionId: 'txn_1' },
+        durationMs: 1,
+      });
+
+      expect(result).toBeNull();
+      expect(traceLogRepository.createRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logQueued', () => {
+    beforeEach(() => {
+      process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+      process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+    });
+
+    it('emits a request_queued trace linked to the requestLogId', async () => {
+      await logger.logQueued({
+        requestLogId: 'req_abc',
+        organizationId: 'org_1',
+        environmentId: 'env_1',
+        transactionId: 'txn_1',
+      });
+
+      const [traces] = traceLogRepository.createRequest.mock.calls[0];
+      expect(traces[0].event_type).toBe('request_queued');
+      expect(traces[0].entity_id).toBe('req_abc');
+      expect(traces[0].status).toBe('success');
+    });
+
+    it('no-ops when no requestLogId is provided', async () => {
+      await logger.logQueued({
+        requestLogId: '',
+        organizationId: 'org_1',
+        environmentId: 'env_1',
+        transactionId: 'txn_1',
+      });
+
+      expect(traceLogRepository.createRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logQueueFailed', () => {
+    it('emits a request_failed trace with the failure reason', async () => {
+      process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+      process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+
+      await logger.logQueueFailed({
+        requestLogId: 'req_abc',
+        organizationId: 'org_1',
+        environmentId: 'env_1',
+        transactionId: 'txn_1',
+        message: 'Redis connection refused',
+      });
+
+      const [traces] = traceLogRepository.createRequest.mock.calls[0];
+      expect(traces[0].event_type).toBe('request_failed');
+      expect(traces[0].status).toBe('error');
+      expect(traces[0].message).toBe('Redis connection refused');
+    });
+  });
+
+  describe('logCompleted', () => {
+    beforeEach(() => {
+      process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+      process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED = 'true';
+    });
+
+    it('writes request_delivered when delivered is true', async () => {
+      await logger.logCompleted({
+        requestLogId: 'req_abc',
+        organizationId: 'org_1',
+        environmentId: 'env_1',
+        transactionId: 'txn_1',
+        delivered: true,
+      });
+
+      const [traces] = traceLogRepository.createRequest.mock.calls[0];
+      expect(traces[0].event_type).toBe('request_delivered');
+      expect(traces[0].status).toBe('success');
+    });
+
+    it('writes request_failed with warning severity for 422 outcomes', async () => {
+      await logger.logCompleted({
+        requestLogId: 'req_abc',
+        organizationId: 'org_1',
+        environmentId: 'env_1',
+        transactionId: 'txn_1',
+        delivered: false,
+        severity: 'warning',
+        message: 'No matching inbound route',
+      });
+
+      const [traces] = traceLogRepository.createRequest.mock.calls[0];
+      expect(traces[0].event_type).toBe('request_failed');
+      expect(traces[0].status).toBe('warning');
+      expect(traces[0].message).toBe('No matching inbound route');
+    });
+
+    it('no-ops when no requestLogId is provided (backward compat with pre-rollout jobs)', async () => {
+      await logger.logCompleted({
+        requestLogId: '',
+        organizationId: 'org_1',
+        environmentId: 'env_1',
+        transactionId: 'txn_1',
+        delivered: true,
+      });
+
+      expect(traceLogRepository.createRequest).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-request-logger.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-request-logger.ts
@@ -1,22 +1,18 @@
 import { Injectable, Optional } from '@nestjs/common';
-import { generateObjectId } from '../../utils/generate-id';
 import { PinoLogger } from '../../logging';
+import { generateObjectId } from '../../utils/generate-id';
 import {
   LogRepository,
+  mapEventTypeToTitle,
   RequestLog,
   RequestLogRepository,
   RequestLogSourceEnum,
   RequestTraceInput,
   TraceLogRepository,
   TraceStatus,
-  mapEventTypeToTitle,
 } from '../analytic-logs';
-import {
-  InboundParseStrategy,
-  InboundRequestSource,
-  buildInboundRequestMetadata,
-} from './inbound-request-metadata';
 import { InboundMailTenant } from './inbound-mail-tenant.resolver';
+import { buildInboundRequestMetadata, InboundParseStrategy, InboundRequestSource } from './inbound-request-metadata';
 
 const INBOUND_METHOD = 'INBOUND';
 
@@ -78,9 +74,7 @@ export class InboundMailRequestLogger {
   }
 
   isEnabled(): boolean {
-    return (
-      process.env.IS_ANALYTICS_LOGS_ENABLED === 'true' && process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED === 'true'
-    );
+    return process.env.IS_ANALYTICS_LOGS_ENABLED === 'true' && process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED === 'true';
   }
 
   /**
@@ -101,12 +95,15 @@ export class InboundMailRequestLogger {
     const strategy = context.strategy ?? inferStrategyFromTo(context.toAddress);
 
     try {
-      await this.requestLogRepository.create(
-        this.buildRequestLog(requestLogId, context, strategy),
-        { organizationId: context.tenant.organizationId, environmentId: context.tenant.environmentId }
-      );
+      await this.requestLogRepository.create(this.buildRequestLog(requestLogId, context, strategy), {
+        organizationId: context.tenant.organizationId,
+        environmentId: context.tenant.environmentId,
+      });
     } catch (error) {
-      this.logger?.warn({ err: error, transactionId: context.tenant.transactionId }, 'Failed to write inbound-email request log');
+      this.logger?.warn(
+        { err: error, transactionId: context.tenant.transactionId },
+        'Failed to write inbound-email request log'
+      );
 
       return null;
     }

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-request-logger.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-request-logger.ts
@@ -1,0 +1,263 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { generateObjectId } from '../../utils/generate-id';
+import { PinoLogger } from '../../logging';
+import {
+  LogRepository,
+  RequestLog,
+  RequestLogRepository,
+  RequestLogSourceEnum,
+  RequestTraceInput,
+  TraceLogRepository,
+  TraceStatus,
+  mapEventTypeToTitle,
+} from '../analytic-logs';
+import {
+  InboundParseStrategy,
+  InboundRequestSource,
+  buildInboundRequestMetadata,
+} from './inbound-request-metadata';
+import { InboundMailTenant } from './inbound-mail-tenant.resolver';
+
+const INBOUND_METHOD = 'INBOUND';
+
+/**
+ * HTTP-style status codes overloaded onto inbound mail outcomes so the existing
+ * dashboard "Requests" status filter stays meaningful:
+ *
+ * - 202 = accepted for processing (worker has not yet attempted delivery)
+ * - 200 = delivered successfully
+ * - 422 = resolved but undeliverable (no route / config error)
+ * - 502 = downstream delivery failure (webhook/agent/reply-to call failed)
+ */
+export const INBOUND_REQUEST_STATUS = {
+  ACCEPTED: 202,
+  DELIVERED: 200,
+  UNDELIVERABLE: 422,
+  DOWNSTREAM_FAILURE: 502,
+} as const;
+
+export interface InboundReceivedContext {
+  source: InboundRequestSource;
+  toAddress: string;
+  tenant: InboundMailTenant;
+  durationMs: number;
+  /**
+   * Strategy override — defaults to `inferInboundParseStrategy(toAddress)`.
+   * The worker passes the resolved strategy when emitting the early row from
+   * a synthetic test, but inbound-mail relies on the default.
+   */
+  strategy?: InboundParseStrategy;
+}
+
+export interface InboundCompletionContext {
+  requestLogId: string;
+  organizationId: string;
+  environmentId: string;
+  transactionId: string;
+  message?: string;
+}
+
+/**
+ * Centralized writer for the inbound-mail `requests` row plus its lifecycle
+ * traces. Used by both `apps/inbound-mail` (early row + queued/queue-failed
+ * trace) and `apps/worker` (terminal delivered/failed trace).
+ *
+ * Failures in this writer never propagate — observability must not break the
+ * inbound mail pipeline. Both feature flags must be enabled for any write to
+ * happen: the shared `IS_ANALYTICS_LOGS_ENABLED` switch and the
+ * inbound-specific `IS_INBOUND_ANALYTICS_LOGS_ENABLED` kill-switch.
+ */
+@Injectable()
+export class InboundMailRequestLogger {
+  constructor(
+    private readonly requestLogRepository: RequestLogRepository,
+    private readonly traceLogRepository: TraceLogRepository,
+    @Optional() private readonly logger?: PinoLogger
+  ) {
+    this.logger?.setContext(this.constructor.name);
+  }
+
+  isEnabled(): boolean {
+    return (
+      process.env.IS_ANALYTICS_LOGS_ENABLED === 'true' && process.env.IS_INBOUND_ANALYTICS_LOGS_ENABLED === 'true'
+    );
+  }
+
+  /**
+   * Writes the early `requests` row (`status_code: 202`) plus a
+   * `request_received` trace. Returns the generated `requestLogId` so callers
+   * can thread it onto the BullMQ payload for the worker to link completion
+   * traces.
+   *
+   * Returns `null` if the feature flags are disabled or the write fails — the
+   * caller should still proceed with normal mail processing in that case.
+   */
+  async logReceived(context: InboundReceivedContext): Promise<string | null> {
+    if (!this.isEnabled()) {
+      return null;
+    }
+
+    const requestLogId = `${this.requestLogRepository.identifierPrefix}${generateObjectId()}`;
+    const strategy = context.strategy ?? inferStrategyFromTo(context.toAddress);
+
+    try {
+      await this.requestLogRepository.create(
+        this.buildRequestLog(requestLogId, context, strategy),
+        { organizationId: context.tenant.organizationId, environmentId: context.tenant.environmentId }
+      );
+    } catch (error) {
+      this.logger?.warn({ err: error, transactionId: context.tenant.transactionId }, 'Failed to write inbound-email request log');
+
+      return null;
+    }
+
+    await this.appendTrace({
+      requestLogId,
+      organizationId: context.tenant.organizationId,
+      environmentId: context.tenant.environmentId,
+      transactionId: context.tenant.transactionId,
+      eventType: 'request_received',
+      status: 'success',
+    });
+
+    return requestLogId;
+  }
+
+  /**
+   * Appends a `request_queued` trace after BullMQ enqueue succeeds.
+   */
+  async logQueued(context: InboundCompletionContext): Promise<void> {
+    if (!this.isEnabled() || !context.requestLogId) {
+      return;
+    }
+
+    await this.appendTrace({
+      requestLogId: context.requestLogId,
+      organizationId: context.organizationId,
+      environmentId: context.environmentId,
+      transactionId: context.transactionId,
+      eventType: 'request_queued',
+      status: 'success',
+      message: context.message,
+    });
+  }
+
+  /**
+   * Appends a `request_failed` trace when BullMQ enqueue fails (the SMTP
+   * server returns 451 to the sending MTA). Mail is not lost, but it never
+   * reaches the worker, so this is the terminal trace for that lifecycle.
+   */
+  async logQueueFailed(context: InboundCompletionContext): Promise<void> {
+    if (!this.isEnabled() || !context.requestLogId) {
+      return;
+    }
+
+    await this.appendTrace({
+      requestLogId: context.requestLogId,
+      organizationId: context.organizationId,
+      environmentId: context.environmentId,
+      transactionId: context.transactionId,
+      eventType: 'request_failed',
+      status: 'error',
+      message: context.message,
+    });
+  }
+
+  /**
+   * Worker-side terminal trace. Use `request_delivered` when the message was
+   * delivered (status 200), and `request_failed` for any other terminal state
+   * (422 unresolvable, 502 downstream failure, silent drop, exhausted retries).
+   *
+   * Use `status: 'warning'` for permanent customer-facing failures (422 / drops
+   * / bad request) and `status: 'error'` for downstream/system failures (502 /
+   * unhandled throws on final attempt).
+   */
+  async logCompleted(
+    context: InboundCompletionContext & { delivered: boolean; severity?: TraceStatus }
+  ): Promise<void> {
+    if (!this.isEnabled() || !context.requestLogId) {
+      return;
+    }
+
+    await this.appendTrace({
+      requestLogId: context.requestLogId,
+      organizationId: context.organizationId,
+      environmentId: context.environmentId,
+      transactionId: context.transactionId,
+      eventType: context.delivered ? 'request_delivered' : 'request_failed',
+      status: context.severity ?? (context.delivered ? 'success' : 'error'),
+      message: context.message,
+    });
+  }
+
+  private buildRequestLog(
+    requestLogId: string,
+    context: InboundReceivedContext,
+    strategy: InboundParseStrategy
+  ): Omit<RequestLog, 'expires_at'> {
+    const path = `/inbound-mail/${strategy}`;
+
+    return {
+      id: requestLogId,
+      created_at: LogRepository.formatDateTime64(new Date()),
+      path,
+      url: path,
+      url_pattern: path,
+      hostname: context.source.connection?.clientHostname || '',
+      status_code: INBOUND_REQUEST_STATUS.ACCEPTED,
+      method: INBOUND_METHOD,
+      transaction_id: context.tenant.transactionId,
+      ip: context.source.connection?.remoteAddress || '',
+      user_agent: '',
+      request_body: buildInboundRequestMetadata(context.source),
+      response_body: '',
+      user_id: '',
+      organization_id: context.tenant.organizationId,
+      environment_id: context.tenant.environmentId,
+      auth_type: '',
+      duration_ms: context.durationMs,
+      source: RequestLogSourceEnum.INBOUND_EMAIL,
+    };
+  }
+
+  private async appendTrace(params: {
+    requestLogId: string;
+    organizationId: string;
+    environmentId: string;
+    transactionId: string;
+    eventType: 'request_received' | 'request_queued' | 'request_delivered' | 'request_failed';
+    status: TraceStatus;
+    message?: string;
+  }): Promise<void> {
+    const trace: RequestTraceInput = {
+      created_at: LogRepository.formatDateTime64(new Date()),
+      organization_id: params.organizationId,
+      environment_id: params.environmentId,
+      user_id: '',
+      subscriber_id: '',
+      external_subscriber_id: '',
+      raw_data: '',
+      entity_id: params.requestLogId,
+      workflow_run_identifier: '',
+      workflow_id: '',
+      provider_id: '',
+      event_type: params.eventType,
+      title: mapEventTypeToTitle(params.eventType),
+      status: params.status,
+      message: params.message ?? '',
+    };
+
+    try {
+      await this.traceLogRepository.createRequest([trace]);
+    } catch (error) {
+      this.logger?.warn(
+        { err: error, requestLogId: params.requestLogId, eventType: params.eventType },
+        'Failed to write inbound-email request trace'
+      );
+    }
+  }
+}
+
+function inferStrategyFromTo(toAddress: string): InboundParseStrategy {
+  return toAddress.includes('-nv-e=') ? 'reply-to' : 'domain-route';
+}

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-tenant.resolver.spec.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-tenant.resolver.spec.ts
@@ -1,0 +1,92 @@
+import { DomainRepository } from '@novu/dal';
+import { PinoLogger } from 'nestjs-pino';
+import { InboundMailTenantResolver } from './inbound-mail-tenant.resolver';
+
+describe('InboundMailTenantResolver', () => {
+  let domainRepository: jest.Mocked<Pick<DomainRepository, 'findByName'>>;
+  let pinoLogger: jest.Mocked<PinoLogger>;
+  let resolver: InboundMailTenantResolver;
+
+  beforeEach(() => {
+    domainRepository = {
+      findByName: jest.fn(),
+    } as any;
+    pinoLogger = {
+      setContext: jest.fn(),
+      warn: jest.fn(),
+    } as any;
+    resolver = new InboundMailTenantResolver(domainRepository as unknown as DomainRepository, pinoLogger);
+  });
+
+  describe('reply-to addresses', () => {
+    it('extracts environmentId and transactionId from the address', async () => {
+      const result = await resolver.resolve('parse+txn-nv-e=env_1@reply.novu.co', '<msg-id@example.com>');
+
+      expect(result).toEqual({
+        organizationId: '',
+        environmentId: 'env_1',
+        transactionId: 'txn',
+      });
+      expect(domainRepository.findByName).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a deterministic transactionId when the address is malformed', async () => {
+      const result = await resolver.resolve('parse-nv-e=garbage@reply.novu.co', '<msg-id@example.com>');
+
+      expect(result.organizationId).toBe('');
+      expect(result.environmentId).toBe('');
+      expect(result.transactionId).toBe('msg-id@example.com');
+    });
+  });
+
+  describe('domain-route addresses', () => {
+    it('resolves organization and environment from DomainRepository', async () => {
+      domainRepository.findByName.mockResolvedValueOnce({
+        _id: 'd_1',
+        name: 'customer.com',
+        status: 'verified',
+        mxRecordConfigured: true,
+        _environmentId: 'env_1',
+        _organizationId: 'org_1',
+        data: {},
+      } as any);
+
+      const result = await resolver.resolve('support@customer.com', '<msg-id@example.com>');
+
+      expect(domainRepository.findByName).toHaveBeenCalledWith('customer.com');
+      expect(result).toEqual({
+        organizationId: 'org_1',
+        environmentId: 'env_1',
+        transactionId: 'msg-id@example.com',
+      });
+    });
+
+    it('returns empty tenant when the domain is unknown', async () => {
+      domainRepository.findByName.mockResolvedValueOnce(null);
+
+      const result = await resolver.resolve('support@unknown.com', '<msg-id@example.com>');
+
+      expect(result.organizationId).toBe('');
+      expect(result.environmentId).toBe('');
+      expect(result.transactionId).toBe('msg-id@example.com');
+    });
+
+    it('does not throw when the DB lookup fails', async () => {
+      domainRepository.findByName.mockRejectedValueOnce(new Error('mongo down'));
+
+      const result = await resolver.resolve('support@customer.com', '<msg-id@example.com>');
+
+      expect(result.organizationId).toBe('');
+      expect(result.environmentId).toBe('');
+      expect(pinoLogger.warn).toHaveBeenCalled();
+    });
+  });
+
+  it('generates a synthetic transactionId when messageId is missing', async () => {
+    domainRepository.findByName.mockResolvedValueOnce(null);
+
+    const result = await resolver.resolve('support@example.com', undefined);
+
+    expect(result.transactionId).toMatch(/^inbound_/);
+  });
+});

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-tenant.resolver.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-tenant.resolver.ts
@@ -1,0 +1,86 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { DomainRepository } from '@novu/dal';
+import { generateObjectId } from '../../utils/generate-id';
+import { PinoLogger } from '../../logging';
+import { inferInboundParseStrategy, parseReplyToAddress } from './inbound-request-metadata';
+
+/**
+ * Tenant context for an inbound mail message at the time it is first logged
+ * (in `apps/inbound-mail`). The values are best-effort:
+ *
+ * - reply-to addresses encode `environmentId` in the local-part, so we can
+ *   resolve it without a DB lookup; `organizationId` requires a job lookup
+ *   that the worker performs later
+ * - domain-route addresses resolve org+env from a globally-unique domain name
+ * - everything else (malformed addresses, unknown domains) returns empty
+ *   strings so the row is still written and can be surfaced once tenant
+ *   context is known
+ */
+export interface InboundMailTenant {
+  organizationId: string;
+  environmentId: string;
+  transactionId: string;
+}
+
+@Injectable()
+export class InboundMailTenantResolver {
+  constructor(
+    @Optional() private readonly domainRepository?: DomainRepository,
+    @Optional() private readonly logger?: PinoLogger
+  ) {
+    this.logger?.setContext(this.constructor.name);
+  }
+
+  /**
+   * Resolves the tenant context to scope the early request log row.
+   *
+   * `transactionId` falls back to a deterministic id derived from the RFC 5322
+   * Message-ID so retries of the same email collapse onto one logical request.
+   * The `req_` request log id itself is generated separately (and is the
+   * dedup key inside ClickHouse).
+   */
+  async resolve(toAddress: string, messageId: string | undefined): Promise<InboundMailTenant> {
+    const strategy = inferInboundParseStrategy(toAddress);
+
+    if (strategy === 'reply-to') {
+      const parsed = parseReplyToAddress(toAddress);
+      if (parsed) {
+        return {
+          organizationId: '',
+          environmentId: parsed.environmentId,
+          transactionId: parsed.transactionId,
+        };
+      }
+
+      return { organizationId: '', environmentId: '', transactionId: this.fallbackTransactionId(messageId) };
+    }
+
+    const domainName = toAddress.split('@')[1]?.toLowerCase();
+    if (!domainName || !this.domainRepository) {
+      return { organizationId: '', environmentId: '', transactionId: this.fallbackTransactionId(messageId) };
+    }
+
+    try {
+      const domain = await this.domainRepository.findByName(domainName);
+
+      return {
+        organizationId: domain?._organizationId ?? '',
+        environmentId: domain?._environmentId ?? '',
+        transactionId: this.fallbackTransactionId(messageId),
+      };
+    } catch (error) {
+      this.logger?.warn(
+        { err: error, domainName },
+        'Failed to resolve inbound mail tenant from domain — proceeding with empty tenant context'
+      );
+
+      return { organizationId: '', environmentId: '', transactionId: this.fallbackTransactionId(messageId) };
+    }
+  }
+
+  private fallbackTransactionId(messageId: string | undefined): string {
+    const cleaned = messageId?.replace(/[<>]/g, '').trim();
+
+    return cleaned || `inbound_${generateObjectId()}`;
+  }
+}

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-tenant.resolver.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-mail-tenant.resolver.ts
@@ -1,7 +1,7 @@
 import { Injectable, Optional } from '@nestjs/common';
 import { DomainRepository } from '@novu/dal';
-import { generateObjectId } from '../../utils/generate-id';
 import { PinoLogger } from '../../logging';
+import { generateObjectId } from '../../utils/generate-id';
 import { inferInboundParseStrategy, parseReplyToAddress } from './inbound-request-metadata';
 
 /**

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-request-metadata.spec.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-request-metadata.spec.ts
@@ -1,0 +1,65 @@
+import {
+  buildInboundRequestMetadata,
+  inferInboundParseStrategy,
+  parseReplyToAddress,
+} from './inbound-request-metadata';
+
+describe('inbound-request-metadata', () => {
+  describe('inferInboundParseStrategy', () => {
+    it('returns reply-to when the local-part encodes an environmentId', () => {
+      expect(inferInboundParseStrategy('parse+txn-nv-e=env_1@reply.novu.co')).toBe('reply-to');
+    });
+
+    it('returns domain-route for plain addresses', () => {
+      expect(inferInboundParseStrategy('support@customer.com')).toBe('domain-route');
+    });
+  });
+
+  describe('parseReplyToAddress', () => {
+    it('splits valid reply-to addresses', () => {
+      expect(parseReplyToAddress('parse+txn-nv-e=env_1@reply.novu.co')).toEqual({
+        domain: 'reply.novu.co',
+        transactionId: 'txn',
+        environmentId: 'env_1',
+      });
+    });
+
+    it('returns null for plain domain-route addresses', () => {
+      expect(parseReplyToAddress('support@customer.com')).toBeNull();
+    });
+
+    it('returns null when the metadata segment is missing', () => {
+      expect(parseReplyToAddress('parse@reply.novu.co')).toBeNull();
+    });
+
+    it('returns null when environmentId is missing', () => {
+      expect(parseReplyToAddress('parse+txn@reply.novu.co')).toBeNull();
+    });
+  });
+
+  describe('buildInboundRequestMetadata', () => {
+    it('omits raw html / text and includes only routing metadata', () => {
+      const json = buildInboundRequestMetadata({
+        subject: 'Hello',
+        messageId: 'msg-1',
+        from: [{ address: 'sender@example.com', name: 'Sender' }],
+        to: [{ address: 'parse@example.com', name: '' }],
+        dkim: 'pass',
+        spf: 'pass',
+        spamScore: 1.5,
+        attachments: [{ filename: 'a.pdf', contentType: 'application/pdf', size: 10 }],
+        connection: {} as any,
+      });
+
+      const metadata = JSON.parse(json);
+      expect(metadata.subject).toBe('Hello');
+      expect(metadata.from).toEqual(['sender@example.com']);
+      expect(metadata.to).toEqual(['parse@example.com']);
+      expect(metadata.dkim).toBe('pass');
+      expect(metadata.spamScore).toBe(1.5);
+      expect(metadata.attachments).toEqual([{ filename: 'a.pdf', contentType: 'application/pdf', size: 10 }]);
+      expect(metadata.html).toBeUndefined();
+      expect(metadata.text).toBeUndefined();
+    });
+  });
+});

--- a/libs/application-generic/src/services/inbound-mail-logging/inbound-request-metadata.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/inbound-request-metadata.ts
@@ -1,0 +1,93 @@
+import { IInboundParseDataDto } from '../../dtos/inbound-parse-job.dto';
+
+/**
+ * Path-style identifier for an inbound mail processing strategy. Mirrored into
+ * the `requests` table `path` column so the dashboard "Requests" view can group
+ * inbound mail by the resolution path that produced the row.
+ */
+export type InboundParseStrategy = 'reply-to' | 'domain-route' | 'agent';
+
+const REPLY_TO_DELIMITER = '-nv-e=';
+
+/**
+ * Light-weight inbound message shape that the request log can consume from
+ * either the worker (`InboundEmailParseCommand`) or the inbound-mail server
+ * (the finalized message before it is added to the queue).
+ */
+export type InboundRequestSource = Pick<
+  IInboundParseDataDto,
+  'subject' | 'messageId' | 'from' | 'to' | 'dkim' | 'spf' | 'spamScore' | 'attachments' | 'connection'
+>;
+
+/**
+ * Metadata snapshot of an inbound email for the `requests.request_body` column.
+ * Excludes raw `html`/`text` bodies (same boundary as inbound-mail APM). Includes
+ * routing fields (`from`, `to`, `subject`) so tenant-scoped Requests debugging works;
+ * retention follows the `requests` table TTL policy.
+ */
+export function buildInboundRequestMetadata(source: InboundRequestSource): string {
+  const metadata = {
+    subject: source.subject,
+    messageId: source.messageId,
+    from: source.from?.map((sender) => sender.address),
+    to: source.to?.map((recipient) => recipient.address),
+    dkim: source.dkim,
+    spf: source.spf,
+    spamScore: source.spamScore,
+    attachments: source.attachments?.map((attachment) => ({
+      filename: attachment.filename,
+      contentType: attachment.contentType,
+      size: attachment.size,
+    })),
+  };
+
+  return JSON.stringify(metadata);
+}
+
+/**
+ * Decide which strategy will process an address based on its shape. Used by
+ * inbound-mail to set the synthetic `path` on the early request log row before
+ * the worker actually runs the strategy.
+ *
+ * Note: `agent` is a worker-only sub-classification of domain-route — we cannot
+ * tell it apart at the inbound-mail layer without DB lookups, so domain-route
+ * is the conservative default. The worker emits its terminal trace with the
+ * resolved strategy, so the request detail view still shows the correct outcome.
+ */
+export function inferInboundParseStrategy(toAddress: string): InboundParseStrategy {
+  return toAddress.includes(REPLY_TO_DELIMITER) ? 'reply-to' : 'domain-route';
+}
+
+/**
+ * Reply-to addresses encode the Novu environmentId in the local-part:
+ *   parse+{transactionId}-nv-e={environmentId}@{domain}
+ *
+ * Returns null when the address is malformed; callers should treat the message
+ * as untenant-scoped (the row is still created so the message is not lost).
+ */
+export function parseReplyToAddress(address: string): {
+  domain: string;
+  transactionId: string;
+  environmentId: string;
+} | null {
+  if (!address) {
+    return null;
+  }
+
+  const [user, domain] = address.split('@');
+  if (!user || !domain) {
+    return null;
+  }
+
+  const toMetaIds = user.split('+')[1];
+  if (!toMetaIds) {
+    return null;
+  }
+
+  const [transactionId, environmentId] = toMetaIds.split(REPLY_TO_DELIMITER);
+  if (!transactionId || !environmentId) {
+    return null;
+  }
+
+  return { domain, transactionId, environmentId };
+}

--- a/libs/application-generic/src/services/inbound-mail-logging/index.ts
+++ b/libs/application-generic/src/services/inbound-mail-logging/index.ts
@@ -1,0 +1,3 @@
+export * from './inbound-mail-request-logger';
+export * from './inbound-mail-tenant.resolver';
+export * from './inbound-request-metadata';

--- a/libs/application-generic/src/services/index.ts
+++ b/libs/application-generic/src/services/index.ts
@@ -24,6 +24,7 @@ export * from './helper-service';
 export * from './http-client';
 export * from './in-memory-lru-cache';
 export * from './in-memory-provider';
+export * from './inbound-mail-logging';
 export {
   MessageInteractionResult,
   MessageInteractionService,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1237,6 +1237,9 @@ importers:
       '@novu/application-generic':
         specifier: workspace:*
         version: link:../../libs/application-generic
+      '@novu/dal':
+        specifier: workspace:*
+        version: link:../../libs/dal
       '@novu/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -31659,7 +31662,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       kysely: 0.28.17
       nanostores: 1.2.0
@@ -45416,7 +45419,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.6
       jose: 6.1.3
       kysely: 0.28.17
@@ -45434,15 +45437,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.2(zod@4.3.5):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Move the inbound-email `requests` row creation from the worker into `apps/inbound-mail` so the row is written **immediately after attachment processing, before the BullMQ enqueue**. Worker crashes, exhausted retries, and silent shared-agent drops can no longer skip the analytics record.

## Lifecycle

```mermaid
sequenceDiagram
    participant MTA as Sending_MTA
    participant IM as inbound-mail
    participant CH as ClickHouse
    participant Redis as BullMQ
    participant W as worker

    MTA->>IM: SMTP DATA
    IM->>IM: parse + attachments
    IM->>CH: requests row (202) + request_received
    IM->>Redis: enqueue with requestLogId
    alt queue success
        IM->>CH: request_queued
        IM-->>MTA: 250 OK
    else queue failure
        IM->>CH: request_failed
        IM-->>MTA: 451 retry
    end
    Redis->>W: dequeue
    alt delivery success
        W->>CH: request_delivered
    else terminal failure
        W->>CH: request_failed
    end
```

## What changed

- **`libs/application-generic/src/services/inbound-mail-logging/`** — new `InboundMailRequestLogger`, `InboundMailTenantResolver`, and metadata helpers shared by both services.
- **`apps/inbound-mail`** — wires `ClickHouseService` + `DalService` + `DomainRepository` behind the existing `IS_ANALYTICS_LOGS_ENABLED` / `IS_INBOUND_ANALYTICS_LOGS_ENABLED` flags; calls `logReceived` between attachment processing and `postQueue`, then `logQueued` / `logQueueFailed` around the BullMQ `add`.
- **Queue payload** — `IInboundParseDataDto` now carries `requestLogId?: string` so the worker can append its terminal trace.
- **`apps/worker`** — `LogInboundEmailRequest` becomes trace-only (`request_delivered` / `request_failed`). `InboundEmailParse` now writes a terminal trace for every exit path: 200 (success), 422 (warning), 502 (error), `BadRequestException`, `InboundParseDroppedError`. A new `failed` event handler on `InboundParseWorker` covers unhandled exceptions on the final BullMQ attempt (5/5).
- **Trace schema** — adds `request_delivered` event type + title; status is `success` / `warning` (4xx, non-retriable) / `error` (5xx, retriable).
- **Silent drops** — the shared-agent inbox now throws `InboundParseDroppedError` instead of returning `undefined`, so every drop produces a trace with the reason.

`status_code` on the early row is `202` (accepted for processing). Final outcome (`200` / `422` / `502`) lives in the terminal trace in the request detail view. The existing dashboard list keeps its filter semantics; surfacing terminal status in the list view is a separate follow-up.

All analytics writes are best-effort and never block SMTP acceptance.


### Environment variable update
**inbound-mail**
IS_ANALYTICS_LOGS_ENABLED=true
IS_INBOUND_ANALYTICS_LOGS_ENABLED=true
MONGO_URL
CLICK_HOUSE_URL
CLICK_HOUSE_DATABASE
CLICK_HOUSE_USER
CLICK_HOUSE_PASSWORD
LAUNCH_DARKLY_SDK_KEY

**worker**
IS_INBOUND_ANALYTICS_LOGS_ENABLED=true

**dashboard**
VITE_IS_INBOUND_LOGS_ENABLED=true


## Testing

- ✅ `pnpm --filter @novu/application-generic build`
- ✅ `pnpm --filter @novu/worker build`
- ✅ `pnpm --filter @novu/inbound-mail build`
- ✅ `pnpm --filter @novu/worker test --grep "LogInboundEmailRequest|Should handle the new arrived mail"` — 14 passing (8 new + 6 existing)
- ✅ `PORT=2525 pnpm --filter @novu/inbound-mail test` — 26 passing (3 new SMTP integration tests + 23 existing; pre-existing `Cannot obliterate queue with active jobs` failure is unrelated to this change)
- ⚠️ `pnpm --filter @novu/application-generic jest` — pre-existing jest-environment-node version mismatch in this package prevents the new specs from running locally; they follow the package's existing jest style and will run once the upstream config is fixed.

Manual end-to-end testing (SMTP → worker → ClickHouse) was not performed: it requires the full SMTP stack plus live ClickHouse and the analytics feature flags toggled on, which is more invasive than the SMTP integration test already covers.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3379748-1b5e-4293-8f6e-fee6adaa13d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3379748-1b5e-4293-8f6e-fee6adaa13d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the inbound-mail `requests` row creation from the BullMQ worker into `apps/inbound-mail` so that the analytics record is written immediately after attachment processing, before the job is enqueued. Worker crashes, exhausted retries, and silent shared-agent drops can no longer cause a missing analytics row.

- **Early logging pipeline** (`InboundMailRequestLogger`, `InboundMailTenantResolver`, `InboundRequestMetadata` in `libs/application-generic`) centralises all write logic; `apps/inbound-mail` calls `logReceived` → `logQueued`/`logQueueFailed`, and the worker calls `logCompleted` via the trimmed `LogInboundEmailRequest` usecase.
- **Silent drops now throw** — all `return undefined` paths in `DomainRouteStrategy`'s shared-agent handler are replaced by `InboundParseDroppedError` throws so every drop produces a traceable `request_failed` event.
- **Worker safety net** — a `failed` event handler on `InboundParseWorker` writes a terminal trace when BullMQ exhausts retries for unhandled exceptions; two issues affect correctness: `BadRequestException` is re-thrown after trace write (causing retry loops and duplicate traces), and `InboundParseProcessingError` also produces duplicate traces on the final attempt because both the usecase catch block and the safety net fire independently.

<h3>Confidence Score: 3/5</h3>

The SMTP acceptance path is safe and best-effort analytics writes never block mail delivery, but the worker-side trace deduplication logic has gaps that will produce incorrect analytics data for certain error paths.

The `BadRequestException` handler writes a terminal trace but does not `return`, so BullMQ retries the job and duplicate traces accumulate on every retry. Separately, `InboundParseProcessingError` on the final retry gets two conflicting terminal traces — one from the usecase catch block (with correct org/env) and one from the safety net (with empty strings).

apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts and apps/worker/src/app/workflow/workers/inbound-parse.worker.service.ts need attention for the trace-deduplication issues.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts | Rewired terminal trace writes to delegate to InboundMailRequestLogger; missing `return` after BadRequestException trace means non-retriable errors are re-thrown and re-queued, producing duplicate traces per retry. |
| apps/worker/src/app/workflow/workers/inbound-parse.worker.service.ts | Adds a BullMQ `failed` safety-net handler; the handler fires unconditionally on the final attempt, causing duplicate terminal traces for InboundParseProcessingError that already wrote a trace inside the usecase before re-throwing. |
| libs/application-generic/src/services/inbound-mail-logging/inbound-mail-request-logger.ts | New shared logger for early request row + lifecycle traces; cleanly extracted from the old worker usecase, feature-flag guarded, and best-effort (failures never propagate). |
| apps/inbound-mail/src/server/inbound-mail.service.ts | Adds optional analytics initialization (ClickHouse + MongoDB) behind feature flags; initialization failures are caught and logged without blocking SMTP acceptance. |
| apps/inbound-mail/src/server/index.ts | Inserts logInboundMailReceived before postQueue and emitQueueLifecycleTrace after; also exports __testInboundMailService from production code as a test backdoor. |
| libs/application-generic/src/services/inbound-mail-logging/inbound-mail-tenant.resolver.ts | New tenant resolver for early logging; handles reply-to and domain-route strategies with graceful fallback to empty strings on DB errors. |
| apps/worker/src/app/workflow/usecases/inbound-email-parse/log-inbound-email-request.usecase.ts | Simplified to only write worker-side terminal traces by delegating to InboundMailRequestLogger; correctly no-ops when requestLogId is absent for backward compat. |
| apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts | Converts all silent `return undefined` drops in the shared-agent path to InboundParseDroppedError throws; enables tracing of previously invisible drops. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MTA as Sending MTA
    participant IM as inbound-mail
    participant CH as ClickHouse
    participant Redis as BullMQ
    participant W as Worker

    MTA->>IM: SMTP DATA
    IM->>IM: parse + attachments
    IM->>CH: requests row (202) + request_received
    IM->>Redis: enqueue with requestLogId
    alt queue success
        IM->>CH: request_queued (fire-and-forget)
        IM-->>MTA: 250 OK
    else queue failure
        IM->>CH: request_failed
        IM-->>MTA: 451 retry
    end
    Redis->>W: dequeue
    alt outcome resolved (200)
        W->>CH: request_delivered via logCompleted
    else InboundParseProcessingError (re-thrown)
        W->>CH: request_failed via logCompleted
        W->>CH: duplicate request_failed via safety net (final attempt)
    else BadRequestException (missing return)
        W->>CH: request_failed per retry attempt
        W->>Redis: BullMQ retries non-retriable job
    else InboundParseDroppedError
        W->>CH: request_failed warning (returns, no retry)
    else unhandled exception
        W->>Redis: BullMQ retries
        W->>CH: request_failed via safety net (final attempt only)
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Finbound-email-parse%2Finbound-email-parse.usecase.ts%3A89-101%0A**%60BadRequestException%60%20falls%20through%20to%20%60throw%20error%60%20%E2%80%94%20BullMQ%20will%20retry%20the%20job%20and%20write%20duplicate%20traces**%0A%0AThe%20%60BadRequestException%60%20block%20writes%20a%20terminal%20%60request_failed%60%20trace%20but%20does%20**not**%20%60return%60%20afterwards%2C%20so%20execution%20falls%20through%20to%20the%20unconditional%20%60throw%20error%60%20on%20line%20100.%20BullMQ%20will%20then%20retry%20the%20job%3B%20on%20every%20subsequent%20attempt%20the%20usecase%20catches%20the%20same%20%60BadRequestException%60%2C%20writes%20another%20trace%2C%20and%20re-throws%20again.%20On%20the%20final%20exhausted%20attempt%20the%20safety%20net%20in%20%60InboundParseWorker%60%20fires%20a%20third%20time.%20The%20design%20doc%20comments%20this%20path%20as%20%22non-retriable%20%28malformed%20address%20%2F%20unknown%20domain%29%22%2C%20but%20the%20missing%20%60return%60%20makes%20it%20retriable%20in%20practice.%20Compare%20with%20the%20%60InboundParseDroppedError%60%20handler%20directly%20above%2C%20which%20does%20%60return%60%20after%20logging.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fworkers%2Finbound-parse.worker.service.ts%3A46-99%0A**Safety%20net%20fires%20for%20%60InboundParseProcessingError%60%20on%20the%20final%20attempt%20%E2%80%94%20duplicate%20terminal%20trace%20with%20empty%20org%2Fenv**%0A%0AThe%20%60failed%60%20event%20handler%20fires%20for%20every%20failure%20that%20reaches%20BullMQ's%20final%20attempt%2C%20including%20%60InboundParseProcessingError%60.%20Since%20%60InboundEmailParse.execute%28%29%60%20catches%20%60InboundParseProcessingError%60%2C%20writes%20a%20trace%20%28with%20the%20correct%20%60organizationId%60%2F%60environmentId%60%20from%20the%20outcome%29%2C%20and%20then%20re-throws%2C%20BullMQ%20still%20marks%20the%20job%20as%20failed.%20On%20the%20final%20attempt%20the%20usecase%20already%20wrote%20a%20%60request_failed%60%20trace%20with%20outcome%20context%3B%20then%20this%20safety%20net%20fires%20and%20writes%20a%20second%20%60request_failed%60%20trace%20with%20%60organizationId%3A%20''%60%20and%20%60environmentId%3A%20''%60.%20The%20result%20is%20two%20conflicting%20terminal%20traces%20in%20the%20dashboard%20for%20every%20%60InboundParseProcessingError%60%20that%20exhausts%20its%20retry%20budget.%20The%20safety%20net%20was%20intended%20for%20unhandled%20exceptions%20that%20never%20reach%20the%20usecase%20catch%20block%2C%20but%20it%20lacks%20a%20signal%20to%20distinguish%20that%20case.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Finbound-mail%2Fsrc%2Fserver%2Findex.ts%3A33-39%0A**Test-only%20backdoor%20exported%20from%20production%20module**%0A%0A%60__testInboundMailService%60%20is%20exported%20from%20the%20module%20that%20is%20the%20main%20entry%20point%20of%20the%20%60inbound-mail%60%20service%20so%20tests%20can%20inject%20mock%20%60requestLogger%60%2F%60tenantResolver%60.%20Exporting%20internal%20state%20from%20a%20production%20file%20couples%20the%20test%20fixture%20to%20the%20runtime%20module%20graph%3B%20if%20this%20file%20is%20imported%20by%20anything%20other%20than%20tests%20in%20CI%20the%20export%20pollutes%20the%20public%20surface.%20Consider%20injecting%20the%20service%20instance%20via%20a%20dedicated%20test-helper%20module%20or%20using%20dependency%20injection%20rather%20than%20exporting%20module-level%20state.%0A%0A&pr=11391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts:89-101
**`BadRequestException` falls through to `throw error` — BullMQ will retry the job and write duplicate traces**

The `BadRequestException` block writes a terminal `request_failed` trace but does **not** `return` afterwards, so execution falls through to the unconditional `throw error` on line 100. BullMQ will then retry the job; on every subsequent attempt the usecase catches the same `BadRequestException`, writes another trace, and re-throws again. On the final exhausted attempt the safety net in `InboundParseWorker` fires a third time. The design doc comments this path as "non-retriable (malformed address / unknown domain)", but the missing `return` makes it retriable in practice. Compare with the `InboundParseDroppedError` handler directly above, which does `return` after logging.

### Issue 2 of 3
apps/worker/src/app/workflow/workers/inbound-parse.worker.service.ts:46-99
**Safety net fires for `InboundParseProcessingError` on the final attempt — duplicate terminal trace with empty org/env**

The `failed` event handler fires for every failure that reaches BullMQ's final attempt, including `InboundParseProcessingError`. Since `InboundEmailParse.execute()` catches `InboundParseProcessingError`, writes a trace (with the correct `organizationId`/`environmentId` from the outcome), and then re-throws, BullMQ still marks the job as failed. On the final attempt the usecase already wrote a `request_failed` trace with outcome context; then this safety net fires and writes a second `request_failed` trace with `organizationId: ''` and `environmentId: ''`. The result is two conflicting terminal traces in the dashboard for every `InboundParseProcessingError` that exhausts its retry budget. The safety net was intended for unhandled exceptions that never reach the usecase catch block, but it lacks a signal to distinguish that case.

### Issue 3 of 3
apps/inbound-mail/src/server/index.ts:33-39
**Test-only backdoor exported from production module**

`__testInboundMailService` is exported from the module that is the main entry point of the `inbound-mail` service so tests can inject mock `requestLogger`/`tenantResolver`. Exporting internal state from a production file couples the test fixture to the runtime module graph; if this file is imported by anything other than tests in CI the export pollutes the public surface. Consider injecting the service instance via a dedicated test-helper module or using dependency injection rather than exporting module-level state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(inbound-mail): cover early request ..."](https://github.com/novuhq/novu/commit/4bfe9fd741ad2f622fc45f3d28c8791f0fc963fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34880853)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->