### PR TITLE
chore(dashboard): remove unused patches directory from Dockerfile

### DIFF
--- a/apps/dashboard/dockerfile
+++ b/apps/dashboard/dockerfile
@@ -8,7 +8,6 @@ RUN npm --no-update-notifier --no-fund --global install pnpm@11.0.9
 
 COPY .npmrc .
 COPY package.json .
-COPY patches ./patches
 
 COPY apps/dashboard ./apps/dashboard
 COPY libs ./libs


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The dashboard's Dockerfile builder stage no longer copies an unused `patches` directory during the image build process. This cleanup removes unnecessary steps from the containerization workflow without affecting any application functionality or subsequent build stages.

## Affected areas

**dashboard**: Removed an unused COPY instruction for the patches directory from the Dockerfile builder stage, simplifying the image build process.

## Testing

No tests are needed. This is a configuration cleanup that removes an unused build step with no functional impact on the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
