### PR TITLE
chore(dashboard): remove .npmrc copy from Dockerfile

### DIFF
--- a/apps/dashboard/dockerfile
+++ b/apps/dashboard/dockerfile
@@ -6,7 +6,6 @@ WORKDIR /usr/src/app
 
 RUN npm --no-update-notifier --no-fund --global install pnpm@11.0.9
 
-COPY .npmrc .
 COPY package.json .
 
 COPY apps/dashboard ./apps/dashboard


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Removed the `COPY .npmrc .` instruction from the dashboard Dockerfile's builder stage. The `.npmrc` file does not exist in the repository root (only `.npmrc-cloud` is present), making this copy operation unnecessary and potentially problematic during builds.

## Affected areas

**dashboard**: Removed a non-functional COPY command from the builder stage of the Dockerfile, simplifying the image build process and eliminating a reference to a non-existent file.

## Testing

No tests required. This is a build configuration cleanup that removes a reference to a file that doesn't exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
