### PR TITLE
fix(dashboard): alias CLI anonymous id for Connect funnel fixes NV-7938

### DIFF
--- a/apps/dashboard/src/api/telemetry.ts
+++ b/apps/dashboard/src/api/telemetry.ts
@@ -8,3 +8,11 @@ export const measure = async (event: string, data?: Record<string, unknown>): Pr
     },
   });
 };
+
+export const identifyTelemetry = async (anonymousId: string): Promise<void> => {
+  await post('/telemetry/identify', {
+    body: {
+      anonymousId,
+    },
+  });
+};

--- a/apps/dashboard/src/context/identity-provider.tsx
+++ b/apps/dashboard/src/context/identity-provider.tsx
@@ -1,7 +1,11 @@
 import { setUser as sentrySetUser, setTags as setSentryTags } from '@sentry/react';
 import { useLDClient } from 'launchdarkly-react-client-sdk';
 import { useEffect, useRef } from 'react';
+import { identifyTelemetry } from '@/api/telemetry';
 import { getRegionConfig, useRegion } from '@/context/region';
+import {
+  readPersistedCliOnboardingSessionId,
+} from '@/utils/cli-onboarding-identity';
 import { useAuth } from './auth/hooks';
 import { useCustomerIo } from './customer-io/hooks';
 import { useSegment } from './segment/hooks';
@@ -15,6 +19,28 @@ export function IdentityProvider({ children }: { children: React.ReactNode }) {
   const { currentUser, currentOrganization } = useAuth();
   const { selectedRegion } = useRegion();
   const hasIdentifiedOrg = useRef(false);
+  const hasAliasedCliOnboarding = useRef(false);
+
+  useEffect(() => {
+    const cliOnboardingSessionId = readPersistedCliOnboardingSessionId();
+
+    if (!cliOnboardingSessionId) return;
+
+    segment.setAnonymousId(cliOnboardingSessionId);
+  }, [segment]);
+
+  useEffect(() => {
+    if (!currentUser?._id || hasAliasedCliOnboarding.current) return;
+
+    const cliOnboardingSessionId = readPersistedCliOnboardingSessionId();
+
+    if (!cliOnboardingSessionId) return;
+
+    hasAliasedCliOnboarding.current = true;
+    segment.setAnonymousId(cliOnboardingSessionId);
+    segment.alias(cliOnboardingSessionId, currentUser._id);
+    void identifyTelemetry(cliOnboardingSessionId).catch(() => undefined);
+  }, [currentUser?._id, segment]);
 
   useEffect(() => {
     if (!currentOrganization || !currentUser) return;

--- a/apps/dashboard/src/hooks/use-telemetry.ts
+++ b/apps/dashboard/src/hooks/use-telemetry.ts
@@ -3,6 +3,7 @@ import * as mixpanel from 'mixpanel-browser';
 import { useCallback } from 'react';
 import { measure } from '@/api/telemetry';
 import { IS_SELF_HOSTED, MIXPANEL_KEY } from '@/config';
+import { readPersistedCliOnboardingSessionId } from '@/utils/cli-onboarding-identity';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 export const useTelemetry = () => {
@@ -15,6 +16,7 @@ export const useTelemetry = () => {
       if (IS_SELF_HOSTED) return;
 
       const mixpanelEnabled = !!MIXPANEL_KEY;
+      const onboardingSessionId = readPersistedCliOnboardingSessionId();
 
       if (mixpanelEnabled) {
         // @ts-expect-error missing from types
@@ -22,7 +24,13 @@ export const useTelemetry = () => {
 
         data = {
           ...(data || {}),
+          ...(onboardingSessionId ? { onboardingSessionId } : {}),
           ...sessionReplayProperties,
+        };
+      } else if (onboardingSessionId) {
+        data = {
+          ...(data || {}),
+          onboardingSessionId,
         };
       }
 

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -32,6 +32,7 @@ import {
   withAppId,
   withOnboardingSource,
 } from '@/utils/onboarding-redirect';
+import { clearPersistedCliOnboardingSessionId } from '@/utils/cli-onboarding-identity';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 
@@ -243,6 +244,7 @@ export function AgentsSetupPage() {
       skippedFrom: 'agents-setup',
     });
     telemetry(TelemetryEvent.ONBOARDING_REDIRECT, { appId, from: 'skip' });
+    clearPersistedCliOnboardingSessionId();
 
     if (currentEnvironment?.slug) {
       goToPostOnboardingRoute(getPostOnboardingRoute(appId, currentEnvironment.slug), navigate);
@@ -256,6 +258,7 @@ export function AgentsSetupPage() {
   const handleNavigateToOverview = useCallback(() => {
     telemetry(TelemetryEvent.ONBOARDING_COMPLETED, buildOnboardingCompletionProps());
     telemetry(TelemetryEvent.ONBOARDING_REDIRECT, { appId, from: 'complete' });
+    clearPersistedCliOnboardingSessionId();
 
     if (currentEnvironment?.slug) {
       goToPostOnboardingRoute(getPostOnboardingRoute(appId, currentEnvironment.slug), navigate);

--- a/apps/dashboard/src/pages/cli-auth.tsx
+++ b/apps/dashboard/src/pages/cli-auth.tsx
@@ -12,11 +12,16 @@ import { Button } from '@/components/primitives/button';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { EnvironmentProvider } from '@/context/environment/environment-provider';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useSegment } from '@/context/segment';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchApiKeys } from '@/hooks/use-fetch-api-keys';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { clearPendingCliAuth, storePendingCliAuth } from '@/utils/cli-auth-pending';
+import {
+  persistCliOnboardingSessionId,
+  readActiveCliOnboardingSessionId,
+} from '@/utils/cli-onboarding-identity';
 import { clearConnectProvisioning } from '@/utils/connect';
 import { buildAfterSignOutUrl } from '@/utils/cross-product-sign-out';
 import { readOnboardingSessionId } from '@/utils/onboarding-session-id';
@@ -32,14 +37,23 @@ function isValidDeviceCode(deviceCode: string | null): deviceCode is string {
 export const CliAuthPage = () => {
   const { isLoaded, isSignedIn } = useClerkAuth();
   const [searchParams] = useSearchParams();
+  const segment = useSegment();
   const deviceCode = searchParams.get('device_code');
   const callerName = searchParams.get('name');
+  const onboardingSessionId = readOnboardingSessionId(searchParams);
 
   useEffect(() => {
     if (isValidDeviceCode(deviceCode)) {
       storePendingCliAuth(deviceCode, callerName);
     }
   }, [deviceCode, callerName]);
+
+  useEffect(() => {
+    if (!onboardingSessionId) return;
+
+    persistCliOnboardingSessionId(onboardingSessionId);
+    segment.setAnonymousId(onboardingSessionId);
+  }, [onboardingSessionId, segment]);
 
   useEffect(() => {
     clearConnectProvisioning();
@@ -82,7 +96,7 @@ function CliAuthContent() {
 
   const deviceCode = searchParams.get('device_code');
   const callerName = searchParams.get('name');
-  const onboardingSessionId = readOnboardingSessionId(searchParams);
+  const onboardingSessionId = readActiveCliOnboardingSessionId(readOnboardingSessionId(searchParams));
   const deviceCodeOk = isValidDeviceCode(deviceCode);
   const canReadApiKeys = has({ permission: PermissionsEnum.API_KEY_READ });
 

--- a/apps/dashboard/src/utils/cli-onboarding-identity.ts
+++ b/apps/dashboard/src/utils/cli-onboarding-identity.ts
@@ -1,0 +1,31 @@
+const CLI_ONBOARDING_SESSION_KEY = 'novu.cli.onboardingSessionId';
+
+export function persistCliOnboardingSessionId(sessionId: string): void {
+  try {
+    sessionStorage.setItem(CLI_ONBOARDING_SESSION_KEY, sessionId);
+  } catch {
+    // sessionStorage unavailable — alias will rely on URL param on /cli/auth only
+  }
+}
+
+export function readPersistedCliOnboardingSessionId(): string | undefined {
+  try {
+    const raw = sessionStorage.getItem(CLI_ONBOARDING_SESSION_KEY)?.trim();
+
+    return raw || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearPersistedCliOnboardingSessionId(): void {
+  try {
+    sessionStorage.removeItem(CLI_ONBOARDING_SESSION_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function readActiveCliOnboardingSessionId(urlSessionId?: string): string | undefined {
+  return urlSessionId ?? readPersistedCliOnboardingSessionId();
+}

--- a/packages/novu/src/commands/connect/analytics/events.ts
+++ b/packages/novu/src/commands/connect/analytics/events.ts
@@ -24,16 +24,32 @@ export const CONNECT_EVENTS = {
 
 export type ConnectEvent = (typeof CONNECT_EVENTS)[keyof typeof CONNECT_EVENTS];
 
+type ConnectAuthUser = {
+  id: string;
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+};
+
+export function aliasConnectSession(
+  analytics: AnalyticService,
+  anonymousId: string,
+  user: ConnectAuthUser
+): void {
+  analytics.alias({ previousId: anonymousId, userId: user.id });
+}
+
 export function trackConnect(
   analytics: AnalyticService,
   anonymousId: string | undefined,
   event: ConnectEvent | string,
-  data: Record<string, unknown> = {}
+  data: Record<string, unknown> = {},
+  userId?: string
 ): void {
   if (!anonymousId) return;
 
   analytics.track({
-    identity: { anonymousId },
+    identity: userId ? { userId, anonymousId } : { anonymousId },
     event,
     data,
   });

--- a/packages/novu/src/commands/connect/index.ts
+++ b/packages/novu/src/commands/connect/index.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import chalk from 'chalk';
 import { AnalyticService } from '../../services/analytics.service';
-import { CONNECT_EVENTS, trackConnect } from './analytics/events';
+import { aliasConnectSession, CONNECT_EVENTS, trackConnect } from './analytics/events';
 import { runConnectPipeline } from './pipeline/runner';
 import type { ConnectCommandOptions } from './types';
 import { createLoggingUI } from './ui/logging-ui';
@@ -34,14 +34,32 @@ async function loadInkUi(): Promise<UiBundle> {
 }
 
 export async function connectCommand(options: ConnectCommandOptions, anonymousId?: string): Promise<void> {
-  trackConnect(analytics, anonymousId, CONNECT_EVENTS.STARTED, {
+  let resolvedUserId: string | undefined;
+
+  const trackEvent = (event: string, data?: Record<string, unknown>) => {
+    trackConnect(
+      analytics,
+      anonymousId,
+      event,
+      { ...(data ?? {}), onboardingSessionId: anonymousId },
+      resolvedUserId
+    );
+  };
+
+  const onIdentityResolved = (user: { id: string; email?: string | null; firstName?: string | null; lastName?: string | null }) => {
+    if (!anonymousId || resolvedUserId) return;
+
+    aliasConnectSession(analytics, anonymousId, user);
+    resolvedUserId = user.id;
+  };
+
+  trackEvent(CONNECT_EVENTS.STARTED, {
     region: options.region,
     apiUrl: options.apiUrl,
     connectDashboardUrl: options.connectDashboardUrl,
     ci: !!options.ci,
     hasPrompt: !!options.prompt,
     skipSlack: !!options.skipSlack,
-    onboardingSessionId: anonymousId,
   });
 
   try {
@@ -51,8 +69,8 @@ export async function connectCommand(options: ConnectCommandOptions, anonymousId
         options,
         ui,
         onboardingSessionId: anonymousId,
-        onTrack: (event, data) =>
-          trackConnect(analytics, anonymousId, event, { ...(data ?? {}), onboardingSessionId: anonymousId }),
+        onTrack: trackEvent,
+        onIdentityResolved,
       });
       if (result.exitCode !== 0) process.exitCode = result.exitCode;
     } else {
@@ -62,15 +80,15 @@ export async function connectCommand(options: ConnectCommandOptions, anonymousId
         options,
         ui: mounted.ui,
         onboardingSessionId: anonymousId,
-        onTrack: (event, data) =>
-          trackConnect(analytics, anonymousId, event, { ...(data ?? {}), onboardingSessionId: anonymousId }),
+        onTrack: trackEvent,
+        onIdentityResolved,
       });
       const exitCode = (await mounted.done) || result.exitCode;
       if (exitCode !== 0) process.exitCode = exitCode;
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    trackConnect(analytics, anonymousId, CONNECT_EVENTS.ERROR, { message, onboardingSessionId: anonymousId });
+    trackEvent(CONNECT_EVENTS.ERROR, { message });
     console.error(chalk.red(`Connect failed: ${message}`));
     process.exitCode = 1;
   } finally {

--- a/packages/novu/src/commands/connect/pipeline/runner.ts
+++ b/packages/novu/src/commands/connect/pipeline/runner.ts
@@ -25,6 +25,7 @@ export interface ConnectPipelineInput {
   ui: ConnectUI;
   onboardingSessionId?: string;
   onTrack?: (event: string, data?: Record<string, unknown>) => void;
+  onIdentityResolved?: (user: NonNullable<ResolvedAuth['user']>) => void;
 }
 
 export interface ConnectPipelineResult {
@@ -51,6 +52,10 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
     });
     track(CONNECT_EVENTS.AUTH_COMPLETED, { source: auth.source, region: options.region, ...sessionProps });
     ui.authCompleted(auth.environmentName ?? null);
+
+    if (auth.user?.id) {
+      input.onIdentityResolved?.(auth.user);
+    }
 
     const client = createConnectApiClient({ apiUrl: auth.apiUrl, secretKey: auth.secretKey });
 

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -31,6 +31,9 @@ if (process.env.NODE_ENV === 'development') {
 }
 const anonymousIdLocalState = config.getValue('anonymousId');
 const anonymousId = anonymousIdLocalState || uuidv4();
+if (!anonymousIdLocalState) {
+  config.setValue('anonymousId', anonymousId);
+}
 const program = new Command();
 
 program.name('novu').description(`A CLI tool to interact with Novu Cloud`);

--- a/packages/novu/src/services/analytics.service.ts
+++ b/packages/novu/src/services/analytics.service.ts
@@ -69,7 +69,7 @@ export class AnalyticService {
   }: {
     data?: Record<string, unknown>;
     event: string;
-    identity: { userId: string } | { anonymousId: string };
+    identity: { userId: string } | { anonymousId: string } | { userId: string; anonymousId: string };
   }) {
     if (!this.isAnalyticsEnabled()) {
       return;


### PR DESCRIPTION
### What changed? Why was the change needed?

Connect CLI events (`Connect Started`, etc.) were tracked under a CLI-generated anonymous id, while dashboard signup, org provisioning, and onboarding events used a separate browser/user identity. Mixpanel could not stitch the full Connect onboarding funnel.

This PR aliases the CLI anonymous id to the Novu user after browser auth and keeps `onboardingSessionId` on dashboard telemetry until onboarding completes.

**CLI (`packages/novu`)**
- Persist `anonymousId` in configstore across runs
- Alias CLI anonymous id → Novu user id after device auth succeeds
- Track post-auth Connect events with both `userId` and `anonymousId`

**Dashboard**
- Persist `onboarding_session_id` from `/cli/auth` through sign-in redirects
- Alias CLI session → user in `IdentityProvider` (Segment/Mixpanel + `/telemetry/identify`)
- Attach `onboardingSessionId` to dashboard telemetry events during onboarding
- Clear persisted session on onboarding complete/skip

```mermaid
sequenceDiagram
  participant CLI as novu connect CLI
  participant Browser as Dashboard /cli/auth
  participant Segment as Segment / Mixpanel

  CLI->>Segment: track (anonymousId)
  CLI->>Browser: open auth URL ?onboarding_session_id=
  Browser->>Browser: persist session + setAnonymousId
  Browser->>Segment: alias(anonymousId, userId)
  Browser->>Segment: track onboarding events (userId)
  CLI->>Segment: track post-auth (userId + anonymousId)
```

Linear: [NV-7938](https://linear.app/novu/issue/NV-7938/alias-cli-anonymous-id-to-user-for-connect-onboarding-funnel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR unifies analytics identities across the Connect CLI and dashboard onboarding flows to enable end-to-end funnel tracking in Mixpanel. Previously, CLI analytics events were tracked separately from dashboard signup and onboarding events under different identities. The fix persists CLI session IDs in the browser, aliases them to user identities upon login, and enriches both CLI and dashboard events with cross-compatible identity data.

## Affected areas

**Dashboard**: Added client-side session persistence for CLI onboarding IDs via a new utility module (`cli-onboarding-identity.ts`). The identity provider now reads persisted session IDs, sets Segment's anonymous ID, and aliases the session to the authenticated user. The telemetry hook enriches all events with `onboardingSessionId` when present, and the agents setup page clears the persisted session when onboarding completes.

**CLI (packages/novu)**: Updated analytics event tracking to support dual identity payloads (`{ userId, anonymousId }`), added an `aliasConnectSession` helper to alias the CLI session after authentication, and wired identity resolution callbacks through the Connect pipeline. CLI now persists its anonymousId across runs and tracks post-auth events with both identities.

## Key technical decisions

- Alias runs immediately once `currentUser._id` is available during login, rather than waiting for full org resolution, to capture new signups initiated from the CLI.
- The `onboardingSessionId` persists in `sessionStorage` until setup completion or skip, serving as a fallback funnel property.
- Analytics identity type expanded to support `{ userId, anonymousId }` payloads simultaneously, moving away from either/or semantics.

## Testing

No new tests were added. This is analytics and identity plumbing; validation is planned via Mixpanel funnel analysis and manual QA of the auth and onboarding flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — analytics/identity plumbing only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Alias runs as soon as `currentUser._id` is available (does not wait for org resolution), so new signups mid–CLI-auth still stitch correctly.
- `onboardingSessionId` remains in sessionStorage until agents setup completes/skips, as a property-based funnel fallback.

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stitches the Connect CLI onboarding funnel in Mixpanel/Segment by aliasing the CLI-generated `anonymousId` to the Novu user ID in both the CLI (after device auth) and the dashboard (`IdentityProvider`), and persists `onboardingSessionId` across sign-in redirects via `sessionStorage` so it can be attached to every dashboard telemetry event until onboarding completes.

- **CLI**: generates and persists a stable `anonymousId` in the configstore, calls `alias` after successful device auth, and tracks post-auth events with both `userId` and `anonymousId`.
- **Dashboard**: introduces `cli-onboarding-identity.ts` for sessionStorage persistence; `CliAuthPage` writes the session ID on load; `IdentityProvider` calls `setAnonymousId` + `alias` once `currentUser._id` is known; `use-telemetry` attaches `onboardingSessionId` to every event; `agents-setup-page` clears the stored ID on complete/skip.

<h3>Confidence Score: 3/5</h3>

Analytics-only change that is safe for product functionality, but contains an incorrect alias path in a multi-user browser session that permanently corrupts Segment/Mixpanel profiles.

The sessionStorage key is only cleared in agents-setup-page (complete/skip), never on sign-out. Since sessionStorage survives full-page reloads within the same tab, if User A goes through /cli/auth, signs out before finishing onboarding, and User B signs in on the same tab, IdentityProvider will read the stale session ID and call segment.alias(userA_cliSession, userB_id). This permanently merges User A's CLI funnel events into User B's analytics profile in both Segment and Mixpanel — an irreversible write that corrupts tracking data for both users.

apps/dashboard/src/context/identity-provider.tsx — the alias effect reads sessionStorage without verifying the stored session ID belongs to the current sign-in session.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/context/identity-provider.tsx | Adds two new effects: one to set anonymous ID from sessionStorage on mount, and one to alias the CLI session to the user ID when auth resolves. Missing sign-out cleanup leaves stale sessionStorage data that can incorrectly alias a different user. |
| apps/dashboard/src/utils/cli-onboarding-identity.ts | New utility module exposing persist/read/clear/readActive helpers for the CLI onboarding session ID in sessionStorage. All four functions have appropriate try/catch guards for unavailable storage. |
| apps/dashboard/src/pages/cli-auth.tsx | Adds effect to persist the onboarding session ID from URL params into sessionStorage and call setAnonymousId at page load (even before auth redirect), and falls back to stored ID when URL param is absent via readActiveCliOnboardingSessionId. |
| packages/novu/src/commands/connect/index.ts | Refactors event tracking into a trackEvent closure that captures resolvedUserId by reference, and introduces onIdentityResolved callback to alias the session and populate resolvedUserId after device auth succeeds. |
| packages/novu/src/index.ts | Persists the generated anonymousId to the configstore so the same anonymous identity is reused across CLI invocations. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant CLI as novu CLI
  participant ConfigStore as ConfigStore
  participant Browser as Dashboard /cli/auth
  participant IP as IdentityProvider
  participant Segment as Segment / Mixpanel

  CLI->>ConfigStore: read/persist anonymousId
  CLI->>Segment: track STARTED (anonymousId)
  CLI->>Browser: "open /cli/auth?onboarding_session_id=anonymousId"

  Browser->>Browser: persistCliOnboardingSessionId(sessionId)
  Browser->>Segment: setAnonymousId(sessionId)

  Note over Browser: user signs in if needed (redirect preserves param)

  Browser->>IP: currentUser._id available
  IP->>Segment: setAnonymousId(sessionId)
  IP->>Segment: alias(sessionId to userId)
  IP->>Browser: POST /telemetry/identify(anonymousId)

  CLI->>Segment: alias(anonymousId to userId) CLI-side
  CLI->>Segment: track AUTH_COMPLETED (anonymousId)
  CLI->>Segment: track post-auth events (userId + anonymousId)

  Browser->>Segment: dashboard events with onboardingSessionId prop
  Browser->>Browser: clearPersistedCliOnboardingSessionId() on complete/skip
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcontext%2Fidentity-provider.tsx%3A32-43%0A**Stale%20CLI%20session%20ID%20aliased%20to%20wrong%20user%20after%20sign-out**%0A%0A%60clearPersistedCliOnboardingSessionId%60%20is%20only%20called%20in%20%60agents-setup-page%60%20%28complete%2Fskip%29%2C%20but%20never%20on%20sign-out.%20%60sessionStorage%60%20survives%20full-page%20reloads%20within%20the%20same%20tab%2C%20so%20if%20User%20A%20runs%20%60novu%20connect%60%2C%20authorizes%20via%20%60%2Fcli%2Fauth%60%20%28writing%20the%20session%20ID%20to%20%60sessionStorage%60%29%2C%20then%20signs%20out%20without%20completing%20onboarding%2C%20and%20User%20B%20signs%20in%20on%20the%20same%20tab%2C%20this%20effect%20fires%20with%20User%20B's%20%60currentUser._id%60%20but%20User%20A's%20stale%20%60cliOnboardingSessionId%60.%20%60segment.alias%28staleSessionId%2C%20userB._id%29%60%20is%20then%20called%2C%20merging%20User%20A's%20CLI%20events%20into%20User%20B's%20Mixpanel%2FSegment%20profile%20permanently.%0A%0A&pr=11396&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/context/identity-provider.tsx:32-43
**Stale CLI session ID aliased to wrong user after sign-out**

`clearPersistedCliOnboardingSessionId` is only called in `agents-setup-page` (complete/skip), but never on sign-out. `sessionStorage` survives full-page reloads within the same tab, so if User A runs `novu connect`, authorizes via `/cli/auth` (writing the session ID to `sessionStorage`), then signs out without completing onboarding, and User B signs in on the same tab, this effect fires with User B's `currentUser._id` but User A's stale `cliOnboardingSessionId`. `segment.alias(staleSessionId, userB._id)` is then called, merging User A's CLI events into User B's Mixpanel/Segment profile permanently.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard,novu): alias CLI anonymous..."](https://github.com/novuhq/novu/commit/9e3ff5f777c4c994e80edced0f0389109106d7fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34895837)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->