### PR TITLE
fix(api-service): provider-managed setup card redirect and per-subscriber vault fixes NV-7939

### DIFF
--- a/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
@@ -66,6 +66,10 @@ export interface ResolvedAgentConfig {
 
 const DEFAULT_REACTION_ON_RESOLVED: WellKnownEmoji = 'check';
 
+function isDuplicateKeyError(err: unknown): boolean {
+  return Boolean(err && typeof err === 'object' && 'code' in err && (err as { code: unknown }).code === 11000);
+}
+
 async function resolveReaction(
   value: string | null | undefined,
   defaultEmoji: WellKnownEmoji,
@@ -328,12 +332,48 @@ export class AgentConfigResolver {
       return null;
     }
 
-    const link = await this.agentIntegrationRepository.create({
-      _agentId: params.agentId,
-      _integrationId: params.integration._id,
-      _environmentId: params.environmentId,
-      _organizationId: params.organizationId,
-    });
+    let link: AgentIntegrationEntity;
+
+    try {
+      link = await this.agentIntegrationRepository.create({
+        _agentId: params.agentId,
+        _integrationId: params.integration._id,
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+      });
+    } catch (err) {
+      if (!isDuplicateKeyError(err)) {
+        throw err;
+      }
+
+      const winner = await this.agentIntegrationRepository.findOne(
+        {
+          _integrationId: params.integration._id,
+          _environmentId: params.environmentId,
+          _organizationId: params.organizationId,
+        },
+        '*'
+      );
+
+      if (!winner) {
+        throw err;
+      }
+
+      if (winner._agentId !== params.agentId) {
+        this.logger.warn(
+          {
+            agentId: params.agentId,
+            integrationIdentifier: params.integrationIdentifier,
+            linkedAgentId: winner._agentId,
+          },
+          'Inbound webhook targets an integration already linked to a different agent'
+        );
+
+        return null;
+      }
+
+      link = winner;
+    }
 
     this.logger.info(
       {

--- a/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
@@ -6,10 +6,12 @@ import {
   PinoLogger,
 } from '@novu/application-generic';
 import {
+  AgentIntegrationEntity,
   AgentIntegrationRepository,
   AgentRepository,
   ChannelConnectionRepository,
   ICredentialsEntity,
+  IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
 import { EmailProviderIdEnum } from '@novu/shared';
@@ -128,7 +130,7 @@ export class AgentConfigResolver {
       throw new UnprocessableEntityException(`Email channel is disabled for agent ${agentId}`);
     }
 
-    const agentIntegration = await this.agentIntegrationRepository.findOne(
+    let agentIntegration = await this.agentIntegrationRepository.findOne(
       {
         _environmentId: environmentId,
         _organizationId: organizationId,
@@ -138,7 +140,21 @@ export class AgentConfigResolver {
       '*'
     );
     if (!agentIntegration) {
-      throw new UnprocessableEntityException(`Agent ${agentId} is not linked to integration ${integrationIdentifier}`);
+      agentIntegration = await this.tryHealMissingAgentIntegrationLink({
+        agentId,
+        agentIdentifier: agent.identifier,
+        integration,
+        integrationIdentifier,
+        environmentId,
+        organizationId,
+        source: options.source,
+      });
+
+      if (!agentIntegration) {
+        throw new UnprocessableEntityException(
+          `Agent ${agentId} is not linked to integration ${integrationIdentifier}`
+        );
+      }
     }
 
     const platform = resolveAgentPlatform(integration.providerId);
@@ -166,14 +182,32 @@ export class AgentConfigResolver {
     }
 
     let connectionAccessToken: string | undefined;
-    const connection = await this.channelConnectionRepository.findOne({
-      _environmentId: environmentId,
-      _organizationId: organizationId,
-      integrationIdentifier,
-    });
-    if (connection) {
-      const decryptedAuth = decryptChannelConnectionAuth(connection.auth);
-      connectionAccessToken = decryptedAuth?.accessToken;
+    if (platform === AgentPlatformEnum.SLACK) {
+      connectionAccessToken = await this.resolveSlackBotToken(environmentId, organizationId, integrationIdentifier);
+
+      if (options.source === 'webhook_message') {
+        if (!credentials.signingSecret) {
+          throw new UnprocessableEntityException(
+            'Slack signing secret is missing. Complete Slack app setup (quick setup or paste credentials) for this integration.'
+          );
+        }
+
+        if (!connectionAccessToken) {
+          throw new UnprocessableEntityException(
+            'Slack workspace is not installed. Open the agent Slack setup guide and click Install to connect your workspace via OAuth.'
+          );
+        }
+      }
+    } else {
+      const connection = await this.channelConnectionRepository.findOne({
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        integrationIdentifier,
+      });
+      if (connection) {
+        const decryptedAuth = decryptChannelConnectionAuth(connection.auth);
+        connectionAccessToken = decryptedAuth?.accessToken;
+      }
     }
 
     // `connectedAt` is set the first time the platform actually delivers a
@@ -223,5 +257,94 @@ export class AgentConfigResolver {
       devBridgeUrl: agent.devBridgeUrl,
       devBridgeActive: agent.devBridgeActive,
     };
+  }
+
+  /**
+   * Workspace bot tokens live on channel connections (created by Slack OAuth). Pick the
+   * first connection for this integration that has an access token.
+   */
+  private async resolveSlackBotToken(
+    environmentId: string,
+    organizationId: string,
+    integrationIdentifier: string
+  ): Promise<string | undefined> {
+    const connections = await this.channelConnectionRepository.find(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        integrationIdentifier,
+      },
+      'auth'
+    );
+
+    for (const connection of connections) {
+      const decryptedAuth = decryptChannelConnectionAuth(connection.auth);
+      if (decryptedAuth?.accessToken) {
+        return decryptedAuth.accessToken;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Slack/Telegram setup can persist credentials and register a webhook URL before the
+   * dashboard link step completes, leaving an orphaned integration. On the first real
+   * inbound webhook, attach the integration to the agent when it is not linked anywhere
+   * else in this environment.
+   */
+  private async tryHealMissingAgentIntegrationLink(params: {
+    agentId: string;
+    agentIdentifier: string;
+    integration: IntegrationEntity;
+    integrationIdentifier: string;
+    environmentId: string;
+    organizationId: string;
+    source?: AgentConfigResolveSource;
+  }): Promise<AgentIntegrationEntity | null> {
+    if (params.source !== 'webhook_message') {
+      return null;
+    }
+
+    const existingForIntegration = await this.agentIntegrationRepository.findOne(
+      {
+        _integrationId: params.integration._id,
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+      },
+      ['_id', '_agentId']
+    );
+
+    if (existingForIntegration) {
+      this.logger.warn(
+        {
+          agentId: params.agentId,
+          integrationIdentifier: params.integrationIdentifier,
+          linkedAgentId: existingForIntegration._agentId,
+        },
+        'Inbound webhook targets an integration already linked to a different agent'
+      );
+
+      return null;
+    }
+
+    const link = await this.agentIntegrationRepository.create({
+      _agentId: params.agentId,
+      _integrationId: params.integration._id,
+      _environmentId: params.environmentId,
+      _organizationId: params.organizationId,
+    });
+
+    this.logger.info(
+      {
+        agentId: params.agentId,
+        agentIdentifier: params.agentIdentifier,
+        integrationIdentifier: params.integrationIdentifier,
+        integrationId: params.integration._id,
+      },
+      'Auto-linked orphaned integration to agent on first inbound webhook'
+    );
+
+    return link;
   }
 }

--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -248,8 +248,16 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
 
     switch (platform) {
       case AgentPlatformEnum.SLACK: {
-        if (!connectionAccessToken || !credentials.signingSecret) {
-          throw new BadRequestException('Slack agent integration requires botToken and signingSecret credentials');
+        if (!credentials.signingSecret) {
+          throw new BadRequestException(
+            'Slack agent integration requires a signing secret. Complete Slack app setup for this integration.'
+          );
+        }
+
+        if (!connectionAccessToken) {
+          throw new BadRequestException(
+            'Slack agent integration requires a workspace bot token. Install the app to your Slack workspace via OAuth in the agent setup guide.'
+          );
         }
 
         const { createSlackAdapter } = await esmImport('@chat-adapter/slack');

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.spec.ts
@@ -1,13 +1,14 @@
 import { expect } from 'chai';
-import { buildErrorMessage } from './managed-agent-event-handler.service';
+import { buildErrorMessage, parseMcpInitFailureServerName } from './managed-agent-event-handler.service';
 
 describe('buildErrorMessage', () => {
   it('maps webhook-deserialized MCP init failures to a connect prompt', () => {
-    const message = buildErrorMessage({
+    const error = {
       name: 'ThalamusError',
       message:
         "MCP server 'Asana' initialize failed: no credential is stored for this server URL — check that the agent's MCP server URL matches the URL in the vault",
-    });
+    };
+    const message = buildErrorMessage(error);
 
     expect(message).to.contain('**Asana**');
     expect(message).to.contain('Connect');
@@ -18,5 +19,16 @@ describe('buildErrorMessage', () => {
     const message = buildErrorMessage({ name: 'ThalamusError', message: 'Upstream provider unavailable' });
 
     expect(message).to.contain('temporarily unavailable');
+  });
+});
+
+describe('parseMcpInitFailureServerName', () => {
+  it('extracts the MCP display name from init failure errors', () => {
+    expect(
+      parseMcpInitFailureServerName({
+        name: 'ThalamusError',
+        message: "MCP server 'Slack' initialize failed: no credential is stored",
+      })
+    ).to.equal('Slack');
   });
 });

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
-import { ConversationRepository } from '@novu/dal';
+import {
+  AgentMcpServerRepository,
+  ConversationRepository,
+  McpConnectionRepository,
+  SubscriberRepository,
+} from '@novu/dal';
 import {
   CredentialExpiredError,
   McpServerError,
@@ -13,8 +18,13 @@ import { HandleAgentReplyCommand } from '../conversation-runtime/reply/handle-ag
 import { HandleAgentReply } from '../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
 import { HandlePlanProgressCommand } from '../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.command';
 import { HandlePlanProgress } from '../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase';
+import { EnsureProviderManagedVault } from '../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase';
+import { GenerateMcpOAuthUrl } from '../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
 import { captureAgentException } from '../shared/errors/capture-agent-sentry';
 import { DemoClaudeQuotaPolicy } from './demo-claude-quota-policy.service';
+import { listOAuthMcps } from './setup/list-oauth-mcps.helper';
+import { findOAuthMcpByServerName } from './setup/oauth-mcp.types';
+import { buildSetupCardForMcps } from './setup/setup-card.builder';
 import { HandlePendingToolApprovalsCommand } from './tool-approval/handle-pending-tool-approvals.command';
 import { HandlePendingToolApprovals } from './tool-approval/handle-pending-tool-approvals.usecase';
 
@@ -31,6 +41,11 @@ interface BaseCommandFields {
 export class ManagedAgentEventHandler {
   constructor(
     private readonly conversationRepository: ConversationRepository,
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly mcpConnectionRepository: McpConnectionRepository,
+    private readonly generateMcpOAuthUrl: GenerateMcpOAuthUrl,
+    private readonly ensureProviderManagedVault: EnsureProviderManagedVault,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly handlePlanProgress: HandlePlanProgress,
     private readonly handlePendingToolApprovals: HandlePendingToolApprovals,
@@ -217,6 +232,34 @@ export class ManagedAgentEventHandler {
       return;
     }
 
+    const failedMcpServerName = parseMcpInitFailureServerName(error);
+
+    const postedReconnectSetupCard =
+      failedMcpServerName && metadata.subscriberId
+        ? await this.tryPostMcpReconnectSetupCard({
+            ...baseCommand,
+            subscriberId: metadata.subscriberId,
+            serverName: failedMcpServerName,
+          })
+        : false;
+
+    if (postedReconnectSetupCard) {
+      try {
+        await this.handlePlanProgress.execute(
+          HandlePlanProgressCommand.create({ ...baseCommand, toolProgress: { turnId, action: 'fail' } })
+        );
+      } catch (err) {
+        this.logger.error(err, `Failed to mark plan progress failed for session ${sessionId}`);
+        captureAgentException(err, {
+          component: 'managed-agent-event-handler',
+          operation: 'deliver-error-plan-progress',
+          sessionId,
+        });
+      }
+
+      return;
+    }
+
     const message = buildErrorMessage(error);
 
     try {
@@ -233,6 +276,90 @@ export class ManagedAgentEventHandler {
         operation: 'deliver-error-message',
         sessionId,
       });
+    }
+  }
+
+  private async tryPostMcpReconnectSetupCard(params: {
+    userId: string;
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    agentIdentifier: string;
+    integrationIdentifier: string;
+    subscriberId: string;
+    serverName: string;
+  }): Promise<boolean> {
+    const conversation = await this.conversationRepository.findOne(
+      {
+        _id: params.conversationId,
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+      },
+      ['_agentId']
+    );
+
+    if (!conversation?._agentId) {
+      return false;
+    }
+
+    const mcps = await listOAuthMcps(
+      {
+        subscriberRepository: this.subscriberRepository,
+        agentMcpServerRepository: this.agentMcpServerRepository,
+        mcpConnectionRepository: this.mcpConnectionRepository,
+      },
+      {
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+        agentId: conversation._agentId,
+        subscriberId: params.subscriberId,
+      }
+    );
+    const mcp = findOAuthMcpByServerName(mcps, params.serverName);
+
+    if (!mcp) {
+      this.logger.warn(
+        {
+          conversationId: params.conversationId,
+          serverName: params.serverName,
+        },
+        'MCP init failure did not match an OAuth MCP on the agent'
+      );
+
+      return false;
+    }
+
+    try {
+      const card = await buildSetupCardForMcps({
+        mcps,
+        forceReconnectAgentMcpServerIds: new Set([mcp.agentMcpServerId]),
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+        agentIdentifier: params.agentIdentifier,
+        subscriberId: params.subscriberId,
+        conversationId: params.conversationId,
+        generateMcpOAuthUrl: this.generateMcpOAuthUrl,
+        ensureProviderManagedVault: this.ensureProviderManagedVault,
+        logger: this.logger,
+      });
+
+      await this.handleAgentReply.execute(
+        HandleAgentReplyCommand.create({
+          userId: params.userId,
+          organizationId: params.organizationId,
+          environmentId: params.environmentId,
+          conversationId: params.conversationId,
+          agentIdentifier: params.agentIdentifier,
+          integrationIdentifier: params.integrationIdentifier,
+          reply: { card },
+        })
+      );
+
+      return true;
+    } catch (err) {
+      this.logger.warn(err, `Failed to post MCP reconnect setup card for conversation ${params.conversationId}`);
+
+      return false;
     }
   }
 }
@@ -253,6 +380,18 @@ function extractErrorMessage(err: unknown): string | undefined {
   return undefined;
 }
 
+export function parseMcpInitFailureServerName(err: unknown): string | undefined {
+  const message = extractErrorMessage(err);
+
+  if (!message) {
+    return undefined;
+  }
+
+  const mcpInitMatch = message.match(/MCP server ['"]([^'"]+)['"] initialize failed/i);
+
+  return mcpInitMatch?.[1];
+}
+
 export function buildErrorMessage(err: unknown): string {
   if (err instanceof CredentialExpiredError) {
     return `Agent error: Credentials for "${err.serverName}" have expired. Please update them in your integration settings.`;
@@ -261,12 +400,10 @@ export function buildErrorMessage(err: unknown): string {
     return `Agent error: MCP server "${err.serverName}" is unavailable (${err.statusCode ?? 'unknown status'}).`;
   }
 
-  const message = extractErrorMessage(err);
-  if (message) {
-    const mcpInitMatch = message.match(/MCP server ['"]([^'"]+)['"] initialize failed/i);
-    if (mcpInitMatch) {
-      return buildMcpInitFailureMessage(mcpInitMatch[1]);
-    }
+  const failedMcpServerName = parseMcpInitFailureServerName(err);
+
+  if (failedMcpServerName) {
+    return buildMcpInitFailureMessage(failedMcpServerName);
   }
 
   return 'The agent is temporarily unavailable. Please try again later.';
@@ -275,6 +412,6 @@ export function buildErrorMessage(err: unknown): string {
 export function buildMcpInitFailureMessage(serverName: string): string {
   return (
     `I couldn't connect to the **${serverName}** MCP server yet. ` +
-    `If this thread shows a setup card, use Connect to authorize ${serverName}, then send your message again.`
+    `Use Connect to authorize ${serverName}, then send your message again.`
   );
 }

--- a/apps/api/src/app/agents/managed-runtime/setup/complete-managed-agent-setup.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/complete-managed-agent-setup.usecase.ts
@@ -16,6 +16,7 @@ import { AgentConfigResolver, type ResolvedAgentConfig } from '../../channels/ag
 import { OutboundGateway } from '../../conversation-runtime/egress/outbound.gateway';
 import { HandleAgentReplyCommand } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
+import { EnsureProviderManagedVault } from '../../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase';
 import { GenerateMcpOAuthUrl } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
 import { PLATFORMS_WITH_TYPING_INDICATOR } from '../../shared/enums/agent-platform.enum';
 import { ManagedAgentService } from '../managed-agent.service';
@@ -40,6 +41,7 @@ export class CompleteManagedAgentSetup {
     private readonly agentConfigResolver: AgentConfigResolver,
     private readonly managedAgentService: ManagedAgentService,
     private readonly generateMcpOAuthUrl: GenerateMcpOAuthUrl,
+    private readonly ensureProviderManagedVault: EnsureProviderManagedVault,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly outboundGateway: OutboundGateway,
     private readonly logger: PinoLogger
@@ -195,6 +197,7 @@ export class CompleteManagedAgentSetup {
       subscriberId: subscriber.subscriberId,
       conversationId: conversation._id,
       generateMcpOAuthUrl: this.generateMcpOAuthUrl,
+      ensureProviderManagedVault: this.ensureProviderManagedVault,
       logger: this.logger,
     });
 
@@ -284,6 +287,7 @@ export class CompleteManagedAgentSetup {
         subscriberId: subscriber.subscriberId,
         conversationId: conversation._id,
         generateMcpOAuthUrl: this.generateMcpOAuthUrl,
+        ensureProviderManagedVault: this.ensureProviderManagedVault,
         logger: this.logger,
       });
 

--- a/apps/api/src/app/agents/managed-runtime/setup/handle-managed-agent-setup-inbound.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/handle-managed-agent-setup-inbound.usecase.ts
@@ -10,6 +10,7 @@ import {
 } from '@novu/dal';
 import { HandleAgentReplyCommand } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
+import { EnsureProviderManagedVault } from '../../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase';
 import { GenerateMcpOAuthUrl } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
 import { listOAuthMcps } from './list-oauth-mcps.helper';
 import { ManagedAgentSetupInboundCommand } from './managed-agent-setup-inbound.command';
@@ -30,6 +31,7 @@ export class HandleManagedAgentSetupInbound {
     private readonly mcpConnectionRepository: McpConnectionRepository,
     private readonly conversationRepository: ConversationRepository,
     private readonly generateMcpOAuthUrl: GenerateMcpOAuthUrl,
+    private readonly ensureProviderManagedVault: EnsureProviderManagedVault,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly logger: PinoLogger
   ) {
@@ -113,6 +115,7 @@ export class HandleManagedAgentSetupInbound {
       subscriberId: command.subscriberId,
       conversationId: command.conversationId,
       generateMcpOAuthUrl: this.generateMcpOAuthUrl,
+      ensureProviderManagedVault: this.ensureProviderManagedVault,
       logger: this.logger,
     });
 
@@ -204,6 +207,7 @@ export class HandleManagedAgentSetupInbound {
       subscriberId: command.subscriberId,
       conversationId: command.conversationId,
       generateMcpOAuthUrl: this.generateMcpOAuthUrl,
+      ensureProviderManagedVault: this.ensureProviderManagedVault,
       logger: this.logger,
     });
 

--- a/apps/api/src/app/agents/managed-runtime/setup/oauth-mcp.types.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/oauth-mcp.types.ts
@@ -23,9 +23,11 @@ export function isProviderManagedOAuthMcp(mcp: OAuthMcp): boolean {
 }
 
 export function isOAuthMcpPending(mcp: OAuthMcp): boolean {
-  if (isProviderManagedOAuthMcp(mcp)) {
-    return false;
-  }
-
   return mcp.status !== McpConnectionStatusEnum.Connected;
+}
+
+export function findOAuthMcpByServerName(mcps: OAuthMcp[], serverName: string): OAuthMcp | undefined {
+  const normalized = serverName.trim().toLowerCase();
+
+  return mcps.find((mcp) => mcp.name.toLowerCase() === normalized || mcp.mcpId.toLowerCase() === normalized);
 }

--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts
@@ -70,7 +70,7 @@ export async function buildSetupCardForMcps(params: {
           'EnsureProviderManagedVault failed while building managed-agent setup card'
         );
 
-        rows.push(mcp);
+        throw err;
       }
 
       continue;

--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts
@@ -1,34 +1,77 @@
 import { PinoLogger } from '@novu/application-generic';
 import { McpConnectionStatusEnum } from '@novu/shared';
 
+import { EnsureProviderManagedVaultCommand } from '../../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.command';
+import { EnsureProviderManagedVault } from '../../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase';
 import { GenerateMcpOAuthUrlCommand } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.command';
 import { GenerateMcpOAuthUrl } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
 import { isProviderManagedOAuthMcp, type OAuthMcp } from './oauth-mcp.types';
 import { buildSetupCard, type SetupCardRow } from './setup-card.helpers';
 
+const PROVIDER_MANAGED_CONNECT_LABEL = 'Connect from provider';
+
 export async function buildSetupCardForMcps(params: {
   mcps: OAuthMcp[];
   resolved?: boolean;
   showProcessingHint?: boolean;
+  /**
+   * `agentMcpServerId`s that should be re-authorized even if their DB row is
+   * already `connected` (e.g. Thalamus reported `MCP server '<name>' initialize
+   * failed`). Other connected MCPs still render as a checkmark.
+   */
+  forceReconnectAgentMcpServerIds?: ReadonlySet<string>;
   environmentId: string;
   organizationId: string;
   agentIdentifier: string;
   subscriberId: string;
   conversationId: string;
   generateMcpOAuthUrl: GenerateMcpOAuthUrl;
+  ensureProviderManagedVault: EnsureProviderManagedVault;
   logger: PinoLogger;
 }): Promise<Record<string, unknown>> {
   const rows: SetupCardRow[] = [];
 
   for (const mcp of params.mcps) {
-    if (params.resolved || mcp.status === McpConnectionStatusEnum.Connected) {
+    const needsReconnect = params.forceReconnectAgentMcpServerIds?.has(mcp.agentMcpServerId) ?? false;
+    const skipConnectUrl = !needsReconnect && (params.resolved || mcp.status === McpConnectionStatusEnum.Connected);
+
+    if (skipConnectUrl) {
       rows.push(mcp);
 
       continue;
     }
 
     if (isProviderManagedOAuthMcp(mcp)) {
-      rows.push({ ...mcp, treatAsConnected: true });
+      try {
+        const result = await params.ensureProviderManagedVault.executeForSetupCard(
+          EnsureProviderManagedVaultCommand.create({
+            userId: 'system',
+            environmentId: params.environmentId,
+            organizationId: params.organizationId,
+            agentIdentifier: params.agentIdentifier,
+            mcpId: mcp.mcpId,
+            subscriberId: params.subscriberId,
+            conversationId: params.conversationId,
+          })
+        );
+
+        rows.push({
+          ...mcp,
+          authorizeUrl: result.vaultUrl,
+          connectButtonLabel: PROVIDER_MANAGED_CONNECT_LABEL,
+        });
+      } catch (err) {
+        params.logger.warn(
+          {
+            err: err instanceof Error ? err.message : String(err),
+            mcpId: mcp.mcpId,
+            conversationId: params.conversationId,
+          },
+          'EnsureProviderManagedVault failed while building managed-agent setup card'
+        );
+
+        rows.push(mcp);
+      }
 
       continue;
     }

--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.spec.ts
@@ -1,6 +1,6 @@
-import { McpConnectionAuthModeEnum } from '@novu/shared';
+import { McpConnectionAuthModeEnum, McpConnectionStatusEnum } from '@novu/shared';
 import { expect } from 'chai';
-import { isOAuthMcpPending, isProviderManagedOAuthMcp } from './oauth-mcp.types';
+import { findOAuthMcpByServerName, isOAuthMcpPending, isProviderManagedOAuthMcp } from './oauth-mcp.types';
 import { buildSetupCard } from './setup-card.helpers';
 
 describe('setup-card helpers', () => {
@@ -27,14 +27,52 @@ describe('setup-card helpers', () => {
     });
   });
 
+  describe('findOAuthMcpByServerName', () => {
+    it('matches by catalog display name', () => {
+      const mcps = [
+        {
+          mcpId: 'slack',
+          name: 'Slack',
+          agentMcpServerId: 'en-1',
+        },
+      ];
+
+      expect(findOAuthMcpByServerName(mcps, 'Slack')?.mcpId).to.equal('slack');
+    });
+
+    it('matches by mcpId case-insensitively', () => {
+      const mcps = [
+        {
+          mcpId: 'linear',
+          name: 'Linear',
+          agentMcpServerId: 'en-2',
+        },
+      ];
+
+      expect(findOAuthMcpByServerName(mcps, 'LINEAR')?.mcpId).to.equal('linear');
+    });
+  });
+
   describe('isOAuthMcpPending', () => {
-    it('treats provider-managed MCPs as not pending', () => {
+    it('treats provider-managed MCPs without a connection as pending', () => {
       expect(
         isOAuthMcpPending({
           mcpId: 'slack',
           name: 'Slack',
           agentMcpServerId: 'en-1',
           defaultAuthMode: McpConnectionAuthModeEnum.ProviderManaged,
+        })
+      ).to.equal(true);
+    });
+
+    it('treats provider-managed MCPs with status connected as not pending', () => {
+      expect(
+        isOAuthMcpPending({
+          mcpId: 'slack',
+          name: 'Slack',
+          agentMcpServerId: 'en-1',
+          defaultAuthMode: McpConnectionAuthModeEnum.ProviderManaged,
+          status: McpConnectionStatusEnum.Connected,
         })
       ).to.equal(false);
     });
@@ -52,14 +90,14 @@ describe('setup-card helpers', () => {
   });
 
   describe('buildSetupCard', () => {
-    it('renders provider-managed rows with a checkmark when treatAsConnected is set', () => {
+    it('renders a checkmark when the MCP status is connected', () => {
       const card = buildSetupCard({
         mcps: [
           {
             mcpId: 'figma',
             name: 'Figma',
             agentMcpServerId: 'en-1',
-            treatAsConnected: true,
+            status: McpConnectionStatusEnum.Connected,
           },
         ],
       });
@@ -68,6 +106,79 @@ describe('setup-card helpers', () => {
       const figmaRow = children.find((block) => block.type === 'text' && block.content?.includes('Figma'));
 
       expect(figmaRow?.content).to.equal('**Figma**  ✅');
+    });
+
+    it('renders a "Connect from provider" button when connectButtonLabel is set', () => {
+      const card = buildSetupCard({
+        mcps: [
+          {
+            mcpId: 'slack',
+            name: 'Slack',
+            agentMcpServerId: 'en-1',
+            authorizeUrl: 'https://platform.claude.com/workspaces/ws_1/vaults/vlt_1',
+            connectButtonLabel: 'Connect from provider',
+          },
+        ],
+      });
+
+      const children = card.children as Array<{
+        type: string;
+        children?: Array<{ type: string; label?: string; url?: string }>;
+      }>;
+      const actions = children.find((block) => block.type === 'actions');
+      const linkButton = actions?.children?.find((child) => child.type === 'link-button');
+
+      expect(linkButton?.label).to.equal('Connect from provider');
+      expect(linkButton?.url).to.equal('https://platform.claude.com/workspaces/ws_1/vaults/vlt_1');
+    });
+
+    it('falls back to the default "Connect" label for DCR MCPs', () => {
+      const card = buildSetupCard({
+        mcps: [
+          {
+            mcpId: 'linear',
+            name: 'Linear',
+            agentMcpServerId: 'en-2',
+            authorizeUrl: 'https://example.com/oauth/authorize',
+          },
+        ],
+      });
+
+      const children = card.children as Array<{
+        type: string;
+        children?: Array<{ type: string; label?: string }>;
+      }>;
+      const actions = children.find((block) => block.type === 'actions');
+      const linkButton = actions?.children?.find((child) => child.type === 'link-button');
+
+      expect(linkButton?.label).to.equal('Connect');
+    });
+
+    it('renders the Connect button on a connected MCP that needs to be re-authorized', () => {
+      const card = buildSetupCard({
+        mcps: [
+          {
+            mcpId: 'slack',
+            name: 'Slack',
+            agentMcpServerId: 'en-1',
+            status: McpConnectionStatusEnum.Connected,
+            authorizeUrl: 'https://platform.claude.com/workspaces/ws_1/vaults/vlt_1',
+            connectButtonLabel: 'Connect from provider',
+          },
+        ],
+      });
+
+      const children = card.children as Array<{
+        type: string;
+        content?: string;
+        children?: Array<{ type: string; label?: string; url?: string }>;
+      }>;
+      const slackRow = children.find((block) => block.type === 'text' && block.content?.includes('Slack'));
+      const actions = children.find((block) => block.type === 'actions');
+      const linkButton = actions?.children?.find((child) => child.type === 'link-button');
+
+      expect(slackRow?.content).to.equal('**Slack**');
+      expect(linkButton?.label).to.equal('Connect from provider');
     });
 
     it('renders pending DCR rows without a checkmark when authorizeUrl is absent', () => {

--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.ts
@@ -4,8 +4,12 @@ import type { OAuthMcp } from './oauth-mcp.types';
 
 export interface SetupCardRow extends OAuthMcp {
   authorizeUrl?: string;
-  /** Provider-managed MCPs render as connected without Novu OAuth. */
-  treatAsConnected?: boolean;
+  /**
+   * Override for the link-button label. Defaults to "Connect" / "Retry"
+   * (on error) when omitted. Provider-managed MCPs use "Connect from provider"
+   * to signal that auth completes inside the runtime provider's vault UI.
+   */
+  connectButtonLabel?: string;
 }
 
 const SETUP_REQUIRED_TEXT =
@@ -38,12 +42,14 @@ function buildPendingRowBlocks(mcp: SetupCardRow): Record<string, unknown>[] {
   }
 
   if (mcp.authorizeUrl) {
+    const defaultLabel = isErrorStatus(mcp.status) ? 'Retry' : 'Connect';
+
     blocks.push({
       type: 'actions',
       children: [
         {
           type: 'link-button',
-          label: isErrorStatus(mcp.status) ? 'Retry' : 'Connect',
+          label: mcp.connectButtonLabel ?? defaultLabel,
           url: mcp.authorizeUrl,
           style: 'primary',
         },
@@ -55,7 +61,11 @@ function buildPendingRowBlocks(mcp: SetupCardRow): Record<string, unknown>[] {
 }
 
 function buildMcpRowBlocks(mcp: SetupCardRow): Record<string, unknown>[] {
-  if (mcp.treatAsConnected || mcp.status === McpConnectionStatusEnum.Connected) {
+  // When an authorize URL is present on a connected row, the connection needs
+  // to be re-authorized (e.g. Thalamus reported MCP initialize failed even
+  // though Novu's DB row says connected). Render the pending row so the user
+  // sees the Connect button instead of a stale checkmark.
+  if (mcp.status === McpConnectionStatusEnum.Connected && !mcp.authorizeUrl) {
     return buildConnectedRowBlocks(mcp);
   }
 

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
@@ -70,7 +70,7 @@ export class CompleteProviderManagedRedirect {
         _environmentId: payload.environmentId,
         _organizationId: payload.organizationId,
       },
-      '*'
+      ['_id']
     );
 
     if (!connection) {

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
@@ -55,8 +55,8 @@ export class CompleteProviderManagedRedirect {
       throw new NotFoundException('Environment for redirect state not found or has no API keys.');
     }
 
-    const expected = createHash(environment.apiKeys[0].key, rawPayload);
-    if (signature !== expected) {
+    const isValidSignature = environment.apiKeys.some(({ key }) => createHash(key, rawPayload) === signature);
+    if (!isValidSignature) {
       throw new BadRequestException('Provider-managed redirect signature mismatch.');
     }
 

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
@@ -1,0 +1,131 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { createHash, PinoLogger } from '@novu/application-generic';
+import { EnvironmentRepository, McpConnectionRepository } from '@novu/dal';
+import { buildClaudePlatformVaultUrl, McpConnectionScopeEnum, McpConnectionStatusEnum } from '@novu/shared';
+
+import { CompleteManagedAgentSetup } from '../../../managed-runtime/setup/complete-managed-agent-setup.usecase';
+import { ManagedAgentSetupCompleteCommand } from '../../../managed-runtime/setup/managed-agent-setup-complete.command';
+import type { McpOAuthState } from '../../oauth/generate-mcp-oauth-url/mcp-oauth-state';
+import {
+  decodeProviderManagedRedirectState,
+  PROVIDER_MANAGED_REDIRECT_TTL_MS,
+  type ProviderManagedRedirectState,
+} from './provider-managed-redirect-state';
+
+export interface CompleteProviderManagedRedirectResult {
+  /** Final URL to 302 the user to — the provider's vault UI where OAuth completes. */
+  redirectUrl: string;
+}
+
+/**
+ * Handle the click on an in-channel "Connect from provider" link.
+ *
+ * Provider-managed MCPs have no Novu OAuth callback because Claude owns the
+ * credential entirely. We treat the user opening this signed Novu link as
+ * the user-intent signal — equivalent to clicking "Add from Claude" in the
+ * dashboard — and promote the row to `connected` after forwarding the user
+ * to Claude's vault UI. The signed `state` parameter is the trust boundary;
+ * we verify it against the originating environment's API key so
+ * unauthenticated traffic to this endpoint cannot flip arbitrary rows.
+ *
+ * The 302 is sent as soon as validation passes; persisting `connected` and
+ * driving setup-card refresh / replay run fire-and-forget so the browser
+ * does not wait on Slack API calls or agent replay.
+ */
+@Injectable()
+export class CompleteProviderManagedRedirect {
+  constructor(
+    private readonly mcpConnectionRepository: McpConnectionRepository,
+    private readonly environmentRepository: EnvironmentRepository,
+    private readonly completeManagedAgentSetup: CompleteManagedAgentSetup,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(CompleteProviderManagedRedirect.name);
+  }
+
+  async execute(state: string): Promise<CompleteProviderManagedRedirectResult> {
+    const { payload, rawPayload, signature } = decodeProviderManagedRedirectState(state);
+
+    const environment = await this.environmentRepository.findOne(
+      { _id: payload.environmentId, _organizationId: payload.organizationId },
+      ['apiKeys']
+    );
+
+    if (!environment?.apiKeys?.length) {
+      throw new NotFoundException('Environment for redirect state not found or has no API keys.');
+    }
+
+    const expected = createHash(environment.apiKeys[0].key, rawPayload);
+    if (signature !== expected) {
+      throw new BadRequestException('Provider-managed redirect signature mismatch.');
+    }
+
+    if (Date.now() - payload.timestamp > PROVIDER_MANAGED_REDIRECT_TTL_MS) {
+      throw new BadRequestException('Provider-managed redirect state expired. Restart the setup flow.');
+    }
+
+    const connection = await this.mcpConnectionRepository.findOne(
+      {
+        _id: payload.connectionId,
+        _environmentId: payload.environmentId,
+        _organizationId: payload.organizationId,
+      },
+      '*'
+    );
+
+    if (!connection) {
+      throw new NotFoundException('Provider-managed connection row not found.');
+    }
+
+    const redirectUrl = buildClaudePlatformVaultUrl(payload.externalVaultId, payload.externalWorkspaceId);
+
+    void this.runPostRedirectSideEffects(payload, connection._id).catch((err) =>
+      this.logger.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          connectionId: payload.connectionId,
+          conversationId: payload.conversationId,
+        },
+        'Provider-managed redirect post-work failed (non-fatal)'
+      )
+    );
+
+    return { redirectUrl };
+  }
+
+  /**
+   * Promote the connection and refresh setup cards / replay parked turns.
+   * Runs after the 302 is issued — must not block the redirect response.
+   */
+  private async runPostRedirectSideEffects(payload: ProviderManagedRedirectState, connectionId: string): Promise<void> {
+    await this.mcpConnectionRepository.update(
+      {
+        _id: connectionId,
+        _environmentId: payload.environmentId,
+        _organizationId: payload.organizationId,
+      },
+      {
+        $set: {
+          status: McpConnectionStatusEnum.Connected,
+          connectedAt: new Date(),
+        },
+        $unset: { oauthState: 1, lastError: 1 },
+      }
+    );
+
+    const stateData: McpOAuthState = {
+      agentId: payload.agentId,
+      agentMcpServerId: payload.agentMcpServerId,
+      subscriberId: payload.subscriberId,
+      environmentId: payload.environmentId,
+      organizationId: payload.organizationId,
+      mcpId: payload.mcpId,
+      scope: McpConnectionScopeEnum.Subscriber,
+      timestamp: payload.timestamp,
+      source: 'setup_card',
+      ...(payload.conversationId ? { conversationId: payload.conversationId } : {}),
+    };
+
+    await this.completeManagedAgentSetup.execute(ManagedAgentSetupCompleteCommand.create({ stateData }));
+  }
+}

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.command.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.command.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../../shared/commands/project.command';
 
@@ -10,4 +10,25 @@ export class EnsureProviderManagedVaultCommand extends EnvironmentWithUserComman
   @IsString()
   @IsNotEmpty()
   mcpId: string;
+
+  /**
+   * External subscriberId for the channel turn (Slack, Teams, etc.). When set,
+   * the vault is provisioned for that subscriber directly instead of mapping
+   * the dashboard `userId` to a `connect:<userId>` row. Used by the managed
+   * agent setup-card flow.
+   */
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  subscriberId?: string;
+
+  /**
+   * Conversation that the setup card was posted in. Round-tripped through the
+   * signed "Connect from provider" link so the redirect handler can replay
+   * the parked inbound turn once the user has clicked through.
+   */
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  conversationId?: string;
 }

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase.spec.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase.spec.ts
@@ -10,6 +10,7 @@ import { FeatureFlagsService } from '@novu/application-generic';
 import {
   AgentMcpServerRepository,
   AgentRepository,
+  EnvironmentRepository,
   IntegrationRepository,
   McpConnectionRepository,
   SubscriberRepository,
@@ -75,6 +76,7 @@ describe('EnsureProviderManagedVault', () => {
   let mcpConnectionRepository: sinon.SinonStubbedInstance<McpConnectionRepository>;
   let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
   let subscriberRepository: sinon.SinonStubbedInstance<SubscriberRepository>;
+  let environmentRepository: sinon.SinonStubbedInstance<EnvironmentRepository>;
   let createOrUpdateSubscriber: { execute: sinon.SinonStub };
   let enableAgentMcpServer: { execute: sinon.SinonStub };
   let mcpConnectionVaultService: { ensureConnectionVault: sinon.SinonStub };
@@ -87,6 +89,8 @@ describe('EnsureProviderManagedVault', () => {
     mcpConnectionRepository = sinon.createStubInstance(McpConnectionRepository);
     integrationRepository = sinon.createStubInstance(IntegrationRepository);
     subscriberRepository = sinon.createStubInstance(SubscriberRepository);
+    environmentRepository = sinon.createStubInstance(EnvironmentRepository);
+    environmentRepository.findOne.resolves({ apiKeys: [{ key: 'env-test-api-key' }] } as never);
     createOrUpdateSubscriber = { execute: sinon.stub() };
     enableAgentMcpServer = { execute: sinon.stub().resolves({}) };
     mcpConnectionVaultService = { ensureConnectionVault: sinon.stub().resolves(EXTERNAL_VAULT_ID) };
@@ -126,6 +130,7 @@ describe('EnsureProviderManagedVault', () => {
       mcpConnectionRepository as never,
       integrationRepository as never,
       subscriberRepository as never,
+      environmentRepository as never,
       createOrUpdateSubscriber as never,
       enableAgentMcpServer as never,
       mcpConnectionVaultService as never,
@@ -255,5 +260,65 @@ describe('EnsureProviderManagedVault', () => {
 
     expect(result.externalVaultId).to.equal('vlt_winner');
     expect(mcpConnectionVaultService.ensureConnectionVault.called).to.equal(false);
+  });
+
+  describe('executeForSetupCard', () => {
+    const CHANNEL_SUBSCRIBER_ID = 'slack-user-42';
+    const CHANNEL_SUBSCRIBER_MONGO_ID = 'sub_mongo_channel';
+    let originalApiRootUrl: string | undefined;
+
+    beforeEach(() => {
+      originalApiRootUrl = process.env.API_ROOT_URL;
+      process.env.API_ROOT_URL = 'https://api.example.com';
+      subscriberRepository.findBySubscriberId.withArgs(ENV_ID, CHANNEL_SUBSCRIBER_ID).resolves({
+        _id: CHANNEL_SUBSCRIBER_MONGO_ID,
+        subscriberId: CHANNEL_SUBSCRIBER_ID,
+      } as never);
+    });
+
+    afterEach(() => {
+      if (originalApiRootUrl === undefined) {
+        delete process.env.API_ROOT_URL;
+      } else {
+        process.env.API_ROOT_URL = originalApiRootUrl;
+      }
+    });
+
+    it('rejects when subscriberId is missing', async () => {
+      try {
+        await useCase.executeForSetupCard(makeCommand());
+        expect.fail('Expected BadRequestException');
+      } catch (err) {
+        expect(err).to.be.instanceOf(BadRequestException);
+      }
+    });
+
+    it('resolves the channel subscriber directly without falling back to connect:<userId>', async () => {
+      const result = await useCase.executeForSetupCard(makeCommand({ subscriberId: CHANNEL_SUBSCRIBER_ID }));
+
+      // The setup-card flow returns a signed Novu intermediate URL that
+      // promotes the connection on click and 302s to the Claude vault.
+      expect(result.vaultUrl).to.match(/\/v1\/agents\/mcp\/provider-managed\/redirect\?state=/);
+      expect(result.externalVaultId).to.equal(EXTERNAL_VAULT_ID);
+      expect(subscriberRepository.findBySubscriberId.calledOnce).to.equal(true);
+      expect(subscriberRepository.findBySubscriberId.firstCall.args).to.deep.equal([ENV_ID, CHANNEL_SUBSCRIBER_ID]);
+      expect(createOrUpdateSubscriber.execute.called).to.equal(false);
+      // Side-effect bug fix: must not promote the row to `connected` during
+      // card construction; promotion happens via the redirect endpoint.
+      expect(mcpConnectionRepository.update.called).to.equal(false);
+    });
+
+    it('throws NotFoundException when the channel subscriber cannot be found', async () => {
+      subscriberRepository.findBySubscriberId.withArgs(ENV_ID, CHANNEL_SUBSCRIBER_ID).resolves(null);
+
+      try {
+        await useCase.executeForSetupCard(makeCommand({ subscriberId: CHANNEL_SUBSCRIBER_ID }));
+        expect.fail('Expected NotFoundException');
+      } catch (err) {
+        expect(err).to.be.instanceOf(NotFoundException);
+      }
+
+      expect(createOrUpdateSubscriber.execute.called).to.equal(false);
+    });
   });
 });

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase.ts
@@ -15,6 +15,7 @@ import {
 import {
   AgentMcpServerRepository,
   AgentRepository,
+  EnvironmentRepository,
   IntegrationRepository,
   McpConnectionRepository,
   SubscriberRepository,
@@ -35,6 +36,7 @@ import { EnableAgentMcpServerCommand } from '../../servers/enable-agent-mcp-serv
 import { EnableAgentMcpServer } from '../../servers/enable-agent-mcp-server/enable-agent-mcp-server.usecase';
 import { McpConnectionVaultService } from '../mcp-connection-vault.service';
 import { EnsureProviderManagedVaultCommand } from './ensure-provider-managed-vault.command';
+import { buildProviderManagedRedirectUrl, signProviderManagedRedirectState } from './provider-managed-redirect-state';
 
 export type EnsureProviderManagedVaultResult = {
   /** Deep link the dashboard opens in a new tab so the user can finish connector OAuth in Claude. */
@@ -79,6 +81,7 @@ export class EnsureProviderManagedVault {
     private readonly mcpConnectionRepository: McpConnectionRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly subscriberRepository: SubscriberRepository,
+    private readonly environmentRepository: EnvironmentRepository,
     private readonly createOrUpdateSubscriber: CreateOrUpdateSubscriberUseCase,
     private readonly enableAgentMcpServer: EnableAgentMcpServer,
     private readonly mcpConnectionVaultService: McpConnectionVaultService,
@@ -88,7 +91,84 @@ export class EnsureProviderManagedVault {
     this.logger.setContext(EnsureProviderManagedVault.name);
   }
 
+  /**
+   * Provision (or reuse) the provider-managed vault for the channel subscriber
+   * triggering a managed-agent setup card and return the deep link the in-thread
+   * "Connect from provider" button opens. Mirrors `execute` but resolves the
+   * subscriber from the inbound `subscriberId` instead of mapping a dashboard
+   * `userId` to `connect:<userId>`.
+   */
+  async executeForSetupCard(command: EnsureProviderManagedVaultCommand): Promise<EnsureProviderManagedVaultResult> {
+    if (!command.subscriberId) {
+      throw new BadRequestException('subscriberId is required for the setup-card vault flow.');
+    }
+
+    // Setup-card flow only provisions the vault container; it must NOT promote
+    // the connection to `connected` here. Promotion happens when the user
+    // clicks the in-channel link, which is intercepted by the Novu redirect
+    // endpoint (the click is the user-intent signal — provider-managed MCPs
+    // have no Novu OAuth callback that could confirm OAuth completion).
+    const internal = await this.executeInternal(command, { markConnectedOnProvision: false });
+
+    const apiKey = await this.getEnvironmentApiKey(command.environmentId);
+    const signedState = signProviderManagedRedirectState(
+      {
+        connectionId: internal.connection._id,
+        agentId: internal.agentId,
+        agentMcpServerId: internal.agentMcpServerId,
+        subscriberId: internal.subscriberMongoId,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        mcpId: command.mcpId,
+        externalVaultId: internal.externalVaultId,
+        ...(internal.externalWorkspaceId ? { externalWorkspaceId: internal.externalWorkspaceId } : {}),
+        ...(command.conversationId ? { conversationId: command.conversationId } : {}),
+        timestamp: Date.now(),
+      },
+      apiKey
+    );
+
+    return {
+      vaultUrl: buildProviderManagedRedirectUrl(signedState),
+      externalVaultId: internal.externalVaultId,
+    };
+  }
+
   async execute(command: EnsureProviderManagedVaultCommand): Promise<EnsureProviderManagedVaultResult> {
+    // Dashboard "Add from Claude" flow: the user explicitly clicked the
+    // button, so we treat the click as intent and promote the connection
+    // to `connected` so the "Added from Claude" badge can light up.
+    const internal = await this.executeInternal(command, { markConnectedOnProvision: true });
+
+    return {
+      vaultUrl: buildClaudePlatformVaultUrl(internal.externalVaultId, internal.externalWorkspaceId),
+      externalVaultId: internal.externalVaultId,
+    };
+  }
+
+  private async getEnvironmentApiKey(environmentId: string): Promise<string> {
+    const environment = await this.environmentRepository.findOne({ _id: environmentId }, ['apiKeys']);
+
+    if (!environment?.apiKeys?.length) {
+      throw new UnprocessableEntityException(
+        'Environment has no API keys; cannot sign provider-managed redirect state.'
+      );
+    }
+
+    return environment.apiKeys[0].key;
+  }
+
+  private async executeInternal(
+    command: EnsureProviderManagedVaultCommand,
+    options: { markConnectedOnProvision: boolean }
+  ): Promise<{
+    externalVaultId: string;
+    externalWorkspaceId?: string;
+    connection: { _id: string; _subscriberId?: string };
+    agentId: string;
+    agentMcpServerId: string;
+    subscriberMongoId: string;
+  }> {
     const catalog = MCP_SERVERS.find((entry) => entry.id === command.mcpId);
 
     if (!catalog) {
@@ -201,10 +281,11 @@ export class EnsureProviderManagedVault {
     });
 
     let externalVaultId: string;
+    let provisionedConnection: { _id: string; _subscriberId?: string } | null = null;
 
     if (existingConnection?.auth?.externalVaultId) {
       externalVaultId = existingConnection.auth.externalVaultId;
-      await this.markProviderManagedConnectionConnected(existingConnection, command);
+      provisionedConnection = existingConnection;
     } else {
       const connection = await this.createOrFetchProviderManagedConnection({
         command,
@@ -214,7 +295,6 @@ export class EnsureProviderManagedVault {
 
       if (connection.auth?.externalVaultId) {
         externalVaultId = connection.auth.externalVaultId;
-        await this.markProviderManagedConnectionConnected(connection, command);
       } else if (subscriberVaultId) {
         await this.mcpConnectionRepository.setConnectionExternalVaultIdIfMissing({
           connectionId: connection._id,
@@ -223,34 +303,61 @@ export class EnsureProviderManagedVault {
           externalVaultId: subscriberVaultId,
         });
         externalVaultId = subscriberVaultId;
-        await this.markProviderManagedConnectionConnected(connection, command);
       } else {
         externalVaultId = await this.mcpConnectionVaultService.ensureConnectionVault({
           connection,
           agentId: agent._id,
           runtimeProvider: resolved.provider,
         });
-
-        await this.markProviderManagedConnectionConnected(connection, command);
       }
+
+      provisionedConnection = connection;
+    }
+
+    if (options.markConnectedOnProvision && provisionedConnection) {
+      await this.markProviderManagedConnectionConnected(provisionedConnection, command);
+    }
+
+    if (!provisionedConnection) {
+      throw new UnprocessableEntityException('Provider-managed vault provisioning produced no connection row.');
     }
 
     return {
-      vaultUrl: buildClaudePlatformVaultUrl(externalVaultId, externalWorkspaceId),
       externalVaultId,
+      ...(externalWorkspaceId ? { externalWorkspaceId } : {}),
+      connection: provisionedConnection,
+      agentId: agent._id,
+      agentMcpServerId: enablement._id,
+      subscriberMongoId: subscriber._id,
     };
   }
 
   /**
-   * Map the dashboard user to a Novu subscriber. Connect-product platform
-   * flows (Slack setup-card OAuth, CLI onboarding) key vaults by the
-   * `connect:<userId>` subscriber id — not the raw dashboard user id.
-   * Prefer that row so "Add from Claude" reuses the same vault container
-   * the in-channel Connect button already provisioned.
+   * Map the calling identity to a Novu subscriber.
+   *
+   * - When `command.subscriberId` is set (managed-agent setup-card flow), use
+   *   the channel subscriber directly. The vault must belong to the person
+   *   triggering the agent in Slack/Teams, not the dashboard admin.
+   * - Otherwise (dashboard "Add from Claude") map `userId` to a
+   *   `connect:<userId>` subscriber, falling back to the legacy raw `userId`
+   *   row before provisioning a fresh one.
    */
   private async resolveSubscriber(
     command: EnsureProviderManagedVaultCommand
   ): Promise<{ _id: string; subscriberId: string }> {
+    if (command.subscriberId) {
+      const channelSubscriber = await this.subscriberRepository.findBySubscriberId(
+        command.environmentId,
+        command.subscriberId
+      );
+
+      if (!channelSubscriber) {
+        throw new NotFoundException(`Subscriber "${command.subscriberId}" not found in this environment.`);
+      }
+
+      return channelSubscriber;
+    }
+
     const connectSubscriberId = buildConnectSubscriberId(command.userId);
     const connectSubscriber = await this.subscriberRepository.findBySubscriberId(
       command.environmentId,
@@ -341,7 +448,7 @@ export class EnsureProviderManagedVault {
    * vault id is known. Idempotent — safe on every "Add from Claude" retry.
    */
   private async markProviderManagedConnectionConnected(
-    connection: { _id: string },
+    connection: { _id: string; _subscriberId?: string },
     command: EnsureProviderManagedVaultCommand
   ): Promise<void> {
     await this.mcpConnectionRepository.update(

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/provider-managed-redirect-state.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/provider-managed-redirect-state.ts
@@ -1,0 +1,108 @@
+import { BadRequestException } from '@nestjs/common';
+import { createHash, encodeOAuthState, splitOAuthState } from '@novu/application-generic';
+
+/**
+ * Public path mounted under `AgentsMcpOAuthController`. Receives the click on
+ * the in-channel "Connect from provider" link, marks the connection row as
+ * `connected` (the click itself is the user-intent signal, mirroring the
+ * dashboard "Add from Claude" model), and 302s to the provider's vault UI.
+ */
+export const PROVIDER_MANAGED_REDIRECT_PATH = '/v1/agents/mcp/provider-managed/redirect';
+
+/**
+ * Signed payload that round-trips through the in-thread "Connect from provider"
+ * link. Provider-managed MCPs have no Novu OAuth callback, so we use this
+ * Novu-owned intermediate redirect as the user-intent signal: opening the link
+ * is what flips the connection row to `connected`, immediately before we
+ * forward the user to Claude's vault UI to finish OAuth.
+ *
+ * Lifetime is intentionally long (24h) — the user might leave the setup card
+ * untouched in a Slack thread for a while before coming back to click. The
+ * signed payload itself stays compact because we re-derive the Claude URL
+ * from the state at click time, instead of round-tripping a full URL.
+ */
+export interface ProviderManagedRedirectState {
+  /** Mongo `_id` of the `mcp_connection` row to promote on click. */
+  connectionId: string;
+  /** Mongo `Agent._id` for the agent the enablement belongs to. */
+  agentId: string;
+  /** Mongo `AgentMcpServer._id` for the enablement the connection backs. */
+  agentMcpServerId: string;
+  /** Mongo `Subscriber._id` (NOT the external channel subscriberId). */
+  subscriberId: string;
+  environmentId: string;
+  organizationId: string;
+  mcpId: string;
+  /** Anthropic vault container id Novu provisioned for the subscriber. */
+  externalVaultId: string;
+  /** Optional Anthropic workspace id; falls back to the default workspace. */
+  externalWorkspaceId?: string;
+  /**
+   * Conversation that originated the setup card. Round-tripped so the redirect
+   * handler can drive `CompleteManagedAgentSetup` and replay the parked turn.
+   */
+  conversationId?: string;
+  /** Issuance timestamp; verified against `PROVIDER_MANAGED_REDIRECT_TTL_MS`. */
+  timestamp: number;
+}
+
+/** Maximum lifetime of a signed redirect link before re-issue is required. */
+export const PROVIDER_MANAGED_REDIRECT_TTL_MS = 24 * 60 * 60 * 1000;
+
+export function signProviderManagedRedirectState(payload: ProviderManagedRedirectState, apiKey: string): string {
+  const jsonPayload = JSON.stringify(payload);
+  const signature = createHash(apiKey, jsonPayload);
+
+  if (!signature) {
+    throw new Error('Failed to sign provider-managed redirect state.');
+  }
+
+  return encodeOAuthState(jsonPayload, signature);
+}
+
+export function decodeProviderManagedRedirectState(state: string): {
+  payload: ProviderManagedRedirectState;
+  rawPayload: string;
+  signature: string;
+} {
+  let parts: { payload: string; signature: string };
+  try {
+    parts = splitOAuthState(state);
+  } catch {
+    throw new BadRequestException('Invalid provider-managed redirect state.');
+  }
+
+  let payload: ProviderManagedRedirectState;
+  try {
+    payload = JSON.parse(parts.payload) as ProviderManagedRedirectState;
+  } catch {
+    throw new BadRequestException('Invalid provider-managed redirect state.');
+  }
+
+  if (
+    !payload.connectionId ||
+    !payload.agentId ||
+    !payload.agentMcpServerId ||
+    !payload.subscriberId ||
+    !payload.environmentId ||
+    !payload.organizationId ||
+    !payload.mcpId ||
+    !payload.externalVaultId ||
+    typeof payload.timestamp !== 'number'
+  ) {
+    throw new BadRequestException('Provider-managed redirect state missing required fields.');
+  }
+
+  return { payload, rawPayload: parts.payload, signature: parts.signature };
+}
+
+export function buildProviderManagedRedirectUrl(signedState: string): string {
+  const rootUrl = process.env.AGENT_API_HOSTNAME?.trim() || process.env.API_ROOT_URL?.trim();
+  if (!rootUrl) {
+    throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL environment variable is required');
+  }
+
+  const baseUrl = rootUrl.replace(/\/$/, '');
+
+  return `${baseUrl}${PROVIDER_MANAGED_REDIRECT_PATH}?state=${encodeURIComponent(signedState)}`;
+}

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Get, HttpStatus, Query, Res } from '@nestjs/common';
+import { BadRequestException, Controller, Get, HttpStatus, NotFoundException, Query, Res } from '@nestjs/common';
 import { ApiExcludeController, ApiOperation } from '@nestjs/swagger';
 import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { Response } from 'express';
@@ -105,8 +105,43 @@ export class AgentsMcpOAuthController {
       throw new BadRequestException('Missing required redirect parameter: state');
     }
 
-    const result = await this.completeProviderManagedRedirect.execute(state);
+    try {
+      const result = await this.completeProviderManagedRedirect.execute(state);
 
-    res.redirect(HttpStatus.FOUND, result.redirectUrl);
+      res.redirect(HttpStatus.FOUND, result.redirectUrl);
+    } catch (err) {
+      const isExpired =
+        err instanceof BadRequestException &&
+        typeof err.message === 'string' &&
+        err.message.includes('redirect state expired');
+      const isNotFound = err instanceof NotFoundException;
+
+      let title = 'Connection failed';
+      let heading = "We couldn't connect";
+      let message =
+        'Something went wrong while opening the provider connection. Send a new message to your agent and try again.';
+
+      if (isExpired) {
+        title = 'Link expired';
+        heading = 'This link has expired';
+        message =
+          'This setup link is no longer valid. Send a new message to your agent to get a fresh Connect from provider link.';
+      } else if (isNotFound) {
+        message =
+          'The connection or environment for this link no longer exists. Send a new message to your agent to restart setup.';
+      }
+
+      const page = renderConnectionResultPage({
+        status: 'error',
+        title,
+        heading,
+        message,
+      });
+
+      res.status(HttpStatus.OK);
+      res.setHeader('Content-Type', 'text/html');
+      res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
+      res.send(page);
+    }
   }
 }

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -1,10 +1,12 @@
-import { BadRequestException, Controller, Get, Query, Res } from '@nestjs/common';
+import { BadRequestException, Controller, Get, HttpStatus, Query, Res } from '@nestjs/common';
 import { ApiExcludeController, ApiOperation } from '@nestjs/swagger';
 import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { Response } from 'express';
 
 import { ThrottlerCategory } from '../../../rate-limiting/guards';
 import { CONNECTION_RESULT_CSP, renderConnectionResultPage } from '../../../shared/html/connection-result-page';
+import { CompleteProviderManagedRedirect } from '../connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase';
+import { PROVIDER_MANAGED_REDIRECT_PATH } from '../connections/ensure-provider-managed-vault/provider-managed-redirect-state';
 import { McpOAuthCallbackCommand } from './mcp-oauth-callback/mcp-oauth-callback.command';
 import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecase';
 
@@ -23,7 +25,10 @@ import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecas
 @Controller('/agents/mcp')
 @ApiExcludeController()
 export class AgentsMcpOAuthController {
-  constructor(private readonly mcpOAuthCallbackUsecase: McpOAuthCallback) {}
+  constructor(
+    private readonly mcpOAuthCallbackUsecase: McpOAuthCallback,
+    private readonly completeProviderManagedRedirect: CompleteProviderManagedRedirect
+  ) {}
 
   @Get('/oauth/callback')
   @ApiOperation({
@@ -77,5 +82,31 @@ export class AgentsMcpOAuthController {
     res.setHeader('Content-Type', 'text/html');
     res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
     res.send(page);
+  }
+
+  /**
+   * Intercept the in-channel "Connect from provider" link and 302 the user
+   * to the provider's vault UI to finish OAuth. Trust is established via the
+   * signed `state` parameter issued by `EnsureProviderManagedVault.executeForSetupCard`.
+   *
+   * The connection row is promoted to `connected` fire-and-forget after the
+   * redirect is sent so the browser does not wait on DB writes or Slack API calls.
+   */
+  @Get('/provider-managed/redirect')
+  @ApiOperation({
+    summary: 'Provider-managed MCP connect redirect',
+    description:
+      'Marks the provider-managed connection row as connected and 302-redirects to the provider vault UI ' +
+      'where OAuth completes. Mounted under the same public controller as the OAuth callback because ' +
+      `${PROVIDER_MANAGED_REDIRECT_PATH} is hit by an unauthenticated browser tab opened from a Slack/Teams card.`,
+  })
+  async getProviderManagedRedirect(@Res() res: Response, @Query('state') state?: string): Promise<void> {
+    if (!state) {
+      throw new BadRequestException('Missing required redirect parameter: state');
+    }
+
+    const result = await this.completeProviderManagedRedirect.execute(state);
+
+    res.redirect(HttpStatus.FOUND, result.redirectUrl);
   }
 }

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -33,6 +33,7 @@ import { UpdateAgentInboxShared } from '../management/usecases/update-agent-inbo
 import { UpdateAgentRuntimeConfig } from '../management/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase';
 import { UploadCustomSkill } from '../management/usecases/upload-custom-skill/upload-custom-skill.usecase';
 import { VerifyManagedCredentials } from '../management/usecases/verify-managed-credentials/verify-managed-credentials.usecase';
+import { CompleteProviderManagedRedirect } from '../mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase';
 import { EnsureProviderManagedVault } from '../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase';
 import { GetMcpConnectionStatus } from '../mcp/connections/get-mcp-connection-status/get-mcp-connection-status.usecase';
 import { GenerateMcpOAuthUrl } from '../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
@@ -92,6 +93,7 @@ export const USE_CASES = [
   ListAgentMcpServers,
   GenerateMcpOAuthUrl,
   EnsureProviderManagedVault,
+  CompleteProviderManagedRedirect,
   HandleManagedAgentSetupInbound,
   CompleteManagedAgentSetup,
   McpOAuthCallback,

--- a/apps/api/src/app/channel-connections/channel-connections.module.ts
+++ b/apps/api/src/app/channel-connections/channel-connections.module.ts
@@ -1,5 +1,11 @@
 import { Module } from '@nestjs/common';
-import { featureFlagsService } from '@novu/application-generic';
+import {
+  analyticsService,
+  CreateOrUpdateSubscriberUseCase,
+  featureFlagsService,
+  UpdateSubscriber,
+  UpdateSubscriberChannel,
+} from '@novu/application-generic';
 import {
   ChannelConnectionRepository,
   CommunityOrganizationRepository,
@@ -8,6 +14,7 @@ import {
   IntegrationRepository,
   SubscriberRepository,
 } from '@novu/dal';
+import { SharedModule } from '../shared/shared.module';
 import { ChannelConnectionsController } from './channel-connections.controller';
 import { CreateChannelConnection } from './usecases/create-channel-connection/create-channel-connection.usecase';
 import { DeleteChannelConnection } from './usecases/delete-channel-connection/delete-channel-connection.usecase';
@@ -33,8 +40,17 @@ const DAL_MODELS = [
 ];
 
 @Module({
+  imports: [SharedModule],
   controllers: [ChannelConnectionsController],
-  providers: [...USE_CASES, ...DAL_MODELS, featureFlagsService],
+  providers: [
+    ...USE_CASES,
+    ...DAL_MODELS,
+    featureFlagsService,
+    analyticsService,
+    CreateOrUpdateSubscriberUseCase,
+    UpdateSubscriber,
+    UpdateSubscriberChannel,
+  ],
   exports: [...USE_CASES, ...DAL_MODELS],
 })
 export class ChannelConnectionsModule {}

--- a/apps/api/src/app/channel-connections/usecases/create-channel-connection/create-channel-connection.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/create-channel-connection/create-channel-connection.usecase.ts
@@ -1,5 +1,10 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
-import { encryptChannelConnectionAuth, InstrumentUsecase, shortId } from '@novu/application-generic';
+import {
+  CreateOrUpdateSubscriberUseCase,
+  encryptChannelConnectionAuth,
+  InstrumentUsecase,
+  shortId,
+} from '@novu/application-generic';
 import {
   ChannelConnectionEntity,
   ChannelConnectionRepository,
@@ -9,6 +14,7 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import { validateConnectionMode } from '../channel-connection.utils';
+import { ensureConnectDashboardSubscriber } from '../ensure-connect-dashboard-subscriber';
 import { CreateChannelConnectionCommand } from './create-channel-connection.command';
 
 @Injectable()
@@ -17,7 +23,8 @@ export class CreateChannelConnection {
     private readonly channelConnectionRepository: ChannelConnectionRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly subscriberRepository: SubscriberRepository,
-    private readonly contextRepository: ContextRepository
+    private readonly contextRepository: ContextRepository,
+    private readonly createOrUpdateSubscriber: CreateOrUpdateSubscriberUseCase
   ) {}
 
   @InstrumentUsecase()
@@ -134,15 +141,13 @@ export class CreateChannelConnection {
       return;
     }
 
-    const found = await this.subscriberRepository.findOne({
+    await ensureConnectDashboardSubscriber({
       subscriberId: command.subscriberId,
-      _organizationId: command.organizationId,
-      _environmentId: command.environmentId,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberRepository: this.subscriberRepository,
+      createOrUpdateSubscriber: this.createOrUpdateSubscriber,
     });
-
-    if (!found) throw new NotFoundException(`Subscriber not found: ${command.subscriberId}`);
-
-    return;
   }
 
   private async findIntegration(command: CreateChannelConnectionCommand) {

--- a/apps/api/src/app/channel-connections/usecases/ensure-connect-dashboard-subscriber.ts
+++ b/apps/api/src/app/channel-connections/usecases/ensure-connect-dashboard-subscriber.ts
@@ -1,0 +1,51 @@
+import { NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { CreateOrUpdateSubscriberCommand, CreateOrUpdateSubscriberUseCase } from '@novu/application-generic';
+import { SubscriberRepository } from '@novu/dal';
+import { CONNECT_SUBSCRIBER_PREFIX } from '@novu/shared';
+
+type EnsureConnectDashboardSubscriberParams = {
+  subscriberId: string;
+  environmentId: string;
+  organizationId: string;
+  subscriberRepository: SubscriberRepository;
+  createOrUpdateSubscriber: CreateOrUpdateSubscriberUseCase;
+};
+
+/**
+ * Ensures the subscriber exists before creating a channel connection or
+ * starting OAuth. Dashboard Connect flows pass `connect:<userId>` ids that
+ * may not be provisioned yet — auto-create those on demand. All other
+ * subscriber ids must already exist.
+ */
+export async function ensureConnectDashboardSubscriber({
+  subscriberId,
+  environmentId,
+  organizationId,
+  subscriberRepository,
+  createOrUpdateSubscriber,
+}: EnsureConnectDashboardSubscriberParams): Promise<void> {
+  const existingSubscriber = await subscriberRepository.findBySubscriberId(environmentId, subscriberId);
+
+  if (existingSubscriber) {
+    return;
+  }
+
+  const isConnectDashboardSubscriber = subscriberId.startsWith(`${CONNECT_SUBSCRIBER_PREFIX}:`);
+
+  if (!isConnectDashboardSubscriber) {
+    throw new NotFoundException(`Subscriber not found: ${subscriberId}`);
+  }
+
+  const created = await createOrUpdateSubscriber.execute(
+    CreateOrUpdateSubscriberCommand.create({
+      environmentId,
+      organizationId,
+      subscriberId,
+      allowUpdate: false,
+    })
+  );
+
+  if (!created) {
+    throw new UnprocessableEntityException(`Failed to provision subscriber: ${subscriberId}`);
+  }
+}

--- a/apps/api/src/app/channel-connections/usecases/ensure-connect-dashboard-subscriber.ts
+++ b/apps/api/src/app/channel-connections/usecases/ensure-connect-dashboard-subscriber.ts
@@ -3,13 +3,13 @@ import { CreateOrUpdateSubscriberCommand, CreateOrUpdateSubscriberUseCase } from
 import { SubscriberRepository } from '@novu/dal';
 import { CONNECT_SUBSCRIBER_PREFIX } from '@novu/shared';
 
-type EnsureConnectDashboardSubscriberParams = {
+interface EnsureConnectDashboardSubscriberParams {
   subscriberId: string;
   environmentId: string;
   organizationId: string;
   subscriberRepository: SubscriberRepository;
   createOrUpdateSubscriber: CreateOrUpdateSubscriberUseCase;
-};
+}
 
 /**
  * Ensures the subscriber exists before creating a channel connection or

--- a/apps/api/src/app/integrations/integrations.module.ts
+++ b/apps/api/src/app/integrations/integrations.module.ts
@@ -1,10 +1,14 @@
 import { forwardRef, Module } from '@nestjs/common';
 import {
+  analyticsService,
   CalculateLimitNovuIntegration,
   ChannelFactory,
   CompileTemplate,
+  CreateOrUpdateSubscriberUseCase,
   GetNovuProviderCredentials,
   MsTeamsTokenService,
+  UpdateSubscriber,
+  UpdateSubscriberChannel,
 } from '@novu/application-generic';
 import { CommunityOrganizationRepository, CommunityUserRepository } from '@novu/dal';
 import { TelegramMobileLinkTokenService } from '../agents/channels/telegram-linking/telegram-mobile-link-token.service';
@@ -33,6 +37,10 @@ const PROVIDERS = [
     CommunityUserRepository,
     TelegramMobileLinkTokenService,
     ...PROVIDERS,
+    analyticsService,
+    CreateOrUpdateSubscriberUseCase,
+    UpdateSubscriber,
+    UpdateSubscriberChannel,
   ],
   exports: [...USE_CASES],
 })

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import {
+  CreateOrUpdateSubscriberUseCase,
   createHash,
   GetNovuProviderCredentials,
   GetNovuProviderCredentialsCommand,
@@ -20,6 +21,7 @@ import {
   SLACK_AGENT_OAUTH_SCOPES,
 } from '@novu/shared';
 import { validateConnectionMode } from '../../../../channel-connections/usecases/channel-connection.utils';
+import { ensureConnectDashboardSubscriber } from '../../../../channel-connections/usecases/ensure-connect-dashboard-subscriber';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../chat-oauth.constants';
 import { encodeOAuthState, splitOAuthState } from '../chat-oauth-state.util';
 import { GenerateSlackOauthUrlCommand } from './generate-slack-oauth-url.command';
@@ -60,6 +62,7 @@ export class GenerateSlackOauthUrl {
     private getNovuProviderCredentials: GetNovuProviderCredentials,
     private subscriberRepository: SubscriberRepository,
     private agentIntegrationRepository: AgentIntegrationRepository,
+    private createOrUpdateSubscriber: CreateOrUpdateSubscriberUseCase,
     private logger: PinoLogger
   ) {
     this.logger.setContext(GenerateSlackOauthUrl.name);
@@ -131,15 +134,13 @@ export class GenerateSlackOauthUrl {
       return;
     }
 
-    const found = await this.subscriberRepository.findOne({
+    await ensureConnectDashboardSubscriber({
       subscriberId,
-      _organizationId: organizationId,
-      _environmentId: environmentId,
+      environmentId,
+      organizationId,
+      subscriberRepository: this.subscriberRepository,
+      createOrUpdateSubscriber: this.createOrUpdateSubscriber,
     });
-
-    if (!found) throw new NotFoundException(`Subscriber not found: ${subscriberId}`);
-
-    return;
   }
 
   private async getOAuthUrl(

--- a/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { encryptCredentials, PinoLogger } from '@novu/application-generic';
 import { AgentIntegrationRepository, IntegrationRepository } from '@novu/dal';
 import { ChatProviderIdEnum, SLACK_AGENT_OAUTH_SCOPES } from '@novu/shared';
@@ -78,8 +78,8 @@ export class SlackQuickSetup {
 
     const { client_id, client_secret, signing_secret } = slackResponse.credentials;
 
-    await this.saveCredentials(command, client_id, client_secret, signing_secret, slackResponse.app_id);
     await this.ensureAgentIntegrationLink(command);
+    await this.saveCredentials(command, client_id, client_secret, signing_secret, slackResponse.app_id);
 
     this.logger.info(`Slack quick setup: credentials saved for integrationId=${command.integrationId}`);
 
@@ -111,16 +111,7 @@ export class SlackQuickSetup {
     );
 
     if (linkedElsewhere) {
-      this.logger.warn(
-        {
-          agentId: command.agentId,
-          integrationId: command.integrationId,
-          linkedAgentId: linkedElsewhere._agentId,
-        },
-        'Slack quick setup: integration is already linked to a different agent'
-      );
-
-      return;
+      throw new ConflictException('Integration is already linked to a different agent');
     }
 
     await this.agentIntegrationRepository.create({

--- a/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { encryptCredentials, PinoLogger } from '@novu/application-generic';
-import { IntegrationRepository } from '@novu/dal';
+import { AgentIntegrationRepository, IntegrationRepository } from '@novu/dal';
 import { ChatProviderIdEnum, SLACK_AGENT_OAUTH_SCOPES } from '@novu/shared';
 import axios, { AxiosError } from 'axios';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../generate-chat-oath-url/chat-oauth.constants';
@@ -33,6 +33,7 @@ export class SlackQuickSetup {
 
   constructor(
     private integrationRepository: IntegrationRepository,
+    private agentIntegrationRepository: AgentIntegrationRepository,
     private logger: PinoLogger
   ) {
     this.logger.setContext(SlackQuickSetup.name);
@@ -78,10 +79,56 @@ export class SlackQuickSetup {
     const { client_id, client_secret, signing_secret } = slackResponse.credentials;
 
     await this.saveCredentials(command, client_id, client_secret, signing_secret, slackResponse.app_id);
+    await this.ensureAgentIntegrationLink(command);
 
     this.logger.info(`Slack quick setup: credentials saved for integrationId=${command.integrationId}`);
 
     return {};
+  }
+
+  private async ensureAgentIntegrationLink(command: SlackQuickSetupCommand): Promise<void> {
+    const existing = await this.agentIntegrationRepository.findOne(
+      {
+        _agentId: command.agentId,
+        _integrationId: command.integrationId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      ['_id']
+    );
+
+    if (existing) {
+      return;
+    }
+
+    const linkedElsewhere = await this.agentIntegrationRepository.findOne(
+      {
+        _integrationId: command.integrationId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      ['_agentId']
+    );
+
+    if (linkedElsewhere) {
+      this.logger.warn(
+        {
+          agentId: command.agentId,
+          integrationId: command.integrationId,
+          linkedAgentId: linkedElsewhere._agentId,
+        },
+        'Slack quick setup: integration is already linked to a different agent'
+      );
+
+      return;
+    }
+
+    await this.agentIntegrationRepository.create({
+      _agentId: command.agentId,
+      _integrationId: command.integrationId,
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+    });
   }
 
   /**

--- a/apps/dashboard/src/components/agents/mcps-section.tsx
+++ b/apps/dashboard/src/components/agents/mcps-section.tsx
@@ -259,6 +259,7 @@ export function McpsSection({ agent }: McpsSectionProps) {
                       onClick={() => handleRemove(enablement.mcpId)}
                       disabled={isRowPending}
                       aria-label={`Remove ${displayName}`}
+                      className="-mr-1"
                     >
                       <span className="sr-only">Remove {displayName}</span>
                     </CompactButton>


### PR DESCRIPTION
## Summary

- Fix false ✅ on provider-managed MCPs (e.g. Slack) in the managed-agent setup card by **not** promoting connections to `connected` while building the card
- Add a signed Novu intermediate redirect (`GET /v1/agents/mcp/provider-managed/redirect`) so the row is marked `connected` only when the user clicks **Connect from provider**
- Fire-and-forget post-redirect work (Mongo update + setup-card refresh / replay) so the browser gets a fast 302 to Claude's vault UI
- Scope vault provisioning to the **channel subscriber** who messaged the agent (not the dashboard `connect:<userId>` row)
- Wire provider-managed MCPs into the setup gate like standard OAuth MCPs (`isOAuthMcpPending` no longer skips them)

Follow-up to [NV-7930](https://linear.app/novu/issue/NV-7930/provider-managed-mcp-vault-flow-add-from-claude).

## Flow

```mermaid
sequenceDiagram
  participant User as Slack user
  participant Novu as Novu API
  participant DB as MongoDB
  participant Claude as Claude vault UI

  User->>Novu: Message agent (setup required)
  Novu->>DB: listOAuthMcps (Slack pending/undefined)
  Novu->>Novu: executeForSetupCard (provision vault, no Connected write)
  Novu->>User: Setup card with signed Novu redirect link

  User->>Novu: Click Connect from provider
  Novu->>Novu: Verify signed state
  Novu->>User: 302 to Claude vault (immediate)
  Novu-->>DB: Fire-and-forget: status=connected
  Novu-->>Novu: Fire-and-forget: CompleteManagedAgentSetup

  User->>Claude: Complete OAuth in vault
```

## Test plan

- [ ] Enable Linear + Slack MCPs on a managed agent; message from two different Slack users
- [ ] First message: setup card shows **Connect from provider** for Slack (not ✅) for each user independently
- [ ] Second message without clicking: Slack still shows **Connect from provider** (not ✅)
- [ ] Click **Connect from provider**: browser redirects quickly to Claude vault; setup card eventually updates / agent replays when all MCPs connected
- [ ] Dashboard **Add from Claude** still promotes to connected on click (unchanged path)
- [ ] `cd apps/api && pnpm test -- --grep "EnsureProviderManagedVault"` passes


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the false ✅ shown for provider-managed MCPs (e.g. Slack) in the managed-agent setup card, routes the "Connect from provider" click through a signed Novu intermediate redirect endpoint, and scopes vault provisioning to the channel subscriber rather than the dashboard user.

- Adds `GET /v1/agents/mcp/provider-managed/redirect` — a signed, TTL-gated intermediate that promotes the connection row to `connected` fire-and-forget and 302s the browser to Claude's vault UI immediately.
- Rewires `buildSetupCardForMcps` to call `EnsureProviderManagedVault.executeForSetupCard` (builds a signed redirect URL without writing `connected`) for provider-managed MCPs, and wires them into the `isOAuthMcpPending` setup gate.
- Adds `tryHealMissingAgentIntegrationLink` to auto-link orphaned integrations on first inbound webhook, with duplicate-key error handling.

<h3>Confidence Score: 4/5</h3>

The redirect and vault-provisioning core is well-structured, but two error-handling gaps can leave users stuck with no setup card under transient failures.

The signed redirect flow, subscriber-scoping fix, and TOCTOU-safe connection creation are all solid. Two spots in the setup-card building path re-throw or propagate exceptions instead of continuing past a failed MCP — in a mixed-MCP scenario a transient provider-managed vault failure discards the already-built standard OAuth rows, and the conversation-refresh loop breaks on the first error leaving other threads with stale cards.

apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts and apps/api/src/app/agents/managed-runtime/setup/complete-managed-agent-setup.usecase.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts | Re-routes provider-managed MCPs through executeForSetupCard; throws on failure rather than falling back gracefully, which can destroy already-built rows for other MCPs in the same batch. |
| apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts | New usecase handling the signed redirect click: validates state, issues 302, promotes connection fire-and-forget. Logic is sound. |
| apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase.ts | New executeForSetupCard path provisions vault without marking connected; resolveSubscriber correctly uses channel subscriberId; race-safe connection creation with duplicate-key catch. |
| apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/provider-managed-redirect-state.ts | Signed redirect state helpers: HMAC over JSON payload, 24h TTL, field validation. Correct use of encodeOAuthState/splitOAuthState. |
| apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts | New redirect endpoint added; error handling renders user-friendly HTML pages for expired, not-found, and generic failure cases. |
| apps/api/src/app/agents/channels/agent-config-resolver.service.ts | Adds tryHealMissingAgentIntegrationLink for auto-linking orphaned integrations; duplicate-key error is caught and re-reads winner row. |
| apps/api/src/app/agents/managed-runtime/setup/complete-managed-agent-setup.usecase.ts | Now calls buildSetupCardForMcps with ensureProviderManagedVault for refresh/replay paths; resolved:true flag prevents executeForSetupCard calls when building the completion card. |
| apps/api/src/app/agents/managed-runtime/setup/oauth-mcp.types.ts | isOAuthMcpPending simplified to check status !== Connected; isProviderManagedOAuthMcp added to distinguish flow at card-building time. |
| apps/api/src/app/channel-connections/usecases/ensure-connect-dashboard-subscriber.ts | New helper extracted to centralize dashboard-subscriber auto-provisioning logic; rejects non-connect-prefixed subscriber IDs with NotFoundException. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User as Slack User
  participant Novu as Novu API
  participant DB as MongoDB
  participant Claude as Claude Vault UI

  User->>Novu: Inbound message (setup required)
  Novu->>DB: listOAuthMcps (Slack pending/undefined)
  Novu->>Novu: executeForSetupCard (provision vault, NO connected write)
  Novu->>Novu: signProviderManagedRedirectState (HMAC + TTL 24h)
  Novu->>User: Setup card with signed redirect link

  User->>Novu: "GET /v1/agents/mcp/provider-managed/redirect?state=…"
  Novu->>Novu: decodeProviderManagedRedirectState (verify sig + TTL)
  Novu->>DB: findOne connection (existence check)
  Novu->>User: 302 to Claude vault (immediate)
  Novu-->>DB: "fire-and-forget: status=connected, connectedAt=now"
  Novu-->>Novu: fire-and-forget: CompleteManagedAgentSetup (refresh cards / replay)

  User->>Claude: Complete OAuth in vault
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts`, line 599-618 ([link](https://github.com/novuhq/novu/blob/178868b9d1d57e9270cfff534a63b428c88d54d8/apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts#L599-L618)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`userId: 'system'` is a fragile workaround**

   `EnsureProviderManagedVaultCommand` extends `EnvironmentWithUserCommand`, which carries `userId` as a validated field. Passing the literal `'system'` works today because `executeForSetupCard` → `resolveSubscriber` short-circuits on `command.subscriberId` and never reads `command.userId`. However, if any future change in `executeInternal` (e.g., audit logging, ACL enforcement) reads `command.userId` for paths that reach this branch, it would silently use `'system'` as the actor identity, or — worse — fall through to the `buildConnectSubscriberId(command.userId)` path and create a `connect:system` subscriber.

   Consider threading a real `userId` (or the subscriber's user context) down to `buildSetupCardForMcps`, or extracting a separate command type for the setup-card flow that omits `userId` entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts
   Line: 599-618

   Comment:
   **`userId: 'system'` is a fragile workaround**

   `EnsureProviderManagedVaultCommand` extends `EnvironmentWithUserCommand`, which carries `userId` as a validated field. Passing the literal `'system'` works today because `executeForSetupCard` → `resolveSubscriber` short-circuits on `command.subscriberId` and never reads `command.userId`. However, if any future change in `executeInternal` (e.g., audit logging, ACL enforcement) reads `command.userId` for paths that reach this branch, it would silently use `'system'` as the actor identity, or — worse — fall through to the `buildConnectSubscriberId(command.userId)` path and create a `connect:system` subscriber.

   Consider threading a real `userId` (or the subscriber's user context) down to `buildSetupCardForMcps`, or extracting a separate command type for the setup-card flow that omits `userId` entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fmanaged-runtime%2Fsetup%2Fsetup-card.builder.ts%0ALine%3A%20599-618%0A%0AComment%3A%0A**%60userId%3A%20'system'%60%20is%20a%20fragile%20workaround**%0A%0A%60EnsureProviderManagedVaultCommand%60%20extends%20%60EnvironmentWithUserCommand%60%2C%20which%20carries%20%60userId%60%20as%20a%20validated%20field.%20Passing%20the%20literal%20%60'system'%60%20works%20today%20because%20%60executeForSetupCard%60%20%E2%86%92%20%60resolveSubscriber%60%20short-circuits%20on%20%60command.subscriberId%60%20and%20never%20reads%20%60command.userId%60.%20However%2C%20if%20any%20future%20change%20in%20%60executeInternal%60%20%28e.g.%2C%20audit%20logging%2C%20ACL%20enforcement%29%20reads%20%60command.userId%60%20for%20paths%20that%20reach%20this%20branch%2C%20it%20would%20silently%20use%20%60'system'%60%20as%20the%20actor%20identity%2C%20or%20%E2%80%94%20worse%20%E2%80%94%20fall%20through%20to%20the%20%60buildConnectSubscriberId%28command.userId%29%60%20path%20and%20create%20a%20%60connect%3Asystem%60%20subscriber.%0A%0AConsider%20threading%20a%20real%20%60userId%60%20%28or%20the%20subscriber's%20user%20context%29%20down%20to%20%60buildSetupCardForMcps%60%2C%20or%20extracting%20a%20separate%20command%20type%20for%20the%20setup-card%20flow%20that%20omits%20%60userId%60%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `apps/api/src/app/agents/channels/agent-config-resolver.service.ts`, line 143-163 ([link](https://github.com/novuhq/novu/blob/178868b9d1d57e9270cfff534a63b428c88d54d8/apps/api/src/app/agents/channels/agent-config-resolver.service.ts#L143-L163)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **TOCTOU race in `tryHealMissingAgentIntegrationLink`**

   The method reads `existingForIntegration` and then — if absent — calls `agentIntegrationRepository.create`. Under concurrent inbound webhooks for the same integration (e.g., two Slack messages arriving within milliseconds of each other when the agent link hasn't been created yet), both requests can observe `existingForIntegration = null` and both proceed to `create`, producing two `AgentIntegration` rows pointing to the same integration. Subsequent `findOne` calls would return one of the duplicates non-deterministically.

   Adding a unique compound index on `(_integrationId, _environmentId, _organizationId)` in the repository, or catching `ConflictException`/duplicate-key errors from `create` and re-reading the row (like `ensureEnablementRow` does), would make this idempotent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/agents/channels/agent-config-resolver.service.ts
   Line: 143-163

   Comment:
   **TOCTOU race in `tryHealMissingAgentIntegrationLink`**

   The method reads `existingForIntegration` and then — if absent — calls `agentIntegrationRepository.create`. Under concurrent inbound webhooks for the same integration (e.g., two Slack messages arriving within milliseconds of each other when the agent link hasn't been created yet), both requests can observe `existingForIntegration = null` and both proceed to `create`, producing two `AgentIntegration` rows pointing to the same integration. Subsequent `findOne` calls would return one of the duplicates non-deterministically.

   Adding a unique compound index on `(_integrationId, _environmentId, _organizationId)` in the repository, or catching `ConflictException`/duplicate-key errors from `create` and re-reading the row (like `ensureEnablementRow` does), would make this idempotent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fchannels%2Fagent-config-resolver.service.ts%0ALine%3A%20143-163%0A%0AComment%3A%0A**TOCTOU%20race%20in%20%60tryHealMissingAgentIntegrationLink%60**%0A%0AThe%20method%20reads%20%60existingForIntegration%60%20and%20then%20%E2%80%94%20if%20absent%20%E2%80%94%20calls%20%60agentIntegrationRepository.create%60.%20Under%20concurrent%20inbound%20webhooks%20for%20the%20same%20integration%20%28e.g.%2C%20two%20Slack%20messages%20arriving%20within%20milliseconds%20of%20each%20other%20when%20the%20agent%20link%20hasn't%20been%20created%20yet%29%2C%20both%20requests%20can%20observe%20%60existingForIntegration%20%3D%20null%60%20and%20both%20proceed%20to%20%60create%60%2C%20producing%20two%20%60AgentIntegration%60%20rows%20pointing%20to%20the%20same%20integration.%20Subsequent%20%60findOne%60%20calls%20would%20return%20one%20of%20the%20duplicates%20non-deterministically.%0A%0AAdding%20a%20unique%20compound%20index%20on%20%60%28_integrationId%2C%20_environmentId%2C%20_organizationId%29%60%20in%20the%20repository%2C%20or%20catching%20%60ConflictException%60%2Fduplicate-key%20errors%20from%20%60create%60%20and%20re-reading%20the%20row%20%28like%20%60ensureEnablementRow%60%20does%29%2C%20would%20make%20this%20idempotent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fmanaged-runtime%2Fsetup%2Fsetup-card.builder.ts%3A63-74%0A**Provider-managed%20vault%20failure%20silently%20kills%20the%20entire%20setup%20card%20for%20all%20MCPs**%0A%0AWhen%20%60executeForSetupCard%60%20throws%20%28e.g.%2C%20transient%20vault%20API%20failure%2C%20Anthropic%20API%20timeout%2C%20or%20the%20agent's%20runtime%20changes%20to%20a%20non-Claude%20platform%20after%20the%20MCP%20was%20enabled%29%2C%20the%20%60throw%20err%60%20exits%20%60buildSetupCardForMcps%60%20entirely.%20Any%20rows%20already%20built%20for%20standard%20OAuth%20MCPs%20earlier%20in%20the%20loop%20are%20discarded%2C%20and%20no%20setup%20card%20is%20posted%20at%20all.%20The%20user's%20message%20is%20left%20parked%20with%20no%20visible%20card%20and%20no%20way%20to%20connect%20even%20the%20non-provider-managed%20MCPs.%0A%0AThe%20standard%20OAuth%20branch%20handles%20failures%20gracefully%20by%20pushing%20the%20row%20without%20%60authorizeUrl%60%20%28line%20103%29.%20The%20provider-managed%20branch%20should%20do%20the%20same%20for%20resilience%20%E2%80%94%20showing%20the%20MCP%20entry%20without%20a%20connect%20button%20is%20still%20actionable%20for%20the%20other%20MCPs%20in%20the%20card.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20%20%20params.logger.warn%28%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20err%3A%20err%20instanceof%20Error%20%3F%20err.message%20%3A%20String%28err%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20mcpId%3A%20mcp.mcpId%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20conversationId%3A%20params.conversationId%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20'EnsureProviderManagedVault%20failed%20while%20building%20managed-agent%20setup%20card'%0A%20%20%20%20%20%20%20%20%29%3B%0A%0A%20%20%20%20%20%20%20%20rows.push%28mcp%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fmanaged-runtime%2Fsetup%2Fcomplete-managed-agent-setup.usecase.ts%3A175-177%0A**Unguarded%20loop%20breaks%20setup-card%20refresh%20for%20remaining%20conversations%20on%20first%20failure**%0A%0A%60refreshSetupCardsForPendingConversations%60%20iterates%20conversations%20without%20a%20per-iteration%20try-catch.%20If%20%60refreshSetupCardForConversation%60%20throws%20for%20any%20conversation%2C%20the%20loop%20exits%20early%20and%20remaining%20conversations%20never%20get%20their%20setup%20cards%20refreshed.%20Because%20this%20runs%20inside%20the%20fire-and-forget%20%60runPostRedirectSideEffects%60%2C%20the%20overall%20error%20is%20swallowed%2C%20but%20affected%20users%20end%20up%20with%20stale%20setup%20cards%20and%20no%20retry%20path.%20Compare%20%60completeAndReplayForAllPendingConversations%60%20which%20already%20wraps%20each%20iteration%20in%20try-catch.%0A%0A%60%60%60suggestion%0A%20%20%20%20for%20%28const%20conversation%20of%20conversations%29%20%7B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20await%20this.refreshSetupCardForConversation%28conversation%2C%20config%2C%20subscriber%2C%20mcps%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20%20%20this.logger.warn%28%0A%20%20%20%20%20%20%20%20%20%20err%2C%0A%20%20%20%20%20%20%20%20%20%20%60Failed%20to%20refresh%20setup%20card%20for%20conversation%20%24%7Bconversation._id%7D%3B%20continuing%20batch%60%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=11397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/agents/managed-runtime/setup/setup-card.builder.ts:63-74
**Provider-managed vault failure silently kills the entire setup card for all MCPs**

When `executeForSetupCard` throws (e.g., transient vault API failure, Anthropic API timeout, or the agent's runtime changes to a non-Claude platform after the MCP was enabled), the `throw err` exits `buildSetupCardForMcps` entirely. Any rows already built for standard OAuth MCPs earlier in the loop are discarded, and no setup card is posted at all. The user's message is left parked with no visible card and no way to connect even the non-provider-managed MCPs.

The standard OAuth branch handles failures gracefully by pushing the row without `authorizeUrl` (line 103). The provider-managed branch should do the same for resilience — showing the MCP entry without a connect button is still actionable for the other MCPs in the card.

```suggestion
      } catch (err) {
        params.logger.warn(
          {
            err: err instanceof Error ? err.message : String(err),
            mcpId: mcp.mcpId,
            conversationId: params.conversationId,
          },
          'EnsureProviderManagedVault failed while building managed-agent setup card'
        );

        rows.push(mcp);
      }
```

### Issue 2 of 2
apps/api/src/app/agents/managed-runtime/setup/complete-managed-agent-setup.usecase.ts:175-177
**Unguarded loop breaks setup-card refresh for remaining conversations on first failure**

`refreshSetupCardsForPendingConversations` iterates conversations without a per-iteration try-catch. If `refreshSetupCardForConversation` throws for any conversation, the loop exits early and remaining conversations never get their setup cards refreshed. Because this runs inside the fire-and-forget `runPostRedirectSideEffects`, the overall error is swallowed, but affected users end up with stale setup cards and no retry path. Compare `completeAndReplayForAllPendingConversations` which already wraps each iteration in try-catch.

```suggestion
    for (const conversation of conversations) {
      try {
        await this.refreshSetupCardForConversation(conversation, config, subscriber, mcps);
      } catch (err) {
        this.logger.warn(
          err,
          `Failed to refresh setup card for conversation ${conversation._id}; continuing batch`
        );
      }
    }
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/nex..."](https://github.com/novuhq/novu/commit/fef3299b6b81d3993ebbbb0d6f1e195996d51ee5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34897472)</sub>

<!-- /greptile_comment -->