### PR TITLE
fix(api-service): use DASHBOARD_URL for Slack MCP icon URLs fixes NV-7921

### DIFF
--- a/apps/api/src/app/agents/managed-runtime/tool-approval/approval-card.builder.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/approval-card.builder.ts
@@ -8,11 +8,24 @@ import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 
 export const TOOL_APPROVAL_ACTION_PREFIX = 'mcp-approval' as const;
 
+function resolveDashboardBaseUrl(): string {
+  for (const candidate of [process.env.DASHBOARD_URL, process.env.FRONT_BASE_URL]) {
+    const trimmed = candidate?.trim();
+
+    if (!trimmed || trimmed.startsWith('^')) {
+      continue;
+    }
+
+    return trimmed.replace(/\/$/, '');
+  }
+
+  return 'https://dashboard.novu.co';
+}
+
 function resolveSlackMcpIconUrl(mcpServerName?: string): string {
   const mcpId = resolveMcpCatalogIdByName(mcpServerName) ?? MCP_ICON_DEFAULT_ID;
-  const baseUrl = process.env.FRONT_BASE_URL || 'https://dashboard.novu.co';
 
-  return getMcpIconUrl(mcpId, baseUrl);
+  return getMcpIconUrl(mcpId, resolveDashboardBaseUrl());
 }
 
 type SlackCardBlock = Block & {


### PR DESCRIPTION
## Summary

- Slack MCP approval card icons were built from `FRONT_BASE_URL`, which on staging is a CORS allowlist regex — not a fetchable URL.
- Resolve icon URLs from `DASHBOARD_URL` first, skip regex-shaped env values, then fall back to production dashboard.

## Test plan

- [ ] On staging, trigger a new Slack tool approval card
- [ ] Confirm `icon.image_url` is `https://dashboard.novu-staging.co/agents/mcp/{id}.png` (not a `^https?://...` regex)
- [ ] Confirm the icon renders in Slack


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Slack MCP approval card builder now resolves icon URLs using a new dashboard base URL helper instead of directly referencing `FRONT_BASE_URL`. The helper checks `DASHBOARD_URL` first, skips invalid values (including CORS regex patterns), normalizes URLs by removing trailing slashes, and defaults to `https://dashboard.novu.co`. This ensures valid, fetchable icon URLs are generated for Slack approval cards.

## Affected areas

**api**: Updated the tool approval card builder to use a smarter dashboard URL resolution strategy that avoids CORS allowlist regex patterns on staging environments.

## Testing

Manual testing is required on staging to verify that Slack tool approval card icons display valid, fetchable URLs (e.g., `https://dashboard.novu-staging.co/agents/mcp/{id}.png`) and render correctly in Slack. No unit tests were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->