### PR TITLE
fix(dashbord,api-service): managed agents create integration form behaviour and validation fixes NV-7831

### DIFF
--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -183,6 +183,7 @@ export function CreateAgentDialog({
   const [externalEnvironmentId, setExternalEnvironmentId] = useState('');
   const [errors, setErrors] = useState<CreateAgentFormErrors>({});
   const [isIdentifierTouched, setIsIdentifierTouched] = useState(false);
+  const [isIntegrationNameTouched, setIsIntegrationNameTouched] = useState(false);
   // Brief confirmation badge that flashes in the dropdown trigger right after a successful save.
   const [showSavedBadge, setShowSavedBadge] = useState(false);
   const savedBadgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -298,7 +299,7 @@ export function CreateAgentDialog({
   // Default integration name = "<Provider> <next-index>"
   useEffect(() => {
     if (!credentialsPanelVisible || !selectedConnector?.providerLabel) return;
-    if (integrationName.trim()) return;
+    if (isIntegrationNameTouched || integrationName.trim()) return;
 
     const nextIndex = matchingAnthropicIntegrations.length + 1;
     setIntegrationName(`${selectedConnector.providerLabel} ${nextIndex}`);
@@ -307,6 +308,7 @@ export function CreateAgentDialog({
     selectedConnector?.providerLabel,
     matchingAnthropicIntegrations.length,
     integrationName,
+    isIntegrationNameTouched,
   ]);
 
   useEffect(() => {
@@ -336,6 +338,7 @@ export function CreateAgentDialog({
     setInstructions('');
     resetCredentials();
     setIntegrationName('');
+    setIsIntegrationNameTouched(false);
     setExternalAgentId('');
     setExternalEnvironmentId('');
     setErrors({});
@@ -455,7 +458,7 @@ export function CreateAgentDialog({
     setCredentialsPanelVisible(true);
     setCredentialsPanelExpanded(true);
 
-    if (option.providerLabel && !integrationName.trim()) {
+    if (option.providerLabel && !isIntegrationNameTouched && !integrationName.trim()) {
       const nextIndex = getClaudeManagedAgentIntegrations(integrations, option.providerId).length + 1;
       setIntegrationName(`${option.providerLabel} ${nextIndex}`);
     }
@@ -483,8 +486,10 @@ export function CreateAgentDialog({
       },
       onError: (err) => {
         if (lastVerifiedKeyRef.current !== verifyKey) return;
+        const message = err instanceof Error ? err.message : 'Invalid';
         setVerifyStatus('invalid');
-        setVerifyMessage(err instanceof Error ? err.message : 'Invalid');
+        setVerifyMessage(message);
+        showErrorToast(`Verification failed: ${message}`, 'Verification failed');
       },
     });
   };
@@ -526,7 +531,6 @@ export function CreateAgentDialog({
       setCredentialsPanelVisible(true);
       setCredentialsPanelExpanded(false);
       setSelectedIntegrationId(integration._id);
-      resetCredentials();
       setShowSavedBadge(true);
       if (savedBadgeTimerRef.current) clearTimeout(savedBadgeTimerRef.current);
       savedBadgeTimerRef.current = setTimeout(() => setShowSavedBadge(false), 2500);
@@ -725,9 +729,11 @@ export function CreateAgentDialog({
                   status={verifyStatus}
                   statusMessage={verifyMessage}
                   isSaving={isSavingIntegration}
+                  showSaveButton={!selectedIntegrationId}
                   expanded={credentialsPanelExpanded}
                   onExpandedChange={setCredentialsPanelExpanded}
                   onIntegrationNameChange={(next) => {
+                    setIsIntegrationNameTouched(true);
                     setIntegrationName(next);
                     setErrors((prev) => ({ ...prev, integrationName: undefined }));
                   }}

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
@@ -46,6 +46,7 @@ import {
   buildMcpOAuthCreateAuth,
   buildMcpOAuthUpdateAuth,
   buildToolsPayload,
+  extractApiErrorMessage,
   extractSkillNameFromBundle,
   isDuplicateDisplayTitleError,
   isTransient,
@@ -118,29 +119,30 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
 
     if (err instanceof APIError) {
       const requestId = err.requestID ?? err.headers?.get?.('request-id') ?? undefined;
+      const message = extractApiErrorMessage(err);
 
       if (err.status === 401) {
-        throw new AgentRuntimeUnauthorizedError(err.message, providerId, requestId);
+        throw new AgentRuntimeUnauthorizedError(message, providerId, requestId);
       }
       if (err.status === 403) {
-        throw new AgentRuntimeForbiddenError(err.message, providerId, requestId);
+        throw new AgentRuntimeForbiddenError(message, providerId, requestId);
       }
       if (err.status === 404) {
-        throw new AgentRuntimeNotFoundError(err.message, providerId, requestId);
+        throw new AgentRuntimeNotFoundError(message, providerId, requestId);
       }
       if (err.status === 429) {
         const retryAfterMs = parseRetryAfter(err.headers?.get?.('retry-after') ?? undefined);
 
-        throw new AgentRuntimeRateLimitedError(err.message, providerId, retryAfterMs, requestId);
+        throw new AgentRuntimeRateLimitedError(message, providerId, retryAfterMs, requestId);
       }
       if (err.status === 529) {
-        throw new AgentRuntimeOverloadedError(err.message, providerId, requestId);
+        throw new AgentRuntimeOverloadedError(message, providerId, requestId);
       }
       if (err.status >= 500) {
-        throw new AgentRuntimeServiceUnavailableError(err.message, providerId, requestId);
+        throw new AgentRuntimeServiceUnavailableError(message, providerId, requestId);
       }
       if (err.status === 400 || err.status === 422) {
-        throw new AgentRuntimeBadRequestError(err.message, providerId, requestId);
+        throw new AgentRuntimeBadRequestError(message, providerId, requestId);
       }
     }
 

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
@@ -39,6 +39,24 @@ export function truncateWithEllipsis(value: string, max: number): string {
 }
 
 /**
+ * Anthropic's SDK formats `APIError.message` as `"<status> <raw-json-body>"`
+ * (e.g. `400 {"type":"error","error":{"message":"…"}}`), which is unreadable
+ * when surfaced to end users. The SDK also exposes the parsed response body on
+ * `error.error`, so we prefer the upstream `error.message` field and fall back
+ * to the raw message only when the structured body is missing.
+ */
+export function extractApiErrorMessage(err: APIError): string {
+  const body = err.error as { error?: { message?: unknown } } | undefined;
+  const providerMessage = body?.error?.message;
+
+  if (typeof providerMessage === 'string' && providerMessage.trim().length > 0) {
+    return providerMessage.trim();
+  }
+
+  return err.message;
+}
+
+/**
  * Reads the `name` field out of the YAML frontmatter of the `SKILL.md` at the
  * root of an uploaded skill bundle. Anthropic enforces that the bundle's
  * top-level folder name equals this value, so we use it verbatim as the


### PR DESCRIPTION
### What changed? Why was the change needed?

Agents - managed agents - create integration form behaviour and validation errors handling fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR fixes form behavior and validation in the managed agents integration creation workflow. It prevents the integration name field from being auto-overwritten after user interaction by adding touch-state tracking, removes unnecessary credential resets after successful integration saves, and improves error message extraction from the Anthropic API for better end-user readability.

## Affected areas

**dashboard**: The `CreateAgentDialog` component now tracks user interaction with the integration name field via `isIntegrationNameTouched` flag to gate auto-prefilling behavior, conditionally renders the save button based on integration selection, and no longer resets credentials when a new integration is successfully created.

**application-generic**: Added a new `extractApiErrorMessage` helper function to normalize Anthropic SDK API error messages by preferring nested structured error messages when available. Updated the Anthropic agent runtime provider's `normaliseError` method to use this helper for extracting user-friendly error messages instead of relying on raw `err.message`.

## Testing

No new tests were added for the `extractApiErrorMessage` helper function. The existing unit tests for `mapToolset` and `buildToolsPayload` remain unchanged. The form behavior changes in the dashboard component would benefit from manual testing to verify the touch-state tracking and credential handling work as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

https://github.com/user-attachments/assets/fb0b3a17-35b3-4bb9-9dc9-aa3829486210


https://github.com/user-attachments/assets/abb5a1c2-87f9-49cb-b3c9-40de1ffaecef


https://github.com/user-attachments/assets/21029fba-6bad-4d5b-889a-a6016ee50700



