### PR TITLE
feat(dashboard): add Share feedback button to Connect sidebar fixes NV-7941

### DIFF
--- a/apps/dashboard/src/components/side-navigation/bottom-section.tsx
+++ b/apps/dashboard/src/components/side-navigation/bottom-section.tsx
@@ -10,7 +10,7 @@ import { NavigationLink } from './navigation-link';
 
 // TODO: restore FreeTrialCard / UsageCard once Connect has its own billing flow.
 export function BottomSection() {
-  const { showPlainLiveChat } = usePlainChat();
+  const { showPlainLiveChat, isLiveChatVisible } = usePlainChat();
   const track = useTelemetry();
 
   if (IS_SELF_HOSTED) {
@@ -25,18 +25,20 @@ export function BottomSection() {
   return (
     <div className="relative mt-auto gap-8 pt-4">
       <NavigationGroup>
-        <button
-          type="button"
-          onClick={handleShareFeedback}
-          className={cn(
-            'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm',
-            'text-foreground-600/95 transition duration-300 ease-out hover:bg-accent',
-            'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring'
-          )}
-        >
-          <RiChat1Line className="size-4" />
-          <span>Share feedback</span>
-        </button>
+        {isLiveChatVisible && (
+          <button
+            type="button"
+            onClick={handleShareFeedback}
+            className={cn(
+              'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm',
+              'text-foreground-600/95 transition duration-300 ease-out hover:bg-accent',
+              'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring'
+            )}
+          >
+            <RiChat1Line className="size-4" />
+            <span>Share feedback</span>
+          </button>
+        )}
         <NavigationLink to={ROUTES.SETTINGS_TEAM}>
           <RiUserAddLine className="size-4" />
           <span>Invite teammates</span>

--- a/apps/dashboard/src/components/side-navigation/bottom-section.tsx
+++ b/apps/dashboard/src/components/side-navigation/bottom-section.tsx
@@ -1,4 +1,8 @@
-import { RiUserAddLine } from 'react-icons/ri';
+import { RiChat1Line, RiUserAddLine } from 'react-icons/ri';
+import { usePlainChat } from '@/hooks/use-plain-chat';
+import { useTelemetry } from '@/hooks/use-telemetry';
+import { cn } from '@/utils/ui';
+import { TelemetryEvent } from '@/utils/telemetry';
 import { IS_SELF_HOSTED } from '../../config';
 import { ROUTES } from '../../utils/routes';
 import { NavigationGroup } from './navigation-group';
@@ -6,13 +10,33 @@ import { NavigationLink } from './navigation-link';
 
 // TODO: restore FreeTrialCard / UsageCard once Connect has its own billing flow.
 export function BottomSection() {
+  const { showPlainLiveChat } = usePlainChat();
+  const track = useTelemetry();
+
   if (IS_SELF_HOSTED) {
     return null;
+  }
+
+  function handleShareFeedback() {
+    track(TelemetryEvent.SHARE_FEEDBACK_LINK_CLICKED);
+    showPlainLiveChat();
   }
 
   return (
     <div className="relative mt-auto gap-8 pt-4">
       <NavigationGroup>
+        <button
+          type="button"
+          onClick={handleShareFeedback}
+          className={cn(
+            'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm',
+            'text-foreground-600/95 transition duration-300 ease-out hover:bg-accent',
+            'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring'
+          )}
+        >
+          <RiChat1Line className="size-4" />
+          <span>Share feedback</span>
+        </button>
         <NavigationLink to={ROUTES.SETTINGS_TEAM}>
           <RiUserAddLine className="size-4" />
           <span>Invite teammates</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Share feedback** button to the Connect sidebar bottom section. Clicking it opens the Plain support chat widget and tracks the existing `SHARE_FEEDBACK_LINK_CLICKED` telemetry event.

## Changes

- Updated `apps/dashboard/src/components/side-navigation/bottom-section.tsx` to render a sidebar action above **Invite teammates**
- Reuses the existing `usePlainChat` hook (same integration as the help icon and command palette)

## Testing

- Open Connect dashboard sidebar
- Click **Share feedback**
- Verify Plain chat widget opens
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2779e59c-8443-43f5-b089-5a65afc39a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2779e59c-8443-43f5-b089-5a65afc39a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

A "Share feedback" button was added to the Connect dashboard sidebar bottom section. Clicking it opens the Plain live chat widget and emits a `SHARE_FEEDBACK_LINK_CLICKED` telemetry event, giving users a quick way to submit feedback from the sidebar. The button is conditionally rendered (hidden when Plain chat is unavailable or when running in self-hosted mode).

## Affected areas

**dashboard**: The side-navigation bottom section now renders a "Share feedback" action that reuses the existing `usePlainChat` hook to open the Plain chat and `useTelemetry` to track the click; the button is only shown when live chat is available and when not self-hosted.

## Key technical decisions

- Reused the existing `usePlainChat` integration (same as help icon and command palette) to avoid duplicating chat integration logic.
- Added conditional rendering to hide the button if the Plain chat integration is unavailable or if `IS_SELF_HOSTED` is set.

## Testing

Manual verification: open the Connect sidebar, confirm the "Share feedback" button appears when live chat is available, click it, and verify the Plain chat widget opens and the telemetry event is emitted. No new automated tests were added due to the change being UI wiring of an existing integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a **Share feedback** button to the Connect sidebar's bottom section, wiring the existing `usePlainChat` hook and `SHARE_FEEDBACK_LINK_CLICKED` telemetry event. The button is conditionally rendered via `isLiveChatVisible`, so it only appears when the Plain widget is properly configured for the user.

- `BottomSection` now calls `usePlainChat` and `useTelemetry` at the top of the component (before the self-hosted early return), correctly following React's Rules of Hooks.
- The `isLiveChatVisible` guard ensures the button is hidden when `servicesHashes.plain` is absent or `PLAIN_SUPPORT_CHAT_APP_ID` is unset, preventing a silent no-op click.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, self-contained UI addition that reuses proven integrations and introduces no new logic paths.

The change is minimal: one file touched, no new hooks or utilities introduced, and the isLiveChatVisible guard correctly prevents rendering the button when the Plain widget is not configured. Hooks are called in the right place (before the early self-hosted return), and the telemetry call matches the established pattern used elsewhere in the dashboard.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/side-navigation/bottom-section.tsx | Adds a "Share feedback" button gated on `isLiveChatVisible`, reusing the existing `usePlainChat` hook and `SHARE_FEEDBACK_LINK_CLICKED` telemetry event. Hooks are correctly called before the self-hosted early return. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BottomSection
    participant usePlainChat
    participant Telemetry
    participant PlainWidget

    User->>BottomSection: Click "Share feedback"
    BottomSection->>Telemetry: track(SHARE_FEEDBACK_LINK_CLICKED)
    BottomSection->>usePlainChat: showPlainLiveChat()
    usePlainChat->>PlainWidget: window.Plain.open()
    PlainWidget-->>User: Chat widget opens

    Note over BottomSection,usePlainChat: Button only rendered when isLiveChatVisible is true
```

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): hide Share feedback when..."](https://github.com/novuhq/novu/commit/e727474ed7711e5e1044c3ce03ae4fc4a58cc6ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34909215)</sub>

<!-- /greptile_comment -->