### PR TITLE
chore(api, worker, ws, dashboard): changes required for new release and bug fixes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/api-service",
-  "version": "3.15.0",
+  "version": "3.17.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/api/src/app/auth/community.auth.module.config.ts
+++ b/apps/api/src/app/auth/community.auth.module.config.ts
@@ -1,7 +1,7 @@
 import { MiddlewareConsumer, ModuleMetadata, Provider, RequestMethod } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-import { FeatureFlagsService } from '@novu/application-generic';
+import { FeatureFlagsService, featureFlagsService } from '@novu/application-generic';
 import { CommunityMemberRepository, CommunityOrganizationRepository, CommunityUserRepository } from '@novu/dal';
 import { AuthProviderEnum, PassportStrategyEnum } from '@novu/shared';
 import passport from 'passport';
@@ -37,7 +37,7 @@ export function getCommunityAuthModuleConfig(): ModuleMetadata {
     }),
   ];
 
-  const baseProviders = [...AUTH_STRATEGIES, AuthService, RootEnvironmentGuard];
+  const baseProviders = [...AUTH_STRATEGIES, AuthService, RootEnvironmentGuard, featureFlagsService];
 
   // Wherever is the string token used, override it with the provider
   const injectableProviders = [

--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -71,7 +71,9 @@ export const envValidators = {
   STEP_RESOLVER_DISPATCH_URL: str({ default: undefined }),
   STEP_RESOLVER_HMAC_SECRET: str({ default: '' }),
   THALAMUS_CF_API_KEY: str({ default: undefined }),
-  ...(processEnv.THALAMUS_CF_URL
+  // Managed-agent (Thalamus) config is a Novu Cloud concern. On self-hosted we never require it,
+  // even if a URL happens to be present in the environment.
+  ...(processEnv.THALAMUS_CF_URL && processEnv.IS_SELF_HOSTED !== 'true'
     ? {
         THALAMUS_CF_URL: url(),
         THALAMUS_WEBHOOK_SECRET: str(),

--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -23,7 +23,10 @@ function getFeatureFlagValidator(key: FeatureFlagsKeysEnum): ValidatorSpec<strin
 // Managed-agent (Thalamus) config is a Novu Cloud concern. On self-hosted (or whenever the URL is
 // blank) we must not run envalid's `url()` validator, which rejects an empty string even with a
 // default — a blank `THALAMUS_CF_URL=` is common in self-hosted .env files and would block boot.
-function getThalamusValidators(): Record<string, ValidatorSpec<unknown>> {
+function getThalamusValidators(): {
+  THALAMUS_CF_URL: ValidatorSpec<string>;
+  THALAMUS_WEBHOOK_SECRET: ValidatorSpec<string>;
+} {
   if (processEnv.IS_SELF_HOSTED === 'true' || !processEnv.THALAMUS_CF_URL) {
     return {
       THALAMUS_CF_URL: str({ default: undefined }),

--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -20,6 +20,23 @@ function getFeatureFlagValidator(key: FeatureFlagsKeysEnum): ValidatorSpec<strin
   return str({ default: undefined });
 }
 
+// Managed-agent (Thalamus) config is a Novu Cloud concern. On self-hosted (or whenever the URL is
+// blank) we must not run envalid's `url()` validator, which rejects an empty string even with a
+// default — a blank `THALAMUS_CF_URL=` is common in self-hosted .env files and would block boot.
+function getThalamusValidators(): Record<string, ValidatorSpec<unknown>> {
+  if (processEnv.IS_SELF_HOSTED === 'true' || !processEnv.THALAMUS_CF_URL) {
+    return {
+      THALAMUS_CF_URL: str({ default: undefined }),
+      THALAMUS_WEBHOOK_SECRET: str({ default: undefined }),
+    };
+  }
+
+  return {
+    THALAMUS_CF_URL: url(),
+    THALAMUS_WEBHOOK_SECRET: str(),
+  };
+}
+
 export const envValidators = {
   TZ: str({ default: 'UTC' }),
   NODE_ENV: str({ choices: ['dev', 'test', 'production', 'ci', 'local'], default: 'local' }),
@@ -71,17 +88,7 @@ export const envValidators = {
   STEP_RESOLVER_DISPATCH_URL: str({ default: undefined }),
   STEP_RESOLVER_HMAC_SECRET: str({ default: '' }),
   THALAMUS_CF_API_KEY: str({ default: undefined }),
-  // Managed-agent (Thalamus) config is a Novu Cloud concern. On self-hosted we never require it,
-  // even if a URL happens to be present in the environment.
-  ...(processEnv.THALAMUS_CF_URL && processEnv.IS_SELF_HOSTED !== 'true'
-    ? {
-        THALAMUS_CF_URL: url(),
-        THALAMUS_WEBHOOK_SECRET: str(),
-      }
-    : {
-        THALAMUS_CF_URL: url({ default: undefined }),
-        THALAMUS_WEBHOOK_SECRET: str({ default: undefined }),
-      }),
+  ...getThalamusValidators(),
   /**
    * Shared inbound domain for the agent default inbox feature, e.g. `agentconnect.sh`.
    * When unset the feature is disabled and the worker falls through to the existing

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@novu/dashboard",
   "private": true,
-  "version": "3.15.4",
+  "version": "3.17.0",
   "type": "module",
   "portless": {
     "name": "dashboard.novu"

--- a/apps/dashboard/src/context/auth/auth-provider.tsx
+++ b/apps/dashboard/src/context/auth/auth-provider.tsx
@@ -102,6 +102,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   // org (old membership, cross-tab, or a deliberate Platform sign-in) fails the recency check and
   // falls through to the normal Platform resolution below.
   const recentlyJoinedConnect = useMemo(() => {
+    // Connect only exists when hostnames are split (never on self-hosted, which uses custom auth
+    // and has no Connect product). Bail early so we don't touch the Clerk-shaped membership shim,
+    // whose entries lack a real `createdAt` and would crash on `.getTime()`.
+    if (!IS_HOSTNAME_SPLIT_ENABLED) {
+      return false;
+    }
+
     const memberships = clerkUser?.organizationMemberships ?? [];
 
     if (memberships.length === 0) {
@@ -111,6 +118,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const newest = memberships.reduce((latest, membership) =>
       membership.createdAt > latest.createdAt ? membership : latest
     );
+
+    if (!newest.createdAt) {
+      return false;
+    }
 
     const joinedAgoMs = Date.now() - newest.createdAt.getTime();
     const isFreshJoin = joinedAgoMs >= 0 && joinedAgoMs <= FRESH_JOIN_WINDOW_MS;

--- a/apps/webhook/package.json
+++ b/apps/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/webhook",
-  "version": "3.15.0",
+  "version": "3.17.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/worker",
-  "version": "3.15.0",
+  "version": "3.17.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/ws",
-  "version": "3.15.0",
+  "version": "3.17.0",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Preparation for a new release (3.17.0) with targeted bug fixes and environment validation improvements. Package versions for several apps were bumped for release; the API’s community auth module now provides the feature flags service; Thalamus (managed-agent) env validators were refactored to avoid boot failures on self‑hosted installs when URL vars are blank; and the dashboard auth provider gained defensive checks to prevent a runtime crash when hostname-splitting is disabled.

## Affected areas
- **api**: Added the featureFlagsService token to the community auth module providers and refactored Thalamus-related env validation into getThalamusValidators() so cloud-only URL validation is skipped for self-hosted deployments.
- **dashboard**: Prevented a crash in the auth provider by short-circuiting Connect invite logic when hostname splitting is disabled and by guarding against missing membership createdAt values.
- **worker**, **ws**, **webhook**, **dashboard (package)**, **api (package)**: Bumped package versions to 3.17.0 to prepare the release.
- **dependencies**: No new external packages introduced; notable package references include `@novu/thalamus` at 0.1.0-alpha.11 in the API.

## Key technical decisions
- Thalamus validators now use a runtime check to choose between strict url() validation (cloud) and permissive str({ default: undefined }) for self-hosted, avoiding startup failures from blank env entries.
- The community auth module exposes featureFlagsService via its provider list to ensure the service token is injectable where required.

## Testing
No tests were added. Changes are defensive and configuration-focused: the auth fix prevents a known runtime crash and the env validator refactor preserves existing behavior for cloud while enabling self-hosted configs, so manual verification and existing integration/e2e tests are expected to cover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
