### PR TITLE
fix(dashboard): route first agent creation to onboarding setup page fixes NV-7944

### DIFF
--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -30,7 +30,8 @@ import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { AGENTS_DOCS_PROVIDERS_URL } from '@/utils/agent-docs';
 import { APP_IDS } from '@/utils/apps';
-import { AGENT_DETAILS_DEFAULT_TAB, buildRoute } from '@/utils/routes';
+import { withAppId } from '@/utils/onboarding-redirect';
+import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 const PAGE_SIZE_OPTIONS = [10, 12, 20, 50];
@@ -207,6 +208,10 @@ export function AgentsList() {
     setBefore(undefined);
   }, []);
 
+  const goToFirstAgentSetup = useCallback(() => {
+    navigate(withAppId(ROUTES.AGENTS_SETUP, currentApp));
+  }, [currentApp, navigate]);
+
   const handleCreateSubmit = useCallback(
     async (form: CreateAgentForm) => {
       await submitCreateAgent(form, {
@@ -275,7 +280,7 @@ export function AgentsList() {
               variant="secondary"
               mode="gradient"
               trailingIcon={RiArrowRightSLine}
-              onClick={() => setCreateOpen(true)}
+              onClick={goToFirstAgentSetup}
             >
               Setup an agent
             </PermissionButton>

--- a/apps/dashboard/src/components/connect/dashboard/set-things-up-section.tsx
+++ b/apps/dashboard/src/components/connect/dashboard/set-things-up-section.tsx
@@ -6,6 +6,8 @@ import { docsUrl } from '@/components/header-navigation/support-drawer-constants
 import { Button } from '@/components/primitives/button';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { APP_IDS } from '@/utils/apps';
+import { withAppId } from '@/utils/onboarding-redirect';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
@@ -170,9 +172,7 @@ export function SetThingsUpSection() {
 
   const goToAddAgent = () => {
     trackCtaClick('add-agent');
-    if (!environmentSlug) return;
-
-    navigate(`${buildRoute(ROUTES.CONNECT_AGENTS, { environmentSlug })}?create=1`);
+    navigate(withAppId(ROUTES.AGENTS_SETUP, APP_IDS.CONNECT));
   };
 
   const goToSetupChannel = () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When creating the first agent, the "Add an agent" CTA now navigates to the full onboarding setup flow at `/onboarding/agents/setup` instead of opening the create agent modal. Subsequent agents continue to use the modal.

## Changes

- **Connect onboarding checklist** (`SetThingsUpSection`): "Add an agent" button navigates to `/onboarding/agents/setup?appId=connect` instead of `/connect/agents?create=1`.
- **Agents page empty state** (`AgentsList`): "Setup an agent" button navigates to `/onboarding/agents/setup` instead of opening `CreateAgentDialog`.
- **Subsequent agents**: The "Add Agent" header button (when agents already exist) still opens the modal as before.

## Flow

```mermaid
flowchart LR
  A[Add an agent CTA] --> B{Has existing agents?}
  B -->|No| C["/onboarding/agents/setup"]
  B -->|Yes| D[CreateAgentDialog modal]
```

## Test plan

- [ ] From Connect home onboarding checklist with no agents, click "Add an agent" → lands on `/onboarding/agents/setup`
- [ ] From agents page empty state, click "Setup an agent" → lands on `/onboarding/agents/setup`
- [ ] With at least one agent, click "Add Agent" in the agents list header → opens create agent modal
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edf0dc4e-7663-4c78-966f-fb600a05cff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edf0dc4e-7663-4c78-966f-fb600a05cff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

When creating the first agent, users are now routed to the full onboarding setup flow at `/onboarding/agents/setup` instead of opening an inline create agent modal. The change affects two entry points: the "Add an agent" CTA on the Connect onboarding checklist and the "Setup an agent" button in the agents page empty state. Subsequent agents continue to use the quick-create modal. This ensures new users follow the complete onboarding flow for their first agent while allowing quick creation of additional agents.

## Affected areas

**dashboard**: Updated the agents list component to route first agent creation to the onboarding setup page with app-scoped navigation. Updated the Connect onboarding checklist component to navigate to the agents setup route instead of opening the create modal.

## Testing

No automated tests were added. The PR relies on manual verification according to the test plan: confirming the routing works from the Connect checklist, the agents empty state, and that the modal still opens for subsequent agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes first-agent creation to the dedicated onboarding setup page (`/onboarding/agents/setup`) instead of opening the `CreateAgentDialog` modal, affecting two entry points: the Connect dashboard onboarding checklist and the `AgentsList` empty state. The \"Add Agent\" header button (when agents already exist) is untouched and still opens the modal.

- **`set-things-up-section.tsx`**: The \"Add an agent\" CTA now calls `navigate(withAppId(ROUTES.AGENTS_SETUP, APP_IDS.CONNECT))`, removing the previously required `environmentSlug` guard (correctly, since `AGENTS_SETUP` is a static path).
- **`agents-list.tsx`**: A new `goToFirstAgentSetup` callback replaces the `setCreateOpen(true)` call in the empty state, forwarding the current app ID via `withAppId`. The existing `?create=1` search-param handler is left intact for backward compatibility with any other callers.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the routing change is narrow and the fallback modal path for existing agents is untouched.

Both entry points correctly route to the onboarding setup page and the existing modal flow for returning users is preserved. The only open question is whether AgentsList is ever rendered outside the Connect app context — if so, the empty state would forward ?appId=novu to a Connect-specific onboarding route.

A second look at agents-list.tsx is worthwhile to confirm AgentsList is never rendered in the non-Connect app context, or to add an explicit guard around goToFirstAgentSetup.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agents-list.tsx | Empty-state 'Setup an agent' CTA now navigates to AGENTS_SETUP with the current app ID appended, instead of opening the CreateAgentDialog; the header 'Add Agent' button (when agents exist) is unchanged. goToFirstAgentSetup always forwards currentApp, which is always a defined AppId, so if AgentsList is rendered in a non-Connect context the user lands on /onboarding/agents/setup?appId=novu. |
| apps/dashboard/src/components/connect/dashboard/set-things-up-section.tsx | Replaces the old ?create=1 modal-trigger navigation with a direct navigate(withAppId(ROUTES.AGENTS_SETUP, APP_IDS.CONNECT)) call; the environmentSlug guard is correctly removed since AGENTS_SETUP is a static path that requires no slug. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Add an agent CTA] --> B{Entry point?}
    B -->|Connect onboarding checklist| C[goToAddAgent in set-things-up-section]
    B -->|AgentsList empty state| D[goToFirstAgentSetup in agents-list]
    B -->|AgentsList header with existing agents| E[setCreateOpen true]
    C --> F["withAppId(ROUTES.AGENTS_SETUP, APP_IDS.CONNECT)"]
    D --> G["withAppId(ROUTES.AGENTS_SETUP, currentApp)"]
    E --> H[CreateAgentDialog modal]
    F --> I["/onboarding/agents/setup?appId=connect"]
    G --> J["/onboarding/agents/setup?appId=currentApp"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Fagents-list.tsx%3A211-213%0A**Non-Connect%20app%20lands%20on%20Connect-specific%20onboarding**%0A%0A%60useCurrentApp%28%29%60%20always%20returns%20a%20defined%20%60AppId%60%2C%20so%20%60withAppId%60%20will%20always%20append%20%60%3FappId%3D%3CcurrentApp%3E%60.%20If%20%60AgentsList%60%20is%20rendered%20in%20the%20NOVU%20%28non-Connect%29%20app%20context%20and%20a%20user%20hits%20the%20empty%20state%2C%20they%20navigate%20to%20%60%2Fonboarding%2Fagents%2Fsetup%3FappId%3Dnovu%60.%20%60ROUTES.AGENTS_SETUP%60%20is%20the%20Connect%20agent-setup%20onboarding%20flow%2C%20and%20it's%20not%20obvious%20that%20the%20same%20page%20handles%20the%20NOVU%20app%20variant%20correctly.%20If%20the%20Agents%20list%20is%20only%20ever%20visible%20in%20the%20Connect%20app%20this%20is%20harmless%2C%20but%20it%20may%20be%20worth%20an%20explicit%20guard%20%28e.g.%20hardcoding%20%60APP_IDS.CONNECT%60%20or%20checking%20%60isConnectApp%60%20before%20using%20%60currentApp%60%29.%0A%0A&pr=11407&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/agents/agents-list.tsx:211-213
**Non-Connect app lands on Connect-specific onboarding**

`useCurrentApp()` always returns a defined `AppId`, so `withAppId` will always append `?appId=<currentApp>`. If `AgentsList` is rendered in the NOVU (non-Connect) app context and a user hits the empty state, they navigate to `/onboarding/agents/setup?appId=novu`. `ROUTES.AGENTS_SETUP` is the Connect agent-setup onboarding flow, and it's not obvious that the same page handles the NOVU app variant correctly. If the Agents list is only ever visible in the Connect app this is harmless, but it may be worth an explicit guard (e.g. hardcoding `APP_IDS.CONNECT` or checking `isConnectApp` before using `currentApp`).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): route first agent creati..."](https://github.com/novuhq/novu/commit/82ff5fe726c6c1cbe3e414afedd8a1ee5e166c3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34948351)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->