### PR TITLE
fix(dashboard): redirect platform org create to usecase onboarding fixes NV-7945

### DIFF
--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -174,6 +174,9 @@ export function AgentsSetupPage() {
   const appId = useMemo(() => resolveOnboardingAppId(searchParams), [searchParams]);
   const isConnectFlow = appId === APP_IDS.CONNECT;
   const isConnectHost = IS_NOVU_CONNECT || isConnectFlow;
+  const pageTitle = isConnectHost
+    ? "Let's connect your agent to where you work"
+    : 'Connect your first agent';
 
   const [envLoaded, setEnvLoaded] = useState(false);
   const { environments } = useFetchEnvironments({
@@ -293,9 +296,7 @@ export function AgentsSetupPage() {
 
     return (
       <div className="flex h-screen w-full items-center justify-center">
-        <PageMeta
-          title={isConnectHost ? 'Build and distribute agents' : "Let's connect your agent to where you work"}
-        />
+        <PageMeta title={isConnectHost ? 'Build and distribute agents' : pageTitle} />
         <OnboardingLoader variant={isConnectHost ? 'connect' : 'platform'} />
       </div>
     );
@@ -303,15 +304,13 @@ export function AgentsSetupPage() {
 
   const leftContent = (
     <>
-      <PageMeta title="Let's connect your agent to where you work" />
+      <PageMeta title={pageTitle} />
       <StepHeader
         current={phase === 'connect' ? 2 : 3}
         onBack={phase === 'connect' ? handleBackFromConnectPhase : handleBackToConnect}
       />
 
-      <h1 className="text-foreground text-lg font-medium tracking-[-0.27px]">
-        Let's connect your agent to where you work
-      </h1>
+      <h1 className="text-foreground text-lg font-medium tracking-[-0.27px]">{pageTitle}</h1>
       <p className="text-text-soft mt-1 text-xs font-medium leading-4">
         A few steps to your first multi-channel agent conversation.
       </p>

--- a/apps/dashboard/src/utils/better-auth/components/organization-create.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/organization-create.tsx
@@ -175,7 +175,7 @@ function OrganizationListContent({
   };
 
   const handleCreateSuccess = () => {
-    window.location.href = afterCreateOrganizationUrl || ROUTES.INBOX_USECASE;
+    window.location.href = afterCreateOrganizationUrl || ROUTES.USECASE_SELECT;
   };
 
   if (isLoading) {

--- a/apps/dashboard/src/utils/better-auth/index.tsx
+++ b/apps/dashboard/src/utils/better-auth/index.tsx
@@ -410,11 +410,10 @@ export function OrganizationList(props?: {
   afterSelectOrganizationUrl?: string;
   afterCreateOrganizationUrl?: string;
 }) {
-  // Platform skips the usecase picker and starts directly with notifications/inbox.
   return (
     <OrganizationCreateComponent
       afterSelectOrganizationUrl={props?.afterSelectOrganizationUrl || ROUTES.ENV}
-      afterCreateOrganizationUrl={props?.afterCreateOrganizationUrl || ROUTES.INBOX_USECASE}
+      afterCreateOrganizationUrl={props?.afterCreateOrganizationUrl || ROUTES.USECASE_SELECT}
     />
   );
 }

--- a/apps/dashboard/src/utils/onboarding-redirect.ts
+++ b/apps/dashboard/src/utils/onboarding-redirect.ts
@@ -71,8 +71,7 @@ export function getPostOrgCreateRoute(appId: AppId, _isAgentsEnabled: boolean): 
     return ROUTES.AGENTS_SETUP;
   }
 
-  // Platform skips the usecase picker and starts directly with notifications/inbox.
-  return ROUTES.INBOX_USECASE;
+  return ROUTES.USECASE_SELECT;
 }
 
 // May return an absolute URL when crossing to the other product host — callers must check


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After creating an organization from the organization picker on **Novu Cloud** (not Novu Connect), users are sent to `/onboarding/usecase` so they can choose their use case before continuing. Previously they were sent straight to `/onboarding/inbox`, skipping the picker.

On the agents setup onboarding page (`/onboarding/agents/setup`), Novu Cloud now shows the headline **Connect your first agent** instead of the Connect-oriented copy.

## Changes

- `getPostOrgCreateRoute()` returns `ROUTES.USECASE_SELECT` for platform (`APP_IDS.NOVU`) instead of `ROUTES.INBOX_USECASE`
- Align Better Auth `OrganizationList` / create fallbacks with the same default
- Platform agents setup page title: **Connect your first agent** (Connect host unchanged)

Connect org creation is unchanged (`/onboarding/agents/setup`).

## Verification

- Create org from organization picker on Novu Cloud → lands on `/onboarding/usecase`
- Choose agents path → agents setup shows **Connect your first agent**
- Create org on Novu Connect → still lands on agents setup with existing Connect copy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fce143d1-1672-4a41-9870-301b0174c9f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fce143d1-1672-4a41-9870-301b0174c9f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Creating an organization from the Novu Cloud organization picker now redirects to the use-case selection page (/onboarding/usecase) instead of jumping straight to the inbox; this restores the intended onboarding flow so users choose a use case before continuing. Additionally, the agents setup onboarding page on Novu Cloud shows a platform-specific headline ("Connect your first agent") while Novu Connect’s copy and behavior remain unchanged.

## Affected areas

**dashboard**: Updated Better Auth components and onboarding helpers so the default post-organization-creation route for the platform app (APP_IDS.NOVU) is ROUTES.USECASE_SELECT; aligned OrganizationList/OrganizationListContent fallbacks and the getPostOrgCreateRoute() helper. Also adjusted the AgentsSetupPage to show a platform-specific page title for Novu Cloud.

## Testing

Manual verification was performed: creating an org via the Novu Cloud picker lands on /onboarding/usecase and choosing the agents path shows the new "Connect your first agent" title; org creation on Novu Connect is unchanged. No automated tests were added because this is a redirect/ui copy fix that is best validated via integration or manual browser checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the post-organization-creation redirect for Novu Cloud (platform) users, routing them through `/onboarding/usecase` so they can pick a use case before continuing, rather than landing directly on `/onboarding/inbox`. It also updates the agents setup page headline for platform users to "Connect your first agent".

- `getPostOrgCreateRoute()` and both Better Auth `OrganizationList` / `OrganizationListContent` fallbacks now consistently return `ROUTES.USECASE_SELECT` for non-Connect flows, removing the prior inconsistency where the helper and the UI components defaulted to different routes.
- `agents-setup-page.tsx` extracts `pageTitle` into a variable driven by `isConnectHost`, so the loading state and the visible `<h1>` both reflect the new platform copy without duplicating the conditional.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused redirect target swap with no new logic paths.

All three redirect sites (the helper function, the OrganizationList wrapper, and the OrganizationListContent fallback) are updated consistently to ROUTES.USECASE_SELECT. The agents setup page title refactor is purely cosmetic and preserves existing Connect-host behavior. No edge cases or regressions are apparent.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/onboarding-redirect.ts | getPostOrgCreateRoute() now returns ROUTES.USECASE_SELECT for platform apps; stale comment removed. Change is clean and consistent with the other three touched files. |
| apps/dashboard/src/utils/better-auth/components/organization-create.tsx | handleCreateSuccess fallback updated from ROUTES.INBOX_USECASE to ROUTES.USECASE_SELECT; aligns with the helper and the OrganizationList wrapper. |
| apps/dashboard/src/utils/better-auth/index.tsx | OrganizationList afterCreateOrganizationUrl default changed to ROUTES.USECASE_SELECT and stale inline comment removed; straightforward one-liner fix. |
| apps/dashboard/src/pages/agents-setup-page.tsx | pageTitle variable extracted and keyed on isConnectHost; both the loading-state PageMeta and the live h1/PageMeta now use it, removing copy duplication without behavioral regression for Connect users. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User creates organization] --> B{App type?}
    B -->|Connect| C[ROUTES.AGENTS_SETUP]
    B -->|Platform| D[ROUTES.USECASE_SELECT]
    D --> E{Choose use case}
    E -->|Agents| F[ROUTES.AGENTS_SETUP - Connect your first agent]
    E -->|Other| G[ROUTES.INBOX_USECASE]
    C --> H[ROUTES.AGENTS_SETUP - Lets connect your agent]
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;next&#39; into cursor/platform..."](https://github.com/novuhq/novu/commit/9fd70485710baa33fd9d11bce8d586d446ec26e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34952072)</sub>

<!-- /greptile_comment -->