### PR TITLE
feat(api-service): gate managed agent MCP permissions behind feature flag fixes NV-7946

### DIFF
--- a/apps/api/src/app/agents/management/usecases/migrate-agent-runtime/migrate-agent-runtime.usecase.spec.ts
+++ b/apps/api/src/app/agents/management/usecases/migrate-agent-runtime/migrate-agent-runtime.usecase.spec.ts
@@ -1,5 +1,5 @@
 import * as ApplicationGeneric from '@novu/application-generic';
-import { AnalyticsService, encryptCredentials } from '@novu/application-generic';
+import { AnalyticsService, encryptCredentials, FeatureFlagsService } from '@novu/application-generic';
 import { AgentRepository, ConversationRepository, IntegrationRepository } from '@novu/dal';
 import { AgentRuntimeProviderIdEnum, IntegrationKindEnum } from '@novu/shared';
 import { expect } from 'chai';
@@ -14,6 +14,7 @@ describe('MigrateAgentRuntime', () => {
   let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
   let conversationRepository: sinon.SinonStubbedInstance<ConversationRepository>;
   let analyticsService: sinon.SinonStubbedInstance<AnalyticsService>;
+  let featureFlagsService: sinon.SinonStubbedInstance<FeatureFlagsService>;
   let sourceProvider: ReturnType<typeof buildMockProvider>;
   let targetProvider: ReturnType<typeof buildMockProvider>;
   let previousApiKey: string | undefined;
@@ -44,6 +45,8 @@ describe('MigrateAgentRuntime', () => {
     integrationRepository = sinon.createStubInstance(IntegrationRepository);
     conversationRepository = sinon.createStubInstance(ConversationRepository);
     analyticsService = sinon.createStubInstance(AnalyticsService);
+    featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
+    featureFlagsService.getFlag.resolves(false);
 
     sourceProvider = buildMockProvider();
     targetProvider = buildMockProvider();
@@ -108,7 +111,8 @@ describe('MigrateAgentRuntime', () => {
       agentRepository as any,
       integrationRepository as any,
       conversationRepository as any,
-      analyticsService as any
+      analyticsService as any,
+      featureFlagsService as any
     );
   });
 

--- a/apps/api/src/app/agents/management/usecases/migrate-agent-runtime/migrate-agent-runtime.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/migrate-agent-runtime/migrate-agent-runtime.usecase.ts
@@ -2,12 +2,14 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import {
   AnalyticsService,
   decryptCredentials,
+  FeatureFlagsService,
   getAgentRuntimeProvider,
   getNovuManagedClaudeApiKey,
   resolveAgentRuntime,
 } from '@novu/application-generic';
 import { AgentRepository, ConversationRepository, IntegrationRepository } from '@novu/dal';
 import { AgentRuntimeProviderIdEnum, IntegrationKindEnum } from '@novu/shared';
+import { resolveManagedAgentAlwaysAllowToolPermissions } from '../../../mcp/resolve-managed-agent-always-allow-tool-permissions';
 import { MigrateAgentRuntimeCommand } from './migrate-agent-runtime.command';
 
 @Injectable()
@@ -16,7 +18,8 @@ export class MigrateAgentRuntime {
     private readonly agentRepository: AgentRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly conversationRepository: ConversationRepository,
-    private readonly analyticsService: AnalyticsService
+    private readonly analyticsService: AnalyticsService,
+    private readonly featureFlagsService: FeatureFlagsService
   ) {}
 
   async execute(command: MigrateAgentRuntimeCommand): Promise<{ integrationId: string; externalAgentId: string }> {
@@ -91,6 +94,11 @@ export class MigrateAgentRuntime {
     const targetProvider = targetResolved.provider;
 
     const config = await sourceProvider.getConfig(agent.managedRuntime.externalAgentId);
+    const useAlwaysAllowToolPermissions = await resolveManagedAgentAlwaysAllowToolPermissions({
+      featureFlagsService: this.featureFlagsService,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    });
     const created = await targetProvider.createAgent({
       name: agent.name,
       model: config.model,
@@ -98,6 +106,7 @@ export class MigrateAgentRuntime {
       tools: config.tools.map((tool) => tool.externalId),
       mcpServers: config.mcpServers.map((server) => ({ name: server.name, url: server.url })),
       skills: config.skills,
+      useAlwaysAllowToolPermissions,
     });
 
     try {

--- a/apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts
@@ -3,6 +3,7 @@ import {
   areNovuManagedClaudeCredentialsSet,
   decryptCredentials,
   encryptCredentials,
+  FeatureFlagsService,
   getAgentRuntimeProvider,
   getNovuManagedClaudeApiKey,
   PinoLogger,
@@ -13,6 +14,7 @@ import { AgentMcpServerRepository, AgentRepository, IntegrationRepository } from
 import { AgentRuntimeProviderIdEnum, type ICredentialsDto, MCP_SERVERS, McpConnectionScopeEnum } from '@novu/shared';
 import type { ClientSession } from 'mongoose';
 import { resolveMcpServersById } from '../../../mcp/resolve-mcp-servers';
+import { resolveManagedAgentAlwaysAllowToolPermissions } from '../../../mcp/resolve-managed-agent-always-allow-tool-permissions';
 import { ProvisionManagedAgentCommand } from './provision-managed-agent.command';
 
 export type ProvisionManagedAgentOptions = {
@@ -33,6 +35,7 @@ export class ProvisionManagedAgent {
     private readonly agentRepository: AgentRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly featureFlagsService: FeatureFlagsService,
     private readonly logger: PinoLogger
   ) {}
 
@@ -97,6 +100,11 @@ export class ProvisionManagedAgent {
       await runtimeProvider.validateCredentials(validateCredentialsInput);
 
       const resolvedMcpServers = command.mcpServers ? resolveMcpServersById(command.mcpServers) : undefined;
+      const useAlwaysAllowToolPermissions = await resolveManagedAgentAlwaysAllowToolPermissions({
+        featureFlagsService: this.featureFlagsService,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+      });
 
       const response = await runtimeProvider.createAgent({
         name: command.name ?? '',
@@ -105,6 +113,7 @@ export class ProvisionManagedAgent {
         tools: command.tools,
         mcpServers: resolvedMcpServers,
         skills: command.skills,
+        useAlwaysAllowToolPermissions,
       });
 
       externalAgentId = response.externalAgentId;

--- a/apps/api/src/app/agents/management/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts
@@ -1,8 +1,9 @@
 import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
-import { PinoLogger, resolveAgentRuntime } from '@novu/application-generic';
+import { FeatureFlagsService, PinoLogger, resolveAgentRuntime } from '@novu/application-generic';
 import { AgentMcpServerRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import { AGENT_RUNTIME_PROVIDERS } from '@novu/shared';
 import { projectMcpRowsToCatalog } from '../../../mcp/project-mcp-servers';
+import { resolveManagedAgentAlwaysAllowToolPermissions } from '../../../mcp/resolve-managed-agent-always-allow-tool-permissions';
 import type {
   AgentRuntimeCapabilitiesDto,
   AgentRuntimeConfigResponseDto,
@@ -15,6 +16,7 @@ export class UpdateAgentRuntimeConfig {
     private readonly agentRepository: AgentRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly featureFlagsService: FeatureFlagsService,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -62,12 +64,18 @@ export class UpdateAgentRuntimeConfig {
     }
 
     const runtimeProvider = resolved.provider;
+    const useAlwaysAllowToolPermissions = await resolveManagedAgentAlwaysAllowToolPermissions({
+      featureFlagsService: this.featureFlagsService,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    });
 
     const updated = await runtimeProvider.updateConfig(externalAgentId, {
       model: command.model,
       systemPrompt: command.systemPrompt,
       tools: command.tools,
       skills: command.skills,
+      useAlwaysAllowToolPermissions,
     });
 
     const mcpRows = await this.agentMcpServerRepository.findByAgent({

--- a/apps/api/src/app/agents/mcp/resolve-managed-agent-always-allow-tool-permissions.spec.ts
+++ b/apps/api/src/app/agents/mcp/resolve-managed-agent-always-allow-tool-permissions.spec.ts
@@ -1,0 +1,44 @@
+import { FeatureFlagsService } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { resolveManagedAgentAlwaysAllowToolPermissions } from './resolve-managed-agent-always-allow-tool-permissions';
+
+describe('resolveManagedAgentAlwaysAllowToolPermissions', () => {
+  let featureFlagsService: sinon.SinonStubbedInstance<FeatureFlagsService>;
+
+  beforeEach(() => {
+    featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
+  });
+
+  it('returns true when the feature flag is enabled', async () => {
+    featureFlagsService.getFlag.resolves(true);
+
+    const result = await resolveManagedAgentAlwaysAllowToolPermissions({
+      featureFlagsService: featureFlagsService as never,
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+    });
+
+    expect(result).to.equal(true);
+    expect(featureFlagsService.getFlag.calledOnce).to.equal(true);
+    expect(featureFlagsService.getFlag.firstCall.args[0]).to.deep.include({
+      key: FeatureFlagsKeysEnum.IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED,
+      defaultValue: false,
+      environment: { _id: 'env-1' },
+      organization: { _id: 'org-1' },
+    });
+  });
+
+  it('returns false when the feature flag is disabled', async () => {
+    featureFlagsService.getFlag.resolves(false);
+
+    const result = await resolveManagedAgentAlwaysAllowToolPermissions({
+      featureFlagsService: featureFlagsService as never,
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+    });
+
+    expect(result).to.equal(false);
+  });
+});

--- a/apps/api/src/app/agents/mcp/resolve-managed-agent-always-allow-tool-permissions.ts
+++ b/apps/api/src/app/agents/mcp/resolve-managed-agent-always-allow-tool-permissions.ts
@@ -1,0 +1,20 @@
+import { FeatureFlagsService } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+
+/**
+ * Per-org rollout gate for provisioning managed agents with permissive
+ * tool/MCP defaults. When enabled, upstream toolsets are created with
+ * `always_allow` permission policies instead of the default `always_ask`.
+ */
+export async function resolveManagedAgentAlwaysAllowToolPermissions(args: {
+  featureFlagsService: FeatureFlagsService;
+  environmentId: string;
+  organizationId: string;
+}): Promise<boolean> {
+  return args.featureFlagsService.getFlag({
+    key: FeatureFlagsKeysEnum.IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED,
+    defaultValue: false,
+    environment: { _id: args.environmentId },
+    organization: { _id: args.organizationId },
+  });
+}

--- a/apps/api/src/app/agents/mcp/servers/sync-agent-mcp-servers/sync-agent-mcp-servers.usecase.ts
+++ b/apps/api/src/app/agents/mcp/servers/sync-agent-mcp-servers/sync-agent-mcp-servers.usecase.ts
@@ -1,9 +1,10 @@
 import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
-import { PinoLogger, resolveAgentRuntime } from '@novu/application-generic';
+import { FeatureFlagsService, PinoLogger, resolveAgentRuntime } from '@novu/application-generic';
 import { AgentMcpServerRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import { MCP_SERVERS } from '@novu/shared';
 
 import { projectMcpRowsToCatalog } from '../../project-mcp-servers';
+import { resolveManagedAgentAlwaysAllowToolPermissions } from '../../resolve-managed-agent-always-allow-tool-permissions';
 import { SyncAgentMcpServersCommand } from './sync-agent-mcp-servers.command';
 
 /**
@@ -27,6 +28,7 @@ export class SyncAgentMcpServers {
     private readonly agentRepository: AgentRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly featureFlagsService: FeatureFlagsService,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -86,9 +88,17 @@ export class SyncAgentMcpServers {
     });
 
     const runtimeProvider = resolved.provider;
+    const useAlwaysAllowToolPermissions = await resolveManagedAgentAlwaysAllowToolPermissions({
+      featureFlagsService: this.featureFlagsService,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    });
 
     try {
-      await runtimeProvider.updateConfig(externalAgentId, { mcpServers: projection });
+      await runtimeProvider.updateConfig(externalAgentId, {
+        mcpServers: projection,
+        useAlwaysAllowToolPermissions,
+      });
     } catch (err) {
       const code = err instanceof Error ? err.name || 'sync_error' : 'sync_error';
       const message = err instanceof Error ? err.message : 'Unknown provider error';

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
@@ -576,4 +576,43 @@ describe('AnthropicAgentRuntimeProvider.updateConfig', () => {
     expect(mcpToolset?.mcp_server_name).to.equal('Slack');
     expect(mcpToolset?.default_config?.permission_policy).to.deep.equal({ type: 'always_ask' });
   });
+
+  it('uses always_allow permission policies when useAlwaysAllowToolPermissions is true', async () => {
+    const provider = createAnthropicProvider(AgentRuntimeProviderIdEnum.Anthropic, { apiKey: 'test-key' });
+
+    const retrieve = jest.fn().mockResolvedValue({
+      version: 1,
+      tools: [
+        {
+          type: 'agent_toolset_20260401',
+          configs: [{ name: 'bash', enabled: true }],
+        },
+      ],
+      mcp_servers: [],
+    });
+
+    const update = jest.fn().mockResolvedValue({
+      model: 'claude-sonnet-4-5',
+      system: '',
+      tools: [],
+      mcp_servers: [{ name: 'Slack', url: 'https://mcp.slack.com/mcp' }],
+      skills: [],
+    });
+
+    installUpdateConfigMockClient(provider, { retrieve, update });
+
+    await provider.updateConfig('ext-agent-id', {
+      mcpServers: [{ externalId: 'Slack', name: 'Slack', url: 'https://mcp.slack.com/mcp' }],
+      useAlwaysAllowToolPermissions: true,
+    });
+
+    const [, updatePayload] = update.mock.calls[0];
+    const toolset = getToolsetPayload(updatePayload as { tools?: AgentToolsetPayloadEntry[] });
+    const mcpToolset = (updatePayload as { tools?: AgentToolsetPayloadEntry[] }).tools?.find(
+      (t) => t.type === 'mcp_toolset'
+    );
+
+    expect(toolset?.default_config?.permission_policy).to.deep.equal({ type: 'always_allow' });
+    expect(mcpToolset?.default_config?.permission_policy).to.deep.equal({ type: 'always_allow' });
+  });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
@@ -46,6 +46,7 @@ import {
   buildMcpOAuthCreateAuth,
   buildMcpOAuthUpdateAuth,
   buildToolsPayload,
+  resolveManagedAgentPermissionConfig,
   extractApiErrorMessage,
   extractSkillNameFromBundle,
   isDuplicateDisplayTitleError,
@@ -179,7 +180,8 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
     // Not retried: agent creation is not idempotent and a retry after a
     // dropped response would create a duplicate billable agent upstream.
     try {
-      const toolsPayload = buildToolsPayload(input.tools, input.mcpServers);
+      const permissionConfig = resolveManagedAgentPermissionConfig(input.useAlwaysAllowToolPermissions);
+      const toolsPayload = buildToolsPayload(input.tools, input.mcpServers, permissionConfig);
 
       const agent = await (client as any).beta.agents.create({
         name: input.name,
@@ -291,7 +293,8 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
             patch.mcpServers !== undefined
               ? patch.mcpServers.map((s) => ({ name: s.name, url: s.url }))
               : currentMcpServers.map((s) => ({ name: s.name, url: s.url }));
-          const toolsPayload = buildToolsPayload(toolTypes, mcpServers);
+          const permissionConfig = resolveManagedAgentPermissionConfig(patch.useAlwaysAllowToolPermissions);
+          const toolsPayload = buildToolsPayload(toolTypes, mcpServers, permissionConfig);
 
           if (toolsPayload.length > 0) updatePayload.tools = toolsPayload;
         }

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
@@ -1,6 +1,12 @@
 import { CLAUDE_BUILTIN_TOOLS } from '@novu/shared';
 import { expect } from 'chai';
-import { buildToolsPayload, MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG, mapToolset } from './anthropic-runtime.helpers';
+import {
+  buildToolsPayload,
+  MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG,
+  MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
+  mapToolset,
+  resolveManagedAgentPermissionConfig,
+} from './anthropic-runtime.helpers';
 
 describe('mapToolset', () => {
   it('maps enabled builtin toolset configs to AgentToolDto entries', () => {
@@ -30,7 +36,7 @@ describe('mapToolset', () => {
 });
 
 describe('buildToolsPayload', () => {
-  it('sets always_allow on the agent toolset default_config', () => {
+  it('sets always_ask on the agent toolset default_config by default', () => {
     const payload = buildToolsPayload(['bash'], undefined);
     const toolset = payload[0] as {
       type: string;
@@ -46,7 +52,7 @@ describe('buildToolsPayload', () => {
     expect(bashConfig?.enabled).to.equal(true);
   });
 
-  it('sets always_allow on each mcp_toolset default_config', () => {
+  it('sets always_ask on each mcp_toolset default_config by default', () => {
     const payload = buildToolsPayload(undefined, [{ name: 'GitHub', url: 'https://mcp.example.com/github' }]);
     const mcpToolset = payload.find((entry) => entry.type === 'mcp_toolset');
 
@@ -55,5 +61,29 @@ describe('buildToolsPayload', () => {
       mcp_server_name: 'GitHub',
       default_config: MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
     });
+  });
+
+  it('sets always_allow when the permission config override is provided', () => {
+    const payload = buildToolsPayload(
+      ['bash'],
+      [{ name: 'GitHub', url: 'https://mcp.example.com/github' }],
+      MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG
+    );
+    const toolset = payload.find((entry) => entry.type === 'agent_toolset_20260401');
+    const mcpToolset = payload.find((entry) => entry.type === 'mcp_toolset');
+
+    expect(toolset?.default_config).to.deep.equal(MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG);
+    expect(mcpToolset?.default_config).to.deep.equal(MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG);
+  });
+});
+
+describe('resolveManagedAgentPermissionConfig', () => {
+  it('returns always_ask when the flag is false or undefined', () => {
+    expect(resolveManagedAgentPermissionConfig(false)).to.deep.equal(MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG);
+    expect(resolveManagedAgentPermissionConfig(undefined)).to.deep.equal(MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG);
+  });
+
+  it('returns always_allow when the flag is true', () => {
+    expect(resolveManagedAgentPermissionConfig(true)).to.deep.equal(MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG);
   });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
@@ -221,6 +221,24 @@ export const MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG = {
   permission_policy: { type: 'always_ask' },
 } as const;
 
+export const MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG = {
+  permission_policy: { type: 'always_allow' },
+} as const;
+
+export type ManagedAgentPermissionConfig =
+  | typeof MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG
+  | typeof MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG;
+
+export function resolveManagedAgentPermissionConfig(
+  useAlwaysAllow: boolean | undefined
+): ManagedAgentPermissionConfig {
+  if (useAlwaysAllow) {
+    return MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG;
+  }
+
+  return MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG;
+}
+
 /**
  * The agent response `tools` array contains toolset objects, not plain tool entries.
  * Flatten builtin toolset configs into individual AgentToolDto entries.
@@ -254,7 +272,8 @@ export function mapToolset(raw: Record<string, unknown>): AgentToolDto[] {
  */
 export function buildToolsPayload(
   toolTypes?: string[],
-  mcpServers?: Array<{ name: string; url: string }>
+  mcpServers?: Array<{ name: string; url: string }>,
+  permissionConfig: ManagedAgentPermissionConfig = MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG
 ): Record<string, unknown>[] {
   const hasTools = Array.isArray(toolTypes) && toolTypes.length > 0;
   const hasMcpServers = Array.isArray(mcpServers) && mcpServers.length > 0;
@@ -270,7 +289,7 @@ export function buildToolsPayload(
 
   payload.push({
     type: 'agent_toolset_20260401',
-    default_config: MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
+    default_config: permissionConfig,
     configs: allToolNames.map((name) => ({ name, enabled: enabledSet.has(name) })),
   });
 
@@ -279,7 +298,7 @@ export function buildToolsPayload(
       payload.push({
         type: 'mcp_toolset',
         mcp_server_name: server.name,
-        default_config: MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
+        default_config: permissionConfig,
       });
     }
   }

--- a/libs/application-generic/src/agent-runtimes/i-agent-runtime-provider.ts
+++ b/libs/application-generic/src/agent-runtimes/i-agent-runtime-provider.ts
@@ -18,6 +18,11 @@ export type CreateAgentInput = {
   mcpServers?: Array<{ name: string; url: string }>;
   /** Skills to attach to the agent at creation time. Maximum 20. */
   skills?: AgentSkillDto[];
+  /**
+   * When true, builtin and MCP toolsets are provisioned with `always_allow`
+   * permission policies instead of the default `always_ask`.
+   */
+  useAlwaysAllowToolPermissions?: boolean;
 };
 
 export type CreateAgentResult = {
@@ -40,6 +45,11 @@ export type UpdateAgentRuntimeConfigInput = {
   mcpServers?: AgentMcpServerDto[];
   tools?: AgentToolDto[];
   skills?: AgentSkillDto[];
+  /**
+   * When true, rebuilt toolset payloads use `always_allow` permission policies
+   * instead of the default `always_ask`.
+   */
+  useAlwaysAllowToolPermissions?: boolean;
 };
 
 export type ProvisionIntegrationInput = {

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -119,6 +119,12 @@ export enum FeatureFlagsKeysEnum {
    * button is disabled.
    */
   IS_MCP_PROVIDER_MANAGED_ENABLED = 'IS_MCP_PROVIDER_MANAGED_ENABLED',
+  /**
+   * When enabled, managed agents are provisioned with `always_allow` permission
+   * policies on builtin toolsets and MCP toolsets instead of the default
+   * `always_ask`. Gates org-by-org rollout of permissive MCP defaults.
+   */
+  IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED = 'IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED',
 
   // String flags
   CF_SCHEDULER_MODE = 'CF_SCHEDULER_MODE', // Values: "off" | "shadow" | "live" | "complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the `IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED` feature flag to control default permission policies when provisioning or syncing managed agent toolsets and MCP toolsets.

- **Flag off (default):** keeps existing behavior — `always_ask` on builtin toolsets and MCP toolsets
- **Flag on:** sets `always_allow` on both builtin toolsets and MCP toolsets when projecting to the Anthropic managed agent runtime

## Changes

- Added `IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED` to `FeatureFlagsKeysEnum`
- Added `resolveManagedAgentPermissionConfig()` and `MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG` in `anthropic-runtime.helpers.ts`
- Extended `CreateAgentInput` / `UpdateAgentRuntimeConfigInput` with `useAlwaysAllowToolPermissions`
- Wired flag resolution into:
  - `ProvisionManagedAgent`
  - `SyncAgentMcpServers`
  - `UpdateAgentRuntimeConfig`
  - `MigrateAgentRuntime`

## Rollout

Create the boolean flag in LaunchDarkly as `IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED` and target per org/environment as needed.

## Testing

- Updated unit tests for permission config helpers and Anthropic provider update path
- Added unit tests for flag resolver helper
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25e500b7-6525-453c-a195-1fe2b201b0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25e500b7-6525-453c-a195-1fe2b201b0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added a feature flag (`IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED`) to control default permission policies for managed agent toolsets. When disabled (default), toolsets use `always_ask` permissions. When enabled, they use `always_allow` permissions during provisioning and syncing with the Anthropic managed agent runtime. A new resolver function computes the permission config based on environment and organization context.

## Affected areas

**shared**: Added `IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED` to `FeatureFlagsKeysEnum` to define the new feature flag.

**api**: Updated four use cases (`ProvisionManagedAgent`, `SyncAgentMcpServers`, `UpdateAgentRuntimeConfig`, `MigrateAgentRuntime`) to inject `FeatureFlagsService`, resolve the permission config, and pass `useAlwaysAllowToolPermissions` to runtime providers.

**application-generic**: Extended the Anthropic runtime provider to accept and apply permission configs in both `createAgent` and `updateConfig` methods; introduced `resolveManagedAgentPermissionConfig` helper and `MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG` constant; updated `buildToolsPayload` to accept an optional permission config parameter.

**application-generic (interfaces)**: Extended `CreateAgentInput` and `UpdateAgentRuntimeConfigInput` with optional `useAlwaysAllowToolPermissions` field.

## Key technical decisions

- Permission config resolution abstracted into a dedicated helper function that queries the feature flag with environment/organization context.
- Introduced `ManagedAgentPermissionConfig` union type to encapsulate permission policy definitions.
- Default permission behavior remains `always_ask` when the feature flag is not set or disabled.

## Testing

Added unit tests for the permission config resolver function, updated existing Anthropic runtime helper and provider tests to reflect the new configurable permission behavior, and updated tests for the four modified use cases to mock and assert feature flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates managed agent MCP permission policies behind a new `IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED` feature flag, enabling per-org rollout of `always_allow` toolset permissions as an alternative to the existing `always_ask` default.

- Adds `MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG`, `resolveManagedAgentPermissionConfig`, and a new `resolveManagedAgentAlwaysAllowToolPermissions` helper; threads the resolved config through `buildToolsPayload` as an optional third parameter (defaulting to the existing `always_ask` behavior).
- Wires the flag lookup into all four provisioning/update paths — `ProvisionManagedAgent`, `SyncAgentMcpServers`, `UpdateAgentRuntimeConfig`, and `MigrateAgentRuntime` — with consistent injection of `FeatureFlagsService` in each constructor.
- Unit tests cover the new helper, the permission-config resolver, and the Anthropic provider's `updateConfig` path when the flag is on.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the flag is off by default so no behavior changes until LaunchDarkly is configured.

The flag defaults to false, preserving the existing always_ask behavior for all orgs unless explicitly targeted in LaunchDarkly. The one quirk worth tracking: UpdateAgentRuntimeConfig fetches the flag on every call but the resolved permission config is only forwarded to the Anthropic API when tools are included in the update — a model-only update leaves the toolset policy unchanged at the provider level. This is a bounded operational concern, not a correctness problem.

update-agent-runtime-config.usecase.ts — the flag fetch is unconditional but the resolved value is conditional on whether tools are present in the patch.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts | Adds MANAGED_AGENT_ALWAYS_ALLOW_PERMISSION_CONFIG constant, ManagedAgentPermissionConfig union type, resolveManagedAgentPermissionConfig helper, and threads permissionConfig through buildToolsPayload as an optional parameter defaulting to always_ask. Logic is correct and backward-compatible. |
| libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts | Wires resolveManagedAgentPermissionConfig into createAgent and updateConfig. Non-alphabetical import order for the new symbol is a minor style issue; logic is otherwise correct. |
| apps/api/src/app/agents/management/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts | Injects FeatureFlagsService and resolves the flag on every call. Resolved value is silently ignored when the call touches neither tools nor mcpServers. |
| apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts | Correctly resolves the flag only in the provision (not adopt) branch and passes it to createAgent. Consistent with existing patterns. |
| apps/api/src/app/agents/mcp/servers/sync-agent-mcp-servers/sync-agent-mcp-servers.usecase.ts | Adds FeatureFlagsService dependency and resolves the flag before every MCP sync, passing it into updateConfig. Because mcpServers is always provided, the permission config is always applied — including to built-in toolsets, which is documented intent. |
| apps/api/src/app/agents/management/usecases/migrate-agent-runtime/migrate-agent-runtime.usecase.ts | Resolves the flag immediately before createAgent in the migration path. Migration correctly applies the current flag value to the newly-created provider agent. |
| libs/application-generic/src/agent-runtimes/i-agent-runtime-provider.ts | Extends CreateAgentInput and UpdateAgentRuntimeConfigInput with the optional useAlwaysAllowToolPermissions field. Well-documented with JSDoc comments. |
| packages/shared/src/types/feature-flags.ts | Adds IS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED to FeatureFlagsKeysEnum with clear JSDoc. Clean addition with no issues. |
| apps/api/src/app/agents/mcp/resolve-managed-agent-always-allow-tool-permissions.ts | New helper that delegates to FeatureFlagsService.getFlag; well-typed and narrowly scoped. Well-tested by the new spec file. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request: Provision / Sync / Update / Migrate] --> B[resolveManagedAgentAlwaysAllowToolPermissions]
    B --> C{FeatureFlagsService.getFlag\nIS_AGENT_DEFAULT_MCP_ALWAYS_ALLOW_ENABLED}
    C -- true --> D[resolveManagedAgentPermissionConfig → ALWAYS_ALLOW]
    C -- false/undefined --> E[resolveManagedAgentPermissionConfig → ALWAYS_ASK]
    D --> F[buildToolsPayload\ntoolTypes, mcpServers, permissionConfig]
    E --> F
    F --> G[agent_toolset_20260401\ndefault_config: permissionConfig]
    F --> H[mcp_toolset entries\ndefault_config: permissionConfig]
    G --> I[Anthropic API: createAgent / updateConfig]
    H --> I
    I --> J[Agent provisioned with\nalways_allow OR always_ask on all toolsets]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Fapplication-generic%2Fsrc%2Fagent-runtimes%2Fanthropic%2Fanthropic-agent-runtime.provider.ts%3A46-51%0A**Import%20out%20of%20alphabetical%20order**%0A%0A%60resolveManagedAgentPermissionConfig%60%20is%20inserted%20between%20%60buildToolsPayload%60%20%28b%29%20and%20%60extractApiErrorMessage%60%20%28e%29%2C%20while%20it%20starts%20with%20%60r%60%20%E2%80%94%20it%20should%20appear%20after%20%60parseRetryAfter%60%20and%20before%20%60sleep%60%20to%20keep%20the%20list%20sorted.%20The%20other%20identifiers%20in%20this%20block%20appear%20to%20be%20in%20order%3B%20this%20insertion%20breaks%20the%20pattern.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fmanagement%2Fusecases%2Fupdate-agent-runtime-config%2Fupdate-agent-runtime-config.usecase.ts%3A67-78%0A**Permission%20flag%20resolved%20but%20silently%20dropped%20when%20only%20model%2FsystemPrompt%20changes**%0A%0A%60useAlwaysAllowToolPermissions%60%20is%20always%20resolved%20from%20the%20feature%20flag%20service%2C%20but%20the%20Anthropic%20provider%20only%20applies%20it%20inside%20the%20%60if%20%28patch.tools%20!%3D%3D%20undefined%20%7C%7C%20patch.mcpServers%20!%3D%3D%20undefined%29%60%20branch.%20Since%20%60UpdateAgentRuntimeConfig%60%20never%20passes%20%60mcpServers%60%20to%20%60runtimeProvider.updateConfig%60%2C%20the%20permission%20config%20is%20only%20effective%20when%20%60command.tools%60%20is%20also%20present%20in%20the%20request.%20A%20call%20that%20only%20updates%20%60model%60%20or%20%60systemPrompt%60%20fetches%20the%20flag%20but%20has%20no%20effect%20on%20the%20stored%20permission%20policies%20%E2%80%94%20the%20agent%20keeps%20whatever%20policy%20was%20set%20during%20its%20last%20tool%2FMCP%20sync.%0A%0A&pr=11409&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts:46-51
**Import out of alphabetical order**

`resolveManagedAgentPermissionConfig` is inserted between `buildToolsPayload` (b) and `extractApiErrorMessage` (e), while it starts with `r` — it should appear after `parseRetryAfter` and before `sleep` to keep the list sorted. The other identifiers in this block appear to be in order; this insertion breaks the pattern.

### Issue 2 of 2
apps/api/src/app/agents/management/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts:67-78
**Permission flag resolved but silently dropped when only model/systemPrompt changes**

`useAlwaysAllowToolPermissions` is always resolved from the feature flag service, but the Anthropic provider only applies it inside the `if (patch.tools !== undefined || patch.mcpServers !== undefined)` branch. Since `UpdateAgentRuntimeConfig` never passes `mcpServers` to `runtimeProvider.updateConfig`, the permission config is only effective when `command.tools` is also present in the request. A call that only updates `model` or `systemPrompt` fetches the flag but has no effect on the stored permission policies — the agent keeps whatever policy was set during its last tool/MCP sync.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api-service): gate managed agent MC..."](https://github.com/novuhq/novu/commit/62a236148f34457d42af17216979997ed13181d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34959161)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->