### PR TITLE
chore(root): update API, worker, ws, and dashboard images to version 3.17.0

### DIFF
--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       start_period: 20s
 
   api:
-    image: "ghcr.io/novuhq/novu/api:3.15.0"
+    image: "ghcr.io/novuhq/novu/api:3.17.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -109,7 +109,7 @@ services:
       start_period: 40s
 
   worker:
-    image: "ghcr.io/novuhq/novu/worker:3.15.0"
+    image: "ghcr.io/novuhq/novu/worker:3.17.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -162,7 +162,7 @@ services:
       start_period: 20s
 
   ws:
-    image: "ghcr.io/novuhq/novu/ws:3.15.0"
+    image: "ghcr.io/novuhq/novu/ws:3.17.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -203,7 +203,7 @@ services:
       start_period: 40s
 
   dashboard:
-    image: "ghcr.io/novuhq/novu/dashboard:3.15.0"
+    image: "ghcr.io/novuhq/novu/dashboard:3.17.0"
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
…

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Docker Compose configuration for the community deployment was updated to use version 3.17.0 of the API, worker, WebSocket, and dashboard container images, upgrading from the previous 3.15.0 version. This ensures the local development and community Docker deployment environments use the latest stable service versions.

## Affected areas

**docker/community**: Updated the container image tags in `docker-compose.yml` for the `api`, `worker`, `ws`, and `dashboard` services from version 3.15.0 to 3.17.0.

## Testing

No tests are needed for this change. Docker image version references are validated when the Docker Compose file is deployed or used, ensuring the specified images are available and can be pulled from the registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
