### PR TITLE
fix(dashboard): dismiss provisioning overlay on usecase select page fixes NV-7947

### DIFF
--- a/apps/dashboard/src/pages/usecase-select-page.tsx
+++ b/apps/dashboard/src/pages/usecase-select-page.tsx
@@ -21,6 +21,7 @@ import { AgentUsecasePreviewIllustration } from '@/components/onboarding/agent-u
 import { OnboardingShell } from '@/components/onboarding/onboarding-shell';
 import { PageMeta } from '@/components/page-meta';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useOnboardingProvisioningActive, useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { getOnboardingAppId, withAppId } from '@/utils/onboarding-redirect';
 import { ROUTES } from '@/utils/routes';
@@ -356,10 +357,20 @@ export function UsecaseSelectPage() {
   const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
   const telemetry = useTelemetry();
   const [selected, setSelected] = useState<UsecaseId>('agents');
+  const provisioningActive = useOnboardingProvisioningActive();
+
+  useOnboardingProvisioningDismiss({
+    isReady: true,
+    fallbackVariant: 'platform',
+  });
 
   useEffect(() => {
     telemetry(TelemetryEvent.USECASE_SELECT_PAGE_VIEWED);
   }, [telemetry]);
+
+  if (provisioningActive) {
+    return null;
+  }
 
   if (!isAgentsEnabled) {
     return <Navigate to={ROUTES.INBOX_USECASE} replace />;

--- a/apps/dashboard/src/routes/dashboard.tsx
+++ b/apps/dashboard/src/routes/dashboard.tsx
@@ -3,13 +3,29 @@ import { AiDrawerProvider } from '@/components/ai-drawer';
 import { CommandPalette } from '@/components/command-palette';
 import { CommandPaletteProvider } from '@/components/command-palette/command-palette-provider';
 import { Toaster } from '@/components/primitives/sonner';
+import { useAuth } from '@/context/auth/hooks';
 import { OptInProvider } from '@/context/opt-in-provider';
+import { useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { HostnameGuard } from './hostname-guard';
 import { ProtectedRoute } from './protected-route';
+
+function DashboardProvisioningDismiss() {
+  const { isOrganizationLoaded, currentOrganization } = useAuth();
+
+  // Clear stale org-create provisioning when the user lands on any dashboard route
+  // (e.g. /env/:slug/workflows) without going through an onboarding dismiss page.
+  useOnboardingProvisioningDismiss({
+    isReady: isOrganizationLoaded && Boolean(currentOrganization),
+    fallbackVariant: 'platform',
+  });
+
+  return null;
+}
 
 export const DashboardRoute = () => {
   return (
     <ProtectedRoute>
+      <DashboardProvisioningDismiss />
       <OptInProvider>
         <AiDrawerProvider>
           <CommandPaletteProvider>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes post-signup onboarding getting stuck on the "Setting up your workspace" loader in the platform (non-Connect) flow — both on `/onboarding/usecase` and on dashboard routes like `/env/:slug/workflows`.

After org creation, `OrganizationPicker` starts platform provisioning and stores it in `sessionStorage`. The global `OnboardingProvisioningOverlay` keeps showing until a page calls `useOnboardingProvisioningDismiss`. Inbox and agents setup already did this, but the usecase picker and main dashboard routes did not — so users could land on the correct URL while the overlay never cleared.

## Changes

- Wire `useOnboardingProvisioningDismiss` into `UsecaseSelectPage` (primary post-org-create destination)
- Add `DashboardProvisioningDismiss` to `DashboardRoute` as a safety net for stale provisioning on any `/env/*` route (workflows, etc.)

## Flow

```mermaid
sequenceDiagram
  participant User
  participant OrgPicker
  participant Session as sessionStorage
  participant Overlay as OnboardingProvisioningOverlay
  participant Destination as Usecase or Dashboard

  User->>OrgPicker: Create organization
  OrgPicker->>Session: beginOnboardingProvisioning(platform)
  OrgPicker->>Destination: Navigate
  Overlay->>User: Show loader overlay
  Destination->>Destination: useOnboardingProvisioningDismiss
  Destination->>Session: clearOnboardingProvisioning (after min duration)
  Overlay->>User: Hide overlay
```

## Test plan

- [ ] Sign up on platform dashboard (non-Connect)
- [ ] Create a new organization
- [ ] Confirm redirect to `/onboarding/usecase` and loader completes
- [ ] Create org, manually navigate to `/env/:slug/workflows` — loader should clear
- [ ] Visit `/env/:slug/workflows` with stale provisioning session — loader should clear
- [ ] Confirm inbox onboarding path still works when agents flag is disabled
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a568c9b0-c0cd-43b1-bd96-dedcc070a18b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a568c9b0-c0cd-43b1-bd96-dedcc070a18b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The PR fixes post-signup onboarding being stuck on the "Setting up your workspace" loader in the platform dashboard flow. After organization creation, the global provisioning overlay would persist indefinitely because destination routes weren't calling the provisioning dismissal hook. The fix wires `useOnboardingProvisioningDismiss` into UsecaseSelectPage (the primary post-org-create destination) and adds a provisioning-clearing component to dashboard routes to handle stale provisioning state.

## Affected areas
**dashboard**: Added provisioning dismissal logic to UsecaseSelectPage to dismiss the overlay when reaching the usecase picker, and introduced DashboardProvisioningDismiss component on dashboard routes to clear stale org-create provisioning when users land on `/env/*` routes.

## Testing
Manual testing confirmed the fix resolves the issue: sign-up → org creation → redirect to `/onboarding/usecase` with overlay completing; navigation to `/env/:slug/workflows` clears the loader; stale provisioning sessions are properly handled with inbox onboarding when the agents feature flag is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the onboarding flow getting stuck on the \"Setting up your workspace\" loader when users reach `/onboarding/usecase` in the platform (non-Connect) path, because that page never called the provisioning dismiss hook.

- `UsecaseSelectPage` now calls `useOnboardingProvisioningDismiss({ isReady: true })` on mount and returns `null` while provisioning is active, matching the pattern already used by the inbox and agents setup pages.
- `DashboardRoute` gains a new `DashboardProvisioningDismiss` component as a safety net that clears stale provisioning state whenever a user lands on any dashboard route without passing through an onboarding page — it waits for the org to be loaded before dismissing, preventing a premature clear.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a targeted fix that follows the established provisioning dismiss pattern already used by sibling onboarding pages.

The USECASE_SELECT_PAGE_VIEWED telemetry event is emitted on component mount while the component is still returning null (overlay active), so analytics see a page view before the user actually sees the page. Everything else — the dismiss hook, the null-return guard, and the dashboard catch-all — is correct and consistent with the existing pattern.

apps/dashboard/src/pages/usecase-select-page.tsx — telemetry firing timing relative to provisioning state.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/usecase-select-page.tsx | Wires provisioning dismiss/active hooks into UsecaseSelectPage; returns null while provisioning is active. Minor telemetry timing concern: USECASE_SELECT_PAGE_VIEWED fires on mount while the page is still hidden behind the overlay. |
| apps/dashboard/src/routes/dashboard.tsx | Adds DashboardProvisioningDismiss as a safety net to clear stale provisioning state for users who navigate to any dashboard route without passing through an onboarding dismiss page. Pattern is correct and uses proper org-loaded guard. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant OrgPicker as OrganizationPicker
  participant Session as sessionStorage
  participant Overlay as OnboardingProvisioningOverlay
  participant Usecase as UsecaseSelectPage
  participant Dashboard as DashboardProvisioningDismiss

  User->>OrgPicker: Create organization
  OrgPicker->>Session: beginOnboardingProvisioning(platform)
  OrgPicker->>Usecase: Navigate to /onboarding/usecase
  Overlay->>User: Show loader overlay
  Usecase->>Usecase: useOnboardingProvisioningDismiss(isReady: true)
  Note over Usecase: return null while provisioningActive
  Usecase->>Session: clearOnboardingProvisioning() after minDuration
  Overlay->>User: Hide overlay
  Usecase->>User: Render usecase picker

  alt User skips onboarding, lands on /env/:slug/workflows
    Dashboard->>Dashboard: Wait for isOrganizationLoaded and currentOrganization
    Dashboard->>Session: clearOnboardingProvisioning() stale cleanup
    Overlay->>User: Hide overlay
  end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fpages%2Fusecase-select-page.tsx%3A367-369%0A**Telemetry%20fires%20before%20the%20page%20is%20visible**%0A%0AThe%20%60USECASE_SELECT_PAGE_VIEWED%60%20effect%20runs%20on%20mount%2C%20which%20can%20be%20while%20%60provisioningActive%60%20is%20still%20%60true%60%20and%20the%20component%20is%20returning%20%60null%60.%20The%20event%20is%20emitted%20before%20the%20user%20actually%20sees%20the%20usecase%20picker%2C%20so%20any%20analytics%20funnel%20tied%20to%20this%20event%20will%20report%20a%20view%20slightly%20earlier%20than%20the%20real%20impression.%20Moving%20the%20effect%20inside%20the%20non-provisioning%20branch%20%E2%80%94%20or%20adding%20an%20%60!provisioningActive%60%20guard%20to%20the%20%60useEffect%60%20%E2%80%94%20would%20make%20the%20event%20match%20the%20actual%20render.%0A%0A&pr=11412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/pages/usecase-select-page.tsx:367-369
**Telemetry fires before the page is visible**

The `USECASE_SELECT_PAGE_VIEWED` effect runs on mount, which can be while `provisioningActive` is still `true` and the component is returning `null`. The event is emitted before the user actually sees the usecase picker, so any analytics funnel tied to this event will report a view slightly earlier than the real impression. Moving the effect inside the non-provisioning branch — or adding an `!provisioningActive` guard to the `useEffect` — would make the event match the actual render.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): clear stale provisioning..."](https://github.com/novuhq/novu/commit/caa6181ed91518db6ad7066495d96d15d812b459) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34968228)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->