### PR TITLE
feat(dashboard): set Connect Mixpanel session replay sampling to 100%

### DIFF
--- a/apps/dashboard/src/utils/segment.ts
+++ b/apps/dashboard/src/utils/segment.ts
@@ -2,7 +2,18 @@ import type { IUserEntity } from '@novu/shared';
 import { AnalyticsBrowser } from '@segment/analytics-next';
 import * as Sentry from '@sentry/react';
 import * as mixpanel from 'mixpanel-browser';
-import { MIXPANEL_KEY, SEGMENT_KEY } from '@/config';
+import { IS_NOVU_CONNECT, MIXPANEL_KEY, SEGMENT_KEY } from '@/config';
+
+const CONNECT_SESSION_REPLAY_SAMPLE_PERCENT = 100;
+const PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT = 100;
+
+function getSessionReplaySamplePercent(): number {
+  if (IS_NOVU_CONNECT) {
+    return CONNECT_SESSION_REPLAY_SAMPLE_PERCENT;
+  }
+
+  return PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT;
+}
 
 export class SegmentService {
   private _segment: AnalyticsBrowser | null = null;
@@ -18,15 +29,17 @@ export class SegmentService {
     if (this._mixpanelEnabled) {
       mixpanel.init(MIXPANEL_KEY as string, {
         //@ts-expect-error missing from types
-        record_sessions_percent: 100,
+        record_sessions_percent: getSessionReplaySamplePercent(),
       });
 
-      try {
-        //@ts-expect-error missing from types
-        mixpanel.start_session_recording();
-      } catch (e) {
-        Sentry.captureException(e);
-        console.error(e);
+      if (IS_NOVU_CONNECT) {
+        try {
+          //@ts-expect-error missing from types
+          mixpanel.start_session_recording();
+        } catch (e) {
+          Sentry.captureException(e);
+          console.error(e);
+        }
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Connect session replay is now configured explicitly for the Connect product hostname (`IS_NOVU_CONNECT`):

- **Connect:** `record_sessions_percent: 100` plus `start_session_recording()` to guarantee full session capture during Connect rollout, per [Mixpanel session replay sampling docs](https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript/javascript-replay#sampling).
- **Platform:** Keeps the existing 100% sampling rate; forced recording is no longer applied globally so product-specific rates can diverge later without affecting Connect.

Sampling and manual recording init live in `apps/dashboard/src/utils/segment.ts`.

```mermaid
flowchart LR
  A[Mixpanel init] --> B{IS_NOVU_CONNECT?}
  B -->|yes| C["record_sessions_percent: 100"]
  C --> D[start_session_recording]
  B -->|no| E["record_sessions_percent: 100"]
```

### Screenshots

N/A — analytics configuration only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Verify `$mp_session_record` checkpoint events appear for Connect sessions in Mixpanel after deploy.
- Linear ticket to be attached once created.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30e16310-cec9-406b-ab7e-3d7bce989eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30e16310-cec9-406b-ab7e-3d7bce989eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Session replay configuration for Mixpanel is now explicitly differentiated between the Connect and Platform products. Both platforms maintain 100% session replay sampling via `record_sessions_percent`. For Connect, `mixpanel.start_session_recording()` is called during initialization to guarantee full session capture. For Platform, session recording is initialized as before without the additional forced recording call. This ensures Connect gets complete session replay coverage during rollout while allowing product-specific sampling rates to diverge independently in the future.

## Affected areas

**dashboard**: Session replay and session recording initialization now use a `getSessionReplaySamplePercent()` helper to conditionally set Mixpanel's `record_sessions_percent` based on the `IS_NOVU_CONNECT` flag, and explicitly call `start_session_recording()` only for Connect environments with error handling and Sentry reporting.

## Key technical decisions

- Both products explicitly set `record_sessions_percent` to 100% via a product-aware helper function rather than relying on defaults, enabling independent sampling rates in the future.
- Session recording start is wrapped in try/catch with Sentry error capture and console logging to safely handle potential runtime failures in the Mixpanel browser SDK.

## Testing

Manual verification is planned: after deployment, Novu team will verify that `$mp_session_record` checkpoint events appear in Mixpanel for Connect sessions. No unit tests are required for this configuration-level change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates the `start_session_recording()` call behind `IS_NOVU_CONNECT` so that the explicit manual recording trigger is only applied to the Connect product, while the Platform continues to rely on automatic sampling at 100%. Both products retain `record_sessions_percent: 100` via a new helper function designed to allow the rates to diverge in the future.

- `getSessionReplaySamplePercent()` is introduced to return per-product sampling rates, but both constants are currently `100` — the helper is scaffolding for a future divergence, not a present behavioral split.
- Platform sessions will still be recorded at 100% via Mixpanel's automatic sampling; removing `start_session_recording()` from the Platform path is safe because that call was redundant when the sampling rate is already 100%.
- `IS_NOVU_CONNECT` is evaluated once at module load (from `window.location.host`), consistent with how `SegmentService` is instantiated, so there is no runtime staleness risk.

<h3>Confidence Score: 4/5</h3>

Safe to merge — analytics-only change with no impact on product logic or data pipelines.

The only changed file is `segment.ts`, touching Mixpanel session replay configuration. Platform recording is preserved via the existing 100% sampling rate; only the redundant explicit `start_session_recording()` call is removed for Platform. The two product-specific constants are both `100` today, so the new helper function adds indirection without current functional value, but this does not affect runtime correctness.

apps/dashboard/src/utils/segment.ts — the dual identical constants and the helper function are worth a second glance to confirm the intended future split is documented clearly enough.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/segment.ts | Adds Connect-specific session replay: `start_session_recording()` is now gated on `IS_NOVU_CONNECT`; both products keep `record_sessions_percent: 100` via a helper, though both constants are identical today. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SegmentService constructor] --> B{_mixpanelEnabled?}
    B -->|no| Z[skip]
    B -->|yes| C[mixpanel.init with record_sessions_percent]
    C --> D{IS_NOVU_CONNECT?}
    D -->|yes| E[getSessionReplaySamplePercent → 100]
    D -->|no| F[getSessionReplaySamplePercent → 100]
    E --> G[start_session_recording called explicitly]
    F --> H[rely on auto-sampling at 100%]
    G --> I[Segment middleware attaches session replay props]
    H --> I
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Futils%2Fsegment.ts%3A7-16%0A%60CONNECT_SESSION_REPLAY_SAMPLE_PERCENT%60%20and%20%60PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT%60%20are%20both%20%60100%60%2C%20so%20%60getSessionReplaySamplePercent%28%29%60%20always%20returns%20the%20same%20value%20and%20branches%20on%20a%20condition%20that%20currently%20makes%20no%20difference.%20Until%20the%20two%20rates%20diverge%2C%20the%20function%20adds%20indirection%20without%20any%20functional%20benefit%2C%20and%20a%20reader%20might%20mistakenly%20infer%20that%20the%20two%20products%20already%20use%20different%20rates.%0A%0A%60%60%60suggestion%0Aconst%20CONNECT_SESSION_REPLAY_SAMPLE_PERCENT%20%3D%20100%3B%0A%2F%2F%20Update%20PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT%20when%20the%20rates%20diverge%0Aconst%20PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT%20%3D%20100%3B%0A%0Afunction%20getSessionReplaySamplePercent%28%29%3A%20number%20%7B%0A%20%20if%20%28IS_NOVU_CONNECT%29%20%7B%0A%20%20%20%20return%20CONNECT_SESSION_REPLAY_SAMPLE_PERCENT%3B%0A%20%20%7D%0A%0A%20%20return%20PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT%3B%0A%7D%0A%60%60%60%0A%0A&pr=11414&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/utils/segment.ts:7-16
`CONNECT_SESSION_REPLAY_SAMPLE_PERCENT` and `PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT` are both `100`, so `getSessionReplaySamplePercent()` always returns the same value and branches on a condition that currently makes no difference. Until the two rates diverge, the function adds indirection without any functional benefit, and a reader might mistakenly infer that the two products already use different rates.

```suggestion
const CONNECT_SESSION_REPLAY_SAMPLE_PERCENT = 100;
// Update PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT when the rates diverge
const PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT = 100;

function getSessionReplaySamplePercent(): number {
  if (IS_NOVU_CONNECT) {
    return CONNECT_SESSION_REPLAY_SAMPLE_PERCENT;
  }

  return PLATFORM_SESSION_REPLAY_SAMPLE_PERCENT;
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): set Connect Mixpanel se..."](https://github.com/novuhq/novu/commit/7647b58f4345f11980472ff1d575e3a616701b68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35059673)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->