### PR TITLE
feat(worker): emit step_created trace when step runs are created fixes NV-7949

### DIFF
--- a/apps/api/src/app/activity/e2e/get-workflow-run.e2e.ts
+++ b/apps/api/src/app/activity/e2e/get-workflow-run.e2e.ts
@@ -74,7 +74,7 @@ describe('Workflow Run - GET /v1/activity/workflow-runs/:workflowRunId #novu-v2'
 
     const triggerStepRunTraces = data.steps[0].executionDetails;
     expect(triggerStepRunTraces.length, 'response step execution details count').to.be.greaterThan(0);
-    expect(triggerStepRunTraces[0].detail, 'response step execution details status').to.equal('Step queued');
+    expect(triggerStepRunTraces[0].detail, 'response step execution details status').to.equal('Step created');
   });
 
   it('should return 404 for non-existent workflow run', async () => {

--- a/apps/api/src/app/notifications/e2e/get-activity.e2e.ts
+++ b/apps/api/src/app/notifications/e2e/get-activity.e2e.ts
@@ -118,9 +118,9 @@ describe('Get activity - /notifications/:notificationId (GET) #novu-v2', async (
     expect(activity.jobs).to.be.an('array');
 
     const actualDetails = activity.jobs[0].executionDetails.map((detail) => detail.detail);
-    const expectedExecutionDetails = ['Step queued', 'Message created', 'Message sent', 'Message read'];
+    const expectedExecutionDetails = ['Step created', 'Step queued', 'Message created', 'Message sent', 'Message read'];
 
-    expect(actualDetails.length).to.be.equal(4);
+    expect(actualDetails.length).to.be.equal(5);
     expectedExecutionDetails.forEach((expectedDetail) => {
       expect(actualDetails).to.include(expectedDetail);
     });
@@ -162,9 +162,9 @@ describe('Get activity - /notifications/:notificationId (GET) #novu-v2', async (
     expect(activity.jobs).to.be.an('array');
 
     const actualDetails = activity.jobs[0].executionDetails.map((detail) => detail.detail);
-    const expectedExecutionDetails = ['Step queued', 'Message created', 'Message sent'];
+    const expectedExecutionDetails = ['Step created', 'Step queued', 'Message created', 'Message sent'];
 
-    expect(actualDetails.length).to.be.equal(3);
+    expect(actualDetails.length).to.be.equal(4);
     expectedExecutionDetails.forEach((expectedDetail) => {
       expect(actualDetails).to.include(
         expectedDetail,
@@ -219,9 +219,9 @@ describe('Get activity - /notifications/:notificationId (GET) #novu-v2', async (
     expect(activity.jobs).to.be.an('array');
 
     const actualDetails = activity.jobs[0].executionDetails.map((detail) => detail.detail);
-    const expectedExecutionDetails = ['Step queued', 'Message created', 'Message sent', 'Message read'];
+    const expectedExecutionDetails = ['Step created', 'Step queued', 'Message created', 'Message sent', 'Message read'];
 
-    expect(actualDetails.length).to.be.equal(4);
+    expect(actualDetails.length).to.be.equal(5);
     expectedExecutionDetails.forEach((expectedDetail) => {
       expect(actualDetails).to.include(
         expectedDetail,
@@ -348,9 +348,9 @@ describe('Get activity - /notifications/:notificationId (GET) #novu-v2', async (
     expect(activity.jobs).to.be.an('array');
 
     const actualDetails = activity.jobs[0].executionDetails.map((detail) => detail.detail);
-    const expectedExecutionDetails = ['Step queued', 'Message created', 'Message sent'];
+    const expectedExecutionDetails = ['Step created', 'Step queued', 'Message created', 'Message sent'];
 
-    expect(actualDetails.length).to.be.equal(3);
+    expect(actualDetails.length).to.be.equal(4);
     expectedExecutionDetails.forEach((expectedDetail) => {
       expect(actualDetails).to.include(
         expectedDetail,

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
+import { StepTypeEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { StoreSubscriberJobs } from './store-subscriber-jobs.usecase';
@@ -27,14 +27,14 @@ describe('StoreSubscriberJobs', () => {
   let usecase: StoreSubscriberJobs;
   let jobRepository: { storeJobs: sinon.SinonStub };
   let stepRunRepository: { createMany: sinon.SinonStub };
-  let createExecutionDetails: { execute: sinon.SinonStub };
+  let traceLogRepository: { createStepRun: sinon.SinonStub };
   let addJob: { execute: sinon.SinonStub };
   let bulkCreateExecutionDetails: { execute: sinon.SinonStub };
 
   beforeEach(() => {
     jobRepository = { storeJobs: sinon.stub() };
     stepRunRepository = { createMany: sinon.stub().resolves() };
-    createExecutionDetails = { execute: sinon.stub().resolves() };
+    traceLogRepository = { createStepRun: sinon.stub().resolves() };
     addJob = { execute: sinon.stub().resolves() };
     bulkCreateExecutionDetails = { execute: sinon.stub().resolves() };
 
@@ -43,7 +43,7 @@ describe('StoreSubscriberJobs', () => {
       jobRepository as never,
       bulkCreateExecutionDetails as never,
       stepRunRepository as never,
-      createExecutionDetails as never
+      traceLogRepository as never
     );
   });
 
@@ -63,20 +63,19 @@ describe('StoreSubscriberJobs', () => {
       jobs: [job1, job2],
     } as never);
 
-    expect(createExecutionDetails.execute.callCount).to.equal(2);
+    expect(traceLogRepository.createStepRun.calledOnce).to.be.true;
 
-    const firstCallArg = createExecutionDetails.execute.getCall(0).args[0];
-    expect(firstCallArg.detail).to.equal('Step created');
-    expect(firstCallArg.source).to.equal(ExecutionDetailsSourceEnum.INTERNAL);
-    expect(firstCallArg.status).to.equal(ExecutionDetailsStatusEnum.SUCCESS);
-    expect(firstCallArg.isTest).to.equal(false);
-    expect(firstCallArg.isRetry).to.equal(false);
-    expect(firstCallArg.jobId).to.equal('job_1');
-    expect(firstCallArg.channel).to.equal(StepTypeEnum.EMAIL);
+    const traces = traceLogRepository.createStepRun.getCall(0).args[0];
+    expect(traces).to.have.length(2);
 
-    const secondCallArg = createExecutionDetails.execute.getCall(1).args[0];
-    expect(secondCallArg.jobId).to.equal('job_2');
-    expect(secondCallArg.channel).to.equal(StepTypeEnum.SMS);
+    expect(traces[0].event_type).to.equal('step_created');
+    expect(traces[0].title).to.equal('Step created');
+    expect(traces[0].status).to.equal('success');
+    expect(traces[0].entity_id).to.equal('job_1');
+    expect(traces[0].step_run_type).to.equal(StepTypeEnum.EMAIL);
+
+    expect(traces[1].entity_id).to.equal('job_2');
+    expect(traces[1].step_run_type).to.equal(StepTypeEnum.SMS);
   });
 
   it('emits step_created traces before invoking addJob', async () => {
@@ -84,8 +83,8 @@ describe('StoreSubscriberJobs', () => {
     jobRepository.storeJobs.resolves([job]);
 
     const callOrder: string[] = [];
-    createExecutionDetails.execute.callsFake(async () => {
-      callOrder.push('createExecutionDetails');
+    traceLogRepository.createStepRun.callsFake(async () => {
+      callOrder.push('createStepRun');
     });
     addJob.execute.callsFake(async () => {
       callOrder.push('addJob');
@@ -98,10 +97,10 @@ describe('StoreSubscriberJobs', () => {
       jobs: [job],
     } as never);
 
-    expect(callOrder).to.deep.equal(['createExecutionDetails', 'addJob']);
+    expect(callOrder).to.deep.equal(['createStepRun', 'addJob']);
   });
 
-  it('populates trace fields from job metadata via getDetailsFromJob', async () => {
+  it('populates trace fields from job metadata', async () => {
     const job = buildJobEntity({
       _id: 'job_42',
       _environmentId: 'env_42',
@@ -124,17 +123,15 @@ describe('StoreSubscriberJobs', () => {
       jobs: [job],
     } as never);
 
-    const callArg = createExecutionDetails.execute.getCall(0).args[0];
-    expect(callArg.environmentId).to.equal('env_42');
-    expect(callArg.organizationId).to.equal('org_42');
-    expect(callArg.subscriberId).to.equal('ext_sub_42');
-    expect(callArg._subscriberId).to.equal('int_sub_42');
-    expect(callArg.notificationId).to.equal('notif_42');
-    expect(callArg.notificationTemplateId).to.equal('tpl_42');
-    expect(callArg.providerId).to.equal('prov_42');
-    expect(callArg.transactionId).to.equal('tx_42');
-    expect(callArg.workflowRunIdentifier).to.equal('wf_run_42');
-    expect(callArg.channel).to.equal(StepTypeEnum.PUSH);
+    const trace = traceLogRepository.createStepRun.getCall(0).args[0][0];
+    expect(trace.environment_id).to.equal('env_42');
+    expect(trace.organization_id).to.equal('org_42');
+    expect(trace.external_subscriber_id).to.equal('ext_sub_42');
+    expect(trace.subscriber_id).to.equal('int_sub_42');
+    expect(trace.workflow_id).to.equal('tpl_42');
+    expect(trace.provider_id).to.equal('prov_42');
+    expect(trace.workflow_run_identifier).to.equal('wf_run_42');
+    expect(trace.step_run_type).to.equal(StepTypeEnum.PUSH);
   });
 
   it('calls stepRunRepository.createMany before emitting traces', async () => {
@@ -145,8 +142,8 @@ describe('StoreSubscriberJobs', () => {
     stepRunRepository.createMany.callsFake(async () => {
       callOrder.push('createMany');
     });
-    createExecutionDetails.execute.callsFake(async () => {
-      callOrder.push('createExecutionDetails');
+    traceLogRepository.createStepRun.callsFake(async () => {
+      callOrder.push('createStepRun');
     });
 
     await usecase.execute({
@@ -157,7 +154,7 @@ describe('StoreSubscriberJobs', () => {
     } as never);
 
     expect(callOrder[0]).to.equal('createMany');
-    expect(callOrder[1]).to.equal('createExecutionDetails');
+    expect(callOrder[1]).to.equal('createStepRun');
   });
 
   it('still calls addJob even with a single stored job', async () => {
@@ -179,7 +176,7 @@ describe('StoreSubscriberJobs', () => {
   it('still calls addJob when step_created trace emission fails', async () => {
     const job = buildJobEntity();
     jobRepository.storeJobs.resolves([job]);
-    createExecutionDetails.execute.rejects(new Error('trace write failed'));
+    traceLogRepository.createStepRun.rejects(new Error('trace write failed'));
 
     await usecase.execute({
       environmentId: 'env_1',

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.spec.ts
@@ -1,0 +1,178 @@
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { StoreSubscriberJobs } from './store-subscriber-jobs.usecase';
+
+function buildJobEntity(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'job_1',
+    _userId: 'user_1',
+    _environmentId: 'env_1',
+    _organizationId: 'org_1',
+    _subscriberId: 'subscriber_internal_1',
+    subscriberId: 'subscriber_1',
+    _notificationId: 'notification_1',
+    _templateId: 'template_1',
+    providerId: 'provider_1',
+    transactionId: 'transaction_1',
+    identifier: 'workflow-run-1',
+    type: StepTypeEnum.EMAIL,
+    bridge: false,
+    controlVariables: {},
+    ...overrides,
+  };
+}
+
+describe('StoreSubscriberJobs', () => {
+  let usecase: StoreSubscriberJobs;
+  let jobRepository: { storeJobs: sinon.SinonStub };
+  let stepRunRepository: { createMany: sinon.SinonStub };
+  let createExecutionDetails: { execute: sinon.SinonStub };
+  let addJob: { execute: sinon.SinonStub };
+  let bulkCreateExecutionDetails: { execute: sinon.SinonStub };
+
+  beforeEach(() => {
+    jobRepository = { storeJobs: sinon.stub() };
+    stepRunRepository = { createMany: sinon.stub().resolves() };
+    createExecutionDetails = { execute: sinon.stub().resolves() };
+    addJob = { execute: sinon.stub().resolves() };
+    bulkCreateExecutionDetails = { execute: sinon.stub().resolves() };
+
+    usecase = new StoreSubscriberJobs(
+      addJob as never,
+      jobRepository as never,
+      bulkCreateExecutionDetails as never,
+      stepRunRepository as never,
+      createExecutionDetails as never
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('emits step_created trace for each stored job', async () => {
+    const job1 = buildJobEntity({ _id: 'job_1' });
+    const job2 = buildJobEntity({ _id: 'job_2', type: StepTypeEnum.SMS });
+    jobRepository.storeJobs.resolves([job1, job2]);
+
+    await usecase.execute({
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      jobs: [job1, job2],
+    } as never);
+
+    expect(createExecutionDetails.execute.callCount).to.equal(2);
+
+    const firstCallArg = createExecutionDetails.execute.getCall(0).args[0];
+    expect(firstCallArg.detail).to.equal('Step created');
+    expect(firstCallArg.source).to.equal(ExecutionDetailsSourceEnum.INTERNAL);
+    expect(firstCallArg.status).to.equal(ExecutionDetailsStatusEnum.SUCCESS);
+    expect(firstCallArg.isTest).to.equal(false);
+    expect(firstCallArg.isRetry).to.equal(false);
+    expect(firstCallArg.jobId).to.equal('job_1');
+    expect(firstCallArg.channel).to.equal(StepTypeEnum.EMAIL);
+
+    const secondCallArg = createExecutionDetails.execute.getCall(1).args[0];
+    expect(secondCallArg.jobId).to.equal('job_2');
+    expect(secondCallArg.channel).to.equal(StepTypeEnum.SMS);
+  });
+
+  it('emits step_created traces before invoking addJob', async () => {
+    const job = buildJobEntity();
+    jobRepository.storeJobs.resolves([job]);
+
+    const callOrder: string[] = [];
+    createExecutionDetails.execute.callsFake(async () => {
+      callOrder.push('createExecutionDetails');
+    });
+    addJob.execute.callsFake(async () => {
+      callOrder.push('addJob');
+    });
+
+    await usecase.execute({
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      jobs: [job],
+    } as never);
+
+    expect(callOrder).to.deep.equal(['createExecutionDetails', 'addJob']);
+  });
+
+  it('populates trace fields from job metadata via getDetailsFromJob', async () => {
+    const job = buildJobEntity({
+      _id: 'job_42',
+      _environmentId: 'env_42',
+      _organizationId: 'org_42',
+      subscriberId: 'ext_sub_42',
+      _subscriberId: 'int_sub_42',
+      _notificationId: 'notif_42',
+      _templateId: 'tpl_42',
+      providerId: 'prov_42',
+      transactionId: 'tx_42',
+      identifier: 'wf_run_42',
+      type: StepTypeEnum.PUSH,
+    });
+    jobRepository.storeJobs.resolves([job]);
+
+    await usecase.execute({
+      environmentId: 'env_42',
+      organizationId: 'org_42',
+      userId: 'user_1',
+      jobs: [job],
+    } as never);
+
+    const callArg = createExecutionDetails.execute.getCall(0).args[0];
+    expect(callArg.environmentId).to.equal('env_42');
+    expect(callArg.organizationId).to.equal('org_42');
+    expect(callArg.subscriberId).to.equal('ext_sub_42');
+    expect(callArg._subscriberId).to.equal('int_sub_42');
+    expect(callArg.notificationId).to.equal('notif_42');
+    expect(callArg.notificationTemplateId).to.equal('tpl_42');
+    expect(callArg.providerId).to.equal('prov_42');
+    expect(callArg.transactionId).to.equal('tx_42');
+    expect(callArg.workflowRunIdentifier).to.equal('wf_run_42');
+    expect(callArg.channel).to.equal(StepTypeEnum.PUSH);
+  });
+
+  it('calls stepRunRepository.createMany before emitting traces', async () => {
+    const job = buildJobEntity();
+    jobRepository.storeJobs.resolves([job]);
+
+    const callOrder: string[] = [];
+    stepRunRepository.createMany.callsFake(async () => {
+      callOrder.push('createMany');
+    });
+    createExecutionDetails.execute.callsFake(async () => {
+      callOrder.push('createExecutionDetails');
+    });
+
+    await usecase.execute({
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      jobs: [job],
+    } as never);
+
+    expect(callOrder[0]).to.equal('createMany');
+    expect(callOrder[1]).to.equal('createExecutionDetails');
+  });
+
+  it('still calls addJob even with a single stored job', async () => {
+    const job = buildJobEntity();
+    jobRepository.storeJobs.resolves([job]);
+
+    await usecase.execute({
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      jobs: [job],
+    } as never);
+
+    expect(addJob.execute.calledOnce).to.be.true;
+    const addJobArg = addJob.execute.getCall(0).args[0];
+    expect(addJobArg.jobId).to.equal('job_1');
+  });
+});

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.spec.ts
@@ -175,4 +175,21 @@ describe('StoreSubscriberJobs', () => {
     const addJobArg = addJob.execute.getCall(0).args[0];
     expect(addJobArg.jobId).to.equal('job_1');
   });
+
+  it('still calls addJob when step_created trace emission fails', async () => {
+    const job = buildJobEntity();
+    jobRepository.storeJobs.resolves([job]);
+    createExecutionDetails.execute.rejects(new Error('trace write failed'));
+
+    await usecase.execute({
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      jobs: [job],
+    } as never);
+
+    expect(addJob.execute.calledOnce).to.be.true;
+    const addJobArg = addJob.execute.getCall(0).args[0];
+    expect(addJobArg.jobId).to.equal('job_1');
+  });
 });

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import {
   BulkCreateExecutionDetails,
   CreateExecutionDetails,
@@ -55,7 +55,7 @@ export class StoreSubscriberJobs {
   }
 
   private async emitStepCreatedTraces(storedJobs: JobEntity[]): Promise<void> {
-    await Promise.all(
+    const results = await Promise.allSettled(
       storedJobs.map((job) =>
         this.createExecutionDetails.execute(
           CreateExecutionDetailsCommand.create({
@@ -69,5 +69,14 @@ export class StoreSubscriberJobs {
         )
       )
     );
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        Logger.error(
+          { err: result.reason, jobId: storedJobs[index]._id },
+          'Failed to emit step_created trace'
+        );
+      }
+    });
   }
 }

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
@@ -6,6 +6,7 @@ import {
   mapEventTypeToTitle,
   StepRunRepository,
   StepRunTraceInput,
+  StepType,
   TraceLogRepository,
 } from '@novu/application-generic';
 import { DalException, JobEntity, JobRepository, JobStatusEnum } from '@novu/dal';
@@ -74,19 +75,19 @@ export class StoreSubscriberJobs {
       created_at: LogRepository.formatDateTime64(new Date()),
       organization_id: job._organizationId,
       environment_id: job._environmentId,
-      user_id: null,
+      user_id: '',
       subscriber_id: job._subscriberId ? job._subscriberId : job.subscriberId,
-      external_subscriber_id: job.subscriberId || null,
+      external_subscriber_id: job.subscriberId || '',
       event_type: 'step_created',
       title: mapEventTypeToTitle('step_created'),
-      message: null,
-      raw_data: null,
+      message: '',
+      raw_data: '',
       status: 'success',
       entity_id: job._id,
-      step_run_type: job.type,
+      step_run_type: (job.type ?? '') as StepType,
       workflow_run_identifier: job.identifier,
       workflow_id: job._templateId,
-      provider_id: job.providerId || null,
+      provider_id: job.providerId || '',
     };
   }
 }

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
@@ -1,12 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
+  buildStepRunTraceFromJob,
   BulkCreateExecutionDetails,
   InstrumentUsecase,
-  LogRepository,
   mapEventTypeToTitle,
   StepRunRepository,
-  StepRunTraceInput,
-  StepType,
   TraceLogRepository,
 } from '@novu/application-generic';
 import { DalException, JobEntity, JobRepository, JobStatusEnum } from '@novu/dal';
@@ -61,33 +59,20 @@ export class StoreSubscriberJobs {
     }
 
     try {
-      await this.traceLogRepository.createStepRun(storedJobs.map((job) => this.buildStepCreatedTraceFromJob(job)));
+      await this.traceLogRepository.createStepRun(
+        storedJobs.map((job) =>
+          buildStepRunTraceFromJob(job, {
+            event_type: 'step_created',
+            title: mapEventTypeToTitle('step_created'),
+            status: 'success',
+          })
+        )
+      );
     } catch (error) {
       Logger.error(
         { err: error, jobIds: storedJobs.map((job) => job._id) },
         'Failed to emit step_created traces'
       );
     }
-  }
-
-  private buildStepCreatedTraceFromJob(job: JobEntity): StepRunTraceInput {
-    return {
-      created_at: LogRepository.formatDateTime64(new Date()),
-      organization_id: job._organizationId,
-      environment_id: job._environmentId,
-      user_id: '',
-      subscriber_id: job._subscriberId ?? '',
-      external_subscriber_id: job.subscriberId || '',
-      event_type: 'step_created',
-      title: mapEventTypeToTitle('step_created'),
-      message: '',
-      raw_data: '',
-      status: 'success',
-      entity_id: job._id,
-      step_run_type: (job.type ?? '') as StepType,
-      workflow_run_identifier: job.identifier,
-      workflow_id: job._templateId,
-      provider_id: job.providerId || '',
-    };
   }
 }

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
@@ -76,7 +76,7 @@ export class StoreSubscriberJobs {
       organization_id: job._organizationId,
       environment_id: job._environmentId,
       user_id: '',
-      subscriber_id: job._subscriberId ? job._subscriberId : job.subscriberId,
+      subscriber_id: job._subscriberId ?? '',
       external_subscriber_id: job.subscriberId || '',
       event_type: 'step_created',
       title: mapEventTypeToTitle('step_created'),

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
@@ -1,14 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
   BulkCreateExecutionDetails,
-  CreateExecutionDetails,
-  CreateExecutionDetailsCommand,
-  DetailEnum,
   InstrumentUsecase,
+  LogRepository,
+  mapEventTypeToTitle,
   StepRunRepository,
+  StepRunTraceInput,
+  TraceLogRepository,
 } from '@novu/application-generic';
 import { DalException, JobEntity, JobRepository, JobStatusEnum } from '@novu/dal';
-import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 import { PlatformException } from '../../../shared/utils';
 import { AddJob } from '../add-job';
 import { StoreSubscriberJobsCommand } from './store-subscriber-jobs.command';
@@ -20,7 +20,7 @@ export class StoreSubscriberJobs {
     private jobRepository: JobRepository,
     protected bulkCreateExecutionDetails: BulkCreateExecutionDetails,
     private stepRunRepository: StepRunRepository,
-    private createExecutionDetails: CreateExecutionDetails
+    private traceLogRepository: TraceLogRepository
   ) {}
 
   @InstrumentUsecase()
@@ -55,28 +55,38 @@ export class StoreSubscriberJobs {
   }
 
   private async emitStepCreatedTraces(storedJobs: JobEntity[]): Promise<void> {
-    const results = await Promise.allSettled(
-      storedJobs.map((job) =>
-        this.createExecutionDetails.execute(
-          CreateExecutionDetailsCommand.create({
-            ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
-            detail: DetailEnum.STEP_CREATED,
-            source: ExecutionDetailsSourceEnum.INTERNAL,
-            status: ExecutionDetailsStatusEnum.SUCCESS,
-            isTest: false,
-            isRetry: false,
-          })
-        )
-      )
-    );
+    if (storedJobs.length === 0) {
+      return;
+    }
 
-    results.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        Logger.error(
-          { err: result.reason, jobId: storedJobs[index]._id },
-          'Failed to emit step_created trace'
-        );
-      }
-    });
+    try {
+      await this.traceLogRepository.createStepRun(storedJobs.map((job) => this.buildStepCreatedTraceFromJob(job)));
+    } catch (error) {
+      Logger.error(
+        { err: error, jobIds: storedJobs.map((job) => job._id) },
+        'Failed to emit step_created traces'
+      );
+    }
+  }
+
+  private buildStepCreatedTraceFromJob(job: JobEntity): StepRunTraceInput {
+    return {
+      created_at: LogRepository.formatDateTime64(new Date()),
+      organization_id: job._organizationId,
+      environment_id: job._environmentId,
+      user_id: null,
+      subscriber_id: job._subscriberId ? job._subscriberId : job.subscriberId,
+      external_subscriber_id: job.subscriberId || null,
+      event_type: 'step_created',
+      title: mapEventTypeToTitle('step_created'),
+      message: null,
+      raw_data: null,
+      status: 'success',
+      entity_id: job._id,
+      step_run_type: job.type,
+      workflow_run_identifier: job.identifier,
+      workflow_id: job._templateId,
+      provider_id: job.providerId || null,
+    };
   }
 }

--- a/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts
@@ -1,6 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { BulkCreateExecutionDetails, InstrumentUsecase, StepRunRepository } from '@novu/application-generic';
-import { DalException, JobRepository, JobStatusEnum } from '@novu/dal';
+import {
+  BulkCreateExecutionDetails,
+  CreateExecutionDetails,
+  CreateExecutionDetailsCommand,
+  DetailEnum,
+  InstrumentUsecase,
+  StepRunRepository,
+} from '@novu/application-generic';
+import { DalException, JobEntity, JobRepository, JobStatusEnum } from '@novu/dal';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
 import { PlatformException } from '../../../shared/utils';
 import { AddJob } from '../add-job';
 import { StoreSubscriberJobsCommand } from './store-subscriber-jobs.command';
@@ -11,7 +19,8 @@ export class StoreSubscriberJobs {
     private addJob: AddJob,
     private jobRepository: JobRepository,
     protected bulkCreateExecutionDetails: BulkCreateExecutionDetails,
-    private stepRunRepository: StepRunRepository
+    private stepRunRepository: StepRunRepository,
+    private createExecutionDetails: CreateExecutionDetails
   ) {}
 
   @InstrumentUsecase()
@@ -27,6 +36,9 @@ export class StoreSubscriberJobs {
     }
 
     await this.stepRunRepository.createMany(storedJobs, { status: JobStatusEnum.QUEUED });
+
+    await this.emitStepCreatedTraces(storedJobs);
+
     const firstJob = storedJobs[0];
 
     const addJobCommand = {
@@ -40,5 +52,22 @@ export class StoreSubscriberJobs {
     };
 
     await this.addJob.execute(addJobCommand);
+  }
+
+  private async emitStepCreatedTraces(storedJobs: JobEntity[]): Promise<void> {
+    await Promise.all(
+      storedJobs.map((job) =>
+        this.createExecutionDetails.execute(
+          CreateExecutionDetailsCommand.create({
+            ...CreateExecutionDetailsCommand.getDetailsFromJob(job),
+            detail: DetailEnum.STEP_CREATED,
+            source: ExecutionDetailsSourceEnum.INTERNAL,
+            status: ExecutionDetailsStatusEnum.SUCCESS,
+            isTest: false,
+            isRetry: false,
+          })
+        )
+      )
+    );
   }
 }

--- a/libs/application-generic/src/services/analytic-logs/index.ts
+++ b/libs/application-generic/src/services/analytic-logs/index.ts
@@ -6,6 +6,8 @@ export * from './log.repository';
 export * from './request-log';
 export { StepRun, StepRunFinalStatus, StepRunNonFinalStatus, StepRunRepository, StepRunStatus } from './step-run';
 export {
+  BuildStepRunTraceFromJobParams,
+  buildStepRunTraceFromJob,
   EventType,
   mapEventTypeToTitle,
   RequestTraceInput,

--- a/libs/application-generic/src/services/analytic-logs/trace-log/build-step-run-trace-from-job.ts
+++ b/libs/application-generic/src/services/analytic-logs/trace-log/build-step-run-trace-from-job.ts
@@ -1,0 +1,34 @@
+import { JobEntity } from '@novu/dal';
+import { LogRepository } from '../log.repository';
+import { StepType } from '../types';
+import { EventType, StepRunTraceInput, TraceStatus } from './trace-log.schema';
+
+export type BuildStepRunTraceFromJobParams = {
+  event_type: EventType;
+  title: string;
+  status: TraceStatus;
+  message?: string;
+  raw_data?: string;
+  created_at?: Date;
+};
+
+export function buildStepRunTraceFromJob(job: JobEntity, params: BuildStepRunTraceFromJobParams): StepRunTraceInput {
+  return {
+    created_at: LogRepository.formatDateTime64(params.created_at ?? new Date()),
+    organization_id: job._organizationId,
+    environment_id: job._environmentId,
+    user_id: '',
+    subscriber_id: job._subscriberId ?? '',
+    external_subscriber_id: job.subscriberId || '',
+    event_type: params.event_type,
+    title: params.title,
+    message: params.message ?? '',
+    raw_data: params.raw_data ?? '',
+    status: params.status,
+    entity_id: job._id,
+    step_run_type: (job.type ?? '') as StepType,
+    workflow_run_identifier: job.identifier,
+    workflow_id: job._templateId,
+    provider_id: job.providerId || '',
+  };
+}

--- a/libs/application-generic/src/services/analytic-logs/trace-log/index.ts
+++ b/libs/application-generic/src/services/analytic-logs/trace-log/index.ts
@@ -1,2 +1,3 @@
+export * from './build-step-run-trace-from-job';
 export * from './trace-log.repository';
 export * from './trace-log.schema';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Emits a `step_created` trace (`entity_type = 'step_run'`, `event_type = 'step_created'`) when step runs are created during workflow execution, closing a gap in step run trace coverage.

**Problem:** The `step_created` event type already existed in the ClickHouse traces schema, but no production code ever wrote it. The `step_runs` ClickHouse table received records via `StepRunRepository.createMany()`, but the unified `traces` table never got a `step_created` event — making it impossible to build a complete step lifecycle timeline.

**Solution:** In `StoreSubscriberJobs`, after `stepRunRepository.createMany()` stores step runs and before `AddJob` emits `step_queued`, we now write `step_created` traces directly to ClickHouse via `TraceLogRepository.createStepRun()` — bypassing `CreateExecutionDetails` so no MongoDB execution-details record is created.

**Key details:**
- Each trace includes `entity_id` (job id), `step_run_type` (channel), `workflow_id`, `workflow_run_identifier`, and subscriber/provider fields from the job entity
- `entity_type` is set to `step_run` and `event_type` to `step_created` by `TraceLogRepository.createStepRun()`
- Status is set to `success`
- Trace is gated behind `IS_TRACE_LOGS_ENABLED` feature flag (handled inside `TraceLogRepository`)
- Emitted before `step_queued` so the lifecycle timeline is chronologically correct
- Trace emission is best-effort (try/catch) so infrastructure failures do not block job queuing
- `subscriber_id` uses internal MongoDB subscriber ID only; `external_subscriber_id` holds the external ID

```mermaid
sequenceDiagram
    participant SSJ as StoreSubscriberJobs
    participant JR as JobRepository
    participant SRR as StepRunRepository
    participant TLR as TraceLogRepository
    participant AJ as AddJob

    SSJ->>JR: storeJobs(jobs)
    JR-->>SSJ: storedJobs
    SSJ->>SRR: createMany(storedJobs, QUEUED)
    SSJ->>TLR: createStepRun(step_created traces) [NEW]
    SSJ->>AJ: execute(firstJob)
    AJ->>CED: step_queued trace (via CreateExecutionDetails)
```

### Test plan

- [x] Worker unit tests for `StoreSubscriberJobs` (6 passing) — trace emission, ordering, field mapping, and failure resilience
- [x] Updated API e2e expectations in `get-activity.e2e.ts` and `get-workflow-run.e2e.ts` for the new `Step created` trace
- [x] CI green — all 4 E2E shards passing, worker build passing

### Screenshots

N/A — backend-only change, no UI modifications.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- `BulkCreateExecutionDetails` is still injected but unused — it was already present before this change and only writes to MongoDB (not ClickHouse traces).
- The `let storedJobs` implicit-any lint warning is pre-existing and not introduced by this change.
- `step_created` traces are ClickHouse-only; `step_queued` and subsequent lifecycle events still go through `CreateExecutionDetails`.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7949](https://linear.app/novu/issue/NV-7949/store-step-created-trace-when-step-runs-are-created)

<div><a href="https://cursor.com/agents/bc-b1f0cde6-3b6d-4a7a-b3a1-91f1547c5f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1f0cde6-3b6d-4a7a-b3a1-91f1547c5f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The worker now emits a step_created trace (entity_type = "step_run", event_type = "step_created") when step runs are created, closing a gap in step-run trace coverage. After persisting step_runs, StoreSubscriberJobs writes step_created traces directly to ClickHouse before queuing the step; trace failures are logged and do not block job queuing. A follow-up fix ensures the trace uses the internal subscriber ID.

## Affected areas

- worker: StoreSubscriberJobs now injects TraceLogRepository and emits step_created traces via TraceLogRepository.createStepRun immediately after StepRunRepository.createMany and before queuing; emission is best-effort and non-blocking.
- api: e2e tests for activity and workflow-run endpoints updated to expect the new "Step created" execution detail in activity/workflow-run responses.
- libs/application-generic (tracing utilities/types): existing trace types and helpers are reused/mapped for the step_created payload (no DB/schema migrations).

## Key technical decisions

- Traces are written directly to ClickHouse via TraceLogRepository.createStepRun, bypassing CreateExecutionDetails to avoid creating MongoDB execution-details records for this fast path.
- step_created is emitted before step_queued to preserve chronological lifecycle ordering.
- Trace writes are best-effort (try/catch) and gated by the existing tracing feature flag inside TraceLogRepository so failures are logged but do not block job processing.

## Testing

Added/updated unit tests for StoreSubscriberJobs to cover trace emission, field mapping, ordering, and resilience to trace-write failures; updated API e2e tests (activity and workflow-run) to include the new "Step created" execution detail. CI e2e shards should be re-run after the push.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a gap in step-run trace coverage by emitting a `step_created` trace to ClickHouse immediately after `StepRunRepository.createMany()` and before `AddJob` enqueues the first job, completing the step lifecycle timeline that was previously missing its earliest event. The new `buildStepRunTraceFromJob` helper centralises field mapping from `JobEntity` to `StepRunTraceInput`, and the emission is best-effort (try/catch) so ClickHouse or feature-flag failures never block job queuing.

- **`StoreSubscriberJobs`** injects `TraceLogRepository` and calls `emitStepCreatedTraces` (guarded with try/catch + `Logger.error`) between `stepRunRepository.createMany` and `addJob.execute`, preserving correct lifecycle ordering.
- **`buildStepRunTraceFromJob`** maps all relevant `JobEntity` fields (`_id`, `_templateId`, `_subscriberId`, `subscriberId`, `type`, `identifier`, etc.) to `StepRunTraceInput`; `entity_type` and `expires_at` are set by `TraceLogRepository.createStepRun`.
- **Tests and E2E** are updated to cover trace emission, field mapping, ordering, and resilience to write failures, and to expect `'Step created'` as the first execution detail in activity/workflow-run responses.

<h3>Confidence Score: 5/5</h3>

Safe to merge — trace emission is best-effort and cannot block job queuing; no schema or data-path changes.

The change is additive and isolated: it writes to ClickHouse traces only, the existing createMany path in TraceLogRepository already swallows errors internally, and emitStepCreatedTraces adds a second try/catch layer. The core job-queuing path through stepRunRepository.createMany and addJob.execute is unchanged. Unit tests cover the failure-resilience path, and E2E tests confirm the new trace appears in the correct lifecycle position.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts | Injects TraceLogRepository and adds best-effort emitStepCreatedTraces (try/catch guarded) called after stepRunRepository.createMany and before addJob. Minor NestJS Logger.error argument-order issue in the catch block. |
| libs/application-generic/src/services/analytic-logs/trace-log/build-step-run-trace-from-job.ts | New helper that maps JobEntity fields to StepRunTraceInput; user_id is intentionally left empty (system-generated trace), all other relevant fields are correctly mapped. |
| apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.spec.ts | New unit test file with 6 tests covering trace emission, field mapping, ordering (createMany before createStepRun before addJob), and failure resilience — addresses previous review gaps. |
| apps/api/src/app/notifications/e2e/get-activity.e2e.ts | E2E test updated to expect 'Step created' as the first execution detail in four test cases, with counts bumped by one accordingly. |
| apps/api/src/app/activity/e2e/get-workflow-run.e2e.ts | E2E test updated to expect 'Step created' as the first execution detail in the workflow-run response. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SSJ as StoreSubscriberJobs
    participant JR as JobRepository
    participant SRR as StepRunRepository
    participant TLR as TraceLogRepository
    participant CH as ClickHouse
    participant AJ as AddJob

    SSJ->>JR: storeJobs(jobs)
    JR-->>SSJ: storedJobs

    SSJ->>SRR: createMany(storedJobs, QUEUED)

    SSJ->>TLR: createStepRun(step_created traces) [NEW]
    TLR->>TLR: check IS_TRACE_LOGS_ENABLED flag
    TLR->>CH: "insertMany(traces, entity_type=step_run)"
    note over SSJ,TLR: failures are caught and logged — non-blocking

    SSJ->>AJ: execute(firstJob)
    note over AJ: emits step_queued via CreateExecutionDetails
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Fstore-subscriber-jobs%2Fstore-subscriber-jobs.usecase.ts%3A72-75%0AThe%20NestJS%20static%20%60Logger.error%60%20signature%20is%20%60error%28message%3A%20any%2C%20stackOrContext%3F%3A%20string%2C%20context%3F%3A%20string%29%60.%20Here%20the%20object%20%60%7B%20err%2C%20jobIds%20%7D%60%20is%20passed%20as%20the%20%60message%60%20and%20the%20human-readable%20string%20%60'Failed%20to%20emit%20step_created%20traces'%60%20lands%20in%20the%20%60stackOrContext%60%20slot%20%28treated%20as%20context%2Fclass-name%20by%20NestJS%29.%20The%20output%20ends%20up%20as%20%60%5Bobject%20Object%5D%20%2B0ms%20%28Failed%20to%20emit%20step_created%20traces%29%60%20%E2%80%94%20the%20error%20details%20are%20buried%20and%20the%20readable%20message%20appears%20as%20the%20log%20context%2C%20making%20alerting%20and%20grep%20harder.%20Swap%20them%20to%20match%20NestJS%20convention.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20Logger.error%28%0A%20%20%20%20%20%20%20%20%60Failed%20to%20emit%20step_created%20traces%20for%20jobIds%3A%20%24%7BstoredJobs.map%28%28job%29%20%3D%3E%20job._id%29.join%28'%2C%20'%29%7D%60%2C%0A%20%20%20%20%20%20%20%20error%20instanceof%20Error%20%3F%20error.stack%20%3A%20String%28error%29%2C%0A%20%20%20%20%20%20%20%20StoreSubscriberJobs.name%0A%20%20%20%20%20%20%29%3B%0A%60%60%60%0A%0A&pr=11418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/worker/src/app/workflow/usecases/store-subscriber-jobs/store-subscriber-jobs.usecase.ts:72-75
The NestJS static `Logger.error` signature is `error(message: any, stackOrContext?: string, context?: string)`. Here the object `{ err, jobIds }` is passed as the `message` and the human-readable string `'Failed to emit step_created traces'` lands in the `stackOrContext` slot (treated as context/class-name by NestJS). The output ends up as `[object Object] +0ms (Failed to emit step_created traces)` — the error details are buried and the readable message appears as the log context, making alerting and grep harder. Swap them to match NestJS convention.

```suggestion
      Logger.error(
        `Failed to emit step_created traces for jobIds: ${storedJobs.map((job) => job._id).join(', ')}`,
        error instanceof Error ? error.stack : String(error),
        StoreSubscriberJobs.name
      );
```

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["refactor(shared): extract buildStepRunTr..."](https://github.com/novuhq/novu/commit/20e600d790e03f2c808416243092caef9c43339d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35098535)</sub>

<!-- /greptile_comment -->