### PR TITLE
feat(api-service, framework): expose email raw payload and resolved routing in agent context (fixes NV-7951)

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -483,6 +483,14 @@ export class AgentInboundHandler implements OnModuleInit {
     });
 
     if (isFirstMessage && message.id) {
+      /*
+       * Reflect the first message id on the in-memory conversation immediately so
+       * downstream context builders (e.g. platformContext.email.rootMessageId) read
+       * a consistent value within this turn, even though the DB write below is
+       * fire-and-forget.
+       */
+      this.conversationService.getPrimaryChannel(conversation).firstPlatformMessageId = message.id;
+
       this.conversationService
         .setFirstPlatformMessageId(
           config.environmentId,

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -20,7 +20,7 @@ import type { MetadataOp } from '../../conversation/agent-conversation.service';
 import { AgentConversationService } from '../../conversation/agent-conversation.service';
 import { OutboundGateway } from '../../egress/outbound.gateway';
 import { BridgeExecutorService } from '../../runtime/bridge-executor.service';
-import { buildAgentPlatformContext } from '../../runtime/build-platform-context.util';
+import { buildAgentPlatformContext, buildEmailPlatformContext } from '../../runtime/build-platform-context.util';
 import { HandleAgentReplyCommand } from './handle-agent-reply.command';
 
 @Injectable()
@@ -472,9 +472,12 @@ export class HandleAgentReply {
         platformThreadId: channel.platformThreadId,
         channelId: '',
         isDM: false,
-        platform: config.platform,
         message: null,
-        firstPlatformMessageId: channel.firstPlatformMessageId,
+        email: buildEmailPlatformContext({
+          platform: config.platform,
+          message: null,
+          firstPlatformMessageId: channel.firstPlatformMessageId,
+        }),
       }),
     });
   }

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -20,6 +20,7 @@ import type { MetadataOp } from '../../conversation/agent-conversation.service';
 import { AgentConversationService } from '../../conversation/agent-conversation.service';
 import { OutboundGateway } from '../../egress/outbound.gateway';
 import { BridgeExecutorService } from '../../runtime/bridge-executor.service';
+import { buildAgentPlatformContext } from '../../runtime/build-platform-context.util';
 import { HandleAgentReplyCommand } from './handle-agent-reply.command';
 
 @Injectable()
@@ -467,11 +468,13 @@ export class HandleAgentReply {
       subscriber,
       history,
       message: null,
-      platformContext: {
-        threadId: channel.platformThreadId,
+      platformContext: buildAgentPlatformContext({
+        platformThreadId: channel.platformThreadId,
         channelId: '',
         isDM: false,
-      },
+        platform: config.platform,
+        message: null,
+      }),
     });
   }
 }

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -474,6 +474,7 @@ export class HandleAgentReply {
         isDM: false,
         platform: config.platform,
         message: null,
+        firstPlatformMessageId: channel.firstPlatformMessageId,
       }),
     });
   }

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
@@ -6,8 +6,10 @@ import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { AgentRuntime } from './agent-runtime.port';
-import { type AgentExecutionParams, BridgeExecutorService, NoBridgeUrlError } from './bridge-executor.service';
+import type { AgentExecutionParams } from './bridge-executor.service';
+import { BridgeExecutorService, NoBridgeUrlError } from './bridge-executor.service';
 import type { ConversationTurn } from './conversation-turn';
+import { buildAgentPlatformContext } from './build-platform-context.util';
 import { applyPlatformThreadIdToThread } from './platform-thread.util';
 
 const BRIDGE_OFFLINE_REPLY_MARKDOWN = `*The agent is currently offline.*
@@ -70,11 +72,13 @@ export class BridgeRuntime implements AgentRuntime {
       subscriber: turn.subscriber,
       history: turn.history,
       message: turn.message,
-      platformContext: {
-        threadId: turn.platformThreadId,
+      platformContext: buildAgentPlatformContext({
+        platformThreadId: turn.platformThreadId,
         channelId: turn.thread.channelId,
         isDM: turn.thread.isDM,
-      },
+        platform: turn.config.platform,
+        message: turn.message,
+      }),
       storedAttachments: turn.storedAttachments,
       action: turn.action,
       reaction: turn.reaction,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
@@ -6,10 +6,9 @@ import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { AgentRuntime } from './agent-runtime.port';
-import type { AgentExecutionParams } from './bridge-executor.service';
-import { BridgeExecutorService, NoBridgeUrlError } from './bridge-executor.service';
-import type { ConversationTurn } from './conversation-turn';
+import { type AgentExecutionParams, BridgeExecutorService, NoBridgeUrlError } from './bridge-executor.service';
 import { buildAgentPlatformContext, buildEmailPlatformContext } from './build-platform-context.util';
+import type { ConversationTurn } from './conversation-turn';
 import { applyPlatformThreadIdToThread } from './platform-thread.util';
 
 const BRIDGE_OFFLINE_REPLY_MARKDOWN = `*The agent is currently offline.*

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
@@ -9,7 +9,7 @@ import type { AgentRuntime } from './agent-runtime.port';
 import type { AgentExecutionParams } from './bridge-executor.service';
 import { BridgeExecutorService, NoBridgeUrlError } from './bridge-executor.service';
 import type { ConversationTurn } from './conversation-turn';
-import { buildAgentPlatformContext } from './build-platform-context.util';
+import { buildAgentPlatformContext, buildEmailPlatformContext } from './build-platform-context.util';
 import { applyPlatformThreadIdToThread } from './platform-thread.util';
 
 const BRIDGE_OFFLINE_REPLY_MARKDOWN = `*The agent is currently offline.*
@@ -76,9 +76,12 @@ export class BridgeRuntime implements AgentRuntime {
         platformThreadId: turn.platformThreadId,
         channelId: turn.thread.channelId,
         isDM: turn.thread.isDM,
-        platform: turn.config.platform,
         message: turn.message,
-        firstPlatformMessageId: this.conversationService.getPrimaryChannel(turn.conversation).firstPlatformMessageId,
+        email: buildEmailPlatformContext({
+          platform: turn.config.platform,
+          message: turn.message,
+          firstPlatformMessageId: this.conversationService.getPrimaryChannel(turn.conversation).firstPlatformMessageId,
+        }),
       }),
       storedAttachments: turn.storedAttachments,
       action: turn.action,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
@@ -78,6 +78,7 @@ export class BridgeRuntime implements AgentRuntime {
         isDM: turn.thread.isDM,
         platform: turn.config.platform,
         message: turn.message,
+        firstPlatformMessageId: this.conversationService.getPrimaryChannel(turn.conversation).firstPlatformMessageId,
       }),
       storedAttachments: turn.storedAttachments,
       action: turn.action,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.spec.ts
@@ -1,0 +1,72 @@
+import type { AgentPlatformContext } from '@novu/framework';
+import { expect } from 'chai';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { buildAgentPlatformContext } from './build-platform-context.util';
+
+describe('buildAgentPlatformContext', () => {
+  it('includes chat SDK raw message on platformContext.message', () => {
+    const raw = { messageId: 'msg-1@example.com', subject: 'Hello' };
+
+    const context = buildAgentPlatformContext({
+      platformThreadId: 'email:dima@novu.co:abc',
+      channelId: 'email:dima@novu.co',
+      isDM: false,
+      platform: AgentPlatformEnum.EMAIL,
+      message: { raw } as never,
+    });
+
+    expect(context.message).to.deep.equal(raw);
+  });
+
+  it('extracts resolved domain and route for email platform', () => {
+    const raw = {
+      messageId: 'msg-1@example.com',
+      domain: { id: 'domain-1', name: 'inbox.example.com', data: { tier: 'pro' } },
+      route: { address: 'support', data: { queue: 'tier-1' } },
+    };
+
+    const context = buildAgentPlatformContext({
+      platformThreadId: 'email:dima@novu.co:abc',
+      channelId: 'email:dima@novu.co',
+      isDM: false,
+      platform: AgentPlatformEnum.EMAIL,
+      message: { raw } as never,
+    });
+
+    expect(context.email).to.deep.equal({
+      domain: raw.domain,
+      route: raw.route,
+    });
+  });
+
+  it('does not set email metadata for non-email platforms', () => {
+    const raw = {
+      domain: { id: 'domain-1', name: 'inbox.example.com' },
+      route: { address: 'support' },
+    };
+
+    const context = buildAgentPlatformContext({
+      platformThreadId: 'slack:C123:123.456',
+      channelId: 'slack:C123',
+      isDM: false,
+      platform: AgentPlatformEnum.SLACK,
+      message: { raw } as never,
+    });
+
+    expect(context.message).to.deep.equal(raw);
+    expect(context.email).to.be.undefined;
+  });
+
+  it('omits message and email when no chat message is provided', () => {
+    const context: AgentPlatformContext = buildAgentPlatformContext({
+      platformThreadId: 'email:dima@novu.co:abc',
+      channelId: 'email:dima@novu.co',
+      isDM: false,
+      platform: AgentPlatformEnum.EMAIL,
+      message: null,
+    });
+
+    expect(context.message).to.be.undefined;
+    expect(context.email).to.be.undefined;
+  });
+});

--- a/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.spec.ts
@@ -1,109 +1,104 @@
 import type { AgentPlatformContext } from '@novu/framework';
 import { expect } from 'chai';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
-import { buildAgentPlatformContext } from './build-platform-context.util';
+import { buildAgentPlatformContext, buildEmailPlatformContext } from './build-platform-context.util';
 
 describe('buildAgentPlatformContext', () => {
-  it('includes chat SDK raw message on platformContext.message', () => {
+  it('exposes the chat SDK raw payload on platformContext.message', () => {
     const raw = { messageId: 'msg-1@example.com', subject: 'Hello' };
 
     const context = buildAgentPlatformContext({
       platformThreadId: 'email:dima@novu.co:abc',
       channelId: 'email:dima@novu.co',
       isDM: false,
-      platform: AgentPlatformEnum.EMAIL,
       message: { raw } as never,
     });
 
     expect(context.message).to.deep.equal(raw);
   });
 
-  it('extracts resolved domain, route, and thread root for email platform', () => {
-    const raw = {
-      id: 'reply3@example.com',
-      messageId: 'reply3@example.com',
-      domain: { id: 'domain-1', name: 'inbox.example.com', data: { tier: 'pro' } },
-      route: { address: 'support', data: { queue: 'tier-1' } },
-    };
-
-    const context = buildAgentPlatformContext({
-      platformThreadId: 'email:dima@novu.co:abc',
-      channelId: 'email:dima@novu.co',
-      isDM: false,
-      platform: AgentPlatformEnum.EMAIL,
-      message: { raw, id: 'reply3@example.com' } as never,
-      firstPlatformMessageId: 'root@example.com',
-    });
-
-    expect(context.email).to.deep.equal({
-      domain: raw.domain,
-      route: raw.route,
-      rootMessageId: 'root@example.com',
-    });
-  });
-
-  it('falls back to the current message id as the email root when no first message id is tracked', () => {
-    const context = buildAgentPlatformContext({
-      platformThreadId: 'email:dima@novu.co:abc',
-      channelId: 'email:dima@novu.co',
-      isDM: false,
-      platform: AgentPlatformEnum.EMAIL,
-      message: { raw: { messageId: 'root@example.com' }, id: 'root@example.com' } as never,
-    });
-
-    expect(context.email).to.deep.equal({
-      domain: undefined,
-      route: undefined,
-      rootMessageId: 'root@example.com',
-    });
-  });
-
-  it('does not set email metadata for non-email platforms', () => {
-    const raw = {
+  it('attaches the email context when one is provided', () => {
+    const email: AgentPlatformContext['email'] = {
       domain: { id: 'domain-1', name: 'inbox.example.com' },
       route: { address: 'support' },
+      rootMessageId: 'root@example.com',
     };
 
     const context = buildAgentPlatformContext({
+      platformThreadId: 'email:dima@novu.co:abc',
+      channelId: 'email:dima@novu.co',
+      isDM: false,
+      message: null,
+      email,
+    });
+
+    expect(context.email).to.deep.equal(email);
+  });
+
+  it('omits message and email when neither is provided', () => {
+    const context: AgentPlatformContext = buildAgentPlatformContext({
       platformThreadId: 'slack:C123:123.456',
       channelId: 'slack:C123',
       isDM: false,
-      platform: AgentPlatformEnum.SLACK,
-      message: { raw, id: '123.456' } as never,
-      firstPlatformMessageId: '123.456',
-    });
-
-    expect(context.message).to.deep.equal(raw);
-    expect(context.email).to.be.undefined;
-  });
-
-  it('omits message and email when there is no chat message or tracked root', () => {
-    const context: AgentPlatformContext = buildAgentPlatformContext({
-      platformThreadId: 'email:dima@novu.co:abc',
-      channelId: 'email:dima@novu.co',
-      isDM: false,
-      platform: AgentPlatformEnum.EMAIL,
       message: null,
     });
 
     expect(context.message).to.be.undefined;
     expect(context.email).to.be.undefined;
   });
+});
 
-  it('sets email root from the tracked first message id during onResolve (no inbound message)', () => {
-    const context = buildAgentPlatformContext({
-      platformThreadId: 'email:dima@novu.co:abc',
-      channelId: '',
-      isDM: false,
+describe('buildEmailPlatformContext', () => {
+  it('returns undefined for non-email platforms', () => {
+    const result = buildEmailPlatformContext({
+      platform: AgentPlatformEnum.SLACK,
+      message: { raw: { domain: { id: 'd', name: 'n' } } } as never,
+      firstPlatformMessageId: 'root',
+    });
+
+    expect(result).to.be.undefined;
+  });
+
+  it('extracts domain, route, and root message id for email', () => {
+    const raw = {
+      messageId: 'reply3@example.com',
+      domain: { id: 'domain-1', name: 'inbox.example.com', data: { tier: 'pro' } },
+      route: { address: 'support', data: { queue: 'tier-1' } },
+    };
+
+    const result = buildEmailPlatformContext({
+      platform: AgentPlatformEnum.EMAIL,
+      message: { raw } as never,
+      firstPlatformMessageId: 'root@example.com',
+    });
+
+    expect(result).to.deep.equal({
+      domain: raw.domain,
+      route: raw.route,
+      rootMessageId: 'root@example.com',
+    });
+  });
+
+  it('returns only the root message id during onResolve when there is no inbound message', () => {
+    const result = buildEmailPlatformContext({
       platform: AgentPlatformEnum.EMAIL,
       message: null,
       firstPlatformMessageId: 'root@example.com',
     });
 
-    expect(context.email).to.deep.equal({
+    expect(result).to.deep.equal({
       domain: undefined,
       route: undefined,
       rootMessageId: 'root@example.com',
     });
+  });
+
+  it('returns undefined when an email turn carries no resolved data at all', () => {
+    const result = buildEmailPlatformContext({
+      platform: AgentPlatformEnum.EMAIL,
+      message: null,
+    });
+
+    expect(result).to.be.undefined;
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.spec.ts
@@ -18,9 +18,10 @@ describe('buildAgentPlatformContext', () => {
     expect(context.message).to.deep.equal(raw);
   });
 
-  it('extracts resolved domain and route for email platform', () => {
+  it('extracts resolved domain, route, and thread root for email platform', () => {
     const raw = {
-      messageId: 'msg-1@example.com',
+      id: 'reply3@example.com',
+      messageId: 'reply3@example.com',
       domain: { id: 'domain-1', name: 'inbox.example.com', data: { tier: 'pro' } },
       route: { address: 'support', data: { queue: 'tier-1' } },
     };
@@ -30,12 +31,30 @@ describe('buildAgentPlatformContext', () => {
       channelId: 'email:dima@novu.co',
       isDM: false,
       platform: AgentPlatformEnum.EMAIL,
-      message: { raw } as never,
+      message: { raw, id: 'reply3@example.com' } as never,
+      firstPlatformMessageId: 'root@example.com',
     });
 
     expect(context.email).to.deep.equal({
       domain: raw.domain,
       route: raw.route,
+      rootMessageId: 'root@example.com',
+    });
+  });
+
+  it('falls back to the current message id as the email root when no first message id is tracked', () => {
+    const context = buildAgentPlatformContext({
+      platformThreadId: 'email:dima@novu.co:abc',
+      channelId: 'email:dima@novu.co',
+      isDM: false,
+      platform: AgentPlatformEnum.EMAIL,
+      message: { raw: { messageId: 'root@example.com' }, id: 'root@example.com' } as never,
+    });
+
+    expect(context.email).to.deep.equal({
+      domain: undefined,
+      route: undefined,
+      rootMessageId: 'root@example.com',
     });
   });
 
@@ -50,14 +69,15 @@ describe('buildAgentPlatformContext', () => {
       channelId: 'slack:C123',
       isDM: false,
       platform: AgentPlatformEnum.SLACK,
-      message: { raw } as never,
+      message: { raw, id: '123.456' } as never,
+      firstPlatformMessageId: '123.456',
     });
 
     expect(context.message).to.deep.equal(raw);
     expect(context.email).to.be.undefined;
   });
 
-  it('omits message and email when no chat message is provided', () => {
+  it('omits message and email when there is no chat message or tracked root', () => {
     const context: AgentPlatformContext = buildAgentPlatformContext({
       platformThreadId: 'email:dima@novu.co:abc',
       channelId: 'email:dima@novu.co',
@@ -68,5 +88,22 @@ describe('buildAgentPlatformContext', () => {
 
     expect(context.message).to.be.undefined;
     expect(context.email).to.be.undefined;
+  });
+
+  it('sets email root from the tracked first message id during onResolve (no inbound message)', () => {
+    const context = buildAgentPlatformContext({
+      platformThreadId: 'email:dima@novu.co:abc',
+      channelId: '',
+      isDM: false,
+      platform: AgentPlatformEnum.EMAIL,
+      message: null,
+      firstPlatformMessageId: 'root@example.com',
+    });
+
+    expect(context.email).to.deep.equal({
+      domain: undefined,
+      route: undefined,
+      rootMessageId: 'root@example.com',
+    });
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.ts
@@ -1,3 +1,4 @@
+import type { NovuEmailRawMessage } from '@novu/chat-adapter-email';
 import type { AgentPlatformContext } from '@novu/framework';
 import type { Message } from 'chat';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
@@ -6,48 +7,54 @@ interface BuildAgentPlatformContextParams {
   platformThreadId: string;
   channelId: string;
   isDM: boolean;
-  platform: string;
   message?: Message | null;
-  /**
-   * Server-tracked Message-ID of the first message in the conversation, used as
-   * the email thread root. Falls back to the current message ID when absent
-   * (e.g. the first message of a brand-new thread).
-   */
-  firstPlatformMessageId?: string;
+  /** Resolved email-specific context (see `buildEmailPlatformContext`). */
+  email?: AgentPlatformContext['email'];
 }
 
 export function buildAgentPlatformContext(params: BuildAgentPlatformContextParams): AgentPlatformContext {
-  const { platformThreadId, channelId, isDM, platform, message, firstPlatformMessageId } = params;
-  const raw = message?.raw;
-
   const context: AgentPlatformContext = {
-    threadId: platformThreadId,
-    channelId,
-    isDM,
+    threadId: params.platformThreadId,
+    channelId: params.channelId,
+    isDM: params.isDM,
   };
 
+  const raw = params.message?.raw;
   if (raw !== undefined && raw !== null) {
     context.message = raw;
   }
 
-  if (platform === AgentPlatformEnum.EMAIL) {
-    const emailRaw =
-      raw && typeof raw === 'object' && !Array.isArray(raw)
-        ? (raw as {
-            domain?: NonNullable<AgentPlatformContext['email']>['domain'];
-            route?: NonNullable<AgentPlatformContext['email']>['route'];
-          })
-        : {};
-    const rootMessageId = firstPlatformMessageId ?? message?.id ?? undefined;
-
-    if (emailRaw.domain !== undefined || emailRaw.route !== undefined || rootMessageId !== undefined) {
-      context.email = {
-        domain: emailRaw.domain,
-        route: emailRaw.route,
-        rootMessageId,
-      };
-    }
+  if (params.email) {
+    context.email = params.email;
   }
 
   return context;
+}
+
+/**
+ * Resolved email-specific context for `platformContext.email`. Domain and route
+ * are extracted from the chat-adapter-email raw payload; `rootMessageId` is the
+ * server-tracked first platform message id for this conversation.
+ *
+ * Returns `undefined` for non-email platforms or when no resolved data exists.
+ */
+export function buildEmailPlatformContext(params: {
+  platform: string;
+  message?: Message | null;
+  firstPlatformMessageId?: string;
+}): AgentPlatformContext['email'] | undefined {
+  if (params.platform !== AgentPlatformEnum.EMAIL) {
+    return undefined;
+  }
+
+  const raw = params.message?.raw as NovuEmailRawMessage | undefined;
+  const domain = raw?.domain;
+  const route = raw?.route;
+  const rootMessageId = params.firstPlatformMessageId;
+
+  if (!domain && !route && !rootMessageId) {
+    return undefined;
+  }
+
+  return { domain, route, rootMessageId };
 }

--- a/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.ts
@@ -8,10 +8,16 @@ interface BuildAgentPlatformContextParams {
   isDM: boolean;
   platform: string;
   message?: Message | null;
+  /**
+   * Server-tracked Message-ID of the first message in the conversation, used as
+   * the email thread root. Falls back to the current message ID when absent
+   * (e.g. the first message of a brand-new thread).
+   */
+  firstPlatformMessageId?: string;
 }
 
 export function buildAgentPlatformContext(params: BuildAgentPlatformContextParams): AgentPlatformContext {
-  const { platformThreadId, channelId, isDM, platform, message } = params;
+  const { platformThreadId, channelId, isDM, platform, message, firstPlatformMessageId } = params;
   const raw = message?.raw;
 
   const context: AgentPlatformContext = {
@@ -24,16 +30,21 @@ export function buildAgentPlatformContext(params: BuildAgentPlatformContextParam
     context.message = raw;
   }
 
-  if (platform === AgentPlatformEnum.EMAIL && raw && typeof raw === 'object' && !Array.isArray(raw)) {
-    const emailRaw = raw as {
-      domain?: NonNullable<AgentPlatformContext['email']>['domain'];
-      route?: NonNullable<AgentPlatformContext['email']>['route'];
-    };
+  if (platform === AgentPlatformEnum.EMAIL) {
+    const emailRaw =
+      raw && typeof raw === 'object' && !Array.isArray(raw)
+        ? (raw as {
+            domain?: NonNullable<AgentPlatformContext['email']>['domain'];
+            route?: NonNullable<AgentPlatformContext['email']>['route'];
+          })
+        : {};
+    const rootMessageId = firstPlatformMessageId ?? message?.id ?? undefined;
 
-    if (emailRaw.domain !== undefined || emailRaw.route !== undefined) {
+    if (emailRaw.domain !== undefined || emailRaw.route !== undefined || rootMessageId !== undefined) {
       context.email = {
         domain: emailRaw.domain,
         route: emailRaw.route,
+        rootMessageId,
       };
     }
   }

--- a/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.ts
@@ -1,0 +1,42 @@
+import type { AgentPlatformContext } from '@novu/framework';
+import type { Message } from 'chat';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+
+interface BuildAgentPlatformContextParams {
+  platformThreadId: string;
+  channelId: string;
+  isDM: boolean;
+  platform: string;
+  message?: Message | null;
+}
+
+export function buildAgentPlatformContext(params: BuildAgentPlatformContextParams): AgentPlatformContext {
+  const { platformThreadId, channelId, isDM, platform, message } = params;
+  const raw = message?.raw;
+
+  const context: AgentPlatformContext = {
+    threadId: platformThreadId,
+    channelId,
+    isDM,
+  };
+
+  if (raw !== undefined && raw !== null) {
+    context.message = raw;
+  }
+
+  if (platform === AgentPlatformEnum.EMAIL && raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const emailRaw = raw as {
+      domain?: NonNullable<AgentPlatformContext['email']>['domain'];
+      route?: NonNullable<AgentPlatformContext['email']>['route'];
+    };
+
+    if (emailRaw.domain !== undefined || emailRaw.route !== undefined) {
+      context.email = {
+        domain: emailRaw.domain,
+        route: emailRaw.route,
+      };
+    }
+  }
+
+  return context;
+}

--- a/apps/api/src/app/domains/usecases/test-domain-route/test-domain-route.usecase.ts
+++ b/apps/api/src/app/domains/usecases/test-domain-route/test-domain-route.usecase.ts
@@ -61,7 +61,7 @@ export class TestDomainRoute {
         };
       }
 
-      const agentPayload = this.inboundDomainRouteDelivery.previewAgentMailPayload(mail);
+      const agentPayload = this.inboundDomainRouteDelivery.previewAgentMailPayload(mail, { domain, route });
       const apiBaseUrl = process.env.API_ROOT_URL ?? '';
       const agentId = route.destination ?? '';
       const wouldDeliverTo =

--- a/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.spec.ts
+++ b/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AgentIntegrationRepository, IntegrationRepository } from '@novu/dal';
+import { DomainRouteTypeEnum, DomainStatusEnum } from '@novu/shared';
+import { AgentIntegrationRepository, DomainRouteEntity, IntegrationRepository } from '@novu/dal';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { PinoLogger } from '../../logging';
@@ -142,5 +143,66 @@ describe('InboundDomainRouteDelivery.previewAgentMailPayload', () => {
     expect(payload.inReplyTo).to.equal('previous@example.com');
     expect(payload.references).to.equal('ref-1@example.com ref-2@example.com');
     expect(payload.date).to.equal(new Date('2024-01-01T00:00:00.000Z').toISOString());
+  });
+
+  it('includes normalized headers with a size cap', () => {
+    const payload = usecase.previewAgentMailPayload({
+      ...baseMail,
+      headers: {
+        from: 'sender@example.com',
+        to: 'agent@inbox.example.com',
+        subject: 'Hello',
+        'message-id': 'msg-001@example.com',
+        'content-type': 'text/plain',
+        date: 'Mon, 01 Jan 2024 00:00:00 +0000',
+        'mime-version': '1.0',
+      } as InboundDomainRouteMailInput['headers'],
+    });
+
+    expect(payload.headers).to.deep.equal({
+      from: 'sender@example.com',
+      to: 'agent@inbox.example.com',
+      subject: 'Hello',
+      'message-id': 'msg-001@example.com',
+      'content-type': 'text/plain',
+      date: 'Mon, 01 Jan 2024 00:00:00 +0000',
+      'mime-version': '1.0',
+    });
+  });
+
+  it('includes resolved domain and route metadata when provided', () => {
+    const payload = usecase.previewAgentMailPayload(baseMail, {
+      domain: {
+        _id: 'domain-1',
+        name: 'inbox.example.com',
+        status: DomainStatusEnum.VERIFIED,
+        mxRecordConfigured: true,
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        data: { tier: 'pro' },
+      },
+      route: {
+        _id: 'route-1',
+        _domainId: 'domain-1',
+        address: 'support',
+        destination: 'agent-1',
+        type: DomainRouteTypeEnum.AGENT,
+        data: { queue: 'tier-1' },
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      } as DomainRouteEntity,
+    });
+
+    expect(payload.domain).to.deep.equal({
+      id: 'domain-1',
+      name: 'inbox.example.com',
+      data: { tier: 'pro' },
+    });
+    expect(payload.route).to.deep.equal({
+      address: 'support',
+      data: { queue: 'tier-1' },
+    });
   });
 });

--- a/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts
+++ b/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts
@@ -38,10 +38,10 @@ function normalizeMailHeaders(headers: InboundDomainRouteMailInput['headers'] | 
 
   for (const [key, value] of Object.entries(headers)) {
     const stringValue = Array.isArray(value) ? value.join(', ') : String(value ?? '');
-    const entrySize = key.length + stringValue.length;
+    const entrySize = Buffer.byteLength(key) + Buffer.byteLength(stringValue);
 
     if (totalSize + entrySize > MAX_HEADERS_BYTES) {
-      break;
+      continue;
     }
 
     normalized[key] = stringValue;

--- a/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts
+++ b/libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts
@@ -26,6 +26,34 @@ import { AttachmentRehydrator } from './attachment-rehydrator';
  * cap and skip the binary (forward metadata only) when it is exceeded.
  */
 const MAX_INLINE_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+const MAX_HEADERS_BYTES = 16 * 1024;
+
+function normalizeMailHeaders(headers: InboundDomainRouteMailInput['headers'] | undefined): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  const normalized: Record<string, string> = {};
+  let totalSize = 0;
+
+  for (const [key, value] of Object.entries(headers)) {
+    const stringValue = Array.isArray(value) ? value.join(', ') : String(value ?? '');
+    const entrySize = key.length + stringValue.length;
+
+    if (totalSize + entrySize > MAX_HEADERS_BYTES) {
+      break;
+    }
+
+    normalized[key] = stringValue;
+    totalSize += entrySize;
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    return undefined;
+  }
+
+  return normalized;
+}
 
 export interface RoutableDomain
   extends Pick<
@@ -171,7 +199,10 @@ export class InboundDomainRouteDelivery {
       params.domain._organizationId
     );
 
-    const payload = this.buildAgentEmailWebhookPayload(params.mail);
+    const payload = this.buildAgentEmailWebhookPayload(params.mail, {
+      domain: params.domain,
+      route: params.route,
+    });
     const signature = buildNovuSignatureHeader(secretKey, payload);
     const apiBaseUrl = process.env.API_ROOT_URL;
 
@@ -196,13 +227,20 @@ export class InboundDomainRouteDelivery {
     };
   }
 
-  previewAgentMailPayload(mail: InboundDomainRouteMailInput): EmailWebhookPayload {
-    return this.buildAgentEmailWebhookPayload(mail);
+  previewAgentMailPayload(
+    mail: InboundDomainRouteMailInput,
+    options?: { domain?: RoutableDomain; route?: DomainRouteEntity }
+  ): EmailWebhookPayload {
+    return this.buildAgentEmailWebhookPayload(mail, options);
   }
 
-  private buildAgentEmailWebhookPayload(mail: InboundDomainRouteMailInput): EmailWebhookPayload {
+  private buildAgentEmailWebhookPayload(
+    mail: InboundDomainRouteMailInput,
+    options?: { domain?: RoutableDomain; route?: DomainRouteEntity }
+  ): EmailWebhookPayload {
     const from = mail.from[0];
     const refs = normalizeReferences(mail.references);
+    const headers = normalizeMailHeaders(mail.headers);
 
     return {
       messageId: mail.messageId,
@@ -216,6 +254,20 @@ export class InboundDomainRouteDelivery {
       subject: mail.subject,
       text: mail.text || undefined,
       html: mail.html || undefined,
+      headers,
+      domain: options?.domain
+        ? {
+            id: options.domain._id,
+            name: options.domain.name,
+            data: options.domain.data ?? {},
+          }
+        : undefined,
+      route: options?.route
+        ? {
+            address: options.route.address,
+            data: options.route.data ?? {},
+          }
+        : undefined,
       attachments: mail.attachments?.map((att) => {
         /*
          * Inline-mode (S3-not-configured) fallback: the inbound-mail server

--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -109,22 +109,18 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
     });
 
     const agentAddress = payload.to[0]?.address;
-    const [, , rootMessageId] = await Promise.all([
+    await Promise.all([
       this.threadResolver.trackSubject(threadId, payload.subject),
       agentAddress ? this.threadResolver.trackAgentAddress(threadId, agentAddress) : Promise.resolve(),
-      this.threadResolver.getRootMessageId(threadId),
     ]);
 
-    const message = this.parseMessage(this.toRawMessage(payload, rootMessageId));
+    const message = this.parseMessage(this.toRawMessage(payload));
     this.chat.processMessage(this, threadId, message, options);
 
     return new Response(null, { status: 200 });
   }
 
-  private toRawMessage(
-    payload: import('./types.js').EmailWebhookPayload,
-    rootMessageId?: string
-  ): NovuEmailRawMessage {
+  private toRawMessage(payload: import('./types.js').EmailWebhookPayload): NovuEmailRawMessage {
     return {
       id: payload.messageId,
       messageId: payload.messageId,
@@ -135,7 +131,6 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
       html: payload.html,
       inReplyTo: payload.inReplyTo,
       references: payload.references,
-      rootMessageId: rootMessageId ?? payload.messageId,
       headers: payload.headers,
       domain: payload.domain,
       route: payload.route,

--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -109,18 +109,22 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
     });
 
     const agentAddress = payload.to[0]?.address;
-    await Promise.all([
+    const [, , rootMessageId] = await Promise.all([
       this.threadResolver.trackSubject(threadId, payload.subject),
       agentAddress ? this.threadResolver.trackAgentAddress(threadId, agentAddress) : Promise.resolve(),
+      this.threadResolver.getRootMessageId(threadId),
     ]);
 
-    const message = this.parseMessage(this.toRawMessage(payload, threadId));
+    const message = this.parseMessage(this.toRawMessage(payload, rootMessageId));
     this.chat.processMessage(this, threadId, message, options);
 
     return new Response(null, { status: 200 });
   }
 
-  private toRawMessage(payload: import('./types.js').EmailWebhookPayload, _threadId: string): NovuEmailRawMessage {
+  private toRawMessage(
+    payload: import('./types.js').EmailWebhookPayload,
+    rootMessageId?: string
+  ): NovuEmailRawMessage {
     return {
       id: payload.messageId,
       messageId: payload.messageId,
@@ -129,6 +133,12 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
       subject: payload.subject,
       text: payload.text,
       html: payload.html,
+      inReplyTo: payload.inReplyTo,
+      references: payload.references,
+      rootMessageId: rootMessageId ?? payload.messageId,
+      headers: payload.headers,
+      domain: payload.domain,
+      route: payload.route,
       createdAt: payload.date,
       attachments: payload.attachments,
     };

--- a/packages/chat-adapter-email/src/thread-resolver.ts
+++ b/packages/chat-adapter-email/src/thread-resolver.ts
@@ -98,6 +98,17 @@ export class ThreadResolver {
     await state.setIfNotExists(threadSubjectKey(threadId), subject, STATE_TTL_MS);
   }
 
+  /**
+   * Returns the first message ID recorded for the thread — the authoritative
+   * thread root. `undefined` when the thread has no tracked messages yet.
+   */
+  async getRootMessageId(threadId: string): Promise<string | undefined> {
+    const state = this.getState();
+    const messages = await state.getList<string>(threadMessagesKey(threadId));
+
+    return messages?.[0] ?? undefined;
+  }
+
   async getReplyHeaders(threadId: string): Promise<Record<string, string> | undefined> {
     const state = this.getState();
     const messages = await state.getList<string>(threadMessagesKey(threadId));

--- a/packages/chat-adapter-email/src/thread-resolver.ts
+++ b/packages/chat-adapter-email/src/thread-resolver.ts
@@ -98,17 +98,6 @@ export class ThreadResolver {
     await state.setIfNotExists(threadSubjectKey(threadId), subject, STATE_TTL_MS);
   }
 
-  /**
-   * Returns the first message ID recorded for the thread — the authoritative
-   * thread root. `undefined` when the thread has no tracked messages yet.
-   */
-  async getRootMessageId(threadId: string): Promise<string | undefined> {
-    const state = this.getState();
-    const messages = await state.getList<string>(threadMessagesKey(threadId));
-
-    return messages?.[0] ?? undefined;
-  }
-
   async getReplyHeaders(threadId: string): Promise<Record<string, string> | undefined> {
     const state = this.getState();
     const messages = await state.getList<string>(threadMessagesKey(threadId));

--- a/packages/chat-adapter-email/src/types.ts
+++ b/packages/chat-adapter-email/src/types.ts
@@ -78,11 +78,6 @@ export interface NovuEmailRawMessage {
   inReplyTo?: string;
   /** RFC 2822 `References` header as sent by the client (whitespace-separated chain). */
   references?: string;
-  /**
-   * Server-authoritative root message ID for this thread — the first message Novu
-   * recorded for the thread. Equals `messageId` on the first message of a thread.
-   */
-  rootMessageId?: string;
   headers?: Record<string, string>;
   domain?: EmailWebhookDomainContext;
   route?: EmailWebhookRouteContext;

--- a/packages/chat-adapter-email/src/types.ts
+++ b/packages/chat-adapter-email/src/types.ts
@@ -1,4 +1,9 @@
-import type { IEmailAlternative, NovuEmailAttachment } from '@novu/shared';
+import type {
+  EmailWebhookDomainContext,
+  EmailWebhookRouteContext,
+  IEmailAlternative,
+  NovuEmailAttachment,
+} from '@novu/shared';
 import type { Adapter } from 'chat';
 
 export type { EmailWebhookPayload, NovuEmailAttachment } from '@novu/shared';
@@ -69,7 +74,18 @@ export interface NovuEmailRawMessage {
   subject: string;
   text?: string;
   html?: string;
+  /** RFC 2822 `In-Reply-To` header as sent by the client (parent message). */
+  inReplyTo?: string;
+  /** RFC 2822 `References` header as sent by the client (whitespace-separated chain). */
+  references?: string;
+  /**
+   * Server-authoritative root message ID for this thread — the first message Novu
+   * recorded for the thread. Equals `messageId` on the first message of a thread.
+   */
+  rootMessageId?: string;
   headers?: Record<string, string>;
+  domain?: EmailWebhookDomainContext;
+  route?: EmailWebhookRouteContext;
   createdAt: string;
   attachments?: NovuEmailAttachment[];
 }

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -443,6 +443,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
             email: {
               domain: emailRaw.domain,
               route: emailRaw.route,
+              rootMessageId: 'root@example.com',
             },
           },
         });
@@ -466,6 +467,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(capturedCtx.platformContext.email).toEqual({
       domain: emailRaw.domain,
       route: emailRaw.route,
+      rootMessageId: 'root@example.com',
     });
   });
 

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -411,6 +411,64 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(capturedCtx.history).toEqual([]);
   });
 
+  it('should expose platformContext.message and platformContext.email for email agents', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async (_message, ctx) => {
+        capturedCtx = ctx;
+        await ctx.reply('ok');
+      },
+    });
+
+    const emailRaw = {
+      messageId: 'msg-1@example.com',
+      subject: 'Hello',
+      domain: { id: 'domain-1', name: 'inbox.example.com', data: { tier: 'pro' } },
+      route: { address: 'support', data: { queue: 'tier-1' } },
+    };
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({
+          platform: 'email',
+          platformContext: {
+            threadId: 'email:user@example.com:abc',
+            channelId: 'email:user@example.com',
+            isDM: false,
+            message: emailRaw,
+            email: {
+              domain: emailRaw.domain,
+              route: emailRaw.route,
+            },
+          },
+        });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.platform).toBe('email');
+    expect(capturedCtx.platformContext.message).toEqual(emailRaw);
+    expect(capturedCtx.platformContext.email).toEqual({
+      domain: emailRaw.domain,
+      route: emailRaw.route,
+    });
+  });
+
   it('should serialize markdown content on reply', async () => {
     const testBot = agent('test-bot', {
       onMessage: async (_message, ctx) => {

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -105,6 +105,17 @@ export interface AgentEmailRouteContext {
   data?: Record<string, string>;
 }
 
+/** Resolved inbound email envelope (present when `platform === 'email'`). */
+export interface AgentEmailContext {
+  domain?: AgentEmailDomainContext;
+  route?: AgentEmailRouteContext;
+  /**
+   * Platform-native Message-ID of the message that started this email thread.
+   * Equals the current message ID on the first message of a thread.
+   */
+  rootMessageId?: string;
+}
+
 /** Platform-specific identifiers for the thread and channel. */
 export interface AgentPlatformContext {
   /** Platform-native thread ID (e.g. Slack thread `ts`, Teams conversation ID). */
@@ -116,15 +127,7 @@ export interface AgentPlatformContext {
   /** Platform-native raw message payload from the chat SDK adapter (e.g. email `NovuEmailRawMessage`). */
   message?: unknown;
   /** Resolved inbound email routing metadata extracted from the raw payload. */
-  email?: {
-    domain?: AgentEmailDomainContext;
-    route?: AgentEmailRouteContext;
-    /**
-     * Platform-native Message-ID of the message that started this email thread.
-     * Equals the current message ID on the first message of a thread.
-     */
-    rootMessageId?: string;
-  };
+  email?: AgentEmailContext;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -92,6 +92,19 @@ export interface AgentHistoryEntry {
   createdAt: string;
 }
 
+/** Resolved inbound email domain metadata (present when `platform === 'email'`). */
+export interface AgentEmailDomainContext {
+  id: string;
+  name: string;
+  data?: Record<string, string>;
+}
+
+/** Resolved inbound email route metadata (present when `platform === 'email'`). */
+export interface AgentEmailRouteContext {
+  address: string;
+  data?: Record<string, string>;
+}
+
 /** Platform-specific identifiers for the thread and channel. */
 export interface AgentPlatformContext {
   /** Platform-native thread ID (e.g. Slack thread `ts`, Teams conversation ID). */
@@ -100,6 +113,13 @@ export interface AgentPlatformContext {
   channelId: string;
   /** Whether the message arrived in a direct message rather than a shared channel. */
   isDM: boolean;
+  /** Platform-native raw message payload from the chat SDK adapter (e.g. email `NovuEmailRawMessage`). */
+  message?: unknown;
+  /** Resolved inbound email routing metadata extracted from the raw payload. */
+  email?: {
+    domain?: AgentEmailDomainContext;
+    route?: AgentEmailRouteContext;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -119,6 +119,11 @@ export interface AgentPlatformContext {
   email?: {
     domain?: AgentEmailDomainContext;
     route?: AgentEmailRouteContext;
+    /**
+     * Platform-native Message-ID of the message that started this email thread.
+     * Equals the current message ID on the first message of a thread.
+     */
+    rootMessageId?: string;
   };
 }
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -18,6 +18,17 @@ export interface NovuEmailAttachment {
   url?: string;
 }
 
+export interface EmailWebhookDomainContext {
+  id: string;
+  name: string;
+  data?: Record<string, string>;
+}
+
+export interface EmailWebhookRouteContext {
+  address: string;
+  data?: Record<string, string>;
+}
+
 export interface EmailWebhookPayload {
   messageId: string;
   inReplyTo?: string;
@@ -29,4 +40,7 @@ export interface EmailWebhookPayload {
   html?: string;
   attachments?: NovuEmailAttachment[];
   date: string;
+  headers?: Record<string, string>;
+  domain?: EmailWebhookDomainContext;
+  route?: EmailWebhookRouteContext;
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR surfaces email platform data to agents by adding optional AgentPlatformContext.message (raw chat-adapter payload) and AgentPlatformContext.email (resolved domain, route, and server-authoritative rootMessageId). Inbound email headers are normalized and capped at 16 KB, email threading fields (inReplyTo, references) and domain/route metadata are forwarded through the delivery pipeline, and a new buildAgentPlatformContext/buildEmailPlatformContext pair centralizes platform-context construction so rootMessageId is available within the same turn.

## Affected areas

- **api**: Conversation runtime, reply handling, and ingress now set firstPlatformMessageId synchronously in-memory and use buildAgentPlatformContext/buildEmailPlatformContext so agents receive message/email context during the same turn.  
- **application-generic**: Inbound domain-route delivery normalizes and caps headers, threads domain/route into agent payloads, and extends previewAgentMailPayload to accept domain/route options.  
- **chat-adapter-email**: NovuEmailRawMessage now includes headers, inReplyTo, references, domain, and route; webhook handling populates these fields for downstream routing/context.  
- **framework**: Agent SDK types extended with AgentEmailDomainContext, AgentEmailRouteContext, AgentEmailContext and AgentPlatformContext.message/email; runtime wiring and unit tests updated to verify behavior.  
- **shared**: EmailWebhookPayload and new EmailWebhookDomainContext/EmailWebhookRouteContext types added to carry normalized headers and resolved domain/route metadata.

## Key technical decisions

- Centralize platform-context creation via buildAgentPlatformContext/buildEmailPlatformContext to avoid duplication and ensure consistent email context extraction.  
- Use conversation.firstPlatformMessageId (set synchronously in-memory on first inbound message) as the server-authoritative rootMessageId so thread identity is available before async persistence completes.  
- Changes are additive and optional (non-breaking/minor).

## Testing

Unit tests added or updated in api, application-generic, and framework to cover header normalization/capping, platform-context composition, domain/route propagation, and threading metadata; chat-adapter-email was validated via TypeScript build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Surfaces email platform-specific data to the framework agent SDK so agent handlers can access the inbound email payload and the resolved routing context. Previously the agent `ctx` only carried generic cross-platform thread/channel identifiers, dropping email `from`/`to`/headers and the server-resolved domain/route.

- `platformContext.message` carries the chat-SDK raw message verbatim (Chat SDK parity, typed `unknown`).
- `platformContext.email` exposes the resolved `{ domain, route }`.
- `NovuEmailRawMessage` now includes `headers`, `inReplyTo`, `references`, and a server-authoritative `rootMessageId` resolved from thread state (equals `messageId` on the first message of a thread).
- Threads email headers (normalized, 16KB cap) and resolved domain/route from the worker delivery (`inbound-domain-route-delivery`) through `chat-adapter-email` into the bridge payload.

Both new `platformContext` fields are additive/optional, so `@novu/framework` remains a non-breaking (minor) change.

Linear: [NV-7951](https://linear.app/novu/issue/NV-7951/expose-email-raw-payload-and-resolved-routing-in-agent-context)

### Screenshots

<!-- N/A - backend/SDK type changes only -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- N/A -->

### Special notes for your reviewer

- `@novu/chat-adapter-email` has no test runner configured; verification there relied on a clean `tsc` build. New/updated unit tests live in `apps/api` (`build-platform-context.util.spec.ts`) and `libs/application-generic` (`inbound-domain-route-delivery.usecase.spec.ts`), plus `packages/framework` (`agent.test.ts`).
- Header forwarding defaults to the full normalized map with a 16KB size cap; can be narrowed to a curated allow-list if preferred.

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces email-specific data to the agent framework's `ctx.platformContext`, adding `platformContext.message` (raw chat-adapter payload) and `platformContext.email` (resolved domain, route, `rootMessageId`). It also threads `inReplyTo`, `references`, normalized headers (16 KB cap), and domain/route metadata from the worker delivery pipeline through `chat-adapter-email` into the bridge payload.

- **`build-platform-context.util.ts`** centralizes platform-context construction via `buildAgentPlatformContext`/`buildEmailPlatformContext`; both sites (`bridge.runtime.ts`, `handle-agent-reply.usecase.ts`) are migrated to this utility, removing duplicated inline objects.
- **`inbound-domain-route-delivery.usecase.ts`** is extended with `normalizeMailHeaders` (now using `continue` for per-entry skipping instead of an early `break`), and domain/route metadata is injected into the agent webhook payload.
- **`inbound-turn.handler.ts`** eagerly writes `firstPlatformMessageId` to the in-memory conversation so `rootMessageId` resolves consistently within the same turn before the fire-and-forget DB write lands.

<h3>Confidence Score: 5/5</h3>

All changes are additive and optional; no existing fields are removed or altered, and the new platform context fields are guarded at every callsite.

The change threads new fields through a well-understood pipeline, adds targeted unit tests for each new code path, and centralises previously duplicated inline objects into a dedicated utility. The in-memory synchronisation of firstPlatformMessageId before the async DB write is deliberately documented. No regressions were identified in the changed paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/runtime/build-platform-context.util.ts | New utility that centralizes platform-context assembly; correctly gates email context on platform type and handles null message gracefully |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Adds an eager in-memory write of firstPlatformMessageId before the async DB call, ensuring rootMessageId is visible within the same turn |
| libs/application-generic/src/usecases/inbound-domain-route-delivery/inbound-domain-route-delivery.usecase.ts | Adds normalizeMailHeaders with 16 KB cap (uses continue, not break), and forwards domain/route metadata through buildAgentEmailWebhookPayload |
| packages/chat-adapter-email/src/adapter.ts | Propagates inReplyTo, references, headers, domain, and route from EmailWebhookPayload into NovuEmailRawMessage; removes unused _threadId parameter |
| packages/framework/src/resources/agent/agent.types.ts | Adds AgentEmailDomainContext, AgentEmailRouteContext, AgentEmailContext, and optional message/email fields to AgentPlatformContext; all additions are additive |
| packages/shared/src/types/agent.ts | Adds EmailWebhookDomainContext, EmailWebhookRouteContext, and optional headers/domain/route fields to EmailWebhookPayload |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Mail as Inbound Mail
    participant Delivery as InboundDomainRouteDelivery
    participant API as Agent Webhook API
    participant Adapter as NovuEmailAdapterImpl
    participant Runtime as BridgeRuntime
    participant Agent as Framework Agent Handler

    Mail->>Delivery: deliverToAgent(domain, route, mail)
    Delivery->>Delivery: normalizeMailHeaders(mail.headers)
    Delivery->>Delivery: "buildAgentEmailWebhookPayload(mail, {domain, route})"
    Note over Delivery: Payload includes headers, domain, route
    Delivery->>API: POST /v1/agents/:id/webhook (signed)
    API->>Adapter: handleWebhook(payload)
    Adapter->>Adapter: toRawMessage(payload) maps inReplyTo, references, headers, domain, route
    Adapter->>Runtime: processMessage(thread, rawMessage)
    Runtime->>Runtime: buildEmailPlatformContext(platform, message, firstPlatformMessageId)
    Runtime->>Runtime: "buildAgentPlatformContext({threadId, email})"
    Runtime->>Agent: "execute(ctx) ctx.platformContext.email = {domain, route, rootMessageId}"
```

<sub>Reviews (4): Last reviewed commit: ["refactor(api-service, framework): keep p..."](https://github.com/novuhq/novu/commit/21ac9377a8b4a557549227b09f5369f05ef89ea3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35147875)</sub>

<!-- /greptile_comment -->