### PR TITLE
fix(root): preserve terminal selection for connect CLI URLs fixes NV-7952

### DIFF
--- a/packages/novu/src/commands/connect/ui/app.tsx
+++ b/packages/novu/src/commands/connect/ui/app.tsx
@@ -5,6 +5,7 @@ import type { ChannelChoice } from '../types';
 import { PersistentOrb } from './orb/orb-renderer';
 import { computeOrbLabel, computeOrbTint } from './orb/orb-tint';
 import { usePreviewOrbMorph } from './orb/use-preview-orb-morph';
+import { phaseHasCopyableUrl } from './phase-has-copyable-url';
 import { PhaseContent } from './phase-content';
 import type { ConnectStore } from './store';
 import { useStore } from './use-store';
@@ -39,6 +40,7 @@ export function App({ store, registerExit }: AppProps): React.ReactElement {
 
   const tintColor = computeOrbTint(phase, hoveredChannel, previewMorphProgress);
   const label = computeOrbLabel(phase, hoveredChannel);
+  const orbPaused = phaseHasCopyableUrl(phase);
 
   return (
     <Box flexDirection="column" paddingX={1} paddingY={1} gap={1} alignItems="center">
@@ -46,6 +48,7 @@ export function App({ store, registerExit }: AppProps): React.ReactElement {
         tintColor={tintColor}
         label={label}
         previewMorphProgress={phase.kind === 'preview-generated' ? previewMorphProgress : null}
+        paused={orbPaused}
       />
       <PhaseContent phase={phase} onChannelHover={setHoveredChannel} previewMorphComplete={previewMorphComplete} />
     </Box>

--- a/packages/novu/src/commands/connect/ui/copyable-link.tsx
+++ b/packages/novu/src/commands/connect/ui/copyable-link.tsx
@@ -1,0 +1,70 @@
+import clipboardy from 'clipboardy';
+import { Box, Text, useInput } from 'ink';
+import open from 'open';
+// biome-ignore lint/correctness/noUnusedImports: classic-JSX linter falls back here because tsconfig.json excludes ui/.
+import React from 'react';
+
+const ACTION_HINT_TIMEOUT_MS = 2000;
+
+/**
+ * OSC 8 hyperlink escapes. Terminals that support OSC 8 treat the wrapped
+ * visible string as one click target for the full URL (see wizard auth-pane).
+ */
+const OSC8_OPEN = (url: string): string => `\u001B]8;;${url}\u0007`;
+const OSC8_CLOSE = '\u001B]8;;\u0007';
+
+export type CopyableLinkProps = {
+  url: string;
+  hint?: string;
+  color?: string;
+};
+
+/**
+ * Renders a URL on its own stable line with OSC 8 linking and keyboard shortcuts.
+ * Pair with Ink `incrementalRendering: true` so orb animation does not redraw this line.
+ */
+export function CopyableLink({ url, hint, color = 'cyan' }: CopyableLinkProps): React.ReactElement {
+  const [actionHint, setActionHint] = React.useState<{ text: string; tone: 'ok' | 'error' } | null>(null);
+
+  useInput(
+    (input) => {
+      if (input === 'c') {
+        try {
+          clipboardy.writeSync(url);
+          setActionHint({ text: 'Copied URL to clipboard', tone: 'ok' });
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          setActionHint({ text: `Copy failed: ${reason}`, tone: 'error' });
+        }
+
+        return;
+      }
+      if (input === 'o') {
+        open(url).then(
+          () => setActionHint({ text: 'Opened URL in your default browser', tone: 'ok' }),
+          (error) => {
+            const reason = error instanceof Error ? error.message : String(error);
+            setActionHint({ text: `Open failed: ${reason}`, tone: 'error' });
+          }
+        );
+      }
+    },
+    { isActive: true }
+  );
+
+  React.useEffect(() => {
+    if (!actionHint) return;
+    const timer = setTimeout(() => setActionHint(null), ACTION_HINT_TIMEOUT_MS);
+
+    return () => clearTimeout(timer);
+  }, [actionHint]);
+
+  return (
+    <Box flexDirection="column">
+      {hint ? <Text dimColor>{hint}</Text> : null}
+      <Text color={color}>{`${OSC8_OPEN(url)}${url}${OSC8_CLOSE}`}</Text>
+      <Text dimColor>Press c to copy · o to open in browser</Text>
+      {actionHint ? <Text color={actionHint.tone === 'ok' ? 'green' : 'yellow'}>{actionHint.text}</Text> : null}
+    </Box>
+  );
+}

--- a/packages/novu/src/commands/connect/ui/copyable-link.tsx
+++ b/packages/novu/src/commands/connect/ui/copyable-link.tsx
@@ -28,6 +28,8 @@ export function CopyableLink({ url, hint, color = 'cyan' }: CopyableLinkProps): 
 
   useInput(
     (input) => {
+      if (!url) return;
+
       if (input === 'c') {
         try {
           clipboardy.writeSync(url);
@@ -49,7 +51,7 @@ export function CopyableLink({ url, hint, color = 'cyan' }: CopyableLinkProps): 
         );
       }
     },
-    { isActive: true }
+    { isActive: Boolean(url) }
   );
 
   React.useEffect(() => {
@@ -64,7 +66,7 @@ export function CopyableLink({ url, hint, color = 'cyan' }: CopyableLinkProps): 
       {hint ? <Text dimColor>{hint}</Text> : null}
       <Text color={color}>{`${OSC8_OPEN(url)}${url}${OSC8_CLOSE}`}</Text>
       <Text dimColor>Press c to copy · o to open in browser</Text>
-      {actionHint ? <Text color={actionHint.tone === 'ok' ? 'green' : 'yellow'}>{actionHint.text}</Text> : null}
+      {actionHint ? <Text color={actionHint.tone === 'ok' ? 'green' : 'red'}>{actionHint.text}</Text> : null}
     </Box>
   );
 }

--- a/packages/novu/src/commands/connect/ui/index.tsx
+++ b/packages/novu/src/commands/connect/ui/index.tsx
@@ -34,6 +34,12 @@ export function mountConnectUI(_params: MountConnectUIParams): MountConnectUIRes
     {
       patchConsole: false,
       exitOnCtrlC: false,
+      /**
+       * Only re-emit terminal lines that changed between frames. Without this,
+       * the orb animation (~10 fps) redraws the whole screen and clears any
+       * active mouse selection on static URL lines (auth, Slack OAuth, etc.).
+       */
+      incrementalRendering: true,
       // No alternate-screen here: the connect flow is short and we want the
       // final success message to remain visible in scrollback after exit.
     }

--- a/packages/novu/src/commands/connect/ui/orb/orb-renderer.tsx
+++ b/packages/novu/src/commands/connect/ui/orb/orb-renderer.tsx
@@ -9,23 +9,28 @@ export function PersistentOrb({
   tintColor,
   label,
   previewMorphProgress,
+  paused = false,
 }: {
   tintColor: string;
   label: string | undefined;
   previewMorphProgress: number | null;
+  /** When true, freeze the orb so URL lines beneath it are not redrawn every frame. */
+  paused?: boolean;
 }): React.ReactElement {
   const [frame, setFrame] = React.useState(0);
   const [elapsedMs, setElapsedMs] = React.useState(0);
   const bornAtRef = React.useRef(Date.now());
 
   React.useEffect(() => {
+    if (paused) return;
+
     const t = setInterval(() => {
       setFrame((f) => f + 1);
       setElapsedMs(Date.now() - bornAtRef.current);
     }, ORB_FRAME_MS);
 
     return () => clearInterval(t);
-  }, []);
+  }, [paused]);
 
   const entryProgress = Math.min(1, elapsedMs / ENTRY_MS);
   // Ease-out cubic — fast start, gentle landing. Plays nicer than linear

--- a/packages/novu/src/commands/connect/ui/phase-content.tsx
+++ b/packages/novu/src/commands/connect/ui/phase-content.tsx
@@ -5,6 +5,7 @@ import { Box, Text, useInput } from 'ink';
 import React from 'react';
 import { channelDisplayName, isDashboardOnlyChannel } from '../dashboard-urls';
 import type { AgentRuntimeChoice, ChannelChoice } from '../types';
+import { CopyableLink } from './copyable-link';
 import { PreviewGeneratedContent } from './preview-generated-content';
 import type { ConnectStore } from './store';
 import { WelcomeContent } from './welcome-content';
@@ -39,10 +40,7 @@ export function PhaseContent({
         <Box flexDirection="column" gap={1}>
           <Text color="cyan">{phase.status}</Text>
           {phase.dashboardUrl ? (
-            <Box flexDirection="column">
-              <Text dimColor>If your browser didn't open, visit:</Text>
-              <Text color="cyan">{phase.dashboardUrl}</Text>
-            </Box>
+            <CopyableLink url={phase.dashboardUrl} hint="If your browser didn't open, visit:" />
           ) : null}
         </Box>
       );
@@ -255,10 +253,7 @@ export function PhaseContent({
       return (
         <Box flexDirection="column" gap={1}>
           <Text bold>Authorize Slack to finish setup</Text>
-          <Box flexDirection="column">
-            <Text dimColor>Opened in your browser. If nothing happened, visit:</Text>
-            <Text color="cyan">{phase.authorizeUrl}</Text>
-          </Box>
+          <CopyableLink url={phase.authorizeUrl} hint="Opened in your browser. If nothing happened, visit:" />
           <Text dimColor>Waiting for Slack authorization…</Text>
         </Box>
       );
@@ -305,10 +300,7 @@ export function PhaseContent({
             webhook for you.
           </Text>
           <Text>{phase.mobileQr}</Text>
-          <Box flexDirection="column">
-            <Text dimColor>Or open this on your phone:</Text>
-            <Text color="cyan">{phase.mobileUrl}</Text>
-          </Box>
+          <CopyableLink url={phase.mobileUrl} hint="Or open this on your phone:" />
           <Text dimColor>Waiting for your bot token…</Text>
         </Box>
       );
@@ -323,10 +315,7 @@ export function PhaseContent({
             Scan to open <Text color="white">@{phase.botUsername}</Text> in Telegram and tap Start.
           </Text>
           <Text>{phase.deepLinkQr}</Text>
-          <Box flexDirection="column">
-            <Text dimColor>Or open this link:</Text>
-            <Text color="cyan">{phase.deepLinkUrl}</Text>
-          </Box>
+          <CopyableLink url={phase.deepLinkUrl} hint="Or open this link:" />
           <Text dimColor>Waiting for /start in Telegram…</Text>
         </Box>
       );
@@ -631,7 +620,7 @@ function DashboardChannelReadyContent({
         {channelLabel} setup is not available in the CLI yet. Press Enter to open your agent in Novu Connect and finish
         connecting there.
       </Text>
-      <Text color="cyan">{agentDetailsUrl}</Text>
+      <CopyableLink url={agentDetailsUrl} hint="Or open this link:" />
       <Text dimColor>Press Enter to open Novu Connect →</Text>
     </Box>
   );

--- a/packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts
+++ b/packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts
@@ -1,0 +1,16 @@
+import type { Phase } from './store';
+
+/** Phases that show a long URL users may need to copy while the orb keeps animating. */
+export function phaseHasCopyableUrl(phase: Phase): boolean {
+  switch (phase.kind) {
+    case 'auth':
+      return Boolean(phase.dashboardUrl);
+    case 'waiting-slack':
+    case 'telegram-link-token':
+    case 'telegram-test':
+    case 'dashboard-channel-ready':
+      return true;
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Copying auth and OAuth URLs during `npx novu connect` was difficult because the Ink TUI redraws the full frame on every orb animation tick (~10 fps), which clears terminal text selection after a second or two.

## Root cause

The connect flow mounts Ink without `incrementalRendering`, unlike `novu wizard`. The animated orb updates state every 100ms, so the entire screen (including static URL lines) is rewritten and mouse selection is lost.

## Fix

- Enable **`incrementalRendering: true`** on the connect Ink instance so unchanged lines (including URLs) are not redrawn.
- **Pause the orb** on phases that display copyable URLs (auth, Slack OAuth wait, Telegram links, dashboard redirect).
- Add a **`CopyableLink`** component (aligned with wizard `AuthPane`): OSC 8 hyperlinks for click-to-open, plus **`c`** to copy and **`o`** to open in the browser.

## Affected phases

- Dashboard auth URL
- Slack OAuth waiting
- Telegram mobile / deep-link URLs
- Dashboard channel redirect URL

## How to verify

1. Run `npx novu connect` in an interactive terminal.
2. On the auth screen, select the dashboard URL with the mouse — selection should stay stable while waiting.
3. Press **`c`** to copy or **`o`** to reopen the browser.
4. Repeat during Slack OAuth waiting if you reach that step.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7952](https://linear.app/novu/issue/NV-7952/copying-the-cli-url-from-terminal-is-difficult)

<div><a href="https://cursor.com/agents/bc-bea8e5ce-8257-474d-8e2c-cffa4f31d1ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bea8e5ce-8257-474d-8e2c-cffa4f31d1ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The `npx novu connect` CLI preserves terminal text selection and improves copy/open UX for auth and OAuth URLs by enabling Ink's incremental rendering to avoid full-screen redraws, pausing the animated orb while copyable links are shown, and adding a new `CopyableLink` component that renders OSC 8 hyperlinks and supports `c` (copy) and `o` (open) keyboard shortcuts with transient action hints and error handling.

## Affected areas

**js** — Updated the connect command UI: enabled `incrementalRendering` for the Ink app, added a pausable orb animation, introduced `CopyableLink`, and replaced plain URL text with the component in auth, Slack OAuth waiting, Telegram, and dashboard channel redirect phases.

## Key technical decisions

- Enabled Ink's `incrementalRendering: true` so unchanged terminal lines (like URLs) are not redrawn each frame, preserving mouse selection.
- Used OSC 8 terminal hyperlinks to provide clickable links while retaining compatibility across terminals.
- Added a `paused` prop to the orb renderer to stop animation frame progression during URL display phases instead of fully removing the animation.

## Testing

Manual verification in an interactive terminal is required: run `npx novu connect`, select the displayed URL with the mouse (selection should persist), press `c` to copy and `o` to open; repeat during Slack/Telegram phases as applicable. No automated tests were added due to the terminal-interaction nature of the changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes terminal text selection being lost during `npx novu connect` by enabling `incrementalRendering: true` on the Ink instance and pausing the animated orb during phases that display copyable URLs.

- **`incrementalRendering: true`** is added to the Ink render call so only changed terminal lines are rewritten per frame, keeping static URL lines stable for mouse selection.
- A new **`CopyableLink`** component wraps URL display with OSC 8 hyperlinks and `c`/`o` keyboard shortcuts; it replaces plain `Text` nodes across auth, Slack OAuth waiting, Telegram, and dashboard-channel-ready phases.
- The orb animation is **paused** via a new `paused` prop on `PersistentOrb` when `phaseHasCopyableUrl` is true, reducing redraws while users interact with URLs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive UI enhancements with no effect on business logic, data, or auth flows.

The core fix mirrors how novu wizard already works. phaseHasCopyableUrl exhaustively covers every phase that renders a CopyableLink, the effect dependency on [paused] correctly manages the interval lifecycle, and error paths are handled. The only concern is a cosmetic messaging inaccuracy for Telegram deep-link URLs.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/ui/copyable-link.tsx | New component with OSC 8 hyperlinking and c/o keyboard shortcuts. Hardcoded 'open in browser' text is inaccurate for Telegram t.me/... deep-link URLs. |
| packages/novu/src/commands/connect/ui/orb/orb-renderer.tsx | Adds paused prop; effect dependency on [paused] correctly clears and restarts the interval across transitions. |
| packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts | Exhaustive switch covering all CopyableLink phases; correctly guards auth with Boolean(phase.dashboardUrl). |
| packages/novu/src/commands/connect/ui/index.tsx | Enables incrementalRendering: true to prevent full-frame redraws from clearing terminal selection. |
| packages/novu/src/commands/connect/ui/app.tsx | Computes orbPaused via phaseHasCopyableUrl and passes it to PersistentOrb. Clean integration. |
| packages/novu/src/commands/connect/ui/phase-content.tsx | Replaces plain Text URL nodes with CopyableLink across all relevant phases. No logic regressions. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Phase changes] --> B{phaseHasCopyableUrl?}
    B -- Yes --> C[orbPaused = true]
    B -- No --> D[orbPaused = false]
    C --> E[PersistentOrb: interval cleared]
    D --> F[PersistentOrb: 10fps updates]
    E --> G[incrementalRendering: true]
    F --> G
    G --> H[URL lines not redrawn]
    H --> I[CopyableLink: OSC8 + c/o shortcuts]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fui%2Fcopyable-link.tsx%3A44-51%0A**Misleading%20feedback%20for%20Telegram%20deep-link%20URLs**%0A%0AThe%20success%20feedback%20after%20pressing%20%60o%60%20is%20hardcoded%20to%20%60'Opened%20URL%20in%20your%20default%20browser'%60.%20For%20the%20%60telegram-test%60%20phase%20the%20URL%20is%20a%20%60t.me%2F%E2%80%A6%60%20deep%20link%2C%20so%20%60open%28url%29%60%20will%20launch%20the%20Telegram%20desktop%20app%20%28if%20installed%29%20rather%20than%20a%20browser%20%E2%80%94%20the%20message%20is%20then%20inaccurate.%20For%20%60telegram-link-token%60%2C%20the%20component%20hint%20says%20%22Or%20open%20this%20on%20your%20phone%3A%22%20but%20the%20instructional%20line%20says%20%22o%20to%20open%20in%20browser%22%2C%20which%20contradicts%20the%20phone-specific%20guidance.%20Consider%20accepting%20an%20optional%20%60openLabel%60%20prop%20so%20callers%20can%20tailor%20the%20hint%20line%20and%20the%20success%20message%20to%20their%20context.%0A%0A&pr=11423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/novu/src/commands/connect/ui/copyable-link.tsx:44-51
**Misleading feedback for Telegram deep-link URLs**

The success feedback after pressing `o` is hardcoded to `'Opened URL in your default browser'`. For the `telegram-test` phase the URL is a `t.me/…` deep link, so `open(url)` will launch the Telegram desktop app (if installed) rather than a browser — the message is then inaccurate. For `telegram-link-token`, the component hint says "Or open this on your phone:" but the instructional line says "o to open in browser", which contradicts the phone-specific guidance. Consider accepting an optional `openLabel` prop so callers can tailor the hint line and the success message to their context.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(root): address CopyableLink review f..."](https://github.com/novuhq/novu/commit/66b101004a872ae670f51808820ee9835b3eadbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35151635)</sub>

<!-- /greptile_comment -->