### PR TITLE
fix(api-service): flatten portable MCP setup card so all chat providers render Connect buttons (fixes NV-7953)

### DIFF
--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.spec.ts
@@ -197,5 +197,36 @@ describe('setup-card helpers', () => {
 
       expect(linearRow?.content).to.equal('**Linear**');
     });
+
+    it('keeps pending rows flat (no nested card) so portable adapters render the buttons', () => {
+      const card = buildSetupCard({
+        mcps: [
+          {
+            mcpId: 'linear',
+            name: 'Linear',
+            agentMcpServerId: 'en-1',
+            authorizeUrl: 'https://example.com/oauth/linear',
+          },
+          {
+            mcpId: 'slack',
+            name: 'Slack',
+            agentMcpServerId: 'en-2',
+            authorizeUrl: 'https://example.com/oauth/slack',
+            connectButtonLabel: 'Connect from provider',
+          },
+        ],
+      });
+
+      const children = card.children as Array<{ type: string; children?: Array<{ type: string }> }>;
+
+      expect(children.some((block) => block.type === 'card')).to.equal(false);
+
+      const actionBlocks = children.filter((block) => block.type === 'actions');
+
+      expect(actionBlocks).to.have.length(2);
+      actionBlocks.forEach((actions) => {
+        expect(actions.children?.every((child) => child.type === 'link-button')).to.equal(true);
+      });
+    });
   });
 });

--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.spec.ts
@@ -1,7 +1,7 @@
 import { McpConnectionAuthModeEnum, McpConnectionStatusEnum } from '@novu/shared';
 import { expect } from 'chai';
 import { findOAuthMcpByServerName, isOAuthMcpPending, isProviderManagedOAuthMcp } from './oauth-mcp.types';
-import { buildSetupCard } from './setup-card.helpers';
+import { buildSetupCard, SETUP_AUTO_APPROVE_HINT } from './setup-card.helpers';
 
 describe('setup-card helpers', () => {
   describe('isProviderManagedOAuthMcp', () => {
@@ -130,6 +130,28 @@ describe('setup-card helpers', () => {
 
       expect(linkButton?.label).to.equal('Connect from provider');
       expect(linkButton?.url).to.equal('https://platform.claude.com/workspaces/ws_1/vaults/vlt_1');
+    });
+
+    it('omits the auto-approve hint when connectButtonLabel overrides the dual-button row', () => {
+      const card = buildSetupCard({
+        mcps: [
+          {
+            mcpId: 'slack',
+            name: 'Slack',
+            agentMcpServerId: 'en-1',
+            authorizeUrl: 'https://example.com/oauth/slack',
+            authorizeUrlWithAutoApprove: 'https://example.com/oauth/slack?auto_approve=true',
+            connectButtonLabel: 'Connect from provider',
+          },
+        ],
+      });
+
+      const children = card.children as Array<{ type: string; content?: string }>;
+      const autoApproveHint = children.find(
+        (block) => block.type === 'text' && block.content === SETUP_AUTO_APPROVE_HINT
+      );
+
+      expect(autoApproveHint).to.equal(undefined);
     });
 
     it('falls back to the default "Connect" label for DCR MCPs', () => {

--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.ts
@@ -281,18 +281,6 @@ export function resolveMcpSlackCardSubtext(mcp: SetupCardRow): string | undefine
   return undefined;
 }
 
-export function buildMcpRowMarkdown(mcp: SetupCardRow): string {
-  const lines = [`*${mcp.name}*`, ...buildMcpCardBodyMarkdown(mcp).split('\n').filter(Boolean)];
-
-  return lines.join('\n');
-}
-
-function appendHintLine(lines: string[], hint: string | undefined): void {
-  if (hint) {
-    lines.push(hint);
-  }
-}
-
 export function buildMcpRowPlainText(mcp: SetupCardRow): string {
   const body = buildMcpCardBodyMarkdown(mcp)
     .split('\n')
@@ -302,55 +290,51 @@ export function buildMcpRowPlainText(mcp: SetupCardRow): string {
   return body.join('\n');
 }
 
-export function buildSetupMcpPortableCard(mcp: SetupCardRow): Record<string, unknown> {
-  const children: Record<string, unknown>[] = [{ type: 'text', content: buildMcpRowPlainText(mcp) }];
+type SetupActionButton = { type: 'link-button'; label: string; url: string; style?: string };
+
+function buildSetupMcpActionButtons(mcp: SetupCardRow): SetupActionButton[] {
+  const authorizeUrl = mcp.authorizeUrl as string;
+
+  if (mcp.authorizeUrlWithAutoApprove && !mcp.connectButtonLabel) {
+    const labels = resolveSetupConnectButtonLabels(mcp);
+
+    return [
+      { type: 'link-button', label: labels.connectWithAutoApprove, url: mcp.authorizeUrlWithAutoApprove },
+      { type: 'link-button', label: labels.connect, url: authorizeUrl },
+    ];
+  }
+
+  const defaultLabel = isSetupMcpRowError(mcp) ? SETUP_RETRY_BUTTON_LABEL : SETUP_CONNECT_BUTTON_LABEL;
+
+  return [{ type: 'link-button', label: mcp.connectButtonLabel ?? defaultLabel, url: authorizeUrl, style: 'primary' }];
+}
+
+/**
+ * Flat portable blocks for one MCP: a bold name header, optional description/status
+ * lines, and an `actions` block with the Connect link-buttons — all appended directly
+ * to the parent card's children rather than wrapped in a nested `card`. The Chat SDK
+ * card schema has no nested-card element, so non-Slack adapters (Telegram, Teams,
+ * Discord, Google Chat, WhatsApp, …) silently drop a `card` placed inside a card and
+ * never render its buttons. Keeping the rows flat lets every portable adapter render
+ * the Connect buttons. Slack uses its own native Block Kit builder in setup-card.slack.ts.
+ */
+export function buildSetupMcpPortableRowBlocks(mcp: SetupCardRow): Record<string, unknown>[] {
+  const blocks: Record<string, unknown>[] = [{ type: 'text', content: `**${mcp.name}**` }];
+
+  const body = buildMcpRowPlainText(mcp);
+  if (body) {
+    blocks.push({ type: 'text', content: body, style: 'muted' });
+  }
 
   if (mcp.authorizeUrlWithAutoApprove && isSetupMcpRowPending(mcp)) {
-    children.push({ type: 'text', content: SETUP_AUTO_APPROVE_HINT });
+    blocks.push({ type: 'text', content: SETUP_AUTO_APPROVE_HINT, style: 'muted' });
   }
 
   if (mcp.authorizeUrl && isSetupMcpRowPending(mcp)) {
-    const actionButtons: Array<{ type: string; label: string; url: string; style?: string }> = [];
-
-    if (mcp.authorizeUrlWithAutoApprove && !mcp.connectButtonLabel) {
-      const labels = resolveSetupConnectButtonLabels(mcp);
-
-      actionButtons.push({
-        type: 'link-button',
-        label: labels.connectWithAutoApprove,
-        url: mcp.authorizeUrlWithAutoApprove,
-      });
-      actionButtons.push({
-        type: 'link-button',
-        label: labels.connect,
-        url: mcp.authorizeUrl,
-      });
-    } else {
-      const defaultLabel = isSetupMcpRowError(mcp) ? SETUP_RETRY_BUTTON_LABEL : SETUP_CONNECT_BUTTON_LABEL;
-
-      actionButtons.push({
-        type: 'link-button',
-        label: mcp.connectButtonLabel ?? defaultLabel,
-        url: mcp.authorizeUrl,
-        style: 'primary',
-      });
-    }
-
-    children.push({
-      type: 'actions',
-      children: actionButtons,
-    });
+    blocks.push({ type: 'actions', children: buildSetupMcpActionButtons(mcp) });
   }
 
-  return {
-    type: 'card',
-    title: mcp.name,
-    children,
-  };
-}
-
-function buildPendingRowBlocks(mcp: SetupCardRow): Record<string, unknown>[] {
-  return [buildSetupMcpPortableCard(mcp)];
+  return blocks;
 }
 
 export function buildPendingPortableRowBlocks(mcps: SetupCardRow[]): Record<string, unknown>[] {
@@ -362,7 +346,7 @@ export function buildPendingPortableRowBlocks(mcps: SetupCardRow[]): Record<stri
       blocks.push({ type: 'divider' });
     }
 
-    blocks.push(...buildPendingRowBlocks(mcp));
+    blocks.push(...buildSetupMcpPortableRowBlocks(mcp));
   });
 
   return blocks;

--- a/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.ts
+++ b/apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.ts
@@ -290,10 +290,15 @@ export function buildMcpRowPlainText(mcp: SetupCardRow): string {
   return body.join('\n');
 }
 
-type SetupActionButton = { type: 'link-button'; label: string; url: string; style?: string };
+interface SetupActionButton {
+  type: 'link-button';
+  label: string;
+  url: string;
+  style?: string;
+}
 
-function buildSetupMcpActionButtons(mcp: SetupCardRow): SetupActionButton[] {
-  const authorizeUrl = mcp.authorizeUrl as string;
+function buildSetupMcpActionButtons(mcp: SetupCardRow & { authorizeUrl: string }): SetupActionButton[] {
+  const authorizeUrl = mcp.authorizeUrl;
 
   if (mcp.authorizeUrlWithAutoApprove && !mcp.connectButtonLabel) {
     const labels = resolveSetupConnectButtonLabels(mcp);
@@ -326,12 +331,13 @@ export function buildSetupMcpPortableRowBlocks(mcp: SetupCardRow): Record<string
     blocks.push({ type: 'text', content: body, style: 'muted' });
   }
 
-  if (mcp.authorizeUrlWithAutoApprove && isSetupMcpRowPending(mcp)) {
+  if (mcp.authorizeUrlWithAutoApprove && !mcp.connectButtonLabel && isSetupMcpRowPending(mcp)) {
     blocks.push({ type: 'text', content: SETUP_AUTO_APPROVE_HINT, style: 'muted' });
   }
 
-  if (mcp.authorizeUrl && isSetupMcpRowPending(mcp)) {
-    blocks.push({ type: 'actions', children: buildSetupMcpActionButtons(mcp) });
+  const authorizeUrl = mcp.authorizeUrl;
+  if (authorizeUrl && isSetupMcpRowPending(mcp)) {
+    blocks.push({ type: 'actions', children: buildSetupMcpActionButtons({ ...mcp, authorizeUrl }) });
   }
 
   return blocks;


### PR DESCRIPTION
### What changed? Why was the change needed?

The managed-agent **"Connect your tools"** MCP setup card only rendered its Connect buttons on Slack. On Telegram — and other non-Slack chat providers (Teams, Discord, Google Chat, WhatsApp) — the card arrived with just the title and intro text, and the Connect buttons were silently dropped.

**Root cause:** the portable setup card (`buildSetupCard` in `setup-card.helpers.ts`) wrapped each MCP in a **nested `card`** element, with the Connect link-buttons buried inside those child cards' `actions`. The Chat SDK card schema has no nested-card element — `CardChild` only allows `text/link/image/divider/actions/section/fields/table`. Every adapter that renders through the portable card converter (all except Slack, which uses a dedicated native Block Kit path) drops a `card` placed inside a card, taking its buttons with it. The nesting was introduced alongside the Slack native setup cards and unintentionally reshaped the portable path too.

**Fix:** flatten the portable card so each MCP renders as a bold name header + optional description/status lines + an `actions` block with the Connect link-buttons, all appended directly under the top-level card's children. Slack's native Block Kit builder (`setup-card.slack.ts`) is unchanged. Added a unit test asserting the portable card has no nested `card` and exposes the Connect link-buttons in top-level `actions`. Also removed two dead helpers (`buildMcpRowMarkdown`, `appendHintLine`).

Linear: [NV-7953](https://linear.app/novu/issue/NV-7953/agent-setup-card-connect-buttons-missing-on-telegram-and-other-non)

### Screenshots

<!-- Behavior is on the chat provider side; the change is structural to the card payload. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- none -->

### Special notes for your reviewer

- Slack delivery is untouched — it still uses the native `slackNative` Block Kit blocks via `buildSetupSlackBlocks`.
- Follow-up (separate ticket needed): the MCP **tool-approval** card is structurally flat (not affected by this bug), but its interactive callback button ids embed `toolUseId` + `turnId` (+ tool/server names), which exceeds Telegram's 64-byte `callback_data` limit. That needs a separate short-token indirection fix.

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The portable MCP setup card builder was changed to emit a flat block structure for each managed chat provider (MCP) row instead of wrapping rows in nested `card` elements. This fixes a bug where non-Slack chat adapters dropped Connect link-buttons because the Chat SDK schema doesn’t support nested cards.

## Affected areas
- **api**: setup-card helpers now build adapter-compatible, flat portable card rows via a new buildSetupMcpPortableRowBlocks function; removed dead helpers buildMcpRowMarkdown and appendHintLine; buildSetupMcpActionButtons computes Connect/retry button ordering and labels. Slack-specific builder is unchanged.

## Key technical decisions
- Portable cards are flattened so each MCP renders as a bold header, optional muted status/description lines, and an `actions` block with Connect link-buttons appended to the top-level card (avoids nested `card` elements).

## Testing
Added unit tests: one verifies pending MCP rows are flat with Connect link-buttons in top-level `actions`, another ensures the auto-approve hint is omitted when a custom connectButtonLabel is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the MCP "Connect your tools" setup card rendered Connect buttons only on Slack, while Telegram and all other non-Slack chat providers silently dropped them. The root cause was that `buildSetupMcpPortableCard` wrapped each MCP in a nested `card` element, which the Chat SDK card schema does not support — so every portable adapter discarded the child `card` along with its buttons.

- **Core fix**: `buildSetupMcpPortableCard` (returning a nested `card`) is replaced by `buildSetupMcpPortableRowBlocks`, which emits a flat sequence of `text` + `actions` blocks appended directly to the parent card's children. Slack's native Block Kit path in `setup-card.slack.ts` is untouched.
- **Removed dead exports**: `buildMcpRowMarkdown` and `appendHintLine` had no callers and are deleted; `buildPendingRowBlocks` (now inlined) is also removed.
- **New tests**: Two new test cases assert the flat structure (no nested `card`) and the correct omission of the auto-approve hint when `connectButtonLabel` overrides the dual-button row.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted structural fix to the portable card builder with no effect on the Slack native path

The refactor correctly removes the nested card wrapper that caused non-Slack adapters to silently discard Connect buttons. All removed exports were verified to have no callers elsewhere in the repo. The new function is well-covered by tests and the Slack path is untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.ts | Refactored portable card builder to produce flat blocks instead of nested card elements; removed three dead helpers with no external callers; logic and exported API are otherwise preserved. |
| apps/api/src/app/agents/managed-runtime/setup/setup-card.helpers.spec.ts | Added two targeted tests: one verifying the auto-approve hint is suppressed when connectButtonLabel is set, and one asserting the flat (no nested card) structure with actions blocks at the top level. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildSetupCard] --> B[buildPendingPortableRowBlocks]
    B --> C[sortPendingSetupCardRows]
    C --> D[buildSetupMcpPortableRowBlocks per MCP]
    D --> E["text: **name**"]
    D --> F{body text?}
    F -- yes --> G["text: body, style:muted"]
    F -- no --> H
    G --> H{autoApprove hint?}
    H -- "authorizeUrlWithAutoApprove && !connectButtonLabel && isPending" --> I["text: SETUP_AUTO_APPROVE_HINT"]
    H -- no --> J
    I --> J{authorizeUrl && isPending?}
    J -- yes --> K[buildSetupMcpActionButtons]
    K --> L["actions: link-button(s)"]
    J -- no --> M[no actions block]
```

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): address setup card rev..."](https://github.com/novuhq/novu/commit/e3df627ca6c50c7358bd66241ad4bd3a5ee698e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35168984)</sub>

<!-- /greptile_comment -->