### PR TITLE
fix(api-service): remove close tab button from email action success page fixes NV-7863

### DIFF
--- a/apps/api/src/app/agents/email/agent-email-actions.controller.ts
+++ b/apps/api/src/app/agents/email/agent-email-actions.controller.ts
@@ -607,9 +607,6 @@ function renderSuccessPage(params: SuccessPageParams): string {
   const { claims } = params;
   const label = claims.label || claims.actionId;
 
-  // Inline onclick on the close link so it works in both the full-page-load path AND the
-  // XHR-swap path (scripts inserted via DOMParser/replaceWith don't auto-execute, but inline
-  // event handler attributes are honored).
   const body = `
 <div class="card" data-state="success">
   <div class="check">
@@ -617,8 +614,6 @@ function renderSuccessPage(params: SuccessPageParams): string {
   </div>
   <h1 class="message-heading">Action submitted</h1>
   <p class="intro"><strong>${escapeHtml(claims.agentName)}</strong> received <strong>${escapeHtml(label)}</strong> and is processing it.</p>
-  <a class="secondary" href="javascript:void(0)" onclick="try{window.close();}catch(e){}setTimeout(function(){if(!document.hidden){var h=this&&this.nextElementSibling;if(h)h.classList.add('visible');}}.bind(this),150);return false;">← Close this tab</a>
-  <div class="cancel-hint">You can close this tab manually.</div>
 </div>`;
 
   return pageShell('Action submitted', body);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the non-functional "← Close this tab" link and fallback hint from the agent email action success page (`Action submitted`).

`window.close()` only works for tabs opened by script, so email action links opened from Gmail/Outlook could never be closed programmatically. Users can dismiss the tab manually; the success message is sufficient.

## Changes

- `apps/api/src/app/agents/email/agent-email-actions.controller.ts`: drop close-tab link and manual-close hint from `renderSuccessPage`

## Test plan

- [ ] Click an email action approve link → confirm → verify success page shows checkmark and message only (no close-tab control)
- [ ] Confirm page Cancel flow unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7863](https://linear.app/novu/issue/NV-7863/close-this-tab-button-doesnt-work)

<div><a href="https://cursor.com/agents/bc-3be901ec-96d8-4dec-8125-05344068eeeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be901ec-96d8-4dec-8125-05344068eeeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Removed the non-functional "← Close this tab" link and manual-close hint from the email action success page. The `window.close()` API only works for tabs opened programmatically, so links opened directly from Gmail or Outlook could not be closed this way. The success message itself is sufficient user feedback; users can dismiss the tab manually if needed.

## Affected areas
**api** — Simplified the success page rendered in the email action handler by removing the close-tab link and fallback hint, leaving only the checkmark icon and "Action submitted" message.

## Testing
Manual verification only. The test plan covers clicking an email action approve link to confirm the success page displays without the close-tab control, and verifying the Cancel flow remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `window.close()` -powered "← Close this tab" anchor and its "You can close this tab manually." fallback hint from the email-action success page, since `window.close()` is a no-op for tabs opened directly from email clients.

- The `.cancel-hint` CSS class and the JS logic that toggles it remain intact and are still exercised by the cancel-form flow, so nothing is left dead or orphaned.
- The "Already submitted" page's plain-text mention of closing the tab is intentionally kept; it is informational prose, not a scripted action.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes a small block of non-functional HTML from a single render function with no side-effects on other pages or the cancel flow.

The deletion is surgical: three lines of HTML are removed from renderSuccessPage, the .cancel-hint CSS and related JS remain fully used by the cancel-form page, and no other render path is touched. The rationale is technically sound — window.close() is a no-op for tabs opened by email links.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/email/agent-email-actions.controller.ts | Removes non-functional '← Close this tab' link and its fallback hint from renderSuccessPage; no orphaned CSS or dead code — cancel-hint class is still used by the cancel form page |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Email as Email Client (Gmail/Outlook)
    participant API as Agent Email Actions API

    User->>Email: Opens action link from email
    Email->>API: "GET /action?token=..."
    API-->>User: renderSuccessPage (before)
    Note over User: Shows checkmark + Action submitted<br/>+ Close this tab link (non-functional)<br/>+ You can close this tab manually hint

    User->>Email: Opens action link from email
    Email->>API: "GET /action?token=..."
    API-->>User: renderSuccessPage (after)
    Note over User: Shows checkmark + Action submitted only
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): remove non-functional ..."](https://github.com/novuhq/novu/commit/28197a26e20bcdfebe6a6ad8594d20d13a88a22b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35215566)</sub>

<!-- /greptile_comment -->