### PR TITLE
fix(shared): honour retry/onRetry on the SSRF-safe outbound path

### DIFF
--- a/libs/application-generic/src/services/http-client/http-client.service.spec.ts
+++ b/libs/application-generic/src/services/http-client/http-client.service.spec.ts
@@ -1,0 +1,195 @@
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { expect } from 'chai';
+import { HttpClientService } from './http-client.service';
+import { HttpClientError, HttpClientErrorType } from './http-client.types';
+
+type RetryEvent = { attemptCount: number; statusCode?: number; errorCode?: string; delay: number };
+
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+
+function createService(): HttpClientService {
+  const logger = {
+    setContext: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  return new HttpClientService(logger);
+}
+
+describe('HttpClientService — SSRF-safe path retries', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let hitCount: number;
+  let handler: (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+  beforeAll(() => {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_ALLOW === undefined) {
+      delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+    } else {
+      process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+    }
+  });
+
+  beforeEach(async () => {
+    hitCount = 0;
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    };
+
+    server = http.createServer((req, res) => {
+      hitCount += 1;
+      handler(req, res);
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('retries on a retryable status code and eventually succeeds', async () => {
+    const retries: RetryEvent[] = [];
+    handler = (_req, res) => {
+      if (hitCount < 3) {
+        res.writeHead(503);
+        res.end('try again');
+
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    };
+
+    const service = createService();
+    const response = await service.request<{ ok: boolean }>({
+      url: baseUrl,
+      method: 'GET',
+      enforceSsrfProtection: true,
+      retry: { limit: 3 },
+      onRetry: (event) => retries.push(event),
+    });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.body).to.deep.equal({ ok: true });
+    expect(hitCount).to.equal(3);
+    expect(retries).to.have.lengthOf(2);
+    expect(retries[0]).to.include({ attemptCount: 1, statusCode: 503 });
+    expect(retries[1]).to.include({ attemptCount: 2, statusCode: 503 });
+  });
+
+  it('throws after exhausting the retry budget', async () => {
+    const retries: RetryEvent[] = [];
+    handler = (_req, res) => {
+      res.writeHead(503);
+      res.end('always down');
+    };
+
+    const service = createService();
+    let caught: unknown;
+    try {
+      await service.request({
+        url: baseUrl,
+        method: 'GET',
+        enforceSsrfProtection: true,
+        retry: { limit: 2 },
+        onRetry: (event) => retries.push(event),
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(HttpClientError);
+    expect((caught as HttpClientError).statusCode).to.equal(503);
+    // 1 initial attempt + 2 retries.
+    expect(hitCount).to.equal(3);
+    expect(retries).to.have.lengthOf(2);
+  });
+
+  it('does not retry on a non-retryable status code', async () => {
+    const retries: RetryEvent[] = [];
+    handler = (_req, res) => {
+      res.writeHead(400);
+      res.end('bad request');
+    };
+
+    const service = createService();
+    let caught: unknown;
+    try {
+      await service.request({
+        url: baseUrl,
+        method: 'GET',
+        enforceSsrfProtection: true,
+        retry: { limit: 3 },
+        onRetry: (event) => retries.push(event),
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(HttpClientError);
+    expect((caught as HttpClientError).statusCode).to.equal(400);
+    expect(hitCount).to.equal(1);
+    expect(retries).to.have.lengthOf(0);
+  });
+
+  it('does not retry an SSRF policy rejection', async () => {
+    const retries: RetryEvent[] = [];
+    const service = createService();
+
+    let caught: unknown;
+    try {
+      await service.request({
+        url: 'http://localhost/blocked',
+        method: 'GET',
+        enforceSsrfProtection: true,
+        retry: { limit: 3 },
+        onRetry: (event) => retries.push(event),
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(HttpClientError);
+    expect((caught as HttpClientError).type).to.equal(HttpClientErrorType.SSRF_BLOCKED);
+    expect(retries).to.have.lengthOf(0);
+  });
+
+  it('retries on a socket timeout (ETIMEDOUT)', async () => {
+    const retries: RetryEvent[] = [];
+    handler = (_req, res) => {
+      // Never respond within the timeout window on the first attempt; respond fast afterwards.
+      if (hitCount < 2) {
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    };
+
+    const service = createService();
+    const response = await service.request<{ ok: boolean }>({
+      url: baseUrl,
+      method: 'GET',
+      timeout: 150,
+      enforceSsrfProtection: true,
+      retry: { limit: 2 },
+      onRetry: (event) => retries.push(event),
+    });
+
+    expect(response.statusCode).to.equal(200);
+    expect(retries).to.have.lengthOf(1);
+    expect(retries[0]).to.include({ attemptCount: 1, errorCode: 'ETIMEDOUT' });
+  });
+});

--- a/libs/application-generic/src/services/http-client/http-client.service.spec.ts
+++ b/libs/application-generic/src/services/http-client/http-client.service.spec.ts
@@ -192,4 +192,28 @@ describe('HttpClientService — SSRF-safe path retries', () => {
     expect(retries).to.have.lengthOf(1);
     expect(retries[0]).to.include({ attemptCount: 1, errorCode: 'ETIMEDOUT' });
   });
+
+  it('classifies an exhausted timeout as TIMEOUT and preserves the ETIMEDOUT code', async () => {
+    handler = () => {
+      // Never respond so every attempt hits the socket timeout.
+    };
+
+    const service = createService();
+    let caught: unknown;
+    try {
+      await service.request({
+        url: baseUrl,
+        method: 'GET',
+        timeout: 100,
+        enforceSsrfProtection: true,
+        retry: { limit: 1 },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(HttpClientError);
+    expect((caught as HttpClientError).type).to.equal(HttpClientErrorType.TIMEOUT);
+    expect((caught as HttpClientError).networkCode).to.equal('ETIMEDOUT');
+  });
 });

--- a/libs/application-generic/src/services/http-client/http-client.service.ts
+++ b/libs/application-generic/src/services/http-client/http-client.service.ts
@@ -43,7 +43,7 @@ type GotRequestParams = {
   httpsOptions: { rejectUnauthorized: boolean };
 };
 
-type SafeRequestParams = {
+interface SafeRequestParams {
   url: string;
   method: Method;
   headers: Record<string, string> | undefined;
@@ -51,14 +51,14 @@ type SafeRequestParams = {
   timeout: number;
   responseType: 'json' | 'text';
   rejectUnauthorized: boolean;
-};
+}
 
-type RetryConfig = {
+interface RetryConfig {
   retriesLimit: number;
   retryStatusCodes: number[];
   retryErrorCodes: string[];
   onRetry?: HttpRequestOptions['onRetry'];
-};
+}
 
 /** A retry signal describes which condition (status or transport code) makes the failure retryable. */
 type RetrySignal = { statusCode: number } | { errorCode: string };
@@ -153,8 +153,10 @@ export class HttpClientService {
   private async requestSafeWithRetry<T>(params: SafeRequestParams, retryConfig: RetryConfig): Promise<HttpResponse<T>> {
     const { retriesLimit, retryStatusCodes, retryErrorCodes, onRetry } = retryConfig;
 
-    // `attempt` counts retries (1 = first retry), mirroring `got`'s
-    // `attemptCount` so the backoff curve matches the non-SSRF path.
+    // `attempt` is a 1-based iteration counter: it is 1 when the initial
+    // request fails (the decision point for the first retry), 2 when the first
+    // retry fails, etc. This mirrors `got`'s `attemptCount` so the backoff curve
+    // and `onRetry` semantics are identical to the non-SSRF path.
     for (let attempt = 1; ; attempt += 1) {
       try {
         return await this.requestSafe<T>(params);
@@ -316,6 +318,21 @@ export class HttpClientService {
     }
 
     if (!(error instanceof RequestError)) {
+      // The SSRF-safe runner does not use `got`, so its transport failures
+      // surface as plain Node errors carrying an errno `code` (e.g. ETIMEDOUT,
+      // ECONNRESET). Preserve that code as `networkCode` and classify timeouts
+      // as TIMEOUT so callers branching on `error.type` / `error.networkCode`
+      // behave identically to the `got` path.
+      const networkCode = (error as NodeJS.ErrnoException | null)?.code;
+      if (typeof networkCode === 'string') {
+        return new HttpClientError({
+          type: networkCode === 'ETIMEDOUT' ? HttpClientErrorType.TIMEOUT : HttpClientErrorType.NETWORK_ERROR,
+          message: error instanceof Error ? error.message : String(error),
+          networkCode,
+          cause: error,
+        });
+      }
+
       return new HttpClientError({
         type: HttpClientErrorType.UNKNOWN,
         message: error instanceof Error ? error.message : String(error),

--- a/libs/application-generic/src/services/http-client/http-client.service.ts
+++ b/libs/application-generic/src/services/http-client/http-client.service.ts
@@ -43,8 +43,34 @@ type GotRequestParams = {
   httpsOptions: { rejectUnauthorized: boolean };
 };
 
+type SafeRequestParams = {
+  url: string;
+  method: Method;
+  headers: Record<string, string> | undefined;
+  body: unknown;
+  timeout: number;
+  responseType: 'json' | 'text';
+  rejectUnauthorized: boolean;
+};
+
+type RetryConfig = {
+  retriesLimit: number;
+  retryStatusCodes: number[];
+  retryErrorCodes: string[];
+  onRetry?: HttpRequestOptions['onRetry'];
+};
+
+/** A retry signal describes which condition (status or transport code) makes the failure retryable. */
+type RetrySignal = { statusCode: number } | { errorCode: string };
+
 function normalizeHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string> {
   return Object.fromEntries(Object.entries(headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(', ') : (v ?? '')]));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 @Injectable()
@@ -102,18 +128,16 @@ export class HttpClientService {
 
     try {
       if (options.enforceSsrfProtection) {
-        // The safe outbound pipeline does not run through `got`, so the `retry`
-        // / `onRetry` plumbing above is bypassed. Surface that explicitly so a
-        // caller does not silently lose retry semantics — the JSDoc on
-        // `enforceSsrfProtection` documents the same constraint.
-        if ((retriesLimit ?? 0) > 0 || onRetry) {
-          this.logger.warn(
-            { url, method },
-            'enforceSsrfProtection is enabled; retry / onRetry options are not honoured on the safe outbound path'
-          );
-        }
-
-        return await this.requestSafe<T>({ url, method, headers, body, timeout, responseType, rejectUnauthorized });
+        // The safe outbound pipeline does not run through `got`, so `got`'s own
+        // retry machinery is bypassed. We re-implement the same retry contract
+        // (limit, retryable status/error codes, exponential backoff, `onRetry`)
+        // directly around the SSRF-safe runner so callers keep their retry
+        // semantics. SSRF policy rejections (`SsrfBlockedError`) are never
+        // retried — they are deterministic and retrying cannot change them.
+        return await this.requestSafeWithRetry<T>(
+          { url, method, headers, body, timeout, responseType, rejectUnauthorized },
+          { retriesLimit, retryStatusCodes, retryErrorCodes, onRetry }
+        );
       }
 
       if (responseType === 'text') {
@@ -126,15 +150,54 @@ export class HttpClientService {
     }
   }
 
-  private async requestSafe<T>(params: {
-    url: string;
-    method: Method;
-    headers: Record<string, string> | undefined;
-    body: unknown;
-    timeout: number;
-    responseType: 'json' | 'text';
-    rejectUnauthorized: boolean;
-  }): Promise<HttpResponse<T>> {
+  private async requestSafeWithRetry<T>(params: SafeRequestParams, retryConfig: RetryConfig): Promise<HttpResponse<T>> {
+    const { retriesLimit, retryStatusCodes, retryErrorCodes, onRetry } = retryConfig;
+
+    // `attempt` counts retries (1 = first retry), mirroring `got`'s
+    // `attemptCount` so the backoff curve matches the non-SSRF path.
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await this.requestSafe<T>(params);
+      } catch (error) {
+        const signal =
+          attempt <= retriesLimit ? this.getSafeRetrySignal(error, retryStatusCodes, retryErrorCodes) : null;
+
+        if (!signal) {
+          throw error;
+        }
+
+        const delay = 2 ** attempt * RETRY_BASE_INTERVAL_IN_MS;
+        onRetry?.({ attemptCount: attempt, delay, ...signal });
+
+        await sleep(delay);
+      }
+    }
+  }
+
+  /**
+   * Decide whether a failed safe-outbound attempt is retryable. Returns the
+   * matching retry signal (status or transport error code) or `null` when the
+   * error must propagate. `SsrfBlockedError` carries neither a retryable status
+   * code nor a transport `code`, so it always propagates.
+   */
+  private getSafeRetrySignal(
+    error: unknown,
+    retryStatusCodes: number[],
+    retryErrorCodes: string[]
+  ): RetrySignal | null {
+    if (error instanceof HttpClientError && error.statusCode && retryStatusCodes.includes(error.statusCode)) {
+      return { statusCode: error.statusCode };
+    }
+
+    const code = (error as { code?: unknown } | null)?.code;
+    if (typeof code === 'string' && retryErrorCodes.includes(code)) {
+      return { errorCode: code };
+    }
+
+    return null;
+  }
+
+  private async requestSafe<T>(params: SafeRequestParams): Promise<HttpResponse<T>> {
     const safeOptions: SafeOutboundRequestOptions = {
       url: params.url,
       method: params.method as SafeOutboundRequestOptions['method'],

--- a/libs/application-generic/src/services/http-client/http-client.types.ts
+++ b/libs/application-generic/src/services/http-client/http-client.types.ts
@@ -65,8 +65,9 @@ export interface HttpRequestOptions {
    *    strips sensitive headers when crossing origins.
    *
    * Required for any request whose destination is user-controlled (webhooks,
-   * bridge URLs, reply callbacks). When this flag is on, the `retry` and
-   * `onRetry` options are not honoured.
+   * bridge URLs, reply callbacks). The `retry` and `onRetry` options are
+   * honoured on this path too: retries are re-implemented around the SSRF-safe
+   * runner (SSRF policy rejections are never retried).
    */
   enforceSsrfProtection?: boolean;
 }

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -430,7 +430,13 @@ function performPinnedRequest(params: PinnedRequestParams): Promise<SafeOutbound
     });
 
     req.on('timeout', () => {
-      req.destroy(new Error(`Request to ${parsed.hostname} timed out after ${timeoutMs}ms.`));
+      const timeoutError: NodeJS.ErrnoException = new Error(
+        `Request to ${parsed.hostname} timed out after ${timeoutMs}ms.`
+      );
+      // Tag the error so callers (e.g. HttpClientService retry logic) can treat
+      // socket timeouts as a retryable transport failure, matching the `got` path.
+      timeoutError.code = 'ETIMEDOUT';
+      req.destroy(timeoutError);
     });
     req.on('error', reject);
 

--- a/packages/shared/src/utils/safe-outbound-http.ts
+++ b/packages/shared/src/utils/safe-outbound-http.ts
@@ -282,7 +282,13 @@ function performPinnedRequest(params: PinnedRequestParams): Promise<SafeOutbound
     });
 
     req.on('timeout', () => {
-      req.destroy(new Error(`Request to ${parsed.hostname} timed out after ${timeoutMs}ms.`));
+      const timeoutError: NodeJS.ErrnoException = new Error(
+        `Request to ${parsed.hostname} timed out after ${timeoutMs}ms.`
+      );
+      // Tag the error so callers (e.g. HttpClientService retry logic) can treat
+      // socket timeouts as a retryable transport failure, matching the `got` path.
+      timeoutError.code = 'ETIMEDOUT';
+      req.destroy(timeoutError);
     });
     req.on('error', reject);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

`HttpClientService.request` logged:

> `enforceSsrfProtection is enabled; retry / onRetry options are not honoured on the safe outbound path`

That warning came from `libs/application-generic/src/services/http-client/http-client.service.ts`. When `enforceSsrfProtection: true`, requests are routed through the hand-rolled, DNS-pinned `safeOutboundRequest` runner (`utils/ssrf-url-validation.ts`) instead of `got`. `got`'s retry machinery therefore never runs, so `retry`/`onRetry` were silently dropped.

This is a real regression for callers that pass **both** `retry` and `enforceSsrfProtection`, most notably external/stateless bridge requests (`execute-framework-request.usecase.ts`) and the HTTP-request workflow step — they never retried transient `5xx`/timeout failures.

### Why not `got-ssrf`?

The linked [`got-ssrf`](https://github.com/hanover-computing/got-ssrf) is not viable here: its current release requires `got@^14` (and even `2.x` needs `got@^12/13`), all of which are **ESM-only**. `libs/application-generic` is a CommonJS package pinned to `got@11.8.6` (the last CJS release), so adopting `got-ssrf` would force an ESM migration of the lib and would also be a security downgrade versus the existing runner (DNS pinning, per-redirect re-validation, sensitive-header stripping). Pinning an incompatible package made no sense, so no dependency was added.

## Changes

- Re-implement the retry contract natively around the SSRF-safe runner: `retry.limit`, retryable status/error codes, exponential backoff, and the `onRetry` callback — matching the `got` path's semantics.
- SSRF policy rejections (`SsrfBlockedError`) are **never** retried (deterministic; retrying can't change them).
- Tag safe-path socket timeouts with `code = 'ETIMEDOUT'` in **both** mirrored runners (`libs/application-generic/.../ssrf-url-validation.ts` and `packages/shared/.../safe-outbound-http.ts`) so timeouts are retryable, matching `RETRYABLE_ERROR_CODES`.
- `normalizeError` now preserves the errno `code` for non-`got` transport failures (the SSRF-safe runner throws plain Node errors), mapping `ETIMEDOUT` → `TIMEOUT` and others → `NETWORK_ERROR`, so `execute-framework-request`'s timeout / retryable-`networkCode` branches behave the same on both paths.
- Update the `enforceSsrfProtection` JSDoc to state retries are now honoured.

```mermaid
flowchart TD
  A["HttpClientService.request"] --> B{enforceSsrfProtection?}
  B -- no --> C["got (built-in retry)"]
  B -- yes --> D["requestSafeWithRetry"]
  D --> E["requestSafe (DNS-pinned)"]
  E -- success / non-retryable --> F["return / throw"]
  E -- retryable status/code --> G{attempt <= limit?}
  G -- yes --> H["onRetry + backoff sleep"]
  H --> E
  G -- no --> F
  E -- SsrfBlockedError --> F
```

## Testing

- Unit tests in `http-client.service.spec.ts` (real localhost server): retry-then-succeed on `503`, budget exhaustion, no-retry on `400`, no-retry on SSRF block, timeout retry via `ETIMEDOUT`, and exhausted-timeout classification (`TIMEOUT` + `networkCode === 'ETIMEDOUT'`).
- `packages/shared` `safe-outbound-http` + drift specs still pass (mirror parity preserved).
- `nx build @novu/application-generic` passes.

> Note: I could not create/link a Linear ticket — the Linear integration reports `needsAuth` and a cloud agent cannot complete the interactive auth. Please link a ticket and update the title to `... fixes NV-XXX` (the title-lint check requires it).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fac169cb-98e4-4611-927f-346e7d3f2cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fac169cb-98e4-4611-927f-346e7d3f2cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

When enforceSsrfProtection routed requests through the SSRF-safe outbound runner, got's retry/onRetry behavior was being bypassed and retry options dropped. This PR re-implements got-like retry semantics around the SSRF-safe path: honoring retry limits, retryable HTTP status and transport error codes, exponential backoff, and onRetry callbacks. SSRF policy rejections (SsrfBlockedError) are never retried. Socket timeouts on the safe path are now emitted with code = 'ETIMEDOUT' so they match retryable error codes.

## Affected areas

application-generic
- HttpClientService: requests routed through the SSRF-safe runner now use a requestSafeWithRetry wrapper that implements the got-style retry contract; normalizeError preserves errno codes and maps ETIMEDOUT to TIMEOUT.
- JSDoc: enforceSsrfProtection docs updated to state retries are honored.
- Tests: added unit tests covering retry-then-succeed, exhausted retry budget, non-retryable 400, SSRF block (no-retry), ETIMEDOUT retry and timeout exhaustion preserving networkCode.

shared
- safe-outbound HTTP & SSRF URL validation: socket timeout handling now constructs a timeout error with code = 'ETIMEDOUT' before destroying the request so downstream retry logic can detect it.

## Key technical decisions

- Retries are implemented around the existing SSRF-safe runner instead of swapping to a different HTTP library to preserve the pinned/DNS-safe transport and avoid ESM/CommonJS incompatibilities.
- SSRF policy rejections are treated as deterministic and never retried; only transport errors and configured retryable HTTP statuses trigger retries.
- Timeout errors are explicitly tagged with 'ETIMEDOUT' to align with existing RETRYABLE_ERROR_CODES.

## Testing

New unit tests using a real localhost server exercise retry success, retry exhaustion, no-retry cases, SSRF block behavior, and timeout handling; shared package mirrors and builds pass and TypeScript build reports 0 issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent retry regression: when `enforceSsrfProtection: true` routed requests through the hand-rolled SSRF-safe runner instead of `got`, the `retry`/`onRetry` options were dropped with only a warning. The fix re-implements the same retry contract (limit, retryable status/error codes, exponential backoff, `onRetry` callback) natively around the safe runner, and correctly normalises plain Node errno errors so `ETIMEDOUT` is classified as `TIMEOUT` rather than `UNKNOWN` after budget exhaustion.

- **`requestSafeWithRetry` + `getSafeRetrySignal`**: a new private retry loop mirrors `got`'s `calculateDelay` semantics; `SsrfBlockedError` carries no retryable status or transport code and therefore always propagates immediately without consuming retry budget.
- **`normalizeError` extension**: a new `NodeJS.ErrnoException.code` branch maps `ETIMEDOUT` → `HttpClientErrorType.TIMEOUT` and all other errno codes → `NETWORK_ERROR`, so callers branching on `error.type` or `error.networkCode` behave identically on both transport paths.
- **Timeout tagging** in both mirrored SSRF runners: socket timeouts now attach `code = 'ETIMEDOUT'` before destroying the request, making them recognisable as retryable transport failures.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The retry loop, signal classification, backoff formula, and error normalisation are all internally consistent and well-covered by tests using a real localhost server.

The retry loop in `requestSafeWithRetry` correctly mirrors `got`'s `calculateDelay` semantics: the same `2^attempt * BASE_MS` backoff curve, the same `attempt`-count alignment (1-based, incremented after each failed attempt), and the same `onRetry` call-site ordering. `SsrfBlockedError` carries neither a retryable HTTP status nor a Node errno code, so it falls through `getSafeRetrySignal` to `null` and is never retried. The `normalizeError` extension is guarded behind `instanceof RequestError` negation, so it cannot interfere with the existing `got` path. Tests exercise every meaningful branch.

No files require special attention. The two mirrored SSRF runner files receive identical mechanical changes and the existing drift test will catch any future divergence.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/http-client/http-client.service.ts | Core change: adds `requestSafeWithRetry` loop and `getSafeRetrySignal` helper to implement got-compatible retry semantics around the SSRF-safe runner; extends `normalizeError` to classify plain Node errno errors (ETIMEDOUT → TIMEOUT, others → NETWORK_ERROR). Logic is correct and internally consistent. |
| libs/application-generic/src/services/http-client/http-client.service.spec.ts | New test suite using a real localhost server covers retry-then-succeed (503), budget exhaustion, non-retryable 400, SSRF block (no retry), ETIMEDOUT retry, and exhausted-timeout classification (type=TIMEOUT, networkCode=ETIMEDOUT). All critical scenarios are exercised. |
| libs/application-generic/src/services/http-client/http-client.types.ts | JSDoc for `enforceSsrfProtection` updated to reflect that retry/onRetry are now honoured on the safe path. |
| libs/application-generic/src/utils/ssrf-url-validation.ts | Timeout handler now constructs a typed `NodeJS.ErrnoException` with `code = 'ETIMEDOUT'` before destroying the request socket, enabling the retry loop to identify socket timeouts as retryable transport failures. |
| packages/shared/src/utils/safe-outbound-http.ts | Mirror of the ssrf-url-validation.ts timeout-tagging change, keeping both implementations in drift parity as documented. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["HttpClientService.request()"] --> B{enforceSsrfProtection?}
    B -- no --> C["got (built-in retry + calculateDelay)"]
    C -- error --> D["normalizeError (got path)"]
    B -- yes --> E["requestSafeWithRetry()"]
    E --> F["requestSafe() — DNS-pinned runner"]
    F -- success --> G["return HttpResponse"]
    F -- HTTP 4xx/5xx --> H["throw HttpClientError(statusCode)"]
    F -- socket timeout --> I["ETIMEDOUT tagged Error"]
    F -- SsrfBlockedError --> J["getSafeRetrySignal → null"]
    H --> K["getSafeRetrySignal"]
    I --> K
    K -- retryable and attempt <= limit --> L["onRetry + backoff sleep"]
    L --> F
    K -- not retryable OR budget exhausted --> M["re-throw"]
    J --> M
    M --> N["normalizeError (outer catch)"]
    N -- HttpClientError --> O["pass-through"]
    N -- SsrfBlockedError --> P["SSRF_BLOCKED"]
    N -- ETIMEDOUT --> Q["TIMEOUT + networkCode"]
    N -- other errno --> R["NETWORK_ERROR + networkCode"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/application-generic/src/services/http-client/http-client.service.ts`, line 304-323 ([link](https://github.com/novuhq/novu/blob/6a94d6202af0def6a5b13a29dbd64e8d2417d253/libs/application-generic/src/services/http-client/http-client.service.ts#L304-L323)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Timeout errors from the SSRF path surface as `UNKNOWN` after retry exhaustion**

   When the SSRF runner times out, it throws a plain `Error` with `code = 'ETIMEDOUT'` (correctly tagged by this PR). That error is retried up to `retriesLimit` times, but once the budget is exhausted the raw `Error` propagates to the outer `catch` in `request()`, where `normalizeError` classifies it as `HttpClientErrorType.UNKNOWN` — because the `instanceof TimeoutError` branch only matches `got`'s `TimeoutError` class, not a plain `Error`.

   Callers that branch on `error.type === HttpClientErrorType.TIMEOUT` will never match on the SSRF path after retries are exhausted. A targeted fix would be to add an early check in `normalizeError` for `error.code === 'ETIMEDOUT'`, or wrap the thrown error in a typed `HttpClientError` inside `requestSafeWithRetry` before re-throwing.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: libs/application-generic/src/services/http-client/http-client.service.ts
   Line: 304-323

   Comment:
   **Timeout errors from the SSRF path surface as `UNKNOWN` after retry exhaustion**

   When the SSRF runner times out, it throws a plain `Error` with `code = 'ETIMEDOUT'` (correctly tagged by this PR). That error is retried up to `retriesLimit` times, but once the budget is exhausted the raw `Error` propagates to the outer `catch` in `request()`, where `normalizeError` classifies it as `HttpClientErrorType.UNKNOWN` — because the `instanceof TimeoutError` branch only matches `got`'s `TimeoutError` class, not a plain `Error`.

   Callers that branch on `error.type === HttpClientErrorType.TIMEOUT` will never match on the SSRF path after retries are exhausted. A targeted fix would be to add an early check in `normalizeError` for `error.code === 'ETIMEDOUT'`, or wrap the thrown error in a typed `HttpClientError` inside `requestSafeWithRetry` before re-throwing.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Fapplication-generic%2Fsrc%2Fservices%2Fhttp-client%2Fhttp-client.service.ts%0ALine%3A%20304-323%0A%0AComment%3A%0A**Timeout%20errors%20from%20the%20SSRF%20path%20surface%20as%20%60UNKNOWN%60%20after%20retry%20exhaustion**%0A%0AWhen%20the%20SSRF%20runner%20times%20out%2C%20it%20throws%20a%20plain%20%60Error%60%20with%20%60code%20%3D%20'ETIMEDOUT'%60%20%28correctly%20tagged%20by%20this%20PR%29.%20That%20error%20is%20retried%20up%20to%20%60retriesLimit%60%20times%2C%20but%20once%20the%20budget%20is%20exhausted%20the%20raw%20%60Error%60%20propagates%20to%20the%20outer%20%60catch%60%20in%20%60request%28%29%60%2C%20where%20%60normalizeError%60%20classifies%20it%20as%20%60HttpClientErrorType.UNKNOWN%60%20%E2%80%94%20because%20the%20%60instanceof%20TimeoutError%60%20branch%20only%20matches%20%60got%60's%20%60TimeoutError%60%20class%2C%20not%20a%20plain%20%60Error%60.%0A%0ACallers%20that%20branch%20on%20%60error.type%20%3D%3D%3D%20HttpClientErrorType.TIMEOUT%60%20will%20never%20match%20on%20the%20SSRF%20path%20after%20retries%20are%20exhausted.%20A%20targeted%20fix%20would%20be%20to%20add%20an%20early%20check%20in%20%60normalizeError%60%20for%20%60error.code%20%3D%3D%3D%20'ETIMEDOUT'%60%2C%20or%20wrap%20the%20thrown%20error%20in%20a%20typed%20%60HttpClientError%60%20inside%20%60requestSafeWithRetry%60%20before%20re-throwing.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(application-generic): classify SSRF-..."](https://github.com/novuhq/novu/commit/a95cb820b69a5eaaddd54722f0858812519fc561) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35296583)</sub>

<!-- /greptile_comment -->