### PR TITLE
feat(dashboard): inbox first on usecase select and track selection

### DIFF
--- a/apps/dashboard/src/pages/usecase-select-page.tsx
+++ b/apps/dashboard/src/pages/usecase-select-page.tsx
@@ -248,34 +248,34 @@ function InboxFeatureList() {
 
 const USECASE_OPTIONS = [
   {
-    id: 'agents' as const,
-    icon: Bot,
-    title: "I'm building an AI agent",
-    description:
-      'Connect your agent to Novu and Novu gives it voice. Distribute your agent across multiple channels with a unified API.',
-  },
-  {
     id: 'inbox' as const,
     icon: Notification5Fill,
     title: "I'm adding notifications to my app",
     description:
       'Plug in <Inbox />, connect providers, and orchestrate workflows. Go from event → trigger → delivery with full control.',
   },
+  {
+    id: 'agents' as const,
+    icon: Bot,
+    title: "I'm building an AI agent",
+    description:
+      'Connect your agent to Novu and Novu gives it voice. Distribute your agent across multiple channels with a unified API.',
+  },
 ] as const;
 
 type UsecaseId = 'agents' | 'inbox';
 
-function UsecaseSelector({ selected, onSelect }: { selected: UsecaseId; onSelect: (id: UsecaseId) => void }) {
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const appId = useMemo(() => getOnboardingAppId(searchParams), [searchParams]);
-
+function UsecaseSelector({
+  selected,
+  onSelect,
+  onContinue,
+}: {
+  selected: UsecaseId;
+  onSelect: (id: UsecaseId) => void;
+  onContinue: (usecase: UsecaseId) => void;
+}) {
   const handleContinue = () => {
-    if (selected === 'inbox') {
-      navigate(withAppId(ROUTES.INBOX_USECASE, appId));
-    } else if (selected === 'agents') {
-      navigate(withAppId(ROUTES.AGENTS_SETUP, appId));
-    }
+    onContinue(selected);
   };
 
   return (
@@ -356,7 +356,20 @@ function UsecaseSelector({ selected, onSelect }: { selected: UsecaseId; onSelect
 export function UsecaseSelectPage() {
   const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
   const telemetry = useTelemetry();
-  const [selected, setSelected] = useState<UsecaseId>('agents');
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const appId = useMemo(() => getOnboardingAppId(searchParams), [searchParams]);
+  const [selected, setSelected] = useState<UsecaseId>('inbox');
+
+  const handleContinue = (usecase: UsecaseId) => {
+    telemetry(TelemetryEvent.USECASE_SELECTED, { usecase });
+
+    if (usecase === 'inbox') {
+      navigate(withAppId(ROUTES.INBOX_USECASE, appId));
+    } else if (usecase === 'agents') {
+      navigate(withAppId(ROUTES.AGENTS_SETUP, appId));
+    }
+  };
   const provisioningActive = useOnboardingProvisioningActive();
 
   useOnboardingProvisioningDismiss({
@@ -387,7 +400,7 @@ export function UsecaseSelectPage() {
       <p className="text-text-sub mt-2 text-sm leading-relaxed">
         Pick what you would like to start with, you can always set up the other path anytime.
       </p>
-      <UsecaseSelector selected={selected} onSelect={setSelected} />
+      <UsecaseSelector selected={selected} onSelect={setSelected} onContinue={handleContinue} />
     </>
   );
 

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -32,6 +32,7 @@ export enum TelemetryEvent {
   ONBOARDING_WELCOME_SENT = 'Onboarding welcome sent - [Onboarding]',
   ONBOARDING_REDIRECT = 'Onboarding redirect - [Onboarding]',
   USECASE_SELECT_PAGE_VIEWED = 'Use case select page viewed - [Onboarding]',
+  USECASE_SELECTED = 'Use case selected - [Onboarding]',
   AGENTS_USECASE_PAGE_VIEWED = 'Agents use case page viewed - [Onboarding]',
   AGENTS_SETUP_PAGE_VIEWED = 'Agents setup page viewed - [Onboarding]',
   INBOX_USECASE_PAGE_VIEWED = 'Inbox use case page viewed - [Onboarding]',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the onboarding use case selector so **Inbox** is listed first, selected by default, and shows the inbox preview on load.

Adds `USECASE_SELECTED` telemetry when the user clicks **Continue setup**, passing `{ usecase: 'inbox' | 'agents' }`.

## Changes

- Reordered `USECASE_OPTIONS` (inbox before agents)
- Default selection changed from `agents` to `inbox`
- New `TelemetryEvent.USECASE_SELECTED` fired on continue with `usecase` property

## Test plan

- [ ] Open `/onboarding/usecase` with conversational agents feature flag enabled
- [ ] Confirm inbox option is first and pre-selected
- [ ] Confirm inbox preview is shown on initial load
- [ ] Select agents, then continue — navigates to agents setup
- [ ] Continue with inbox selected — navigates to inbox usecase flow
- [ ] Verify telemetry event `Use case selected - [Onboarding] - [DASHBOARD]` includes `usecase` param
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4506839-0aa4-4710-b359-ed6bd7045966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4506839-0aa4-4710-b359-ed6bd7045966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The onboarding use case selector was reorganized to prioritize Inbox as the default choice. The Inbox option now appears first in the selection list instead of Agents, and is pre-selected on page load. When users click "Continue setup," their selection is tracked via a new `USECASE_SELECTED` telemetry event that captures which use case (inbox or agents) was chosen and navigates to the corresponding onboarding flow.

## Affected areas

- **dashboard**: Updated the usecase selection page to reorder the use case options with Inbox first, changed the default selected use case from `'agents'` to `'inbox'`, added a `handleContinue` callback that fires the `USECASE_SELECTED` telemetry event with the selected use case property, and routes to either `ROUTES.INBOX_USECASE` or `ROUTES.AGENTS_SETUP` based on selection.

## Key technical decisions

- New telemetry event `USECASE_SELECTED` added to track onboarding use case selection decisions, enabling product analytics on user preferences during onboarding without requiring database, schema, or API contract changes.

## Testing

Manual verification required: confirm Inbox appears first and is pre-selected on initial page load, verify the onboarding flow correctly navigates to either the Inbox or Agents setup based on user selection, and validate that telemetry events are fired with the correct `usecase` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorders the onboarding use-case selector so Inbox appears first and is pre-selected, and emits a new `USECASE_SELECTED` telemetry event when the user clicks "Continue setup". Navigation logic is lifted from `UsecaseSelector` into `UsecaseSelectPage`, giving the parent sole responsibility for routing and analytics.

- Inbox is now the first option in `USECASE_OPTIONS` and the initial `useState` value, so the inbox preview renders immediately on page load.
- `UsecaseSelector` receives a new `onContinue` prop; the parent `UsecaseSelectPage` handles both the telemetry call and the `navigate()` call, keeping the child component free of side effects.
- `TelemetryEvent.USECASE_SELECTED` follows the existing `- [Onboarding]` suffix convention used by all other events in the enum.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to option ordering, default state initialization, and moving navigation/telemetry into the parent component with no behavioral regressions.

The refactor is small and well-contained: inbox is reordered first, the default selection is updated to match, navigation logic is cleanly lifted to the page level, and a single telemetry event is added. No new network calls, no data mutations, and the feature-flag guard is unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/usecase-select-page.tsx | Reorders USECASE_OPTIONS (inbox first), sets default selection to 'inbox', lifts navigation logic into UsecaseSelectPage and adds USECASE_SELECTED telemetry on continue. Refactoring is clean and types remain consistent. |
| apps/dashboard/src/utils/telemetry.ts | Adds USECASE_SELECTED enum value following the existing naming convention; no issues found. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UsecaseSelectPage
    participant UsecaseSelector
    participant Telemetry
    participant Router

    UsecaseSelectPage->>UsecaseSelectPage: useState('inbox')
    UsecaseSelectPage->>UsecaseSelector: "selected='inbox', onContinue=handleContinue"
    User->>UsecaseSelector: clicks option (agents/inbox)
    UsecaseSelector->>UsecaseSelectPage: onSelect(id)
    User->>UsecaseSelector: clicks "Continue setup"
    UsecaseSelector->>UsecaseSelectPage: onContinue(selected)
    UsecaseSelectPage->>Telemetry: "USECASE_SELECTED { usecase }"
    alt "usecase === 'inbox'"
        UsecaseSelectPage->>Router: navigate(INBOX_USECASE)
    else "usecase === 'agents'"
        UsecaseSelectPage->>Router: navigate(AGENTS_SETUP)
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): inbox first on usecase ..."](https://github.com/novuhq/novu/commit/bf55fa82b62953cf076142f0963a6891fe04a2e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35296689)</sub>

<!-- /greptile_comment -->