### PR TITLE
fix(api-service): resolve plan card stuck on thinking after turn interrupts fixes NV-7934

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.command.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.command.ts
@@ -2,7 +2,6 @@ import { IsNotEmpty, IsObject, IsString } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../../shared/commands/project.command';
 
 export interface ToolProgressPayload {
-  turnId: string;
   action: 'tool-use' | 'complete' | 'fail' | 'awaiting-approval' | 'approved' | 'denied';
   toolUseId?: string;
   toolName?: string;

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase.ts
@@ -1,6 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PinoLogger, shortId } from '@novu/application-generic';
-import { ConversationActivityEntity, ConversationActivityRepository, type ConversationChannel } from '@novu/dal';
+import {
+  ConversationActivityEntity,
+  ConversationActivityRepository,
+  type ConversationChannel,
+  ConversationRepository,
+} from '@novu/dal';
 import type { PlanModel, PlanTaskStatus } from 'chat';
 import { AgentConversationService } from '../../conversation/agent-conversation.service';
 import { HandleAgentReplyCommand } from '../handle-agent-reply/handle-agent-reply.command';
@@ -19,6 +24,7 @@ interface ToolTask {
 export class HandlePlanProgress {
   constructor(
     private readonly activityRepository: ConversationActivityRepository,
+    private readonly conversationRepository: ConversationRepository,
     private readonly conversationService: AgentConversationService,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly logger: PinoLogger
@@ -39,38 +45,44 @@ export class HandlePlanProgress {
     const channel = this.conversationService.getPrimaryChannel(conversation);
     const { toolProgress } = command;
 
-    const existingActivities = await this.activityRepository.findToolActivitiesByTurnId(
-      command.environmentId,
-      command.conversationId,
-      toolProgress.turnId
-    );
+    const activePlanMessageId = conversation.activePlanMessageId;
+    const existingActivities = activePlanMessageId
+      ? await this.activityRepository.findToolActivitiesByPlanMessageId(
+          command.environmentId,
+          command.conversationId,
+          activePlanMessageId
+        )
+      : [];
 
     if (toolProgress.action === 'tool-use') {
-      await this.handleToolUse(command, channel, toolProgress, existingActivities);
+      await this.handleToolUse(command, channel, toolProgress, existingActivities, activePlanMessageId);
 
       return;
     }
 
     if (toolProgress.action === 'awaiting-approval') {
-      await this.handleAwaitingApproval(command, existingActivities);
+      await this.handleAwaitingApproval(command, existingActivities, activePlanMessageId);
 
       return;
     }
 
     if (toolProgress.action === 'approved' || toolProgress.action === 'denied') {
-      await this.handleVerdictUpdate(command, toolProgress.action, existingActivities);
+      await this.handleVerdictUpdate(command, toolProgress.action, existingActivities, activePlanMessageId);
 
       return;
     }
 
-    await this.handleFinalize(command, toolProgress, existingActivities);
+    if (toolProgress.action === 'complete' || toolProgress.action === 'fail') {
+      await this.handleFinalize(command, toolProgress, existingActivities, activePlanMessageId);
+    }
   }
 
   private async handleToolUse(
     command: HandlePlanProgressCommand,
     channel: ConversationChannel,
     toolProgress: ToolProgressPayload,
-    existingActivities: ConversationActivityEntity[]
+    existingActivities: ConversationActivityEntity[],
+    activePlanMessageId: string | undefined
   ): Promise<void> {
     if (!toolProgress.toolUseId || !toolProgress.status) {
       return;
@@ -86,60 +98,69 @@ export class HandlePlanProgress {
     tasks.set(toolProgress.toolUseId, { toolUseId: toolProgress.toolUseId, toolName, mcpServerName, status, details });
 
     const model = this.toModel('Thinking…', tasks, false);
-    const planMessageId = await this.postOrEditPlan(command, this.findPlanMessageId(existingActivities), model);
+    const planMessageId = await this.postOrEditPlan(command, activePlanMessageId, model);
+
+    if (planMessageId && planMessageId !== activePlanMessageId) {
+      await this.conversationRepository.setActivePlanMessageId(
+        command.environmentId,
+        command.organizationId,
+        command.conversationId,
+        planMessageId
+      );
+    }
 
     await this.persistToolActivity(command, channel, toolProgress, toolName, details, planMessageId);
   }
 
   private async handleAwaitingApproval(
     command: HandlePlanProgressCommand,
-    existingActivities: ConversationActivityEntity[]
+    existingActivities: ConversationActivityEntity[],
+    activePlanMessageId: string | undefined
   ): Promise<void> {
-    const planMessageId = this.findPlanMessageId(existingActivities);
-    if (!existingActivities.length || !planMessageId) {
+    if (!activePlanMessageId || !existingActivities.length) {
       return;
     }
 
     const tasks = this.collectTasks(existingActivities);
-    for (const task of tasks.values()) {
-      if (task.status === 'in_progress') {
-        task.status = 'in_progress';
-      }
-    }
 
-    await this.postOrEditPlan(command, planMessageId, this.toModel('Waiting for approval…', tasks, false));
+    await this.postOrEditPlan(command, activePlanMessageId, this.toModel('Waiting for approval…', tasks, false));
   }
 
   private async handleVerdictUpdate(
     command: HandlePlanProgressCommand,
     verdict: 'approved' | 'denied',
-    existingActivities: ConversationActivityEntity[]
+    existingActivities: ConversationActivityEntity[],
+    activePlanMessageId: string | undefined
   ): Promise<void> {
-    const planMessageId = this.findPlanMessageId(existingActivities);
-    if (!existingActivities.length || !planMessageId) {
+    if (!activePlanMessageId || !existingActivities.length) {
       return;
     }
 
     const title = verdict === 'approved' ? 'Approved, resuming…' : 'Denied, resuming…';
     const tasks = this.collectTasks(existingActivities);
 
-    await this.postOrEditPlan(command, planMessageId, this.toModel(title, tasks, false));
+    await this.postOrEditPlan(command, activePlanMessageId, this.toModel(title, tasks, false));
   }
 
   private async handleFinalize(
     command: HandlePlanProgressCommand,
     toolProgress: ToolProgressPayload,
-    existingActivities: ConversationActivityEntity[]
+    existingActivities: ConversationActivityEntity[],
+    activePlanMessageId: string | undefined
   ): Promise<void> {
-    const planMessageId = this.findPlanMessageId(existingActivities);
-    if (!existingActivities.length || !planMessageId) {
+    if (!activePlanMessageId || !existingActivities.length) {
       return;
     }
 
     const title = toolProgress.action === 'fail' ? 'Something went wrong' : 'Finished thinking';
     const tasks = this.collectTasks(existingActivities);
 
-    await this.postOrEditPlan(command, planMessageId, this.toModel(title, tasks, true));
+    await this.postOrEditPlan(command, activePlanMessageId, this.toModel(title, tasks, true));
+    await this.conversationRepository.clearActivePlanMessageId(
+      command.environmentId,
+      command.organizationId,
+      command.conversationId
+    );
   }
 
   private async postOrEditPlan(
@@ -187,7 +208,6 @@ export class HandlePlanProgress {
       signalData: {
         type: 'tool-use',
         payload: {
-          turnId: toolProgress.turnId,
           planMessageId,
           toolUseId: toolProgress.toolUseId,
           toolName,
@@ -199,15 +219,6 @@ export class HandlePlanProgress {
       environmentId: command.environmentId,
       organizationId: command.organizationId,
     });
-  }
-
-  private findPlanMessageId(activities: ConversationActivityEntity[]): string | undefined {
-    for (const activity of activities) {
-      const id = activity.signalData?.payload?.planMessageId;
-      if (typeof id === 'string' && id) return id;
-    }
-
-    return undefined;
   }
 
   private collectTasks(activities: ConversationActivityEntity[]): Map<string, ToolTask> {

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -56,7 +56,7 @@ export class ManagedAgentEventHandler {
   }
 
   createHandlers(context: SessionEventContext): StreamCallbacks {
-    const { sessionId, turnId, metadata } = context;
+    const { sessionId, metadata } = context;
 
     if (!metadata.conversationId || !metadata.environmentId || !metadata.organizationId) {
       this.logger.error(`Webhook event missing required metadata: session=${sessionId}`);
@@ -76,7 +76,6 @@ export class ManagedAgentEventHandler {
             HandlePlanProgressCommand.create({
               ...baseFields,
               toolProgress: {
-                turnId,
                 action: 'tool-use',
                 toolUseId: event.toolUseId,
                 toolName: event.toolName,
@@ -109,7 +108,6 @@ export class ManagedAgentEventHandler {
             HandlePlanProgressCommand.create({
               ...baseFields,
               toolProgress: {
-                turnId,
                 action: 'tool-use',
                 toolUseId: event.toolUseId,
                 toolName: event.toolName,
@@ -135,7 +133,6 @@ export class ManagedAgentEventHandler {
             HandlePlanProgressCommand.create({
               ...baseFields,
               toolProgress: {
-                turnId,
                 action: 'tool-use',
                 toolUseId: event.toolUseId,
                 status: event.isError === true ? 'error' : 'complete',
@@ -161,7 +158,6 @@ export class ManagedAgentEventHandler {
                 subscriberId: metadata.subscriberId,
                 platform: metadata.platform,
                 sessionId,
-                turnId,
                 response: event.response,
               })
             );
@@ -179,7 +175,7 @@ export class ManagedAgentEventHandler {
             event.response.usage
           );
           await this.handlePlanProgress.execute(
-            HandlePlanProgressCommand.create({ ...baseFields, toolProgress: { turnId, action: 'complete' } })
+            HandlePlanProgressCommand.create({ ...baseFields, toolProgress: { action: 'complete' } })
           );
         } catch (err) {
           this.logger.error(err, `onFinish failed: session=${sessionId}`);
@@ -194,7 +190,7 @@ export class ManagedAgentEventHandler {
 
       onError: async (event: { error: Error }) => {
         try {
-          await this.handleErrorEvent(metadata, sessionId, event.error, baseFields, turnId);
+          await this.handleErrorEvent(metadata, sessionId, event.error, baseFields);
         } catch (err) {
           this.logger.error(err, `onError handler failed: session=${sessionId}`);
           captureAgentException(err, {
@@ -222,8 +218,7 @@ export class ManagedAgentEventHandler {
     metadata: Record<string, string>,
     sessionId: string,
     error: Error,
-    baseCommand: BaseCommandFields,
-    turnId: string
+    baseCommand: BaseCommandFields
   ): Promise<void> {
     if (error instanceof SessionExpiredError) {
       this.logger.warn(`Session ${sessionId} expired, clearing for next message`);
@@ -246,7 +241,7 @@ export class ManagedAgentEventHandler {
     if (postedReconnectSetupCard) {
       try {
         await this.handlePlanProgress.execute(
-          HandlePlanProgressCommand.create({ ...baseCommand, toolProgress: { turnId, action: 'fail' } })
+          HandlePlanProgressCommand.create({ ...baseCommand, toolProgress: { action: 'fail' } })
         );
       } catch (err) {
         this.logger.error(err, `Failed to mark plan progress failed for session ${sessionId}`);
@@ -267,7 +262,7 @@ export class ManagedAgentEventHandler {
         HandleAgentReplyCommand.create({ ...baseCommand, reply: { markdown: message } })
       );
       await this.handlePlanProgress.execute(
-        HandlePlanProgressCommand.create({ ...baseCommand, toolProgress: { turnId, action: 'fail' } })
+        HandlePlanProgressCommand.create({ ...baseCommand, toolProgress: { action: 'fail' } })
       );
     } catch (err) {
       this.logger.error(err, `Failed to deliver error message for session ${sessionId}`);

--- a/apps/api/src/app/agents/managed-runtime/managed-agent.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent.service.ts
@@ -156,7 +156,6 @@ export class ManagedAgentService implements OnModuleInit {
     platform?: AgentPlatformEnum;
     toolUseIds: string[];
     approved: boolean;
-    turnId: string;
   }): Promise<void> {
     const conversation = await this.conversationRepository.findOne(
       { _id: params.conversationId, _environmentId: params.environmentId, _organizationId: params.organizationId },
@@ -213,7 +212,6 @@ export class ManagedAgentService implements OnModuleInit {
       messages: [],
       sessionId,
       vaultIds,
-      turnId: params.turnId,
       toolResults: params.toolUseIds.map((toolUseId) => ({ toolUseId, approved: params.approved, content: [] })),
       webhookMetadata,
     });

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/approval-card.builder.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/approval-card.builder.ts
@@ -49,12 +49,11 @@ export type ManagedCardDelivery = {
 };
 
 // Slack button clicks include action.id (parsed below) and action.value (label text only).
-// Id: mcp-approval:{approve|deny|approve-tool|approve-server}:{toolUseIds}:{turnId}
-// "Always allow" buttons append :{toolName}:{mcpServerName} (URI-encoded) for trust storage.
+// Id: mcp-approval:{approve|deny}:{toolUseIds}
+// "Always allow" buttons: mcp-approval:{approve-tool|approve-server}:{toolUseIds}:{toolName}:{mcpServerName}
 export type ParsedToolApprovalAction = {
   approved: boolean;
   toolUseIds: string[];
-  turnId: string;
   persistScope?: 'tool' | 'server';
   toolName?: string;
   mcpServerName?: string;
@@ -64,15 +63,14 @@ export function parseToolApprovalActionId(id: string | undefined): ParsedToolApp
   if (!id) return null;
   const parts = id.split(':');
   if (parts[0] !== TOOL_APPROVAL_ACTION_PREFIX) return null;
-  if (parts.length !== 4 && parts.length !== 6) return null;
+  if (parts.length !== 3 && parts.length !== 5) return null;
 
   const verdict = parts[1];
   const toolUseIdsPart = parts[2];
-  const turnId = parts[3];
   const isApprove = verdict === 'approve' || verdict === 'approve-tool' || verdict === 'approve-server';
   const isDeny = verdict === 'deny';
 
-  if ((!isApprove && !isDeny) || !toolUseIdsPart || !turnId) return null;
+  if ((!isApprove && !isDeny) || !toolUseIdsPart) return null;
 
   const toolUseIds = toolUseIdsPart.split(',').filter(Boolean);
   if (toolUseIds.length === 0) return null;
@@ -80,7 +78,6 @@ export function parseToolApprovalActionId(id: string | undefined): ParsedToolApp
   const parsed: ParsedToolApprovalAction = {
     approved: isApprove,
     toolUseIds,
-    turnId,
   };
 
   if (verdict === 'approve-tool') {
@@ -91,9 +88,9 @@ export function parseToolApprovalActionId(id: string | undefined): ParsedToolApp
     parsed.persistScope = 'server';
   }
 
-  if (parts.length === 6) {
-    parsed.toolName = decodeURIComponent(parts[4]) || undefined;
-    parsed.mcpServerName = decodeURIComponent(parts[5]) || undefined;
+  if (parts.length === 5) {
+    parsed.toolName = decodeURIComponent(parts[3]) || undefined;
+    parsed.mcpServerName = decodeURIComponent(parts[4]) || undefined;
   }
 
   return parsed;
@@ -101,13 +98,12 @@ export function parseToolApprovalActionId(id: string | undefined): ParsedToolApp
 
 export function buildToolApprovalPersistActionId(
   verdict: 'approve-tool' | 'approve-server',
-  tool: PendingToolApproval,
-  turnId: string
+  tool: PendingToolApproval
 ): string {
   const toolName = encodeURIComponent(tool.toolName);
   const mcpServerName = encodeURIComponent(tool.mcpServerName ?? '');
 
-  return `${TOOL_APPROVAL_ACTION_PREFIX}:${verdict}:${tool.toolUseId}:${turnId}:${toolName}:${mcpServerName}`;
+  return `${TOOL_APPROVAL_ACTION_PREFIX}:${verdict}:${tool.toolUseId}:${toolName}:${mcpServerName}`;
 }
 
 export function extractPendingToolApprovals(response: ThalamusResponse): PendingToolApproval[] {
@@ -134,7 +130,7 @@ export function formatToolLabelForApproval(tool: PendingToolApproval): string {
   return `${tool.toolName}${input}`;
 }
 
-export function buildToolApprovalCard(tool: PendingToolApproval, turnId: string): Record<string, unknown> {
+export function buildToolApprovalCard(tool: PendingToolApproval): Record<string, unknown> {
   const toolLabel = formatToolLabelForApproval(tool);
 
   const children: Record<string, unknown>[] = [
@@ -143,14 +139,14 @@ export function buildToolApprovalCard(tool: PendingToolApproval, turnId: string)
       children: [
         {
           type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${tool.toolUseId}:${turnId}`,
+          id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${tool.toolUseId}`,
           label: 'Deny',
           style: 'default',
           value: toolLabel,
         },
         {
           type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${tool.toolUseId}:${turnId}`,
+          id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${tool.toolUseId}`,
           label: 'Approve once',
           style: 'primary',
           value: toolLabel,
@@ -163,14 +159,14 @@ export function buildToolApprovalCard(tool: PendingToolApproval, turnId: string)
       children: [
         {
           type: 'button',
-          id: buildToolApprovalPersistActionId('approve-tool', tool, turnId),
+          id: buildToolApprovalPersistActionId('approve-tool', tool),
           label: 'Always allow this tool',
           style: 'default',
           value: toolLabel,
         },
         {
           type: 'button',
-          id: buildToolApprovalPersistActionId('approve-server', tool, turnId),
+          id: buildToolApprovalPersistActionId('approve-server', tool),
           label: `Always allow ${tool.mcpServerName ?? 'MCP'}`,
           style: 'default',
           value: toolLabel,
@@ -215,7 +211,7 @@ function formatToolArgumentsBody(tool: PendingToolApproval): string | undefined 
   return truncatedBody.length <= SLACK_CARD_BODY_MAX ? truncatedBody : truncatedBody.slice(0, SLACK_CARD_BODY_MAX);
 }
 
-function buildToolApprovalSlackBlocks(tool: PendingToolApproval, turnId: string): SlackNativeDelivery {
+function buildToolApprovalSlackBlocks(tool: PendingToolApproval): SlackNativeDelivery {
   const argumentsBody = formatToolArgumentsBody(tool);
   const toolLabel = formatToolLabelForApproval(tool);
 
@@ -232,14 +228,14 @@ function buildToolApprovalSlackBlocks(tool: PendingToolApproval, turnId: string)
     actions: [
       {
         type: 'button',
-        action_id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${tool.toolUseId}:${turnId}`,
+        action_id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${tool.toolUseId}`,
         value: toolLabel,
         text: { type: 'plain_text', text: 'Deny', emoji: false },
       },
       {
         type: 'button',
         style: 'primary',
-        action_id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${tool.toolUseId}:${turnId}`,
+        action_id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${tool.toolUseId}`,
         value: toolLabel,
         text: { type: 'plain_text', text: 'Approve once', emoji: false },
       },
@@ -251,7 +247,7 @@ function buildToolApprovalSlackBlocks(tool: PendingToolApproval, turnId: string)
     elements: [
       {
         type: 'button',
-        action_id: buildToolApprovalPersistActionId('approve-tool', tool, turnId),
+        action_id: buildToolApprovalPersistActionId('approve-tool', tool),
         value: toolLabel,
         text: {
           type: 'plain_text',
@@ -261,7 +257,7 @@ function buildToolApprovalSlackBlocks(tool: PendingToolApproval, turnId: string)
       },
       {
         type: 'button',
-        action_id: buildToolApprovalPersistActionId('approve-server', tool, turnId),
+        action_id: buildToolApprovalPersistActionId('approve-server', tool),
         value: toolLabel,
         text: {
           type: 'plain_text',
@@ -281,16 +277,15 @@ function buildToolApprovalSlackBlocks(tool: PendingToolApproval, turnId: string)
 export function getToolApprovalCard(params: {
   platform?: string;
   tool: PendingToolApproval;
-  turnId: string;
   pendingQueueTotal?: number;
 }): ManagedCardDelivery {
-  const card = buildToolApprovalCard(params.tool, params.turnId);
+  const card = buildToolApprovalCard(params.tool);
   const content: ReplyContentDto = { card };
 
   if (params.platform === AgentPlatformEnum.SLACK) {
     return {
       content,
-      slackNative: buildToolApprovalSlackBlocks(params.tool, params.turnId),
+      slackNative: buildToolApprovalSlackBlocks(params.tool),
     };
   }
 

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/confirm-tool-approval.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/confirm-tool-approval.usecase.ts
@@ -48,7 +48,6 @@ export class ConfirmToolApproval {
       platform: command.platform,
       toolUseIds,
       approved: parsed.approved,
-      turnId: parsed.turnId,
     });
 
     this.deleteApprovalCard(command);
@@ -190,7 +189,6 @@ export class ConfirmToolApproval {
               agentIdentifier: command.agentIdentifier,
               integrationIdentifier: command.integrationIdentifier,
               toolProgress: {
-                turnId: parsed.turnId,
                 action: 'tool-use',
                 toolUseId,
                 status: 'error',
@@ -216,7 +214,6 @@ export class ConfirmToolApproval {
           agentIdentifier: command.agentIdentifier,
           integrationIdentifier: command.integrationIdentifier,
           toolProgress: {
-            turnId: parsed.turnId,
             action: 'approved',
           },
         })

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.command.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.command.ts
@@ -28,9 +28,5 @@ export class HandlePendingToolApprovalsCommand extends EnvironmentWithUserComman
   @IsNotEmpty()
   sessionId: string;
 
-  @IsString()
-  @IsNotEmpty()
-  turnId: string;
-
   response: ThalamusResponse;
 }

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
@@ -124,7 +124,6 @@ export class HandlePendingToolApprovals {
         platform: command.platform as AgentPlatformEnum | undefined,
         toolUseIds: trustedTools.map((tool) => tool.toolUseId),
         approved: true,
-        turnId: command.turnId,
       });
     } catch (err) {
       this.logger.warn(
@@ -168,7 +167,7 @@ export class HandlePendingToolApprovals {
           conversationId: command.conversationId,
           agentIdentifier: command.agentIdentifier,
           integrationIdentifier: command.integrationIdentifier,
-          toolProgress: { turnId: command.turnId, action: 'fail' },
+          toolProgress: { action: 'fail' },
         })
       );
     } catch (deliveryErr) {
@@ -238,7 +237,6 @@ export class HandlePendingToolApprovals {
     const delivery = getToolApprovalCard({
       platform: command.platform,
       tool,
-      turnId: command.turnId,
       pendingQueueTotal,
     });
 
@@ -274,7 +272,7 @@ export class HandlePendingToolApprovals {
         conversationId: command.conversationId,
         agentIdentifier: command.agentIdentifier,
         integrationIdentifier: command.integrationIdentifier,
-        toolProgress: { turnId: command.turnId, action: 'awaiting-approval' },
+        toolProgress: { action: 'awaiting-approval' },
       })
     );
   }

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -141,10 +141,10 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     });
   }
 
-  async findToolActivitiesByTurnId(
+  async findToolActivitiesByPlanMessageId(
     environmentId: string,
     conversationId: string,
-    turnId: string
+    planMessageId: string
   ): Promise<ConversationActivityEntity[]> {
     return this.find(
       {
@@ -152,7 +152,7 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
         _conversationId: conversationId,
         type: ConversationActivityTypeEnum.SIGNAL,
         'signalData.type': 'tool-use',
-        'signalData.payload.turnId': turnId,
+        'signalData.payload.planMessageId': planMessageId,
       } as FilterQuery<ConversationActivityDBModel> & EnforceEnvOrOrgIds,
       '*',
       { sort: { createdAt: 1 } }

--- a/libs/dal/src/repositories/conversation/conversation.entity.ts
+++ b/libs/dal/src/repositories/conversation/conversation.entity.ts
@@ -86,6 +86,13 @@ export class ConversationEntity {
   managedSessionVaultId?: string;
 
   /**
+   * Slack message ID of the currently active plan card.
+   * Set on first tool, cleared on finalize.
+   * Only one card is always active per conversation.
+   */
+  activePlanMessageId?: string;
+
+  /**
    * Set while managed-agent setup blocks dispatch for this thread. Cleared after
    * the parked inbound is replayed or the setup card is resolved without replay.
    */

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -232,6 +232,25 @@ export class ConversationRepository extends BaseRepositoryV2<
     );
   }
 
+  async setActivePlanMessageId(
+    environmentId: string,
+    organizationId: string,
+    conversationId: string,
+    planMessageId: string
+  ): Promise<void> {
+    await this.update(
+      { _id: conversationId, _environmentId: environmentId, _organizationId: organizationId },
+      { $set: { activePlanMessageId: planMessageId } }
+    );
+  }
+
+  async clearActivePlanMessageId(environmentId: string, organizationId: string, conversationId: string): Promise<void> {
+    await this.update(
+      { _id: conversationId, _environmentId: environmentId, _organizationId: organizationId },
+      { $unset: { activePlanMessageId: '' } }
+    );
+  }
+
   async clearPendingManagedAgentSetup(
     environmentId: string,
     organizationId: string,

--- a/libs/dal/src/repositories/conversation/conversation.schema.ts
+++ b/libs/dal/src/repositories/conversation/conversation.schema.ts
@@ -84,6 +84,9 @@ const conversationSchema = new Schema<ConversationDBModel>(
     managedSessionVaultId: {
       type: Schema.Types.String,
     },
+    activePlanMessageId: {
+      type: Schema.Types.String,
+    },
     pendingManagedAgentSetup: {
       type: new Schema(
         {


### PR DESCRIPTION
## Summary

- **Root cause**: Plan card state was tracked via `turnId` (Thalamus observation ID), which changes when a new user message triggers a new `provider.send()` call. This caused `HandlePlanProgress` to lose track of the active plan card, leaving it stuck on "Thinking…" indefinitely.
- **Fix**: Replaced `turnId`-based plan tracking with `activePlanMessageId` on the conversation entity. Set on first tool event, cleared on `onFinish`. This gives a single deterministic pointer to the current plan card regardless of observation changes.
- **Cleanup**: Removed `turnId` from the entire API-side codebase — it was only a passthrough token with no functional use after the tracking change. Simplified approval card button format from 4-part to 3-part action IDs.

## Changes

### `libs/dal/`
- Added `activePlanMessageId` field to `ConversationEntity` + schema
- Added `setActivePlanMessageId` / `clearActivePlanMessageId` repository methods
- Replaced `findToolActivitiesByToolUseId` + `findLatestPlanActivities` with `findToolActivitiesByPlanMessageId`

### `apps/api/` — Plan progress
- `HandlePlanProgress` now reads `conversation.activePlanMessageId` to find the active card
- New `handleFinalize` method for `complete`/`fail` actions — marks card as "Finished thinking" and clears `activePlanMessageId`
- Removed `turnId` from `ToolProgressPayload`

### `apps/api/` — Approval flow
- Removed `turnId` from approval card builder, parser, button action IDs, commands, and `resumeWithToolResults`
- Button format: `mcp-approval:{verdict}:{toolUseIds}` (was `..:{turnId}`)
- Persist buttons: `mcp-approval:{verdict}:{toolUseIds}:{toolName}:{mcpServerName}` (was `..:{turnId}:..`)

```mermaid
sequenceDiagram
    participant U as User (Slack)
    participant API as Novu API
    participant T as Thalamus
    participant A as Anthropic

    U->>API: Message 1
    API->>T: provider.send()
    T->>A: SSE stream
    A-->>T: onToolUseStart
    T-->>API: webhook (tool-use running)
    API->>API: handleToolUse → post card, set activePlanMessageId
    A-->>T: onToolUseResult
    T-->>API: webhook (tool-use complete)
    API->>API: handleToolUse → edit card
    A-->>T: onFinish
    T-->>API: webhook (complete)
    API->>API: handleFinalize → "Finished thinking", clear activePlanMessageId

    U->>API: Message 2
    Note over API: activePlanMessageId is null → fresh card
    API->>T: provider.send()
    T->>A: new SSE stream
    A-->>T: onToolUseStart
    T-->>API: webhook (tool-use running)
    API->>API: handleToolUse → NEW card, set activePlanMessageId
```

## Test plan
- [x] Single tool call → card posts, shows tool, finalizes as "Finished thinking"
- [x] Multi-tool batch (e.g. "call 2 web search tools") → both tools on same card
- [x] Sequential messages with tools → each message gets its own card
- [x] Approval flow → card shows "Waiting for approval…", approve resumes correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Plan cards are no longer stuck in "Thinking…" state when conversations receive new user messages. The fix replaces `turnId`-based card tracking (which changed on each new user message) with a persistent `activePlanMessageId` stored on the conversation entity. This pointer is set when the first tool event occurs and cleared after plan finalization, allowing subsequent messages to get fresh plan cards.

## Affected areas

**dal**: Added `activePlanMessageId` field to `ConversationEntity` and schema; replaced `findToolActivitiesByTurnId` with `findToolActivitiesByPlanMessageId`; added `setActivePlanMessageId` and `clearActivePlanMessageId` repository methods.

**api**: Updated `HandlePlanProgress` to read and update `conversation.activePlanMessageId` instead of deriving card IDs from tool activities; added `handleFinalize` to clear the active plan message ID; added `ConversationRepository` as a dependency.

**api (Approval flow)**: Removed `turnId` from all approval card IDs, buttons, and command payloads; simplified button action format from 4-part to 3-part (`mcp-approval:{verdict}:{toolUseIds}`); removed `turnId` from `resumeWithToolResults` call.

## Key technical decisions

- **Schema change**: Added optional `activePlanMessageId: string` field to `ConversationEntity` to persist the current plan card message ID across tool lifecycle events.
- **Removed `turnId` parameter**: Eliminated `turnId` from `ToolProgressPayload`, `HandlePendingToolApprovalsCommand`, approval card builders, and managed agent service signatures—this field was driving the root cause bug.
- **Deterministic tracking**: Conversation-level `activePlanMessageId` provides a single source of truth, replacing the implicit state derived from tool activities tied to transient turn IDs.

## Testing

Test plan verified single tool calls, multi-tool batch aggregation, sequential message isolation, and approval flow with correct state transitions. Manual verification confirms plan cards finalize as "Finished thinking" and no longer get stuck on interrupts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->