### PR TITLE
feat(framework): allow passing a custom logger to the client fixes NV-7963

### DIFF
--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -98,6 +98,63 @@ describe('Novu Client', () => {
       expect(newClient.strictAuthentication).toBe(true);
       process.env = { ...process.env, NOVU_STRICT_AUTHENTICATION_ENABLED: originalEnv };
     });
+
+    it('should set logger to the global console by default', () => {
+      const newClient = new Client({ secretKey: 'some-secret-key' });
+      expect(newClient.logger).toBe(console);
+    });
+
+    it('should set logger to the provided logger', () => {
+      const customLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const newClient = new Client({ secretKey: 'some-secret-key', logger: customLogger });
+      expect(newClient.logger).toBe(customLogger);
+    });
+  });
+
+  describe('logger option', () => {
+    it('should route verbose discovery and execution logs through the provided logger', async () => {
+      const customLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      const loggingWorkflow = workflow('logging-workflow', async ({ step }) => {
+        await step.email('send-email', async () => ({ body: 'Test Body', subject: 'Subject' }));
+      });
+
+      const newClient = new Client({ secretKey: 'some-secret-key', verbose: true, logger: customLogger });
+      await newClient.addWorkflows([loggingWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.EXECUTE,
+        workflowId: 'logging-workflow',
+        stepId: 'send-email',
+        subscriber: {},
+        state: [],
+        payload: {},
+        controls: {},
+        context: {},
+        env: testEventEnv,
+      };
+
+      await newClient.executeWorkflow(event);
+
+      expect(customLogger.info).toHaveBeenCalled();
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should not emit discovery or execution logs when verbose is false', async () => {
+      const customLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const silentWorkflow = workflow('silent-workflow', async ({ step }) => {
+        await step.email('send-email', async () => ({ body: 'Test Body', subject: 'Subject' }));
+      });
+
+      const newClient = new Client({ secretKey: 'some-secret-key', verbose: false, logger: customLogger });
+      await newClient.addWorkflows([silentWorkflow]);
+
+      expect(customLogger.info).not.toHaveBeenCalled();
+    });
   });
 
   describe('discover method', () => {

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -32,6 +32,7 @@ import type {
   Event,
   ExecuteOutput,
   HealthCheck,
+  Logger,
   Schema,
   Skip,
   State,
@@ -71,12 +72,15 @@ export class Client {
 
   public verbose: boolean;
 
+  public logger: Logger;
+
   constructor(options?: ClientOptions) {
     const builtOpts = this.buildOptions(options);
     this.apiUrl = builtOpts.apiUrl;
     this.secretKey = builtOpts.secretKey;
     this.strictAuthentication = builtOpts.strictAuthentication;
     this.verbose = builtOpts.verbose;
+    this.logger = builtOpts.logger;
     this.templateEngine = createLiquidEngine();
   }
 
@@ -86,6 +90,7 @@ export class Client {
       secretKey: resolveSecretKey(providedOptions?.secretKey),
       strictAuthentication: !isRuntimeInDevelopment(),
       verbose: isRuntimeInDevelopment(),
+      logger: console,
     };
 
     if (providedOptions?.strictAuthentication !== undefined) {
@@ -98,12 +103,16 @@ export class Client {
       builtConfiguration.verbose = providedOptions.verbose;
     }
 
+    if (providedOptions?.logger !== undefined) {
+      builtConfiguration.logger = providedOptions.logger;
+    }
+
     return builtConfiguration;
   }
 
   private log(...args: any[]): void {
     if (this.verbose) {
-      console.log(...args);
+      this.logger.info(...args);
     }
   }
 
@@ -147,7 +156,7 @@ export class Client {
   private async addWorkflow(workflow: Workflow): Promise<void> {
     try {
       const definition = await workflow.discover();
-      prettyPrintDiscovery(definition, this.verbose);
+      prettyPrintDiscovery(definition, this.verbose, this.logger);
       this.discoveredWorkflows.set(workflow.id, definition);
     } finally {
       this.discoverWorkflowPromises.delete(workflow.id);
@@ -217,7 +226,7 @@ export class Client {
     } catch (error) {
       // If JSONSchemaFaker fails, return an empty object as fallback
       // This prevents the preview from crashing on complex schemas
-      console.warn('Failed to mock schema, returning empty object:', error);
+      this.logger.warn('Failed to mock schema, returning empty object:', error);
       return {};
     }
   }
@@ -572,10 +581,12 @@ export class Client {
     const message = error ? 'Failed to execute' : actionMessage;
     const executionLog = error ? log.error : log.success;
     const logMessage = `${successPrefix} ${message} workflowId: '${event.workflowId}`;
-    console.log(`\n  ${log.bold(executionLog(logMessage))}'`);
-    console.log(`  ├ ${EMOJI.STEP} stepId: '${event.stepId}'`);
-    console.log(`  ├ ${EMOJI.ACTION} action: '${event.action}'`);
-    console.log(`  └ ${EMOJI.DURATION} duration: '${duration.toFixed(2)}ms'\n`);
+    this.logger.info(
+      `\n  ${log.bold(executionLog(logMessage))}'\n` +
+        `  ├ ${EMOJI.STEP} stepId: '${event.stepId}'\n` +
+        `  ├ ${EMOJI.ACTION} action: '${event.action}'\n` +
+        `  └ ${EMOJI.DURATION} duration: '${duration.toFixed(2)}ms'\n`
+    );
   }
 
   private async executeProviders(

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -235,9 +235,9 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
 
         const handlerPromise = this.runAgentHandler(registeredAgent, agentEvent, ctx).catch((err) => {
           if (err instanceof AgentDeliveryError) {
-            console.error(`[agent:${agentId}] ${err.message}`);
+            this.client.logger.error(`[agent:${agentId}] ${err.message}`);
           } else {
-            console.error(`[agent:${agentId}] Handler error:`, err);
+            this.client.logger.error(`[agent:${agentId}] Handler error:`, err);
           }
         });
 
@@ -354,7 +354,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
          * Log bridge server errors to assist the Developer in debugging errors with their integration.
          * This path is reached when the Bridge application throws an error, ensuring they can see the error in their logs.
          */
-        console.error(error);
+        this.client.logger.error(error);
       }
 
       return this.createError(error);
@@ -362,7 +362,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
       return this.createError(error);
     } else {
       const bridgeError = new BridgeError(error);
-      console.error(bridgeError);
+      this.client.logger.error(bridgeError);
 
       return this.createError(bridgeError);
     }

--- a/packages/framework/src/resources/workflow/pretty-print-discovery.ts
+++ b/packages/framework/src/resources/workflow/pretty-print-discovery.ts
@@ -1,19 +1,23 @@
-import type { DiscoverWorkflowOutput } from '../../types';
+import type { DiscoverWorkflowOutput, Logger } from '../../types';
 import { EMOJI, log } from '../../utils';
 
-export function prettyPrintDiscovery(discoveredWorkflow: DiscoverWorkflowOutput, verbose: boolean = true): void {
+export function prettyPrintDiscovery(
+  discoveredWorkflow: DiscoverWorkflowOutput,
+  verbose: boolean = true,
+  logger: Logger = console
+): void {
   if (!verbose) return;
 
-  console.log(`\n${log.bold(log.underline('Discovered workflowId:'))} '${discoveredWorkflow.workflowId}'`);
+  logger.info(`\n${log.bold(log.underline('Discovered workflowId:'))} '${discoveredWorkflow.workflowId}'`);
   discoveredWorkflow.steps.forEach((step, i) => {
     const isLastStep = i === discoveredWorkflow.steps.length - 1;
     const prefix = isLastStep ? '└' : '├';
-    console.log(`${prefix} ${EMOJI.STEP} Discovered stepId: '${step.stepId}'\tType: '${step.type}'`);
+    logger.info(`${prefix} ${EMOJI.STEP} Discovered stepId: '${step.stepId}'\tType: '${step.type}'`);
     step.providers.forEach((provider, providerIndex) => {
       const isLastProvider = providerIndex === step.providers.length - 1;
       const stepPrefix = isLastStep ? ' ' : '│';
       const providerPrefix = isLastProvider ? '└' : '├';
-      console.log(`${stepPrefix} ${providerPrefix} ${EMOJI.PROVIDER} Discovered provider: '${provider.type}'`);
+      logger.info(`${stepPrefix} ${providerPrefix} ${EMOJI.PROVIDER} Discovered provider: '${provider.type}'`);
     });
   });
 }

--- a/packages/framework/src/types/config.types.ts
+++ b/packages/framework/src/types/config.types.ts
@@ -1,3 +1,19 @@
+/**
+ * A minimal logger interface used for all of the framework's internal logging
+ * (workflow discovery, execution and bridge error reporting).
+ *
+ * The methods (`info`/`warn`/`error`) are chosen so that both the global
+ * `console` and common structured loggers (pino, winston, ...) satisfy this
+ * interface directly, with no adapter. The global `console` is the default;
+ * provide your own to route Novu's internal logs wherever the rest of your
+ * application logs go.
+ */
+export type Logger = {
+  info: typeof console.info;
+  warn: typeof console.warn;
+  error: typeof console.error;
+};
+
 export type ClientOptions = {
   /**
    * Use Novu Cloud US (https://api.novu.co) or EU deployment (https://eu.api.novu.co). Defaults to US.
@@ -30,4 +46,18 @@ export type ClientOptions = {
    * Defaults to `true` in development, `false` in production.
    */
   verbose?: boolean;
+
+  /**
+   * A custom logger used for all of the framework's internal logging
+   * (workflow discovery, execution and bridge error reporting).
+   *
+   * Defaults to the global `console`. Provide your own logger to route Novu's
+   * internal logs through your application's structured logger.
+   *
+   * Note: `verbose` still controls *whether* discovery and execution logs are
+   * emitted; `logger` only controls *where* all logs are written. Bridge errors
+   * (HTTP status >= 500) are always logged via this logger, regardless of
+   * `verbose`.
+   */
+  logger?: Logger;
 };


### PR DESCRIPTION
The framework logs workflow discovery, execution and bridge errors directly via the global `console`. The `verbose` option can silence the discovery/execution logs, but there is no way to redirect any of them into an application logger, and the bridge-error logs (HTTP >= 500) are emitted regardless of `verbose`.

This adds an optional `logger` to `ClientOptions`. The interface (`info`/`warn`/`error`) is chosen so that both the global `console` and common structured loggers (pino, winston, ...) satisfy it directly with no adapter. It defaults to the global `console`, so existing behaviour is unchanged. All internal `console.*` calls in the client, discovery pretty-printer and request handler now go through this logger.

`verbose` keeps controlling *whether* discovery/execution logs are emitted; `logger` controls *where* all logs are written.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The framework client now supports an optional injectable `logger` parameter in `ClientOptions`, enabling applications to route internal logs to their own logger (e.g., pino, winston) instead of the global `console`. The `Logger` interface accepts `info`, `warn`, and `error` methods—compatible with both `console` and common structured loggers. When not provided, the logger defaults to `console`, preserving existing behavior. The `verbose` option continues to control whether discovery/execution logs are emitted, while the logger instance controls where they are written.

## Affected areas
**framework**: Updated the `Client` class to accept and store an optional `logger` property, route all internal logging calls (`console.info`, `console.warn`, `console.error`) through the injected logger, and pass the logger to utility functions like `prettyPrintDiscovery`. Added the `Logger` type export in configuration types. Updated the request handler to emit bridge and execution errors via the client's logger instead of the global `console`.

## Key technical decisions
- The `Logger` interface uses only `info`, `warn`, and `error` methods to maintain compatibility with the global `console` and common structured loggers without requiring an adapter layer.
- The logger defaults to `console` in `buildOptions` to preserve backward compatibility for existing code that doesn't provide a custom logger.
- The `verbose` option remains decoupled from logger selection, so applications can silence logs via `verbose: false` while still capturing errors through the logger when `verbose: true`.

## Testing
New unit tests were added to verify that the `Client` logger defaults to `console` when not provided, uses a custom logger instance when passed, and correctly routes discovery/execution logs through the provided logger based on the `verbose` flag. Test coverage confirms that logs are not emitted via `console.info` when a custom logger is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `logger` field to `ClientOptions` that lets consumers redirect all internal framework logs (workflow discovery, execution, and bridge errors) to any structured logger (pino, winston, etc.) that exposes `info`/`warn`/`error` methods. It defaults to the global `console`, so existing behaviour is fully preserved.

- **New `Logger` type** defined in `config.types.ts`, wired through `buildOptions` and stored as `Client.logger`; all internal `console.*` calls in `client.ts`, `handler.ts`, and `pretty-print-discovery.ts` now go through this logger.
- **`verbose` semantics unchanged**: it still gates whether discovery/execution logs are emitted; the new `logger` only controls the destination. Bridge errors (HTTP ≥ 500) always log regardless of `verbose`.
- **Tests added** for default logger, custom logger assignment, routing through the custom logger when `verbose` is true, and suppression when `verbose` is false.

<h3>Confidence Score: 4/5</h3>

Safe to merge; change is additive and fully backward-compatible, with `console` as the unchanged default.

The `Logger` type is defined and used internally but never added to the named exports in `src/index.ts`, so consumers cannot import it to annotate their own logger variables. Additionally, the refactor in `prettyPrintExecute` merges four separate log calls into one multi-line string, which changes how the output lands in JSON-based structured loggers. Neither issue is a runtime regression, but both are worth addressing before or shortly after merge.

`src/index.ts` (missing `Logger` export) and `src/client.ts` `prettyPrintExecute` method (multi-line string collapsing).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/types/config.types.ts | Adds `Logger` type and optional `logger` field to `ClientOptions`. Type is well-documented; not yet exported from the package's public API. |
| packages/framework/src/client.ts | Wires `logger` through `buildOptions`, replaces all `console.*` calls with `this.logger.*`, and collapses four `console.log` calls in `prettyPrintExecute` into a single `logger.info` with embedded newlines. |
| packages/framework/src/handler.ts | Replaces three `console.error` calls with `this.client.logger.error`, correctly routing bridge and agent errors through the custom logger. |
| packages/framework/src/resources/workflow/pretty-print-discovery.ts | Accepts an optional `Logger` parameter (defaulting to `console`) and replaces all `console.log` calls with `logger.info`. Backward-compatible signature change. |
| packages/framework/src/client.test.ts | Adds tests for default logger, custom logger assignment, routing through custom logger when verbose, and suppression when verbose is false. Coverage looks adequate. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ClientOptions\n{ logger?, verbose? }"] --> B["Client.buildOptions()"]
    B --> C{"logger provided?"}
    C -- Yes --> D["this.logger = providedLogger"]
    C -- No --> E["this.logger = console (default)"]
    D --> F["Client.logger"]
    E --> F

    F --> G["this.log() — verbose guard"]
    F --> H["this.logger.warn() — always"]
    F --> I["this.logger.error() — always"]

    G --> J{"this.verbose?"}
    J -- true --> K["logger.info()\ndiscovery / execution logs"]
    J -- false --> L["suppressed"]

    H --> M["mockSchema warning"]
    I --> N["NovuRequestHandler\nbridge & agent errors"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fframework%2Fsrc%2Fclient.ts%3A584-589%0A**Multi-line%20string%20collapses%20four%20log%20events%20into%20one**%0A%0AThe%20original%20code%20made%20four%20distinct%20%60console.log%60%20calls%3B%20each%20produced%20a%20separate%2C%20time-stamped%20entry%20in%20structured%20logging%20systems.%20The%20refactor%20concatenates%20all%20lines%20into%20a%20single%20%60logger.info%28...%29%60%20call%20with%20embedded%20%60%5Cn%60%20characters.%20For%20%60console%60%20%28default%29%20the%20rendered%20output%20is%20identical%2C%20but%20for%20JSON-based%20loggers%20%28pino%2C%20winston%20in%20JSON%20mode%29%20all%20four%20lines%20end%20up%20in%20one%20message%20field%20rather%20than%20discrete%20entries.%20This%20can%20make%20log%20ingestion%2C%20filtering%2C%20and%20correlation%20harder.%20Consider%20keeping%20each%20line%20as%20a%20separate%20%60logger.info%60%20call%20to%20preserve%20the%20original%20one-record-per-line%20structure.%0A%0A&pr=11440&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/framework/src/client.ts:584-589
**Multi-line string collapses four log events into one**

The original code made four distinct `console.log` calls; each produced a separate, time-stamped entry in structured logging systems. The refactor concatenates all lines into a single `logger.info(...)` call with embedded `\n` characters. For `console` (default) the rendered output is identical, but for JSON-based loggers (pino, winston in JSON mode) all four lines end up in one message field rather than discrete entries. This can make log ingestion, filtering, and correlation harder. Consider keeping each line as a separate `logger.info` call to preserve the original one-record-per-line structure.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(framework): allow passing a custom ..."](https://github.com/novuhq/novu/commit/aa89a2f1463ef6b0bc18acde059a859b9972f28c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35431324)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->