### PR TITLE
feat(dashboard): update platform agents empty state copy

### DIFF
--- a/apps/dashboard/src/components/agents/agents-empty-teaser.tsx
+++ b/apps/dashboard/src/components/agents/agents-empty-teaser.tsx
@@ -26,9 +26,10 @@ function AgentsPill({ children, className }: AgentsPillProps) {
 
 type AgentsEmptyTeaserProps = {
   cta: ReactNode;
+  isConnectApp?: boolean;
 };
 
-export function AgentsEmptyTeaser({ cta }: AgentsEmptyTeaserProps) {
+export function AgentsEmptyTeaser({ cta, isConnectApp = false }: AgentsEmptyTeaserProps) {
   return (
     <div className="flex h-full flex-col items-center justify-center px-4 py-10 md:px-8">
       <div className="flex w-full max-w-[800px] flex-col items-stretch gap-12">
@@ -43,10 +44,14 @@ export function AgentsEmptyTeaser({ cta }: AgentsEmptyTeaserProps) {
         <div className="flex w-full max-w-[700px] flex-col items-start gap-3 self-start">
           <div className="flex flex-col gap-1 text-left">
             <p className="text-text-strong text-[16px] font-medium leading-6 tracking-[-0.176px]">
-              Connect your agent. Everywhere your team works.
+              {isConnectApp
+                ? 'Connect your agent. Everywhere your team works.'
+                : 'Connect your agent. Everywhere your customers are.'}
             </p>
             <p className="text-text-soft text-[14px] font-medium leading-5 tracking-[-0.084px]">
-              Give it a voice in every channel your team uses.
+              {isConnectApp
+                ? 'Give it a voice in every channel your team uses.'
+                : 'A unified API to connect AI SDK/Langchain/Claude managed agents to any channel'}
             </p>
           </div>
 
@@ -74,23 +79,25 @@ export function AgentsEmptyTeaser({ cta }: AgentsEmptyTeaserProps) {
               <span>Authorize tools mid-conversation. No setup gauntlets.</span>
             </li>
 
-            <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
-              <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
-              <span>Connect tools and MCPs</span>
-              <AgentsPill className="-rotate-1">
-                <RiGithubFill className="size-3.5 shrink-0" aria-hidden />
-                <span>GitHub</span>
-              </AgentsPill>
-              <AgentsPill className="rotate-1">
-                <SiLinear className="size-3.5 shrink-0 text-[#5C6BF1]" aria-hidden />
-                <span>Linear</span>
-              </AgentsPill>
-              <AgentsPill className="-rotate-1">
-                <SiNotion className="text-text-strong size-3.5 shrink-0" aria-hidden />
-                <span>Notion</span>
-              </AgentsPill>
-              <span>and custom tools your team works on.</span>
-            </li>
+            {isConnectApp ? (
+              <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
+                <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
+                <span>Connect tools and MCPs</span>
+                <AgentsPill className="-rotate-1">
+                  <RiGithubFill className="size-3.5 shrink-0" aria-hidden />
+                  <span>GitHub</span>
+                </AgentsPill>
+                <AgentsPill className="rotate-1">
+                  <SiLinear className="size-3.5 shrink-0 text-[#5C6BF1]" aria-hidden />
+                  <span>Linear</span>
+                </AgentsPill>
+                <AgentsPill className="-rotate-1">
+                  <SiNotion className="text-text-strong size-3.5 shrink-0" aria-hidden />
+                  <span>Notion</span>
+                </AgentsPill>
+                <span>and custom tools your team works on.</span>
+              </li>
+            ) : null}
           </ul>
 
           <div className="flex w-full justify-start">{cta}</div>

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -273,6 +273,7 @@ export function AgentsList() {
 
       return (
         <AgentsEmptyTeaser
+          isConnectApp={isConnectApp}
           cta={
             <PermissionButton
               permission={PermissionsEnum.AGENT_WRITE}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the agents empty state copy for the **Platform** (non-Connect) product type.

### Platform empty state (new)
- **Headline:** Connect your agent. Everywhere your customers are.
- **Description:** A unified API to connect AI SDK/Langchain/Claude managed agents to any channel
- **Bullets:** Removed the third bullet (Connect tools and MCPs) for now

### Connect empty state
- Unchanged — keeps existing team-focused copy and all three bullets

## Changes
- `AgentsEmptyTeaser` accepts an `isConnectApp` prop to render product-specific copy
- `AgentsList` passes `isConnectApp` when rendering the empty state

## Testing
- Verified no linter errors on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9d0b9b3-f090-426b-a9cb-efadb12abd70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9d0b9b3-f090-426b-a9cb-efadb12abd70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

`AgentsEmptyTeaser` now accepts an optional `isConnectApp` prop to render product-specific copy for Platform vs Connect product types. When `false` (default), it displays Platform messaging ("Connect your agent. Everywhere your customers are.") targeting end customers. When `true`, it switches to team-focused Connect copy and shows the "Connect tools and MCPs" feature bullet. The `AgentsList` component now passes `isConnectApp` when rendering the empty state, ensuring the correct messaging appears for each product context.

## Affected areas

**`@novu/dashboard`**: Updated `AgentsEmptyTeaser` component to conditionally render headline, description, and feature bullets based on product type (Platform vs Connect), and modified `AgentsList` to pass the `isConnectApp` prop to the empty state teaser.

## Testing

No automated tests were added. The PR was verified against linter checks on modified files. Given the narrowly scoped conditional rendering of copy and the existing manual verification, additional test coverage is recommended for the different rendering paths (Platform vs Connect states).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the agents empty state component to show product-specific copy depending on whether the user is in the Platform or Connect app context. The change is minimal and well-contained, reusing the already-computed `isConnectApp` flag from `AgentsList`.

- `AgentsEmptyTeaser` gains an optional `isConnectApp` prop (defaults to `false`) that switches the headline, description, and third feature bullet between Platform-facing and Connect-facing copy.
- `AgentsList` threads the existing `isConnectApp` boolean into the empty state render, with no logic changes elsewhere.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow copy update with no logic, data, or API surface changes.

Both files touch only UI copy and conditional rendering of existing JSX. The isConnectApp flag is already computed upstream and simply threaded down to the teaser; no new logic paths, state changes, or external calls are introduced. The default value of false preserves the new Platform messaging as the fallback, which matches the stated intent.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agents-empty-teaser.tsx | Adds `isConnectApp` prop (defaults to `false`) to conditionally render Platform vs Connect copy; third bullet conditionally rendered only for Connect. |
| apps/dashboard/src/components/agents/agents-list.tsx | Passes the existing `isConnectApp` boolean (already derived from `currentApp === APP_IDS.CONNECT`) down to `AgentsEmptyTeaser`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    AL[AgentsList] -->|derives| ICA{isConnectApp}
    ICA -->|true: Connect| AET_C[AgentsEmptyTeaser\nConnect copy\n+ MCPs bullet]
    ICA -->|false: Platform| AET_P[AgentsEmptyTeaser\nPlatform copy\nno MCPs bullet]
    AL -->|passes isConnectApp| AET_C
    AL -->|passes isConnectApp| AET_P
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;next&#39; into cursor/agents-e..."](https://github.com/novuhq/novu/commit/4d59bb72a9a1f45e08ba474b6ed6c43757d9c7f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35546554)</sub>

<!-- /greptile_comment -->