### PR TITLE
fix(shared,dashboard): keep catalog oauth and $schema on duplicates fixes NV-7964

### DIFF
--- a/apps/dashboard/src/components/schema-editor/use-schema-form.ts
+++ b/apps/dashboard/src/components/schema-editor/use-schema-form.ts
@@ -1,10 +1,11 @@
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { MAX_NESTING_DEPTH } from './constants';
 import type { JSONSchema7, JSONSchema7TypeName } from './json-schema';
 import type { SchemaFormPath, UseSchemaFormProps, UseSchemaFormReturn } from './types';
 import {
+  carryOverCommonKeywords,
   convertPropertyListToSchema,
   convertSchemaToPropertyList,
   createPropertyItem,
@@ -24,6 +25,12 @@ const defaultFormValues: SchemaEditorFormValues = {
 const DEBOUNCE_DELAY = 300;
 
 export function useSchemaForm({ initialSchema, onChange, onValidityChange }: UseSchemaFormProps): UseSchemaFormReturn {
+  const rootSchemaRef = useRef(initialSchema);
+
+  useEffect(() => {
+    rootSchemaRef.current = initialSchema;
+  }, [initialSchema]);
+
   const initialTransformedValues: SchemaEditorFormValues = {
     propertyList: initialSchema?.properties
       ? convertSchemaToPropertyList(initialSchema.properties, initialSchema.required)
@@ -58,7 +65,10 @@ export function useSchemaForm({ initialSchema, onChange, onValidityChange }: Use
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         if (onChange && value.propertyList) {
-          const outputSchema = createSchemaFromPropertyList(value.propertyList as PropertyListItem[]);
+          const outputSchema = createSchemaFromPropertyList(
+            value.propertyList as PropertyListItem[],
+            rootSchemaRef.current
+          );
           onChange(outputSchema);
         }
       }, DEBOUNCE_DELAY);
@@ -115,7 +125,8 @@ export function useSchemaForm({ initialSchema, onChange, onValidityChange }: Use
 
   const getCurrentSchema = useCallback((): JSONSchema7 => {
     const propertyList = getValues().propertyList as PropertyListItem[];
-    return createSchemaFromPropertyList(propertyList);
+
+    return createSchemaFromPropertyList(propertyList, rootSchemaRef.current);
   }, [getValues]);
 
   const resetToSchema = useCallback(
@@ -145,14 +156,20 @@ export function useSchemaForm({ initialSchema, onChange, onValidityChange }: Use
 }
 
 // Helper functions
-function createSchemaFromPropertyList(propertyList: PropertyListItem[]): JSONSchema7 {
+function createSchemaFromPropertyList(propertyList: PropertyListItem[], rootSchema?: JSONSchema7): JSONSchema7 {
   const { properties, required } = convertPropertyListToSchema(propertyList);
 
-  return {
+  const schema: JSONSchema7 = {
     type: 'object',
     properties,
     ...(required && required.length > 0 ? { required } : {}),
   };
+
+  if (rootSchema) {
+    carryOverCommonKeywords(rootSchema, schema);
+  }
+
+  return schema;
 }
 
 function appendRootProperty(

--- a/apps/dashboard/src/components/schema-editor/utils/json-helpers.ts
+++ b/apps/dashboard/src/components/schema-editor/utils/json-helpers.ts
@@ -1,7 +1,7 @@
 import type { JSONSchema7, JSONSchema7TypeName } from '../json-schema';
 
 // Helper to carry over common/metadata keywords
-function carryOverCommonKeywords(originalSchema: JSONSchema7, newSchema: Partial<JSONSchema7>) {
+export function carryOverCommonKeywords(originalSchema: JSONSchema7, newSchema: Partial<JSONSchema7>) {
   if (originalSchema.title !== undefined) newSchema.title = originalSchema.title;
   if (originalSchema.description !== undefined) newSchema.description = originalSchema.description;
   if (originalSchema.default !== undefined) newSchema.default = originalSchema.default; // Type compatibility should be ensured by caller or validation

--- a/apps/dashboard/src/components/schema-editor/utils/schema-converter.ts
+++ b/apps/dashboard/src/components/schema-editor/utils/schema-converter.ts
@@ -87,6 +87,10 @@ export function convertPropertyListToSchema(propertyList?: PropertyListItem[]): 
       return;
     }
 
+    if (properties[item.keyName] !== undefined) {
+      return;
+    }
+
     const currentDefinition = processPropertyDefinition(item.definition, item.isNullable);
 
     if (item.isRequired) {

--- a/packages/shared/src/consts/providers/mcp-servers.spec.ts
+++ b/packages/shared/src/consts/providers/mcp-servers.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { McpConnectionAuthModeEnum } from '../../dto/agent/managed-runtime.dto';
 import {
   MCP_SERVERS,
+  mergeMcpCatalogEntries,
   type McpOAuthCatalogEntry,
+  type McpServer,
   type McpServerCategory,
   type NovuAppOAuthCatalogEntry,
 } from './mcp-servers';
@@ -162,5 +164,79 @@ describe('MCP_SERVERS catalog', () => {
       expect(assertExhaustive({ mode: McpConnectionAuthModeEnum.Dcr })).toBe('web');
       expect(assertExhaustive({ mode: McpConnectionAuthModeEnum.ProviderManaged })).toBe('provider-managed');
     });
+  });
+});
+
+describe('mergeMcpCatalogEntries', () => {
+  const existing: McpServer[] = [
+    {
+      id: 'miro',
+      name: 'Miro',
+      description: 'Existing Miro entry',
+      url: 'https://mcp.miro.com/mcp',
+      category: 'design',
+      popular: false,
+      oauth: { mode: McpConnectionAuthModeEnum.Dcr },
+    },
+  ];
+
+  it('keeps existing oauth schema when incoming row duplicates id', () => {
+    const incoming: McpServer[] = [
+      {
+        id: 'miro',
+        name: 'Miro',
+        description: 'Vault delta overwrite attempt',
+        url: 'https://mcp.miro.com/mcp',
+        category: 'design',
+        popular: false,
+        oauth: { mode: McpConnectionAuthModeEnum.ProviderManaged },
+      },
+    ];
+
+    const { catalog, skippedIds } = mergeMcpCatalogEntries(existing, incoming);
+
+    expect(skippedIds).toEqual(['miro']);
+    expect(catalog).toHaveLength(1);
+    expect(catalog[0]?.oauth?.mode).toBe(McpConnectionAuthModeEnum.Dcr);
+  });
+
+  it('keeps existing row when incoming row duplicates url with a different id', () => {
+    const incoming: McpServer[] = [
+      {
+        id: 'miro-vault-alias',
+        name: 'Miro alias',
+        description: 'Same URL as catalog row',
+        url: 'https://mcp.miro.com/mcp',
+        category: 'design',
+        popular: false,
+        oauth: { mode: McpConnectionAuthModeEnum.ProviderManaged },
+      },
+    ];
+
+    const { catalog, skippedIds } = mergeMcpCatalogEntries(existing, incoming);
+
+    expect(skippedIds).toEqual(['miro-vault-alias']);
+    expect(catalog[0]?.id).toBe('miro');
+    expect(catalog[0]?.oauth?.mode).toBe(McpConnectionAuthModeEnum.Dcr);
+  });
+
+  it('appends net-new vault delta rows', () => {
+    const incoming: McpServer[] = [
+      {
+        id: 'new-vault-mcp',
+        name: 'New Vault MCP',
+        description: 'Net-new connector',
+        url: 'https://mcp.example.com/mcp',
+        category: 'other',
+        popular: false,
+        oauth: { mode: McpConnectionAuthModeEnum.ProviderManaged },
+      },
+    ];
+
+    const { catalog, skippedIds } = mergeMcpCatalogEntries(existing, incoming);
+
+    expect(skippedIds).toEqual([]);
+    expect(catalog).toHaveLength(2);
+    expect(catalog[1]?.id).toBe('new-vault-mcp');
   });
 });

--- a/packages/shared/src/consts/providers/mcp-servers.ts
+++ b/packages/shared/src/consts/providers/mcp-servers.ts
@@ -2557,6 +2557,40 @@ export function getMcpIconUrl(mcpId: string, baseUrl: string): string {
   return `${normalizedBase}${getMcpIconPath(mcpId)}`;
 }
 
+export type MergeMcpCatalogEntriesResult = {
+  catalog: McpServer[];
+  /** Incoming catalog ids skipped because `id` or `url` already exists in the catalog. */
+  skippedIds: string[];
+};
+
+/**
+ * Merges Claude vault delta (or other) rows into a catalog. When an incoming row
+ * collides on `id` or `url`, the existing row is kept in full so catalog oauth
+ * schema (mode, endpoints, scopes) is not overwritten.
+ */
+export function mergeMcpCatalogEntries(
+  existing: McpServer[],
+  incoming: McpServer[]
+): MergeMcpCatalogEntriesResult {
+  const ids = new Set(existing.map((entry) => entry.id));
+  const urls = new Set(existing.map((entry) => entry.url));
+  const catalog = [...existing];
+  const skippedIds: string[] = [];
+
+  for (const entry of incoming) {
+    if (ids.has(entry.id) || urls.has(entry.url)) {
+      skippedIds.push(entry.id);
+      continue;
+    }
+
+    catalog.push(entry);
+    ids.add(entry.id);
+    urls.add(entry.url);
+  }
+
+  return { catalog, skippedIds };
+}
+
 export function resolveMcpCatalogIdByName(name: string | undefined): string | undefined {
   if (!name) {
     return undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When merging Claude vault delta rows into the MCP catalog, duplicate `id` or `url` collisions now keep the existing catalog entry in full (including oauth mode/endpoints/scopes) instead of being overwritten by incoming vault data.

The workflow schema editor also preserves root JSON Schema metadata such as `$schema` when rebuilding schemas from the property list, and duplicate property keys keep the first definition.

## Changes

- **`mergeMcpCatalogEntries`** in `packages/shared` — skips incoming rows that collide on `id` or `url`; returns `skippedIds` for tooling.
- **`use-schema-form`** — carries over root schema keywords (including `$schema`) from `initialSchema` on every emit.
- **`convertPropertyListToSchema`** — ignores later rows with duplicate `keyName` (keeps first schema).

## Tests

- `packages/shared`: `mcp-servers.spec.ts` (14 tests, including merge behavior)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb13f778-7047-4c6f-875a-6f33229341d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb13f778-7047-4c6f-875a-6f33229341d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR fixes a data integrity issue where duplicate entries in the MCP server catalog would overwrite existing oauth configurations. Three related changes ensure duplicates are preserved: (1) a new `mergeMcpCatalogEntries` function in `shared` that skips incoming entries colliding on `id` or `url`, (2) the schema editor now preserves root-level JSON Schema keywords (like `$schema`) when emitting updated schemas, and (3) property list conversion ignores later duplicate property names, keeping the first definition.

## Affected areas

**shared**: Added `mergeMcpCatalogEntries` utility function that detects collisions on `id` or `url` in existing catalog entries and returns a result object with the merged catalog and a list of skipped IDs.

**dashboard**: Updated the schema editor to carry over root-level JSON Schema keywords from the initial schema through form edits and conversions, and modified property list conversion to skip duplicate property names.

## Testing

Added 14 unit tests in `packages/shared` covering merge behavior: collisions on `id`, collisions on `url`, and successful addition of new entries. Tests verify that existing entries with oauth configurations are preserved when collisions occur and that `skippedIds` are returned appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two distinct bugs: (1) `mergeMcpCatalogEntries` prevents Claude vault delta rows from overwriting existing catalog entries — on `id` or `url` collision the existing entry (including its OAuth mode/endpoints/scopes) is kept and the incoming row is skipped; (2) the workflow schema editor now re-attaches root JSON Schema keywords like `$schema` on every `onChange` emission and silently drops later duplicate property keys.

- **`packages/shared` — `mergeMcpCatalogEntries`**: new function with a `Set`-based deduplication pass over both `id` and `url`; returns `skippedIds` so callers know what was dropped. Covered by 3 new vitest cases.
- **`apps/dashboard` schema editor**: `use-schema-form` tracks the root schema via a `useRef` and passes it to `createSchemaFromPropertyList`; `carryOverCommonKeywords` (now exported) copies `$schema`, `definitions`, conditional keywords, etc. back onto every emitted schema; `convertPropertyListToSchema` now short-circuits on the first duplicate `keyName`.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The MCP catalog merge logic and schema duplicate-key guard are both straightforward and well-tested. The only noteworthy gap is that resetToSchema bypasses the rootSchemaRef update, which could silently drop root-level metadata from AI-generated schemas in the HTTP response body editor.

Both fixes are narrow and targeted. The mergeMcpCatalogEntries function is fully exercised by the new spec. The schema editor fix correctly threads rootSchemaRef through every emission path except resetToSchema, which doesn't update the ref — meaning a schema passed to resetToSchema that carries its own $schema, definitions, or similar keywords would lose those in subsequent onChange calls.

apps/dashboard/src/components/schema-editor/use-schema-form.ts — specifically the resetToSchema callback and its interaction with rootSchemaRef.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/schema-editor/use-schema-form.ts | Adds rootSchemaRef to carry over root-level JSON Schema metadata on every onChange/getCurrentSchema call. resetToSchema does not update rootSchemaRef, so schemas passed to it lose their own root keywords in subsequent emissions. |
| apps/dashboard/src/components/schema-editor/utils/json-helpers.ts | Exports carryOverCommonKeywords (previously module-private) to allow use-schema-form to call it directly. No logic changes. |
| apps/dashboard/src/components/schema-editor/utils/schema-converter.ts | Adds early-return guard for duplicate keyName entries in convertPropertyListToSchema, keeping the first definition. Logic is correct and defensive. |
| packages/shared/src/consts/providers/mcp-servers.ts | Adds mergeMcpCatalogEntries that prevents vault delta rows from overwriting existing catalog entries on id or url collision. Well-implemented with correct Set-based deduplication and skippedIds reporting. |
| packages/shared/src/consts/providers/mcp-servers.spec.ts | Adds 3 focused tests for the new mergeMcpCatalogEntries function covering id collision, url collision, and net-new append. Coverage is adequate for the new behavior. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Form property list changes] --> B[watch callback fires]
    B --> C[createSchemaFromPropertyList\npropertyList, rootSchemaRef.current]
    C --> D[convertPropertyListToSchema\nskip duplicate keyNames]
    D --> E[base schema\ntype: object, properties, required]
    E --> F{rootSchema provided?}
    F -- Yes --> G[carryOverCommonKeywords\nrootSchema → schema\n$schema, definitions, allOf, etc.]
    G --> H[onChange emitted]
    F -- No --> H

    subgraph rootSchemaRef lifecycle
        I[useSchemaForm initialSchema] -->|useRef init| J[rootSchemaRef.current]
        I -->|useEffect on change| J
        K[resetToSchema called] -->|does NOT update| J
    end

    subgraph mergeMcpCatalogEntries
        L[existing catalog] --> M{id or url collision?}
        N[incoming vault row] --> M
        M -- collision --> O[skip row, add to skippedIds]
        M -- no collision --> P[append to catalog\nadd id+url to Sets]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/components/schema-editor/use-schema-form.ts`, line 132-140 ([link](https://github.com/novuhq/novu/blob/622eabf180b1f547441be7f22aca8253cbeee518/apps/dashboard/src/components/schema-editor/use-schema-form.ts#L132-L140)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`resetToSchema` doesn't update `rootSchemaRef`**

   When `resetToSchema(schema)` is called (e.g., from `EnforceSchemaValidation`), the form property list is reset to the new schema's properties but `rootSchemaRef.current` continues to point to the original `initialSchema`. Any subsequent `onChange` emissions will carry over root-level metadata (like `$schema`, `definitions`, `$defs`, etc.) from the *original* initial schema, not from the schema that was passed to `resetToSchema`. If the schema produced by `EnforceSchemaValidation` contains its own root-level keywords, they will be silently dropped from all subsequent emissions. Consider adding `rootSchemaRef.current = schema;` at the top of the callback before calling `methods.reset`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/components/schema-editor/use-schema-form.ts
   Line: 132-140

   Comment:
   **`resetToSchema` doesn't update `rootSchemaRef`**

   When `resetToSchema(schema)` is called (e.g., from `EnforceSchemaValidation`), the form property list is reset to the new schema's properties but `rootSchemaRef.current` continues to point to the original `initialSchema`. Any subsequent `onChange` emissions will carry over root-level metadata (like `$schema`, `definitions`, `$defs`, etc.) from the *original* initial schema, not from the schema that was passed to `resetToSchema`. If the schema produced by `EnforceSchemaValidation` contains its own root-level keywords, they will be silently dropped from all subsequent emissions. Consider adding `rootSchemaRef.current = schema;` at the top of the callback before calling `methods.reset`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fcomponents%2Fschema-editor%2Fuse-schema-form.ts%0ALine%3A%20132-140%0A%0AComment%3A%0A**%60resetToSchema%60%20doesn't%20update%20%60rootSchemaRef%60**%0A%0AWhen%20%60resetToSchema%28schema%29%60%20is%20called%20%28e.g.%2C%20from%20%60EnforceSchemaValidation%60%29%2C%20the%20form%20property%20list%20is%20reset%20to%20the%20new%20schema's%20properties%20but%20%60rootSchemaRef.current%60%20continues%20to%20point%20to%20the%20original%20%60initialSchema%60.%20Any%20subsequent%20%60onChange%60%20emissions%20will%20carry%20over%20root-level%20metadata%20%28like%20%60%24schema%60%2C%20%60definitions%60%2C%20%60%24defs%60%2C%20etc.%29%20from%20the%20*original*%20initial%20schema%2C%20not%20from%20the%20schema%20that%20was%20passed%20to%20%60resetToSchema%60.%20If%20the%20schema%20produced%20by%20%60EnforceSchemaValidation%60%20contains%20its%20own%20root-level%20keywords%2C%20they%20will%20be%20silently%20dropped%20from%20all%20subsequent%20emissions.%20Consider%20adding%20%60rootSchemaRef.current%20%3D%20schema%3B%60%20at%20the%20top%20of%20the%20callback%20before%20calling%20%60methods.reset%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11443&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fschema-editor%2Fuse-schema-form.ts%3A132-140%0A**%60resetToSchema%60%20doesn't%20update%20%60rootSchemaRef%60**%0A%0AWhen%20%60resetToSchema%28schema%29%60%20is%20called%20%28e.g.%2C%20from%20%60EnforceSchemaValidation%60%29%2C%20the%20form%20property%20list%20is%20reset%20to%20the%20new%20schema's%20properties%20but%20%60rootSchemaRef.current%60%20continues%20to%20point%20to%20the%20original%20%60initialSchema%60.%20Any%20subsequent%20%60onChange%60%20emissions%20will%20carry%20over%20root-level%20metadata%20%28like%20%60%24schema%60%2C%20%60definitions%60%2C%20%60%24defs%60%2C%20etc.%29%20from%20the%20*original*%20initial%20schema%2C%20not%20from%20the%20schema%20that%20was%20passed%20to%20%60resetToSchema%60.%20If%20the%20schema%20produced%20by%20%60EnforceSchemaValidation%60%20contains%20its%20own%20root-level%20keywords%2C%20they%20will%20be%20silently%20dropped%20from%20all%20subsequent%20emissions.%20Consider%20adding%20%60rootSchemaRef.current%20%3D%20schema%3B%60%20at%20the%20top%20of%20the%20callback%20before%20calling%20%60methods.reset%60.%0A%0A&pr=11443&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/schema-editor/use-schema-form.ts:132-140
**`resetToSchema` doesn't update `rootSchemaRef`**

When `resetToSchema(schema)` is called (e.g., from `EnforceSchemaValidation`), the form property list is reset to the new schema's properties but `rootSchemaRef.current` continues to point to the original `initialSchema`. Any subsequent `onChange` emissions will carry over root-level metadata (like `$schema`, `definitions`, `$defs`, etc.) from the *original* initial schema, not from the schema that was passed to `resetToSchema`. If the schema produced by `EnforceSchemaValidation` contains its own root-level keywords, they will be silently dropped from all subsequent emissions. Consider adding `rootSchemaRef.current = schema;` at the top of the callback before calling `methods.reset`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared,dashboard): keep catalog oaut..."](https://github.com/novuhq/novu/commit/622eabf180b1f547441be7f22aca8253cbeee518) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35553972)</sub>

<!-- /greptile_comment -->