### PR TITLE
feat(dashbord): agent templates from sanity fixes NV-7790

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -78,6 +78,7 @@
     "@rjsf/core": "^5.22.3",
     "@rjsf/utils": "^5.20.0",
     "@rjsf/validator-ajv8": "^5.17.1",
+    "@sanity/client": "^7.22.1",
     "@segment/analytics-next": "^1.81.0",
     "@sentry/react": "^8.35.0",
     "@shopify/prettier-plugin-liquid": "^1.9.3",

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -15,6 +15,7 @@ import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsProductionEmptyState } from '@/components/agents/agents-production-empty-state';
 import { AgentsTable } from '@/components/agents/agents-table';
 import { CreateAgentDialog, CreateAgentForm } from '@/components/agents/create-agent-dialog';
+import { findAgentTemplateById } from '@/components/agents/create-agent-fields';
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
 import { ListNoResults } from '@/components/list-no-results';
 import { Button } from '@/components/primitives/button';
@@ -24,11 +25,17 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { useAgentTemplates } from '@/hooks/use-agent-templates';
 import { useCreateAgentMutation } from '@/hooks/use-create-agent-mutation';
 import { useCurrentApp } from '@/hooks/use-current-app';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { AGENTS_DOCS_PROVIDERS_URL } from '@/utils/agent-docs';
+import {
+  AGENT_TEMPLATE_ID_PARAM,
+  clearPersistedAgentTemplateId,
+  readActiveAgentTemplateId,
+} from '@/utils/agent-template-identity';
 import { APP_IDS } from '@/utils/apps';
 import { withAppId } from '@/utils/onboarding-redirect';
 import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
@@ -54,28 +61,51 @@ export function AgentsList() {
   const [before, setBefore] = useState<string | undefined>();
   const [limit, setLimit] = useState(12);
   const [createOpen, setCreateOpen] = useState(false);
-  const [initialCreateValues, setInitialCreateValues] = useState<{ name?: string; description?: string }>({});
+  const [initialCreateValues, setInitialCreateValues] = useState<{
+    name?: string;
+    description?: string;
+    prompt?: string;
+  }>({});
   const [agentToDelete, setAgentToDelete] = useState<AgentResponse | null>(null);
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const { templates: agentTemplates } = useAgentTemplates();
 
   // Allow external links (e.g. connect dashboard) to open the create dialog with prefilled values
-  // via `?create=1&name=...&description=...`. Consume the params once and strip them from the URL.
+  // via `?create=1&name=...&description=...`, or a Sanity-backed template via `?agentTemplateId=...`
+  // (also picked up from sessionStorage when it survived the auth flow). Consume once and strip the
+  // params from the URL.
   useEffect(() => {
-    if (searchParams.get('create') !== '1') return;
+    const hasCreate = searchParams.get('create') === '1';
+    const templateId = readActiveAgentTemplateId(searchParams.get(AGENT_TEMPLATE_ID_PARAM));
 
-    const nextName = searchParams.get('name') ?? undefined;
-    const nextDescription = searchParams.get('description') ?? undefined;
+    if (!hasCreate && !templateId) return;
 
-    setInitialCreateValues({ name: nextName, description: nextDescription });
+    let nextName = searchParams.get('name') ?? undefined;
+    let nextDescription = searchParams.get('description') ?? undefined;
+    let nextPrompt: string | undefined;
+
+    if (templateId) {
+      const template = findAgentTemplateById(agentTemplates, templateId);
+      // Templates may still be loading — wait for the match before consuming the id.
+      if (!template) return;
+
+      nextName = nextName ?? template.name;
+      nextDescription = nextDescription ?? template.instructions;
+      nextPrompt = template.instructions;
+      clearPersistedAgentTemplateId();
+    }
+
+    setInitialCreateValues({ name: nextName, description: nextDescription, prompt: nextPrompt });
     setCreateOpen(true);
 
     const nextParams = new URLSearchParams(searchParams);
     nextParams.delete('create');
     nextParams.delete('name');
     nextParams.delete('description');
+    nextParams.delete(AGENT_TEMPLATE_ID_PARAM);
     setSearchParams(nextParams, { replace: true });
-  }, [searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams, agentTemplates]);
 
   const handleCreateOpenChange = useCallback((next: boolean) => {
     setCreateOpen(next);
@@ -87,6 +117,7 @@ export function AgentsList() {
 
   const memoizedInitialName = useMemo(() => initialCreateValues.name, [initialCreateValues.name]);
   const memoizedInitialDescription = useMemo(() => initialCreateValues.description, [initialCreateValues.description]);
+  const memoizedInitialPrompt = useMemo(() => initialCreateValues.prompt, [initialCreateValues.prompt]);
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -376,6 +407,7 @@ export function AgentsList() {
         isSubmitting={isCreatingAgent}
         initialName={memoizedInitialName}
         initialInstructions={memoizedInitialDescription}
+        initialPrompt={memoizedInitialPrompt}
       />
 
       <DeleteAgentDialog

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/primitives/segmented-control';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useAgentTemplates } from '@/hooks/use-agent-templates';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
@@ -49,7 +50,6 @@ import {
   getConnectorIdForProviderId,
 } from './connectors/connector-options';
 import {
-  AGENT_TEMPLATES,
   type AgentTemplate,
   buildManagedIntegrationCredentials,
   buildVerifyCredentialsPayload,
@@ -78,6 +78,8 @@ type CreateAgentDialogProps = {
   isSubmitting: boolean;
   initialName?: string;
   initialInstructions?: string;
+  /** When provided, the dialog opens in prompt mode with the textarea prefilled. */
+  initialPrompt?: string;
 };
 
 const DEFAULT_CONNECTOR_ID: ConnectorId = 'claude';
@@ -129,6 +131,21 @@ function dropdownStatusFor(verify: VerifyStatus, hasIntegration: boolean): Conne
   return 'idle';
 }
 
+function resolveInitialGenerationMode({
+  initialName,
+  initialInstructions,
+  initialPrompt,
+}: {
+  initialName?: string;
+  initialInstructions?: string;
+  initialPrompt?: string;
+}): AgentGenerationMode {
+  if (initialPrompt) return 'prompt';
+  if (initialName || initialInstructions) return 'manual';
+
+  return 'prompt';
+}
+
 export function CreateAgentDialog({
   open,
   onOpenChange,
@@ -136,11 +153,13 @@ export function CreateAgentDialog({
   isSubmitting,
   initialName,
   initialInstructions,
+  initialPrompt,
 }: CreateAgentDialogProps) {
   const isManagedEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED, false);
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
   const { integrations } = useFetchIntegrations();
+  const { templates: agentTemplates } = useAgentTemplates();
   const verifyMutation = useVerifyManagedCredentials();
   const { mutateAsync: createIntegration, isPending: isSavingIntegration } = useCreateIntegration();
 
@@ -148,12 +167,12 @@ export function CreateAgentDialog({
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
   const [credentialsPanelVisible, setCredentialsPanelVisible] = useState(false);
   const [credentialsPanelExpanded, setCredentialsPanelExpanded] = useState(true);
-  // If the caller pre-populated a name or instructions, default to manual mode so the form is
-  // already filled out. Otherwise show the prompt textarea by default.
+  // A caller-provided prompt opens in prompt mode; a pre-populated name/instructions defaults to
+  // manual mode so the form is already filled out. Otherwise show the prompt textarea by default.
   const [generationMode, setGenerationMode] = useState<AgentGenerationMode>(() =>
-    initialName || initialInstructions ? 'manual' : 'prompt'
+    resolveInitialGenerationMode({ initialName, initialInstructions, initialPrompt })
   );
-  const [prompt, setPrompt] = useState('');
+  const [prompt, setPrompt] = useState(initialPrompt ?? '');
   const [promptError, setPromptError] = useState<string | undefined>(undefined);
   const promptTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   // Keeps the dialog in a busy state for the whole submit lifecycle — across the LLM call (prompt
@@ -319,10 +338,10 @@ export function CreateAgentDialog({
     setInstructions(initialInstructions ?? '');
     setIsIdentifierTouched(false);
     setErrors({});
-    setGenerationMode(initialName || initialInstructions ? 'manual' : 'prompt');
-    setPrompt('');
+    setGenerationMode(resolveInitialGenerationMode({ initialName, initialInstructions, initialPrompt }));
+    setPrompt(initialPrompt ?? '');
     setPromptError(undefined);
-  }, [open, initialName, initialInstructions]);
+  }, [open, initialName, initialInstructions, initialPrompt]);
 
   const reset = useCallback(() => {
     setConnectorId(DEFAULT_CONNECTOR_ID);
@@ -705,8 +724,8 @@ export function CreateAgentDialog({
 
         <div className="border-stroke-soft border-y" />
 
-        <form onSubmit={handleSubmit}>
-          <div className="bg-background flex max-h-[70vh] flex-col gap-5 overflow-y-auto p-4">
+        <form onSubmit={handleSubmit} className="min-w-0">
+          <div className="bg-background flex min-w-0 max-h-[70vh] flex-col gap-5 overflow-y-auto p-4">
             <div className="flex flex-col gap-2">
               <span className="text-text-strong text-label-xs font-medium">Where do you want your agent?</span>
               <ConnectorIntegrationDropdown
@@ -850,7 +869,7 @@ export function CreateAgentDialog({
 
                 {generationMode === 'prompt' && (
                   <AgentSuggestionPills
-                    suggestions={AGENT_TEMPLATES}
+                    suggestions={agentTemplates}
                     onSelect={handleSelectAiSuggestion}
                     disabled={isSubmitBusy}
                   />

--- a/apps/dashboard/src/components/agents/create-agent-fields/types.ts
+++ b/apps/dashboard/src/components/agents/create-agent-fields/types.ts
@@ -4,12 +4,38 @@ export type RuntimeType = 'scratch' | 'claude' | 'vertex';
 
 export type CreateAgentMode = 'create' | 'existing';
 
+/**
+ * Normalized MCP server reference for a template pill. `iconUrl` is set when the icon comes from a
+ * remote source (e.g. Sanity); otherwise the pill falls back to the local `McpIcon` keyed by `id`.
+ */
+export type McpServerPreview = {
+  id: string;
+  name?: string;
+  iconUrl?: string;
+};
+
 export type AgentTemplate = {
+  /** Stable identifier used to match an incoming `agentTemplateId` (Sanity `id.current`). */
+  templateId?: string;
   label: string;
   name: string;
   instructions: string;
+  /** MCP server ids (e.g. `sentry`, `datadog`). Drives the pill icons via the local `McpIcon`. */
   suggestedMcpServers: string[];
+  /** Richer MCP server data (with remote icon URLs) used by the pills when available. */
+  mcpServers?: McpServerPreview[];
 };
+
+export function findAgentTemplateById(
+  templates: AgentTemplate[],
+  id: string | undefined | null
+): AgentTemplate | undefined {
+  if (!id) {
+    return undefined;
+  }
+
+  return templates.find((template) => template.templateId === id);
+}
 
 export type CreateAgentForm = {
   name: string;
@@ -75,6 +101,7 @@ export const AWS_CLAUDE_API_KEYS_HREF =
 
 export const AGENT_TEMPLATES: AgentTemplate[] = [
   {
+    templateId: 'incident-triage',
     label: 'Incident Triage',
     name: 'Incident Triage Agent',
     instructions: `You are an on-call engineer. When the user asks about production issues or error spikes:
@@ -105,6 +132,7 @@ Rules:
     suggestedMcpServers: ['sentry', 'datadog'],
   },
   {
+    templateId: 'ship-and-track',
     label: 'Ship & Track',
     name: 'Ship & Track Agent',
     instructions: `You are an engineering lead assistant. When the user asks about shipping work, PRs, or sprint progress:
@@ -136,6 +164,7 @@ Rules:
     suggestedMcpServers: ['github', 'linear'],
   },
   {
+    templateId: 'feature-adoption',
     label: 'Feature Adoption',
     name: 'Feature Adoption Agent',
     instructions: `You are a product engineer focused on launch quality. When the user asks about a feature rollout, experiment, or funnel:

--- a/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { type AgentTemplate } from '@/components/agents/create-agent-fields';
+import { type AgentTemplate, type McpServerPreview } from '@/components/agents/create-agent-fields';
 import { McpIcon } from '@/components/agents/mcp-icon';
 import { OrbIcon } from '@/components/icons/orb';
 import { buildEdgeFadeMask, useHorizontalScrollEdges } from '@/hooks/use-horizontal-scroll-edges';
@@ -42,11 +42,12 @@ type SuggestionPillProps = {
 
 function SuggestionPill({ suggestion, disabled, onSelect }: SuggestionPillProps) {
   const { visibleIcons, overflowCount } = useMemo(() => {
-    const visible = suggestion.suggestedMcpServers.slice(0, VISIBLE_INTEGRATION_ICONS);
-    const overflow = Math.max(0, suggestion.suggestedMcpServers.length - VISIBLE_INTEGRATION_ICONS);
+    const servers: McpServerPreview[] = suggestion.mcpServers ?? suggestion.suggestedMcpServers.map((id) => ({ id }));
+    const visible = servers.slice(0, VISIBLE_INTEGRATION_ICONS);
+    const overflow = Math.max(0, servers.length - VISIBLE_INTEGRATION_ICONS);
 
     return { visibleIcons: visible, overflowCount: overflow };
-  }, [suggestion.suggestedMcpServers]);
+  }, [suggestion.mcpServers, suggestion.suggestedMcpServers]);
 
   return (
     <button
@@ -64,12 +65,12 @@ function SuggestionPill({ suggestion, disabled, onSelect }: SuggestionPillProps)
       </span>
       {(visibleIcons.length > 0 || overflowCount > 0) && (
         <span className="inline-flex items-center gap-0.5">
-          {visibleIcons.map((id) => (
+          {visibleIcons.map((server) => (
             <span
-              key={id}
+              key={server.id}
               className="border-stroke-soft-100 inline-flex size-[18px] items-center justify-center rounded-[4px] border bg-[#fbfbfb]"
             >
-              <McpIcon mcpId={id} className="size-[14px]" />
+              <McpIcon mcpId={server.id} className="size-[14px]" />
             </span>
           ))}
           {overflowCount > 0 && (

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -12,13 +12,13 @@ import {
 import { type ConnectorIntegrationStatus } from '@/components/agents/connectors/connector-integration-dropdown';
 import { type ConnectorOption } from '@/components/agents/connectors/connector-options';
 import {
-  AGENT_TEMPLATES,
   type AgentTemplate,
   buildManagedIntegrationCredentials,
   buildVerifyCredentialsPayload,
   buildVerifyFingerprint,
   type CreateAgentForm,
   type CreateAgentFormErrors,
+  findAgentTemplateById,
   hasCompleteManagedCredentials,
   hasFormErrors,
   type ManagedAgentRuntimeOverrides,
@@ -32,6 +32,7 @@ import { ClaudeIcon } from '@/components/icons/claude';
 import { Button } from '@/components/primitives/button';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useAgentTemplates } from '@/hooks/use-agent-templates';
 import { useCreateAgentMutation } from '@/hooks/use-create-agent-mutation';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
@@ -39,6 +40,7 @@ import { GenerationCancelledError, useGenerateManagedAgent } from '@/hooks/use-g
 import { useManagedClaudeCredentialsFlow } from '@/hooks/use-managed-claude-credentials-flow';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { useVerifyManagedCredentials } from '@/hooks/use-verify-managed-credentials';
+import { clearPersistedAgentTemplateId } from '@/utils/agent-template-identity';
 import { QueryKeys } from '@/utils/query-keys';
 import { TelemetryEvent } from '@/utils/telemetry';
 import type { AgentGenerationMode } from './connect-agent-form';
@@ -106,6 +108,11 @@ type ConnectAgentStepProps = {
   onPreviewChange?: (preview: ConnectAgentPreview) => void;
   isManagedEnabled: boolean;
   /**
+   * Optional template id (Sanity `id.current`) coming from an external deep-link. When it matches a
+   * fetched template, the prompt + agent fields are prefilled once and the persisted id is cleared.
+   */
+  agentTemplateId?: string;
+  /**
    * Onboarding "demo agent" mode: renders only the simplified brain step (prompt + suggestions +
    * demo-credentials hint + full-width "Setup agent" CTA). The connector, template, and
    * credentials surfaces are hidden — the agent is provisioned on the Novu demo Claude credentials.
@@ -122,6 +129,7 @@ export function ConnectAgentStep({
   onRuntimeChange,
   onPreviewChange,
   isManagedEnabled,
+  agentTemplateId,
   simplifiedDemo,
 }: ConnectAgentStepProps) {
   const telemetry = useTelemetry();
@@ -129,6 +137,7 @@ export function ConnectAgentStep({
   const { currentEnvironment } = useEnvironment();
   const { submit, isPending } = useCreateAgentMutation();
   const { integrations } = useFetchIntegrations();
+  const { templates: agentTemplates } = useAgentTemplates();
   const verifyMutation = useVerifyManagedCredentials();
   const { mutateAsync: createIntegration, isPending: isSavingIntegration } = useCreateIntegration();
 
@@ -150,6 +159,8 @@ export function ConnectAgentStep({
   // Set when the user cancels generation, so the in-flight submit bails before creating the agent
   // even if the aborted request's promise resolves (or settles late) instead of rejecting.
   const generationCancelledRef = useRef(false);
+  // Guards the deep-link template prefill so it runs at most once per template id.
+  const appliedTemplateIdRef = useRef<string | undefined>(undefined);
 
   const {
     generate: generateManagedAgent,
@@ -224,6 +235,28 @@ export function ConnectAgentStep({
   useEffect(() => {
     onRuntimeChange?.(runtime);
   }, [runtime, onRuntimeChange]);
+
+  // Deep-link prefill: when an `agentTemplateId` matches a fetched template, drop into prompt mode
+  // with the prompt + agent fields filled in. Runs once per id (templates may load asynchronously),
+  // then clears the persisted id so a refresh doesn't re-apply it.
+  useEffect(() => {
+    if (!agentTemplateId) return;
+    if (appliedTemplateIdRef.current === agentTemplateId) return;
+
+    const template = findAgentTemplateById(agentTemplates, agentTemplateId);
+    if (!template) return;
+
+    appliedTemplateIdRef.current = agentTemplateId;
+    setGenerationMode('prompt');
+    setPrompt(template.instructions);
+    setPromptError(undefined);
+    setName(template.name);
+    if (!isIdentifierTouched) {
+      setIdentifier(slugify(template.name));
+    }
+    setInstructions(template.instructions);
+    clearPersistedAgentTemplateId();
+  }, [agentTemplateId, agentTemplates, isIdentifierTouched]);
 
   const dropdownStatus = dropdownStatusFor(verifyStatus, Boolean(selectedIntegrationId));
   const isSubmitBusy = isPending || isGenerating || isPromptSubmitInFlight;
@@ -843,7 +876,7 @@ export function ConnectAgentStep({
                 prompt,
                 onPromptChange: handlePromptChange,
                 promptError,
-                suggestions: AGENT_TEMPLATES,
+                suggestions: agentTemplates,
                 onSelectSuggestion: handleSelectSuggestion,
                 textareaRef: promptTextareaRef,
                 isGenerating: isSubmitBusy,

--- a/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
+++ b/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { RiCloseLine } from 'react-icons/ri';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { fetchSanity, SANITY_CDN_URL } from '@/utils/sanity';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 type SanityAsset = {
@@ -38,8 +39,6 @@ type Changelog = {
 };
 
 const CONSTANTS = {
-  SANITY_API_URL: 'https://w2rl2099.api.sanity.io/v2025-02-19/data/query/production',
-  SANITY_CDN_URL: 'https://cdn.sanity.io/images/w2rl2099/production',
   NUMBER_OF_CARDS: 3,
   CARD_OFFSET: 10,
   SCALE_FACTOR: 0.06,
@@ -95,7 +94,7 @@ export function ChangelogStack() {
     const [, assetId, dimensions, format] = match;
 
     // Use Sanity's CDN URL format with the constant
-    return `${CONSTANTS.SANITY_CDN_URL}/${assetId}-${dimensions}.${format}?w=400&h=300&fit=crop&auto=format`;
+    return `${SANITY_CDN_URL}/${assetId}-${dimensions}.${format}?w=400&h=300&fit=crop&auto=format`;
   };
 
   // Transform Sanity data to our internal format
@@ -113,8 +112,8 @@ export function ChangelogStack() {
   };
 
   const fetchChangelogs = async (): Promise<Changelog[]> => {
-    // Build Sanity query to get published changelog posts with covers, sorted by publishedAt
-    const query = encodeURIComponent(`
+    // Get published changelog posts with covers, sorted by publishedAt.
+    const query = `
       *[_type == "changelogPost" && defined(cover.asset)] | order(publishedAt desc, _createdAt desc) [0...10] {
         _id,
         _createdAt,
@@ -131,19 +130,11 @@ export function ChangelogStack() {
           }
         }
       }
-    `);
+    `;
 
-    const url = `${CONSTANTS.SANITY_API_URL}?query=${query}&perspective=published`;
-    const response = await fetch(url);
+    const sanityPosts = await fetchSanity<SanityChangelogPost[]>(query);
 
-    if (!response.ok) {
-      throw new Error('Failed to fetch changelogs from Sanity');
-    }
-
-    const data = await response.json();
-    const sanityPosts: SanityChangelogPost[] = data.result || [];
-
-    const transformedData = transformSanityData(sanityPosts);
+    const transformedData = transformSanityData(sanityPosts ?? []);
     return filterChangelogs(transformedData, getDismissedChangelogs());
   };
 

--- a/apps/dashboard/src/hooks/use-agent-templates.ts
+++ b/apps/dashboard/src/hooks/use-agent-templates.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query';
+import { AGENT_TEMPLATES, type AgentTemplate, type McpServerPreview } from '@/components/agents/create-agent-fields';
+import { fetchSanity } from '@/utils/sanity';
+import { agentTemplatesQuery } from '@/utils/sanity-queries';
+
+const QUERY_KEY = ['agent-templates'];
+
+type SanityImage = {
+  url?: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+};
+
+type SanityMcpServer = {
+  id?: string;
+  name?: string;
+  description?: string;
+  icon?: SanityImage;
+  url?: string;
+};
+
+type SanityAgentTemplate = {
+  _id: string;
+  id?: string;
+  name?: string;
+  agentName?: string;
+  summary?: string;
+  systemPrompt?: string;
+  mcpServerList?: SanityMcpServer[];
+};
+
+function mapSanityTemplate(template: SanityAgentTemplate): AgentTemplate | null {
+  if (!template.id || !template.name) {
+    return null;
+  }
+
+  const mcpServers: McpServerPreview[] = (template.mcpServerList ?? [])
+    .filter((server): server is SanityMcpServer & { id: string } => Boolean(server?.id))
+    .map((server) => ({ id: server.id, name: server.name, iconUrl: server.icon?.url }));
+
+  return {
+    templateId: template.id,
+    label: template.name,
+    name: template.agentName || template.name,
+    instructions: template.systemPrompt || '',
+    suggestedMcpServers: mcpServers.map((server) => server.id),
+    mcpServers,
+  };
+}
+
+/**
+ * Fetches agent templates from Sanity for the onboarding/create-agent pills. Falls back to the
+ * hardcoded `AGENT_TEMPLATES` when Sanity is unavailable or returns nothing.
+ */
+export function useAgentTemplates() {
+  const { data, isLoading } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: async ({ signal }) => {
+      const result = await fetchSanity<SanityAgentTemplate[]>(agentTemplatesQuery, { signal });
+
+      return (result ?? []).map(mapSanityTemplate).filter((template): template is AgentTemplate => template !== null);
+    },
+    // Templates rarely change — keep them fresh for an hour like the changelog query.
+    staleTime: 60 * 60 * 1000,
+  });
+
+  const templates = data && data.length > 0 ? data : AGENT_TEMPLATES;
+
+  return { templates, isLoading };
+}

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -85,12 +85,15 @@ import { AuthRoute, CatchAllRoute, DashboardRoute, ProtectedAuthRoute, RootRoute
 import { ConnectProtectedRoute } from './routes/connect-protected-route';
 import { OnboardingParentRoute } from './routes/onboarding';
 import { ProtectedRoute } from './routes/protected-route';
+import { captureAgentTemplateIdFromUrl } from './utils/agent-template-identity';
 import { ROUTES } from './utils/routes';
 import { initializeSentry } from './utils/sentry';
 import { overrideZodErrorMap } from './utils/validation';
 
 initializeSentry();
 overrideZodErrorMap();
+// Stash an incoming `?agentTemplateId=` before Clerk's auth redirects drop the query params.
+captureAgentTemplateIdFromUrl();
 
 const router = createBrowserRouter([
   {

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -20,6 +20,7 @@ import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useOnboardingProvisioningActive, useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { AGENT_TEMPLATE_ID_PARAM, readActiveAgentTemplateId } from '@/utils/agent-template-identity';
 import { APP_IDS, isAbsoluteUrl } from '@/utils/apps';
 import { clearPersistedCliOnboardingSessionId } from '@/utils/cli-onboarding-identity';
 import {
@@ -159,6 +160,10 @@ export function AgentsSetupPage() {
 
   const [searchParams] = useSearchParams();
   const appId = useMemo(() => resolveOnboardingAppId(searchParams), [searchParams]);
+  const agentTemplateId = useMemo(
+    () => readActiveAgentTemplateId(searchParams.get(AGENT_TEMPLATE_ID_PARAM)),
+    [searchParams]
+  );
   const isConnectFlow = appId === APP_IDS.CONNECT;
   const isConnectHost = IS_NOVU_CONNECT || isConnectFlow;
   const pageTitle = isConnectHost ? 'Connect your agent to where work happens' : 'Connect your first agent';
@@ -370,6 +375,7 @@ export function AgentsSetupPage() {
               <ConnectAgentStep
                 onAgentCreated={handleAgentCreated}
                 isManagedEnabled={isManagedEnabled}
+                agentTemplateId={agentTemplateId}
                 simplifiedDemo
               />
             </div>

--- a/apps/dashboard/src/routes/catch-all.tsx
+++ b/apps/dashboard/src/routes/catch-all.tsx
@@ -1,6 +1,13 @@
 import { RiLoader4Line } from 'react-icons/ri';
 import { Navigate, useLocation } from 'react-router-dom';
-import { buildAppHomeRoute, getCurrentAppId } from '@/utils/apps';
+import { AGENT_TEMPLATE_ID_PARAM, readActiveAgentTemplateId } from '@/utils/agent-template-identity';
+import {
+  APP_IDS,
+  buildAppHomeRoute,
+  getAgentRouteTemplates,
+  getCurrentAppId,
+  LEGACY_CONNECT_PATH_REGEX,
+} from '@/utils/apps';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { useEnvironment } from '../context/environment/hooks';
 
@@ -40,6 +47,24 @@ export const CatchAllRoute = () => {
         return <Navigate to={`${targetPath}${location.search}${location.hash}`} />;
       }
     }
+  }
+
+  // A signed-in user arriving with an `agentTemplateId` (deep-link from an external app, possibly
+  // persisted across the auth flow) is sent straight to the agents list, which opens the create
+  // dialog prefilled from the matching template. Resolve the list route per app (Platform vs
+  // Connect) so the redirect lands on a route that actually exists on the current host.
+  const agentTemplateId = readActiveAgentTemplateId(new URLSearchParams(location.search).get(AGENT_TEMPLATE_ID_PARAM));
+
+  if (agentTemplateId) {
+    // Detect Connect by hostname (split-host deploys) or by the `/env/:slug/connect/*` path
+    // (single-host dev, where the hostname can't tell the apps apart), so we land on the right
+    // agents route for the active project.
+    const isConnect =
+      getCurrentAppId(location.pathname) === APP_IDS.CONNECT || LEGACY_CONNECT_PATH_REGEX.test(location.pathname);
+    const agentsListRoute = getAgentRouteTemplates(isConnect ? APP_IDS.CONNECT : APP_IDS.NOVU).list;
+    const agentsPath = buildRoute(agentsListRoute, { environmentSlug: currentEnvironment.slug });
+
+    return <Navigate to={`${agentsPath}?${AGENT_TEMPLATE_ID_PARAM}=${encodeURIComponent(agentTemplateId)}`} />;
   }
 
   const homePath = buildAppHomeRoute(getCurrentAppId(location.pathname), currentEnvironment.slug);

--- a/apps/dashboard/src/utils/agent-template-identity.ts
+++ b/apps/dashboard/src/utils/agent-template-identity.ts
@@ -1,0 +1,51 @@
+// Preserves an incoming `?agentTemplateId=` across the auth flow. Clerk performs full-document
+// reloads (sign-up -> org-create -> setup) that drop query params, so we stash the value in
+// sessionStorage at app boot and read it back on the agent setup page / create-agent dialog.
+
+const AGENT_TEMPLATE_ID_KEY = 'novu.onboarding.agentTemplateId';
+
+export const AGENT_TEMPLATE_ID_PARAM = 'agentTemplateId';
+
+export function persistAgentTemplateId(id: string): void {
+  try {
+    sessionStorage.setItem(AGENT_TEMPLATE_ID_KEY, id);
+  } catch {
+    // sessionStorage unavailable — the value will rely on the URL param only
+  }
+}
+
+export function readPersistedAgentTemplateId(): string | undefined {
+  try {
+    const raw = sessionStorage.getItem(AGENT_TEMPLATE_ID_KEY)?.trim();
+
+    return raw || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function clearPersistedAgentTemplateId(): void {
+  try {
+    sessionStorage.removeItem(AGENT_TEMPLATE_ID_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function readActiveAgentTemplateId(urlValue?: string | null): string | undefined {
+  return urlValue?.trim() || readPersistedAgentTemplateId();
+}
+
+// Reads the param from the current URL and persists it. Safe to call at module load on every
+// document load — only writes when the param is present.
+export function captureAgentTemplateIdFromUrl(): void {
+  try {
+    const id = new URLSearchParams(window.location.search).get(AGENT_TEMPLATE_ID_PARAM)?.trim();
+
+    if (id) {
+      persistAgentTemplateId(id);
+    }
+  } catch {
+    // ignore — no window/search available
+  }
+}

--- a/apps/dashboard/src/utils/agent-template-identity.ts
+++ b/apps/dashboard/src/utils/agent-template-identity.ts
@@ -33,7 +33,11 @@ export function clearPersistedAgentTemplateId(): void {
 }
 
 export function readActiveAgentTemplateId(urlValue?: string | null): string | undefined {
-  return urlValue?.trim() || readPersistedAgentTemplateId();
+  if (urlValue !== null && urlValue !== undefined) {
+    return urlValue.trim() || undefined;
+  }
+
+  return readPersistedAgentTemplateId();
 }
 
 // Reads the param from the current URL and persists it. Safe to call at module load on every

--- a/apps/dashboard/src/utils/sanity-queries.ts
+++ b/apps/dashboard/src/utils/sanity-queries.ts
@@ -1,0 +1,86 @@
+// GROQ queries for Sanity content, kept as plain template strings (mirroring the Sanity source of
+// truth) so we don't pull in a `groq`-tag dependency.
+
+const imageFields = `
+  "url": asset->url + "?auto=format",
+  "width": asset->metadata.dimensions.width,
+  "height": asset->metadata.dimensions.height,
+  "alt": alt
+`;
+
+const templateCategoryFields = `
+  "id": slug.current,
+  title,
+  description
+`;
+
+const templateReferenceFields = `
+  "id": slug.current,
+  name,
+  description
+`;
+
+const templateChannelFields = `
+  ${templateReferenceFields},
+  "isComingSoon": isComingSoon == true,
+  "icon": icon {
+    ${imageFields}
+  }
+`;
+
+const templateIconReferenceFields = `
+  ${templateReferenceFields},
+  "icon": icon {
+    ${imageFields}
+  }
+`;
+
+const templateMcpServerFields = `
+  ${templateIconReferenceFields},
+  url
+`;
+
+const templateAvatarFields = `
+  "id": slug.current,
+  name,
+  "darkImage": darkImage {
+    ${imageFields}
+  },
+  "lightImage": lightImage {
+    ${imageFields}
+  }
+`;
+
+const agentTemplateFields = `
+  _id,
+  _createdAt,
+  "id": id.current,
+  name,
+  agentName,
+  summary,
+  avatar->{
+    ${templateAvatarFields}
+  },
+  category->{
+    ${templateCategoryFields}
+  },
+  mcpServerList[]->{
+    ${templateMcpServerFields}
+  },
+  channels[]->{
+    ${templateChannelFields}
+  },
+  "skillsList": skillsList[]{
+    "value": select(defined(_ref) => @->slug.current, @)
+  }.value,
+  "tools": coalesce(tools[]->{
+    ${templateReferenceFields}
+  }, []),
+  systemPrompt
+`;
+
+export const agentTemplatesQuery = `
+  *[_type == "agentTemplate"] | order(category->orderRank asc, name asc) {
+    ${agentTemplateFields}
+  }
+`;

--- a/apps/dashboard/src/utils/sanity.ts
+++ b/apps/dashboard/src/utils/sanity.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@sanity/client';
+
+const SANITY_PROJECT_ID = 'w2rl2099';
+const SANITY_DATASET = 'production';
+const SANITY_API_VERSION = '2025-02-19';
+
+export const SANITY_CDN_URL = `https://cdn.sanity.io/images/${SANITY_PROJECT_ID}/${SANITY_DATASET}`;
+
+export const sanityClient = createClient({
+  projectId: SANITY_PROJECT_ID,
+  dataset: SANITY_DATASET,
+  apiVersion: SANITY_API_VERSION,
+  useCdn: false,
+  perspective: 'published',
+});
+
+type FetchSanityOptions = {
+  params?: Record<string, unknown>;
+  signal?: AbortSignal;
+};
+
+export async function fetchSanity<T>(query: string, options?: FetchSanityOptions): Promise<T> {
+  return sanityClient.fetch<T>(query, options?.params ?? {}, { signal: options?.signal });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,6 +897,9 @@ importers:
       '@rjsf/validator-ajv8':
         specifier: ^5.17.1
         version: 5.17.1(@rjsf/utils@5.20.1(react@19.2.3))
+      '@sanity/client':
+        specifier: ^7.22.1
+        version: 7.22.1
       '@segment/analytics-next':
         specifier: ^1.81.0
         version: 1.81.0(encoding@0.1.13)
@@ -12352,6 +12355,13 @@ packages:
       zen-observable:
         optional: true
 
+  '@sanity/client@7.22.1':
+    resolution: {integrity: sha512-DrQqLAes7W9Ek2iKgTZ+ffY1v3DURJ6//iXJZMEQSUeRbxls2ifRTdV1gRS26v8nMkL0OCH+WCoUUseD4vhuQQ==}
+    engines: {node: '>=20'}
+
+  '@sanity/eventsource@5.0.2':
+    resolution: {integrity: sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -14520,6 +14530,12 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/event-source-polyfill@1.0.5':
+    resolution: {integrity: sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==}
+
+  '@types/eventsource@1.1.15':
+    resolution: {integrity: sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==}
 
   '@types/express-serve-static-core@4.17.33':
     resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
@@ -17808,6 +17824,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  decompress-response@7.0.0:
+    resolution: {integrity: sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==}
+    engines: {node: '>=10'}
+
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
 
@@ -18540,6 +18560,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-source-polyfill@1.0.31:
+    resolution: {integrity: sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==}
+
   event-stream@4.0.1:
     resolution: {integrity: sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==}
 
@@ -18566,6 +18589,10 @@ packages:
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
+
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
@@ -19168,6 +19195,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-it@8.7.3:
+    resolution: {integrity: sha512-Fcv6n05iKMY/obxWb7wL0T8xOiUN/5ptBlg/Vf2WAvfs175wAV7Qf+UtWKp7Jdneu+KbUe6MIL0js2WBzoAoyg==}
+    engines: {node: '>=14.0.0'}
 
   get-monorepo-packages@1.2.0:
     resolution: {integrity: sha512-aDP6tH+eM3EuVSp3YyCutOcFS4Y9AhRRH9FAd+cjtR/g63Hx+DCXdKoP1ViRPUJz5wm+BOEXB4FhoffGHxJ7jQ==}
@@ -20192,6 +20223,10 @@ packages:
   is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
+
+  is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
 
   is-shared-array-buffer@1.0.3:
     resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
@@ -39815,6 +39850,20 @@ snapshots:
     transitivePeerDependencies:
       - zenObservable
 
+  '@sanity/client@7.22.1':
+    dependencies:
+      '@sanity/eventsource': 5.0.2
+      get-it: 8.7.3
+      nanoid: 3.3.11
+      rxjs: 7.8.2
+
+  '@sanity/eventsource@5.0.2':
+    dependencies:
+      '@types/event-source-polyfill': 1.0.5
+      '@types/eventsource': 1.1.15
+      event-source-polyfill: 1.0.31
+      eventsource: 2.0.2
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@segment/analytics-core@1.4.0':
@@ -42930,6 +42979,10 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/event-source-polyfill@1.0.5': {}
+
+  '@types/eventsource@1.1.15': {}
 
   '@types/express-serve-static-core@4.17.33':
     dependencies:
@@ -46891,6 +46944,10 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  decompress-response@7.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@0.7.0: {}
 
   dedent@1.5.1(babel-plugin-macros@3.1.0):
@@ -47730,6 +47787,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-source-polyfill@1.0.31: {}
+
   event-stream@4.0.1:
     dependencies:
       duplexer: 0.1.2
@@ -47754,6 +47813,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource@2.0.2: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -48622,6 +48683,13 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-it@8.7.3:
+    dependencies:
+      decompress-response: 7.0.0
+      is-retry-allowed: 2.2.0
+      through2: 4.0.2
+      tunnel-agent: 0.6.0
 
   get-monorepo-packages@1.2.0:
     dependencies:
@@ -49895,6 +49963,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-regexp@1.0.0: {}
+
+  is-retry-allowed@2.2.0: {}
 
   is-shared-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
### What changed? Why was the change needed?

**Related Novu Website PR:** https://github.com/novuhq/website-new/pull/81

Agents Onboarding:
- Preserve and use the `agentTemplateId` query param from the Novu Connect marketing website to pre-fill the Agents Onboarding form
- Fetch the agent templates from Sanity 
- When user is signed-in --> redirect to the agents list page with create dialog opened

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR enables deep-linking to agent templates from the Novu Connect marketing site: an incoming ?agentTemplateId is captured and preserved across auth redirects, used to prefill the Agents onboarding/create flows (name, description, prompt, MCP servers), and can open the create dialog for signed-in users. Agent templates are now fetched from Sanity CMS (instead of being hardcoded), allowing dynamic template updates without code changes.

## Affected areas

**dashboard**: Added Sanity integration and runtime dependency, new hook `useAgentTemplates`, and Sanity utilities/queries; persisted agentTemplateId helpers to survive Clerk auth flows; updated agents list, create dialog, onboarding/connect step, routing and pages to accept and apply template IDs; changelog cards now use the shared Sanity fetch utility.  
(Scopes not listed are unchanged.)

## Key technical decisions

- New runtime dependency: added `@sanity/client` to fetch templates from Sanity.  
- Templates are fetched via react-query with a 1-hour staleTime and fall back to hardcoded AGENT_TEMPLATES when Sanity returns nothing.  
- agentTemplateId is captured from the URL and stored in sessionStorage to survive full-page reloads caused by auth redirects.  
- Routing logic preserves the template id when redirecting to the appropriate agents list route for the current app/environment.

## Testing

No automated tests included; changes require manual verification (deep-linking flows, prefilled create dialog, and Sanity-driven template suggestions). Provided screenshots accompany the PR for manual validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

https://github.com/user-attachments/assets/0dd1c71b-a460-4097-aa37-14a7e97b8507

https://github.com/user-attachments/assets/5596df32-a7ea-49d9-99d4-64751de81c42



