### PR TITLE
fix(api-service): Redact MCP URLs in managed agent adoption logs fixes NV-7967

### DIFF
--- a/apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts
@@ -15,6 +15,7 @@ import { AgentRuntimeProviderIdEnum, type ICredentialsDto, MCP_SERVERS, McpConne
 import type { ClientSession } from 'mongoose';
 import { resolveManagedAgentAlwaysAllowToolPermissions } from '../../../mcp/resolve-managed-agent-always-allow-tool-permissions';
 import { resolveMcpServersById, resolveProviderMcpServerIds } from '../../../mcp/resolve-mcp-servers';
+import { sanitizeUrlForLogging } from '../../../mcp/sanitize-url-for-logging';
 import { ProvisionManagedAgentCommand } from './provision-managed-agent.command';
 
 export type ProvisionManagedAgentOptions = {
@@ -117,7 +118,10 @@ export class ProvisionManagedAgent {
             agentId: command.agentId,
             externalAgentId,
             providerId: runtimeProviderId,
-            unmatched: unmatched.map((entry) => ({ name: entry.name, url: entry.url })),
+            unmatched: unmatched.map((entry) => ({
+              name: entry.name,
+              url: entry.url ? sanitizeUrlForLogging(entry.url) : entry.url,
+            })),
           },
           `Dropping ${unmatched.length} provider MCP server(s) with no matching catalog entry during adoption. ` +
             'Rows are skipped so Mongo never points at servers Novu cannot render in the picker.'

--- a/apps/api/src/app/agents/mcp/sanitize-url-for-logging.spec.ts
+++ b/apps/api/src/app/agents/mcp/sanitize-url-for-logging.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import { sanitizeUrlForLogging } from './sanitize-url-for-logging';
+
+describe('sanitizeUrlForLogging', () => {
+  it('returns origin and pathname without query params', () => {
+    expect(sanitizeUrlForLogging('https://mcp.example.com/slack?token=super-secret')).to.equal(
+      'https://mcp.example.com/slack'
+    );
+  });
+
+  it('strips userinfo from parseable URLs via origin', () => {
+    expect(sanitizeUrlForLogging('https://user:password@mcp.example.com/slack')).to.equal(
+      'https://mcp.example.com/slack'
+    );
+  });
+
+  it('strips hash fragments', () => {
+    expect(sanitizeUrlForLogging('https://mcp.example.com/slack#access-token')).to.equal(
+      'https://mcp.example.com/slack'
+    );
+  });
+
+  it('redacts userinfo from unparseable URLs', () => {
+    expect(sanitizeUrlForLogging('/mcp/slack?token=secret')).to.equal('/mcp/slack');
+    expect(sanitizeUrlForLogging('//user:pass@host/path?token=secret')).to.equal('//[REDACTED]@host/path');
+  });
+
+  it('returns empty string for blank input', () => {
+    expect(sanitizeUrlForLogging('   ')).to.equal('');
+  });
+});

--- a/apps/api/src/app/agents/mcp/sanitize-url-for-logging.ts
+++ b/apps/api/src/app/agents/mcp/sanitize-url-for-logging.ts
@@ -1,0 +1,19 @@
+/**
+ * Produce a log-safe representation of a URL by stripping userinfo and
+ * query/hash segments that may contain credentials or access tokens.
+ */
+export function sanitizeUrlForLogging(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return trimmed.replace(/\/\/[^@/]+@/g, '//[REDACTED]@').split(/[?#]/)[0];
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses a medium-severity security finding from the agentic security review: adoption warning logs in `provision-managed-agent.usecase.ts` were including provider-supplied MCP URLs verbatim. Those URLs can carry credentials or access tokens in userinfo or query parameters, which would then be persisted to centralized logs.

## Changes

- Added `sanitizeUrlForLogging()` to strip userinfo and query/hash segments from URLs before logging.
- Applied sanitization to the `unmatched` MCP server entries in the managed-agent adoption warning log.

## Security impact

Logs now record only `origin + pathname` for parseable URLs (e.g. `https://mcp.example.com/slack` instead of `https://user:pass@mcp.example.com/slack?token=secret`), preserving enough context to debug catalog mismatches without leaking secrets.

## Testing

- Added unit tests for `sanitizeUrlForLogging` covering query params, userinfo, hash fragments, and unparseable URL fallbacks.
- `cd apps/api && pnpm test -- --grep "sanitizeUrlForLogging"` — 5 passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d5dfb36-15d5-4f26-94b1-888549d44be8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d5dfb36-15d5-4f26-94b1-888549d44be8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Added a URL sanitization utility to redact sensitive information from MCP URLs before logging in managed-agent adoption warnings. The new `sanitizeUrlForLogging()` function strips userinfo (credentials), query parameters, and hash fragments from URLs, leaving only the origin and pathname. This prevents accidental exposure of secrets to centralized logs while preserving debugging context.

## Affected areas
**api**: Integrated the new `sanitizeUrlForLogging()` helper into the managed-agent adoption logging flow to sanitize MCP server URLs in warning logs, preventing credentials and access tokens embedded in URLs from being persisted.

## Testing
Unit tests were added for `sanitizeUrlForLogging()` covering query parameter removal, userinfo redaction, hash fragment stripping, and fallback handling for unparseable URLs. All tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR patches a medium-severity security gap where provider-supplied MCP URLs — which can embed credentials or tokens in userinfo or query parameters — were being written verbatim into warning logs during managed-agent adoption. A new `sanitizeUrlForLogging()` helper strips those segments before logging, and its call site in `provision-managed-agent.usecase.ts` is guarded against falsy `url` values.

- **`sanitize-url-for-logging.ts`**: New utility using `new URL()` for the happy path (strips query, hash, and userinfo via `origin + pathname`) and a regex-plus-split fallback for relative/protocol-relative URLs; five unit tests cover all branches.
- **`provision-managed-agent.usecase.ts`**: Applies `sanitizeUrlForLogging()` to `unmatched` MCP entries before emitting the adoption warning, preserving server name and sanitized URL for debugging without exposing secrets.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix correctly eliminates credential leakage from adoption warning logs for all practical MCP URL shapes.

The change is narrow and well-tested. The only noteworthy edge case is that URL.origin returns the string 'null' for opaque-origin schemes (file:, blob:, data:), which would produce slightly garbled log output — though no credentials would be leaked. Since MCP server URLs are always http/https in practice, this edge case is unlikely to surface.

No files require special attention beyond the minor opaque-origin edge case in sanitize-url-for-logging.ts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/mcp/sanitize-url-for-logging.ts | New URL sanitizer; correctly handles http/https URLs via URL.origin (strips userinfo), plus a regex fallback for relative/protocol-relative URLs. Minor: URL.origin returns the string "null" for opaque-origin schemes (file:, data:, blob:), which would produce "null/pathname" — harmless for MCP URLs but worth knowing. |
| apps/api/src/app/agents/mcp/sanitize-url-for-logging.spec.ts | Unit tests cover query-param stripping, userinfo redaction, hash fragment removal, relative-URL fallback, and blank-input handling — all five cases pass. |
| apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts | Integration of sanitizeUrlForLogging is minimal and correct; falsy-URL guard (entry.url ? ... : entry.url) safely preserves null/undefined without calling the utility. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Provider as Agent Runtime Provider
    participant Usecase as ProvisionManagedAgent
    participant Sanitizer as sanitizeUrlForLogging()
    participant Logger as PinoLogger

    Provider->>Usecase: getConfig(externalAgentId) → mcpServers[]
    Usecase->>Usecase: "resolveProviderMcpServerIds(mcpServers) → { matchedIds, unmatched }"
    alt "unmatched.length > 0"
        loop each unmatched entry
            Usecase->>Sanitizer: entry.url (raw, may contain credentials)
            Sanitizer-->>Usecase: origin + pathname only
        end
        Usecase->>Logger: "warn({ unmatched: [{name, sanitizedUrl}] })"
        Note over Logger: Credentials/tokens stripped from URL
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fmcp%2Fsanitize-url-for-logging.ts%3A12-16%0AFor%20non-http%28s%29%20schemes%20that%20%60new%20URL%28%29%60%20can%20still%20parse%20%28e.g.%20%60file%3A%60%2C%20%60blob%3A%60%2C%20%60data%3A%60%29%2C%20%60URL.origin%60%20returns%20the%20string%20literal%20%60%22null%22%60%20per%20the%20URL%20spec%2C%20producing%20output%20like%20%60%22null%2Fpath%22%60%20instead%20of%20a%20meaningful%20sanitized%20URL.%20This%20wouldn't%20leak%20credentials%2C%20but%20could%20produce%20confusing%20log%20entries.%20Checking%20that%20%60parsed.origin%20!%3D%3D%20'null'%60%20before%20using%20it%20avoids%20the%20confusion.%0A%0A%60%60%60suggestion%0A%20%20try%20%7B%0A%20%20%20%20const%20parsed%20%3D%20new%20URL%28trimmed%29%3B%0A%20%20%20%20const%20origin%20%3D%20parsed.origin%20!%3D%3D%20'null'%20%3F%20parsed.origin%20%3A%20%60%24%7Bparsed.protocol%7D%2F%2F%24%7Bparsed.host%7D%60%3B%0A%0A%20%20%20%20return%20%60%24%7Borigin%7D%24%7Bparsed.pathname%7D%60%3B%0A%20%20%7D%20catch%20%7B%0A%60%60%60%0A%0A&pr=11449&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/mcp/sanitize-url-for-logging.ts:12-16
For non-http(s) schemes that `new URL()` can still parse (e.g. `file:`, `blob:`, `data:`), `URL.origin` returns the string literal `"null"` per the URL spec, producing output like `"null/path"` instead of a meaningful sanitized URL. This wouldn't leak credentials, but could produce confusing log entries. Checking that `parsed.origin !== 'null'` before using it avoids the confusion.

```suggestion
  try {
    const parsed = new URL(trimmed);
    const origin = parsed.origin !== 'null' ? parsed.origin : `${parsed.protocol}//${parsed.host}`;

    return `${origin}${parsed.pathname}`;
  } catch {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): redact MCP URLs in managed age..."](https://github.com/novuhq/novu/commit/2cef755b37432a73470055de6743e375e398883f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36051653)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->