### PR TITLE
feat(api-service,dashboard,shared): keyless novu connect flow fixes NV-7968

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,15 @@ Run `pnpm build` after changes to `packages/` or `enterprise/`. Direct changes t
 ### Never
 - Inactive apps — do not touch, unless monorepo wide refactor: `apps/webhook`
 - Auto-generated — never edit: `libs/internal-sdk`
-- Read-only dirs: `.idea/`, `.github/`, `scripts/`, `docker/`
 - UI: reuse existing Radix/shadcn components only; do not copy patterns from `playground/` into production code
 - If doing a monorepo wide refactor, you can touch the read only, but only when necessary.
+
+
+## Novu Distribution
+Novu is distributed in 3 modes, Community Edition, Enterprise Cloud Edition, and On-Prem Enterprise Edition.
+
+When making changes targeted to the Enterprise distribution, we need to make sure that the changes are not breaking the Community edition, and are properly gated behind a flag, or the novu enterpise env variables. Similarly when some changes are only targeting the Cloud, self-hosted on prem should not be affected.
+
 
 <!-- Infrastructure & services: see .cursor/rules/infrastructure.mdc -->
 <!-- Dependency graph: see .cursor/rules/dependency-graph.mdc -->

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { ChangeModule } from './app/change/change.module';
 import { ChannelConnectionsModule } from './app/channel-connections/channel-connections.module';
 import { ChannelEndpointsModule } from './app/channel-endpoints/channel-endpoints.module';
 import { CliAuthModule } from './app/cli-auth/cli-auth.module';
+import { ConnectModule } from './app/connect/connect.module';
 import { ContentTemplatesModule } from './app/content-templates/content-templates.module';
 import { ContextsModule } from './app/contexts/contexts.module';
 import { DomainsModule } from './app/domains/domains.module';
@@ -133,6 +134,7 @@ const baseModules: Array<Type | DynamicModule | Promise<DynamicModule> | Forward
   OrganizationModule,
   ActivityModule,
   AgentsModule,
+  ConnectModule,
   DomainsModule.forRoot(),
   UserModule,
   IntegrationModule,

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -22,6 +22,7 @@ import {
 import { AuthModule } from '../auth/auth.module';
 import { ChannelEndpointsModule } from '../channel-endpoints/channel-endpoints.module';
 import { ConnectModule } from '../connect/connect.module';
+import { KeylessModule } from '../keyless/keyless.module';
 import { EventsModule } from '../events/events.module';
 import { SharedModule } from '../shared/shared.module';
 import { AgentConfigResolver } from './channels/agent-config-resolver.service';
@@ -64,7 +65,7 @@ import { AgentRuntimeExceptionFilter } from './shared/agent-runtime-exception.fi
 import { USE_CASES } from './usecases';
 
 @Module({
-  imports: [SharedModule, AuthModule, EventsModule, ChannelEndpointsModule, ConnectModule],
+  imports: [SharedModule, AuthModule, EventsModule, ChannelEndpointsModule, ConnectModule, KeylessModule],
   controllers: [
     AgentsController,
     AgentIntegrationsController,

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -21,7 +21,7 @@ import {
 
 import { AuthModule } from '../auth/auth.module';
 import { ChannelEndpointsModule } from '../channel-endpoints/channel-endpoints.module';
-import { ConnectClaimTokenService } from '../connect/services/connect-claim-token.service';
+import { ConnectModule } from '../connect/connect.module';
 import { EventsModule } from '../events/events.module';
 import { SharedModule } from '../shared/shared.module';
 import { AgentConfigResolver } from './channels/agent-config-resolver.service';
@@ -64,7 +64,7 @@ import { AgentRuntimeExceptionFilter } from './shared/agent-runtime-exception.fi
 import { USE_CASES } from './usecases';
 
 @Module({
-  imports: [SharedModule, AuthModule, EventsModule, ChannelEndpointsModule],
+  imports: [SharedModule, AuthModule, EventsModule, ChannelEndpointsModule, ConnectModule],
   controllers: [
     AgentsController,
     AgentIntegrationsController,
@@ -116,7 +116,6 @@ import { USE_CASES } from './usecases';
     McpOAuthDiscoveryService,
     TelegramMobileLinkTokenService,
     TelegramStartCodeService,
-    ConnectClaimTokenService,
     CalculateLimitNovuIntegration,
     CalculateDemoClaudeQuota,
     CreateOrUpdateSubscriberUseCase,

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -21,6 +21,7 @@ import {
 
 import { AuthModule } from '../auth/auth.module';
 import { ChannelEndpointsModule } from '../channel-endpoints/channel-endpoints.module';
+import { ConnectClaimTokenService } from '../connect/services/connect-claim-token.service';
 import { EventsModule } from '../events/events.module';
 import { SharedModule } from '../shared/shared.module';
 import { AgentConfigResolver } from './channels/agent-config-resolver.service';
@@ -115,6 +116,7 @@ import { USE_CASES } from './usecases';
     McpOAuthDiscoveryService,
     TelegramMobileLinkTokenService,
     TelegramStartCodeService,
+    ConnectClaimTokenService,
     CalculateLimitNovuIntegration,
     CalculateDemoClaudeQuota,
     CreateOrUpdateSubscriberUseCase,

--- a/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
@@ -51,7 +51,6 @@ export interface ResolvedAgentConfig {
   connectionAccessToken?: string;
   environmentId: string;
   organizationId: string;
-  /** True when this agent lives in the shared keyless org (anonymous Connect demo). */
   isKeyless: boolean;
   agentId: string;
   agentIdentifier: string;

--- a/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
@@ -51,6 +51,8 @@ export interface ResolvedAgentConfig {
   connectionAccessToken?: string;
   environmentId: string;
   organizationId: string;
+  /** True when this agent lives in the shared keyless org (anonymous Connect demo). */
+  isKeyless: boolean;
   agentId: string;
   agentIdentifier: string;
   /** Human-readable display name; used in email-action confirmation UI. */
@@ -246,6 +248,7 @@ export class AgentConfigResolver {
       connectionAccessToken,
       environmentId,
       organizationId,
+      isKeyless: Boolean(process.env.KEYLESS_ORGANIZATION_ID && organizationId === process.env.KEYLESS_ORGANIZATION_ID),
       agentId: agent._id,
       agentIdentifier: agent.identifier,
       agentName: agent.name,

--- a/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
+++ b/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
@@ -30,6 +30,7 @@ import {
   ApiNotFoundResponse,
   ApiResponse,
 } from '../../../shared/framework/response.decorator';
+import { KeylessAccessible } from '../../../shared/framework/swagger/keyless.security';
 import { UserSession } from '../../../shared/framework/user.decorator';
 import { SendAgentWelcomeMessageCommand } from '../../conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.command';
 import { SendAgentWelcomeMessage } from '../../conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase';
@@ -100,6 +101,7 @@ export class AgentIntegrationsController {
 
   @Post('/:identifier/integrations')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @ApiResponse(AgentIntegrationResponseDto, 201)
   @ApiOperation({
     summary: 'Link integration to agent',
@@ -129,6 +131,7 @@ export class AgentIntegrationsController {
 
   @Get('/:identifier/integrations')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @ApiResponse(ListAgentIntegrationsResponseDto)
   @ApiOperation({
     summary: 'List agent integrations',
@@ -330,6 +333,7 @@ export class AgentIntegrationsController {
 
   @Post('/:identifier/welcome-message')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Send onboarding welcome message',
@@ -358,6 +362,7 @@ export class AgentIntegrationsController {
 
   @Post('/:identifier/integrations/:integrationId/telegram/configure')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @HttpCode(HttpStatus.OK)
   @ApiResponse(ConfigureTelegramWebhookResponseDto, 200)
   @ApiOperation({
@@ -388,6 +393,7 @@ export class AgentIntegrationsController {
 
   @Post('/:identifier/integrations/:integrationId/telegram/mobile-link')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @HttpCode(HttpStatus.OK)
   @ApiResponse(IssueTelegramMobileLinkResponseDto, 200)
   @ApiOperation({
@@ -420,6 +426,7 @@ export class AgentIntegrationsController {
 
   @Post('/:identifier/integrations/:integrationId/telegram/subscriber-link')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @HttpCode(HttpStatus.OK)
   @ApiResponse(IssueTelegramSubscriberLinkResponseDto, 200)
   @ApiOperation({

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -257,7 +257,6 @@ export class AgentConversationService {
     return this.activityRepository.findByConversation(environmentId, conversationId, limit);
   }
 
-  /** Counts outbound agent messages in a conversation; used to enforce the keyless demo reply cap. */
   async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
     return this.activityRepository.countAgentMessages(environmentId, conversationId);
   }

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -257,6 +257,11 @@ export class AgentConversationService {
     return this.activityRepository.findByConversation(environmentId, conversationId, limit);
   }
 
+  /** Counts outbound agent messages in a conversation; used to enforce the keyless demo reply cap. */
+  async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
+    return this.activityRepository.countAgentMessages(environmentId, conversationId);
+  }
+
   async getConversation(
     conversationId: string,
     environmentId: string,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -132,6 +132,9 @@ describe('AgentInboundHandler', () => {
     const channelEndpointRepository = {
       findByPlatformIdentity: overrides.findTelegramEndpointByIdentity ?? sinon.stub().resolves(null),
     };
+    const connectClaimTokenService = {
+      issue: sinon.stub().resolves({ token: 'claim-token', expiresAt: new Date().toISOString() }),
+    };
     const handler = new AgentInboundHandler(
       logger as any,
       subscriberResolver as any,
@@ -145,7 +148,8 @@ describe('AgentInboundHandler', () => {
       attachmentStorage as any,
       startCodeService as any,
       channelEndpointRepository as any,
-      linkTelegramChatToSubscriber as any
+      linkTelegramChatToSubscriber as any,
+      connectClaimTokenService as any
     );
 
     return {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -134,6 +134,10 @@ describe('AgentInboundHandler', () => {
     };
     const connectClaimTokenService = {
       issue: sinon.stub().resolves({ token: 'claim-token', expiresAt: new Date().toISOString() }),
+      issueOrGetForEnvironment: sinon
+        .stub()
+        .resolves({ token: 'claim-token', expiresAt: new Date().toISOString() }),
+      tryMarkSignupCtaPosted: sinon.stub().resolves(true),
     };
     const handler = new AgentInboundHandler(
       logger as any,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -140,6 +140,11 @@ describe('AgentInboundHandler', () => {
       isSignupCtaPosted: sinon.stub().resolves(false),
       tryMarkSignupCtaPosted: sinon.stub().resolves(true),
     };
+    const keylessAbuseGuard = {
+      isKeylessAgentAiEnabled: sinon.stub().resolves(true),
+      assertKeylessAiEnabled: sinon.stub().resolves(),
+      assertManagedAgentCap: sinon.stub().resolves(),
+    };
     const handler = new AgentInboundHandler(
       logger as any,
       subscriberResolver as any,
@@ -154,7 +159,8 @@ describe('AgentInboundHandler', () => {
       startCodeService as any,
       channelEndpointRepository as any,
       linkTelegramChatToSubscriber as any,
-      connectClaimTokenService as any
+      connectClaimTokenService as any,
+      keylessAbuseGuard as any
     );
 
     return {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -137,6 +137,7 @@ describe('AgentInboundHandler', () => {
       issueOrGetForEnvironment: sinon
         .stub()
         .resolves({ token: 'claim-token', expiresAt: new Date().toISOString() }),
+      isSignupCtaPosted: sinon.stub().resolves(false),
       tryMarkSignupCtaPosted: sinon.stub().resolves(true),
     };
     const handler = new AgentInboundHandler(

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -14,6 +14,7 @@ import { ENDPOINT_TYPES } from '@novu/shared';
 import type { CardElement, EmojiValue, Message, Thread } from 'chat';
 import { ConnectClaimTokenService } from '../../../connect/services/connect-claim-token.service';
 import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
+import { parsePositiveIntEnv } from '../../../keyless/keyless-abuse.constants';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { LinkTelegramChatToSubscriberCommand } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
 import { LinkTelegramChatToSubscriber } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
@@ -85,12 +86,7 @@ const ACKNOWLEDGE_FALLBACK_EMOJI = 'eyes' as const;
 
 const NOVU_PRICING_URL = 'https://novu.co/pricing';
 
-const keylessDemoReplyCapRaw = process.env.KEYLESS_DEMO_REPLY_CAP;
-const parsedKeylessDemoReplyCap = Number(keylessDemoReplyCapRaw);
-const KEYLESS_DEMO_REPLY_CAP =
-  keylessDemoReplyCapRaw != null && keylessDemoReplyCapRaw !== '' && !Number.isNaN(parsedKeylessDemoReplyCap)
-    ? parsedKeylessDemoReplyCap
-    : 5;
+const KEYLESS_DEMO_REPLY_CAP = parsePositiveIntEnv(process.env.KEYLESS_DEMO_REPLY_CAP, 5);
 
 function resolveConnectClaimBaseUrl(): string {
   for (const candidate of [process.env.DASHBOARD_URL, process.env.FRONT_BASE_URL]) {
@@ -369,6 +365,26 @@ export class AgentInboundHandler implements OnModuleInit {
     const platformThreadId = getInboundPlatformThreadId(config.platform, thread, message);
     const conversation = await this.openConversation(agentId, config, message, subscriberId, platformThreadId);
 
+    if (config.isKeyless) {
+      const aiEnabled = await this.keylessAbuseGuard.isKeylessAgentAiEnabled(config.organizationId);
+
+      if (!aiEnabled) {
+        await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
+
+        return;
+      }
+
+      if (await this.connectClaimTokenService.isSignupCtaPosted(conversation._id)) {
+        return;
+      }
+
+      if (await this.isKeylessDemoCapReached(config, conversation._id)) {
+        await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
+
+        return;
+      }
+    }
+
     const storedAttachments = await this.storeInboundAttachments(config, conversation, message);
     const isFirstMessage = !this.conversationService.getPrimaryChannel(conversation).firstPlatformMessageId;
 
@@ -391,26 +407,6 @@ export class AgentInboundHandler implements OnModuleInit {
         'managedRuntime',
       ]),
     ]);
-
-    if (config.isKeyless) {
-      const aiEnabled = await this.keylessAbuseGuard.isKeylessAgentAiEnabled(config.organizationId);
-
-      if (!aiEnabled) {
-        await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
-
-        return;
-      }
-
-      if (await this.connectClaimTokenService.isSignupCtaPosted(conversation._id)) {
-        return;
-      }
-
-      if (await this.isKeylessDemoCapReached(config, conversation._id)) {
-        await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
-
-        return;
-      }
-    }
 
     await this.acknowledgeReceipt(agentId, config, thread, message, isFirstMessage);
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -388,7 +388,7 @@ export class AgentInboundHandler implements OnModuleInit {
     // until the env is claimed into a real org (after which `isKeyless` is false
     // and dispatch resumes with the full prior history intact).
     if (config.isKeyless && (await this.isKeylessDemoCapReached(config, conversation._id))) {
-      await this.postKeylessSignupCta(agentId, config, thread);
+      await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
 
       return;
     }
@@ -770,10 +770,16 @@ export class AgentInboundHandler implements OnModuleInit {
   private async postKeylessSignupCta(
     agentId: string,
     config: ResolvedAgentConfig,
-    thread: Thread
+    thread: Thread,
+    conversationId: string
   ): Promise<void> {
     try {
-      const { token } = await this.connectClaimTokenService.issue({
+      const shouldPost = await this.connectClaimTokenService.tryMarkSignupCtaPosted(conversationId);
+      if (!shouldPost) {
+        return;
+      }
+
+      const { token } = await this.connectClaimTokenService.issueOrGetForEnvironment({
         env: config.environmentId,
         org: config.organizationId,
       });

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -84,13 +84,25 @@ const ACKNOWLEDGE_FALLBACK_EMOJI = 'eyes' as const;
 
 const NOVU_PRICING_URL = 'https://novu.co/pricing';
 
-const KEYLESS_DEMO_REPLY_CAP = Number(process.env.KEYLESS_DEMO_REPLY_CAP) || 5;
+const keylessDemoReplyCapRaw = process.env.KEYLESS_DEMO_REPLY_CAP;
+const parsedKeylessDemoReplyCap = Number(keylessDemoReplyCapRaw);
+const KEYLESS_DEMO_REPLY_CAP =
+  keylessDemoReplyCapRaw != null && keylessDemoReplyCapRaw !== '' && !Number.isNaN(parsedKeylessDemoReplyCap)
+    ? parsedKeylessDemoReplyCap
+    : 5;
 
 function resolveConnectClaimBaseUrl(): string {
-  return (process.env.CONNECT_WEB_URL || process.env.CONNECT_DASHBOARD_URL || 'https://connect.novu.co').replace(
-    /\/$/,
-    ''
-  );
+  for (const candidate of [process.env.DASHBOARD_URL, process.env.FRONT_BASE_URL]) {
+    const trimmed = candidate?.trim();
+
+    if (!trimmed || trimmed.startsWith('^')) {
+      continue;
+    }
+
+    return trimmed.replace(/\/$/, '');
+  }
+
+  return 'https://dashboard.novu.co';
 }
 
 function buildKeylessSignupCard(claimUrl: string): CardElement {
@@ -378,10 +390,16 @@ export class AgentInboundHandler implements OnModuleInit {
       ]),
     ]);
 
-    if (config.isKeyless && (await this.isKeylessDemoCapReached(config, conversation._id))) {
-      await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
+    if (config.isKeyless) {
+      if (await this.connectClaimTokenService.isSignupCtaPosted(conversation._id)) {
+        return;
+      }
 
-      return;
+      if (await this.isKeylessDemoCapReached(config, conversation._id)) {
+        await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
+
+        return;
+      }
     }
 
     await this.acknowledgeReceipt(agentId, config, thread, message, isFirstMessage);

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -776,7 +776,6 @@ export class AgentInboundHandler implements OnModuleInit {
     return agentReplies >= KEYLESS_DEMO_REPLY_CAP;
   }
 
-  /** Failing to post the signup CTA must not crash the inbound webhook. */
   private async postKeylessSignupCta(
     agentId: string,
     config: ResolvedAgentConfig,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -13,6 +13,7 @@ import type { AgentAction } from '@novu/framework';
 import { ENDPOINT_TYPES } from '@novu/shared';
 import type { CardElement, EmojiValue, Message, Thread } from 'chat';
 import { ConnectClaimTokenService } from '../../../connect/services/connect-claim-token.service';
+import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { LinkTelegramChatToSubscriberCommand } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
 import { LinkTelegramChatToSubscriber } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
@@ -291,7 +292,8 @@ export class AgentInboundHandler implements OnModuleInit {
     private readonly startCodeService: TelegramStartCodeService,
     private readonly channelEndpointRepository: ChannelEndpointRepository,
     private readonly linkTelegramChatToSubscriber: LinkTelegramChatToSubscriber,
-    private readonly connectClaimTokenService: ConnectClaimTokenService
+    private readonly connectClaimTokenService: ConnectClaimTokenService,
+    private readonly keylessAbuseGuard: KeylessAbuseGuardService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -391,6 +393,14 @@ export class AgentInboundHandler implements OnModuleInit {
     ]);
 
     if (config.isKeyless) {
+      const aiEnabled = await this.keylessAbuseGuard.isKeylessAgentAiEnabled(config.organizationId);
+
+      if (!aiEnabled) {
+        await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
+
+        return;
+      }
+
       if (await this.connectClaimTokenService.isSignupCtaPosted(conversation._id)) {
         return;
       }

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -84,11 +84,6 @@ const ACKNOWLEDGE_FALLBACK_EMOJI = 'eyes' as const;
 
 const NOVU_PRICING_URL = 'https://novu.co/pricing';
 
-/**
- * Number of agent replies a keyless (anonymous Connect) demo conversation gets
- * before the agent stops responding and asks the user to sign up. Overridable
- * via `KEYLESS_DEMO_REPLY_CAP`.
- */
 const KEYLESS_DEMO_REPLY_CAP = Number(process.env.KEYLESS_DEMO_REPLY_CAP) || 5;
 
 function resolveConnectClaimBaseUrl(): string {
@@ -383,10 +378,6 @@ export class AgentInboundHandler implements OnModuleInit {
       ]),
     ]);
 
-    // Keyless (anonymous Connect demo) conversations get a hard cap on agent
-    // replies. Once reached, the agent stops responding and posts a signup CTA
-    // until the env is claimed into a real org (after which `isKeyless` is false
-    // and dispatch resumes with the full prior history intact).
     if (config.isKeyless && (await this.isKeylessDemoCapReached(config, conversation._id))) {
       await this.postKeylessSignupCta(agentId, config, thread, conversation._id);
 
@@ -761,12 +752,7 @@ export class AgentInboundHandler implements OnModuleInit {
     return agentReplies >= KEYLESS_DEMO_REPLY_CAP;
   }
 
-  /**
-   * Posts the keyless demo signup CTA into the live thread. Mints a single-use,
-   * signed claim token bound to the keyless environment and links to the
-   * dashboard claim page. Errors are logged but swallowed — failing to post the
-   * card must not crash the inbound webhook.
-   */
+  /** Failing to post the signup CTA must not crash the inbound webhook. */
   private async postKeylessSignupCta(
     agentId: string,
     config: ResolvedAgentConfig,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -783,8 +783,7 @@ export class AgentInboundHandler implements OnModuleInit {
     conversationId: string
   ): Promise<void> {
     try {
-      const shouldPost = await this.connectClaimTokenService.tryMarkSignupCtaPosted(conversationId);
-      if (!shouldPost) {
+      if (await this.connectClaimTokenService.isSignupCtaPosted(conversationId)) {
         return;
       }
 
@@ -797,6 +796,8 @@ export class AgentInboundHandler implements OnModuleInit {
       await this.outboundGateway.replyOnThread(thread, {
         card: buildKeylessSignupCard(claimUrl) as unknown as Record<string, unknown>,
       });
+
+      await this.connectClaimTokenService.tryMarkSignupCtaPosted(conversationId);
     } catch (err) {
       this.logger.warn(err, `[agent:${agentId}] Failed to post keyless signup CTA`);
       captureAgentWarning(err, {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -12,6 +12,7 @@ import {
 import type { AgentAction } from '@novu/framework';
 import { ENDPOINT_TYPES } from '@novu/shared';
 import type { CardElement, EmojiValue, Message, Thread } from 'chat';
+import { ConnectClaimTokenService } from '../../../connect/services/connect-claim-token.service';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { LinkTelegramChatToSubscriberCommand } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
 import { LinkTelegramChatToSubscriber } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
@@ -82,6 +83,46 @@ const SUBSCRIBER_LINK_WRONG_BOT_REPLY =
 const ACKNOWLEDGE_FALLBACK_EMOJI = 'eyes' as const;
 
 const NOVU_PRICING_URL = 'https://novu.co/pricing';
+
+/**
+ * Number of agent replies a keyless (anonymous Connect) demo conversation gets
+ * before the agent stops responding and asks the user to sign up. Overridable
+ * via `KEYLESS_DEMO_REPLY_CAP`.
+ */
+const KEYLESS_DEMO_REPLY_CAP = Number(process.env.KEYLESS_DEMO_REPLY_CAP) || 5;
+
+function resolveConnectClaimBaseUrl(): string {
+  return (process.env.CONNECT_WEB_URL || process.env.CONNECT_DASHBOARD_URL || 'https://connect.novu.co').replace(
+    /\/$/,
+    ''
+  );
+}
+
+function buildKeylessSignupCard(claimUrl: string): CardElement {
+  return {
+    type: 'card',
+    children: [
+      {
+        type: 'text',
+        content:
+          "You've reached the limit of this free demo. Sign up for a free Novu account to keep this agent — your " +
+          'conversation and setup carry over, and the agent picks up right where it left off.',
+      },
+      { type: 'divider' },
+      {
+        type: 'actions',
+        children: [
+          {
+            type: 'link-button',
+            label: 'Sign up & keep this agent',
+            url: claimUrl,
+            style: 'primary',
+          },
+        ],
+      },
+    ],
+  };
+}
 
 /**
  * Workspace-label copy keyed by every platform in `AUTO_PROVISION_PLATFORMS`.
@@ -242,7 +283,8 @@ export class AgentInboundHandler implements OnModuleInit {
     private readonly attachmentStorage: AgentAttachmentStorage,
     private readonly startCodeService: TelegramStartCodeService,
     private readonly channelEndpointRepository: ChannelEndpointRepository,
-    private readonly linkTelegramChatToSubscriber: LinkTelegramChatToSubscriber
+    private readonly linkTelegramChatToSubscriber: LinkTelegramChatToSubscriber,
+    private readonly connectClaimTokenService: ConnectClaimTokenService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -340,6 +382,16 @@ export class AgentInboundHandler implements OnModuleInit {
         'managedRuntime',
       ]),
     ]);
+
+    // Keyless (anonymous Connect demo) conversations get a hard cap on agent
+    // replies. Once reached, the agent stops responding and posts a signup CTA
+    // until the env is claimed into a real org (after which `isKeyless` is false
+    // and dispatch resumes with the full prior history intact).
+    if (config.isKeyless && (await this.isKeylessDemoCapReached(config, conversation._id))) {
+      await this.postKeylessSignupCta(agentId, config, thread);
+
+      return;
+    }
 
     await this.acknowledgeReceipt(agentId, config, thread, message, isFirstMessage);
 
@@ -699,6 +751,43 @@ export class AgentInboundHandler implements OnModuleInit {
         operation: 'post-capacity-reached-card',
         agentId,
         platform: config.platform,
+      });
+    }
+  }
+
+  private async isKeylessDemoCapReached(config: ResolvedAgentConfig, conversationId: string): Promise<boolean> {
+    const agentReplies = await this.conversationService.countAgentMessages(config.environmentId, conversationId);
+
+    return agentReplies >= KEYLESS_DEMO_REPLY_CAP;
+  }
+
+  /**
+   * Posts the keyless demo signup CTA into the live thread. Mints a single-use,
+   * signed claim token bound to the keyless environment and links to the
+   * dashboard claim page. Errors are logged but swallowed — failing to post the
+   * card must not crash the inbound webhook.
+   */
+  private async postKeylessSignupCta(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    thread: Thread
+  ): Promise<void> {
+    try {
+      const { token } = await this.connectClaimTokenService.issue({
+        env: config.environmentId,
+        org: config.organizationId,
+      });
+      const claimUrl = `${resolveConnectClaimBaseUrl()}/connect/claim?token=${encodeURIComponent(token)}`;
+
+      await this.outboundGateway.replyOnThread(thread, {
+        card: buildKeylessSignupCard(claimUrl) as unknown as Record<string, unknown>,
+      });
+    } catch (err) {
+      this.logger.warn(err, `[agent:${agentId}] Failed to post keyless signup CTA`);
+      captureAgentWarning(err, {
+        component: 'agent-inbound-handler',
+        operation: 'post-keyless-signup-cta',
+        agentId,
       });
     }
   }

--- a/apps/api/src/app/agents/management/agent-runtime.controller.ts
+++ b/apps/api/src/app/agents/management/agent-runtime.controller.ts
@@ -29,6 +29,7 @@ import {
   ApiNotFoundResponse,
   ApiResponse,
 } from '../../shared/framework/response.decorator';
+import { KeylessAccessible } from '../../shared/framework/swagger/keyless.security';
 import { UserSession } from '../../shared/framework/user.decorator';
 import { EnsureProviderManagedVaultCommand } from '../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.command';
 import { EnsureProviderManagedVault } from '../mcp/connections/ensure-provider-managed-vault/ensure-provider-managed-vault.usecase';
@@ -106,6 +107,7 @@ export class AgentRuntimeController {
 
   @Post('/verify-credentials')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @ApiResponse(VerifyManagedCredentialsResponseDto)
   @ApiOperation({
     summary: 'Verify managed-runtime credentials',
@@ -134,6 +136,7 @@ export class AgentRuntimeController {
 
   @Post('/generate')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @ApiResponse(GenerateManagedAgentResponseDto)
   @ApiOperation({
     summary: 'Generate an agent configuration from a free-form prompt',

--- a/apps/api/src/app/agents/management/agent-runtime.controller.ts
+++ b/apps/api/src/app/agents/management/agent-runtime.controller.ts
@@ -17,8 +17,9 @@ import {
 } from '@nestjs/common';
 import { ApiExcludeController, ApiOperation } from '@nestjs/swagger';
 import { RequirePermissions } from '@novu/application-generic';
-import { ApiRateLimitCategoryEnum, PermissionsEnum, UserSessionData } from '@novu/shared';
+import { ApiRateLimitCategoryEnum, ApiAuthSchemeEnum, PermissionsEnum, UserSessionData } from '@novu/shared';
 import type { Request } from 'express';
+import { getClientIp } from 'request-ip';
 import { RequireAuthentication } from '../../auth/framework/auth.decorator';
 import { ExternalApiAccessible } from '../../auth/framework/external-api.decorator';
 import { ThrottlerCategory } from '../../rate-limiting/guards';
@@ -166,6 +167,9 @@ export class AgentRuntimeController {
     // `class-transformer`'s `plainToInstance` triggers `new AbortSignal()`, which is
     // disallowed by the runtime (`ERR_ILLEGAL_CONSTRUCTOR`).
     command.signal = abortController.signal;
+    if (user.scheme === ApiAuthSchemeEnum.KEYLESS) {
+      command.clientIp = getClientIp(request) ?? undefined;
+    }
 
     try {
       return await this.generateManagedAgentUsecase.execute(command);

--- a/apps/api/src/app/agents/management/agents.controller.ts
+++ b/apps/api/src/app/agents/management/agents.controller.ts
@@ -26,6 +26,7 @@ import {
   ApiNotFoundResponse,
   ApiResponse,
 } from '../../shared/framework/response.decorator';
+import { KeylessAccessible } from '../../shared/framework/swagger/keyless.security';
 import { UserSession } from '../../shared/framework/user.decorator';
 import { AgentRuntimeExceptionFilter } from '../shared/agent-runtime-exception.filter';
 import {
@@ -78,6 +79,7 @@ export class AgentsController {
 
   @Post('/')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @ApiResponse(AgentResponseDto, 201)
   @ApiOperation({
     summary: 'Create agent',
@@ -103,6 +105,7 @@ export class AgentsController {
 
   @Get('/')
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @ApiResponse(ListAgentsResponseDto)
   @ApiOperation({
     summary: 'List agents',

--- a/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
@@ -72,11 +72,12 @@ export class CreateAgent {
 
     if (isManaged) {
       await this.keylessAbuseGuard.assertKeylessAiEnabled(command.organizationId);
-      await this.keylessAbuseGuard.assertManagedAgentCap(command.environmentId, command.organizationId);
     }
 
     const agent = isManaged
       ? await this.agentRepository.withTransaction(async (session) => {
+          await this.keylessAbuseGuard.assertManagedAgentCap(command.environmentId, command.organizationId);
+
           const managedRuntime = command.managedRuntime!;
 
           // In adopt mode we don't know the name/identifier yet — use temporary placeholders.

--- a/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
@@ -16,6 +16,7 @@ import { GetAgentRuntimeConfigCommand } from '../get-agent-runtime-config/get-ag
 import { GetAgentRuntimeConfig } from '../get-agent-runtime-config/get-agent-runtime-config.usecase';
 import { ProvisionManagedAgentCommand } from '../provision-managed-agent/provision-managed-agent.command';
 import { ProvisionManagedAgent } from '../provision-managed-agent/provision-managed-agent.usecase';
+import { KeylessAbuseGuardService } from '../../../../keyless/keyless-abuse-guard.service';
 import { CreateAgentCommand } from './create-agent.command';
 
 /** Temporary placeholder used for the initial Mongo insert in adopt mode. */
@@ -31,7 +32,8 @@ export class CreateAgent {
     private readonly getAgentRuntimeConfigUsecase: GetAgentRuntimeConfig,
     private readonly environmentRepository: EnvironmentRepository,
     private readonly organizationRepository: CommunityOrganizationRepository,
-    private readonly logger: PinoLogger
+    private readonly logger: PinoLogger,
+    private readonly keylessAbuseGuard: KeylessAbuseGuardService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -67,6 +69,11 @@ export class CreateAgent {
     }
 
     const isManaged = command.runtime === 'managed';
+
+    if (isManaged) {
+      await this.keylessAbuseGuard.assertKeylessAiEnabled(command.organizationId);
+      await this.keylessAbuseGuard.assertManagedAgentCap(command.environmentId, command.organizationId);
+    }
 
     const agent = isManaged
       ? await this.agentRepository.withTransaction(async (session) => {

--- a/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.command.ts
+++ b/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.command.ts
@@ -37,4 +37,7 @@ export class GenerateManagedAgentCommand extends BaseCommand {
    * assigns this field directly on the command instance after `create(...)`.
    */
   signal?: AbortSignal;
+
+  /** Client IP for keyless per-IP generation caps. Assigned by the controller after `create(...)`. */
+  clientIp?: string;
 }

--- a/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.command.ts
+++ b/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.command.ts
@@ -38,6 +38,5 @@ export class GenerateManagedAgentCommand extends BaseCommand {
    */
   signal?: AbortSignal;
 
-  /** Client IP for keyless per-IP generation caps. Assigned by the controller after `create(...)`. */
   clientIp?: string;
 }

--- a/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
@@ -1,8 +1,9 @@
 import { Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { AnalyticsService, InstrumentUsecase, PinoLogger } from '@novu/application-generic';
-import { CLAUDE_ANTHROPIC_SKILLS, CLAUDE_BUILTIN_TOOLS, CLAUDE_DEFAULT_TOOL_TYPES, MCP_SERVERS } from '@novu/shared';
+import { ApiAuthSchemeEnum, CLAUDE_ANTHROPIC_SKILLS, CLAUDE_BUILTIN_TOOLS, CLAUDE_DEFAULT_TOOL_TYPES, MCP_SERVERS } from '@novu/shared';
 
+import { KeylessAbuseGuardService } from '../../../../keyless/keyless-abuse-guard.service';
 import { GenerateManagedAgentCommand } from './generate-managed-agent.command';
 import { type ManagedAgentGenerationOutput, managedAgentGenerationSchema } from './managed-agent-generation.schema';
 
@@ -173,7 +174,8 @@ export class GenerateManagedAgent {
   constructor(
     private readonly moduleRef: ModuleRef,
     private readonly analyticsService: AnalyticsService,
-    private readonly logger: PinoLogger
+    private readonly logger: PinoLogger,
+    private readonly keylessAbuseGuard: KeylessAbuseGuardService
   ) {}
 
   @InstrumentUsecase()
@@ -181,6 +183,11 @@ export class GenerateManagedAgent {
     const { user, prompt } = command;
     const runtime = command.runtime ?? 'managed';
     const { organizationId, environmentId, _id: userId } = user;
+
+    if (user.scheme === ApiAuthSchemeEnum.KEYLESS) {
+      await this.keylessAbuseGuard.assertKeylessAiEnabled(organizationId);
+      await this.keylessAbuseGuard.assertGenerateAllowed(command.clientIp);
+    }
 
     const eeAi = this.loadEeAi();
     const llmService = this.moduleRef.get(eeAi.LlmService, { strict: false });

--- a/apps/api/src/app/channel-connections/channel-connections.controller.ts
+++ b/apps/api/src/app/channel-connections/channel-connections.controller.ts
@@ -17,6 +17,7 @@ import { ApiRateLimitCategoryEnum, PermissionsEnum, UserSessionData } from '@nov
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { ThrottlerCategory } from '../rate-limiting/guards/throttler.decorator';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
+import { KeylessAccessible } from '../shared/framework/swagger/keyless.security';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { UserSession } from '../shared/framework/user.decorator';
 import { CreateChannelConnectionRequestDto } from './dtos/create-channel-connection-request.dto';
@@ -61,6 +62,7 @@ export class ChannelConnectionsController {
   @SdkMethodName('list')
   @RequirePermissions(PermissionsEnum.INTEGRATION_READ)
   @ExternalApiAccessible()
+  @KeylessAccessible()
   async listChannelConnections(
     @UserSession() user: UserSessionData,
     @Query() query: ListChannelConnectionsQueryDto

--- a/apps/api/src/app/connect/connect.controller.ts
+++ b/apps/api/src/app/connect/connect.controller.ts
@@ -1,0 +1,42 @@
+import { Body, ClassSerializerInterceptor, Controller, HttpCode, HttpStatus, Post, UseInterceptors } from '@nestjs/common';
+import { ApiExcludeController, ApiOperation } from '@nestjs/swagger';
+import { UserSessionData } from '@novu/shared';
+import { RequireAuthentication } from '../auth/framework/auth.decorator';
+import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
+import { UserSession } from '../shared/framework/user.decorator';
+import { ClaimKeylessConnectRequestDto } from './dtos/claim-keyless-connect-request.dto';
+import { ClaimKeylessConnectResponseDto } from './dtos/claim-keyless-connect-response.dto';
+import { ClaimKeylessConnectCommand } from './usecases/claim-keyless-connect/claim-keyless-connect.command';
+import { ClaimKeylessConnect } from './usecases/claim-keyless-connect/claim-keyless-connect.usecase';
+
+@ApiCommonResponses()
+@Controller('/connect')
+@UseInterceptors(ClassSerializerInterceptor)
+@ApiExcludeController()
+@RequireAuthentication()
+export class ConnectController {
+  constructor(private readonly claimKeylessConnectUsecase: ClaimKeylessConnect) {}
+
+  @Post('/claim')
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse(ClaimKeylessConnectResponseDto)
+  @ApiOperation({
+    summary: 'Claim a keyless connect session',
+    description:
+      'Merges the agent, channel integration, and conversation created during an anonymous keyless `novu connect` ' +
+      'session into the authenticated user\u2019s Development environment, so the in-channel conversation continues ' +
+      'under their account.',
+  })
+  async claim(
+    @UserSession() user: UserSessionData,
+    @Body() body: ClaimKeylessConnectRequestDto
+  ): Promise<ClaimKeylessConnectResponseDto> {
+    return this.claimKeylessConnectUsecase.execute(
+      ClaimKeylessConnectCommand.create({
+        userId: user._id,
+        organizationId: user.organizationId,
+        token: body.token,
+      })
+    );
+  }
+}

--- a/apps/api/src/app/connect/connect.module.ts
+++ b/apps/api/src/app/connect/connect.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import {
+  AgentIntegrationRepository,
+  AgentRepository,
+  ChannelConnectionRepository,
+  ChannelEndpointRepository,
+  ConversationActivityRepository,
+  ConversationRepository,
+  EnvironmentRepository,
+  IntegrationRepository,
+  SubscriberRepository,
+} from '@novu/dal';
+import { AuthModule } from '../auth/auth.module';
+import { SharedModule } from '../shared/shared.module';
+import { ConnectController } from './connect.controller';
+import { ConnectClaimTokenService } from './services/connect-claim-token.service';
+import { ClaimKeylessConnect } from './usecases/claim-keyless-connect/claim-keyless-connect.usecase';
+
+@Module({
+  imports: [SharedModule, AuthModule],
+  controllers: [ConnectController],
+  providers: [
+    ConnectClaimTokenService,
+    ClaimKeylessConnect,
+    AgentRepository,
+    AgentIntegrationRepository,
+    IntegrationRepository,
+    ChannelConnectionRepository,
+    ChannelEndpointRepository,
+    ConversationRepository,
+    ConversationActivityRepository,
+    SubscriberRepository,
+    EnvironmentRepository,
+  ],
+  exports: [ConnectClaimTokenService],
+})
+export class ConnectModule {}

--- a/apps/api/src/app/connect/connect.module.ts
+++ b/apps/api/src/app/connect/connect.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import {
   AgentIntegrationRepository,
+  AgentMcpServerRepository,
   AgentRepository,
   ChannelConnectionRepository,
   ChannelEndpointRepository,
@@ -8,6 +9,7 @@ import {
   ConversationRepository,
   EnvironmentRepository,
   IntegrationRepository,
+  McpConnectionRepository,
   SubscriberRepository,
 } from '@novu/dal';
 import { AuthModule } from '../auth/auth.module';
@@ -30,6 +32,8 @@ import { ClaimKeylessConnect } from './usecases/claim-keyless-connect/claim-keyl
     ConversationRepository,
     ConversationActivityRepository,
     SubscriberRepository,
+    AgentMcpServerRepository,
+    McpConnectionRepository,
     EnvironmentRepository,
   ],
   exports: [ConnectClaimTokenService],

--- a/apps/api/src/app/connect/dtos/claim-keyless-connect-request.dto.ts
+++ b/apps/api/src/app/connect/dtos/claim-keyless-connect-request.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class ClaimKeylessConnectRequestDto {
+  @ApiProperty({ description: 'The single-use claim token issued in the connected channel signup CTA.' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/apps/api/src/app/connect/dtos/claim-keyless-connect-response.dto.ts
+++ b/apps/api/src/app/connect/dtos/claim-keyless-connect-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ClaimKeylessConnectResponseDto {
+  @ApiProperty({ description: 'The Development environment the keyless assets were merged into.' })
+  environmentId: string;
+
+  @ApiPropertyOptional({ description: 'External identifier of the claimed agent, when one was present.' })
+  agentIdentifier?: string;
+}

--- a/apps/api/src/app/connect/services/connect-claim-token.service.ts
+++ b/apps/api/src/app/connect/services/connect-claim-token.service.ts
@@ -118,6 +118,17 @@ export class ConnectClaimTokenService {
     return issued;
   }
 
+  async isSignupCtaPosted(conversationId: string): Promise<boolean> {
+    if (!this.cacheService.cacheEnabled()) {
+      return false;
+    }
+
+    const key = `${CTA_POSTED_KEY_PREFIX}{${conversationId}}`;
+    const posted = await this.cacheService.get(key);
+
+    return posted != null;
+  }
+
   async tryMarkSignupCtaPosted(conversationId: string): Promise<boolean> {
     this.assertCacheAvailable('tryMarkSignupCtaPosted');
 

--- a/apps/api/src/app/connect/services/connect-claim-token.service.ts
+++ b/apps/api/src/app/connect/services/connect-claim-token.service.ts
@@ -1,0 +1,225 @@
+import { randomBytes } from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import { CacheService, PinoLogger } from '@novu/application-generic';
+
+/**
+ * Lifetime of a connect claim token (seconds). The user receives the link in
+ * their connected channel after hitting the keyless demo cap and may take a
+ * while to sign up, so this is intentionally long-lived (7 days).
+ */
+export const CONNECT_CLAIM_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+const CACHE_KEY_PREFIX = 'connect_claim_link:';
+const USED_KEY_PREFIX = 'connect_claim_link_used:';
+
+/** 24 bytes → 32 URL-safe base64url characters. */
+const TOKEN_BYTES = 24;
+const TOKEN_FORMAT = /^[A-Za-z0-9_-]{32}$/;
+
+/** Wrap token in `{…}` so storage + used-marker keys share a Redis Cluster hash slot. */
+function clusterSlotTag(token: string): string {
+  return `{${token}}`;
+}
+
+/**
+ * Atomically GETDEL the payload and set the used-marker with matching TTL.
+ * Returns '' (missing), 'U' (already used), 'I' (corrupt payload), or 'M' + JSON body.
+ */
+const CLAIM_ATOMIC_SCRIPT = `
+local raw = redis.call('GETDEL', KEYS[1])
+if not raw then
+  if redis.call('GET', KEYS[2]) then
+    return 'U'
+  end
+  return ''
+end
+local ok, parsed = pcall(cjson.decode, raw)
+if not ok or not parsed.expiresAt or not parsed.payload then
+  return 'I'
+end
+local now = tonumber(ARGV[1])
+local ttl = parsed.expiresAt - now
+if ttl < 1 then ttl = 1 end
+redis.call('SET', KEYS[2], '1', 'EX', ttl)
+return 'M' .. raw
+`;
+
+export interface ConnectClaimTokenPayload {
+  /** Keyless environment id being claimed. */
+  env: string;
+  /** Keyless organization id (the shared keyless org). */
+  org: string;
+}
+
+interface StoredEntry {
+  payload: ConnectClaimTokenPayload;
+  /** Epoch seconds when this entry naturally expires. */
+  expiresAt: number;
+}
+
+export interface IssuedConnectClaimToken {
+  token: string;
+  /** ISO timestamp when this token expires. */
+  expiresAt: string;
+}
+
+export class InvalidConnectClaimTokenError extends Error {
+  constructor(public readonly reason: 'invalid' | 'expired' | 'used') {
+    super(`Connect claim token is ${reason}`);
+    this.name = 'InvalidConnectClaimTokenError';
+  }
+}
+
+export class ConnectClaimTokenCacheUnavailableError extends Error {
+  constructor(operation: string, cause?: unknown) {
+    super(`Connect claim token cache unavailable during ${operation}`);
+    this.name = 'ConnectClaimTokenCacheUnavailableError';
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+@Injectable()
+export class ConnectClaimTokenService {
+  constructor(
+    private readonly cacheService: CacheService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async issue(payload: ConnectClaimTokenPayload): Promise<IssuedConnectClaimToken> {
+    this.assertCacheAvailable('issue');
+
+    const token = randomBytes(TOKEN_BYTES).toString('base64url');
+    const mintedAt = Math.floor(Date.now() / 1000);
+    const expiresAtEpoch = mintedAt + CONNECT_CLAIM_TOKEN_TTL_SECONDS;
+    const entry: StoredEntry = { payload, expiresAt: expiresAtEpoch };
+
+    await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), {
+      ttl: CONNECT_CLAIM_TOKEN_TTL_SECONDS,
+    });
+
+    return { token, expiresAt: new Date(expiresAtEpoch * 1000).toISOString() };
+  }
+
+  /**
+   * Reads the stored payload without consuming the token. Used to run the claim
+   * merge before marking the token used, so a failed merge can be retried with
+   * the same link.
+   */
+  async verify(token: string): Promise<ConnectClaimTokenPayload> {
+    this.assertCacheAvailable('verify');
+
+    if (!this.isTokenFormatValid(token)) {
+      throw new InvalidConnectClaimTokenError('invalid');
+    }
+
+    let used: string | null | undefined;
+    try {
+      used = await this.cacheService.get(this.usedKey(token));
+    } catch (err) {
+      throw new ConnectClaimTokenCacheUnavailableError('verify', err);
+    }
+    if (used != null) {
+      throw new InvalidConnectClaimTokenError('used');
+    }
+
+    let raw: string | null | undefined;
+    try {
+      raw = await this.cacheService.get(this.storageKey(token));
+    } catch (err) {
+      throw new ConnectClaimTokenCacheUnavailableError('verify', err);
+    }
+    if (!raw) {
+      throw new InvalidConnectClaimTokenError('expired');
+    }
+
+    const entry = this.parseEntry(raw);
+    if (!entry || !entry.payload.env || !entry.payload.org) {
+      throw new InvalidConnectClaimTokenError('invalid');
+    }
+
+    return entry.payload;
+  }
+
+  /**
+   * Atomically claims a token for single-use consumption (GETDEL + used marker).
+   * Returns the stored payload, or throws {@link InvalidConnectClaimTokenError}.
+   */
+  async claim(token: string): Promise<ConnectClaimTokenPayload> {
+    this.assertCacheAvailable('claim');
+
+    if (!this.isTokenFormatValid(token)) {
+      throw new InvalidConnectClaimTokenError('invalid');
+    }
+
+    let raw: string;
+    try {
+      raw = await this.cacheService.eval<string>(
+        CLAIM_ATOMIC_SCRIPT,
+        [this.storageKey(token), this.usedKey(token)],
+        [Math.floor(Date.now() / 1000)]
+      );
+    } catch (err) {
+      throw new ConnectClaimTokenCacheUnavailableError('claim', err);
+    }
+
+    if (raw === 'U') {
+      throw new InvalidConnectClaimTokenError('used');
+    }
+
+    if (raw === 'I') {
+      throw new InvalidConnectClaimTokenError('invalid');
+    }
+
+    if (!raw) {
+      throw new InvalidConnectClaimTokenError('expired');
+    }
+
+    if (raw.charAt(0) !== 'M') {
+      throw new InvalidConnectClaimTokenError('invalid');
+    }
+
+    const entry = this.parseEntry(raw.slice(1));
+    if (!entry || !entry.payload.env || !entry.payload.org) {
+      throw new InvalidConnectClaimTokenError('invalid');
+    }
+
+    return entry.payload;
+  }
+
+  private parseEntry(raw: string): StoredEntry | null {
+    try {
+      const parsed = JSON.parse(raw) as Partial<StoredEntry>;
+      if (!parsed?.payload || typeof parsed.expiresAt !== 'number') {
+        return null;
+      }
+
+      return { payload: parsed.payload as ConnectClaimTokenPayload, expiresAt: parsed.expiresAt };
+    } catch {
+      return null;
+    }
+  }
+
+  private isTokenFormatValid(token: string): boolean {
+    return typeof token === 'string' && TOKEN_FORMAT.test(token);
+  }
+
+  private assertCacheAvailable(operation: string): void {
+    if (!this.cacheService.cacheEnabled()) {
+      this.logger.warn(`Cache unavailable for connect claim token ${operation}`);
+
+      throw new ConnectClaimTokenCacheUnavailableError(operation);
+    }
+  }
+
+  private storageKey(token: string): string {
+    return `${CACHE_KEY_PREFIX}${clusterSlotTag(token)}`;
+  }
+
+  private usedKey(token: string): string {
+    return `${USED_KEY_PREFIX}${clusterSlotTag(token)}`;
+  }
+}

--- a/apps/api/src/app/connect/services/connect-claim-token.service.ts
+++ b/apps/api/src/app/connect/services/connect-claim-token.service.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto';
 import { Injectable } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
+import { CONNECT_CLAIM_TOKEN_PATTERN } from '@novu/shared';
 
 /**
  * Lifetime of a connect claim token (seconds). The user receives the link in
@@ -11,10 +12,15 @@ export const CONNECT_CLAIM_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 const CACHE_KEY_PREFIX = 'connect_claim_link:';
 const USED_KEY_PREFIX = 'connect_claim_link_used:';
+const ENV_TOKEN_KEY_PREFIX = 'connect_claim_link_env:';
+const CTA_POSTED_KEY_PREFIX = 'connect_claim_cta_posted:';
+const CLAIM_LOCK_KEY_PREFIX = 'connect_claim_link_lock:';
+
+/** Short lock so concurrent claim requests for the same token serialize. */
+const CLAIM_LOCK_TTL_SECONDS = 60;
 
 /** 24 bytes → 32 URL-safe base64url characters. */
 const TOKEN_BYTES = 24;
-const TOKEN_FORMAT = /^[A-Za-z0-9_-]{32}$/;
 
 /** Wrap token in `{…}` so storage + used-marker keys share a Redis Cluster hash slot. */
 function clusterSlotTag(token: string): string {
@@ -102,6 +108,66 @@ export class ConnectClaimTokenService {
     });
 
     return { token, expiresAt: new Date(expiresAtEpoch * 1000).toISOString() };
+  }
+
+  /**
+   * Returns an existing claim token for the keyless environment when one is still
+   * valid, otherwise mints a new one. Prevents unbounded Redis growth when users
+   * keep messaging after the demo cap.
+   */
+  async issueOrGetForEnvironment(payload: ConnectClaimTokenPayload): Promise<IssuedConnectClaimToken> {
+    this.assertCacheAvailable('issueOrGetForEnvironment');
+
+    const envKey = `${ENV_TOKEN_KEY_PREFIX}{${payload.env}}`;
+    const existingToken = await this.cacheService.get(envKey);
+
+    if (existingToken && this.isTokenFormatValid(existingToken)) {
+      const reused = await this.readIssuedToken(existingToken, payload);
+
+      if (reused) {
+        return reused;
+      }
+    }
+
+    const issued = await this.issue(payload);
+    await this.cacheService.set(envKey, issued.token, { ttl: CONNECT_CLAIM_TOKEN_TTL_SECONDS });
+
+    return issued;
+  }
+
+  /**
+   * Marks the signup CTA as posted for a conversation. Returns true only the
+   * first time so the card is not re-sent on every subsequent inbound message.
+   */
+  async tryMarkSignupCtaPosted(conversationId: string): Promise<boolean> {
+    this.assertCacheAvailable('tryMarkSignupCtaPosted');
+
+    const key = `${CTA_POSTED_KEY_PREFIX}{${conversationId}}`;
+    const acquired = await this.cacheService.setIfNotExist(key, '1', { ttl: CONNECT_CLAIM_TOKEN_TTL_SECONDS });
+
+    return acquired === 'OK';
+  }
+
+  /** Serializes concurrent claim attempts for the same token. */
+  async tryAcquireClaimLock(token: string): Promise<boolean> {
+    this.assertCacheAvailable('tryAcquireClaimLock');
+
+    if (!this.isTokenFormatValid(token)) {
+      return false;
+    }
+
+    const key = `${CLAIM_LOCK_KEY_PREFIX}${clusterSlotTag(token)}`;
+    const acquired = await this.cacheService.setIfNotExist(key, '1', { ttl: CLAIM_LOCK_TTL_SECONDS });
+
+    return acquired === 'OK';
+  }
+
+  async releaseClaimLock(token: string): Promise<void> {
+    if (!this.cacheService.cacheEnabled() || !this.isTokenFormatValid(token)) {
+      return;
+    }
+
+    await this.cacheService.del(`${CLAIM_LOCK_KEY_PREFIX}${clusterSlotTag(token)}`);
   }
 
   /**
@@ -203,8 +269,29 @@ export class ConnectClaimTokenService {
     }
   }
 
+  private async readIssuedToken(
+    token: string,
+    expectedPayload: ConnectClaimTokenPayload
+  ): Promise<IssuedConnectClaimToken | null> {
+    const raw = await this.cacheService.get(this.storageKey(token));
+    if (!raw) {
+      return null;
+    }
+
+    const entry = this.parseEntry(raw);
+    if (
+      !entry ||
+      entry.payload.env !== expectedPayload.env ||
+      entry.payload.org !== expectedPayload.org
+    ) {
+      return null;
+    }
+
+    return { token, expiresAt: new Date(entry.expiresAt * 1000).toISOString() };
+  }
+
   private isTokenFormatValid(token: string): boolean {
-    return typeof token === 'string' && TOKEN_FORMAT.test(token);
+    return typeof token === 'string' && CONNECT_CLAIM_TOKEN_PATTERN.test(token);
   }
 
   private assertCacheAvailable(operation: string): void {

--- a/apps/api/src/app/connect/services/connect-claim-token.service.ts
+++ b/apps/api/src/app/connect/services/connect-claim-token.service.ts
@@ -3,11 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 import { CONNECT_CLAIM_TOKEN_PATTERN } from '@novu/shared';
 
-/**
- * Lifetime of a connect claim token (seconds). The user receives the link in
- * their connected channel after hitting the keyless demo cap and may take a
- * while to sign up, so this is intentionally long-lived (7 days).
- */
 export const CONNECT_CLAIM_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 const CACHE_KEY_PREFIX = 'connect_claim_link:';
@@ -16,10 +11,7 @@ const ENV_TOKEN_KEY_PREFIX = 'connect_claim_link_env:';
 const CTA_POSTED_KEY_PREFIX = 'connect_claim_cta_posted:';
 const CLAIM_LOCK_KEY_PREFIX = 'connect_claim_link_lock:';
 
-/** Short lock so concurrent claim requests for the same token serialize. */
 const CLAIM_LOCK_TTL_SECONDS = 60;
-
-/** 24 bytes → 32 URL-safe base64url characters. */
 const TOKEN_BYTES = 24;
 
 /** Wrap token in `{…}` so storage + used-marker keys share a Redis Cluster hash slot. */
@@ -51,21 +43,17 @@ return 'M' .. raw
 `;
 
 export interface ConnectClaimTokenPayload {
-  /** Keyless environment id being claimed. */
   env: string;
-  /** Keyless organization id (the shared keyless org). */
   org: string;
 }
 
 interface StoredEntry {
   payload: ConnectClaimTokenPayload;
-  /** Epoch seconds when this entry naturally expires. */
   expiresAt: number;
 }
 
 export interface IssuedConnectClaimToken {
   token: string;
-  /** ISO timestamp when this token expires. */
   expiresAt: string;
 }
 
@@ -110,11 +98,6 @@ export class ConnectClaimTokenService {
     return { token, expiresAt: new Date(expiresAtEpoch * 1000).toISOString() };
   }
 
-  /**
-   * Returns an existing claim token for the keyless environment when one is still
-   * valid, otherwise mints a new one. Prevents unbounded Redis growth when users
-   * keep messaging after the demo cap.
-   */
   async issueOrGetForEnvironment(payload: ConnectClaimTokenPayload): Promise<IssuedConnectClaimToken> {
     this.assertCacheAvailable('issueOrGetForEnvironment');
 
@@ -135,10 +118,6 @@ export class ConnectClaimTokenService {
     return issued;
   }
 
-  /**
-   * Marks the signup CTA as posted for a conversation. Returns true only the
-   * first time so the card is not re-sent on every subsequent inbound message.
-   */
   async tryMarkSignupCtaPosted(conversationId: string): Promise<boolean> {
     this.assertCacheAvailable('tryMarkSignupCtaPosted');
 
@@ -148,7 +127,6 @@ export class ConnectClaimTokenService {
     return acquired === 'OK';
   }
 
-  /** Serializes concurrent claim attempts for the same token. */
   async tryAcquireClaimLock(token: string): Promise<boolean> {
     this.assertCacheAvailable('tryAcquireClaimLock');
 
@@ -170,11 +148,6 @@ export class ConnectClaimTokenService {
     await this.cacheService.del(`${CLAIM_LOCK_KEY_PREFIX}${clusterSlotTag(token)}`);
   }
 
-  /**
-   * Reads the stored payload without consuming the token. Used to run the claim
-   * merge before marking the token used, so a failed merge can be retried with
-   * the same link.
-   */
   async verify(token: string): Promise<ConnectClaimTokenPayload> {
     this.assertCacheAvailable('verify');
 
@@ -210,10 +183,6 @@ export class ConnectClaimTokenService {
     return entry.payload;
   }
 
-  /**
-   * Atomically claims a token for single-use consumption (GETDEL + used marker).
-   * Returns the stored payload, or throws {@link InvalidConnectClaimTokenError}.
-   */
   async claim(token: string): Promise<ConnectClaimTokenPayload> {
     this.assertCacheAvailable('claim');
 

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.command.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.command.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { AuthenticatedCommand } from '@novu/application-generic';
+
+export class ClaimKeylessConnectCommand extends AuthenticatedCommand {
+  @IsString()
+  @IsNotEmpty()
+  readonly token: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly organizationId: string;
+}

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
@@ -90,6 +90,8 @@ export class ClaimKeylessConnect {
       const sourceScope = { _environmentId: keylessEnvironment._id, _organizationId: keylessOrganizationId };
       const target = { _environmentId: targetEnvironment._id, _organizationId: command.organizationId };
 
+      const sourceAgents = await this.agentRepository.find(sourceScope, ['_id', 'identifier']);
+
       await this.agentRepository.withTransaction(async (session) => {
         await this.agentRepository.update(sourceScope, { $set: target }, { session });
         await this.agentIntegrationRepository.update(sourceScope, { $set: target }, { session });
@@ -111,7 +113,10 @@ export class ClaimKeylessConnect {
         );
       });
 
-      const agent = await this.agentRepository.findOne(target, ['identifier']);
+      const migratedAgentId = sourceAgents[0]?._id;
+      const agent = migratedAgentId
+        ? await this.agentRepository.findOne({ _id: migratedAgentId, ...target }, ['identifier'])
+        : null;
 
       this.logger.info(
         {

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import {
   AgentIntegrationRepository,
@@ -52,80 +52,89 @@ export class ClaimKeylessConnect {
       throw new BadRequestException('Keyless mode is not enabled on this deployment.');
     }
 
-    // Peek (do not consume yet) so a failed merge can be retried with the same link.
-    const payload = await this.connectClaimTokenService.verify(command.token);
-
-    if (payload.org !== keylessOrganizationId) {
-      throw new BadRequestException('Invalid claim token.');
+    const lockAcquired = await this.connectClaimTokenService.tryAcquireClaimLock(command.token);
+    if (!lockAcquired) {
+      throw new ConflictException('This claim is already in progress. Please wait and try again.');
     }
 
-    const keylessEnvironment = await this.environmentRepository.findOne({
-      _id: payload.env,
-      _organizationId: keylessOrganizationId,
-    });
-    if (!keylessEnvironment) {
-      throw new NotFoundException('The keyless environment for this claim no longer exists.');
-    }
+    try {
+      // Peek (do not consume yet) so a failed merge can be retried with the same link.
+      const payload = await this.connectClaimTokenService.verify(command.token);
 
-    const targetEnvironment = await this.resolveDevelopmentEnvironment(command.organizationId);
+      if (payload.org !== keylessOrganizationId) {
+        throw new BadRequestException('Invalid claim token.');
+      }
 
-    const sourceScope = { _environmentId: keylessEnvironment._id, _organizationId: keylessOrganizationId };
-    const target = { _environmentId: targetEnvironment._id, _organizationId: command.organizationId };
+      const keylessEnvironment = await this.environmentRepository.findOne({
+        _id: payload.env,
+        _organizationId: keylessOrganizationId,
+      });
+      if (!keylessEnvironment) {
+        throw new NotFoundException('The keyless environment for this claim no longer exists.');
+      }
 
-    const agent = await this.agentRepository.findOne(sourceScope, ['identifier']);
+      const targetEnvironment = await this.resolveDevelopmentEnvironment(command.organizationId);
 
-    await this.agentRepository.withTransaction(async (session) => {
-      // Agent + its links.
-      await this.agentRepository.update(sourceScope, { $set: target }, { session });
-      await this.agentIntegrationRepository.update(sourceScope, { $set: target }, { session });
+      const sourceScope = { _environmentId: keylessEnvironment._id, _organizationId: keylessOrganizationId };
+      const target = { _environmentId: targetEnvironment._id, _organizationId: command.organizationId };
 
-      // Integrations — move the agent runtime + channel integrations, but skip
-      // the keyless inbox in-app integration (the target Dev env already has its
-      // own default integrations).
-      await this.integrationRepository.update(
-        { ...sourceScope, channel: { $ne: ChannelTypeEnum.IN_APP } },
-        { $set: target },
-        { session }
+      await this.agentRepository.withTransaction(async (session) => {
+        // Agent + its links.
+        await this.agentRepository.update(sourceScope, { $set: target }, { session });
+        await this.agentIntegrationRepository.update(sourceScope, { $set: target }, { session });
+
+        // Integrations — move the agent runtime + channel integrations, but skip
+        // the keyless inbox in-app integration (the target Dev env already has its
+        // own default integrations).
+        await this.integrationRepository.update(
+          { ...sourceScope, channel: { $ne: ChannelTypeEnum.IN_APP } },
+          { $set: target },
+          { session }
+        );
+
+        // Channel wiring for the moved channel integration.
+        await this.channelConnectionRepository.update(sourceScope, { $set: target }, { session });
+        await this.channelEndpointRepository.update(sourceScope, { $set: target }, { session });
+
+        // The conversation + its full activity history (preserves continuity).
+        await this.conversationRepository.update(sourceScope, { $set: target }, { session });
+        await this.conversationActivityRepository.update(sourceScope, { $set: target }, { session });
+
+        // The agent's MCP enablements + their OAuth connections (e.g. Supabase),
+        // otherwise the MCPs are stranded in the keyless env and disappear.
+        await this.agentMcpServerRepository.update(sourceScope, { $set: target }, { session });
+        await this.mcpConnectionRepository.update(sourceScope, { $set: target }, { session });
+
+        // The channel subscriber(s); skip the inbox demo subscriber.
+        await this.subscriberRepository.update(
+          { ...sourceScope, subscriberId: { $ne: KEYLESS_SUBSCRIBER_ID } },
+          { $set: target },
+          { session }
+        );
+      });
+
+      const agent = await this.agentRepository.findOne(target, ['identifier']);
+
+      this.logger.info(
+        {
+          keylessEnvironmentId: keylessEnvironment._id,
+          targetEnvironmentId: targetEnvironment._id,
+          organizationId: command.organizationId,
+          agentIdentifier: agent?.identifier,
+        },
+        'Claimed keyless connect assets into Development environment'
       );
 
-      // Channel wiring for the moved channel integration.
-      await this.channelConnectionRepository.update(sourceScope, { $set: target }, { session });
-      await this.channelEndpointRepository.update(sourceScope, { $set: target }, { session });
+      // Consume the token only after a successful merge so partial failures stay retryable.
+      await this.connectClaimTokenService.claim(command.token);
 
-      // The conversation + its full activity history (preserves continuity).
-      await this.conversationRepository.update(sourceScope, { $set: target }, { session });
-      await this.conversationActivityRepository.update(sourceScope, { $set: target }, { session });
-
-      // The agent's MCP enablements + their OAuth connections (e.g. Supabase),
-      // otherwise the MCPs are stranded in the keyless env and disappear.
-      await this.agentMcpServerRepository.update(sourceScope, { $set: target }, { session });
-      await this.mcpConnectionRepository.update(sourceScope, { $set: target }, { session });
-
-      // The channel subscriber(s); skip the inbox demo subscriber.
-      await this.subscriberRepository.update(
-        { ...sourceScope, subscriberId: { $ne: KEYLESS_SUBSCRIBER_ID } },
-        { $set: target },
-        { session }
-      );
-    });
-
-    this.logger.info(
-      {
-        keylessEnvironmentId: keylessEnvironment._id,
-        targetEnvironmentId: targetEnvironment._id,
-        organizationId: command.organizationId,
+      return {
+        environmentId: targetEnvironment._id,
         agentIdentifier: agent?.identifier,
-      },
-      'Claimed keyless connect assets into Development environment'
-    );
-
-    // Consume the token only after a successful merge so partial failures stay retryable.
-    await this.connectClaimTokenService.claim(command.token);
-
-    return {
-      environmentId: targetEnvironment._id,
-      agentIdentifier: agent?.identifier,
-    };
+      };
+    } finally {
+      await this.connectClaimTokenService.releaseClaimLock(command.token);
+    }
   }
 
   private async resolveDevelopmentEnvironment(organizationId: string): Promise<EnvironmentEntity> {

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { PinoLogger } from '@novu/application-generic';
 import {
   AgentIntegrationRepository,
+  AgentMcpServerRepository,
   AgentRepository,
   ChannelConnectionRepository,
   ChannelEndpointRepository,
@@ -10,6 +11,7 @@ import {
   EnvironmentEntity,
   EnvironmentRepository,
   IntegrationRepository,
+  McpConnectionRepository,
   SubscriberRepository,
 } from '@novu/dal';
 import { ChannelTypeEnum, EnvironmentTypeEnum } from '@novu/shared';
@@ -37,6 +39,8 @@ export class ClaimKeylessConnect {
     private readonly conversationRepository: ConversationRepository,
     private readonly conversationActivityRepository: ConversationActivityRepository,
     private readonly subscriberRepository: SubscriberRepository,
+    private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly mcpConnectionRepository: McpConnectionRepository,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -91,6 +95,11 @@ export class ClaimKeylessConnect {
       // The conversation + its full activity history (preserves continuity).
       await this.conversationRepository.update(sourceScope, { $set: target }, { session });
       await this.conversationActivityRepository.update(sourceScope, { $set: target }, { session });
+
+      // The agent's MCP enablements + their OAuth connections (e.g. Supabase),
+      // otherwise the MCPs are stranded in the keyless env and disappear.
+      await this.agentMcpServerRepository.update(sourceScope, { $set: target }, { session });
+      await this.mcpConnectionRepository.update(sourceScope, { $set: target }, { session });
 
       // The channel subscriber(s); skip the inbox demo subscriber.
       await this.subscriberRepository.update(

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
@@ -1,0 +1,135 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import {
+  AgentIntegrationRepository,
+  AgentRepository,
+  ChannelConnectionRepository,
+  ChannelEndpointRepository,
+  ConversationActivityRepository,
+  ConversationRepository,
+  EnvironmentEntity,
+  EnvironmentRepository,
+  IntegrationRepository,
+  SubscriberRepository,
+} from '@novu/dal';
+import { ChannelTypeEnum, EnvironmentTypeEnum } from '@novu/shared';
+import { KEYLESS_SUBSCRIBER_ID } from '../../../inbox/utils/keyless.constants';
+import { ConnectClaimTokenService } from '../../services/connect-claim-token.service';
+import { ClaimKeylessConnectCommand } from './claim-keyless-connect.command';
+
+export interface ClaimKeylessConnectResult {
+  /** The Development environment the assets were merged into. */
+  environmentId: string;
+  /** External identifier of the claimed agent, when one was present. */
+  agentIdentifier?: string;
+}
+
+@Injectable()
+export class ClaimKeylessConnect {
+  constructor(
+    private readonly connectClaimTokenService: ConnectClaimTokenService,
+    private readonly environmentRepository: EnvironmentRepository,
+    private readonly agentRepository: AgentRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly integrationRepository: IntegrationRepository,
+    private readonly channelConnectionRepository: ChannelConnectionRepository,
+    private readonly channelEndpointRepository: ChannelEndpointRepository,
+    private readonly conversationRepository: ConversationRepository,
+    private readonly conversationActivityRepository: ConversationActivityRepository,
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async execute(command: ClaimKeylessConnectCommand): Promise<ClaimKeylessConnectResult> {
+    const keylessOrganizationId = process.env.KEYLESS_ORGANIZATION_ID;
+    if (!keylessOrganizationId) {
+      throw new BadRequestException('Keyless mode is not enabled on this deployment.');
+    }
+
+    // Peek (do not consume yet) so a failed merge can be retried with the same link.
+    const payload = await this.connectClaimTokenService.verify(command.token);
+
+    if (payload.org !== keylessOrganizationId) {
+      throw new BadRequestException('Invalid claim token.');
+    }
+
+    const keylessEnvironment = await this.environmentRepository.findOne({
+      _id: payload.env,
+      _organizationId: keylessOrganizationId,
+    });
+    if (!keylessEnvironment) {
+      throw new NotFoundException('The keyless environment for this claim no longer exists.');
+    }
+
+    const targetEnvironment = await this.resolveDevelopmentEnvironment(command.organizationId);
+
+    const sourceScope = { _environmentId: keylessEnvironment._id, _organizationId: keylessOrganizationId };
+    const target = { _environmentId: targetEnvironment._id, _organizationId: command.organizationId };
+
+    const agent = await this.agentRepository.findOne(sourceScope, ['identifier']);
+
+    await this.agentRepository.withTransaction(async (session) => {
+      // Agent + its links.
+      await this.agentRepository.update(sourceScope, { $set: target }, { session });
+      await this.agentIntegrationRepository.update(sourceScope, { $set: target }, { session });
+
+      // Integrations — move the agent runtime + channel integrations, but skip
+      // the keyless inbox in-app integration (the target Dev env already has its
+      // own default integrations).
+      await this.integrationRepository.update(
+        { ...sourceScope, channel: { $ne: ChannelTypeEnum.IN_APP } },
+        { $set: target },
+        { session }
+      );
+
+      // Channel wiring for the moved channel integration.
+      await this.channelConnectionRepository.update(sourceScope, { $set: target }, { session });
+      await this.channelEndpointRepository.update(sourceScope, { $set: target }, { session });
+
+      // The conversation + its full activity history (preserves continuity).
+      await this.conversationRepository.update(sourceScope, { $set: target }, { session });
+      await this.conversationActivityRepository.update(sourceScope, { $set: target }, { session });
+
+      // The channel subscriber(s); skip the inbox demo subscriber.
+      await this.subscriberRepository.update(
+        { ...sourceScope, subscriberId: { $ne: KEYLESS_SUBSCRIBER_ID } },
+        { $set: target },
+        { session }
+      );
+    });
+
+    this.logger.info(
+      {
+        keylessEnvironmentId: keylessEnvironment._id,
+        targetEnvironmentId: targetEnvironment._id,
+        organizationId: command.organizationId,
+        agentIdentifier: agent?.identifier,
+      },
+      'Claimed keyless connect assets into Development environment'
+    );
+
+    // Consume the token only after a successful merge so partial failures stay retryable.
+    await this.connectClaimTokenService.claim(command.token);
+
+    return {
+      environmentId: targetEnvironment._id,
+      agentIdentifier: agent?.identifier,
+    };
+  }
+
+  private async resolveDevelopmentEnvironment(organizationId: string): Promise<EnvironmentEntity> {
+    const environments = await this.environmentRepository.findOrganizationEnvironments(organizationId);
+
+    const development =
+      environments.find((env) => env.type === EnvironmentTypeEnum.DEV && !env._parentId) ??
+      environments.find((env) => !env._parentId);
+
+    if (!development) {
+      throw new NotFoundException('No Development environment was found for your organization.');
+    }
+
+    return development;
+  }
+}

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import {
   AgentIntegrationRepository,
@@ -16,7 +22,11 @@ import {
 } from '@novu/dal';
 import { ChannelTypeEnum, EnvironmentTypeEnum } from '@novu/shared';
 import { KEYLESS_SUBSCRIBER_ID } from '../../../inbox/utils/keyless.constants';
-import { ConnectClaimTokenService } from '../../services/connect-claim-token.service';
+import {
+  ConnectClaimTokenCacheUnavailableError,
+  ConnectClaimTokenService,
+  InvalidConnectClaimTokenError,
+} from '../../services/connect-claim-token.service';
 import { ClaimKeylessConnectCommand } from './claim-keyless-connect.command';
 
 export interface ClaimKeylessConnectResult {
@@ -56,7 +66,12 @@ export class ClaimKeylessConnect {
     }
 
     try {
-      const payload = await this.connectClaimTokenService.verify(command.token);
+      let payload;
+      try {
+        payload = await this.connectClaimTokenService.verify(command.token);
+      } catch (error) {
+        this.rethrowConnectClaimTokenError(error);
+      }
 
       if (payload.org !== keylessOrganizationId) {
         throw new BadRequestException('Invalid claim token.');
@@ -108,7 +123,11 @@ export class ClaimKeylessConnect {
         'Claimed keyless connect assets into Development environment'
       );
 
-      await this.connectClaimTokenService.claim(command.token);
+      try {
+        await this.connectClaimTokenService.claim(command.token);
+      } catch (error) {
+        this.rethrowConnectClaimTokenError(error);
+      }
 
       return {
         environmentId: targetEnvironment._id,
@@ -117,6 +136,26 @@ export class ClaimKeylessConnect {
     } finally {
       await this.connectClaimTokenService.releaseClaimLock(command.token);
     }
+  }
+
+  private rethrowConnectClaimTokenError(error: unknown): never {
+    if (error instanceof InvalidConnectClaimTokenError) {
+      if (error.reason === 'used') {
+        throw new BadRequestException('This claim link has already been used.');
+      }
+
+      if (error.reason === 'expired') {
+        throw new BadRequestException('This claim link has expired.');
+      }
+
+      throw new BadRequestException('Invalid claim token.');
+    }
+
+    if (error instanceof ConnectClaimTokenCacheUnavailableError) {
+      throw new ServiceUnavailableException('Claim service is temporarily unavailable. Please try again.');
+    }
+
+    throw error;
   }
 
   private async resolveDevelopmentEnvironment(organizationId: string): Promise<EnvironmentEntity> {

--- a/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
+++ b/apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts
@@ -20,9 +20,7 @@ import { ConnectClaimTokenService } from '../../services/connect-claim-token.ser
 import { ClaimKeylessConnectCommand } from './claim-keyless-connect.command';
 
 export interface ClaimKeylessConnectResult {
-  /** The Development environment the assets were merged into. */
   environmentId: string;
-  /** External identifier of the claimed agent, when one was present. */
   agentIdentifier?: string;
 }
 
@@ -58,7 +56,6 @@ export class ClaimKeylessConnect {
     }
 
     try {
-      // Peek (do not consume yet) so a failed merge can be retried with the same link.
       const payload = await this.connectClaimTokenService.verify(command.token);
 
       if (payload.org !== keylessOrganizationId) {
@@ -79,33 +76,19 @@ export class ClaimKeylessConnect {
       const target = { _environmentId: targetEnvironment._id, _organizationId: command.organizationId };
 
       await this.agentRepository.withTransaction(async (session) => {
-        // Agent + its links.
         await this.agentRepository.update(sourceScope, { $set: target }, { session });
         await this.agentIntegrationRepository.update(sourceScope, { $set: target }, { session });
-
-        // Integrations — move the agent runtime + channel integrations, but skip
-        // the keyless inbox in-app integration (the target Dev env already has its
-        // own default integrations).
         await this.integrationRepository.update(
           { ...sourceScope, channel: { $ne: ChannelTypeEnum.IN_APP } },
           { $set: target },
           { session }
         );
-
-        // Channel wiring for the moved channel integration.
         await this.channelConnectionRepository.update(sourceScope, { $set: target }, { session });
         await this.channelEndpointRepository.update(sourceScope, { $set: target }, { session });
-
-        // The conversation + its full activity history (preserves continuity).
         await this.conversationRepository.update(sourceScope, { $set: target }, { session });
         await this.conversationActivityRepository.update(sourceScope, { $set: target }, { session });
-
-        // The agent's MCP enablements + their OAuth connections (e.g. Supabase),
-        // otherwise the MCPs are stranded in the keyless env and disappear.
         await this.agentMcpServerRepository.update(sourceScope, { $set: target }, { session });
         await this.mcpConnectionRepository.update(sourceScope, { $set: target }, { session });
-
-        // The channel subscriber(s); skip the inbox demo subscriber.
         await this.subscriberRepository.update(
           { ...sourceScope, subscriberId: { $ne: KEYLESS_SUBSCRIBER_ID } },
           { $set: target },
@@ -125,7 +108,6 @@ export class ClaimKeylessConnect {
         'Claimed keyless connect assets into Development environment'
       );
 
-      // Consume the token only after a successful merge so partial failures stay retryable.
       await this.connectClaimTokenService.claim(command.token);
 
       return {

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -19,6 +19,8 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { MessageActionStatusEnum, PreferenceLevelEnum, UserSessionData } from '@novu/shared';
+import type { Request } from 'express';
+import { getClientIp } from 'request-ip';
 import { ListChannelConnectionsQueryDto } from '../channel-connections/dtos/list-channel-connections-query.dto';
 import { DeleteChannelConnectionCommand } from '../channel-connections/usecases/delete-channel-connection/delete-channel-connection.command';
 import { DeleteChannelConnection } from '../channel-connections/usecases/delete-channel-connection/delete-channel-connection.usecase';
@@ -141,12 +143,14 @@ export class InboxController {
   @Post('/session')
   async sessionInitialize(
     @Body() body: SubscriberSessionRequestDto,
-    @Headers('origin') origin: string
+    @Headers('origin') origin: string,
+    @Req() request: Request
   ): Promise<SubscriberSessionResponseDto> {
     return await this.initializeSessionUsecase.execute(
       SessionCommand.create({
         requestData: body,
         origin,
+        clientIp: getClientIp(request) ?? undefined,
       })
     );
   }

--- a/apps/api/src/app/inbox/inbox.module.ts
+++ b/apps/api/src/app/inbox/inbox.module.ts
@@ -21,12 +21,14 @@ import { CreateSubscriptionsUsecase } from '../subscriptions/usecases/create-sub
 import { UpdateSubscriptionUsecase } from '../subscriptions/usecases/update-subscription/update-subscription.usecase';
 import { TopicsV2Module } from '../topics-v2/topics-v2.module';
 import { UpsertTopicUseCase } from '../topics-v2/usecases/upsert-topic/upsert-topic.usecase';
+import { KeylessModule } from '../keyless/keyless.module';
 import { InboxController } from './inbox.controller';
 import { InboxTopicController } from './inbox.topic.controller';
 import { USE_CASES } from './usecases';
 
 @Module({
   imports: [
+    KeylessModule,
     SharedModule,
     SubscribersV1Module,
     AuthModule,

--- a/apps/api/src/app/inbox/usecases/session/session.command.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.command.ts
@@ -13,4 +13,8 @@ export class SessionCommand extends BaseCommand {
   @IsOptional()
   @IsString()
   readonly origin?: string;
+
+  @IsOptional()
+  @IsString()
+  readonly clientIp?: string;
 }

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -543,6 +543,9 @@ export class Session {
         userId: user._id,
         name: 'Keyless Integration',
         channels: [ChannelTypeEnum.IN_APP],
+        // Provision the Novu-managed Claude demo agent integration so the keyless
+        // `novu connect` flow can create an agent on the default demo runtime.
+        includeManagedClaude: true,
       })
     );
 

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -78,6 +78,7 @@ import { NotificationsCount } from '../notifications-count/notifications-count.u
 import { UpdatePreferencesCommand } from '../update-preferences/update-preferences.command';
 import { UpdatePreferences } from '../update-preferences/update-preferences.usecase';
 import { SessionCommand } from './session.command';
+import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
 
 const ALLOWED_ORIGINS_REGEX = new RegExp(process.env.FRONT_BASE_URL || '');
 const KEYLESS_RETENTION_TIME_IN_HOURS = parseInt(process.env.KEYLESS_RETENTION_TIME_IN_HOURS || '', 10) || 24;
@@ -110,7 +111,8 @@ export class Session {
     private logger: PinoLogger,
     private featureFlagsService: FeatureFlagsService,
     private getSubscriberSchedule: GetSubscriberSchedule,
-    private updatePreferencesUsecase: UpdatePreferences
+    private updatePreferencesUsecase: UpdatePreferences,
+    private keylessAbuseGuard: KeylessAbuseGuardService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -120,7 +122,7 @@ export class Session {
     this.validateRequestData(command.requestData);
 
     const subscriber = this.buildPlatformSubscriber(command.requestData);
-    const applicationIdentifier = await this.getApplicationIdentifier(command.requestData);
+    const applicationIdentifier = await this.getApplicationIdentifier(command.requestData, command.clientIp);
 
     const environment = await this.environmentRepository.findEnvironmentByIdentifier(applicationIdentifier);
     if (!environment) {
@@ -408,17 +410,28 @@ export class Session {
     return subscriber;
   }
 
-  private async getApplicationIdentifier(requestData: SubscriberSessionRequestDto): Promise<string> {
+  private async getApplicationIdentifier(
+    requestData: SubscriberSessionRequestDto,
+    clientIp?: string
+  ): Promise<string> {
     const isKeylessInitialize = !requestData.applicationIdentifier;
     const isKeyless = requestData.applicationIdentifier?.includes(this.KEYLESS_ENVIRONMENT_PREFIX);
     const isKeylessExpired = isKeyless ? await this.isKeylessExpired(requestData.applicationIdentifier) : false;
 
-    const applicationIdentifier =
-      isKeylessInitialize || isKeylessExpired
-        ? (await this.processKeyless()).identifier
-        : requestData.applicationIdentifier;
+    if (isKeylessInitialize || isKeylessExpired) {
+      const decision = await this.keylessAbuseGuard.resolveEnvCreation(clientIp);
 
-    return applicationIdentifier;
+      if (decision.action === 'reuse') {
+        return decision.applicationIdentifier;
+      }
+
+      const environment = await this.processKeyless();
+      await this.keylessAbuseGuard.recordEnvCreated(clientIp, environment.identifier);
+
+      return environment.identifier;
+    }
+
+    return requestData.applicationIdentifier!;
   }
 
   private async resolveContexts(

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -543,8 +543,6 @@ export class Session {
         userId: user._id,
         name: 'Keyless Integration',
         channels: [ChannelTypeEnum.IN_APP],
-        // Provision the Novu-managed Claude demo agent integration so the keyless
-        // `novu connect` flow can create an agent on the default demo runtime.
         includeManagedClaude: true,
       })
     );

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -54,7 +54,6 @@ import {
   StepTypeEnum,
 } from '@novu/shared';
 import { createHash } from 'crypto';
-import { differenceInHours } from 'date-fns';
 import { AuthService } from '../../../auth/services/auth.service';
 import { EnvironmentResponseDto } from '../../../environments-v1/dtos/environment-response.dto';
 import { GenerateUniqueApiKey } from '../../../environments-v1/usecases/generate-unique-api-key/generate-unique-api-key.usecase';
@@ -79,9 +78,9 @@ import { UpdatePreferencesCommand } from '../update-preferences/update-preferenc
 import { UpdatePreferences } from '../update-preferences/update-preferences.usecase';
 import { SessionCommand } from './session.command';
 import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
+import { isKeylessEnvironmentExpired } from '../../utils/keyless-expiry';
 
 const ALLOWED_ORIGINS_REGEX = new RegExp(process.env.FRONT_BASE_URL || '');
-const KEYLESS_RETENTION_TIME_IN_HOURS = parseInt(process.env.KEYLESS_RETENTION_TIME_IN_HOURS || '', 10) || 24;
 const MAX_NOTIFICATIONS_COUNT = 100;
 
 @Injectable()
@@ -416,17 +415,17 @@ export class Session {
   ): Promise<string> {
     const isKeylessInitialize = !requestData.applicationIdentifier;
     const isKeyless = requestData.applicationIdentifier?.includes(this.KEYLESS_ENVIRONMENT_PREFIX);
-    const isKeylessExpired = isKeyless ? await this.isKeylessExpired(requestData.applicationIdentifier) : false;
+    const isKeylessExpired = isKeyless ? isKeylessEnvironmentExpired(requestData.applicationIdentifier) : false;
 
     if (isKeylessInitialize || isKeylessExpired) {
-      const decision = await this.keylessAbuseGuard.resolveEnvCreation(clientIp);
+      const decision = await this.keylessAbuseGuard.reserveEnvCreation(clientIp);
 
       if (decision.action === 'reuse') {
         return decision.applicationIdentifier;
       }
 
       const environment = await this.processKeyless();
-      await this.keylessAbuseGuard.recordEnvCreated(clientIp, environment.identifier);
+      await this.keylessAbuseGuard.rememberLastEnv(clientIp, environment.identifier);
 
       return environment.identifier;
     }
@@ -464,41 +463,6 @@ export class Session {
     );
 
     return tierLimitMs / 1000 / 60 / 60;
-  }
-
-  async isKeylessExpired(applicationIdentifier: string | undefined) {
-    if (!applicationIdentifier) {
-      return true; // If no identifier is provided, consider it expired
-    }
-
-    const parts = applicationIdentifier.replace(this.KEYLESS_ENVIRONMENT_PREFIX, '').split('_');
-    if (parts.length < 1) {
-      return true; // Invalid format, consider expired
-    }
-
-    const createdDate = parts[0];
-
-    if (!createdDate || createdDate.length < 8) {
-      // Ensure we have at least 4 bytes (8 hex chars)
-      return true; // Invalid timestamp format, consider expired
-    }
-
-    try {
-      const createdDateTimestamp = timestampHexToDate(createdDate);
-      const now = new Date();
-      const diffTimeInHours = differenceInHours(now, createdDateTimestamp);
-
-      if (diffTimeInHours > KEYLESS_RETENTION_TIME_IN_HOURS) {
-        return true;
-      }
-    } catch (error) {
-      this.logger.error({ err: error }, 'Error parsing timestamp');
-
-      // If there's any error parsing the timestamp, consider it expired
-      return true;
-    }
-
-    return false;
   }
 
   async processKeyless(): Promise<EnvironmentResponseDto> {
@@ -885,19 +849,4 @@ export class Session {
 
     return dto;
   }
-}
-
-function timestampHexToDate(timestampHex) {
-  if (!timestampHex || typeof timestampHex !== 'string' || timestampHex.length < 8) {
-    throw new Error('Invalid timestamp hex format');
-  }
-
-  const buffer = Buffer.from(timestampHex, 'hex');
-  if (buffer.length < 4) {
-    throw new Error('Buffer too small to read 32-bit integer');
-  }
-
-  const timestamp = buffer.readUInt32BE(0);
-
-  return new Date(timestamp * 1000);
 }

--- a/apps/api/src/app/inbox/utils/keyless-expiry.spec.ts
+++ b/apps/api/src/app/inbox/utils/keyless-expiry.spec.ts
@@ -16,4 +16,16 @@ describe('isKeylessEnvironmentExpired', () => {
 
     expect(isKeylessEnvironmentExpired(identifier)).to.be.false;
   });
+
+  it('returns true for malformed identifiers', () => {
+    expect(isKeylessEnvironmentExpired(`${KEYLESS_ENVIRONMENT_PREFIX}not-a-timestamp_abcd`)).to.be.true;
+  });
+
+  it('returns true for expired identifiers', () => {
+    const timestampHex = Buffer.alloc(4);
+    timestampHex.writeUInt32BE(Math.floor(Date.now() / 1000) - 48 * 3600, 0);
+    const identifier = `${KEYLESS_ENVIRONMENT_PREFIX}${timestampHex.toString('hex')}_abcd`;
+
+    expect(isKeylessEnvironmentExpired(identifier)).to.be.true;
+  });
 });

--- a/apps/api/src/app/inbox/utils/keyless-expiry.spec.ts
+++ b/apps/api/src/app/inbox/utils/keyless-expiry.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+
+import { KEYLESS_ENVIRONMENT_PREFIX } from './keyless.constants';
+import { isKeylessEnvironmentExpired } from './keyless-expiry';
+
+describe('isKeylessEnvironmentExpired', () => {
+  it('returns true for missing identifiers', () => {
+    expect(isKeylessEnvironmentExpired(undefined)).to.be.true;
+    expect(isKeylessEnvironmentExpired('')).to.be.true;
+  });
+
+  it('returns false for a freshly minted keyless identifier', () => {
+    const timestampHex = Buffer.alloc(4);
+    timestampHex.writeUInt32BE(Math.floor(Date.now() / 1000), 0);
+    const identifier = `${KEYLESS_ENVIRONMENT_PREFIX}${timestampHex.toString('hex')}_abcd`;
+
+    expect(isKeylessEnvironmentExpired(identifier)).to.be.false;
+  });
+});

--- a/apps/api/src/app/inbox/utils/keyless-expiry.ts
+++ b/apps/api/src/app/inbox/utils/keyless-expiry.ts
@@ -1,7 +1,12 @@
 import { differenceInHours } from 'date-fns';
 import { KEYLESS_ENVIRONMENT_PREFIX } from './keyless.constants';
 
-const KEYLESS_RETENTION_TIME_IN_HOURS = parseInt(process.env.KEYLESS_RETENTION_TIME_IN_HOURS || '', 10) || 24;
+const DEFAULT_KEYLESS_RETENTION_HOURS = 24;
+const parsedRetentionHours = Number(process.env.KEYLESS_RETENTION_TIME_IN_HOURS);
+const KEYLESS_RETENTION_TIME_IN_HOURS =
+  Number.isInteger(parsedRetentionHours) && parsedRetentionHours >= 0
+    ? parsedRetentionHours
+    : DEFAULT_KEYLESS_RETENTION_HOURS;
 
 function timestampHexToDate(timestampHex: string): Date {
   if (!timestampHex || typeof timestampHex !== 'string' || timestampHex.length < 8) {

--- a/apps/api/src/app/inbox/utils/keyless-expiry.ts
+++ b/apps/api/src/app/inbox/utils/keyless-expiry.ts
@@ -1,0 +1,53 @@
+import { differenceInHours } from 'date-fns';
+import { KEYLESS_ENVIRONMENT_PREFIX } from './keyless.constants';
+
+const KEYLESS_RETENTION_TIME_IN_HOURS = parseInt(process.env.KEYLESS_RETENTION_TIME_IN_HOURS || '', 10) || 24;
+
+function timestampHexToDate(timestampHex: string): Date {
+  if (!timestampHex || typeof timestampHex !== 'string' || timestampHex.length < 8) {
+    throw new Error('Invalid timestamp hex format');
+  }
+
+  const buffer = Buffer.from(timestampHex, 'hex');
+  if (buffer.length < 4) {
+    throw new Error('Buffer too small to read 32-bit integer');
+  }
+
+  const timestamp = buffer.readUInt32BE(0);
+
+  return new Date(timestamp * 1000);
+}
+
+export function isKeylessEnvironmentExpired(applicationIdentifier: string | undefined): boolean {
+  if (!applicationIdentifier) {
+    return true;
+  }
+
+  const parts = applicationIdentifier.replace(KEYLESS_ENVIRONMENT_PREFIX, '').split('_');
+  if (parts.length < 1) {
+    return true;
+  }
+
+  const createdDate = parts[0];
+
+  if (!createdDate || createdDate.length < 8) {
+    return true;
+  }
+
+  try {
+    const createdDateTimestamp = timestampHexToDate(createdDate);
+    const diffTimeInHours = differenceInHours(new Date(), createdDateTimestamp);
+
+    if (diffTimeInHours > KEYLESS_RETENTION_TIME_IN_HOURS) {
+      return true;
+    }
+  } catch {
+    return true;
+  }
+
+  return false;
+}
+
+export function keylessEnvironmentRetentionTtlSeconds(): number {
+  return KEYLESS_RETENTION_TIME_IN_HOURS * 3600;
+}

--- a/apps/api/src/app/inbox/utils/keyless-expiry.ts
+++ b/apps/api/src/app/inbox/utils/keyless-expiry.ts
@@ -24,10 +24,6 @@ export function isKeylessEnvironmentExpired(applicationIdentifier: string | unde
   }
 
   const parts = applicationIdentifier.replace(KEYLESS_ENVIRONMENT_PREFIX, '').split('_');
-  if (parts.length < 1) {
-    return true;
-  }
-
   const createdDate = parts[0];
 
   if (!createdDate || createdDate.length < 8) {

--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -667,7 +667,7 @@ describe('Create Integration - /integration (POST) #novu-v2', () => {
         .send(payload);
 
       expect(body.statusCode).to.equal(403);
-      expect(body.message).to.contain('API key authentication is scoped to a single environment');
+      expect(body.message).to.contain('is scoped to a single environment');
     });
 
     it('should allow creating without `_environmentId` (defaults to API key environment) via API key', async () => {

--- a/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
@@ -1061,7 +1061,7 @@ describe('Update Integration - /integrations/:integrationId (PUT) #novu-v2', () 
         .send(payload);
 
       expect(body.statusCode).to.equal(403);
-      expect(body.message).to.contain('API key authentication is scoped to a single environment');
+      expect(body.message).to.contain('is scoped to a single environment');
 
       const untouched = await integrationRepository.findOne({
         _id: integrationOne._id,
@@ -1122,7 +1122,7 @@ describe('Update Integration - /integrations/:integrationId (PUT) #novu-v2', () 
         .send(payload);
 
       expect(body.statusCode).to.equal(403);
-      expect(body.message).to.contain('API key authentication is scoped to a single environment');
+      expect(body.message).to.contain('is scoped to a single environment');
 
       const untouched = await integrationRepository.findOne({
         _id: otherEnvironmentIntegration._id,

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -165,9 +165,6 @@ export class IntegrationsController {
         organizationId: user.organizationId,
         userId: user._id,
         returnCredentials: canAccessCredentials,
-        // Keyless callers share a single backing org, so org-wide listing would
-        // leak other keyless sessions' integrations. Always scope keyless (and
-        // API key) callers to their own environment.
         scopeToEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
@@ -875,9 +872,6 @@ export class IntegrationsController {
   }
 
   private assertEnvironmentScopedForApiKey(user: UserSessionData, requestedEnvironmentId?: string): void {
-    // Keyless callers share a single backing org; pin them to their own
-    // environment exactly like API key callers so they can't target another
-    // keyless session's environment via `_environmentId`.
     const isEnvironmentScopedScheme = isEnvironmentScopedAuthScheme(user.scheme);
     if (!isEnvironmentScopedScheme) {
       return;

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -890,8 +890,7 @@ export class IntegrationsController {
      * API-key and keyless auth must never receive decrypted provider credentials, regardless of RBAC state.
      * API keys grant ALL_PERMISSIONS in `community.auth.service.ts`, which would otherwise
      * allow the RBAC path below to succeed and leak every stored provider secret to any
-     * caller holding an environment API key. Keyless sessions are anonymous and must not
-     * receive decrypted integration secrets either.
+     * caller holding an environment API key.
      */
     if (user.scheme === ApiAuthSchemeEnum.API_KEY || user.scheme === ApiAuthSchemeEnum.KEYLESS) {
       return false;

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -48,6 +48,7 @@ import {
   ApiOkResponse,
   ApiResponse,
 } from '../shared/framework/response.decorator';
+import { isEnvironmentScopedAuthScheme } from '../shared/utils/auth.utils';
 import { KeylessAccessible } from '../shared/framework/swagger/keyless.security';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { UserSession } from '../shared/framework/user.decorator';
@@ -167,8 +168,7 @@ export class IntegrationsController {
         // Keyless callers share a single backing org, so org-wide listing would
         // leak other keyless sessions' integrations. Always scope keyless (and
         // API key) callers to their own environment.
-        scopeToEnvironment:
-          user.scheme === ApiAuthSchemeEnum.API_KEY || user.scheme === ApiAuthSchemeEnum.KEYLESS,
+        scopeToEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
   }
@@ -195,7 +195,7 @@ export class IntegrationsController {
         organizationId: user.organizationId,
         userId: user._id,
         returnCredentials: canAccessCredentials,
-        scopeToEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
+        scopeToEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
   }
@@ -878,8 +878,7 @@ export class IntegrationsController {
     // Keyless callers share a single backing org; pin them to their own
     // environment exactly like API key callers so they can't target another
     // keyless session's environment via `_environmentId`.
-    const isEnvironmentScopedScheme =
-      user.scheme === ApiAuthSchemeEnum.API_KEY || user.scheme === ApiAuthSchemeEnum.KEYLESS;
+    const isEnvironmentScopedScheme = isEnvironmentScopedAuthScheme(user.scheme);
     if (!isEnvironmentScopedScheme) {
       return;
     }

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -887,12 +887,13 @@ export class IntegrationsController {
 
   private async canUserAccessCredentials(user: UserSessionData): Promise<boolean> {
     /*
-     * API-key auth must never receive decrypted provider credentials, regardless of RBAC state.
+     * API-key and keyless auth must never receive decrypted provider credentials, regardless of RBAC state.
      * API keys grant ALL_PERMISSIONS in `community.auth.service.ts`, which would otherwise
      * allow the RBAC path below to succeed and leak every stored provider secret to any
-     * caller holding an environment API key.
+     * caller holding an environment API key. Keyless sessions are anonymous and must not
+     * receive decrypted integration secrets either.
      */
-    if (user.scheme === ApiAuthSchemeEnum.API_KEY) {
+    if (user.scheme === ApiAuthSchemeEnum.API_KEY || user.scheme === ApiAuthSchemeEnum.KEYLESS) {
       return false;
     }
 

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -48,6 +48,7 @@ import {
   ApiOkResponse,
   ApiResponse,
 } from '../shared/framework/response.decorator';
+import { KeylessAccessible } from '../shared/framework/swagger/keyless.security';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { UserSession } from '../shared/framework/user.decorator';
 import { CONNECTION_RESULT_CSP } from '../shared/html/connection-result-page';
@@ -151,6 +152,7 @@ export class IntegrationsController {
     description: 'List all the channels integrations created in the organization',
   })
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @RequireAuthentication()
   @RequirePermissions(PermissionsEnum.INTEGRATION_READ)
   async listIntegrations(@UserSession() user: UserSessionData): Promise<IntegrationResponseDto[]> {
@@ -162,7 +164,11 @@ export class IntegrationsController {
         organizationId: user.organizationId,
         userId: user._id,
         returnCredentials: canAccessCredentials,
-        scopeToEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
+        // Keyless callers share a single backing org, so org-wide listing would
+        // leak other keyless sessions' integrations. Always scope keyless (and
+        // API key) callers to their own environment.
+        scopeToEnvironment:
+          user.scheme === ApiAuthSchemeEnum.API_KEY || user.scheme === ApiAuthSchemeEnum.KEYLESS,
       })
     );
   }
@@ -231,6 +237,7 @@ export class IntegrationsController {
     Each provider supports different credentials, check the provider documentation for more details.`,
   })
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @RequireAuthentication()
   @RequirePermissions(PermissionsEnum.INTEGRATION_WRITE)
   async createIntegration(
@@ -405,6 +412,7 @@ export class IntegrationsController {
     This action is irreversible.`,
   })
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @RequireAuthentication()
   @RequirePermissions(PermissionsEnum.INTEGRATION_WRITE)
   async removeIntegration(
@@ -687,6 +695,7 @@ export class IntegrationsController {
   @SdkMethodName('generateConnectOAuthUrl')
   @RequirePermissions(PermissionsEnum.INTEGRATION_WRITE)
   @ExternalApiAccessible()
+  @KeylessAccessible()
   @RequireAuthentication()
   async generateConnectOAuthUrl(
     @UserSession() user: UserSessionData,
@@ -843,6 +852,7 @@ export class IntegrationsController {
     description: `Creates a Slack app from a manifest using the provided App Configuration Token and saves the resulting credentials (client ID, client secret, signing secret) directly on the integration. The configuration token is used ephemerally and is never stored.`,
   })
   @ApiExcludeEndpoint()
+  @KeylessAccessible()
   @RequireAuthentication()
   @RequirePermissions(PermissionsEnum.INTEGRATION_WRITE)
   async slackQuickSetup(
@@ -865,14 +875,19 @@ export class IntegrationsController {
   }
 
   private assertEnvironmentScopedForApiKey(user: UserSessionData, requestedEnvironmentId?: string): void {
-    if (user.scheme !== ApiAuthSchemeEnum.API_KEY) {
+    // Keyless callers share a single backing org; pin them to their own
+    // environment exactly like API key callers so they can't target another
+    // keyless session's environment via `_environmentId`.
+    const isEnvironmentScopedScheme =
+      user.scheme === ApiAuthSchemeEnum.API_KEY || user.scheme === ApiAuthSchemeEnum.KEYLESS;
+    if (!isEnvironmentScopedScheme) {
       return;
     }
 
     if (requestedEnvironmentId && requestedEnvironmentId !== user.environmentId) {
       throw new ForbiddenException(
-        'API key authentication is scoped to a single environment and cannot target a different `_environmentId`. ' +
-          'Use an API key from the target environment, or authenticate with a session token.'
+        'This authentication scheme is scoped to a single environment and cannot target a different `_environmentId`. ' +
+          'Use credentials from the target environment, or authenticate with a session token.'
       );
     }
   }

--- a/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.command.ts
+++ b/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.command.ts
@@ -1,5 +1,5 @@
 import { ChannelTypeEnum, EnvironmentEnum, EnvironmentTypeEnum } from '@novu/shared';
-import { IsArray, IsEnum, IsOptional } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsOptional } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
 export class CreateNovuIntegrationsCommand extends EnvironmentWithUserCommand {
@@ -9,6 +9,15 @@ export class CreateNovuIntegrationsCommand extends EnvironmentWithUserCommand {
   @IsArray()
   @IsEnum(ChannelTypeEnum, { each: true })
   readonly channels?: ChannelTypeEnum[];
+
+  /**
+   * Force provisioning of the Novu-managed Claude (demo) agent integration even
+   * when the environment is not named `Development`. Used by the keyless
+   * (`novu connect`) flow so the anonymous demo env has a demo runtime to use.
+   */
+  @IsOptional()
+  @IsBoolean()
+  readonly includeManagedClaude?: boolean;
 
   /**
    * Type of the environment the integrations are being created for. Used to decide

--- a/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.command.ts
+++ b/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.command.ts
@@ -10,11 +10,6 @@ export class CreateNovuIntegrationsCommand extends EnvironmentWithUserCommand {
   @IsEnum(ChannelTypeEnum, { each: true })
   readonly channels?: ChannelTypeEnum[];
 
-  /**
-   * Force provisioning of the Novu-managed Claude (demo) agent integration even
-   * when the environment is not named `Development`. Used by the keyless
-   * (`novu connect`) flow so the anonymous demo env has a demo runtime to use.
-   */
   @IsOptional()
   @IsBoolean()
   readonly includeManagedClaude?: boolean;

--- a/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.ts
@@ -118,7 +118,8 @@ export class CreateNovuIntegrations {
   }
 
   private async createManagedClaudeIntegration(command: CreateNovuIntegrationsCommand) {
-    if (!areNovuManagedClaudeCredentialsSet() || command.name !== EnvironmentEnum.DEVELOPMENT) {
+    const isDevelopmentEnvironment = command.name === EnvironmentEnum.DEVELOPMENT;
+    if (!areNovuManagedClaudeCredentialsSet() || (!isDevelopmentEnvironment && !command.includeManagedClaude)) {
       return;
     }
 

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.spec.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.spec.ts
@@ -1,0 +1,103 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { CacheService, FeatureFlagsService } from '@novu/application-generic';
+import { AgentRepository } from '@novu/dal';
+import { ApiAuthSchemeEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { KEYLESS_ENVIRONMENT_PREFIX } from '../inbox/utils/keyless.constants';
+import { KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY, KEYLESS_GENERATE_CAP_PER_IP_PER_DAY } from './keyless-abuse.constants';
+import { KeylessAbuseGuardService } from './keyless-abuse-guard.service';
+
+describe('KeylessAbuseGuardService', () => {
+  const keylessOrgId = 'keyless-org-id';
+  const clientIp = '203.0.113.10';
+  let cacheService: sinon.SinonStubbedInstance<CacheService>;
+  let featureFlagsService: sinon.SinonStubbedInstance<FeatureFlagsService>;
+  let agentRepository: sinon.SinonStubbedInstance<AgentRepository>;
+  let guard: KeylessAbuseGuardService;
+  let previousKeylessOrgId: string | undefined;
+
+  beforeEach(() => {
+    previousKeylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
+    process.env.KEYLESS_ORGANIZATION_ID = keylessOrgId;
+
+    cacheService = sinon.createStubInstance(CacheService);
+    cacheService.cacheEnabled.returns(true);
+    featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
+    agentRepository = sinon.createStubInstance(AgentRepository);
+
+    guard = new KeylessAbuseGuardService(cacheService, featureFlagsService, agentRepository);
+  });
+
+  afterEach(() => {
+    if (previousKeylessOrgId === undefined) {
+      delete process.env.KEYLESS_ORGANIZATION_ID;
+    } else {
+      process.env.KEYLESS_ORGANIZATION_ID = previousKeylessOrgId;
+    }
+
+    sinon.restore();
+  });
+
+  it('allows env creation when the daily counter is below the cap', async () => {
+    cacheService.get.resolves('0');
+    cacheService.eval.resolves(1);
+
+    const decision = await guard.resolveEnvCreation(clientIp);
+
+    expect(decision).to.deep.equal({ action: 'create' });
+  });
+
+  it('reuses the last valid keyless env when the env-create cap is exceeded', async () => {
+    const timestampHex = Buffer.alloc(4);
+    timestampHex.writeUInt32BE(Math.floor(Date.now() / 1000), 0);
+    const identifier = `${KEYLESS_ENVIRONMENT_PREFIX}${timestampHex.toString('hex')}_abcd`;
+
+    cacheService.get.onFirstCall().resolves(String(KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY));
+    cacheService.get.onSecondCall().resolves(identifier);
+
+    const decision = await guard.resolveEnvCreation(clientIp);
+
+    expect(decision).to.deep.equal({ action: 'reuse', applicationIdentifier: identifier });
+  });
+
+  it('rejects generate when the per-IP daily cap is exceeded', async () => {
+    cacheService.eval.resolves(KEYLESS_GENERATE_CAP_PER_IP_PER_DAY + 1);
+
+    try {
+      await guard.assertGenerateAllowed(clientIp);
+      expect.fail('Expected HttpException');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(HttpStatus.TOO_MANY_REQUESTS);
+    }
+  });
+
+  it('rejects keyless AI when the kill-switch flag is disabled', async () => {
+    featureFlagsService.getFlag.resolves(false);
+
+    try {
+      await guard.assertKeylessAiEnabled(keylessOrgId);
+      expect.fail('Expected HttpException');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    expect(featureFlagsService.getFlag.calledOnce).to.be.true;
+    expect(featureFlagsService.getFlag.firstCall.args[0].key).to.equal(FeatureFlagsKeysEnum.IS_KEYLESS_AGENT_AI_ENABLED);
+  });
+
+  it('does not gate non-keyless organizations for AI enablement', async () => {
+    const enabled = await guard.isKeylessAgentAiEnabled('regular-org-id');
+
+    expect(enabled).to.be.true;
+    expect(featureFlagsService.getFlag.called).to.be.false;
+  });
+
+  it('treats keyless auth scheme as non-credential-access', () => {
+    expect(guard.isKeylessAuthScheme(ApiAuthSchemeEnum.KEYLESS)).to.be.true;
+    expect(guard.isKeylessAuthScheme(ApiAuthSchemeEnum.API_KEY)).to.be.false;
+  });
+});

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.spec.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.spec.ts
@@ -1,12 +1,16 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { CacheService, FeatureFlagsService } from '@novu/application-generic';
 import { AgentRepository } from '@novu/dal';
-import { ApiAuthSchemeEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { KEYLESS_ENVIRONMENT_PREFIX } from '../inbox/utils/keyless.constants';
-import { KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY, KEYLESS_GENERATE_CAP_PER_IP_PER_DAY } from './keyless-abuse.constants';
+import {
+  KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY,
+  KEYLESS_GENERATE_CAP_PER_IP_PER_DAY,
+  KEYLESS_MAX_AGENTS_PER_ENV,
+} from './keyless-abuse.constants';
 import { KeylessAbuseGuardService } from './keyless-abuse-guard.service';
 
 describe('KeylessAbuseGuardService', () => {
@@ -41,12 +45,12 @@ describe('KeylessAbuseGuardService', () => {
   });
 
   it('allows env creation when the daily counter is below the cap', async () => {
-    cacheService.get.resolves('0');
     cacheService.eval.resolves(1);
 
-    const decision = await guard.resolveEnvCreation(clientIp);
+    const decision = await guard.reserveEnvCreation(clientIp);
 
     expect(decision).to.deep.equal({ action: 'create' });
+    expect(cacheService.eval.calledOnce).to.be.true;
   });
 
   it('reuses the last valid keyless env when the env-create cap is exceeded', async () => {
@@ -54,12 +58,56 @@ describe('KeylessAbuseGuardService', () => {
     timestampHex.writeUInt32BE(Math.floor(Date.now() / 1000), 0);
     const identifier = `${KEYLESS_ENVIRONMENT_PREFIX}${timestampHex.toString('hex')}_abcd`;
 
-    cacheService.get.onFirstCall().resolves(String(KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY));
-    cacheService.get.onSecondCall().resolves(identifier);
+    cacheService.eval.resolves(KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY + 1);
+    cacheService.get.resolves(identifier);
 
-    const decision = await guard.resolveEnvCreation(clientIp);
+    const decision = await guard.reserveEnvCreation(clientIp);
 
     expect(decision).to.deep.equal({ action: 'reuse', applicationIdentifier: identifier });
+  });
+
+  it('rejects env creation when the cap is exceeded and no valid last env exists', async () => {
+    cacheService.eval.resolves(KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY + 1);
+    cacheService.get.resolves(null);
+
+    try {
+      await guard.reserveEnvCreation(clientIp);
+      expect.fail('Expected HttpException');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(HttpStatus.TOO_MANY_REQUESTS);
+    }
+  });
+
+  it('rejects env creation when client IP is missing and cache is enabled', async () => {
+    try {
+      await guard.reserveEnvCreation(undefined);
+      expect.fail('Expected HttpException');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    expect(cacheService.eval.called).to.be.false;
+  });
+
+  it('skips env caps when cache is disabled', async () => {
+    cacheService.cacheEnabled.returns(false);
+
+    const decision = await guard.reserveEnvCreation(undefined);
+
+    expect(decision).to.deep.equal({ action: 'create' });
+    expect(cacheService.eval.called).to.be.false;
+  });
+
+  it('persists the last env identifier after successful creation', async () => {
+    const identifier = `${KEYLESS_ENVIRONMENT_PREFIX}deadbeef_abcd`;
+
+    await guard.rememberLastEnv(clientIp, identifier);
+
+    expect(cacheService.set.calledOnce).to.be.true;
+    expect(cacheService.set.firstCall.args[0]).to.include(clientIp);
+    expect(cacheService.set.firstCall.args[1]).to.equal(identifier);
   });
 
   it('rejects generate when the per-IP daily cap is exceeded', async () => {
@@ -67,6 +115,16 @@ describe('KeylessAbuseGuardService', () => {
 
     try {
       await guard.assertGenerateAllowed(clientIp);
+      expect.fail('Expected HttpException');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(HttpStatus.TOO_MANY_REQUESTS);
+    }
+  });
+
+  it('rejects generate when client IP is missing and cache is enabled', async () => {
+    try {
+      await guard.assertGenerateAllowed(undefined);
       expect.fail('Expected HttpException');
     } catch (error) {
       expect(error).to.be.instanceOf(HttpException);
@@ -82,7 +140,7 @@ describe('KeylessAbuseGuardService', () => {
       expect.fail('Expected HttpException');
     } catch (error) {
       expect(error).to.be.instanceOf(HttpException);
-      expect((error as HttpException).getStatus()).to.equal(HttpStatus.TOO_MANY_REQUESTS);
+      expect((error as HttpException).getStatus()).to.equal(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     expect(featureFlagsService.getFlag.calledOnce).to.be.true;
@@ -96,8 +154,21 @@ describe('KeylessAbuseGuardService', () => {
     expect(featureFlagsService.getFlag.called).to.be.false;
   });
 
-  it('treats keyless auth scheme as non-credential-access', () => {
-    expect(guard.isKeylessAuthScheme(ApiAuthSchemeEnum.KEYLESS)).to.be.true;
-    expect(guard.isKeylessAuthScheme(ApiAuthSchemeEnum.API_KEY)).to.be.false;
+  it('rejects managed agent creation when the per-env cap is reached', async () => {
+    agentRepository.count.resolves(KEYLESS_MAX_AGENTS_PER_ENV);
+
+    try {
+      await guard.assertManagedAgentCap('env-id', keylessOrgId);
+      expect.fail('Expected HttpException');
+    } catch (error) {
+      expect(error).to.be.instanceOf(HttpException);
+      expect((error as HttpException).getStatus()).to.equal(HttpStatus.TOO_MANY_REQUESTS);
+    }
+  });
+
+  it('does not cap managed agents for non-keyless organizations', async () => {
+    await guard.assertManagedAgentCap('env-id', 'regular-org-id');
+
+    expect(agentRepository.count.called).to.be.false;
   });
 });

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
@@ -1,0 +1,159 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CacheService, FeatureFlagsService } from '@novu/application-generic';
+import { AgentRepository } from '@novu/dal';
+import { ApiAuthSchemeEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { isKeylessEnvironmentExpired, keylessEnvironmentRetentionTtlSeconds } from '../inbox/utils/keyless-expiry';
+import {
+  INCR_WITH_EXPIRE_SCRIPT,
+  KEYLESS_DAILY_COUNTER_TTL_SECONDS,
+  KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY,
+  KEYLESS_GENERATE_CAP_PER_IP_PER_DAY,
+  KEYLESS_MAX_AGENTS_PER_ENV,
+} from './keyless-abuse.constants';
+
+export type KeylessEnvCreationDecision =
+  | { action: 'create' }
+  | { action: 'reuse'; applicationIdentifier: string };
+
+const ENV_CREATE_LIMIT_MESSAGE =
+  'Daily keyless demo limit reached. Sign up for a free Novu account or try again tomorrow.';
+
+const GENERATE_LIMIT_MESSAGE =
+  'Daily agent generation limit reached for this demo. Sign up for a free Novu account or try again tomorrow.';
+
+const AI_DISABLED_MESSAGE = 'Keyless agent AI is temporarily unavailable. Sign up for a free Novu account to continue.';
+
+const MANAGED_AGENT_CAP_MESSAGE =
+  'This keyless demo environment has reached its agent limit. Sign up for a free Novu account to create more agents.';
+
+@Injectable()
+export class KeylessAbuseGuardService {
+  constructor(
+    private readonly cacheService: CacheService,
+    private readonly featureFlagsService: FeatureFlagsService,
+    private readonly agentRepository: AgentRepository
+  ) {}
+
+  isKeylessOrganization(organizationId: string): boolean {
+    const keylessOrganizationId = process.env.KEYLESS_ORGANIZATION_ID;
+
+    return Boolean(keylessOrganizationId && organizationId === keylessOrganizationId);
+  }
+
+  async resolveEnvCreation(clientIp: string | undefined): Promise<KeylessEnvCreationDecision> {
+    if (!clientIp || !this.cacheService.cacheEnabled()) {
+      return { action: 'create' };
+    }
+
+    const counterKey = this.dailyCounterKey('env_create', clientIp);
+    const currentCount = await this.readDailyCounter(counterKey);
+
+    if (currentCount < KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY) {
+      return { action: 'create' };
+    }
+
+    const lastIdentifier = await this.cacheService.get(this.lastEnvKey(clientIp));
+    if (lastIdentifier && !isKeylessEnvironmentExpired(lastIdentifier)) {
+      return { action: 'reuse', applicationIdentifier: lastIdentifier };
+    }
+
+    throw new HttpException(ENV_CREATE_LIMIT_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
+  }
+
+  async recordEnvCreated(clientIp: string | undefined, applicationIdentifier: string): Promise<void> {
+    if (!clientIp || !this.cacheService.cacheEnabled()) {
+      return;
+    }
+
+    await this.incrementDailyCounter(this.dailyCounterKey('env_create', clientIp));
+    await this.cacheService.set(this.lastEnvKey(clientIp), applicationIdentifier, {
+      ttl: keylessEnvironmentRetentionTtlSeconds(),
+    });
+  }
+
+  async assertGenerateAllowed(clientIp: string | undefined): Promise<void> {
+    if (!clientIp || !this.cacheService.cacheEnabled()) {
+      return;
+    }
+
+    const counterKey = this.dailyCounterKey('generate', clientIp);
+    const nextCount = await this.incrementDailyCounter(counterKey);
+
+    if (nextCount > KEYLESS_GENERATE_CAP_PER_IP_PER_DAY) {
+      throw new HttpException(GENERATE_LIMIT_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
+    }
+  }
+
+  async assertKeylessAiEnabled(organizationId: string): Promise<void> {
+    const enabled = await this.isKeylessAgentAiEnabled(organizationId);
+
+    if (!enabled) {
+      throw new HttpException(AI_DISABLED_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
+    }
+  }
+
+  async isKeylessAgentAiEnabled(organizationId: string): Promise<boolean> {
+    if (!this.isKeylessOrganization(organizationId)) {
+      return true;
+    }
+
+    return this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_KEYLESS_AGENT_AI_ENABLED,
+      defaultValue: true,
+      organization: { _id: organizationId },
+    });
+  }
+
+  async assertManagedAgentCap(environmentId: string, organizationId: string): Promise<void> {
+    if (!this.isKeylessOrganization(organizationId)) {
+      return;
+    }
+
+    const count = await this.agentRepository.count({
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+    });
+
+    if (count >= KEYLESS_MAX_AGENTS_PER_ENV) {
+      throw new HttpException(MANAGED_AGENT_CAP_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
+    }
+  }
+
+  isKeylessAuthScheme(scheme: string | undefined): boolean {
+    return scheme === ApiAuthSchemeEnum.KEYLESS;
+  }
+
+  private dailyCounterKey(kind: 'env_create' | 'generate', clientIp: string): string {
+    return `keyless_abuse:${kind}:{${clientIp}}:${this.utcDateKey()}`;
+  }
+
+  private lastEnvKey(clientIp: string): string {
+    return `keyless_abuse:last_env:{${clientIp}}`;
+  }
+
+  private utcDateKey(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  private async readDailyCounter(key: string): Promise<number> {
+    const raw = await this.cacheService.get(key);
+
+    if (raw == null || raw === '') {
+      return 0;
+    }
+
+    const parsed = Number(raw);
+
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  private async incrementDailyCounter(key: string): Promise<number> {
+    const result = await this.cacheService.eval<number>(
+      INCR_WITH_EXPIRE_SCRIPT,
+      [key],
+      [KEYLESS_DAILY_COUNTER_TTL_SECONDS]
+    );
+
+    return result ?? 0;
+  }
+}

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
@@ -1,8 +1,9 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { CacheService, FeatureFlagsService } from '@novu/application-generic';
 import { AgentRepository } from '@novu/dal';
-import { ApiAuthSchemeEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { isKeylessEnvironmentExpired, keylessEnvironmentRetentionTtlSeconds } from '../inbox/utils/keyless-expiry';
+import { KEYLESS_ENVIRONMENT_PREFIX } from '../inbox/utils/keyless.constants';
 import {
   INCR_WITH_EXPIRE_SCRIPT,
   KEYLESS_DAILY_COUNTER_TTL_SECONDS,
@@ -26,6 +27,12 @@ const AI_DISABLED_MESSAGE = 'Keyless agent AI is temporarily unavailable. Sign u
 const MANAGED_AGENT_CAP_MESSAGE =
   'This keyless demo environment has reached its agent limit. Sign up for a free Novu account to create more agents.';
 
+const MISSING_CLIENT_IP_MESSAGE = 'Unable to verify request origin for this demo request.';
+
+/**
+ * Keyless abuse guards keyed by client IP via Redis daily counters.
+ * Requires the API to run with `trust proxy` so Express `req.ip` / getClientIp reflect the real client.
+ */
 @Injectable()
 export class KeylessAbuseGuardService {
   constructor(
@@ -34,46 +41,49 @@ export class KeylessAbuseGuardService {
     private readonly agentRepository: AgentRepository
   ) {}
 
-  isKeylessOrganization(organizationId: string): boolean {
-    const keylessOrganizationId = process.env.KEYLESS_ORGANIZATION_ID;
-
-    return Boolean(keylessOrganizationId && organizationId === keylessOrganizationId);
-  }
-
-  async resolveEnvCreation(clientIp: string | undefined): Promise<KeylessEnvCreationDecision> {
-    if (!clientIp || !this.cacheService.cacheEnabled()) {
+  async reserveEnvCreation(clientIp?: string): Promise<KeylessEnvCreationDecision> {
+    if (!this.cacheService.cacheEnabled() || KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY === 0) {
       return { action: 'create' };
+    }
+
+    if (!clientIp) {
+      throw new HttpException(MISSING_CLIENT_IP_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
     }
 
     const counterKey = this.dailyCounterKey('env_create', clientIp);
-    const currentCount = await this.readDailyCounter(counterKey);
+    const nextCount = await this.incrementDailyCounter(counterKey);
 
-    if (currentCount < KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY) {
+    if (nextCount <= KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY) {
       return { action: 'create' };
     }
 
-    const lastIdentifier = await this.cacheService.get(this.lastEnvKey(clientIp));
-    if (lastIdentifier && !isKeylessEnvironmentExpired(lastIdentifier)) {
-      return { action: 'reuse', applicationIdentifier: lastIdentifier };
+    const lastEnv = await this.getLastEnvApplicationIdentifier(clientIp);
+
+    if (lastEnv && !isKeylessEnvironmentExpired(lastEnv)) {
+      return { action: 'reuse', applicationIdentifier: lastEnv };
     }
 
     throw new HttpException(ENV_CREATE_LIMIT_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
   }
 
-  async recordEnvCreated(clientIp: string | undefined, applicationIdentifier: string): Promise<void> {
+  async rememberLastEnv(clientIp: string | undefined, applicationIdentifier: string): Promise<void> {
     if (!clientIp || !this.cacheService.cacheEnabled()) {
       return;
     }
 
-    await this.incrementDailyCounter(this.dailyCounterKey('env_create', clientIp));
-    await this.cacheService.set(this.lastEnvKey(clientIp), applicationIdentifier, {
+    const lastEnvKey = this.lastEnvKey(clientIp);
+    await this.cacheService.set(lastEnvKey, applicationIdentifier, {
       ttl: keylessEnvironmentRetentionTtlSeconds(),
     });
   }
 
-  async assertGenerateAllowed(clientIp: string | undefined): Promise<void> {
-    if (!clientIp || !this.cacheService.cacheEnabled()) {
+  async assertGenerateAllowed(clientIp?: string): Promise<void> {
+    if (!this.cacheService.cacheEnabled() || KEYLESS_GENERATE_CAP_PER_IP_PER_DAY === 0) {
       return;
+    }
+
+    if (!clientIp) {
+      throw new HttpException(MISSING_CLIENT_IP_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
     }
 
     const counterKey = this.dailyCounterKey('generate', clientIp);
@@ -84,28 +94,28 @@ export class KeylessAbuseGuardService {
     }
   }
 
-  async assertKeylessAiEnabled(organizationId: string): Promise<void> {
-    const enabled = await this.isKeylessAgentAiEnabled(organizationId);
-
-    if (!enabled) {
-      throw new HttpException(AI_DISABLED_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
-    }
-  }
-
   async isKeylessAgentAiEnabled(organizationId: string): Promise<boolean> {
     if (!this.isKeylessOrganization(organizationId)) {
       return true;
     }
 
     return this.featureFlagsService.getFlag({
+      organization: { _id: organizationId },
       key: FeatureFlagsKeysEnum.IS_KEYLESS_AGENT_AI_ENABLED,
       defaultValue: true,
-      organization: { _id: organizationId },
     });
   }
 
+  async assertKeylessAiEnabled(organizationId: string): Promise<void> {
+    const enabled = await this.isKeylessAgentAiEnabled(organizationId);
+
+    if (!enabled) {
+      throw new HttpException(AI_DISABLED_MESSAGE, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
   async assertManagedAgentCap(environmentId: string, organizationId: string): Promise<void> {
-    if (!this.isKeylessOrganization(organizationId)) {
+    if (KEYLESS_MAX_AGENTS_PER_ENV === 0 || !this.isKeylessOrganization(organizationId)) {
       return;
     }
 
@@ -119,32 +129,20 @@ export class KeylessAbuseGuardService {
     }
   }
 
-  isKeylessAuthScheme(scheme: string | undefined): boolean {
-    return scheme === ApiAuthSchemeEnum.KEYLESS;
+  private isKeylessOrganization(organizationId: string): boolean {
+    const keylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
+
+    return Boolean(keylessOrgId && organizationId === keylessOrgId);
   }
 
   private dailyCounterKey(kind: 'env_create' | 'generate', clientIp: string): string {
-    return `keyless_abuse:${kind}:{${clientIp}}:${this.utcDateKey()}`;
+    const date = new Date().toISOString().slice(0, 10);
+
+    return `keyless:${kind}:${date}:${clientIp}`;
   }
 
   private lastEnvKey(clientIp: string): string {
-    return `keyless_abuse:last_env:{${clientIp}}`;
-  }
-
-  private utcDateKey(): string {
-    return new Date().toISOString().slice(0, 10);
-  }
-
-  private async readDailyCounter(key: string): Promise<number> {
-    const raw = await this.cacheService.get(key);
-
-    if (raw == null || raw === '') {
-      return 0;
-    }
-
-    const parsed = Number(raw);
-
-    return Number.isNaN(parsed) ? 0 : parsed;
+    return `keyless:last_env:${clientIp}`;
   }
 
   private async incrementDailyCounter(key: string): Promise<number> {
@@ -155,5 +153,15 @@ export class KeylessAbuseGuardService {
     );
 
     return result ?? 0;
+  }
+
+  private async getLastEnvApplicationIdentifier(clientIp: string): Promise<string | null> {
+    const lastEnv = await this.cacheService.get(this.lastEnvKey(clientIp));
+
+    if (!lastEnv || typeof lastEnv !== 'string' || !lastEnv.startsWith(KEYLESS_ENVIRONMENT_PREFIX)) {
+      return null;
+    }
+
+    return lastEnv;
   }
 }

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
@@ -29,10 +29,6 @@ const MANAGED_AGENT_CAP_MESSAGE =
 
 const MISSING_CLIENT_IP_MESSAGE = 'Unable to verify request origin for this demo request.';
 
-/**
- * Keyless abuse guards keyed by client IP via Redis daily counters.
- * Requires the API to run with `trust proxy` so Express `req.ip` / getClientIp reflect the real client.
- */
 @Injectable()
 export class KeylessAbuseGuardService {
   constructor(

--- a/apps/api/src/app/keyless/keyless-abuse.constants.ts
+++ b/apps/api/src/app/keyless/keyless-abuse.constants.ts
@@ -1,3 +1,4 @@
+/** Parses a non-negative integer env var; `0` disables the corresponding cap. */
 export function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
   if (raw == null || raw === '') {
     return fallback;
@@ -26,12 +27,10 @@ export const KEYLESS_MAX_AGENTS_PER_ENV = parsePositiveIntEnv(process.env.KEYLES
 
 export const KEYLESS_DAILY_COUNTER_TTL_SECONDS = 86_400;
 
-const INCR_WITH_EXPIRE_SCRIPT = `
+export const INCR_WITH_EXPIRE_SCRIPT = `
 local current = redis.call('INCR', KEYS[1])
 if current == 1 then
   redis.call('EXPIRE', KEYS[1], ARGV[1])
 end
 return current
 `;
-
-export { INCR_WITH_EXPIRE_SCRIPT };

--- a/apps/api/src/app/keyless/keyless-abuse.constants.ts
+++ b/apps/api/src/app/keyless/keyless-abuse.constants.ts
@@ -1,0 +1,37 @@
+export function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (raw == null || raw === '') {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export const KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY = parsePositiveIntEnv(
+  process.env.KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY,
+  15
+);
+
+export const KEYLESS_GENERATE_CAP_PER_IP_PER_DAY = parsePositiveIntEnv(
+  process.env.KEYLESS_GENERATE_CAP_PER_IP_PER_DAY,
+  5
+);
+
+export const KEYLESS_MAX_AGENTS_PER_ENV = parsePositiveIntEnv(process.env.KEYLESS_MAX_AGENTS_PER_ENV, 2);
+
+export const KEYLESS_DAILY_COUNTER_TTL_SECONDS = 86_400;
+
+const INCR_WITH_EXPIRE_SCRIPT = `
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return current
+`;
+
+export { INCR_WITH_EXPIRE_SCRIPT };

--- a/apps/api/src/app/keyless/keyless-abuse.constants.ts
+++ b/apps/api/src/app/keyless/keyless-abuse.constants.ts
@@ -1,4 +1,3 @@
-/** Parses a non-negative integer env var; `0` disables the corresponding cap. */
 export function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
   if (raw == null || raw === '') {
     return fallback;

--- a/apps/api/src/app/keyless/keyless-abuse.constants.ts
+++ b/apps/api/src/app/keyless/keyless-abuse.constants.ts
@@ -1,11 +1,11 @@
 export function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
-  if (raw == null || raw === '') {
+  if (raw == null || raw.trim() === '') {
     return fallback;
   }
 
   const parsed = Number(raw);
 
-  if (Number.isNaN(parsed) || parsed < 0) {
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
     return fallback;
   }
 

--- a/apps/api/src/app/keyless/keyless.module.ts
+++ b/apps/api/src/app/keyless/keyless.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
-import { AgentRepository } from '@novu/dal';
 import { SharedModule } from '../shared/shared.module';
 import { KeylessAbuseGuardService } from './keyless-abuse-guard.service';
 
 @Module({
   imports: [SharedModule],
-  providers: [KeylessAbuseGuardService, AgentRepository],
+  providers: [KeylessAbuseGuardService],
   exports: [KeylessAbuseGuardService],
 })
 export class KeylessModule {}

--- a/apps/api/src/app/keyless/keyless.module.ts
+++ b/apps/api/src/app/keyless/keyless.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AgentRepository } from '@novu/dal';
+import { SharedModule } from '../shared/shared.module';
+import { KeylessAbuseGuardService } from './keyless-abuse-guard.service';
+
+@Module({
+  imports: [SharedModule],
+  providers: [KeylessAbuseGuardService, AgentRepository],
+  exports: [KeylessAbuseGuardService],
+})
+export class KeylessModule {}

--- a/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
+++ b/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
@@ -25,7 +25,10 @@ import {
   UserSessionData,
 } from '@novu/shared';
 import { getClientIp } from 'request-ip';
-import { checkIsKeylessHeader } from '../../shared/utils/auth.utils';
+import {
+  isKeylessApplicationIdentifierHeader,
+  isResolvedKeylessAuthScheme,
+} from '../../shared/utils/auth.utils';
 import { EvaluateApiRateLimit, EvaluateApiRateLimitCommand } from '../usecases/evaluate-api-rate-limit';
 import { ThrottlerCategory, ThrottlerCost } from './throttler.decorator';
 
@@ -144,14 +147,14 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
     const handler = context.getHandler();
     const classRef = context.getClass();
 
-    const isKeylessHeader =
-      checkIsKeylessHeader(req.headers.authorization) ||
-      checkIsKeylessHeader(req.headers['novu-application-identifier']);
-    const isKeylessRequest = isKeylessHeader || this.isKeylessRoute(context);
+    const user = this.getReqUser(context);
+    const isKeylessRequest =
+      isResolvedKeylessAuthScheme(req.authScheme) ||
+      user?.scheme === ApiAuthSchemeEnum.KEYLESS ||
+      this.isKeylessRoute(context);
     const apiRateLimitCategory =
       this.reflector.getAllAndOverride(ThrottlerCategory, [handler, classRef]) || defaultApiRateLimitCategory;
 
-    const user = this.getReqUser(context);
     const organizationId = user?.organizationId;
     const _id = user?._id;
     const environmentId = user?.environmentId || req.headers['novu-application-identifier'];
@@ -165,6 +168,7 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
       environmentId,
       apiRateLimitCategory,
       apiRateLimitCost,
+      isKeyless: isKeylessRequest,
       ip: isKeylessRequest ? clientIp : undefined,
     });
 
@@ -313,7 +317,7 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
       return false;
     }
 
-    return applicationIdentifier.startsWith('pk_keyless_');
+    return isKeylessApplicationIdentifierHeader(applicationIdentifier);
   }
 
   private isAllowedRoute(context: ExecutionContext): boolean {

--- a/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
+++ b/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
@@ -149,9 +149,7 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
 
     const user = this.getReqUser(context);
     const isKeylessRequest =
-      isResolvedKeylessAuthScheme(req.authScheme) ||
-      user?.scheme === ApiAuthSchemeEnum.KEYLESS ||
-      this.isKeylessRoute(context);
+      isResolvedKeylessAuthScheme(req.authScheme ?? user?.scheme) || this.isKeylessRoute(context);
     const apiRateLimitCategory =
       this.reflector.getAllAndOverride(ThrottlerCategory, [handler, classRef]) || defaultApiRateLimitCategory;
 

--- a/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.command.ts
+++ b/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.command.ts
@@ -23,7 +23,6 @@ export class EvaluateApiRateLimitCommand extends BaseCommand {
   @IsString()
   ip?: string;
 
-  /** True for keyless callers (resolved auth scheme or inbox session bootstrap). */
   @IsOptional()
   @IsBoolean()
   isKeyless?: boolean;

--- a/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.command.ts
+++ b/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.command.ts
@@ -1,6 +1,6 @@
 import { BaseCommand } from '@novu/application-generic';
 import { ApiRateLimitCategoryEnum, ApiRateLimitCostEnum } from '@novu/shared';
-import { IsDefined, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsDefined, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class EvaluateApiRateLimitCommand extends BaseCommand {
   @IsOptional()
@@ -22,4 +22,9 @@ export class EvaluateApiRateLimitCommand extends BaseCommand {
   @IsOptional()
   @IsString()
   ip?: string;
+
+  /** True for keyless callers (resolved auth scheme or inbox session bootstrap). */
+  @IsOptional()
+  @IsBoolean()
+  isKeyless?: boolean;
 }

--- a/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.usecase.ts
+++ b/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.usecase.ts
@@ -29,8 +29,12 @@ export class EvaluateApiRateLimit {
     let maxLimitPerSecond: number;
     let apiServiceLevel: ApiServiceLevel;
 
-    // For keyless environments, we implement strict rate limiting to prevent abuse:
-    if (!command.organizationId || !command.environmentId) {
+    // For keyless requests we implement strict, IP-keyed rate limiting to prevent
+    // abuse. `command.ip` is only set for keyless callers (see the throttler), so
+    // it also covers authenticated keyless sessions (e.g. `novu connect`) whose
+    // resolved keyless org/env would otherwise pin them to that org's tier limits
+    // and make the high keyless per-request cost unusable across a multi-call flow.
+    if (!command.organizationId || !command.environmentId || command.ip) {
       maxLimitPerSecond = 3000;
       apiServiceLevel = ApiServiceLevelEnum.ENTERPRISE;
     } else {

--- a/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.usecase.ts
+++ b/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.usecase.ts
@@ -29,10 +29,6 @@ export class EvaluateApiRateLimit {
     let maxLimitPerSecond: number;
     let apiServiceLevel: ApiServiceLevel;
 
-    // For keyless requests we implement strict, IP-keyed rate limiting to prevent
-    // abuse. Authenticated keyless sessions (e.g. `novu connect`) would otherwise
-    // pin to the shared keyless org's tier limits and make the high keyless
-    // per-request cost unusable across a multi-call flow.
     if (!command.organizationId || !command.environmentId || command.isKeyless) {
       maxLimitPerSecond = 3000;
       apiServiceLevel = ApiServiceLevelEnum.ENTERPRISE;

--- a/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.usecase.ts
+++ b/apps/api/src/app/rate-limiting/usecases/evaluate-api-rate-limit/evaluate-api-rate-limit.usecase.ts
@@ -30,11 +30,10 @@ export class EvaluateApiRateLimit {
     let apiServiceLevel: ApiServiceLevel;
 
     // For keyless requests we implement strict, IP-keyed rate limiting to prevent
-    // abuse. `command.ip` is only set for keyless callers (see the throttler), so
-    // it also covers authenticated keyless sessions (e.g. `novu connect`) whose
-    // resolved keyless org/env would otherwise pin them to that org's tier limits
-    // and make the high keyless per-request cost unusable across a multi-call flow.
-    if (!command.organizationId || !command.environmentId || command.ip) {
+    // abuse. Authenticated keyless sessions (e.g. `novu connect`) would otherwise
+    // pin to the shared keyless org's tier limits and make the high keyless
+    // per-request cost unusable across a multi-call flow.
+    if (!command.organizationId || !command.environmentId || command.isKeyless) {
       maxLimitPerSecond = 3000;
       apiServiceLevel = ApiServiceLevelEnum.ENTERPRISE;
     } else {

--- a/apps/api/src/app/shared/utils/auth.utils.ts
+++ b/apps/api/src/app/shared/utils/auth.utils.ts
@@ -2,25 +2,14 @@ import { ApiAuthSchemeEnum } from '@novu/shared';
 
 import { KEYLESS_ENVIRONMENT_PREFIX } from '../../inbox/utils/keyless.constants';
 
-/** Auth schemes that are pinned to a single environment (API key and keyless). */
 export function isEnvironmentScopedAuthScheme(scheme: ApiAuthSchemeEnum): boolean {
   return scheme === ApiAuthSchemeEnum.API_KEY || scheme === ApiAuthSchemeEnum.KEYLESS;
 }
 
-/**
- * True when the resolved request auth scheme is keyless. Prefer this over
- * inspecting client headers — a spoofed `Novu-Application-Identifier` must not
- * change rate limits for an authenticated API-key caller.
- */
 export function isResolvedKeylessAuthScheme(authScheme: string | undefined): boolean {
   return authScheme === ApiAuthSchemeEnum.KEYLESS;
 }
 
-/**
- * True when a header value is a keyless application identifier (`pk_keyless_*`).
- * Used only for unauthenticated routes (e.g. inbox session bootstrap) where no
- * resolved auth scheme exists yet.
- */
 export function isKeylessApplicationIdentifierHeader(value: string | undefined): boolean {
   return Boolean(value?.startsWith(KEYLESS_ENVIRONMENT_PREFIX));
 }

--- a/apps/api/src/app/shared/utils/auth.utils.ts
+++ b/apps/api/src/app/shared/utils/auth.utils.ts
@@ -1,16 +1,26 @@
-/**
- * Checks if the authorization header contains a keyless token
- * @param authorizationHeader - The authorization header value
- * @returns boolean indicating if the header contains a keyless token
- */
-export function checkIsKeylessHeader(authorizationHeader: string | undefined): boolean {
-  if (!authorizationHeader) {
-    return false;
-  }
+import { ApiAuthSchemeEnum } from '@novu/shared';
 
-  /*
-   * 'authorization' header 'Keyless pk_keyless_<token>'
-   * 'novu-application-identifier' header 'pk_keyless_<token>'
-   */
-  return authorizationHeader.includes('pk_keyless_');
+import { KEYLESS_ENVIRONMENT_PREFIX } from '../../inbox/utils/keyless.constants';
+
+/** Auth schemes that are pinned to a single environment (API key and keyless). */
+export function isEnvironmentScopedAuthScheme(scheme: ApiAuthSchemeEnum): boolean {
+  return scheme === ApiAuthSchemeEnum.API_KEY || scheme === ApiAuthSchemeEnum.KEYLESS;
+}
+
+/**
+ * True when the resolved request auth scheme is keyless. Prefer this over
+ * inspecting client headers — a spoofed `Novu-Application-Identifier` must not
+ * change rate limits for an authenticated API-key caller.
+ */
+export function isResolvedKeylessAuthScheme(authScheme: string | undefined): boolean {
+  return authScheme === ApiAuthSchemeEnum.KEYLESS;
+}
+
+/**
+ * True when a header value is a keyless application identifier (`pk_keyless_*`).
+ * Used only for unauthenticated routes (e.g. inbox session bootstrap) where no
+ * resolved auth scheme exists yet.
+ */
+export function isKeylessApplicationIdentifierHeader(value: string | undefined): boolean {
+  return Boolean(value?.startsWith(KEYLESS_ENVIRONMENT_PREFIX));
 }

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -56,6 +56,7 @@ import { UpdateNotificationActionCommand } from '../inbox/usecases/update-notifi
 import { UpdateNotificationAction } from '../inbox/usecases/update-notification-action/update-notification-action.usecase';
 import { ThrottlerCategory } from '../rate-limiting/guards/throttler.decorator';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
+import { KeylessAccessible } from '../shared/framework/swagger/keyless.security';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import {
   GetSubscriberGlobalPreference,
@@ -202,6 +203,7 @@ export class SubscribersController {
     description: 'Subscriber already exists (when query param failIfExists=true)',
   })
   @SdkMethodName('create')
+  @KeylessAccessible()
   @RequirePermissions(PermissionsEnum.SUBSCRIBER_WRITE)
   async createSubscriber(
     @UserSession() user: UserSessionData,

--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -117,6 +117,9 @@ export const envValidators = {
       NOVU_INTERNAL_SECRET_KEY: str({ default: '' }),
       KEYLESS_ORGANIZATION_ID: str({ desc: 'Required organizationId for Keyless authentication', default: undefined }),
       KEYLESS_USER_EMAIL: str({ desc: 'Required email for Keyless authentication', default: undefined }),
+      KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY: num({ default: 15 }),
+      KEYLESS_GENERATE_CAP_PER_IP_PER_DAY: num({ default: 5 }),
+      KEYLESS_MAX_AGENTS_PER_ENV: num({ default: 2 }),
       // ClickHouse
       CLICK_HOUSE_URL: str({ default: '' }),
       CLICK_HOUSE_DATABASE: str({ default: '' }),

--- a/apps/dashboard/src/api/connect.ts
+++ b/apps/dashboard/src/api/connect.ts
@@ -1,0 +1,12 @@
+import { post } from './api.client';
+
+export type ClaimKeylessConnectResponse = {
+  environmentId: string;
+  agentIdentifier?: string;
+};
+
+export async function claimKeylessConnect(token: string): Promise<ClaimKeylessConnectResponse> {
+  return post<ClaimKeylessConnectResponse>('/connect/claim', {
+    body: { token },
+  });
+}

--- a/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
+++ b/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
@@ -7,6 +7,7 @@ import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { APP_IDS } from '@/utils/apps';
 import { resolvePendingCliAuthReturnUrl } from '@/utils/cli-auth-pending';
+import { resolvePendingConnectClaimReturnUrl } from '@/utils/connect-claim-pending';
 import {
   beginConnectProvisioning,
   buildConnectOrganizationName,
@@ -59,6 +60,17 @@ function isSlugTakenError(error: unknown): boolean {
 }
 
 function navigateToPostConnectOrgResolution(navigate: NavigateFunction, fallbackPath: string) {
+  // A pending keyless connect claim wins: route back to `/connect/claim` to merge the
+  // agent + conversation and show success, rather than the connect onboarding flow.
+  const pendingConnectClaimReturnUrl = resolvePendingConnectClaimReturnUrl();
+
+  if (pendingConnectClaimReturnUrl) {
+    clearConnectProvisioning();
+    window.location.assign(pendingConnectClaimReturnUrl);
+
+    return;
+  }
+
   const pendingCliAuthReturnUrl = resolvePendingCliAuthReturnUrl();
 
   if (pendingCliAuthReturnUrl) {

--- a/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
+++ b/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
@@ -60,8 +60,6 @@ function isSlugTakenError(error: unknown): boolean {
 }
 
 function navigateToPostConnectOrgResolution(navigate: NavigateFunction, fallbackPath: string) {
-  // A pending keyless connect claim wins: route back to `/connect/claim` to merge the
-  // agent + conversation and show success, rather than the connect onboarding flow.
   const pendingConnectClaimReturnUrl = resolvePendingConnectClaimReturnUrl();
 
   if (pendingConnectClaimReturnUrl) {

--- a/apps/dashboard/src/components/auth/create-organization.tsx
+++ b/apps/dashboard/src/components/auth/create-organization.tsx
@@ -60,9 +60,6 @@ function OrganizationForm() {
   // Only forward `?appId=` when it was set explicitly — hostname detection covers the rest.
   const explicitAppId = useMemo(() => getOnboardingAppId(searchParams), [searchParams]);
   const pendingCliAuthReturnUrl = useMemo(() => resolvePendingCliAuthReturnUrl(), []);
-  // A pending keyless connect claim takes precedence: after creating their org the
-  // user should land on `/connect/claim` (which merges the agent + conversation and
-  // shows success), not the regular onboarding flow.
   const pendingConnectClaimReturnUrl = useMemo(() => resolvePendingConnectClaimReturnUrl(), []);
   const afterCreateUrl =
     pendingConnectClaimReturnUrl ??

--- a/apps/dashboard/src/components/auth/create-organization.tsx
+++ b/apps/dashboard/src/components/auth/create-organization.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import { OrganizationPicker } from '@/components/auth/organization-picker';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { resolvePendingCliAuthReturnUrl } from '@/utils/cli-auth-pending';
+import { resolvePendingConnectClaimReturnUrl } from '@/utils/connect-claim-pending';
 import { buildAfterSignOutUrl } from '@/utils/cross-product-sign-out';
 import { useFeatureFlag } from '../../hooks/use-feature-flag';
 import {
@@ -59,9 +60,16 @@ function OrganizationForm() {
   // Only forward `?appId=` when it was set explicitly — hostname detection covers the rest.
   const explicitAppId = useMemo(() => getOnboardingAppId(searchParams), [searchParams]);
   const pendingCliAuthReturnUrl = useMemo(() => resolvePendingCliAuthReturnUrl(), []);
+  // A pending keyless connect claim takes precedence: after creating their org the
+  // user should land on `/connect/claim` (which merges the agent + conversation and
+  // shows success), not the regular onboarding flow.
+  const pendingConnectClaimReturnUrl = useMemo(() => resolvePendingConnectClaimReturnUrl(), []);
   const afterCreateUrl =
-    pendingCliAuthReturnUrl ?? withAppId(getPostOrgCreateRoute(appId, isAgentsEnabled), explicitAppId);
-  const afterSelectUrl = pendingCliAuthReturnUrl ?? withAppId(ROUTES.ENV, explicitAppId);
+    pendingConnectClaimReturnUrl ??
+    pendingCliAuthReturnUrl ??
+    withAppId(getPostOrgCreateRoute(appId, isAgentsEnabled), explicitAppId);
+  const afterSelectUrl =
+    pendingConnectClaimReturnUrl ?? pendingCliAuthReturnUrl ?? withAppId(ROUTES.ENV, explicitAppId);
 
   const handleSignOut = useCallback(async () => {
     const fallbackUrl = buildAfterSignOutUrl();

--- a/apps/dashboard/src/context/auth/auth-provider.tsx
+++ b/apps/dashboard/src/context/auth/auth-provider.tsx
@@ -180,10 +180,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     // CliAuthPage never mounts here — `shouldBlockChildren` hides it while we redirect to the
     // org picker — so persist the device session before leaving `/cli/auth`.
     storePendingCliAuthFromPath(pathname, location.search);
-
-    // Same rationale for the keyless connect claim: persist the claim token before the org
-    // picker takes over, so post-signup we can route back to `/connect/claim` instead of
-    // dropping the user into regular onboarding.
     storePendingConnectClaimFromPath(pathname, location.search);
 
     const pendingCliAuth = readPendingCliAuth();

--- a/apps/dashboard/src/context/auth/auth-provider.tsx
+++ b/apps/dashboard/src/context/auth/auth-provider.tsx
@@ -6,6 +6,7 @@ import { OnboardingProvisioningOverlay } from '@/components/auth/connect-provisi
 import { IS_HOSTNAME_SPLIT_ENABLED, IS_NOVU_CONNECT } from '@/config';
 import { isPublicAuthPath } from '@/utils/auth-routes';
 import { readPendingCliAuth, storePendingCliAuthFromPath } from '@/utils/cli-auth-pending';
+import { storePendingConnectClaimFromPath } from '@/utils/connect-claim-pending';
 import { buildConnectProvisionOrgListPath, isActiveConnectWorkspace, isConnectWorkspace } from '@/utils/connect';
 import { buildAbsoluteConnectUrl } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
@@ -179,6 +180,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     // CliAuthPage never mounts here — `shouldBlockChildren` hides it while we redirect to the
     // org picker — so persist the device session before leaving `/cli/auth`.
     storePendingCliAuthFromPath(pathname, location.search);
+
+    // Same rationale for the keyless connect claim: persist the claim token before the org
+    // picker takes over, so post-signup we can route back to `/connect/claim` instead of
+    // dropping the user into regular onboarding.
+    storePendingConnectClaimFromPath(pathname, location.search);
 
     const pendingCliAuth = readPendingCliAuth();
     const orgListPath =

--- a/apps/dashboard/src/context/environment/use-bootstrap-organization.ts
+++ b/apps/dashboard/src/context/environment/use-bootstrap-organization.ts
@@ -5,7 +5,7 @@ import { useFetchEnvironments } from '@/context/environment/hooks';
 
 // Non-empty cache key that enables the environments query before Novu's org id is known.
 // The org id is only a React Query cache key — `getEnvironments` authenticates via the session.
-const BOOTSTRAP_ORG_CACHE_KEY = 'org';
+export const BOOTSTRAP_ORG_CACHE_KEY = 'org';
 
 /**
  * Right after org creation, Novu's backend writes `externalOrgId` into Clerk asynchronously.

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -53,6 +53,7 @@ import { AgentTelegramMobileSetupPage } from './pages/agent-telegram-mobile-setu
 import { AgentsPage } from './pages/agents';
 import { AgentsSetupPage } from './pages/agents-setup-page';
 import { CliAuthPage } from './pages/cli-auth';
+import { ConnectClaimPage } from './pages/connect-claim';
 import { ContextsPage } from './pages/contexts';
 import { CreateContextPage } from './pages/create-context';
 import { CreateSubscriberPage } from './pages/create-subscriber';
@@ -104,6 +105,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES.CLI_AUTH,
         element: <CliAuthPage />,
+      },
+      {
+        path: ROUTES.CONNECT_CLAIM,
+        element: <ConnectClaimPage />,
       },
       {
         // Public, unauthenticated mobile setup page for Telegram. Mounted outside

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -1,0 +1,148 @@
+import { useAuth as useClerkAuth } from '@clerk/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RiCheckLine, RiLoader4Line } from 'react-icons/ri';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { claimKeylessConnect } from '@/api/connect';
+import { ConnectBrandLogo } from '@/components/auth/connect-brand-logo';
+import { AuthLayout } from '@/components/auth-layout';
+import { PageMeta } from '@/components/page-meta';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { EnvironmentProvider } from '@/context/environment/environment-provider';
+import { useEnvironment } from '@/context/environment/hooks';
+import { clearConnectProvisioning } from '@/utils/connect';
+import {
+  clearPendingConnectClaim,
+  readPendingConnectClaim,
+  storePendingConnectClaim,
+} from '@/utils/connect-claim-pending';
+import { ROUTES } from '@/utils/routes';
+
+export const ConnectClaimPage = () => {
+  const { isLoaded, isSignedIn } = useClerkAuth();
+  const [searchParams] = useSearchParams();
+  // Prefer the URL token, but fall back to the pending one persisted before the
+  // signup/org-picker hops (the token can drop off the URL across those redirects).
+  const token = searchParams.get('token') ?? readPendingConnectClaim();
+
+  // Persist the token immediately so it survives signup + org creation, after
+  // which the org picker routes back here instead of regular onboarding.
+  useEffect(() => {
+    if (token) {
+      storePendingConnectClaim(token);
+    }
+  }, [token]);
+
+  // The signup/org-create flow leaves the full-screen onboarding provisioning
+  // overlay active; this page is a terminal destination outside that flow, so
+  // clear it (mirrors cli-auth) — otherwise the loader stays stuck on top.
+  useEffect(() => {
+    clearConnectProvisioning();
+  }, []);
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  // Signup-first: the user only lands here after the keyless demo cap, so send
+  // anonymous visitors through sign-up and return them to this page afterwards.
+  if (!isSignedIn) {
+    const search = token ? `?token=${encodeURIComponent(token)}` : '';
+    const redirectUrl = `${ROUTES.CONNECT_CLAIM}${search}`;
+    const signUpUrl = `${ROUTES.SIGN_UP}?redirect_url=${encodeURIComponent(redirectUrl)}`;
+
+    return <Navigate to={signUpUrl} replace />;
+  }
+
+  return (
+    <AuthLayout>
+      <EnvironmentProvider>
+        <PageMeta title="Keep your Novu agent" />
+        <ConnectClaimContent token={token} />
+      </EnvironmentProvider>
+    </AuthLayout>
+  );
+};
+
+function ConnectClaimContent({ token }: { token: string | null }) {
+  const { areEnvironmentsInitialLoading } = useEnvironment();
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [didClaim, setDidClaim] = useState(false);
+  const hasAttemptedRef = useRef(false);
+
+  const tokenOk = Boolean(token);
+
+  const handleClaim = useCallback(async () => {
+    if (!token || hasAttemptedRef.current) {
+      return;
+    }
+
+    hasAttemptedRef.current = true;
+    setIsClaiming(true);
+    try {
+      await claimKeylessConnect(token);
+      clearPendingConnectClaim();
+      setDidClaim(true);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to claim this agent';
+      showErrorToast(`Claim failed: ${message}`);
+      // Allow a manual retry after a failure.
+      hasAttemptedRef.current = false;
+    } finally {
+      setIsClaiming(false);
+    }
+  }, [token]);
+
+  const reason = (() => {
+    if (!tokenOk) return 'This page must be opened from the link in your chat.';
+
+    return null;
+  })();
+
+  const canClaim = !reason && !areEnvironmentsInitialLoading && !isClaiming && !didClaim;
+
+  // Auto-run the merge once the environment is ready so the user lands straight on
+  // the success state (no extra click, no onboarding detour).
+  useEffect(() => {
+    if (canClaim && !hasAttemptedRef.current) {
+      void handleClaim();
+    }
+  }, [canClaim, handleClaim]);
+
+  return (
+    <div className="flex min-h-screen w-full items-center justify-center px-4 py-8">
+      <div className="w-full max-w-[400px] rounded-lg border-[1.5px] border-black/[0.04] bg-gradient-to-b from-white/50 to-white/[0.15] px-6 py-8 shadow-sm backdrop-blur-sm">
+        <div className="mx-auto flex w-full max-w-[350px] flex-col items-center gap-6">
+          <ConnectBrandLogo />
+
+          <div className="flex w-full flex-col items-center gap-3">
+            <h1 className="text-label-sm text-text-strong text-center font-medium tracking-[-0.084px]">
+              Keep the agent you just built
+            </h1>
+            <p className="text-label-xs text-text-sub text-center">
+              We'll move your agent, its connected channel, and your conversation into your new Development environment.
+              The agent picks the conversation back up right where it left off.
+            </p>
+          </div>
+
+          {reason ? (
+            <div className="text-text-sub flex w-full items-start gap-2 rounded-lg border border-dashed border-stroke-soft p-3 text-label-xs">
+              <span>{reason}</span>
+            </div>
+          ) : null}
+
+          {didClaim ? (
+            <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">
+              <RiCheckLine className="mt-0.5 size-4 shrink-0" />
+              <span>Your agent is connected to your account. Head back to your chat — the agent is ready to continue.</span>
+            </div>
+          ) : (
+            <div className="text-text-sub flex w-full items-center justify-center gap-2 p-3 text-label-xs">
+              <RiLoader4Line className="size-4 shrink-0 animate-spin" />
+              <span>Setting up your agent…</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -1,4 +1,6 @@
 import { useAuth as useClerkAuth } from '@clerk/react';
+import type { IEnvironment } from '@novu/shared';
+import { EnvironmentTypeEnum } from '@novu/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { RiCheckLine, RiLoader4Line } from 'react-icons/ri';
 import { Navigate, useSearchParams } from 'react-router-dom';
@@ -8,8 +10,10 @@ import { AuthLayout } from '@/components/auth-layout';
 import { PageMeta } from '@/components/page-meta';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { IS_HOSTNAME_SPLIT_ENABLED } from '@/config';
+import { useAuth } from '@/context/auth/hooks';
 import { EnvironmentProvider } from '@/context/environment/environment-provider';
-import { useEnvironment } from '@/context/environment/hooks';
+import { useFetchEnvironments } from '@/context/environment/hooks';
+import { BOOTSTRAP_ORG_CACHE_KEY } from '@/context/environment/use-bootstrap-organization';
 import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { clearConnectProvisioning } from '@/utils/connect';
 import {
@@ -65,8 +69,32 @@ export const ConnectClaimPage = () => {
   );
 };
 
+function hasClaimableDevelopmentEnvironment(environments?: IEnvironment[]): boolean {
+  if (!environments?.length) {
+    return false;
+  }
+
+  return Boolean(
+    environments.find((env) => env.type === EnvironmentTypeEnum.DEV && !env._parentId) ??
+      environments.find((env) => !env._parentId)
+  );
+}
+
 function ConnectClaimContent({ token }: { token: string | null }) {
-  const { areEnvironmentsInitialLoading } = useEnvironment();
+  const { currentOrganization } = useAuth();
+  const novuOrganizationId = currentOrganization?._id;
+  const [isEnvironmentReady, setIsEnvironmentReady] = useState(false);
+  const { environments } = useFetchEnvironments({
+    organizationId: novuOrganizationId || BOOTSTRAP_ORG_CACHE_KEY,
+    refetchInterval: isEnvironmentReady ? undefined : 1000,
+    showError: false,
+  });
+
+  useEffect(() => {
+    if (hasClaimableDevelopmentEnvironment(environments)) {
+      setIsEnvironmentReady(true);
+    }
+  }, [environments]);
   const [isClaiming, setIsClaiming] = useState(false);
   const [didClaim, setDidClaim] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
@@ -102,7 +130,7 @@ function ConnectClaimContent({ token }: { token: string | null }) {
   };
 
   const reason = tokenOk ? null : 'This page must be opened from the link in your chat.';
-  const canClaim = !reason && !areEnvironmentsInitialLoading && !isClaiming && !didClaim && !claimError;
+  const canClaim = !reason && isEnvironmentReady && !isClaiming && !didClaim && !claimError;
 
   useEffect(() => {
     if (canClaim && !hasAttemptedRef.current) {
@@ -133,7 +161,9 @@ function ConnectClaimContent({ token }: { token: string | null }) {
           ) : didClaim ? (
             <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">
               <RiCheckLine className="mt-0.5 size-4 shrink-0" />
-              <span>Your agent is connected to your account. Head back to your chat — the agent is ready to continue.</span>
+              <span>
+                Your agent is connected to your account. Head back to your chat — the agent is ready to continue.
+              </span>
             </div>
           ) : claimError ? (
             <div className="flex w-full flex-col gap-3">

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -14,6 +14,7 @@ import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { clearConnectProvisioning } from '@/utils/connect';
 import {
   clearPendingConnectClaim,
+  parseConnectClaimToken,
   readPendingConnectClaim,
   storePendingConnectClaim,
 } from '@/utils/connect-claim-pending';
@@ -23,7 +24,7 @@ import { ROUTES } from '@/utils/routes';
 export const ConnectClaimPage = () => {
   const { isLoaded, isSignedIn } = useClerkAuth();
   const [searchParams] = useSearchParams();
-  const token = searchParams.get('token') ?? readPendingConnectClaim();
+  const token = parseConnectClaimToken(`?${searchParams.toString()}`) ?? readPendingConnectClaim();
 
   useEffect(() => {
     if (token) {
@@ -68,6 +69,7 @@ function ConnectClaimContent({ token }: { token: string | null }) {
   const { areEnvironmentsInitialLoading } = useEnvironment();
   const [isClaiming, setIsClaiming] = useState(false);
   const [didClaim, setDidClaim] = useState(false);
+  const [claimError, setClaimError] = useState<string | null>(null);
   const hasAttemptedRef = useRef(false);
 
   const tokenOk = Boolean(token);
@@ -79,6 +81,7 @@ function ConnectClaimContent({ token }: { token: string | null }) {
 
     hasAttemptedRef.current = true;
     setIsClaiming(true);
+    setClaimError(null);
     try {
       await claimKeylessConnect(token);
       clearPendingConnectClaim();
@@ -86,14 +89,20 @@ function ConnectClaimContent({ token }: { token: string | null }) {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to claim this agent';
       showErrorToast(`Claim failed: ${message}`);
-      hasAttemptedRef.current = false;
+      setClaimError(message);
     } finally {
       setIsClaiming(false);
     }
   }, [token]);
 
+  const handleRetry = () => {
+    hasAttemptedRef.current = false;
+    setClaimError(null);
+    void handleClaim();
+  };
+
   const reason = tokenOk ? null : 'This page must be opened from the link in your chat.';
-  const canClaim = !reason && !areEnvironmentsInitialLoading && !isClaiming && !didClaim;
+  const canClaim = !reason && !areEnvironmentsInitialLoading && !isClaiming && !didClaim && !claimError;
 
   useEffect(() => {
     if (canClaim && !hasAttemptedRef.current) {
@@ -125,6 +134,19 @@ function ConnectClaimContent({ token }: { token: string | null }) {
             <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">
               <RiCheckLine className="mt-0.5 size-4 shrink-0" />
               <span>Your agent is connected to your account. Head back to your chat — the agent is ready to continue.</span>
+            </div>
+          ) : claimError ? (
+            <div className="flex w-full flex-col gap-3">
+              <div className="text-text-sub flex w-full items-start gap-2 rounded-lg border border-dashed border-stroke-soft p-3 text-label-xs">
+                <span>{claimError}</span>
+              </div>
+              <button
+                type="button"
+                className="text-label-xs text-text-strong w-full rounded-lg border border-stroke-soft px-3 py-2 font-medium"
+                onClick={handleRetry}
+              >
+                Try again
+              </button>
             </div>
           ) : (
             <div className="text-text-sub flex w-full items-center justify-center gap-2 p-3 text-label-xs">

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -20,21 +20,14 @@ import { ROUTES } from '@/utils/routes';
 export const ConnectClaimPage = () => {
   const { isLoaded, isSignedIn } = useClerkAuth();
   const [searchParams] = useSearchParams();
-  // Prefer the URL token, but fall back to the pending one persisted before the
-  // signup/org-picker hops (the token can drop off the URL across those redirects).
   const token = searchParams.get('token') ?? readPendingConnectClaim();
 
-  // Persist the token immediately so it survives signup + org creation, after
-  // which the org picker routes back here instead of regular onboarding.
   useEffect(() => {
     if (token) {
       storePendingConnectClaim(token);
     }
   }, [token]);
 
-  // The signup/org-create flow leaves the full-screen onboarding provisioning
-  // overlay active; this page is a terminal destination outside that flow, so
-  // clear it (mirrors cli-auth) — otherwise the loader stays stuck on top.
   useEffect(() => {
     clearConnectProvisioning();
   }, []);
@@ -43,8 +36,6 @@ export const ConnectClaimPage = () => {
     return null;
   }
 
-  // Signup-first: the user only lands here after the keyless demo cap, so send
-  // anonymous visitors through sign-up and return them to this page afterwards.
   if (!isSignedIn) {
     const search = token ? `?token=${encodeURIComponent(token)}` : '';
     const redirectUrl = `${ROUTES.CONNECT_CLAIM}${search}`;
@@ -85,23 +76,15 @@ function ConnectClaimContent({ token }: { token: string | null }) {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to claim this agent';
       showErrorToast(`Claim failed: ${message}`);
-      // Allow a manual retry after a failure.
       hasAttemptedRef.current = false;
     } finally {
       setIsClaiming(false);
     }
   }, [token]);
 
-  const reason = (() => {
-    if (!tokenOk) return 'This page must be opened from the link in your chat.';
-
-    return null;
-  })();
-
+  const reason = tokenOk ? null : 'This page must be opened from the link in your chat.';
   const canClaim = !reason && !areEnvironmentsInitialLoading && !isClaiming && !didClaim;
 
-  // Auto-run the merge once the environment is ready so the user lands straight on
-  // the success state (no extra click, no onboarding detour).
   useEffect(() => {
     if (canClaim && !hasAttemptedRef.current) {
       void handleClaim();

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -7,14 +7,17 @@ import { ConnectBrandLogo } from '@/components/auth/connect-brand-logo';
 import { AuthLayout } from '@/components/auth-layout';
 import { PageMeta } from '@/components/page-meta';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { IS_HOSTNAME_SPLIT_ENABLED } from '@/config';
 import { EnvironmentProvider } from '@/context/environment/environment-provider';
 import { useEnvironment } from '@/context/environment/hooks';
+import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { clearConnectProvisioning } from '@/utils/connect';
 import {
   clearPendingConnectClaim,
   readPendingConnectClaim,
   storePendingConnectClaim,
 } from '@/utils/connect-claim-pending';
+import { buildPrimarySignUpUrl } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 
 export const ConnectClaimPage = () => {
@@ -39,7 +42,14 @@ export const ConnectClaimPage = () => {
   if (!isSignedIn) {
     const search = token ? `?token=${encodeURIComponent(token)}` : '';
     const redirectUrl = `${ROUTES.CONNECT_CLAIM}${search}`;
-    const signUpUrl = `${ROUTES.SIGN_UP}?redirect_url=${encodeURIComponent(redirectUrl)}`;
+    const signUpBase = IS_HOSTNAME_SPLIT_ENABLED ? buildPrimarySignUpUrl() : ROUTES.SIGN_UP;
+    const signUpUrl = appendRedirectUrlParam(signUpBase, redirectUrl);
+
+    if (signUpUrl.startsWith('http')) {
+      window.location.replace(signUpUrl);
+
+      return null;
+    }
 
     return <Navigate to={signUpUrl} replace />;
   }
@@ -111,9 +121,7 @@ function ConnectClaimContent({ token }: { token: string | null }) {
             <div className="text-text-sub flex w-full items-start gap-2 rounded-lg border border-dashed border-stroke-soft p-3 text-label-xs">
               <span>{reason}</span>
             </div>
-          ) : null}
-
-          {didClaim ? (
+          ) : didClaim ? (
             <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">
               <RiCheckLine className="mt-0.5 size-4 shrink-0" />
               <span>Your agent is connected to your account. Head back to your chat — the agent is ready to continue.</span>

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -17,6 +17,7 @@ import {
   storePendingCliAuth,
 } from '@/utils/cli-auth-pending';
 import { buildConnectProvisionOrgListPath } from '@/utils/connect';
+import { storePendingConnectClaimFromRedirectUrl } from '@/utils/connect-claim-pending';
 import {
   buildAbsoluteConnectUrl,
   buildPrimarySignInUrl,
@@ -60,6 +61,8 @@ export const SignInPage = () => {
     if (pending) {
       storePendingCliAuth(pending.deviceCode, pending.name, pending.returnHost);
     }
+
+    storePendingConnectClaimFromRedirectUrl(readClerkRedirectUrlParam(searchParams));
   }, [searchParams, isConnectSignIn]);
 
   // Sign-in only runs on the primary; Connect-host visitors bounce back with the Connect flag.

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -9,6 +9,7 @@ import { IS_NOVU_CONNECT, IS_SELF_HOSTED } from '@/config';
 import { useSegment } from '@/context/segment';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { appendRedirectUrlParam, readCliAuthReturnUrl } from '@/utils/cli-auth-pending';
+import { storePendingConnectClaimFromRedirectUrl } from '@/utils/connect-claim-pending';
 import { buildConnectProvisionOrgListPath } from '@/utils/connect';
 import {
   buildAbsoluteConnectUrl,
@@ -42,6 +43,7 @@ export const SignUpPage = () => {
   // Persist pending CLI auth from inbound redirect_url; org creation still runs first.
   useEffect(() => {
     readCliAuthReturnUrl(searchParams, { preferConnectHost: isConnectSignUp });
+    storePendingConnectClaimFromRedirectUrl(readClerkRedirectUrlParam(searchParams));
   }, [searchParams, isConnectSignUp]);
 
   // Sign-up flows are primary-only — bounce Connect-host visitors back with Connect branding.

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -5,7 +5,7 @@ import { ROUTES } from '@/utils/routes';
 const STORAGE_KEY = 'pendingConnectClaim';
 
 function isValidToken(token: string | null | undefined): token is string {
-  return Boolean(token) && CONNECT_CLAIM_TOKEN_PATTERN.test(token as string);
+  return typeof token === 'string' && CONNECT_CLAIM_TOKEN_PATTERN.test(token);
 }
 
 function isAbsoluteUrl(url: string): boolean {
@@ -37,13 +37,9 @@ export function isConnectClaimPath(pathname: string): boolean {
 }
 
 export function parseConnectClaimToken(search: string): string | null {
-  try {
-    const token = new URLSearchParams(search).get('token');
+  const token = new URLSearchParams(search).get('token');
 
-    return isValidToken(token) ? token : null;
-  } catch {
-    return null;
-  }
+  return isValidToken(token) ? token : null;
 }
 
 export function storePendingConnectClaim(token: string): void {

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -1,10 +1,35 @@
 import { CONNECT_CLAIM_TOKEN_PATTERN } from '@novu/shared';
+import { IS_HOSTNAME_SPLIT_ENABLED, NOVU_CONNECT_HOSTNAME, NOVU_PLATFORM_HOSTNAME, normalizeAppHost } from '@/config';
 import { ROUTES } from '@/utils/routes';
 
 const STORAGE_KEY = 'pendingConnectClaim';
 
 function isValidToken(token: string | null | undefined): token is string {
   return Boolean(token) && CONNECT_CLAIM_TOKEN_PATTERN.test(token as string);
+}
+
+function isAbsoluteUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+function getTrustedRedirectOrigins(): Set<string> {
+  const origins = new Set<string>();
+
+  if (typeof window === 'undefined') {
+    return origins;
+  }
+
+  origins.add(window.location.origin);
+
+  if (IS_HOSTNAME_SPLIT_ENABLED) {
+    for (const hostname of [NOVU_CONNECT_HOSTNAME, NOVU_PLATFORM_HOSTNAME]) {
+      if (hostname) {
+        origins.add(`${window.location.protocol}//${normalizeAppHost(hostname)}`);
+      }
+    }
+  }
+
+  return origins;
 }
 
 export function isConnectClaimPath(pathname: string): boolean {
@@ -31,9 +56,22 @@ export function storePendingConnectClaim(token: string): void {
 
 export function isConnectClaimReturnUrl(url: string): boolean {
   try {
-    const parsed = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+    const base = typeof window !== 'undefined' ? window.location.origin : 'http://local';
+    const parsed = new URL(url, base);
 
-    return isConnectClaimPath(parsed.pathname);
+    if (!isConnectClaimPath(parsed.pathname)) {
+      return false;
+    }
+
+    if (isAbsoluteUrl(url) && typeof window !== 'undefined') {
+      const trustedOrigins = getTrustedRedirectOrigins();
+
+      if (!trustedOrigins.has(parsed.origin)) {
+        return false;
+      }
+    }
+
+    return true;
   } catch {
     return false;
   }

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -29,11 +29,6 @@ export function storePendingConnectClaim(token: string): void {
   sessionStorage.setItem(STORAGE_KEY, token);
 }
 
-/**
- * Captures the claim token while still on `/connect/claim`, before the auth flow
- * redirects through the org picker (which would otherwise drop the token and the
- * user would land in regular onboarding). Mirrors `storePendingCliAuthFromPath`.
- */
 export function storePendingConnectClaimFromPath(pathname: string, search = ''): boolean {
   if (!isConnectClaimPath(pathname)) {
     return false;

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -9,7 +9,7 @@ function isValidToken(token: string | null | undefined): token is string {
 }
 
 function isAbsoluteUrl(url: string): boolean {
-  return /^https?:\/\//i.test(url);
+  return /^(https?:)?\/\//i.test(url);
 }
 
 function getTrustedRedirectOrigins(): Set<string> {

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -29,6 +29,16 @@ export function storePendingConnectClaim(token: string): void {
   sessionStorage.setItem(STORAGE_KEY, token);
 }
 
+export function isConnectClaimReturnUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+
+    return isConnectClaimPath(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
 export function storePendingConnectClaimFromPath(pathname: string, search = ''): boolean {
   if (!isConnectClaimPath(pathname)) {
     return false;
@@ -42,6 +52,27 @@ export function storePendingConnectClaimFromPath(pathname: string, search = ''):
   storePendingConnectClaim(token);
 
   return true;
+}
+
+export function storePendingConnectClaimFromRedirectUrl(redirectUrl: string | null | undefined): boolean {
+  if (!redirectUrl || !isConnectClaimReturnUrl(redirectUrl)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(redirectUrl, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+    const token = parseConnectClaimToken(parsed.search);
+
+    if (!token) {
+      return false;
+    }
+
+    storePendingConnectClaim(token);
+
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function readPendingConnectClaim(): string | null {

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -1,12 +1,10 @@
+import { CONNECT_CLAIM_TOKEN_PATTERN } from '@novu/shared';
 import { ROUTES } from '@/utils/routes';
 
 const STORAGE_KEY = 'pendingConnectClaim';
 
-// Connect claim tokens are `randomBytes(24).toString('base64url')` → 32 url-safe chars.
-const TOKEN_PATTERN = /^[A-Za-z0-9_-]{32}$/;
-
 function isValidToken(token: string | null | undefined): token is string {
-  return Boolean(token) && TOKEN_PATTERN.test(token as string);
+  return Boolean(token) && CONNECT_CLAIM_TOKEN_PATTERN.test(token as string);
 }
 
 export function isConnectClaimPath(pathname: string): boolean {

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -1,0 +1,79 @@
+import { ROUTES } from '@/utils/routes';
+
+const STORAGE_KEY = 'pendingConnectClaim';
+
+// Connect claim tokens are `randomBytes(24).toString('base64url')` → 32 url-safe chars.
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{32}$/;
+
+function isValidToken(token: string | null | undefined): token is string {
+  return Boolean(token) && TOKEN_PATTERN.test(token as string);
+}
+
+export function isConnectClaimPath(pathname: string): boolean {
+  return pathname === ROUTES.CONNECT_CLAIM;
+}
+
+export function parseConnectClaimToken(search: string): string | null {
+  try {
+    const token = new URLSearchParams(search).get('token');
+
+    return isValidToken(token) ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+export function storePendingConnectClaim(token: string): void {
+  if (typeof window === 'undefined' || !isValidToken(token)) {
+    return;
+  }
+
+  sessionStorage.setItem(STORAGE_KEY, token);
+}
+
+/**
+ * Captures the claim token while still on `/connect/claim`, before the auth flow
+ * redirects through the org picker (which would otherwise drop the token and the
+ * user would land in regular onboarding). Mirrors `storePendingCliAuthFromPath`.
+ */
+export function storePendingConnectClaimFromPath(pathname: string, search = ''): boolean {
+  if (!isConnectClaimPath(pathname)) {
+    return false;
+  }
+
+  const token = parseConnectClaimToken(search);
+  if (!token) {
+    return false;
+  }
+
+  storePendingConnectClaim(token);
+
+  return true;
+}
+
+export function readPendingConnectClaim(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const token = sessionStorage.getItem(STORAGE_KEY);
+
+  return isValidToken(token) ? token : null;
+}
+
+export function clearPendingConnectClaim(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  sessionStorage.removeItem(STORAGE_KEY);
+}
+
+export function resolvePendingConnectClaimReturnUrl(): string | null {
+  const token = readPendingConnectClaim();
+  if (!token) {
+    return null;
+  }
+
+  return `${ROUTES.CONNECT_CLAIM}?token=${encodeURIComponent(token)}`;
+}

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -16,6 +16,7 @@ export const ROUTES = {
   ROOT: '/',
   LOCAL_STUDIO_AUTH: '/local-studio/auth',
   CLI_AUTH: '/cli/auth',
+  CONNECT_CLAIM: '/connect/claim',
   ENV: '/env',
   SETTINGS: '/settings',
   SETTINGS_ACCOUNT: '/settings/account',

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -45,7 +45,6 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     });
   }
 
-  /** Counts outbound agent messages in a conversation; used to enforce the keyless demo reply cap. */
   async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
     return this.count({
       _environmentId: environmentId,

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -45,6 +45,16 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     });
   }
 
+  /** Counts outbound agent messages in a conversation; used to enforce the keyless demo reply cap. */
+  async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
+    return this.count({
+      _environmentId: environmentId,
+      _conversationId: conversationId,
+      senderType: ConversationActivitySenderTypeEnum.AGENT,
+      type: ConversationActivityTypeEnum.MESSAGE,
+    });
+  }
+
   async createUserActivity(params: {
     identifier: string;
     conversationId: string;

--- a/packages/novu/AGENT_ONBOARDING.md
+++ b/packages/novu/AGENT_ONBOARDING.md
@@ -1,6 +1,6 @@
 # Novu Agent Onboarding — instructions for an AI agent
 
-You are an AI coding agent helping a user create their first **Novu managed agent** and connect it to **Slack**, with **no Novu account required up front** (keyless mode). You will gather a couple of inputs, infer the agent's purpose from the user's project, run one non‑interactive CLI command, hand the user a Slack authorization link, and then explain how they keep the agent by signing up.
+You are an AI coding agent helping a user create their first **Novu managed agent** and connect it to a **channel of their choice**, with **no Novu account required up front** (keyless mode). You will gather a couple of inputs, infer the agent's purpose from the user's project, run one non‑interactive CLI command, hand the user whatever they need to finish connecting the channel, and then explain how they keep the agent by signing up.
 
 Do not wire Novu into the user's codebase. This flow only creates a hosted agent and connects a channel.
 
@@ -8,10 +8,10 @@ Do not wire Novu into the user's codebase. This flow only creates a hosted agent
 
 ## What you will do (overview)
 
-1. Collect inputs from the user (Slack config token; optionally a Claude key).
+1. Ask the user which **channel** they want, and collect channel‑specific inputs.
 2. Infer the agent's purpose from the project and confirm it with the user.
-3. Run `novu connect` non‑interactively (keyless, Slack).
-4. Watch the output, surface the Slack authorize URL to the user immediately.
+3. Run `novu connect` non‑interactively (keyless).
+4. Watch the output and hand the user the channel‑specific next step (authorize link, inbox address, or dashboard link).
 5. Report success and explain the demo limit → sign‑up/claim.
 
 ---
@@ -37,12 +37,25 @@ NOVU_CLI="$NOVU_REPO/packages/novu/dist/src/index.js"
 
 ---
 
-## Step 1 — Collect inputs from the user
+## Step 1 — Ask the user which channel, and collect inputs
 
-Ask the user for:
+**Always ask the user to choose a channel** — do not assume one. Present these options and what each requires:
 
-- **Slack App Configuration Token** (`xoxe.xoxp-…`) — **required**. The CLI uses it once to create the Slack app from a manifest; it is never stored. The user generates it at <https://api.slack.com/apps> under **"Your App Configuration Tokens"** (see <https://api.slack.com/authentication/config-tokens>). Tell them to copy the **access token** (`xoxe.xoxp-…`); it is short‑lived (~12h), so use it promptly.
-- **(Optional) Their own Claude/Anthropic key** — only if they don't want the shared demo runtime. If they provide `sk-ant-…`, you'll pass BYOK flags (see Step 3). Otherwise the default **demo runtime** is used (no key needed).
+| Channel (`--channel`) | What the user must do | Works headlessly? |
+|---|---|---|
+| `slack` | Provide a **Slack App Configuration Token** (`xoxe.xoxp-…`), then click an OAuth link to approve the install. | Yes (with a click) |
+| `email` | Nothing up front. The CLI prints an inbound email address; the user sends one email to it. | Yes (with one email) |
+| `whatsapp` | Finish setup in the Novu dashboard — the CLI prints a dashboard link to open. | Partial (dashboard) |
+| `teams` | Finish setup in the Novu dashboard — the CLI prints a dashboard link to open. | Partial (dashboard) |
+| `telegram` | **Not supported through this agent flow** — Telegram setup is interactive (QR scans) and the non‑interactive CLI rejects it. Tell the user to either pick another channel, or run `node "$NOVU_CLI" connect "<description>" --region local --channel telegram` themselves (without `--ci`) and follow the prompts. | No |
+| `skip` | Create the agent only, connect a channel later. | n/a |
+
+Channel‑specific inputs to collect **after** they choose:
+
+- **slack** → ask for the **Slack App Configuration Token** (`xoxe.xoxp-…`, required). The CLI uses it once to create the Slack app from a manifest; it is never stored. The user generates it at <https://api.slack.com/apps> under **"Your App Configuration Tokens"** (see <https://api.slack.com/authentication/config-tokens>); copy the **access token** (`xoxe.xoxp-…`), which is short‑lived (~12h).
+- **email / whatsapp / teams / skip** → no extra input needed.
+
+Also (any channel), optionally ask: **use your own Claude/Anthropic key?** If yes, capture `sk-ant-…` for BYOK (Step 3). Otherwise the default **demo runtime** is used (no key needed).
 
 Do **not** ask them for the agent name/description — you will infer it next.
 
@@ -58,60 +71,99 @@ From that, draft a concise **1–2 sentence agent description** of the assistant
 
 Show the drafted description to the user, let them edit it, and **get explicit confirmation** before running anything.
 
+**MCP servers — only choose from the supported catalog below.** When the description implies third‑party integrations (e.g. Stripe, GitHub, Linear), only reference ones that exist in the [Supported MCP servers](#supported-mcp-servers) list, by their catalog **id**. Never invent MCP ids, names, or URLs. Keep the set minimal — pick only what the project clearly needs; if a needed integration isn't in the list, omit it (the user can add MCPs later in the dashboard). The generated agent's MCP servers are drawn from this catalog; if you review or adjust them, drop anything whose id is not in the list.
+
 ---
 
-## Step 3 — Run `novu connect` (keyless, Slack, non‑interactive)
+## Supported MCP servers
 
-Run the command **streamed / in the background** so you can read its output live (Step 4 depends on this). Keyless is the default — do **not** pass `--secret-key`.
+The agent may only use MCP servers from this catalog — match by **id**. These are the only valid ids; anything else will not connect.
+
+**Popular (prefer these):** `slack`, `linear`, `atlassian-rovo`, `github`, `gitlab`, `sentry`, `notion`, `asana`, `amplitude`, `airtable`, `stripe`, `intercom`, `datadog`, `grafana`, `new-relic`, `pagerduty`
+
+**Full catalog by category (ids):**
+
+- **code:** `github`, `gitlab`, `sentry`, `datadog`, `grafana`, `new-relic`, `pagerduty`, `aws-marketplace`, `buildkite`, `cloudflare`, `axiom`, `better-stack`, `cloudflare-developer-platform`, `context7`, `google-compute-engine`, `harness-io`, `honeycomb`, `hugging-face`, `incident-io`, `jam`, `jentic`, `ketryx`, `launchdarkly`, `mintlify`, `netlify`, `planetscale`, `postman`, `pulumi`, `railway`, `replicate`, `semgrep`, `sourcegraph`, `stytch`, `vercel`
+- **communication:** `slack`, `intercom`, `campfire`, `circleback`, `fathom`, `fellow-ai`, `fireflies`, `gmail`, `grain`, `guru`, `krisp`, `lorikeet`, `otter-ai`, `pylon`, `read-ai`, `send`, `superhuman-mail`, `tldv`, `unthread`, `zoho-desk`, `zoom-for-claude`
+- **data:** `amplitude`, `airtable`, `mixpanel`, `neon`, `supabase`, `bigdata-com`, `cb-insights`, `cdata-connect-ai`, `consensus`, `contentsquare`, `coupler-io`, `enterpret`, `exa`, `google-cloud-bigquery`, `monte-carlo`, `motherduck`, `motion-creative-analytics`, `omni-analytics`, `orion-by-gravity`, `polar-analytics`, `posthog`, `scholar-gateway`, `scite`, `sprouts-data-intelligence`, `supermetrics-marketing-analytics`, `tavily`, `thoughtspot-spotter`, `windsor-ai`
+- **design:** `canva`, `figma`, `adobe-for-creativity`, `biorender`, `cloudinary`, `descript`, `eraser`, `gamma`, `lucid`, `magic-patterns`, `miro`, `splice`, `three-js-3d-viewer`, `trimble-sketchup`, `webflow`, `wix`
+- **financial-services:** `stripe`, `brex`, `plaid`, `square`, `aiera`, `airwallex-developer`, `carta`, `chronograph`, `coindesk`, `d-b-risk-analytics`, `daloopa`, `datasite`, `digits`, `factset-ai-ready-data`, `fiscal-ai`, `fmp`, `guidepoint`, `gusto`, `harmonic`, `ibisworld`, `ice-data-services`, `intuit-credit-karma`, `intuit-turbotax`, `lseg`, `lunarcrush`, `mercury`, `moodys`, `morningstar`, `msci`, `mt-newswires`, `paypal`, `pitchbook-premium`, `privacy-com`, `quartr`, `ramp`, `razorpay`, `rillet`, `s-p-global`, `third-bridge`, `tropic`, `verisk-underwriting-intelligence`, `xero`, `yardi-virtuoso`, `zocks`, `zoho-books`
+- **health-and-wellness:** `adisinsight`, `medidata`, `owkin`, `synapse-org`, `synthesize-bio`
+- **productivity:** `linear`, `atlassian-rovo`, `notion`, `asana`, `adobe-experience-manager`, `box`, `dropbox`, `google-drive`, `base44`, `calendly`, `clickup`, `craft`, `day-ai`, `devrev`, `docuseal`, `docusign`, `dovetail`, `egnyte`, `era-context`, `euler`, `google-calendar`, `granola`, `ifttt`, `imanage-work`, `ironclad-contracts`, `jotform`, `klarity`, `lumin`, `make`, `mem`, `microsoft-365`, `monday-com`, `netdocuments`, `pandadoc`, `process-street`, `sanity`, `signnow`, `todoist`, `wordpress-com`, `zapier`, `zoho-projects`
+- **sales-and-marketing:** `ahrefs`, `attio`, `hubspot`, `adobe-journey-optimizer`, `adobe-marketing-agent`, `airops`, `apollo-io`, `aura`, `bitly`, `clarify`, `clay`, `close`, `common-room`, `crossbeam`, `g2`, `indeed`, `intuit-mailchimp`, `klaviyo`, `local-falcon`, `lusha`, `mailerlite`, `metaview`, `outreach`, `peec-ai`, `phoenix-by-hg-insights`, `quo`, `semrush`, `shopify`, `similarweb`, `surveymonkey`, `sybill`, `vibe-prospecting`, `workable`, `zoho-crm`, `zoominfo`
+- **other:** `alma`, `aurora`, `candid`, `cocounsel-legal`, `courtlistener`, `definely`, `descrybe-legal-engine`, `everlaw`, `fever-event-discovery`, `gainsight`, `govtribe`, `harvey`, `instacart`, `interactive-brokers`, `lawve-ai`, `legal-data-hunter`, `legalzoom`, `lilt`, `melon`, `midpage-legal-research`, `pdf-viewer`, `play-sheet-music`, `playmcp`, `resy`, `shapes`, `solve-intelligence`, `tango`, `ticket-tailor`, `topcounsel-by-the-l-suite`, `trellis`, `udemy-business`, `verisk-xactrestore`
+
+> Source of truth: `MCP_SERVERS` in `packages/shared/src/consts/providers/mcp-servers.ts`. If this list and the code diverge, the code wins — regenerate this section from `MCP_SERVERS[].id`.
+
+---
+
+## Step 3 — Run `novu connect` (keyless, non‑interactive)
+
+Run the command **streamed / in the background** so you can read its output live (Step 4 depends on this). Keyless is the default — do **not** pass `--secret-key`. Substitute the channel the user picked.
 
 ```bash
 node "$NOVU_CLI" connect "<CONFIRMED AGENT DESCRIPTION>" \
   --ci \
   --region local \
-  --channel slack \
-  --slack-config-token "<xoxe.xoxp-...>"
+  --channel <slack|email|whatsapp|teams|skip>
 ```
 
-- `--ci` forces non‑interactive mode (no prompts, no TUI).
+- For **slack**, also pass the token: `--slack-config-token "<xoxe.xoxp-...>"`.
+- `--ci` forces non‑interactive mode (no prompts, no TUI). Do **not** use `--ci` for `telegram` (it is rejected) — telegram must be run interactively by the user.
 - The positional description is **required** in non‑interactive mode.
-- Default runtime is the **demo** Claude runtime (no key). For **BYOK**, append:
-
-```bash
-  --runtime claude --anthropic-api-key "sk-ant-..."
-```
+- Default runtime is the **demo** Claude runtime (no key). For **BYOK**, append: `--runtime claude --anthropic-api-key "sk-ant-..."`.
+- **Transient Slack‑app‑creation failure:** for `slack`, if the run fails with `Failed to create Slack app: …` (Slack's app‑create can be slow on a cold first call), **silently re‑run the exact same command once** before reporting anything to the user — the step is safe to repeat. Only surface an error if the second attempt also fails.
 
 ---
 
-## Step 4 — Hand off Slack authorization (human‑in‑the‑loop)
+## Step 4 — Channel‑specific handoff (human‑in‑the‑loop)
 
-Slack OAuth cannot be automated — a human must approve the install. The CLI creates the Slack app, prints an authorize URL, then **polls for up to 5 minutes**.
+Watch stdout and act based on the channel the user picked:
 
-- Watch stdout for the line:
+- **slack** — Channel connection can't be automated. Watch for:
 
   ```
   → Authorize Slack here: <url>
   ```
 
-- The moment it appears, **give the user that URL** and ask them to open it and approve the Slack install **within 5 minutes**.
-- The command finishes on its own once they authorize. If it times out (~5 min) it exits with an error — just **re‑run the exact same command**; it reuses the Slack app it already created.
+  The moment it appears, give the user that URL and ask them to approve the Slack install **within 5 minutes**. The command finishes on its own once they authorize; if it times out (~5 min) it exits with an error — **re‑run the same command** (the Slack app is reused).
+
+- **email** — Watch for:
+
+  ```
+  → Your agent's inbound address: <address>
+  ```
+
+  Give the user that address and ask them to send any email to it. The CLI polls **for 5 minutes** and completes once the email arrives; on timeout, re‑run after they've sent it. (Requires `NOVU_AGENT_SHARED_INBOUND_DOMAIN` on the API.)
+
+- **whatsapp / teams** — The CLI prints a Novu Connect dashboard link and exits:
+
+  ```
+  → <Channel> continues in Novu Connect: <url>
+  ```
+
+  Give the user that link and tell them to finish the channel setup in the dashboard.
+
+- **skip** — Nothing to hand off; the agent is created without a channel.
 
 ---
 
 ## Step 5 — Report the result
 
-On success the CLI exits `0` and prints:
+On success the CLI exits `0` and prints a block like:
 
 ```
 ✓ Your agent is live.
   Agent: <name> (<identifier>)
-  → Check Slack — your agent just messaged you.
+  → Check <Channel> — your agent just messaged you.      # connected channels (slack/email)
+  → Finish <Channel> setup in Novu Connect — we opened it for you.   # dashboard channels (whatsapp/teams)
   Dashboard: <dashboard url>
 ```
 
 Extract the **agent identifier** and **Dashboard URL** and tell the user:
 
-- Their agent is live — open Slack and message it (the agent already said hello).
-- **Keyless demo limit:** they get a handful of free replies (about 5). After that, the agent posts a **"Sign up & keep this agent"** link in the channel. Clicking it creates their Novu account and **migrates the agent, the Slack connection, and the whole conversation** into their new workspace's Development environment — and the agent picks the conversation back up right where it left off.
+- Their agent is live — go message it on the channel they connected (or finish the dashboard step for whatsapp/teams).
+- **Keyless demo limit:** they get a handful of free replies (about 5). After that, the agent posts a **"Sign up & keep this agent"** link in the channel. Clicking it creates their Novu account and **migrates the agent, the channel connection, and the whole conversation** into their new workspace's Development environment — and the agent picks the conversation back up right where it left off.
 
 On failure (non‑zero exit, or a line starting with `✗`), surface the error message and the matching fix:
 
@@ -119,7 +171,10 @@ On failure (non‑zero exit, or a line starting with `✗`), surface the error m
 |---|---|
 | `…requires --prompt "<agent description>"` | You didn't pass the positional description — re‑run Step 3 with it. |
 | `…--slack-config-token "xoxe.xoxp-…"` | Ask the user for the Slack App Configuration Token (Step 1) and pass it. |
+| `Failed to create Slack app: …` (e.g. timeout) | Transient — Slack's app‑create can be slow on a cold call. Silently re‑run the same command once; only surface to the user if it fails again. |
 | `Slack OAuth was not completed within … seconds` | The user didn't approve in time — re‑run the same command (the Slack app is reused). |
+| `We didn't see your email at … within …s` | The user hasn't emailed the inbound address yet — re‑run after they send it. |
+| `Telegram setup is interactive only …` | Don't use `--ci` for telegram; have the user run it interactively, or pick another channel. |
 | `Keyless environment creation is currently disabled` / no demo integration | The target API isn't configured for keyless/demo — confirm you're pointing at the right `--region`/`--api-url`, or have the user provide `--secret-key` for their existing account instead. |
 | `credential input required …` | A BYOK runtime was selected without a key — pass `--anthropic-api-key` (or use the default demo runtime). |
 
@@ -130,10 +185,10 @@ On failure (non‑zero exit, or a line starting with `✗`), surface the error m
 | Flag | Purpose |
 |---|---|
 | `connect "<description>"` | Positional agent description (required in `--ci`). |
-| `--ci` | Non‑interactive mode. |
+| `--ci` | Non‑interactive mode (omit for `telegram`). |
 | `--region local` | Target the local stack (drop / change for other environments). |
-| `--channel slack` | Connect Slack (the only channel this guide covers). |
-| `--slack-config-token <xoxe.xoxp-…>` | Create the Slack app headlessly. |
+| `--channel <slack\|email\|whatsapp\|teams\|telegram\|skip>` | Which channel to connect. |
+| `--slack-config-token <xoxe.xoxp-…>` | Create the Slack app headlessly (slack only). |
 | `--runtime claude --anthropic-api-key <sk-ant-…>` | Optional BYOK Claude runtime (default is the shared demo runtime). |
 | `--secret-key <key>` | Optional — use an existing Novu account instead of keyless. |
 
@@ -142,5 +197,5 @@ On failure (non‑zero exit, or a line starting with `✗`), surface the error m
 ## Limitations to keep in mind
 
 - **One run = one new agent + one channel.** Re‑running `connect` creates another agent; there's no "add a channel to the existing agent" in this non‑interactive flow yet.
-- **Slack only** for now. Email is planned; **Telegram is interactive‑only** (QR scans) and **WhatsApp/Teams** only open the dashboard — none of these work headlessly today.
+- **Channel support is uneven headlessly:** `slack` and `email` complete with one user action; `whatsapp`/`teams` finish in the dashboard; `telegram` is interactive‑only (QR) and not usable through this agent flow.
 - Keyless data is temporary until the user claims it via the in‑channel sign‑up link.

--- a/packages/novu/AGENT_ONBOARDING.md
+++ b/packages/novu/AGENT_ONBOARDING.md
@@ -1,0 +1,146 @@
+# Novu Agent Onboarding — instructions for an AI agent
+
+You are an AI coding agent helping a user create their first **Novu managed agent** and connect it to **Slack**, with **no Novu account required up front** (keyless mode). You will gather a couple of inputs, infer the agent's purpose from the user's project, run one non‑interactive CLI command, hand the user a Slack authorization link, and then explain how they keep the agent by signing up.
+
+Do not wire Novu into the user's codebase. This flow only creates a hosted agent and connects a channel.
+
+---
+
+## What you will do (overview)
+
+1. Collect inputs from the user (Slack config token; optionally a Claude key).
+2. Infer the agent's purpose from the project and confirm it with the user.
+3. Run `novu connect` non‑interactively (keyless, Slack).
+4. Watch the output, surface the Slack authorize URL to the user immediately.
+5. Report success and explain the demo limit → sign‑up/claim.
+
+---
+
+## Prerequisites (one‑time)
+
+This is the pre‑npm flow, so you invoke the CLI by its **full path** from the built output.
+
+1. Build the CLI from the repo root:
+
+```bash
+pnpm --filter novu build
+```
+
+2. Resolve the absolute repo root (the directory that contains `packages/novu`) and set the entry path you will use for every command below:
+
+```bash
+NOVU_REPO=~/projects/novu
+NOVU_CLI="$NOVU_REPO/packages/novu/dist/src/index.js"
+```
+
+> Assume the Novu API/stack is already running and configured for keyless. This guide targets the local stack via `--region local`. When the CLI ships to npm, every `node "$NOVU_CLI" connect …` below becomes simply `npx novu connect …`.
+
+---
+
+## Step 1 — Collect inputs from the user
+
+Ask the user for:
+
+- **Slack App Configuration Token** (`xoxe.xoxp-…`) — **required**. The CLI uses it once to create the Slack app from a manifest; it is never stored. The user generates it at <https://api.slack.com/apps> under **"Your App Configuration Tokens"** (see <https://api.slack.com/authentication/config-tokens>). Tell them to copy the **access token** (`xoxe.xoxp-…`); it is short‑lived (~12h), so use it promptly.
+- **(Optional) Their own Claude/Anthropic key** — only if they don't want the shared demo runtime. If they provide `sk-ant-…`, you'll pass BYOK flags (see Step 3). Otherwise the default **demo runtime** is used (no key needed).
+
+Do **not** ask them for the agent name/description — you will infer it next.
+
+---
+
+## Step 2 — Infer the agent's purpose from the project
+
+Read the project to decide what this agent should *do* for the user:
+
+- `README.md`, `package.json` (name/description/keywords), and the app's primary source (routes, domain models, product copy).
+
+From that, draft a concise **1–2 sentence agent description** of the assistant the user likely wants — e.g. _"A support agent for <product> that answers questions about <domain> and can <key action>."_ This string becomes the agent prompt; the server expands it into a system prompt, tools and skills.
+
+Show the drafted description to the user, let them edit it, and **get explicit confirmation** before running anything.
+
+---
+
+## Step 3 — Run `novu connect` (keyless, Slack, non‑interactive)
+
+Run the command **streamed / in the background** so you can read its output live (Step 4 depends on this). Keyless is the default — do **not** pass `--secret-key`.
+
+```bash
+node "$NOVU_CLI" connect "<CONFIRMED AGENT DESCRIPTION>" \
+  --ci \
+  --region local \
+  --channel slack \
+  --slack-config-token "<xoxe.xoxp-...>"
+```
+
+- `--ci` forces non‑interactive mode (no prompts, no TUI).
+- The positional description is **required** in non‑interactive mode.
+- Default runtime is the **demo** Claude runtime (no key). For **BYOK**, append:
+
+```bash
+  --runtime claude --anthropic-api-key "sk-ant-..."
+```
+
+---
+
+## Step 4 — Hand off Slack authorization (human‑in‑the‑loop)
+
+Slack OAuth cannot be automated — a human must approve the install. The CLI creates the Slack app, prints an authorize URL, then **polls for up to 5 minutes**.
+
+- Watch stdout for the line:
+
+  ```
+  → Authorize Slack here: <url>
+  ```
+
+- The moment it appears, **give the user that URL** and ask them to open it and approve the Slack install **within 5 minutes**.
+- The command finishes on its own once they authorize. If it times out (~5 min) it exits with an error — just **re‑run the exact same command**; it reuses the Slack app it already created.
+
+---
+
+## Step 5 — Report the result
+
+On success the CLI exits `0` and prints:
+
+```
+✓ Your agent is live.
+  Agent: <name> (<identifier>)
+  → Check Slack — your agent just messaged you.
+  Dashboard: <dashboard url>
+```
+
+Extract the **agent identifier** and **Dashboard URL** and tell the user:
+
+- Their agent is live — open Slack and message it (the agent already said hello).
+- **Keyless demo limit:** they get a handful of free replies (about 5). After that, the agent posts a **"Sign up & keep this agent"** link in the channel. Clicking it creates their Novu account and **migrates the agent, the Slack connection, and the whole conversation** into their new workspace's Development environment — and the agent picks the conversation back up right where it left off.
+
+On failure (non‑zero exit, or a line starting with `✗`), surface the error message and the matching fix:
+
+| Symptom | Fix |
+|---|---|
+| `…requires --prompt "<agent description>"` | You didn't pass the positional description — re‑run Step 3 with it. |
+| `…--slack-config-token "xoxe.xoxp-…"` | Ask the user for the Slack App Configuration Token (Step 1) and pass it. |
+| `Slack OAuth was not completed within … seconds` | The user didn't approve in time — re‑run the same command (the Slack app is reused). |
+| `Keyless environment creation is currently disabled` / no demo integration | The target API isn't configured for keyless/demo — confirm you're pointing at the right `--region`/`--api-url`, or have the user provide `--secret-key` for their existing account instead. |
+| `credential input required …` | A BYOK runtime was selected without a key — pass `--anthropic-api-key` (or use the default demo runtime). |
+
+---
+
+## Command flag reference (the subset this flow uses)
+
+| Flag | Purpose |
+|---|---|
+| `connect "<description>"` | Positional agent description (required in `--ci`). |
+| `--ci` | Non‑interactive mode. |
+| `--region local` | Target the local stack (drop / change for other environments). |
+| `--channel slack` | Connect Slack (the only channel this guide covers). |
+| `--slack-config-token <xoxe.xoxp-…>` | Create the Slack app headlessly. |
+| `--runtime claude --anthropic-api-key <sk-ant-…>` | Optional BYOK Claude runtime (default is the shared demo runtime). |
+| `--secret-key <key>` | Optional — use an existing Novu account instead of keyless. |
+
+---
+
+## Limitations to keep in mind
+
+- **One run = one new agent + one channel.** Re‑running `connect` creates another agent; there's no "add a channel to the existing agent" in this non‑interactive flow yet.
+- **Slack only** for now. Email is planned; **Telegram is interactive‑only** (QR scans) and **WhatsApp/Teams** only open the dashboard — none of these work headlessly today.
+- Keyless data is temporary until the user claims it via the in‑channel sign‑up link.

--- a/packages/novu/src/commands/connect/api/client.ts
+++ b/packages/novu/src/commands/connect/api/client.ts
@@ -16,16 +16,9 @@ export class NovuApiError extends Error {
 export interface ConnectApiClient {
   readonly axios: AxiosInstance;
   readonly apiUrl: string;
-  /** True when the client authenticates with a keyless `pk_keyless_*` identifier instead of a secret key. */
   readonly isKeyless: boolean;
 }
 
-/**
- * Builds the Connect API client. Pass `secretKey` for the standard authenticated
- * flow, or `keylessApplicationIdentifier` (a `pk_keyless_*` value) for the
- * anonymous keyless flow. Keyless requests authenticate via the `Keyless` scheme
- * which the API resolves to the shared keyless org + per-session environment.
- */
 export function createConnectApiClient(input: {
   apiUrl: string;
   secretKey?: string;

--- a/packages/novu/src/commands/connect/api/client.ts
+++ b/packages/novu/src/commands/connect/api/client.ts
@@ -16,16 +16,42 @@ export class NovuApiError extends Error {
 export interface ConnectApiClient {
   readonly axios: AxiosInstance;
   readonly apiUrl: string;
+  /** True when the client authenticates with a keyless `pk_keyless_*` identifier instead of a secret key. */
+  readonly isKeyless: boolean;
 }
 
-export function createConnectApiClient(input: { apiUrl: string; secretKey: string }): ConnectApiClient {
+/**
+ * Builds the Connect API client. Pass `secretKey` for the standard authenticated
+ * flow, or `keylessApplicationIdentifier` (a `pk_keyless_*` value) for the
+ * anonymous keyless flow. Keyless requests authenticate via the `Keyless` scheme
+ * which the API resolves to the shared keyless org + per-session environment.
+ */
+export function createConnectApiClient(input: {
+  apiUrl: string;
+  secretKey?: string;
+  keylessApplicationIdentifier?: string;
+}): ConnectApiClient {
   const baseURL = input.apiUrl.replace(/\/$/, '');
   const debug = process.env.NOVU_CLI_DEBUG === '1' || process.env.NOVU_CLI_DEBUG === 'true';
+  const keylessIdentifier = input.keylessApplicationIdentifier?.trim();
+  const isKeyless = Boolean(keylessIdentifier);
+
+  if (!isKeyless && !input.secretKey) {
+    throw new Error('createConnectApiClient requires either a secretKey or a keylessApplicationIdentifier.');
+  }
+
+  const authHeaders = isKeyless
+    ? {
+        Authorization: `Keyless ${keylessIdentifier}`,
+        'Novu-Application-Identifier': keylessIdentifier as string,
+      }
+    : {
+        Authorization: `ApiKey ${input.secretKey}`,
+      };
+
   const instance = createNovuAxios({
     apiUrl: baseURL,
-    headers: {
-      Authorization: `ApiKey ${input.secretKey}`,
-    },
+    headers: authHeaders,
   });
 
   if (debug) {
@@ -67,5 +93,5 @@ export function createConnectApiClient(input: { apiUrl: string; secretKey: strin
     }
   );
 
-  return { axios: instance, apiUrl: baseURL };
+  return { axios: instance, apiUrl: baseURL, isKeyless };
 }

--- a/packages/novu/src/commands/connect/api/integrations.ts
+++ b/packages/novu/src/commands/connect/api/integrations.ts
@@ -11,6 +11,10 @@ export interface IntegrationRecord {
   active?: boolean;
 }
 
+function integrationEnvironmentId(environmentId: string) {
+  return environmentId ? { _environmentId: environmentId } : {};
+}
+
 export async function listIntegrations(client: ConnectApiClient): Promise<IntegrationRecord[]> {
   const res = await client.axios.get<{ data?: IntegrationRecord[] } | IntegrationRecord[]>('/v1/integrations');
   const body = res.data;
@@ -52,9 +56,7 @@ export async function createAgentRuntimeIntegration(
     name: input.name,
     active: true,
     credentials: input.credentials,
-    // Omit when empty (keyless mode has no client-side env id); the API then
-    // scopes to the session/keyless environment. Sending '' fails IsMongoId.
-    ...(input.environmentId ? { _environmentId: input.environmentId } : {}),
+    ...integrationEnvironmentId(input.environmentId),
   });
   const body = res.data;
 
@@ -75,9 +77,7 @@ export async function createSlackIntegration(
     name: input.name,
     active: true,
     credentials: {},
-    // Omit when empty (keyless mode has no client-side env id); the API then
-    // scopes to the session/keyless environment. Sending '' fails IsMongoId.
-    ...(input.environmentId ? { _environmentId: input.environmentId } : {}),
+    ...integrationEnvironmentId(input.environmentId),
   });
   const body = res.data;
 
@@ -94,9 +94,7 @@ export async function createTelegramIntegration(
     name: input.name,
     active: true,
     credentials: {},
-    // Omit when empty (keyless mode has no client-side env id); the API then
-    // scopes to the session/keyless environment. Sending '' fails IsMongoId.
-    ...(input.environmentId ? { _environmentId: input.environmentId } : {}),
+    ...integrationEnvironmentId(input.environmentId),
   });
   const body = res.data;
 

--- a/packages/novu/src/commands/connect/api/integrations.ts
+++ b/packages/novu/src/commands/connect/api/integrations.ts
@@ -52,7 +52,9 @@ export async function createAgentRuntimeIntegration(
     name: input.name,
     active: true,
     credentials: input.credentials,
-    _environmentId: input.environmentId,
+    // Omit when empty (keyless mode has no client-side env id); the API then
+    // scopes to the session/keyless environment. Sending '' fails IsMongoId.
+    ...(input.environmentId ? { _environmentId: input.environmentId } : {}),
   });
   const body = res.data;
 
@@ -73,7 +75,9 @@ export async function createSlackIntegration(
     name: input.name,
     active: true,
     credentials: {},
-    _environmentId: input.environmentId,
+    // Omit when empty (keyless mode has no client-side env id); the API then
+    // scopes to the session/keyless environment. Sending '' fails IsMongoId.
+    ...(input.environmentId ? { _environmentId: input.environmentId } : {}),
   });
   const body = res.data;
 
@@ -90,7 +94,9 @@ export async function createTelegramIntegration(
     name: input.name,
     active: true,
     credentials: {},
-    _environmentId: input.environmentId,
+    // Omit when empty (keyless mode has no client-side env id); the API then
+    // scopes to the session/keyless environment. Sending '' fails IsMongoId.
+    ...(input.environmentId ? { _environmentId: input.environmentId } : {}),
   });
   const body = res.data;
 

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -1,0 +1,51 @@
+import { createNovuAxios } from '../../shared/novu-http';
+
+const KEYLESS_ENVIRONMENT_PREFIX = 'pk_keyless_';
+
+interface InboxSessionPayload {
+  applicationIdentifier?: string;
+}
+
+// The API wraps successful responses as `{ data: { ... } }`; tolerate both the
+// wrapped and unwrapped shapes.
+type InboxSessionResponse = InboxSessionPayload & { data?: InboxSessionPayload };
+
+export interface KeylessSession {
+  applicationIdentifier: string;
+}
+
+/**
+ * Bootstraps an anonymous keyless environment for the Connect CLI by reusing the
+ * Inbox session endpoint (`POST /v1/inbox/session`). When `storedIdentifier` is a
+ * still-valid `pk_keyless_*` value the API reuses that environment; otherwise it
+ * provisions a fresh one. The returned identifier is what the keyless API client
+ * sends as the `Keyless` credential for every subsequent Connect request.
+ */
+export async function bootstrapKeylessSession(apiUrl: string, storedIdentifier?: string): Promise<KeylessSession> {
+  const axios = createNovuAxios({ apiUrl });
+  const body = storedIdentifier?.startsWith(KEYLESS_ENVIRONMENT_PREFIX) ? { applicationIdentifier: storedIdentifier } : {};
+
+  const res = await axios.post<InboxSessionResponse>('/v1/inbox/session', body, {
+    validateStatus: () => true,
+  });
+
+  if (res.status >= 400) {
+    const message =
+      res.status === 400
+        ? 'Keyless mode is not available on this Novu deployment. Re-run with `--secret-key <key>` to use an existing environment.'
+        : `Failed to start a keyless session (${res.status}).`;
+    throw new Error(message);
+  }
+
+  const responseBody = res.data;
+  const applicationIdentifier = responseBody?.data?.applicationIdentifier ?? responseBody?.applicationIdentifier;
+  if (!applicationIdentifier || !applicationIdentifier.startsWith(KEYLESS_ENVIRONMENT_PREFIX)) {
+    throw new Error('Keyless session response did not include a valid application identifier.');
+  }
+
+  return { applicationIdentifier };
+}
+
+export function isKeylessIdentifier(value: string | undefined | null): boolean {
+  return Boolean(value && value.startsWith(KEYLESS_ENVIRONMENT_PREFIX));
+}

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -6,21 +6,12 @@ interface InboxSessionPayload {
   applicationIdentifier?: string;
 }
 
-// The API wraps successful responses as `{ data: { ... } }`; tolerate both the
-// wrapped and unwrapped shapes.
 type InboxSessionResponse = InboxSessionPayload & { data?: InboxSessionPayload };
 
 export interface KeylessSession {
   applicationIdentifier: string;
 }
 
-/**
- * Bootstraps an anonymous keyless environment for the Connect CLI by reusing the
- * Inbox session endpoint (`POST /v1/inbox/session`). When `storedIdentifier` is a
- * still-valid `pk_keyless_*` value the API reuses that environment; otherwise it
- * provisions a fresh one. The returned identifier is what the keyless API client
- * sends as the `Keyless` credential for every subsequent Connect request.
- */
 export async function bootstrapKeylessSession(apiUrl: string, storedIdentifier?: string): Promise<KeylessSession> {
   const axios = createNovuAxios({ apiUrl });
   const body = storedIdentifier?.startsWith(KEYLESS_ENVIRONMENT_PREFIX) ? { applicationIdentifier: storedIdentifier } : {};

--- a/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
+++ b/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
@@ -9,18 +9,9 @@ const KEYLESS_CONFIG_KEY = 'connectKeylessApplicationIdentifier' as const;
 export interface ResolvedConnectAuth extends Omit<ResolvedAuth, 'source'> {
   source: ResolvedAuth['source'] | 'keyless';
   isKeyless: boolean;
-  /** Present only when `isKeyless` — the `pk_keyless_*` identifier used for the Keyless credential. */
   keylessApplicationIdentifier?: string;
 }
 
-/**
- * Resolves how `novu connect` authenticates. Keyless is the DEFAULT: when the
- * user has not supplied a secret key (and we're not in a non-interactive shell
- * with `NOVU_SECRET_KEY`), we skip the browser device-auth flow and provision an
- * anonymous keyless environment instead. The user only signs up later, once the
- * agent demo limit is reached. Supplying `--secret-key` (or `NOVU_SECRET_KEY` in
- * CI) bypasses keyless and uses the standard authenticated path.
- */
 export async function resolveConnectAuth(
   options: ConnectCommandOptions,
   resolveOptions: ResolveAuthOptions = {}

--- a/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
+++ b/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
@@ -1,0 +1,71 @@
+import { ConfigService } from '../../../services';
+import { resolveAuth, type ResolveAuthOptions } from '../../wizard/auth/resolve-auth';
+import type { ResolvedAuth, WizardCommandOptions } from '../../wizard/types';
+import { bootstrapKeylessSession } from '../api/keyless-session';
+import type { ConnectCommandOptions } from '../types';
+
+const KEYLESS_CONFIG_KEY = 'connectKeylessApplicationIdentifier' as const;
+
+export interface ResolvedConnectAuth extends Omit<ResolvedAuth, 'source'> {
+  source: ResolvedAuth['source'] | 'keyless';
+  isKeyless: boolean;
+  /** Present only when `isKeyless` — the `pk_keyless_*` identifier used for the Keyless credential. */
+  keylessApplicationIdentifier?: string;
+}
+
+/**
+ * Resolves how `novu connect` authenticates. Keyless is the DEFAULT: when the
+ * user has not supplied a secret key (and we're not in a non-interactive shell
+ * with `NOVU_SECRET_KEY`), we skip the browser device-auth flow and provision an
+ * anonymous keyless environment instead. The user only signs up later, once the
+ * agent demo limit is reached. Supplying `--secret-key` (or `NOVU_SECRET_KEY` in
+ * CI) bypasses keyless and uses the standard authenticated path.
+ */
+export async function resolveConnectAuth(
+  options: ConnectCommandOptions,
+  resolveOptions: ResolveAuthOptions = {}
+): Promise<ResolvedConnectAuth> {
+  const cliFlagSecret = options.secretKey?.trim();
+  const envSecret = process.env.NOVU_SECRET_KEY?.trim();
+  const isInteractive = Boolean(process.stdin.isTTY && process.stdout.isTTY) && process.env.CI !== 'true';
+  const wantsAuthenticated = Boolean(cliFlagSecret || (envSecret && !isInteractive));
+
+  if (wantsAuthenticated) {
+    const auth = await resolveAuth(toWizardAuthOptions(options), resolveOptions);
+
+    return { ...auth, isKeyless: false };
+  }
+
+  resolveOptions.onStatus?.('Setting up a temporary keyless workspace…');
+
+  const config = new ConfigService();
+  const stored = config.getValue(KEYLESS_CONFIG_KEY);
+  const session = await bootstrapKeylessSession(options.apiUrl, stored);
+  config.setValue(KEYLESS_CONFIG_KEY, session.applicationIdentifier);
+
+  return {
+    secretKey: '',
+    environmentId: '',
+    environmentSlug: null,
+    environmentName: 'Keyless',
+    organizationId: null,
+    user: null,
+    apiUrl: options.apiUrl,
+    dashboardUrl: options.dashboardUrl,
+    region: options.region,
+    source: 'keyless',
+    isKeyless: true,
+    keylessApplicationIdentifier: session.applicationIdentifier,
+  };
+}
+
+function toWizardAuthOptions(options: ConnectCommandOptions): WizardCommandOptions {
+  return {
+    secretKey: options.secretKey,
+    apiUrl: options.apiUrl,
+    dashboardUrl: options.dashboardUrl,
+    region: options.region,
+    yes: false,
+    ci: !!options.ci,
+  };
+}

--- a/packages/novu/src/commands/connect/pipeline/runner.ts
+++ b/packages/novu/src/commands/connect/pipeline/runner.ts
@@ -1,6 +1,5 @@
 import open from 'open';
-import { resolveAuth } from '../../wizard/auth/resolve-auth';
-import type { ResolvedAuth, WizardCommandOptions } from '../../wizard/types';
+import { resolveConnectAuth, type ResolvedConnectAuth } from '../auth/resolve-connect-auth';
 import { CONNECT_EVENTS } from '../analytics/events';
 import {
   type AgentRecord,
@@ -25,7 +24,7 @@ export interface ConnectPipelineInput {
   ui: ConnectUI;
   onboardingSessionId?: string;
   onTrack?: (event: string, data?: Record<string, unknown>) => void;
-  onIdentityResolved?: (user: NonNullable<ResolvedAuth['user']>) => void;
+  onIdentityResolved?: (user: NonNullable<ResolvedConnectAuth['user']>) => void;
 }
 
 export interface ConnectPipelineResult {
@@ -41,7 +40,7 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
     await ui.showWelcome();
 
     ui.authStarted();
-    const auth = await resolveAuth(toWizardAuthOptions(options), {
+    const auth = await resolveConnectAuth(options, {
       onStatus: (m) => ui.authStatus(m),
       onDashboardUrl: (u) => ui.authDashboardUrl(u),
       name: 'novu-connect',
@@ -50,14 +49,21 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
       onAuthStarted: () => track(CONNECT_EVENTS.AUTH_STARTED, sessionProps),
       onAuthFailed: (message) => track(CONNECT_EVENTS.AUTH_FAILED, { ...sessionProps, message }),
     });
-    track(CONNECT_EVENTS.AUTH_COMPLETED, { source: auth.source, region: options.region, ...sessionProps });
+    track(CONNECT_EVENTS.AUTH_COMPLETED, {
+      source: auth.source,
+      region: options.region,
+      keyless: auth.isKeyless,
+      ...sessionProps,
+    });
     ui.authCompleted(auth.environmentName ?? null);
 
     if (auth.user?.id) {
       input.onIdentityResolved?.(auth.user);
     }
 
-    const client = createConnectApiClient({ apiUrl: auth.apiUrl, secretKey: auth.secretKey });
+    const client = auth.isKeyless
+      ? createConnectApiClient({ apiUrl: auth.apiUrl, keylessApplicationIdentifier: auth.keylessApplicationIdentifier })
+      : createConnectApiClient({ apiUrl: auth.apiUrl, secretKey: auth.secretKey });
 
     ui.listingAgents();
     const existingAgents = await listAgents(client);
@@ -277,7 +283,7 @@ async function generateAndPreviewAgent(
   }
 }
 
-async function ensureSubscriberForUser(client: ConnectApiClient, auth: ResolvedAuth): Promise<string> {
+async function ensureSubscriberForUser(client: ConnectApiClient, auth: ResolvedConnectAuth): Promise<string> {
   if (auth.user?.id) {
     const subscriberId = `connect:${auth.user.id}`;
     await upsertSubscriber(client, {
@@ -286,6 +292,16 @@ async function ensureSubscriberForUser(client: ConnectApiClient, auth: ResolvedA
       lastName: auth.user.lastName ?? undefined,
       email: auth.user.email ?? undefined,
     });
+
+    return subscriberId;
+  }
+
+  // Keyless sessions have no user; use a stable per-session subscriber id keyed
+  // off the keyless identifier so OAuth endpoint binding and the welcome DM
+  // resolve to the same subscriber, and so the claim flow can locate it later.
+  if (auth.isKeyless && auth.keylessApplicationIdentifier) {
+    const subscriberId = `connect-keyless:${auth.keylessApplicationIdentifier}`;
+    await upsertSubscriber(client, { subscriberId });
 
     return subscriberId;
   }
@@ -309,15 +325,4 @@ function describeError(err: unknown): string {
   if (err instanceof Error) return err.message;
 
   return String(err);
-}
-
-function toWizardAuthOptions(options: ConnectCommandOptions): WizardCommandOptions {
-  return {
-    secretKey: options.secretKey,
-    apiUrl: options.apiUrl,
-    dashboardUrl: options.dashboardUrl,
-    region: options.region,
-    yes: false,
-    ci: !!options.ci,
-  };
 }

--- a/packages/novu/src/commands/connect/pipeline/runner.ts
+++ b/packages/novu/src/commands/connect/pipeline/runner.ts
@@ -296,9 +296,6 @@ async function ensureSubscriberForUser(client: ConnectApiClient, auth: ResolvedC
     return subscriberId;
   }
 
-  // Keyless sessions have no user; use a stable per-session subscriber id keyed
-  // off the keyless identifier so OAuth endpoint binding and the welcome DM
-  // resolve to the same subscriber, and so the claim flow can locate it later.
   if (auth.isKeyless && auth.keylessApplicationIdentifier) {
     const subscriberId = `connect-keyless:${auth.keylessApplicationIdentifier}`;
     await upsertSubscriber(client, { subscriberId });

--- a/packages/novu/src/services/config.service.ts
+++ b/packages/novu/src/services/config.service.ts
@@ -3,7 +3,7 @@ import Configstore from 'configstore';
 import jwt_decode from 'jwt-decode';
 
 type OriginPort = number;
-type ConfigKey = 'token' | 'anonymousId' | `tunnelUrl-${OriginPort}`;
+type ConfigKey = 'token' | 'anonymousId' | 'connectKeylessApplicationIdentifier' | `tunnelUrl-${OriginPort}`;
 
 export class ConfigService {
   private _config: Configstore;

--- a/packages/shared/src/consts/connect-claim.ts
+++ b/packages/shared/src/consts/connect-claim.ts
@@ -1,0 +1,2 @@
+/** Matches `randomBytes(24).toString('base64url')` — 32 URL-safe characters. */
+export const CONNECT_CLAIM_TOKEN_PATTERN = /^[A-Za-z0-9_-]{32}$/;

--- a/packages/shared/src/consts/connect-claim.ts
+++ b/packages/shared/src/consts/connect-claim.ts
@@ -1,2 +1,1 @@
-/** Matches `randomBytes(24).toString('base64url')` — 32 URL-safe characters. */
 export const CONNECT_CLAIM_TOKEN_PATTERN = /^[A-Za-z0-9_-]{32}$/;

--- a/packages/shared/src/consts/index.ts
+++ b/packages/shared/src/consts/index.ts
@@ -1,3 +1,4 @@
+export * from './connect-claim';
 export * from './data-retention';
 export * from './aws-claude-regions';
 export * from './feature-tiers-constants';

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -43,7 +43,6 @@ export enum FeatureFlagsKeysEnum {
   IS_WORKFLOW_NODE_PREVIEW_ENABLED = 'IS_WORKFLOW_NODE_PREVIEW_ENABLED',
   IS_WEBHOOKS_MANAGEMENT_ENABLED = 'IS_WEBHOOKS_MANAGEMENT_ENABLED',
   IS_KEYLESS_ENVIRONMENT_CREATION_ENABLED = 'IS_KEYLESS_ENVIRONMENT_CREATION_ENABLED',
-  /** When disabled, keyless callers cannot use AI generation, managed provisioning, or conversation LLM dispatch. */
   IS_KEYLESS_AGENT_AI_ENABLED = 'IS_KEYLESS_AGENT_AI_ENABLED',
   /** When enabled, API-key auth on GET /v1/environments returns decrypted apiKeys for every environment in the org (pre-NV-7641 opt-in behavior). */
   IS_LIST_ENVIRONMENTS_API_KEYS_ENABLED = 'IS_LIST_ENVIRONMENTS_API_KEYS_ENABLED',

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -43,6 +43,8 @@ export enum FeatureFlagsKeysEnum {
   IS_WORKFLOW_NODE_PREVIEW_ENABLED = 'IS_WORKFLOW_NODE_PREVIEW_ENABLED',
   IS_WEBHOOKS_MANAGEMENT_ENABLED = 'IS_WEBHOOKS_MANAGEMENT_ENABLED',
   IS_KEYLESS_ENVIRONMENT_CREATION_ENABLED = 'IS_KEYLESS_ENVIRONMENT_CREATION_ENABLED',
+  /** When disabled, keyless callers cannot use AI generation, managed provisioning, or conversation LLM dispatch. */
+  IS_KEYLESS_AGENT_AI_ENABLED = 'IS_KEYLESS_AGENT_AI_ENABLED',
   /** When enabled, API-key auth on GET /v1/environments returns decrypted apiKeys for every environment in the org (pre-NV-7641 opt-in behavior). */
   IS_LIST_ENVIRONMENTS_API_KEYS_ENABLED = 'IS_LIST_ENVIRONMENTS_API_KEYS_ENABLED',
   IS_TEST_PROVIDER_LIMITS_ENABLED = 'IS_TEST_PROVIDER_LIMITS_ENABLED',


### PR DESCRIPTION
### What changed? Why was the change needed?

Enables anonymous `novu connect` without a Novu account up front. Users get a keyless workspace, build an agent + channel via the CLI, chat with a capped demo (5 agent replies), then receive a signup CTA in-channel. After signup, `/connect/claim` merges the agent, channel wiring, conversation history, and MCP connections into their Development environment.

**API**
- New `ConnectModule` with claim token service (Redis single-use tokens) and `POST /connect/claim`
- `@KeylessAccessible()` on agent/integration/subscriber endpoints; env-scoped listing for keyless callers
- Demo reply cap in inbound handler + signup CTA card
- Rate-limit hardening: keyless detection from resolved auth scheme (not spoofable headers)
- Claim flow: per-env token reuse, one-time CTA, concurrent-claim lock, MCP migration on claim

**Dashboard**
- `/connect/claim` page with token persistence across signup/org-picker redirects

**CLI (`packages/novu`)**
- Keyless auth as default (`resolveConnectAuth` + inbox session bootstrap)
- `AGENT_ONBOARDING.md` guide for AI-assisted onboarding

```mermaid
sequenceDiagram
  participant User
  participant CLI as novu connect CLI
  participant API
  participant Channel
  participant Dashboard

  User->>CLI: connect (no secret key)
  CLI->>API: POST /v1/inbox/session (keyless)
  API-->>CLI: pk_keyless_* identifier
  CLI->>API: Create agent + channel (Keyless auth)
  User->>Channel: Messages agent
  API->>Channel: Replies until demo cap
  API->>Channel: Signup CTA + claim token
  User->>Dashboard: Sign up via claim link
  Dashboard->>API: POST /connect/claim
  API->>API: Merge assets into Dev env
```

Linear: [NV-7968](https://linear.app/novu/issue/NV-7968/keyless-novu-connect-flow-with-agent-claim)

### Screenshots

N/A — backend/CLI flow; dashboard claim page is a simple loading/success card.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Requires `KEYLESS_ORGANIZATION_ID` and related keyless env config on the API deployment.
- Claim tokens need Redis; flow degrades if cache is unavailable.
- `472b016f76` only updates `AGENT_ONBOARDING.md` copy (mislabeled commit message).

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Adds a keyless "novu connect" flow allowing anonymous CLI users to provision a temporary workspace, create an agent+channel, interact with a demo-capped agent (default 5 replies) and receive an in-channel signup CTA; after signing up they can claim those assets into their authenticated Development environment via POST /connect/claim. The implementation introduces single-use Redis-backed claim tokens consumed atomically (Lua GETDEL), per-token claim locks, demo-reply capping with one-time CTA posting, and keyless abuse protections (per-IP daily caps and managed-agent limits). The flow degrades if Redis is unavailable and requires KEYLESS_ORGANIZATION_ID.

## Affected areas
- api: New ConnectModule, ConnectClaimTokenService (Redis-backed, 7d TTL), ClaimKeylessConnect use case and POST /connect/claim endpoint; `@KeylessAccessible` applied to agent/integration/subscriber/channel endpoints; inbound handler enforces reply cap and posts signup CTA; KeylessAbuseGuardService, keyless expiry utils, env validators, and rate-limit changes to detect keyless via auth scheme.
- dashboard: New /connect/claim page, sessionStorage + URL helpers to persist claim tokens across signup/org-picker redirects, redirect-origin validation for split-hostname flows, and auth flow updates to honor pending connect-claim return URLs with loading/success/error states.
- js (packages/novu CLI): Keyless session bootstrap, resolveConnectAuth (keyless default for connect), Connect API client accepts keyless identifiers (Novu-Application-Identifier header), keyless-aware subscriber IDs, and AGENT_ONBOARDING.md documenting the headless onboarding flow.
- shared: Added CONNECT_CLAIM_TOKEN_PATTERN and re-exported connect-claim constants for validation.
- dal: Added ConversationActivityRepository.countAgentMessages() used to enforce demo reply caps.

## Key technical decisions
- Tokens and abuse counters are stored in Redis and use Lua scripts for atomic actions and daily counters; token issuance may reuse an env-scoped token but claims are single-use and locked to prevent concurrent claims.  
- Keyless abuse guards use per-IP daily counters and last-env reuse to limit churn; managed-agent caps are enforced per environment.  
- Rate-limiting and credential scoping determine keyless callers from the resolved auth scheme (not from spoofable headers).  
- The flow requires KEYLESS_ORGANIZATION_ID and Redis; token operations surface service-unavailable errors when cache is down.

## Testing
Adds unit tests for keyless expiry and KeylessAbuseGuardService and updates inbound handler specs (mocked token service); recommends e2e/manual verification for CLI keyless runs, in-channel demo interactions, signup-to-claim flows, and Redis-backed token lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements an anonymous \"keyless\" `novu connect` flow: users run the CLI without a secret key, get a temporary workspace, build an agent via the CLI, interact with a demo-capped agent (default 5 replies), then receive an in-channel signup CTA. After signing up they can claim all assets into their Development environment via `POST /connect/claim`.

- **API**: New `ConnectModule` with Redis-backed single-use claim tokens (atomic Lua GETDEL), per-env token reuse, concurrent-claim lock, `KeylessAbuseGuardService` with per-IP daily rate limits, `@KeylessAccessible` on agent/integration/subscriber endpoints, and demo-reply capping with one-time CTA posting in the inbound handler.
- **Dashboard**: New `/connect/claim` page with sessionStorage token persistence across signup/org-picker redirects, trusted-origin validation for the redirect URL, and a polling loop waiting for the Development environment to be ready before firing the claim.
- **CLI**: `resolveConnectAuth` defaults to keyless mode (bootstraps an inbox session, stores the application identifier), and `createConnectApiClient` now accepts a keyless identifier and emits the correct `Authorization: Keyless …` + `Novu-Application-Identifier` headers.

<h3>Confidence Score: 3/5</h3>

The claim flow is functionally correct and well-structured, but the atomic Lua script uses GETDEL which is unavailable on Redis < 6.2 — on affected deployments every claim call returns 503 with no obvious error, blocking the entire feature.

The CLAIM_ATOMIC_SCRIPT calls redis.call('GETDEL', …), a command that did not exist before Redis 6.2.0. If the deployment runs an older Redis (e.g., ElastiCache 6.0, Redis 5.x), the Lua evaluation raises ERR Unknown or disabled command 'GETDEL', which is caught and re-thrown as ServiceUnavailableException. Every POST /connect/claim returns 503 and the whole claim feature is silently dead. This is the kind of infrastructure mismatch that is easy to miss in staging if the test cluster happens to be on 6.2+ but production is not, and the PR description does not call out the minimum Redis version required.

apps/api/src/app/connect/services/connect-claim-token.service.ts — specifically the CLAIM_ATOMIC_SCRIPT constant and the claim() method that executes it.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/connect/services/connect-claim-token.service.ts | New Redis-backed claim token service; uses GETDEL in a Lua script which requires Redis ≥ 6.2 (undocumented breaking requirement), and near-expiry tokens can be silently reused in CTAs. |
| apps/api/src/app/connect/usecases/claim-keyless-connect/claim-keyless-connect.usecase.ts | Claim usecase with verify→migrate→claim pattern; migration is idempotent, lock-protected, and error mapping to HTTP exceptions is thorough. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Adds keyless demo-cap logic and CTA posting with correct marker-after-delivery ordering; KEYLESS_DEMO_REPLY_CAP now correctly handles 0 via parsePositiveIntEnv. |
| apps/dashboard/src/utils/connect-claim-pending.ts | Token persistence helpers; isAbsoluteUrl regex correctly catches protocol-relative URLs via optional scheme group, and trusted-origin guard rejects untrusted hosts. |
| apps/dashboard/src/pages/connect-claim.tsx | New claim page; chained ternary correctly suppresses spinner when no token is present; environment polling and hasAttemptedRef guard prevent duplicate claims. |
| apps/api/src/app/keyless/keyless-abuse-guard.service.ts | Per-IP daily counters for env-create and generate limits with Redis Lua atomic INCR+EXPIRE; graceful bypass when cache is disabled; well-tested. |
| apps/api/src/app/rate-limiting/guards/throttler.guard.ts | Keyless detection now uses resolved auth scheme from middleware rather than raw header inspection, closing the header-spoofing vector for rate-limit bypasses. |
| packages/novu/src/commands/connect/auth/resolve-connect-auth.ts | New CLI auth resolver that defaults to keyless mode unless a secret key is provided; stores keyless application identifier in config for session reuse. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant CLI as novu CLI
  participant API as API
  participant IH as Inbound Handler
  participant Redis
  participant DB as MongoDB
  participant Dashboard

  CLI->>API: POST /v1/inbox/session (no appId)
  API->>DB: create keyless env + integration
  API-->>CLI: "pk_keyless_* identifier"
  CLI->>API: Create agent + channel (Keyless auth)

  loop User messages
    IH->>Redis: isSignupCtaPosted?
    IH->>DB: countAgentMessages()
    alt cap not reached
      IH->>IH: normal AI reply
    else cap reached
      IH->>Redis: issueOrGetForEnvironment
      IH->>IH: replyOnThread(CTA card)
      IH->>Redis: tryMarkSignupCtaPosted (SETNX)
    end
  end

  Dashboard->>Dashboard: "/connect/claim?token=T"
  Dashboard->>Dashboard: storePendingConnectClaim
  Dashboard->>Dashboard: redirect to sign-up
  Dashboard->>API: "POST /connect/claim { token }"
  API->>Redis: tryAcquireClaimLock (SETNX)
  API->>Redis: verify token (GET used + GET storage)
  API->>DB: withTransaction: migrate agents/integrations/conversations/MCP
  API->>Redis: claim token (Lua GETDEL + SET used-marker)
  API->>Redis: releaseClaimLock
  API-->>Dashboard: "{ environmentId, agentIdentifier }"
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fconnect%2Fservices%2Fconnect-claim-token.service.ts%3A22-40%0A**%60GETDEL%60%20requires%20Redis%20%E2%89%A5%206.2%20%E2%80%94%20breaks%20on%20older%20deployments**%0A%0A%60CLAIM_ATOMIC_SCRIPT%60%20calls%20%60redis.call%28'GETDEL'%2C%20KEYS%5B1%5D%29%60.%20%60GETDEL%60%20was%20introduced%20in%20Redis%206.2.0.%20On%20older%20clusters%20%28e.g.%2C%20ElastiCache%20Redis%206.0%2C%20Redis%205.x%29%2C%20the%20Lua%20script%20fails%20with%20%60ERR%20Unknown%20or%20disabled%20command%20'GETDEL'%60.%20That%20error%20propagates%20as%20%60ConnectClaimTokenCacheUnavailableError%60%2C%20which%20is%20re-thrown%20as%20%60ServiceUnavailableException%60%2C%20making%20every%20%60POST%20%2Fconnect%2Fclaim%60%20return%20503%20with%20no%20obvious%20root%20cause.%20A%20backward-compatible%20alternative%20replaces%20%60GETDEL%60%20with%20an%20inline%20%60GET%60%20then%20conditional%20%60DEL%60%2C%20which%20maintains%20the%20same%20atomic%20semantics%20%28Lua%20scripts%20execute%20atomically%29%20without%20the%20version%20constraint.%20At%20minimum%20the%20minimum%20Redis%20version%20should%20be%20documented%20explicitly%20as%20a%20deployment%20pre-requisite.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fconnect%2Fservices%2Fconnect-claim-token.service.ts%3A128-152%0A**Near-expiry%20token%20silently%20reused%20in%20CTAs**%0A%0A%60issueOrGetForEnvironment%60%20reuses%20an%20existing%20env-scoped%20token%20without%20checking%20its%20remaining%20TTL.%20%60readIssuedToken%60%20only%20validates%20that%20the%20stored%20payload%20matches%20%E2%80%94%20it%20does%20not%20compare%20%60entry.expiresAt%60%20against%20the%20current%20time.%20If%20the%20env%20key%20was%20written%20with%20a%20token%20that%20is%20moments%20away%20from%20expiry%20%287-day%20TTL%20nearly%20exhausted%29%2C%20the%20same%20token%20is%20embedded%20in%20the%20CTA%20card%20URL.%20The%20user%20clicks%20the%20link%2C%20completes%20sign-up%2C%20lands%20on%20%60%2Fconnect%2Fclaim%60%2C%20and%20%60claim%28%29%60%20finds%20the%20Redis%20key%20already%20gone%20%E2%80%94%20the%20Lua%20script%20returns%20%60''%60%20and%20the%20user%20sees%20%22This%20claim%20link%20has%20expired%22%20despite%20clicking%20a%20live%20CTA.%20Adding%20a%20minimum%20TTL%20buffer%20check%20%28e.g.%2C%20require%20%E2%89%A5%2060s%20remaining%29%20in%20%60readIssuedToken%60%20before%20returning%20the%20reused%20token%20would%20prevent%20this.%0A%0A&pr=11450&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/connect/services/connect-claim-token.service.ts:22-40
**`GETDEL` requires Redis ≥ 6.2 — breaks on older deployments**

`CLAIM_ATOMIC_SCRIPT` calls `redis.call('GETDEL', KEYS[1])`. `GETDEL` was introduced in Redis 6.2.0. On older clusters (e.g., ElastiCache Redis 6.0, Redis 5.x), the Lua script fails with `ERR Unknown or disabled command 'GETDEL'`. That error propagates as `ConnectClaimTokenCacheUnavailableError`, which is re-thrown as `ServiceUnavailableException`, making every `POST /connect/claim` return 503 with no obvious root cause. A backward-compatible alternative replaces `GETDEL` with an inline `GET` then conditional `DEL`, which maintains the same atomic semantics (Lua scripts execute atomically) without the version constraint. At minimum the minimum Redis version should be documented explicitly as a deployment pre-requisite.

### Issue 2 of 2
apps/api/src/app/connect/services/connect-claim-token.service.ts:128-152
**Near-expiry token silently reused in CTAs**

`issueOrGetForEnvironment` reuses an existing env-scoped token without checking its remaining TTL. `readIssuedToken` only validates that the stored payload matches — it does not compare `entry.expiresAt` against the current time. If the env key was written with a token that is moments away from expiry (7-day TTL nearly exhausted), the same token is embedded in the CTA card URL. The user clicks the link, completes sign-up, lands on `/connect/claim`, and `claim()` finds the Redis key already gone — the Lua script returns `''` and the user sees "This claim link has expired" despite clicking a live CTA. Adding a minimum TTL buffer check (e.g., require ≥ 60s remaining) in `readIssuedToken` before returning the reused token would prevent this.

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["Use bootstrap org key when fetching envi..."](https://github.com/novuhq/novu/commit/2a1d9fa1dd27e424e99fbaefc55f8dd6a7d38e8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36052171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->