### PR TITLE
fix(js): validate in-app redirect URLs in inbox API and client fixes NV-7971

### DIFF
--- a/apps/api/src/app/inbox/utils/notification-mapper.ts
+++ b/apps/api/src/app/inbox/utils/notification-mapper.ts
@@ -1,5 +1,5 @@
 import type { MessageEntity } from '@novu/dal';
-import { ButtonTypeEnum, MessageActionStatusEnum, SeverityLevelEnum } from '@novu/shared';
+import { ButtonTypeEnum, MessageActionStatusEnum, sanitizeInAppRedirect, SeverityLevelEnum } from '@novu/shared';
 
 import { InboxNotificationDto, InboxSubscriberResponseDto } from '../dtos/inbox-notification.dto';
 
@@ -62,32 +62,17 @@ const mapSingleItem = ({
     primaryAction: primaryCta && {
       label: primaryCta.content,
       isCompleted: actionType === ButtonTypeEnum.PRIMARY && actionStatus === MessageActionStatusEnum.DONE,
-      redirect: primaryCta.url
-        ? {
-            url: primaryCta.url,
-            target: primaryCta.target,
-          }
-        : undefined,
+      redirect: sanitizeInAppRedirect(primaryCta.url, primaryCta.target),
     },
     secondaryAction: secondaryCta && {
       label: secondaryCta.content,
       isCompleted: actionType === ButtonTypeEnum.SECONDARY && actionStatus === MessageActionStatusEnum.DONE,
-      redirect: secondaryCta.url
-        ? {
-            url: secondaryCta.url,
-            target: secondaryCta.target,
-          }
-        : undefined,
+      redirect: sanitizeInAppRedirect(secondaryCta.url, secondaryCta.target),
     },
     channelType: channel,
     tags,
     severity: severity ?? SeverityLevelEnum.NONE,
-    redirect: cta.data?.url
-      ? {
-          url: cta.data.url,
-          target: cta.data.target,
-        }
-      : undefined,
+    redirect: sanitizeInAppRedirect(cta.data?.url, cta.data?.target),
     data,
     workflow: template
       ? {

--- a/libs/application-generic/src/schemas/control/in-app-control.schema.ts
+++ b/libs/application-generic/src/schemas/control/in-app-control.schema.ts
@@ -1,30 +1,11 @@
 import { JSONSchemaEntity } from '@novu/dal';
-import { UiComponentEnum, UiSchema, UiSchemaGroupEnum } from '@novu/shared';
+import { IN_APP_REDIRECT_URL_REGEX, UiComponentEnum, UiSchema, UiSchemaGroupEnum } from '@novu/shared';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { defaultOptions, skipStepUiSchema, skipZodSchema } from './shared';
 
-/**
- * Regex pattern for validating URLs with template variables. Matches three cases:
- *
- * 1. URLs that start with template variables like {{variable}}
- *    - Example: {{variable}}, {{variable}}/path
- *
- * 2. Full URLs that may contain template variables anywhere
- *    - Excludes mailto: links
- *    - Example: https://example.com, https://example.com/{{variable}}, https://example.com?id={{var1}}&index={{var2}}
- *
- * 3. Paths starting with / that may contain template variables anywhere
- *    - Example: /path/to/page, /path/{{variable}}/page
- *
- * Pattern prevents backtracking by excluding braces from regular character classes,
- * ensuring braces only appear in template variables.
- */
-const redirectUrlRegex =
-  /^(?:\{\{[^}]*\}\}.*|(?!mailto:)(?:https?:\/\/[^\s/$.?#][^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)|\/[^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)$/;
-
 const redirectZodSchema = z.object({
-  url: z.string().regex(redirectUrlRegex),
+  url: z.string().regex(IN_APP_REDIRECT_URL_REGEX),
   target: z.enum(['_self', '_blank', '_parent', '_top', '_unfencedTop']),
 });
 
@@ -39,7 +20,7 @@ const actionZodSchema = z
 const commonInAppProperties = {
   skip: skipZodSchema,
   disableOutputSanitization: z.boolean().optional(),
-  avatar: z.string().regex(redirectUrlRegex).optional(),
+  avatar: z.string().regex(IN_APP_REDIRECT_URL_REGEX).optional(),
   primaryAction: actionZodSchema,
   secondaryAction: actionZodSchema,
   data: z.object({}).catchall(z.unknown()).optional(),

--- a/packages/js/src/ui/context/InboxContext.tsx
+++ b/packages/js/src/ui/context/InboxContext.tsx
@@ -9,6 +9,7 @@ import {
   useContext,
 } from 'solid-js';
 import { NotificationFilter, Redirect } from '../../types';
+import { isValidInAppRedirectTarget, isValidInAppRedirectUrl } from '../../utils/in-app-redirect-url';
 import { DEFAULT_REFERRER, DEFAULT_TARGET, getTagsFromTab } from '../helpers';
 import { useNovuEvent } from '../helpers/useNovuEvent';
 import { NotificationStatus, PreferenceGroups, PreferencesFilter, PreferencesSort, RouterPush, Tab } from '../types';
@@ -105,13 +106,14 @@ export const InboxProvider = (props: InboxProviderProps) => {
   };
 
   const navigate = (url?: string, target?: Redirect['target']) => {
-    if (!url) {
+    if (!url || !isValidInAppRedirectUrl(url)) {
       return;
     }
 
     const isAbsoluteUrl = !url.startsWith('/');
     if (isAbsoluteUrl) {
-      window.open(url, target ?? DEFAULT_TARGET, DEFAULT_REFERRER);
+      const safeTarget = isValidInAppRedirectTarget(target) ? target : DEFAULT_TARGET;
+      window.open(url, safeTarget, DEFAULT_REFERRER);
 
       return;
     }

--- a/packages/js/src/utils/in-app-redirect-url.ts
+++ b/packages/js/src/utils/in-app-redirect-url.ts
@@ -1,5 +1,6 @@
+// Keep in sync with packages/shared/src/utils/in-app-redirect-url.ts
 export const IN_APP_REDIRECT_URL_REGEX =
-  /^(?:\{\{[^}]*\}\}.*|(?!mailto:)(?:https?:\/\/[^\s/$.?#][^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)|\/[^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)$/;
+  /^(?:\{\{[^}]*\}\}.*|(?!mailto:)(?:https?:\/\/[^\s/$.?#][^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)|\/(?!\/)[^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)$/;
 
 const IN_APP_REDIRECT_TARGETS = ['_self', '_blank', '_parent', '_top', '_unfencedTop'] as const;
 

--- a/packages/js/src/utils/in-app-redirect-url.ts
+++ b/packages/js/src/utils/in-app-redirect-url.ts
@@ -1,0 +1,30 @@
+export const IN_APP_REDIRECT_URL_REGEX =
+  /^(?:\{\{[^}]*\}\}.*|(?!mailto:)(?:https?:\/\/[^\s/$.?#][^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)|\/[^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)$/;
+
+const IN_APP_REDIRECT_TARGETS = ['_self', '_blank', '_parent', '_top', '_unfencedTop'] as const;
+
+type InAppRedirectTarget = (typeof IN_APP_REDIRECT_TARGETS)[number];
+
+export function isValidInAppRedirectUrl(url: string): boolean {
+  return IN_APP_REDIRECT_URL_REGEX.test(url);
+}
+
+export function isValidInAppRedirectTarget(target: unknown): target is InAppRedirectTarget {
+  return typeof target === 'string' && IN_APP_REDIRECT_TARGETS.includes(target as InAppRedirectTarget);
+}
+
+type InAppRedirect = {
+  url: string;
+  target?: InAppRedirectTarget;
+};
+
+export function sanitizeInAppRedirect(url?: string, target?: unknown): InAppRedirect | undefined {
+  if (!url || !isValidInAppRedirectUrl(url)) {
+    return undefined;
+  }
+
+  return {
+    url,
+    ...(isValidInAppRedirectTarget(target) ? { target } : {}),
+  };
+}

--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -21,6 +21,7 @@ import {
   WebSocketEvent,
 } from '../types';
 import { NovuError } from '../utils/errors';
+import { sanitizeInAppRedirect } from '../utils/in-app-redirect-url';
 import type { BaseSocketInterface } from './base-socket';
 
 export const PRODUCTION_SOCKET_URL = 'wss://socket.novu.co';
@@ -96,31 +97,16 @@ const mapToNotification = ({
     primaryAction: primaryCta && {
       label: primaryCta.content,
       isCompleted: actionType === ActionTypeEnum.PRIMARY && actionStatus === NotificationActionStatus.DONE,
-      redirect: primaryCta.url
-        ? {
-            target: primaryCta.target,
-            url: primaryCta.url,
-          }
-        : undefined,
+      redirect: sanitizeInAppRedirect(primaryCta.url, primaryCta.target),
     },
     secondaryAction: secondaryCta && {
       label: secondaryCta.content,
       isCompleted: actionType === ActionTypeEnum.SECONDARY && actionStatus === NotificationActionStatus.DONE,
-      redirect: secondaryCta.url
-        ? {
-            target: secondaryCta.target,
-            url: secondaryCta.url,
-          }
-        : undefined,
+      redirect: sanitizeInAppRedirect(secondaryCta.url, secondaryCta.target),
     },
     channelType: channel,
     tags,
-    redirect: cta.data?.url
-      ? {
-          url: cta.data.url,
-          target: cta.data.target,
-        }
-      : undefined,
+    redirect: sanitizeInAppRedirect(cta.data?.url, cta.data?.target),
     data,
     workflow,
     severity,

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -20,6 +20,7 @@ import {
   WebSocketEvent,
 } from '../types';
 import { NovuError } from '../utils/errors';
+import { sanitizeInAppRedirect } from '../utils/in-app-redirect-url';
 import type { BaseSocketInterface } from './base-socket';
 
 const PRODUCTION_SOCKET_URL = 'https://ws.novu.co';
@@ -91,31 +92,16 @@ const mapToNotification = ({
     primaryAction: primaryCta && {
       label: primaryCta.content,
       isCompleted: actionType === ActionTypeEnum.PRIMARY && actionStatus === NotificationActionStatus.DONE,
-      redirect: primaryCta.url
-        ? {
-            target: primaryCta.target,
-            url: primaryCta.url,
-          }
-        : undefined,
+      redirect: sanitizeInAppRedirect(primaryCta.url, primaryCta.target),
     },
     secondaryAction: secondaryCta && {
       label: secondaryCta.content,
       isCompleted: actionType === ActionTypeEnum.SECONDARY && actionStatus === NotificationActionStatus.DONE,
-      redirect: secondaryCta.url
-        ? {
-            target: secondaryCta.target,
-            url: secondaryCta.url,
-          }
-        : undefined,
+      redirect: sanitizeInAppRedirect(secondaryCta.url, secondaryCta.target),
     },
     channelType: channel,
     tags,
-    redirect: cta.data?.url
-      ? {
-          url: cta.data.url,
-          target: cta.data.target,
-        }
-      : undefined,
+    redirect: sanitizeInAppRedirect(cta.data?.url, cta.data?.target),
     data,
     workflow,
     severity,

--- a/packages/shared/src/utils/in-app-redirect-url.spec.ts
+++ b/packages/shared/src/utils/in-app-redirect-url.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isValidInAppRedirectTarget,
+  isValidInAppRedirectUrl,
+  sanitizeInAppRedirect,
+} from './in-app-redirect-url';
+
+describe('in-app-redirect-url', () => {
+  describe('isValidInAppRedirectUrl', () => {
+    it('should accept http and https URLs', () => {
+      expect(isValidInAppRedirectUrl('https://example.com')).toBe(true);
+      expect(isValidInAppRedirectUrl('http://example.com/path')).toBe(true);
+    });
+
+    it('should accept relative paths', () => {
+      expect(isValidInAppRedirectUrl('/dashboard')).toBe(true);
+      expect(isValidInAppRedirectUrl('/path/{{id}}')).toBe(true);
+    });
+
+    it('should accept template-variable URLs', () => {
+      expect(isValidInAppRedirectUrl('{{url}}')).toBe(true);
+      expect(isValidInAppRedirectUrl('https://example.com/{{id}}')).toBe(true);
+    });
+
+    it('should reject javascript and other unsafe schemes', () => {
+      expect(isValidInAppRedirectUrl('javascript:alert(1)')).toBe(false);
+      expect(isValidInAppRedirectUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+      expect(isValidInAppRedirectUrl('vbscript:msgbox(1)')).toBe(false);
+    });
+
+    it('should reject mailto links', () => {
+      expect(isValidInAppRedirectUrl('mailto:test@example.com')).toBe(false);
+    });
+  });
+
+  describe('isValidInAppRedirectTarget', () => {
+    it('should accept supported window targets', () => {
+      expect(isValidInAppRedirectTarget('_self')).toBe(true);
+      expect(isValidInAppRedirectTarget('_blank')).toBe(true);
+    });
+
+    it('should reject arbitrary targets', () => {
+      expect(isValidInAppRedirectTarget('javascript:')).toBe(false);
+      expect(isValidInAppRedirectTarget('_custom')).toBe(false);
+    });
+  });
+
+  describe('sanitizeInAppRedirect', () => {
+    it('should return a redirect when the URL is valid', () => {
+      expect(sanitizeInAppRedirect('https://example.com', '_self')).toEqual({
+        url: 'https://example.com',
+        target: '_self',
+      });
+    });
+
+    it('should drop invalid URLs and targets', () => {
+      expect(sanitizeInAppRedirect('javascript:alert(1)', '_self')).toBeUndefined();
+      expect(sanitizeInAppRedirect('https://example.com', 'invalid-target')).toEqual({
+        url: 'https://example.com',
+      });
+    });
+  });
+});

--- a/packages/shared/src/utils/in-app-redirect-url.spec.ts
+++ b/packages/shared/src/utils/in-app-redirect-url.spec.ts
@@ -31,6 +31,12 @@ describe('in-app-redirect-url', () => {
     it('should reject mailto links', () => {
       expect(isValidInAppRedirectUrl('mailto:test@example.com')).toBe(false);
     });
+
+    it('should reject protocol-relative URLs', () => {
+      expect(isValidInAppRedirectUrl('//evil.com')).toBe(false);
+      expect(isValidInAppRedirectUrl('//evil.com/path')).toBe(false);
+      expect(isValidInAppRedirectUrl('///evil.com')).toBe(false);
+    });
   });
 
   describe('isValidInAppRedirectTarget', () => {

--- a/packages/shared/src/utils/in-app-redirect-url.ts
+++ b/packages/shared/src/utils/in-app-redirect-url.ts
@@ -1,0 +1,43 @@
+/**
+ * Regex pattern for validating in-app redirect URLs with template variables. Matches three cases:
+ *
+ * 1. URLs that start with template variables like {{variable}}
+ *    - Example: {{variable}}, {{variable}}/path
+ *
+ * 2. Full URLs that may contain template variables anywhere
+ *    - Excludes mailto: links
+ *    - Example: https://example.com, https://example.com/{{variable}}
+ *
+ * 3. Paths starting with / that may contain template variables anywhere
+ *    - Example: /path/to/page, /path/{{variable}}/page
+ */
+export const IN_APP_REDIRECT_URL_REGEX =
+  /^(?:\{\{[^}]*\}\}.*|(?!mailto:)(?:https?:\/\/[^\s/$.?#][^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)|\/[^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)$/;
+
+export const IN_APP_REDIRECT_TARGETS = ['_self', '_blank', '_parent', '_top', '_unfencedTop'] as const;
+
+export type InAppRedirectTarget = (typeof IN_APP_REDIRECT_TARGETS)[number];
+
+export function isValidInAppRedirectUrl(url: string): boolean {
+  return IN_APP_REDIRECT_URL_REGEX.test(url);
+}
+
+export function isValidInAppRedirectTarget(target: unknown): target is InAppRedirectTarget {
+  return typeof target === 'string' && IN_APP_REDIRECT_TARGETS.includes(target as InAppRedirectTarget);
+}
+
+export type InAppRedirect = {
+  url: string;
+  target?: InAppRedirectTarget;
+};
+
+export function sanitizeInAppRedirect(url?: string, target?: unknown): InAppRedirect | undefined {
+  if (!url || !isValidInAppRedirectUrl(url)) {
+    return undefined;
+  }
+
+  return {
+    url,
+    ...(isValidInAppRedirectTarget(target) ? { target } : {}),
+  };
+}

--- a/packages/shared/src/utils/in-app-redirect-url.ts
+++ b/packages/shared/src/utils/in-app-redirect-url.ts
@@ -9,10 +9,11 @@
  *    - Example: https://example.com, https://example.com/{{variable}}
  *
  * 3. Paths starting with / that may contain template variables anywhere
+ *    - Excludes protocol-relative URLs (//host)
  *    - Example: /path/to/page, /path/{{variable}}/page
  */
 export const IN_APP_REDIRECT_URL_REGEX =
-  /^(?:\{\{[^}]*\}\}.*|(?!mailto:)(?:https?:\/\/[^\s/$.?#][^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)|\/[^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)$/;
+  /^(?:\{\{[^}]*\}\}.*|(?!mailto:)(?:https?:\/\/[^\s/$.?#][^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)|\/(?!\/)[^\s{}]*(?:\{\{[^}]*\}\}[^\s{}]*)*)$/;
 
 export const IN_APP_REDIRECT_TARGETS = ['_self', '_blank', '_parent', '_top', '_unfencedTop'] as const;
 

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './checkIsResponseError';
 export * from './connect-subscriber-id';
 export * from './data-filter';
 export * from './env';
+export * from './in-app-redirect-url';
 export * from './issues';
 export * from './locales';
 export * from './managed-integration-credentials';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns v1 inbox redirect handling with the existing v2 in-app redirect URL rules.

## Changes

- Added shared helpers to validate and sanitize in-app redirect URLs and targets
- Reused the shared regex in the in-app control schema to avoid duplicated rules
- Sanitized redirect fields in the inbox notification mapper before returning API responses
- Guarded inbox navigation and websocket notification mapping in `@novu/js`
- Rejected protocol-relative paths (`//host`) in the redirect URL regex

## Behavior

Only `http://`, `https://`, single-slash relative paths, and template-variable URLs are accepted for in-app redirects. Invalid URLs are omitted from API responses, and the inbox renderer ignores them instead of opening them.

## Testing

- Added unit tests for the shared redirect URL helpers, including protocol-relative URL rejection
- Built `@novu/shared`, `@novu/js`, and the monorepo successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1780815260202089?thread_ts=1780815260.202089&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-8a42fcb0-b9bd-58d5-ab66-117bd0ec8569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a42fcb0-b9bd-58d5-ab66-117bd0ec8569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Centralized validation and sanitization for in-app redirect URLs across the monorepo so v1 inbox behavior matches v2 security rules. A shared helper enforces a strict pattern (allowing only http(s), root-relative paths, and template-variable URLs; disallowing protocol-relative and unsafe schemes) and validates redirect targets; invalid or disallowed redirects are removed from API responses and ignored by the inbox UI to prevent unsafe navigation.

## Affected areas

**shared**: New in-app redirect utilities expose IN_APP_REDIRECT_URL_REGEX, allowed redirect targets, isValid... helpers, and sanitizeInAppRedirect to centralize validation and sanitization.

**js**: Inbox navigation (InboxContext.navigate) now validates URLs/targets before opening links; WebSocket and socket mappers (party-socket.ts, socket.ts) use sanitizeInAppRedirect so incoming notifications cannot carry unsafe redirects.

**api**: Notification mapper sanitizes primary/secondary CTA and top-level redirect fields before returning API responses, omitting invalid redirects.

**application-generic**: In-app control schema now reuses the shared IN_APP_REDIRECT_URL_REGEX instead of a local regex to keep validation consistent.

## Key technical decisions

- Centralize redirect validation in `@novu/shared` to avoid duplicated rules and ensure consistent behavior across API and clients.  
- Allowlist redirect targets and omit invalid targets rather than passing them through.  
- Explicitly block protocol-relative URLs (//host) and other unsafe schemes to prevent ambiguous/unsafe navigation.

## Testing

Unit tests added in `@novu/shared` covering valid http/https, relative and template-variable URLs, rejection of unsafe schemes including protocol-relative URLs, target allowlist enforcement, and sanitizeInAppRedirect behavior; the affected packages were built successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes in-app redirect URL validation for v1 inbox handling, aligning it with the stricter v2 rules already enforced elsewhere. A new shared utility (`@novu/shared`) provides `IN_APP_REDIRECT_URL_REGEX`, `sanitizeInAppRedirect`, and `isValidInAppRedirectTarget`, which are consumed by the API notification mapper and (via a kept-in-sync copy) by `@novu/js`.

- **Shared helpers added** in `packages/shared/src/utils/in-app-redirect-url.ts` with the protocol-relative-URL fix (`\/(?!\/)`) baked into the regex, an allowlist for `window.open` targets, and a `sanitizeInAppRedirect` helper that returns `undefined` for invalid URLs and drops invalid targets rather than passing them through.
- **API mapper hardened** — `notification-mapper.ts` now replaces the three inline `url ? { url, target } : undefined` expressions with `sanitizeInAppRedirect`, so invalid stored URLs are silently omitted from responses before they ever reach a client.
- **Client guards added** — `InboxContext.navigate` validates both URL and target before calling `window.open`; WebSocket notification mappers in `party-socket.ts` and `socket.ts` sanitize redirects at the point they are deserialized from the wire.

<h3>Confidence Score: 5/5</h3>

Safe to merge — validation logic is correctly centralized, the protocol-relative URL edge case is fixed at both the shared and JS-copy layers, and tests lock in the expected boundaries.

The change adds defense-in-depth at every layer (schema, API mapper, WebSocket mapper, and client navigate helper) without introducing new code paths that could break existing valid redirects. The regex fix for protocol-relative URLs is consistent across both copies, and the new test suite explicitly covers the previously flagged attack vectors. No silent behavior changes are introduced for valid URLs.

No files require special attention. The kept-in-sync copy in packages/js/src/utils/in-app-redirect-url.ts is the only long-term maintenance concern, and it is already annotated with a comment pointing to the canonical source.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/in-app-redirect-url.ts | New canonical validation helpers; regex correctly blocks protocol-relative URLs with \/(?!\/) and unsafe schemes; target allowlist and sanitization logic are sound. |
| packages/shared/src/utils/in-app-redirect-url.spec.ts | Test suite covers http/https, relative paths, template variables, unsafe schemes, mailto, and protocol-relative URLs (//evil.com, ///evil.com); target allowlist and sanitization edge cases included. |
| packages/js/src/utils/in-app-redirect-url.ts | Kept-in-sync copy for @novu/js (which cannot import @novu/shared); regex and logic are identical to the canonical copy; comment links to source of truth. |
| packages/js/src/ui/context/InboxContext.tsx | navigate() now validates URL with isValidInAppRedirectUrl and sanitizes window.open target through the allowlist; defense-in-depth alongside the mapper-level sanitization. |
| apps/api/src/app/inbox/utils/notification-mapper.ts | Three inline redirect conditionals replaced with sanitizeInAppRedirect; invalid stored URLs and targets are now dropped from API responses rather than forwarded. |
| libs/application-generic/src/schemas/control/in-app-control.schema.ts | Replaces local duplicate regex with the exported IN_APP_REDIRECT_URL_REGEX from @novu/shared; local regex and its JSDoc comment removed cleanly. |
| packages/js/src/ws/party-socket.ts | WebSocket notification mapper now uses sanitizeInAppRedirect for primary/secondary CTA redirects and the top-level CTA redirect, eliminating unsafe pass-through on the wire path. |
| packages/js/src/ws/socket.ts | Same sanitization applied to the alternate socket implementation; mirrors party-socket.ts changes consistently. |
| packages/shared/src/utils/index.ts | Re-exports the new in-app-redirect-url module; change is a single line addition and correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow Author defines redirect URL in template] --> B{Schema validation in-app-control.schema.ts}
    B -- Invalid URL --> C[Schema rejects not stored]
    B -- Valid URL --> D[Stored in notification]
    D --> E[Notification delivered via API or WebSocket]
    E --> F1[API: notification-mapper.ts sanitizeInAppRedirect]
    E --> F2[WS: party-socket/socket sanitizeInAppRedirect]
    F1 --> G{URL valid at delivery time?}
    F2 --> G
    G -- No --> H[redirect omitted from response]
    G -- Yes --> I[Redirect included with valid target only]
    I --> J[Client: InboxContext.navigate]
    J --> K{isValidInAppRedirectUrl?}
    K -- No --> L[return no navigation]
    K -- Yes --> M{Absolute URL?}
    M -- Yes --> N[window.open with allowlisted target]
    M -- No --> O[routerPush or pushState]
```

<sub>Reviews (2): Last reviewed commit: ["fix(shared): reject protocol-relative in..."](https://github.com/novuhq/novu/commit/9f24acfa6ecf82c178579e1b1c84933e91570925) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36059699)</sub>

<!-- /greptile_comment -->