### PR TITLE
chore(dashboard): update workflows page title to Workflows bneta fixes NV-7972

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -252,8 +252,10 @@ export const WorkflowsPage = () => {
 
   return (
     <>
-      <PageMeta title="Workflows" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
+      <PageMeta title="Workflows bneta" />
+      <DashboardLayout
+        headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows bneta</h1>}
+      >
         <div className="flex h-full w-full flex-col">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-2 py-2.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the workflows page title in the dashboard from "Workflows" to "Workflows bneta" in both the page header and browser tab (`PageMeta`).

## Changes

- Updated `PageMeta` title in `apps/dashboard/src/pages/workflows.tsx`
- Updated the page header `<h1>` to match

## Screenshot

![Workflows page showing updated title](https://cursor.com/artifacts/c/art-851ad9bb-c473-4c5d-9f7d-34c199b822c6)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5610dde-efa7-4e97-a9c0-3a926d44a577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5610dde-efa7-4e97-a9c0-3a926d44a577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The Workflows page title was updated to display "Workflows bneta" instead of "Workflows". This change was applied in both the browser tab metadata (PageMeta) and the visible page header, ensuring consistent branding across the interface.

## Affected areas

**dashboard**: Updated the Workflows page title in both the `PageMeta` component and the `<h1>` header element to reflect the "bneta" designation.

## Testing

No tests were added, as this is a simple UI text change that can be verified visually by viewing the workflows page in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Workflows page title in `apps/dashboard/src/pages/workflows.tsx`, but it introduces "bneta" as a suffix in both the `PageMeta` title and the `<h1>` heading — a string that looks like accidental debug text rather than an intentional label.

- The `PageMeta` title is changed from `"Workflows"` to `"Workflows bneta"`, which will appear as the browser tab title for all users.
- The visible page heading `<h1>` is similarly changed to `"Workflows bneta"`.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — the change ships a visibly broken page title to all users in both the browser tab and the page heading.

The only change in this PR introduces the string "bneta" into the Workflows page title and heading, which will be immediately visible to every user who visits the page. This looks like debug text that was accidentally committed rather than a deliberate feature.

apps/dashboard/src/pages/workflows.tsx — both the PageMeta title and the h1 heading contain the erroneous "bneta" suffix.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/workflows.tsx | Page title and <h1> heading changed to "Workflows bneta" — "bneta" is a debug artifact that must be removed before merging. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[WorkflowsPage renders] --> B[PageMeta title='Workflows bneta']
    A --> C[DashboardLayout headerStartItems]
    C --> D["<h1>Workflows bneta</h1>"]
    B --> E[Browser tab shows 'Workflows bneta']
    D --> F[Page heading shows 'Workflows bneta']
    style B fill:#f66,color:#fff
    style D fill:#f66,color:#fff
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fpages%2Fworkflows.tsx%3A255-258%0A**Stray%20debug%20text%20in%20page%20title%20and%20heading**%20%E2%80%94%20%22bneta%22%20appears%20to%20be%20a%20leftover%20debug%2Ftest%20artifact%20and%20should%20not%20be%20shipped%20to%20users.%20The%20browser%20tab%20and%20page%20heading%20will%20both%20display%20%22Workflows%20bneta%22%20in%20production.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3CPageMeta%20title%3D%22Workflows%22%20%2F%3E%0A%20%20%20%20%20%20%3CDashboardLayout%0A%20%20%20%20%20%20%20%20headerStartItems%3D%7B%3Ch1%20className%3D%22text-foreground-950%20flex%20items-center%20gap-1%22%3EWorkflows%3C%2Fh1%3E%7D%0A%20%20%20%20%20%20%3E%0A%60%60%60%0A%0A&pr=11454&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/pages/workflows.tsx:255-258
**Stray debug text in page title and heading** — "bneta" appears to be a leftover debug/test artifact and should not be shipped to users. The browser tab and page heading will both display "Workflows bneta" in production.

```suggestion
      <PageMeta title="Workflows" />
      <DashboardLayout
        headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}
      >
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(dashboard): update workflows page ..."](https://github.com/novuhq/novu/commit/a75c422af7c0fd7f5d2eadc903459da402c9bf71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36061998)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->