### PR TITLE
fix(novu): update connect welcome CTA for keyless flow fixes NV-7974

### DIFF
--- a/packages/novu/src/commands/connect/ui/store.ts
+++ b/packages/novu/src/commands/connect/ui/store.ts
@@ -6,7 +6,7 @@ import type { GeneratedAgentPreviewResult, PickAgentIntegrationResult, PickResul
 export type Phase =
   | {
       kind: 'welcome';
-      /** Called when the user hits Enter to authorize. Pipeline awaits this before opening the browser. */
+      /** Called when the user hits Enter to begin. Pipeline awaits this before bootstrapping the session. */
       resolve: () => void;
     }
   | { kind: 'auth'; dashboardUrl: string | null; status: string }

--- a/packages/novu/src/commands/connect/ui/ui.ts
+++ b/packages/novu/src/commands/connect/ui/ui.ts
@@ -12,7 +12,7 @@ export interface ConnectUI {
   /**
    * First screen the user sees. Renders a welcome message and waits for the
    * user to hit Enter before resolving — this is the explicit consent gate
-   * for opening the browser to authorize the CLI. The Ink implementation
+   * before the connect pipeline starts. The Ink implementation
    * delays the visible text until after the orb's entry animation finishes
    * so the welcome lands on a fully-formed orb instead of mid-grow.
    */

--- a/packages/novu/src/commands/connect/ui/welcome-content.tsx
+++ b/packages/novu/src/commands/connect/ui/welcome-content.tsx
@@ -81,7 +81,7 @@ export function WelcomeContent({ onContinue }: { onContinue: () => void }): Reac
       {revealComplete ? (
         <>
           <WelcomeAnimatedTagline />
-          <Text color="cyan">Press Enter to sign in or create an account →</Text>
+          <Text color="cyan">Press Enter to connect your first agent →</Text>
         </>
       ) : (
         // Hold the layout open while the headline finishes dithering so the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `npx novu connect` welcome screen still told users to "sign in or create an account", but the default interactive flow is now keyless — no account is required to get started.

Updated the welcome CTA to match the actual next step:

**Before:** `Press Enter to sign in or create an account →`
**After:** `Press Enter to connect your first agent →`

Also refreshed related comments in the connect UI layer so they no longer describe browser authorization as the welcome-screen gate.

## Why this copy

- Aligns with the animated tagline ("Spin up … and connect it to Slack, Telegram, MS Teams…")
- Matches the existing CTA pattern used elsewhere in the connect flow (`Press Enter to … →`)
- Sets the right expectation for keyless users — they are connecting an agent, not signing up

## Test plan

- [ ] Run `npx novu connect` interactively and confirm the welcome screen shows the updated CTA after the reveal animation
- [ ] Press Enter and verify the keyless bootstrap continues as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91f36b78-2aa1-422c-9cfc-bea7b9c7cca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91f36b78-2aa1-422c-9cfc-bea7b9c7cca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Updated the npx novu connect welcome-screen CTA and accompanying JSDoc to reflect the default keyless interactive flow: the CTA now reads "Press Enter to connect your first agent →" (previously "Press Enter to sign in or create an account →"). JSDoc comments in the connect UI were refreshed to describe bootstrapping the session/starting the connect pipeline rather than framing the step as a browser-authorization gate. This aligns UI copy with the keyless experience and removes misleading authorization language.

## Affected areas

**js** — Connect command UI text and documentation were updated (welcome CTA and JSDoc) so the interactive prompt and internal comments describe the keyless bootstrap/start-of-pipeline behavior instead of suggesting a browser sign-in/authorization step.

## Testing

Manual verification: run `npx novu connect` interactively, confirm the updated CTA appears after the reveal animation, and press Enter to verify the existing keyless bootstrap flow continues unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates copy and inline documentation in the `npx novu connect` welcome screen to reflect that the flow is now keyless — no browser authorization or account creation is required upfront.

- **`welcome-content.tsx`**: CTA text changed from `\"Press Enter to sign in or create an account →\"` to `\"Press Enter to connect your first agent →\"`.
- **`store.ts`** and **`ui.ts`**: JSDoc comments describing the welcome phase updated to replace browser-authorization language with accurate \"bootstrap session / connect pipeline starts\" descriptions.

<h3>Confidence Score: 5/5</h3>

Pure copy and comment update with no logic, behavior, or API contract changes — safe to merge.

All three changed files contain only string literals and JSDoc comments. No runtime logic, state transitions, or interfaces are altered; the resolve() contract on the welcome phase is untouched. There is nothing here that could introduce a regression.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/ui/welcome-content.tsx | CTA text updated from "sign in or create an account" to "connect your first agent" to match the keyless flow |
| packages/novu/src/commands/connect/ui/store.ts | JSDoc comment on welcome Phase updated to reflect "begin / bootstrap session" instead of "authorize / open browser" |
| packages/novu/src/commands/connect/ui/ui.ts | ConnectUI interface JSDoc updated to remove browser-authorization phrasing and describe the Enter-to-begin gate accurately |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant WelcomeScreen
    participant ConnectPipeline

    User->>WelcomeScreen: npx novu connect
    WelcomeScreen-->>User: Orb animation + tagline
    WelcomeScreen-->>User: "Press Enter to connect your first agent →"
    User->>WelcomeScreen: Enter key
    WelcomeScreen->>ConnectPipeline: resolve() — bootstrap keyless session
    ConnectPipeline-->>User: Keyless flow continues (no browser auth)
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into cursor/update-c..."](https://github.com/novuhq/novu/commit/31aa9b39f9a88a8da193d87772714560a44c1d29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36083763)</sub>

<!-- /greptile_comment -->