### PR TITLE
fix(novu,dashboard): use dashboard domain for novu connect flows

### DIFF
--- a/apps/dashboard/src/components/mobile-desktop-prompt.tsx
+++ b/apps/dashboard/src/components/mobile-desktop-prompt.tsx
@@ -32,7 +32,7 @@ export function MobileDesktopPrompt() {
 
   const brandLabel = isConnect ? 'Novu Connect' : 'Novu';
   const productCopy = isConnect ? 'Novu Connect' : "Novu's dashboard";
-  const desktopUrl = isConnect ? (NOVU_CONNECT_HOSTNAME || 'connect.novu.co') : 'dashboard.novu.co';
+  const desktopUrl = isConnect ? NOVU_CONNECT_HOSTNAME || 'dashboard.novu.co' : 'dashboard.novu.co';
 
   return (
     <div className="animate-in slide-in-from-bottom-4 fade-in fixed inset-x-0 bottom-0 z-[100] p-3 duration-500 md:hidden">

--- a/packages/novu/src/commands/connect/types.ts
+++ b/packages/novu/src/commands/connect/types.ts
@@ -13,7 +13,7 @@ export interface ConnectCommandOptions {
   region: CloudRegionEnum;
   apiUrl: string;
   dashboardUrl: string;
-  /** Browser-auth UI for `novu connect` (e.g. connect.novu.co); distinct from `dashboardUrl`. */
+  /** Browser-auth UI for `novu connect` (e.g. dashboard.novu.co). Defaults to `dashboardUrl` per region. */
   connectDashboardUrl: string;
   /** Pre-fill the agent description, skipping the input screen. Enables non-interactive runs. */
   prompt?: string;

--- a/packages/novu/src/commands/dev/enums.ts
+++ b/packages/novu/src/commands/dev/enums.ts
@@ -17,11 +17,5 @@ export enum ApiUrlEnum {
   STAGING = 'https://api.novu-staging.co',
 }
 
-/** Browser-auth surface for `novu connect` (distinct from the main dashboard). */
-export enum ConnectDashboardUrlEnum {
-  PROD = 'https://connect.novu.co',
-  STAGING = 'https://connect.novu-staging.co',
-}
-
 export const LOCAL_API_URL = 'https://api.novu.localhost';
 export const LOCAL_DASHBOARD_URL = 'https://dashboard.novu.localhost';

--- a/packages/novu/src/commands/dev/resolve-region-urls.spec.ts
+++ b/packages/novu/src/commands/dev/resolve-region-urls.spec.ts
@@ -8,7 +8,15 @@ describe('resolveRegionUrls', () => {
 
     expect(urls.apiUrl).toBe('https://api.novu.co');
     expect(urls.dashboardUrl).toBe('https://dashboard.novu.co');
-    expect(urls.connectDashboardUrl).toBe('https://connect.novu.co');
+    expect(urls.connectDashboardUrl).toBe('https://dashboard.novu.co');
+  });
+
+  it('maps eu region to eu production URLs', () => {
+    const urls = getRegionUrls(CloudRegionEnum.EU);
+
+    expect(urls.apiUrl).toBe('https://eu.api.novu.co');
+    expect(urls.dashboardUrl).toBe('https://eu.dashboard.novu.co');
+    expect(urls.connectDashboardUrl).toBe('https://eu.dashboard.novu.co');
   });
 
   it('maps staging region to staging stack URLs', () => {
@@ -16,7 +24,7 @@ describe('resolveRegionUrls', () => {
 
     expect(urls.apiUrl).toBe('https://api.novu-staging.co');
     expect(urls.dashboardUrl).toBe('https://dashboard.novu-staging.co');
-    expect(urls.connectDashboardUrl).toBe('https://connect.novu-staging.co');
+    expect(urls.connectDashboardUrl).toBe('https://dashboard.novu-staging.co');
   });
 
   it('maps local region to local dev URLs with connect dashboard matching dashboard', () => {

--- a/packages/novu/src/commands/dev/resolve-region-urls.ts
+++ b/packages/novu/src/commands/dev/resolve-region-urls.ts
@@ -1,11 +1,4 @@
-import {
-  ApiUrlEnum,
-  CloudRegionEnum,
-  ConnectDashboardUrlEnum,
-  DashboardUrlEnum,
-  LOCAL_API_URL,
-  LOCAL_DASHBOARD_URL,
-} from './enums';
+import { ApiUrlEnum, CloudRegionEnum, DashboardUrlEnum, LOCAL_API_URL, LOCAL_DASHBOARD_URL } from './enums';
 
 export interface RegionUrlSet {
   apiUrl: string;
@@ -22,17 +15,9 @@ export interface RegionUrlOverrides {
 export function getRegionUrls(region: CloudRegionEnum): RegionUrlSet {
   switch (region) {
     case CloudRegionEnum.EU:
-      return {
-        apiUrl: ApiUrlEnum.EU,
-        dashboardUrl: DashboardUrlEnum.EU,
-        connectDashboardUrl: ConnectDashboardUrlEnum.PROD,
-      };
+      return buildRegionUrlSet(ApiUrlEnum.EU, DashboardUrlEnum.EU);
     case CloudRegionEnum.STAGING:
-      return {
-        apiUrl: ApiUrlEnum.STAGING,
-        dashboardUrl: DashboardUrlEnum.STAGING,
-        connectDashboardUrl: ConnectDashboardUrlEnum.STAGING,
-      };
+      return buildRegionUrlSet(ApiUrlEnum.STAGING, DashboardUrlEnum.STAGING);
     case CloudRegionEnum.LOCAL:
       return {
         apiUrl: LOCAL_API_URL,
@@ -41,12 +26,16 @@ export function getRegionUrls(region: CloudRegionEnum): RegionUrlSet {
       };
     case CloudRegionEnum.US:
     default:
-      return {
-        apiUrl: ApiUrlEnum.US,
-        dashboardUrl: DashboardUrlEnum.US,
-        connectDashboardUrl: ConnectDashboardUrlEnum.PROD,
-      };
+      return buildRegionUrlSet(ApiUrlEnum.US, DashboardUrlEnum.US);
   }
+}
+
+function buildRegionUrlSet(apiUrl: string, dashboardUrl: string): RegionUrlSet {
+  return {
+    apiUrl,
+    dashboardUrl,
+    connectDashboardUrl: dashboardUrl,
+  };
 }
 
 /** Apply explicit CLI overrides on top of region defaults. */

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -144,7 +144,7 @@ program
   .option('-d, --dashboard-url <url>', 'Override the Novu Dashboard URL (default follows --region)')
   .option(
     '--connect-dashboard-url <url>',
-    'Override the Connect browser-auth URL (default follows --region, e.g. connect.novu.co)'
+    'Override the Connect browser-auth URL (default follows --region, e.g. dashboard.novu.co)'
   )
   .option('--region <region>', `Novu region (${Object.values(CloudRegionEnum).join(' | ')})`, CloudRegionEnum.US)
   .option('--prompt <text>', 'Pre-fill the agent description (skips the input screen)')


### PR DESCRIPTION
### What changed? Why was the change needed?

Novu Connect CLI flows previously routed browser-auth and dashboard redirects through the separate `connect.novu.co` subdomain (and `connect.novu-staging.co` in staging). Connect is now served from the regional dashboard host instead.

- Removed `ConnectDashboardUrlEnum` and aligned `connectDashboardUrl` with `dashboardUrl` per region (US, EU, staging, local)
- Fixed EU connect URLs, which previously pointed at the US connect host
- Updated CLI help text, types, and tests
- Updated the dashboard mobile prompt fallback hostname

The API already resolves connect claim links via `DASHBOARD_URL` / `FRONT_BASE_URL`, so no backend changes were required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Novu Connect CLI flows now route browser-auth and dashboard redirects through regional dashboard domains instead of separate `connect.novu.co` subdomains. This unifies the URL scheme by deriving `connectDashboardUrl` from `dashboardUrl` per region (US, EU, staging, local) rather than maintaining a separate `ConnectDashboardUrlEnum`. The change fixes EU connect URLs that previously pointed to the US host, updates CLI help text and inline documentation, and ensures the mobile prompt fallback uses the regional dashboard host.

## Affected areas

- **dashboard**: The `MobileDesktopPrompt` component now computes the desktop URL for the Connect variant using `NOVU_CONNECT_HOSTNAME` (defaulting to `dashboard.novu.co`) instead of the hardcoded `connect.novu.co`.
- **novu**: The CLI package's connect command and dev utilities were refactored. `ConnectDashboardUrlEnum` was removed from `enums.ts`, and `resolve-region-urls.ts` now uses a shared `buildRegionUrlSet()` helper to derive `connectDashboardUrl` from `dashboardUrl`. The `ConnectCommandOptions` JSDoc was updated to reflect that `connectDashboardUrl` defaults to `dashboardUrl` per region, and CLI help text for `--connect-dashboard-url` was updated to show the new default example.

## Key technical decisions

- **Removed `ConnectDashboardUrlEnum`** from the dev enums module, consolidating URL configuration into a single regional mapping.
- **Introduced `buildRegionUrlSet()` helper** in `resolve-region-urls.ts` to consistently derive `connectDashboardUrl` from `dashboardUrl` for all regions.
- The `--connect-dashboard-url` CLI override behavior remains unchanged for custom deployments.

## Testing

Unit tests in `resolve-region-urls.spec.ts` were updated to verify that `connectDashboardUrl` now matches the corresponding regional dashboard URL instead of the legacy `connect.*` hostnames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — URL/config change only; no visual UI changes.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- `--connect-dashboard-url` override behavior is unchanged for custom deployments
- Remaining `domainconnect.novu.co` references are for Domain Connect DNS, not Novu Connect

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates Novu Connect browser-auth flows from the separate `connect.novu.co` / `connect.novu-staging.co` subdomains to the regional dashboard host, aligning `connectDashboardUrl` with `dashboardUrl` across all regions. It also corrects a pre-existing bug where EU users were routed to the US connect endpoint instead of the EU one.

- Removed `ConnectDashboardUrlEnum` and introduced a `buildRegionUrlSet` helper so `connectDashboardUrl` always mirrors `dashboardUrl`; the `--connect-dashboard-url` override flag is preserved for custom deployments.
- Fixed the EU region: previously it resolved `connectDashboardUrl` to `https://connect.novu.co` (the US host); it now correctly uses `https://eu.dashboard.novu.co`.
- Updated the dashboard mobile prompt fallback hostname, CLI help text, and JSDoc comments to reflect the new routing; a new EU region test was added to the spec.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are URL/config-only with no logic regressions; the EU routing bug fix is clearly correct.

The changes are narrow and well-tested: connectDashboardUrl is now derived from dashboardUrl via a simple helper, the removed enum had no remaining references, and the new EU test covers the previously broken case. No auth, data, or API logic was modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/dev/resolve-region-urls.ts | Simplified with buildRegionUrlSet helper; connectDashboardUrl now always equals dashboardUrl per region; also fixes a pre-existing bug where EU region was mapped to the US connect endpoint |
| packages/novu/src/commands/dev/enums.ts | Removed ConnectDashboardUrlEnum; no remaining references found; clean deletion |
| packages/novu/src/commands/dev/resolve-region-urls.spec.ts | Tests updated to assert connectDashboardUrl matches dashboardUrl; new EU region test added to cover the previously untested (and previously broken) EU case |
| apps/dashboard/src/components/mobile-desktop-prompt.tsx | Fallback hostname for Novu Connect changed from connect.novu.co to dashboard.novu.co; only used as display text, not as a navigation URL |
| packages/novu/src/commands/connect/types.ts | JSDoc comment for connectDashboardUrl updated to reflect new default behavior; no functional change |
| packages/novu/src/index.ts | CLI help text for --connect-dashboard-url updated with correct example hostname |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[novu connect CLI] --> B{region?}
    B -->|US| C[buildRegionUrlSet\napiUrl: api.novu.co\ndashboardUrl: dashboard.novu.co]
    B -->|EU| D[buildRegionUrlSet\napiUrl: eu.api.novu.co\ndashboardUrl: eu.dashboard.novu.co]
    B -->|STAGING| E[buildRegionUrlSet\napiUrl: api.novu-staging.co\ndashboardUrl: dashboard.novu-staging.co]
    B -->|LOCAL| F[Local URLs\ndashboard.novu.localhost]
    C --> G[connectDashboardUrl = dashboardUrl]
    D --> G
    E --> G
    F --> G
    G --> H{--connect-dashboard-url override?}
    H -->|yes| I[Use custom URL]
    H -->|no| J[Use dashboardUrl]
```

<sub>Reviews (1): Last reviewed commit: ["fix(novu,dashboard): use dashboard domai..."](https://github.com/novuhq/novu/commit/69387ccddbf13f9710eb096e029b74a7b157640d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36143977)</sub>

<!-- /greptile_comment -->