### PR TITLE
fix(api-service): harden keyless flow against IP collision and claim RBAC bypass fixes NV-7978

### DIFF
--- a/apps/api/src/app/connect/connect.controller.ts
+++ b/apps/api/src/app/connect/connect.controller.ts
@@ -1,6 +1,15 @@
-import { Body, ClassSerializerInterceptor, Controller, HttpCode, HttpStatus, Post, UseInterceptors } from '@nestjs/common';
+import {
+  Body,
+  ClassSerializerInterceptor,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseInterceptors,
+} from '@nestjs/common';
 import { ApiExcludeController, ApiOperation } from '@nestjs/swagger';
-import { UserSessionData } from '@novu/shared';
+import { RequirePermissions } from '@novu/application-generic';
+import { PermissionsEnum, UserSessionData } from '@novu/shared';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
 import { UserSession } from '../shared/framework/user.decorator';
@@ -18,6 +27,7 @@ export class ConnectController {
   constructor(private readonly claimKeylessConnectUsecase: ClaimKeylessConnect) {}
 
   @Post('/claim')
+  @RequirePermissions(PermissionsEnum.ENVIRONMENT_WRITE)
   @HttpCode(HttpStatus.OK)
   @ApiResponse(ClaimKeylessConnectResponseDto)
   @ApiOperation({

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -59,6 +59,7 @@ import { EnvironmentResponseDto } from '../../../environments-v1/dtos/environmen
 import { GenerateUniqueApiKey } from '../../../environments-v1/usecases/generate-unique-api-key/generate-unique-api-key.usecase';
 import { CreateNovuIntegrationsCommand } from '../../../integrations/usecases/create-novu-integrations/create-novu-integrations.command';
 import { CreateNovuIntegrations } from '../../../integrations/usecases/create-novu-integrations/create-novu-integrations.usecase';
+import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
 import { GetOrganizationSettingsCommand } from '../../../organization/usecases/get-organization-settings/get-organization-settings.command';
 import { GetOrganizationSettings } from '../../../organization/usecases/get-organization-settings/get-organization-settings.usecase';
 import { ScheduleDto } from '../../../shared/dtos/schedule';
@@ -72,13 +73,12 @@ import {
   KEYLESS_WORKFLOW_IDENTIFIER,
 } from '../../utils';
 import { validateContextHmacEncryption, validateHmacEncryption } from '../../utils/encryption';
+import { isKeylessEnvironmentExpired } from '../../utils/keyless-expiry';
 import { NotificationsCountCommand } from '../notifications-count/notifications-count.command';
 import { NotificationsCount } from '../notifications-count/notifications-count.usecase';
 import { UpdatePreferencesCommand } from '../update-preferences/update-preferences.command';
 import { UpdatePreferences } from '../update-preferences/update-preferences.usecase';
 import { SessionCommand } from './session.command';
-import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
-import { isKeylessEnvironmentExpired } from '../../utils/keyless-expiry';
 
 const ALLOWED_ORIGINS_REGEX = new RegExp(process.env.FRONT_BASE_URL || '');
 const MAX_NOTIFICATIONS_COUNT = 100;
@@ -409,23 +409,14 @@ export class Session {
     return subscriber;
   }
 
-  private async getApplicationIdentifier(
-    requestData: SubscriberSessionRequestDto,
-    clientIp?: string
-  ): Promise<string> {
+  private async getApplicationIdentifier(requestData: SubscriberSessionRequestDto, clientIp?: string): Promise<string> {
     const isKeylessInitialize = !requestData.applicationIdentifier;
     const isKeyless = requestData.applicationIdentifier?.includes(this.KEYLESS_ENVIRONMENT_PREFIX);
     const isKeylessExpired = isKeyless ? isKeylessEnvironmentExpired(requestData.applicationIdentifier) : false;
 
     if (isKeylessInitialize || isKeylessExpired) {
-      const decision = await this.keylessAbuseGuard.reserveEnvCreation(clientIp);
-
-      if (decision.action === 'reuse') {
-        return decision.applicationIdentifier;
-      }
-
+      await this.keylessAbuseGuard.assertEnvCreationAllowed(clientIp);
       const environment = await this.processKeyless();
-      await this.keylessAbuseGuard.rememberLastEnv(clientIp, environment.identifier);
 
       return environment.identifier;
     }

--- a/apps/api/src/app/inbox/utils/keyless-expiry.ts
+++ b/apps/api/src/app/inbox/utils/keyless-expiry.ts
@@ -48,7 +48,3 @@ export function isKeylessEnvironmentExpired(applicationIdentifier: string | unde
 
   return false;
 }
-
-export function keylessEnvironmentRetentionTtlSeconds(): number {
-  return KEYLESS_RETENTION_TIME_IN_HOURS * 3600;
-}

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.spec.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.spec.ts
@@ -5,7 +5,6 @@ import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { KEYLESS_ENVIRONMENT_PREFIX } from '../inbox/utils/keyless.constants';
 import {
   KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY,
   KEYLESS_GENERATE_CAP_PER_IP_PER_DAY,
@@ -47,31 +46,16 @@ describe('KeylessAbuseGuardService', () => {
   it('allows env creation when the daily counter is below the cap', async () => {
     cacheService.eval.resolves(1);
 
-    const decision = await guard.reserveEnvCreation(clientIp);
+    await guard.assertEnvCreationAllowed(clientIp);
 
-    expect(decision).to.deep.equal({ action: 'create' });
     expect(cacheService.eval.calledOnce).to.be.true;
   });
 
-  it('reuses the last valid keyless env when the env-create cap is exceeded', async () => {
-    const timestampHex = Buffer.alloc(4);
-    timestampHex.writeUInt32BE(Math.floor(Date.now() / 1000), 0);
-    const identifier = `${KEYLESS_ENVIRONMENT_PREFIX}${timestampHex.toString('hex')}_abcd`;
-
+  it('rejects env creation when the cap is exceeded', async () => {
     cacheService.eval.resolves(KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY + 1);
-    cacheService.get.resolves(identifier);
-
-    const decision = await guard.reserveEnvCreation(clientIp);
-
-    expect(decision).to.deep.equal({ action: 'reuse', applicationIdentifier: identifier });
-  });
-
-  it('rejects env creation when the cap is exceeded and no valid last env exists', async () => {
-    cacheService.eval.resolves(KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY + 1);
-    cacheService.get.resolves(null);
 
     try {
-      await guard.reserveEnvCreation(clientIp);
+      await guard.assertEnvCreationAllowed(clientIp);
       expect.fail('Expected HttpException');
     } catch (error) {
       expect(error).to.be.instanceOf(HttpException);
@@ -81,7 +65,7 @@ describe('KeylessAbuseGuardService', () => {
 
   it('rejects env creation when client IP is missing and cache is enabled', async () => {
     try {
-      await guard.reserveEnvCreation(undefined);
+      await guard.assertEnvCreationAllowed(undefined);
       expect.fail('Expected HttpException');
     } catch (error) {
       expect(error).to.be.instanceOf(HttpException);
@@ -94,20 +78,9 @@ describe('KeylessAbuseGuardService', () => {
   it('skips env caps when cache is disabled', async () => {
     cacheService.cacheEnabled.returns(false);
 
-    const decision = await guard.reserveEnvCreation(undefined);
+    await guard.assertEnvCreationAllowed(undefined);
 
-    expect(decision).to.deep.equal({ action: 'create' });
     expect(cacheService.eval.called).to.be.false;
-  });
-
-  it('persists the last env identifier after successful creation', async () => {
-    const identifier = `${KEYLESS_ENVIRONMENT_PREFIX}deadbeef_abcd`;
-
-    await guard.rememberLastEnv(clientIp, identifier);
-
-    expect(cacheService.set.calledOnce).to.be.true;
-    expect(cacheService.set.firstCall.args[0]).to.include(clientIp);
-    expect(cacheService.set.firstCall.args[1]).to.equal(identifier);
   });
 
   it('rejects generate when the per-IP daily cap is exceeded', async () => {
@@ -144,7 +117,9 @@ describe('KeylessAbuseGuardService', () => {
     }
 
     expect(featureFlagsService.getFlag.calledOnce).to.be.true;
-    expect(featureFlagsService.getFlag.firstCall.args[0].key).to.equal(FeatureFlagsKeysEnum.IS_KEYLESS_AGENT_AI_ENABLED);
+    expect(featureFlagsService.getFlag.firstCall.args[0].key).to.equal(
+      FeatureFlagsKeysEnum.IS_KEYLESS_AGENT_AI_ENABLED
+    );
   });
 
   it('does not gate non-keyless organizations for AI enablement', async () => {

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
@@ -32,37 +32,16 @@ export class KeylessAbuseGuardService {
   ) {}
 
   async assertEnvCreationAllowed(clientIp?: string): Promise<void> {
-    if (!this.cacheService.cacheEnabled() || KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY === 0) {
-      return;
-    }
-
-    if (!clientIp) {
-      throw new HttpException(MISSING_CLIENT_IP_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
-    }
-
-    const counterKey = this.dailyCounterKey('env_create', clientIp);
-    const nextCount = await this.incrementDailyCounter(counterKey);
-
-    if (nextCount > KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY) {
-      throw new HttpException(ENV_CREATE_LIMIT_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
-    }
+    await this.assertWithinDailyCap(
+      'env_create',
+      clientIp,
+      KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY,
+      ENV_CREATE_LIMIT_MESSAGE
+    );
   }
 
   async assertGenerateAllowed(clientIp?: string): Promise<void> {
-    if (!this.cacheService.cacheEnabled() || KEYLESS_GENERATE_CAP_PER_IP_PER_DAY === 0) {
-      return;
-    }
-
-    if (!clientIp) {
-      throw new HttpException(MISSING_CLIENT_IP_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
-    }
-
-    const counterKey = this.dailyCounterKey('generate', clientIp);
-    const nextCount = await this.incrementDailyCounter(counterKey);
-
-    if (nextCount > KEYLESS_GENERATE_CAP_PER_IP_PER_DAY) {
-      throw new HttpException(GENERATE_LIMIT_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
-    }
+    await this.assertWithinDailyCap('generate', clientIp, KEYLESS_GENERATE_CAP_PER_IP_PER_DAY, GENERATE_LIMIT_MESSAGE);
   }
 
   async isKeylessAgentAiEnabled(organizationId: string): Promise<boolean> {
@@ -97,6 +76,27 @@ export class KeylessAbuseGuardService {
 
     if (count >= KEYLESS_MAX_AGENTS_PER_ENV) {
       throw new HttpException(MANAGED_AGENT_CAP_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
+    }
+  }
+
+  private async assertWithinDailyCap(
+    kind: 'env_create' | 'generate',
+    clientIp: string | undefined,
+    cap: number,
+    limitMessage: string
+  ): Promise<void> {
+    if (!this.cacheService.cacheEnabled() || cap === 0) {
+      return;
+    }
+
+    if (!clientIp) {
+      throw new HttpException(MISSING_CLIENT_IP_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    const nextCount = await this.incrementDailyCounter(this.dailyCounterKey(kind, clientIp));
+
+    if (nextCount > cap) {
+      throw new HttpException(limitMessage, HttpStatus.TOO_MANY_REQUESTS);
     }
   }
 

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
@@ -2,8 +2,6 @@ import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { CacheService, FeatureFlagsService } from '@novu/application-generic';
 import { AgentRepository } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
-import { isKeylessEnvironmentExpired, keylessEnvironmentRetentionTtlSeconds } from '../inbox/utils/keyless-expiry';
-import { KEYLESS_ENVIRONMENT_PREFIX } from '../inbox/utils/keyless.constants';
 import {
   INCR_WITH_EXPIRE_SCRIPT,
   KEYLESS_DAILY_COUNTER_TTL_SECONDS,
@@ -11,10 +9,6 @@ import {
   KEYLESS_GENERATE_CAP_PER_IP_PER_DAY,
   KEYLESS_MAX_AGENTS_PER_ENV,
 } from './keyless-abuse.constants';
-
-export type KeylessEnvCreationDecision =
-  | { action: 'create' }
-  | { action: 'reuse'; applicationIdentifier: string };
 
 const ENV_CREATE_LIMIT_MESSAGE =
   'Daily keyless demo limit reached. Sign up for a free Novu account or try again tomorrow.';
@@ -37,9 +31,9 @@ export class KeylessAbuseGuardService {
     private readonly agentRepository: AgentRepository
   ) {}
 
-  async reserveEnvCreation(clientIp?: string): Promise<KeylessEnvCreationDecision> {
+  async assertEnvCreationAllowed(clientIp?: string): Promise<void> {
     if (!this.cacheService.cacheEnabled() || KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY === 0) {
-      return { action: 'create' };
+      return;
     }
 
     if (!clientIp) {
@@ -49,28 +43,9 @@ export class KeylessAbuseGuardService {
     const counterKey = this.dailyCounterKey('env_create', clientIp);
     const nextCount = await this.incrementDailyCounter(counterKey);
 
-    if (nextCount <= KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY) {
-      return { action: 'create' };
+    if (nextCount > KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY) {
+      throw new HttpException(ENV_CREATE_LIMIT_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
     }
-
-    const lastEnv = await this.getLastEnvApplicationIdentifier(clientIp);
-
-    if (lastEnv && !isKeylessEnvironmentExpired(lastEnv)) {
-      return { action: 'reuse', applicationIdentifier: lastEnv };
-    }
-
-    throw new HttpException(ENV_CREATE_LIMIT_MESSAGE, HttpStatus.TOO_MANY_REQUESTS);
-  }
-
-  async rememberLastEnv(clientIp: string | undefined, applicationIdentifier: string): Promise<void> {
-    if (!clientIp || !this.cacheService.cacheEnabled()) {
-      return;
-    }
-
-    const lastEnvKey = this.lastEnvKey(clientIp);
-    await this.cacheService.set(lastEnvKey, applicationIdentifier, {
-      ttl: keylessEnvironmentRetentionTtlSeconds(),
-    });
   }
 
   async assertGenerateAllowed(clientIp?: string): Promise<void> {
@@ -137,10 +112,6 @@ export class KeylessAbuseGuardService {
     return `keyless:${kind}:${date}:${clientIp}`;
   }
 
-  private lastEnvKey(clientIp: string): string {
-    return `keyless:last_env:${clientIp}`;
-  }
-
   private async incrementDailyCounter(key: string): Promise<number> {
     const result = await this.cacheService.eval<number>(
       INCR_WITH_EXPIRE_SCRIPT,
@@ -149,15 +120,5 @@ export class KeylessAbuseGuardService {
     );
 
     return result ?? 0;
-  }
-
-  private async getLastEnvApplicationIdentifier(clientIp: string): Promise<string | null> {
-    const lastEnv = await this.cacheService.get(this.lastEnvKey(clientIp));
-
-    if (!lastEnv || typeof lastEnv !== 'string' || !lastEnv.startsWith(KEYLESS_ENVIRONMENT_PREFIX)) {
-      return null;
-    }
-
-    return lastEnv;
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Addresses Cursor security review findings on the expanded keyless flow (commit `be8028e`).

- **Remove IP-based keyless environment reuse:** when the per-IP daily cap was exceeded, the backend recycled the last keyless environment created from that IP. Behind shared egress (NAT/VPN/corporate), distinct anonymous users could collide onto one environment and share its per-env claim token. Reuse is now a client concern; the backend hard-fails on cap via `assertEnvCreationAllowed`.
- **Gate `POST /connect/claim` with `ENVIRONMENT_WRITE`:** the endpoint performs broad migration writes into the org Development environment but was guarded only by authentication. Added an explicit permission decorator aligned with other write-heavy controllers.
- **Cleanup:** deduplicated daily-cap assert logic into `assertWithinDailyCap` and removed the orphaned `keylessEnvironmentRetentionTtlSeconds` export.

```mermaid
flowchart LR
  subgraph before [Before]
    A1[Fresh keyless init] --> B1{IP cap exceeded?}
    B1 -->|yes| C1[Reuse last env for IP]
    B1 -->|no| D1[Create new env]
    C1 --> E1[Shared claim token risk]
  end

  subgraph after [After]
    A2[Fresh keyless init] --> B2{IP cap exceeded?}
    B2 -->|yes| C2[429 hard fail]
    B2 -->|no| D2[Create new env]
    F2[POST /connect/claim] --> G2{ENVIRONMENT_WRITE?}
    G2 -->|no| H2[403]
    G2 -->|yes| I2[Migrate assets]
  end
```

Linear: https://linear.app/novu/issue/NV-7978/harden-keyless-flow-against-ip-collision-and-claim-rbac-bypass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR hardens the keyless authentication flow against IP-based environment collision attacks. It removes the IP-keyed environment reuse mechanism that previously recycled the last keyless environment for a given IP when daily caps were exceeded. The /connect/claim endpoint now enforces ENVIRONMENT_WRITE permission, and daily-cap assertion logic has been consolidated into a shared helper method.

## Affected areas

**api**: The keyless environment creation flow now calls `assertEnvCreationAllowed(clientIp)` to prevent distinct users behind shared egress (NAT/VPN/corporate) from colliding onto a single environment and sharing its claim token. The POST /connect/claim endpoint now requires `@RequirePermissions(PermissionsEnum.ENVIRONMENT_WRITE)` authorization, restricting claim operations to owner/admin roles under RBAC. Daily-cap validation was consolidated into a private `assertWithinDailyCap` helper, removing duplication between environment-creation and token-generation checks.

## Key technical decisions

- Removed IP-based environment reuse entirely: the `reserveEnvCreation`, `rememberLastEnv`, and associated cache-key methods on `KeylessAbuseGuardService` were deleted. Environment creation is now hard-failed via `assertEnvCreationAllowed` when daily caps are exceeded, shifting reuse responsibility to clients.
- The `@RequirePermissions(ENVIRONMENT_WRITE)` decorator on /connect/claim is a no-op in Community/OSS and free tier but enforces RBAC restrictions in self-hosted/enterprise deployments.
- Removed the orphaned `keylessEnvironmentRetentionTtlSeconds()` export from the keyless-expiry utility.

## Testing

Test suite updated to cover the new `assertEnvCreationAllowed` flow and cap-exceeded scenarios; previous reserve/reuse coverage was removed as those code paths no longer exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — API-only security hardening.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Returning keyless users still work via their existing `applicationIdentifier`; only the unsafe IP-based cross-user reuse path is removed.
- `@RequirePermissions(ENVIRONMENT_WRITE)` is a no-op in Community/OSS and free tier; under RBAC it right-sizes claim access to owner+admin (previously defaulted to `ALL_PERMISSIONS` when no decorator was present).

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the keyless flow by removing the IP-based environment reuse path (shared egress could cause cross-user collisions) and gating `POST /connect/claim` with `ENVIRONMENT_WRITE` permission. It also deduplicates daily-cap logic into a shared `assertWithinDailyCap` helper.

- **IP-reuse removed:** `reserveEnvCreation` (which fell back to the last-seen env for an IP on cap-exceeded) is replaced by `assertEnvCreationAllowed`, which hard-fails with 429; the Redis `last_env` key and `rememberLastEnv` method are fully removed.
- **RBAC on claim:** `@RequirePermissions(PermissionsEnum.ENVIRONMENT_WRITE)` is added to `POST /connect/claim`; in RBAC-enabled tiers this restricts the endpoint to owner/admin roles, while it remains a no-op in Community/OSS.
- **Cleanup:** `assertGenerateAllowed` and the new `assertEnvCreationAllowed` both delegate to the extracted `assertWithinDailyCap`, and the orphaned `keylessEnvironmentRetentionTtlSeconds` export is deleted.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the security hardening is correct and the refactoring is minimal and well-tested.

All three changes (remove IP reuse, gate claim with ENVIRONMENT_WRITE, deduplicate cap logic) are correctly implemented. The atomic Lua INCR script ensures cap enforcement is race-free. The counter-before-creation ordering means a transient backend error near the cap could strand a legitimate IP for 24 hours — low risk at the default cap of 15, but worth noting for tightly configured deployments.

The session usecase change around assertEnvCreationAllowed + processKeyless() is worth a second read if the deployment uses a custom low cap value.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/keyless/keyless-abuse-guard.service.ts | Removes reuse/rememberLastEnv logic; introduces assertWithinDailyCap to deduplicate cap checks across env-create and generate flows. The atomic Lua INCR script ensures correct cap enforcement under concurrency. |
| apps/api/src/app/connect/connect.controller.ts | Adds @RequirePermissions(ENVIRONMENT_WRITE) to POST /connect/claim; controller already has @RequireAuthentication() at class level so auth is always checked first. No logic changes. |
| apps/api/src/app/inbox/usecases/session/session.usecase.ts | getApplicationIdentifier now calls assertEnvCreationAllowed (hard-fail) instead of reserveEnvCreation (soft-reuse); rememberLastEnv call removed. The new flow is strictly simpler. |
| apps/api/src/app/keyless/keyless-abuse-guard.service.spec.ts | Tests updated to match renamed API; reuse-path test cases removed; cap-exceeded test now simply expects 429 with no get-stub setup, consistent with the removal of Redis last-env reads. |
| apps/api/src/app/inbox/utils/keyless-expiry.ts | Removes the orphaned keylessEnvironmentRetentionTtlSeconds export; no functional change to the remaining expiry logic. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Finbox%2Fusecases%2Fsession%2Fsession.usecase.ts%3A417-421%0A**Counter%20slot%20consumed%20on%20transient%20%60processKeyless%28%29%60%20failure**%0A%0A%60assertEnvCreationAllowed%60%20increments%20the%20Redis%20counter%20before%20%60processKeyless%28%29%60%20is%20called.%20If%20%60processKeyless%28%29%60%20throws%20%28e.g.%20a%20transient%20DB%20timeout%29%2C%20the%20daily%20slot%20for%20that%20IP%20is%20burned%20with%20no%20environment%20created.%20With%20the%20reuse-fallback%20now%20removed%2C%20a%20user%20who%20hits%20even%20one%20transient%20error%20and%20is%20near%20the%20cap%20will%20receive%20a%20429%20on%20the%20next%20attempt%20rather%20than%20being%20served%20the%20previously-created%20env.%20At%20the%20default%20cap%20of%2015%20this%20is%20unlikely%20to%20surface%2C%20but%20operators%20running%20with%20a%20tighter%20cap%20%28e.g.%20%60KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY%3D1%60%20or%20%602%60%29%20could%20strand%20legitimate%20users%20for%20up%20to%2024%20hours%20on%20a%20single%20backend%20hiccup.%0A%0A&pr=11462&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/inbox/usecases/session/session.usecase.ts:417-421
**Counter slot consumed on transient `processKeyless()` failure**

`assertEnvCreationAllowed` increments the Redis counter before `processKeyless()` is called. If `processKeyless()` throws (e.g. a transient DB timeout), the daily slot for that IP is burned with no environment created. With the reuse-fallback now removed, a user who hits even one transient error and is near the cap will receive a 429 on the next attempt rather than being served the previously-created env. At the default cap of 15 this is unlikely to surface, but operators running with a tighter cap (e.g. `KEYLESS_ENV_CREATE_CAP_PER_IP_PER_DAY=1` or `2`) could strand legitimate users for up to 24 hours on a single backend hiccup.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api): dedupe keyless daily-cap ..."](https://github.com/novuhq/novu/commit/c8969476eedaf2b23aa34f00841a4e1d2d0d4b90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36147927)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->