### PR TITLE
fix(root): recover stale keyless sessions and fix Telegram connect polling fixes NV-7980

### DIFF
--- a/packages/novu/src/commands/connect/api/agents.ts
+++ b/packages/novu/src/commands/connect/api/agents.ts
@@ -43,19 +43,11 @@ export interface AgentIntegrationEmbedded {
   defaultSenderName?: string;
 }
 
-/** Agent–integration link row returned by GET/POST `/v1/agents/:identifier/integrations`. */
 export interface AgentIntegrationLink {
   _id: string;
-  _agentId?: string;
   integration: AgentIntegrationEmbedded;
-  _environmentId?: string;
-  _organizationId?: string;
   connectedAt?: string | null;
-  createdAt?: string;
-  updatedAt?: string;
 }
-
-export type AgentEmailIntegrationDetail = AgentIntegrationLink;
 
 export async function listAgents(client: ConnectApiClient): Promise<AgentRecord[]> {
   const res = await client.axios.get<{ data?: AgentRecord[] } | AgentRecord[]>('/v1/agents');
@@ -124,14 +116,14 @@ export async function addAgentIntegration(
 export async function addAgentEmailIntegration(
   client: ConnectApiClient,
   agentIdentifier: string
-): Promise<AgentEmailIntegrationDetail> {
-  const res = await client.axios.post<{ data?: AgentEmailIntegrationDetail } | AgentEmailIntegrationDetail>(
+): Promise<AgentIntegrationLink> {
+  const res = await client.axios.post<{ data?: AgentIntegrationLink } | AgentIntegrationLink>(
     `/v1/agents/${encodeURIComponent(agentIdentifier)}/integrations`,
     { providerId: 'novu-email-agent' }
   );
   const body = res.data;
 
-  return 'data' in body && body.data ? body.data : (body as AgentEmailIntegrationDetail);
+  return 'data' in body && body.data ? body.data : (body as AgentIntegrationLink);
 }
 
 export async function listAgentIntegrations(

--- a/packages/novu/src/commands/connect/api/agents.ts
+++ b/packages/novu/src/commands/connect/api/agents.ts
@@ -109,9 +109,8 @@ export async function addAgentIntegration(
     { integrationIdentifier }
   );
   const body = res.data;
-  const link = 'data' in body && body.data ? body.data : (body as AgentIntegrationLink);
 
-  return normalizeAgentIntegrationLink(link);
+  return 'data' in body && body.data ? body.data : (body as AgentIntegrationLink);
 }
 
 /**
@@ -131,9 +130,8 @@ export async function addAgentEmailIntegration(
     { providerId: 'novu-email-agent' }
   );
   const body = res.data;
-  const link = 'data' in body && body.data ? body.data : (body as AgentEmailIntegrationDetail);
 
-  return normalizeAgentIntegrationLink(link);
+  return 'data' in body && body.data ? body.data : (body as AgentEmailIntegrationDetail);
 }
 
 export async function listAgentIntegrations(
@@ -151,41 +149,8 @@ export async function listAgentIntegrations(
     }
   );
   const body = res.data;
-  const links = Array.isArray(body) ? body : (body.data ?? []);
 
-  return links.map(normalizeAgentIntegrationLink);
-}
-
-function normalizeAgentIntegrationLink(link: AgentIntegrationLink): AgentIntegrationLink {
-  const legacy = link as AgentIntegrationLink & {
-    integrationIdentifier?: string;
-    integrationId?: string;
-    providerId?: string;
-    channel?: string;
-    active?: boolean;
-  };
-
-  if (legacy.integration?.identifier) {
-    return link;
-  }
-
-  if (!legacy.integrationIdentifier) {
-    return link;
-  }
-
-  return {
-    ...link,
-    integration: {
-      _id: legacy.integrationId ?? legacy.integration?._id ?? '',
-      identifier: legacy.integrationIdentifier,
-      name: legacy.integration?.name ?? legacy.integrationIdentifier,
-      providerId: legacy.providerId ?? legacy.integration?.providerId ?? '',
-      channel: legacy.channel ?? legacy.integration?.channel,
-      active: legacy.active ?? legacy.integration?.active ?? true,
-      sharedInboundAddress: legacy.integration?.sharedInboundAddress,
-      defaultSenderName: legacy.integration?.defaultSenderName,
-    },
-  };
+  return Array.isArray(body) ? body : (body.data ?? []);
 }
 
 export async function sendAgentWelcomeMessage(

--- a/packages/novu/src/commands/connect/api/agents.ts
+++ b/packages/novu/src/commands/connect/api/agents.ts
@@ -32,15 +32,30 @@ export interface CreateManagedAgentInput {
   skills: Array<{ skillId: string }>;
 }
 
-export interface AgentIntegrationLink {
+export interface AgentIntegrationEmbedded {
   _id: string;
-  integrationId: string;
-  integrationIdentifier: string;
+  identifier: string;
+  name: string;
   providerId: string;
   channel?: string;
-  active?: boolean;
-  connectedAt?: string | null;
+  active: boolean;
+  sharedInboundAddress?: string;
+  defaultSenderName?: string;
 }
+
+/** Agent–integration link row returned by GET/POST `/v1/agents/:identifier/integrations`. */
+export interface AgentIntegrationLink {
+  _id: string;
+  _agentId?: string;
+  integration: AgentIntegrationEmbedded;
+  _environmentId?: string;
+  _organizationId?: string;
+  connectedAt?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type AgentEmailIntegrationDetail = AgentIntegrationLink;
 
 export async function listAgents(client: ConnectApiClient): Promise<AgentRecord[]> {
   const res = await client.axios.get<{ data?: AgentRecord[] } | AgentRecord[]>('/v1/agents');
@@ -94,21 +109,9 @@ export async function addAgentIntegration(
     { integrationIdentifier }
   );
   const body = res.data;
+  const link = 'data' in body && body.data ? body.data : (body as AgentIntegrationLink);
 
-  return 'data' in body && body.data ? body.data : (body as AgentIntegrationLink);
-}
-
-export interface AgentEmailIntegrationDetail extends AgentIntegrationLink {
-  /** Embedded integration record returned by `POST /v1/agents/:id/integrations`. */
-  integration?: {
-    _id?: string;
-    identifier?: string;
-    name?: string;
-    providerId?: string;
-    channel?: string;
-    active?: boolean;
-    sharedInboundAddress?: string;
-  };
+  return normalizeAgentIntegrationLink(link);
 }
 
 /**
@@ -128,20 +131,61 @@ export async function addAgentEmailIntegration(
     { providerId: 'novu-email-agent' }
   );
   const body = res.data;
+  const link = 'data' in body && body.data ? body.data : (body as AgentEmailIntegrationDetail);
 
-  return 'data' in body && body.data ? body.data : (body as AgentEmailIntegrationDetail);
+  return normalizeAgentIntegrationLink(link);
 }
 
 export async function listAgentIntegrations(
   client: ConnectApiClient,
-  agentIdentifier: string
+  agentIdentifier: string,
+  options?: { integrationIdentifier?: string; limit?: number }
 ): Promise<AgentIntegrationLink[]> {
   const res = await client.axios.get<{ data?: AgentIntegrationLink[] } | AgentIntegrationLink[]>(
-    `/v1/agents/${encodeURIComponent(agentIdentifier)}/integrations`
+    `/v1/agents/${encodeURIComponent(agentIdentifier)}/integrations`,
+    {
+      params: {
+        limit: options?.limit ?? (options?.integrationIdentifier ? 1 : 100),
+        ...(options?.integrationIdentifier ? { integrationIdentifier: options.integrationIdentifier } : {}),
+      },
+    }
   );
   const body = res.data;
+  const links = Array.isArray(body) ? body : (body.data ?? []);
 
-  return Array.isArray(body) ? body : (body.data ?? []);
+  return links.map(normalizeAgentIntegrationLink);
+}
+
+function normalizeAgentIntegrationLink(link: AgentIntegrationLink): AgentIntegrationLink {
+  const legacy = link as AgentIntegrationLink & {
+    integrationIdentifier?: string;
+    integrationId?: string;
+    providerId?: string;
+    channel?: string;
+    active?: boolean;
+  };
+
+  if (legacy.integration?.identifier) {
+    return link;
+  }
+
+  if (!legacy.integrationIdentifier) {
+    return link;
+  }
+
+  return {
+    ...link,
+    integration: {
+      _id: legacy.integrationId ?? legacy.integration?._id ?? '',
+      identifier: legacy.integrationIdentifier,
+      name: legacy.integration?.name ?? legacy.integrationIdentifier,
+      providerId: legacy.providerId ?? legacy.integration?.providerId ?? '',
+      channel: legacy.channel ?? legacy.integration?.channel,
+      active: legacy.active ?? legacy.integration?.active ?? true,
+      sharedInboundAddress: legacy.integration?.sharedInboundAddress,
+      defaultSenderName: legacy.integration?.defaultSenderName,
+    },
+  };
 }
 
 export async function sendAgentWelcomeMessage(

--- a/packages/novu/src/commands/connect/api/demo-agent-integration.spec.ts
+++ b/packages/novu/src/commands/connect/api/demo-agent-integration.spec.ts
@@ -1,7 +1,7 @@
 import { AgentRuntimeProviderIdEnum } from '@novu/shared';
 import { describe, expect, it } from 'vitest';
 import type { IntegrationRecord } from './integrations';
-import { findActiveDemoAgentIntegration, hasActiveDemoAgentIntegration } from './demo-agent-integration';
+import { findActiveDemoAgentIntegration } from './demo-agent-integration';
 
 function demoIntegration(): IntegrationRecord {
   return {
@@ -14,15 +14,12 @@ function demoIntegration(): IntegrationRecord {
   };
 }
 
-describe('demo agent integration helpers', () => {
-  it('finds an active NovuAnthropic agent integration', () => {
-    const integrations = [demoIntegration()];
-
-    expect(findActiveDemoAgentIntegration(integrations)?.identifier).toBe('novu-anthropic');
-    expect(hasActiveDemoAgentIntegration(integrations)).toBe(true);
+describe('findActiveDemoAgentIntegration', () => {
+  it('returns an active NovuAnthropic agent integration', () => {
+    expect(findActiveDemoAgentIntegration([demoIntegration()])?.identifier).toBe('novu-anthropic');
   });
 
-  it('ignores inactive or non-demo integrations', () => {
+  it('returns undefined for inactive or non-demo integrations', () => {
     const integrations = [
       { ...demoIntegration(), active: false },
       { ...demoIntegration(), providerId: AgentRuntimeProviderIdEnum.Anthropic },
@@ -30,6 +27,5 @@ describe('demo agent integration helpers', () => {
     ];
 
     expect(findActiveDemoAgentIntegration(integrations)).toBeUndefined();
-    expect(hasActiveDemoAgentIntegration(integrations)).toBe(false);
   });
 });

--- a/packages/novu/src/commands/connect/api/demo-agent-integration.spec.ts
+++ b/packages/novu/src/commands/connect/api/demo-agent-integration.spec.ts
@@ -1,0 +1,35 @@
+import { AgentRuntimeProviderIdEnum } from '@novu/shared';
+import { describe, expect, it } from 'vitest';
+import type { IntegrationRecord } from './integrations';
+import { findActiveDemoAgentIntegration, hasActiveDemoAgentIntegration } from './demo-agent-integration';
+
+function demoIntegration(): IntegrationRecord {
+  return {
+    _id: 'demo-1',
+    identifier: 'novu-anthropic',
+    name: 'Novu Demo Claude',
+    providerId: AgentRuntimeProviderIdEnum.NovuAnthropic,
+    kind: 'agent',
+    active: true,
+  };
+}
+
+describe('demo agent integration helpers', () => {
+  it('finds an active NovuAnthropic agent integration', () => {
+    const integrations = [demoIntegration()];
+
+    expect(findActiveDemoAgentIntegration(integrations)?.identifier).toBe('novu-anthropic');
+    expect(hasActiveDemoAgentIntegration(integrations)).toBe(true);
+  });
+
+  it('ignores inactive or non-demo integrations', () => {
+    const integrations = [
+      { ...demoIntegration(), active: false },
+      { ...demoIntegration(), providerId: AgentRuntimeProviderIdEnum.Anthropic },
+      { ...demoIntegration(), kind: 'chat' },
+    ];
+
+    expect(findActiveDemoAgentIntegration(integrations)).toBeUndefined();
+    expect(hasActiveDemoAgentIntegration(integrations)).toBe(false);
+  });
+});

--- a/packages/novu/src/commands/connect/api/demo-agent-integration.ts
+++ b/packages/novu/src/commands/connect/api/demo-agent-integration.ts
@@ -1,0 +1,17 @@
+import { AgentRuntimeProviderIdEnum } from '@novu/shared';
+import type { IntegrationRecord } from './integrations';
+
+const AGENT_INTEGRATION_KIND = 'agent' as const;
+
+export function findActiveDemoAgentIntegration(integrations: IntegrationRecord[]): IntegrationRecord | undefined {
+  return integrations.find(
+    (integration) =>
+      integration.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic &&
+      integration.kind === AGENT_INTEGRATION_KIND &&
+      integration.active !== false
+  );
+}
+
+export function hasActiveDemoAgentIntegration(integrations: IntegrationRecord[]): boolean {
+  return findActiveDemoAgentIntegration(integrations) !== undefined;
+}

--- a/packages/novu/src/commands/connect/api/demo-agent-integration.ts
+++ b/packages/novu/src/commands/connect/api/demo-agent-integration.ts
@@ -11,7 +11,3 @@ export function findActiveDemoAgentIntegration(integrations: IntegrationRecord[]
       integration.active !== false
   );
 }
-
-export function hasActiveDemoAgentIntegration(integrations: IntegrationRecord[]): boolean {
-  return findActiveDemoAgentIntegration(integrations) !== undefined;
-}

--- a/packages/novu/src/commands/connect/api/keyless-session.spec.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.spec.ts
@@ -1,0 +1,117 @@
+import { AgentRuntimeProviderIdEnum } from '@novu/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const post = vi.fn();
+const listIntegrations = vi.fn();
+
+vi.mock('../../shared/novu-http', () => ({
+  createNovuAxios: vi.fn(() => ({ post })),
+  extractNovuApiMessage: (body: unknown) => {
+    if (!body || typeof body !== 'object') return undefined;
+    const message = (body as { message?: string }).message;
+
+    return typeof message === 'string' ? message : undefined;
+  },
+}));
+
+vi.mock('./client', () => ({
+  createConnectApiClient: vi.fn(() => ({ axios: {} })),
+}));
+
+vi.mock('./integrations', () => ({
+  listIntegrations: (...args: unknown[]) => listIntegrations(...args),
+}));
+
+import { bootstrapKeylessSession } from './keyless-session';
+
+const apiUrl = 'http://localhost:3000';
+const storedIdentifier = 'pk_keyless_00000001_abcd';
+const freshIdentifier = 'pk_keyless_00000002_efgh';
+
+function sessionResponse(applicationIdentifier: string, status = 200) {
+  return {
+    status,
+    data: { data: { applicationIdentifier } },
+  };
+}
+
+function demoIntegration() {
+  return {
+    _id: 'demo-1',
+    identifier: 'novu-anthropic',
+    name: 'Novu Demo Claude',
+    providerId: AgentRuntimeProviderIdEnum.NovuAnthropic,
+    kind: 'agent',
+    active: true,
+  };
+}
+
+describe('bootstrapKeylessSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listIntegrations.mockResolvedValue([demoIntegration()]);
+  });
+
+  it('reuses a stored keyless session when the environment is still ready', async () => {
+    post.mockResolvedValueOnce(sessionResponse(storedIdentifier));
+
+    const result = await bootstrapKeylessSession(apiUrl, storedIdentifier);
+
+    expect(result).toEqual({
+      applicationIdentifier: storedIdentifier,
+      recoveredFromStaleSession: false,
+    });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][1]).toEqual({ applicationIdentifier: storedIdentifier });
+    expect(listIntegrations).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a fresh session when the stored environment no longer exists', async () => {
+    post
+      .mockResolvedValueOnce({
+        status: 400,
+        data: { message: 'Please provide a valid application identifier' },
+      })
+      .mockResolvedValueOnce(sessionResponse(freshIdentifier));
+
+    const result = await bootstrapKeylessSession(apiUrl, storedIdentifier);
+
+    expect(result).toEqual({
+      applicationIdentifier: freshIdentifier,
+      recoveredFromStaleSession: true,
+    });
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(post.mock.calls[1][1]).toEqual({});
+    expect(listIntegrations).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a fresh session when the stored environment was claimed and lost its demo integration', async () => {
+    post
+      .mockResolvedValueOnce(sessionResponse(storedIdentifier))
+      .mockResolvedValueOnce(sessionResponse(freshIdentifier));
+    listIntegrations.mockResolvedValueOnce([]).mockResolvedValueOnce([demoIntegration()]);
+
+    const result = await bootstrapKeylessSession(apiUrl, storedIdentifier);
+
+    expect(result).toEqual({
+      applicationIdentifier: freshIdentifier,
+      recoveredFromStaleSession: true,
+    });
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(post.mock.calls[1][1]).toEqual({});
+    expect(listIntegrations).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates a new session when no stored identifier exists', async () => {
+    post.mockResolvedValueOnce(sessionResponse(freshIdentifier));
+
+    const result = await bootstrapKeylessSession(apiUrl);
+
+    expect(result).toEqual({
+      applicationIdentifier: freshIdentifier,
+      recoveredFromStaleSession: false,
+    });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0][1]).toEqual({});
+  });
+});

--- a/packages/novu/src/commands/connect/api/keyless-session.spec.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.spec.ts
@@ -114,4 +114,12 @@ describe('bootstrapKeylessSession', () => {
     expect(post).toHaveBeenCalledTimes(1);
     expect(post.mock.calls[0][1]).toEqual({});
   });
+
+  it('propagates integration-list failures instead of treating them as stale sessions', async () => {
+    post.mockResolvedValueOnce(sessionResponse(storedIdentifier));
+    listIntegrations.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(bootstrapKeylessSession(apiUrl, storedIdentifier)).rejects.toThrow('network down');
+    expect(post).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -1,6 +1,10 @@
-import { createNovuAxios } from '../../shared/novu-http';
+import { AgentRuntimeProviderIdEnum } from '@novu/shared';
+import { createNovuAxios, extractNovuApiMessage } from '../../shared/novu-http';
+import { createConnectApiClient } from './client';
+import { listIntegrations } from './integrations';
 
 const KEYLESS_ENVIRONMENT_PREFIX = 'pk_keyless_';
+const AGENT_INTEGRATION_KIND = 'agent';
 
 interface InboxSessionPayload {
   applicationIdentifier?: string;
@@ -12,29 +16,115 @@ export interface KeylessSession {
   applicationIdentifier: string;
 }
 
-export async function bootstrapKeylessSession(apiUrl: string, storedIdentifier?: string): Promise<KeylessSession> {
+export interface BootstrapKeylessSessionResult extends KeylessSession {
+  recoveredFromStaleSession: boolean;
+}
+
+export async function bootstrapKeylessSession(
+  apiUrl: string,
+  storedIdentifier?: string
+): Promise<BootstrapKeylessSessionResult> {
+  const trimmedStored = storedIdentifier?.trim();
+
+  if (trimmedStored && isKeylessIdentifier(trimmedStored)) {
+    const restored = await requestKeylessSession(apiUrl, trimmedStored);
+
+    if (restored && (await isKeylessEnvironmentReadyForConnect(apiUrl, restored.applicationIdentifier))) {
+      return { ...restored, recoveredFromStaleSession: false };
+    }
+  }
+
+  const fresh = await requestKeylessSession(apiUrl);
+
+  if (!fresh) {
+    throw new Error('Failed to start a keyless session.');
+  }
+
+  if (!(await isKeylessEnvironmentReadyForConnect(apiUrl, fresh.applicationIdentifier))) {
+    throw new Error(
+      'Keyless mode is not available on this Novu deployment. Re-run with `--secret-key <key>` to use an existing environment.'
+    );
+  }
+
+  const recoveredFromStaleSession = Boolean(trimmedStored && isKeylessIdentifier(trimmedStored));
+
+  return { ...fresh, recoveredFromStaleSession };
+}
+
+async function requestKeylessSession(
+  apiUrl: string,
+  applicationIdentifier?: string
+): Promise<KeylessSession | null> {
   const axios = createNovuAxios({ apiUrl });
-  const body = storedIdentifier?.startsWith(KEYLESS_ENVIRONMENT_PREFIX) ? { applicationIdentifier: storedIdentifier } : {};
+  const body = applicationIdentifier ? { applicationIdentifier } : {};
 
   const res = await axios.post<InboxSessionResponse>('/v1/inbox/session', body, {
     validateStatus: () => true,
   });
 
   if (res.status >= 400) {
-    const message =
-      res.status === 400
-        ? 'Keyless mode is not available on this Novu deployment. Re-run with `--secret-key <key>` to use an existing environment.'
-        : `Failed to start a keyless session (${res.status}).`;
-    throw new Error(message);
+    if (applicationIdentifier && isRecoverableKeylessSessionFailure(res.status, res.data)) {
+      return null;
+    }
+
+    throw new Error(describeKeylessSessionFailure(res.status, res.data));
   }
 
   const responseBody = res.data;
-  const applicationIdentifier = responseBody?.data?.applicationIdentifier ?? responseBody?.applicationIdentifier;
-  if (!applicationIdentifier || !applicationIdentifier.startsWith(KEYLESS_ENVIRONMENT_PREFIX)) {
+  const resolvedIdentifier = responseBody?.data?.applicationIdentifier ?? responseBody?.applicationIdentifier;
+
+  if (!resolvedIdentifier || !isKeylessIdentifier(resolvedIdentifier)) {
     throw new Error('Keyless session response did not include a valid application identifier.');
   }
 
-  return { applicationIdentifier };
+  return { applicationIdentifier: resolvedIdentifier };
+}
+
+function isRecoverableKeylessSessionFailure(status: number, body: unknown): boolean {
+  const message = extractNovuApiMessage(body)?.toLowerCase() ?? '';
+
+  if (status === 400) {
+    return message.includes('valid application identifier');
+  }
+
+  if (status === 404) {
+    return message.includes('active in-app integration could not be found');
+  }
+
+  return false;
+}
+
+function describeKeylessSessionFailure(status: number, body: unknown): string {
+  if (status === 400) {
+    const message = extractNovuApiMessage(body);
+
+    if (message?.includes('Keyless environment creation is currently disabled')) {
+      return message;
+    }
+
+    return 'Keyless mode is not available on this Novu deployment. Re-run with `--secret-key <key>` to use an existing environment.';
+  }
+
+  const message = extractNovuApiMessage(body);
+
+  return message ? `Failed to start a keyless session (${status}): ${message}` : `Failed to start a keyless session (${status}).`;
+}
+
+async function isKeylessEnvironmentReadyForConnect(apiUrl: string, applicationIdentifier: string): Promise<boolean> {
+  const client = createConnectApiClient({ apiUrl, keylessApplicationIdentifier: applicationIdentifier });
+
+  try {
+    const integrations = await listIntegrations(client);
+
+    return integrations.some(
+      (integration) =>
+        integration.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic &&
+        integration.kind === AGENT_INTEGRATION_KIND &&
+        integration.active !== false
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function isKeylessIdentifier(value: string | undefined | null): boolean {

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -1,6 +1,6 @@
 import { createNovuAxios, extractNovuApiMessage } from '../../shared/novu-http';
 import { createConnectApiClient } from './client';
-import { hasActiveDemoAgentIntegration } from './demo-agent-integration';
+import { findActiveDemoAgentIntegration } from './demo-agent-integration';
 import { listIntegrations } from './integrations';
 
 const KEYLESS_ENVIRONMENT_PREFIX = 'pk_keyless_';
@@ -113,7 +113,7 @@ async function isKeylessEnvironmentReadyForConnect(apiUrl: string, applicationId
   const client = createConnectApiClient({ apiUrl, keylessApplicationIdentifier: applicationIdentifier });
   const integrations = await listIntegrations(client);
 
-  return hasActiveDemoAgentIntegration(integrations);
+  return findActiveDemoAgentIntegration(integrations) != null;
 }
 
 export function isKeylessIdentifier(value: string | undefined | null): boolean {

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -1,10 +1,9 @@
-import { AgentRuntimeProviderIdEnum } from '@novu/shared';
 import { createNovuAxios, extractNovuApiMessage } from '../../shared/novu-http';
 import { createConnectApiClient } from './client';
+import { hasActiveDemoAgentIntegration } from './demo-agent-integration';
 import { listIntegrations } from './integrations';
 
 const KEYLESS_ENVIRONMENT_PREFIX = 'pk_keyless_';
-const AGENT_INTEGRATION_KIND = 'agent';
 
 interface InboxSessionPayload {
   applicationIdentifier?: string;
@@ -25,8 +24,10 @@ export async function bootstrapKeylessSession(
   storedIdentifier?: string
 ): Promise<BootstrapKeylessSessionResult> {
   const trimmedStored = storedIdentifier?.trim();
+  let attemptedStoredSession = false;
 
   if (trimmedStored && isKeylessIdentifier(trimmedStored)) {
+    attemptedStoredSession = true;
     const restored = await requestKeylessSession(apiUrl, trimmedStored);
 
     if (restored && (await isKeylessEnvironmentReadyForConnect(apiUrl, restored.applicationIdentifier))) {
@@ -46,9 +47,7 @@ export async function bootstrapKeylessSession(
     );
   }
 
-  const recoveredFromStaleSession = Boolean(trimmedStored && isKeylessIdentifier(trimmedStored));
-
-  return { ...fresh, recoveredFromStaleSession };
+  return { ...fresh, recoveredFromStaleSession: attemptedStoredSession };
 }
 
 async function requestKeylessSession(
@@ -112,19 +111,9 @@ function describeKeylessSessionFailure(status: number, body: unknown): string {
 
 async function isKeylessEnvironmentReadyForConnect(apiUrl: string, applicationIdentifier: string): Promise<boolean> {
   const client = createConnectApiClient({ apiUrl, keylessApplicationIdentifier: applicationIdentifier });
+  const integrations = await listIntegrations(client);
 
-  try {
-    const integrations = await listIntegrations(client);
-
-    return integrations.some(
-      (integration) =>
-        integration.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic &&
-        integration.kind === AGENT_INTEGRATION_KIND &&
-        integration.active !== false
-    );
-  } catch {
-    return false;
-  }
+  return hasActiveDemoAgentIntegration(integrations);
 }
 
 export function isKeylessIdentifier(value: string | undefined | null): boolean {

--- a/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
+++ b/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
@@ -30,11 +30,9 @@ export async function resolveConnectAuth(
   const config = new ConfigService();
   const stored = config.getValue(KEYLESS_CONFIG_KEY);
 
-  if (stored) {
-    resolveOptions.onStatus?.('Restoring your keyless workspace…');
-  } else {
-    resolveOptions.onStatus?.('Setting up a temporary keyless workspace…');
-  }
+  resolveOptions.onStatus?.(
+    stored ? 'Restoring your keyless workspace…' : 'Setting up a temporary keyless workspace…'
+  );
 
   const session = await bootstrapKeylessSession(options.apiUrl, stored);
 

--- a/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
+++ b/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
@@ -27,11 +27,21 @@ export async function resolveConnectAuth(
     return { ...auth, isKeyless: false };
   }
 
-  resolveOptions.onStatus?.('Setting up a temporary keyless workspace…');
-
   const config = new ConfigService();
   const stored = config.getValue(KEYLESS_CONFIG_KEY);
+
+  if (stored) {
+    resolveOptions.onStatus?.('Restoring your keyless workspace…');
+  } else {
+    resolveOptions.onStatus?.('Setting up a temporary keyless workspace…');
+  }
+
   const session = await bootstrapKeylessSession(options.apiUrl, stored);
+
+  if (session.recoveredFromStaleSession) {
+    resolveOptions.onStatus?.('Previous keyless session is no longer available. Starting a fresh workspace…');
+  }
+
   config.setValue(KEYLESS_CONFIG_KEY, session.applicationIdentifier);
 
   return {

--- a/packages/novu/src/commands/connect/pipeline/channels/email.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/email.ts
@@ -18,7 +18,7 @@ export async function connectEmailForAgent(
   ui.addingEmailIntegration();
 
   const link = await addAgentEmailIntegration(client, agent.identifier);
-  const inboundAddress = link.integration?.sharedInboundAddress;
+  const inboundAddress = link.integration.sharedInboundAddress;
   if (!inboundAddress) {
     throw new Error(
       'The server did not return an inbound address for the email integration. ' +
@@ -29,8 +29,8 @@ export async function connectEmailForAgent(
   const integration: IntegrationRecord = {
     _id: link.integration._id,
     identifier: link.integration.identifier,
-    name: link.integration.name ?? 'Novu Email',
-    providerId: link.integration.providerId ?? 'novu-email-agent',
+    name: link.integration.name,
+    providerId: link.integration.providerId,
     channel: 'email',
     active: link.integration.active !== false,
   };

--- a/packages/novu/src/commands/connect/pipeline/channels/email.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/email.ts
@@ -27,12 +27,12 @@ export async function connectEmailForAgent(
   }
 
   const integration: IntegrationRecord = {
-    _id: link.integration?._id ?? link.integrationId,
-    identifier: link.integrationIdentifier,
-    name: link.integration?.name ?? 'Novu Email',
-    providerId: link.integration?.providerId ?? 'novu-email-agent',
+    _id: link.integration._id,
+    identifier: link.integration.identifier,
+    name: link.integration.name ?? 'Novu Email',
+    providerId: link.integration.providerId ?? 'novu-email-agent',
     channel: 'email',
-    active: link.integration?.active !== false,
+    active: link.integration.active !== false,
   };
 
   if (link.connectedAt) {

--- a/packages/novu/src/commands/connect/pipeline/integration-helpers.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/integration-helpers.spec.ts
@@ -19,7 +19,7 @@ describe('pollForAgentLinkConnected', () => {
     vi.clearAllMocks();
   });
 
-  it('detects connectedAt on the nested integration link shape returned by the API', async () => {
+  it('detects connectedAt on the agent integration link', async () => {
     listAgentIntegrations
       .mockResolvedValueOnce([
         {

--- a/packages/novu/src/commands/connect/pipeline/integration-helpers.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/integration-helpers.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConnectApiClient } from '../api/client';
+
+const listAgentIntegrations = vi.fn();
+
+vi.mock('../api/agents', () => ({
+  listAgentIntegrations: (...args: unknown[]) => listAgentIntegrations(...args),
+  addAgentIntegration: vi.fn(),
+}));
+
+vi.mock('../api/integrations', () => ({
+  listIntegrations: vi.fn(),
+}));
+
+import { pollForAgentLinkConnected } from './integration-helpers';
+
+describe('pollForAgentLinkConnected', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detects connectedAt on the nested integration link shape returned by the API', async () => {
+    listAgentIntegrations
+      .mockResolvedValueOnce([
+        {
+          _id: 'link-1',
+          integration: {
+            _id: 'integration-1',
+            identifier: 'telegram-main',
+            name: 'Telegram',
+            providerId: 'telegram',
+            channel: 'chat',
+            active: true,
+          },
+          connectedAt: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          _id: 'link-1',
+          integration: {
+            _id: 'integration-1',
+            identifier: 'telegram-main',
+            name: 'Telegram',
+            providerId: 'telegram',
+            channel: 'chat',
+            active: true,
+          },
+          connectedAt: '2026-06-08T12:00:00.000Z',
+        },
+      ]);
+
+    const connected = await pollForAgentLinkConnected({} as ConnectApiClient, 'my-agent', 'telegram-main', {
+      intervalMs: 1,
+      timeoutMs: 50,
+    });
+
+    expect(connected).toBe(true);
+    expect(listAgentIntegrations).toHaveBeenCalledWith({}, 'my-agent', {
+      integrationIdentifier: 'telegram-main',
+      limit: 1,
+    });
+  });
+});

--- a/packages/novu/src/commands/connect/pipeline/integration-helpers.ts
+++ b/packages/novu/src/commands/connect/pipeline/integration-helpers.ts
@@ -63,13 +63,6 @@ export async function ensureAgentIntegrationLinked(
   return undefined;
 }
 
-export function findAgentIntegrationLink(
-  links: AgentIntegrationLink[],
-  integrationIdentifier: string
-): AgentIntegrationLink | undefined {
-  return links.find((l) => l.integration.identifier === integrationIdentifier);
-}
-
 /** Poll until `connectedAt` is set on the agent↔integration link (first inbound message). */
 export async function pollForAgentLinkConnected(
   client: ConnectApiClient,

--- a/packages/novu/src/commands/connect/pipeline/integration-helpers.ts
+++ b/packages/novu/src/commands/connect/pipeline/integration-helpers.ts
@@ -31,13 +31,13 @@ export async function resolveIntegrationForAgent(
   const links = await listAgentIntegrations(client, agent.identifier);
   const alreadyLinked = links.find(
     (l) =>
-      l.providerId === match.providerId &&
-      (match.channel === undefined || l.channel === match.channel) &&
-      l.active !== false
+      l.integration.providerId === match.providerId &&
+      (match.channel === undefined || l.integration.channel === match.channel) &&
+      l.integration.active !== false
   );
   if (alreadyLinked) {
     const integrations = await listIntegrations(client);
-    const integration = integrations.find((i) => i.identifier === alreadyLinked.integrationIdentifier);
+    const integration = integrations.find((i) => i.identifier === alreadyLinked.integration.identifier);
     if (integration) return integration;
   }
 
@@ -50,8 +50,8 @@ export async function ensureAgentIntegrationLinked(
   agentIdentifier: string,
   integrationIdentifier: string
 ): Promise<AgentIntegrationLink | undefined> {
-  const links = await listAgentIntegrations(client, agentIdentifier);
-  const existingLink = links.find((l) => l.integrationIdentifier === integrationIdentifier);
+  const links = await listAgentIntegrations(client, agentIdentifier, { integrationIdentifier });
+  const existingLink = links[0];
   if (existingLink) return existingLink;
 
   try {
@@ -67,7 +67,7 @@ export function findAgentIntegrationLink(
   links: AgentIntegrationLink[],
   integrationIdentifier: string
 ): AgentIntegrationLink | undefined {
-  return links.find((l) => l.integrationIdentifier === integrationIdentifier);
+  return links.find((l) => l.integration.identifier === integrationIdentifier);
 }
 
 /** Poll until `connectedAt` is set on the agent↔integration link (first inbound message). */
@@ -78,8 +78,8 @@ export async function pollForAgentLinkConnected(
   options: { intervalMs: number; timeoutMs: number }
 ): Promise<boolean> {
   return pollUntil(async () => {
-    const links = await listAgentIntegrations(client, agentIdentifier);
-    const link = findAgentIntegrationLink(links, integrationIdentifier);
+    const links = await listAgentIntegrations(client, agentIdentifier, { integrationIdentifier, limit: 1 });
+    const link = links[0];
 
     return link?.connectedAt ? 'done' : 'pending';
   }, options);

--- a/packages/novu/src/commands/connect/pipeline/resolve-agent-runtime-integration.ts
+++ b/packages/novu/src/commands/connect/pipeline/resolve-agent-runtime-integration.ts
@@ -6,6 +6,7 @@ import {
 } from '@novu/shared';
 import type { ConnectApiClient } from '../api/client';
 import { NovuApiError } from '../api/client';
+import { findActiveDemoAgentIntegration } from '../api/demo-agent-integration';
 import {
   createAgentRuntimeIntegration,
   type IntegrationRecord,
@@ -98,12 +99,7 @@ export async function resolveAgentRuntimeIntegration(
 }
 
 function resolveDemoIntegration(integrations: IntegrationRecord[]): ResolvedRuntimeIntegration {
-  const demo = integrations.find(
-    (integration) =>
-      integration.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic &&
-      integration.kind === AGENT_INTEGRATION_KIND &&
-      integration.active !== false
-  );
+  const demo = findActiveDemoAgentIntegration(integrations);
 
   if (!demo) {
     throw new Error(


### PR DESCRIPTION
### What changed? Why was the change needed?

- **Keyless session recovery:** `npx novu connect` now detects when the cached keyless environment is invalid, claimed, or missing the demo integration, and automatically starts a fresh keyless workspace instead of failing with the demo Claude integration error.
- **Telegram connect polling:** The CLI now reads agent–integration links from the nested API response (`integration.identifier`, `connectedAt`) so the Telegram `/start` step completes as soon as the webhook is received.

Linear: https://linear.app/novu/issue/NV-7980

### Screenshots

N/A — CLI behavior fix only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- `bootstrapKeylessSession` retries without a stored identifier when the cached env is gone or depleted.
- `pollForAgentLinkConnected` now queries `?integrationIdentifier=...&limit=1` and matches the API’s nested link shape (same fix applied to email polling).

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Connect CLI now recovers gracefully from stale keyless sessions by retrying without a stored identifier when a cached keyless environment is invalid, claimed, or missing the demo agent integration, and surfaces a recoveredFromStaleSession flag to adjust status messaging. Polling for agent integrations (used by Telegram and email connect flows) was updated to consume the API’s nested agent→integration shape and to query with integrationIdentifier + limit=1 so webhook-connected integrations are detected immediately.

## Affected areas

**js**: Connect CLI keyless session bootstrapping now validates environment readiness, returns a BootstrapKeylessSessionResult with recoveredFromStaleSession, and centralizes error classification; agent integration types were changed to embed an integration object and listAgentIntegrations accepts optional filters (integrationIdentifier, limit). Connect pipeline helpers (email/Telegram) were updated to read the nested integration shape and to poll using targeted queries. New helper demo-agent-integration was added and reused.

**shared/tests (Vitest)**: New and updated unit tests covering keyless session recovery paths and integration polling behavior; HTTP client and API listing calls are mocked.

## Key technical decisions

- AgentIntegrationLink now embeds an integration object (AgentIntegrationEmbedded) instead of exposing flat integration fields, simplifying lookups against integration.identifier/providerId.  
- listAgentIntegrations gained optional filtering (integrationIdentifier, limit) and polling uses limit=1 to reduce latency and avoid in-memory filtering.  
- bootstrapKeylessSession uses requestKeylessSession and returns recoveredFromStaleSession to let caller adjust messaging and behavior when falling back from a stale stored identifier.

## Testing

Added Vitest unit tests for bootstrapKeylessSession (stored-valid, stored-invalid, stored-claimed, fresh-only, network-failure) and for pollForAgentLinkConnected (ensures connectedAt detection and correct query args); tests mock the HTTP client and API list calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two CLI connect-flow bugs: stale keyless sessions are now automatically recovered by detecting when a cached workspace has been claimed or is missing its demo integration, and Telegram/email polling now reads the nested `integration` object returned by the API instead of flat fields, allowing the connect step to complete as soon as the webhook arrives.

- **Keyless session recovery**: `bootstrapKeylessSession` now validates the stored session's environment is still ready (demo integration present) before reusing it; if not, it transparently bootstraps a fresh workspace and signals the recovery via `recoveredFromStaleSession`.
- **API shape migration**: `AgentIntegrationLink` was refactored from flat fields (`integrationId`, `integrationIdentifier`) to an embedded `integration: AgentIntegrationEmbedded` object, and all callers (email, Telegram polling, integration helpers) were updated to use the nested shape.
- **Targeted polling**: `listAgentIntegrations` gained optional `integrationIdentifier + limit` filtering; polling calls now request `limit=1` to minimize round-trips and match the correct link immediately.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped CLI fixes with good unit test coverage for all recovery scenarios.

The stale session recovery logic is clearly exercised by four spec cases covering reuse, stale-by-missing-integration, stale-by-invalid-identifier, fresh start, and error propagation. The API shape migration is straightforward and TypeScript-checked. No auth boundaries, data persistence, or server-side logic are modified.

No files require special attention beyond the minor issues already noted in inline comments.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/api/agents.ts | API type refactored from flat fields to nested `integration: AgentIntegrationEmbedded`; `listAgentIntegrations` gains optional server-side filtering with a sensible limit default (1 when filtering by identifier, 100 otherwise). Clean change. |
| packages/novu/src/commands/connect/api/keyless-session.ts | Major refactor adding stale session recovery and demo-integration readiness check. The null guard on `fresh` (line 40–42) is unreachable when called without an identifier — already flagged in a prior review thread. |
| packages/novu/src/commands/connect/api/demo-agent-integration.ts | New utility extracting demo-integration detection; correctly replaces an inline predicate in two callers. Contains a duplicated `AGENT_INTEGRATION_KIND` constant. |
| packages/novu/src/commands/connect/auth/resolve-connect-auth.ts | Improved status messaging; the "Starting a fresh workspace…" message fires after bootstrap completes rather than before — prior review thread already noted this timing issue. |
| packages/novu/src/commands/connect/pipeline/integration-helpers.ts | Polling and link-existence checks now use targeted server-side filtering (`integrationIdentifier + limit=1`) instead of fetching all links and filtering client-side. Clean refactor with dead code removed. |
| packages/novu/src/commands/connect/pipeline/channels/email.ts | Migrated to nested integration shape cleanly; one minor style nit with the redundant `!== false` guard on a required boolean field. |
| packages/novu/src/commands/connect/pipeline/resolve-agent-runtime-integration.ts | Single change: replaced inline demo-integration predicate with the shared `findActiveDemoAgentIntegration` helper. No behavioral change. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bootstrapKeylessSession] --> B{storedIdentifier\npresent & valid?}
    B -- No --> F[requestKeylessSession\nno identifier]
    B -- Yes --> C[requestKeylessSession\nwith storedIdentifier]
    C -- null\nrecoverable 400/404 --> F
    C -- session returned --> D{isKeylessEnvironment\nReadyForConnect?}
    D -- Yes\ndemo integration found --> E[Return session\nrecoveredFromStale=false]
    D -- No\ndemo integration missing --> F
    F[requestKeylessSession\nfresh] --> G{isKeylessEnvironment\nReadyForConnect?}
    G -- Yes --> H[Return fresh session\nrecoveredFromStale=attemptedStored]
    G -- No --> I[Throw: keyless not\navailable on this deployment]
    C -- non-recoverable error --> J[Throw error]
    F -- error --> J
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/novu/src/commands/connect/pipeline/channels/email.ts`, line 21 ([link](https://github.com/novuhq/novu/blob/daf7a937ff0e91202216f716319489c436e20956/packages/novu/src/commands/connect/pipeline/channels/email.ts#L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Optional chaining on a now-required field — `AgentIntegrationLink.integration` is no longer optional in the updated type, so `?.` is a no-op and misleads readers into thinking the field could be absent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/novu/src/commands/connect/pipeline/channels/email.ts
   Line: 21

   Comment:
   Optional chaining on a now-required field — `AgentIntegrationLink.integration` is no longer optional in the updated type, so `?.` is a no-op and misleads readers into thinking the field could be absent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fpipeline%2Fchannels%2Femail.ts%0ALine%3A%2021%0A%0AComment%3A%0AOptional%20chaining%20on%20a%20now-required%20field%20%E2%80%94%20%60AgentIntegrationLink.integration%60%20is%20no%20longer%20optional%20in%20the%20updated%20type%2C%20so%20%60%3F.%60%20is%20a%20no-op%20and%20misleads%20readers%20into%20thinking%20the%20field%20could%20be%20absent.%0A%0A%60%60%60suggestion%0A%20%20const%20inboundAddress%20%3D%20link.integration.sharedInboundAddress%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11468&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fapi%2Fdemo-agent-integration.ts%3A4%0A**Duplicated%20constant%20with%20%60resolve-agent-runtime-integration.ts%60**%0A%0A%60AGENT_INTEGRATION_KIND%60%20is%20defined%20as%20%60'agent'%20as%20const%60%20in%20both%20this%20new%20file%20and%20in%20%60resolve-agent-runtime-integration.ts%60%20%28line%2019%29.%20If%20the%20value%20ever%20changes%2C%20it%20would%20need%20updating%20in%20two%20places.%20Extracting%20it%20to%20a%20shared%20constants%20module%20would%20keep%20this%20single-sourced.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fpipeline%2Fchannels%2Femail.ts%3A35%0A**Redundant%20%60!%3D%3D%20false%60%20guard%20on%20a%20required%20%60boolean%60%20field**%0A%0A%60AgentIntegrationEmbedded.active%60%20is%20typed%20as%20%60boolean%60%20%28not%20%60boolean%20%7C%20undefined%60%29%2C%20so%20%60active%20!%3D%3D%20false%60%20is%20always%20equivalent%20to%20just%20%60active%60.%20Using%20%60!%3D%3D%20false%60%20is%20misleading%20%E2%80%94%20it%20implies%20the%20field%20might%20be%20absent%20or%20undefined%2C%20which%20the%20type%20contract%20rules%20out.%0A%0A%60%60%60suggestion%0A%20%20%20%20active%3A%20link.integration.active%2C%0A%60%60%60%0A%0A&pr=11468&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/novu/src/commands/connect/api/demo-agent-integration.ts:4
**Duplicated constant with `resolve-agent-runtime-integration.ts`**

`AGENT_INTEGRATION_KIND` is defined as `'agent' as const` in both this new file and in `resolve-agent-runtime-integration.ts` (line 19). If the value ever changes, it would need updating in two places. Extracting it to a shared constants module would keep this single-sourced.

### Issue 2 of 2
packages/novu/src/commands/connect/pipeline/channels/email.ts:35
**Redundant `!== false` guard on a required `boolean` field**

`AgentIntegrationEmbedded.active` is typed as `boolean` (not `boolean | undefined`), so `active !== false` is always equivalent to just `active`. Using `!== false` is misleading — it implies the field might be absent or undefined, which the type contract rules out.

```suggestion
    active: link.integration.active,
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(novu): trim connect CLI types and ..."](https://github.com/novuhq/novu/commit/b1c089c91c9d60f0a08662290399fc1af0101d90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36187114)</sub>

<!-- /greptile_comment -->