### PR TITLE
chore(dashboard,api-service): exclude provider managed mcps when using novu demo claude creds fixes NV-7982

### DIFF
--- a/apps/api/src/app/agents/e2e/demo-managed-claude.e2e.ts
+++ b/apps/api/src/app/agents/e2e/demo-managed-claude.e2e.ts
@@ -1,6 +1,6 @@
 import { decryptCredentials, encryptCredentials } from '@novu/application-generic';
 import * as AgentRuntimeFactoryModule from '@novu/application-generic/build/main/agent-runtimes/agent-runtime.factory';
-import { AgentRepository, IntegrationRepository } from '@novu/dal';
+import { AgentMcpServerRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import { AgentRuntimeProviderIdEnum, IntegrationKindEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
@@ -14,6 +14,7 @@ const FAKE_EXTERNAL_ENV_ID = 'env_01DemoClaudeE2E';
 
 const integrationRepository = new IntegrationRepository();
 const agentRepository = new AgentRepository();
+const agentMcpServerRepository = new AgentMcpServerRepository();
 
 function buildMockProvider(overrides: Partial<Record<string, sinon.SinonStub>> = {}) {
   return {
@@ -319,6 +320,53 @@ describe('Demo Managed Claude #novu-v2', () => {
     );
 
     expect(agent).to.equal(null);
+  });
+
+  it('should drop provider-managed MCPs when provisioning on the novu-anthropic demo integration', async () => {
+    const integrationId = await createNovuAnthropicIntegration();
+    const identifier = `e2e-demo-mcp-filter-${Date.now()}`;
+    createdAgentIdentifiers.push(identifier);
+
+    // `sentry` (dcr) connects through Novu's own OAuth and stays; `slack` (provider-managed) needs
+    // the runtime provider's vault UI the demo never exposes, so it must be filtered out.
+    const res = await session.testAgent.post('/v1/agents').send({
+      name: 'Demo MCP Filter Agent',
+      identifier,
+      runtime: 'managed',
+      managedRuntime: {
+        providerId: AgentRuntimeProviderIdEnum.NovuAnthropic,
+        integrationId,
+        systemPrompt: 'You are a demo agent.',
+        mcpServers: ['sentry', 'slack'],
+      },
+    });
+
+    expect(res.status, `create failed: ${JSON.stringify(res.body)}`).to.equal(201);
+    expect(mockProvider.createAgent.calledOnce, 'createAgent should run once').to.equal(true);
+
+    const sentToProvider = mockProvider.createAgent.firstCall.args[0].mcpServers as Array<{ name: string }>;
+    const providerMcpNames = sentToProvider.map((server) => server.name);
+    expect(providerMcpNames).to.deep.equal(['Sentry']);
+    expect(providerMcpNames).to.not.include('Slack');
+
+    const agent = await agentRepository.findOne(
+      {
+        identifier,
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+      },
+      ['_id']
+    );
+
+    const persistedRows = await agentMcpServerRepository.findByAgent({
+      organizationId: session.organization._id,
+      environmentId: session.environment._id,
+      agentId: agent?._id ?? '',
+    });
+
+    const persistedMcpIds = persistedRows.map((row) => row.mcpId);
+    expect(persistedMcpIds).to.deep.equal(['sentry']);
+    expect(persistedMcpIds).to.not.include('slack');
   });
 
   it('should migrate agent runtime to user Anthropic integration', async () => {

--- a/apps/api/src/app/agents/management/usecases/generate-managed-agent/managed-agent-generation.schema.ts
+++ b/apps/api/src/app/agents/management/usecases/generate-managed-agent/managed-agent-generation.schema.ts
@@ -36,7 +36,7 @@ export const managedAgentGenerationSchema = z.object({
   description: z
     .string()
     .min(1)
-    .max(200)
+    .max(140) // max length for the description field, enforced by provider specific limits, for example: Slack
     .describe("Agent description. A short, human-readable summary of the agent's purpose and capabilities."),
   systemPrompt: z
     .string()

--- a/apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/provision-managed-agent/provision-managed-agent.usecase.ts
@@ -11,7 +11,13 @@ import {
   resolveAgentRuntime,
 } from '@novu/application-generic';
 import { AgentMcpServerRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
-import { AgentRuntimeProviderIdEnum, type ICredentialsDto, MCP_SERVERS, McpConnectionScopeEnum } from '@novu/shared';
+import {
+  AgentRuntimeProviderIdEnum,
+  filterDemoConfigurableMcpIds,
+  type ICredentialsDto,
+  MCP_SERVERS,
+  McpConnectionScopeEnum,
+} from '@novu/shared';
 import type { ClientSession } from 'mongoose';
 import { resolveManagedAgentAlwaysAllowToolPermissions } from '../../../mcp/resolve-managed-agent-always-allow-tool-permissions';
 import { resolveMcpServersById, resolveProviderMcpServerIds } from '../../../mcp/resolve-mcp-servers';
@@ -131,7 +137,15 @@ export class ProvisionManagedAgent {
       // ── Provision mode ────────────────────────────────────────────────────
       await runtimeProvider.validateCredentials(validateCredentialsInput);
 
-      const resolvedMcpServers = command.mcpServers ? resolveMcpServersById(command.mcpServers) : undefined;
+      // The Novu-managed demo integration exposes no provider vault, so provider-managed MCPs can
+      // never be connected on it. Drop them here so we mirror the dashboard's demo filtering and
+      // never wire a demo agent to a server the user could not finish authorizing.
+      const requestedMcpServers =
+        command.mcpServers && runtimeProviderId === AgentRuntimeProviderIdEnum.NovuAnthropic
+          ? filterDemoConfigurableMcpIds(command.mcpServers)
+          : command.mcpServers;
+
+      const resolvedMcpServers = requestedMcpServers ? resolveMcpServersById(requestedMcpServers) : undefined;
       const useAlwaysAllowToolPermissions = await resolveManagedAgentAlwaysAllowToolPermissions({
         featureFlagsService: this.featureFlagsService,
         environmentId: command.environmentId,
@@ -149,7 +163,7 @@ export class ProvisionManagedAgent {
       });
 
       externalAgentId = response.externalAgentId;
-      mcpIdsToPersist = command.mcpServers;
+      mcpIdsToPersist = requestedMcpServers;
     }
 
     // Snapshot the pre-update runtime fields so we can compensate when the

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -8,7 +8,7 @@ type AgentSetupGuideProps = {
 
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   return (
-    <SetupGuideCard label="Setup agent" className="min-w-0 flex-1 max-w-[1100px]">
+    <SetupGuideCard label="Setup agent" className="min-w-0 flex-1">
       <AgentSetupSteps agent={agent} />
     </SetupGuideCard>
   );

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -1,8 +1,10 @@
 import {
   AgentRuntimeProviderIdEnum,
   FeatureFlagsKeysEnum,
+  filterDemoConfigurableMcpIds,
   type IIntegration,
   IntegrationKindEnum,
+  isProviderManagedMcp,
   slugify,
 } from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
@@ -227,6 +229,18 @@ export function CreateAgentDialog({
   // teams writing their own runtime see exactly the inputs they need to fill in.
   const useAiGeneration = isManagedClaudeConnector && isManagedEnabled;
   const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
+  // The demo (Novu-managed Claude) integration exposes no provider vault, so provider-managed MCPs
+  // can never be configured on it. Drop them from the suggestion pills so the demo only advertises
+  // tools the user can actually wire up; the API enforces the same filter at provision time.
+  const displayedAgentTemplates = useMemo(() => {
+    if (!isDemoProviderSelected) return agentTemplates;
+
+    return agentTemplates.map((template) => ({
+      ...template,
+      suggestedMcpServers: filterDemoConfigurableMcpIds(template.suggestedMcpServers),
+      mcpServers: template.mcpServers?.filter((server) => !isProviderManagedMcp(server.id)),
+    }));
+  }, [agentTemplates, isDemoProviderSelected]);
   const scope: 'create' | 'existing' = generationMode === 'existing' ? 'existing' : 'create';
   const showScopeTabs = isManagedClaudeConnector && !isDemoProviderSelected;
   const showManagedOptions = isManagedEnabled;
@@ -570,7 +584,10 @@ export function CreateAgentDialog({
     let effectiveName = name;
     let effectiveIdentifier = identifier;
     let effectiveInstructions = instructions;
-    let effectiveDescription = instructions;
+    // In scratch mode the single textarea IS the description, so it maps to `description`. In
+    // managed manual mode that same textarea is the Claude system prompt and must NOT leak into the
+    // description. The prompt-generation path overrides this with `generated.description` below.
+    let effectiveDescription = runtime === 'scratch' ? instructions : '';
     let managedOverrides: ManagedAgentRuntimeOverrides | undefined;
 
     if (isPromptGenerationMode) {
@@ -869,7 +886,7 @@ export function CreateAgentDialog({
 
                 {generationMode === 'prompt' && (
                   <AgentSuggestionPills
-                    suggestions={agentTemplates}
+                    suggestions={displayedAgentTemplates}
                     onSelect={handleSelectAiSuggestion}
                     disabled={isSubmitBusy}
                   />

--- a/apps/dashboard/src/components/agents/mcp-icon.tsx
+++ b/apps/dashboard/src/components/agents/mcp-icon.tsx
@@ -21,6 +21,7 @@ export function McpIcon({ mcpId, fallbackUrl, className }: McpIconProps) {
   const sourcesKey = sources.join('|');
   const [index, setIndex] = useState(0);
   const [trackedKey, setTrackedKey] = useState(sourcesKey);
+  const safeIndex = index < sources.length ? index : 0;
 
   if (trackedKey !== sourcesKey) {
     setTrackedKey(sourcesKey);
@@ -29,7 +30,7 @@ export function McpIcon({ mcpId, fallbackUrl, className }: McpIconProps) {
 
   return (
     <img
-      src={sources[index]}
+      src={sources[safeIndex]}
       alt=""
       aria-hidden
       className={cn('size-5 shrink-0 object-contain', className)}

--- a/apps/dashboard/src/components/agents/mcp-icon.tsx
+++ b/apps/dashboard/src/components/agents/mcp-icon.tsx
@@ -1,25 +1,40 @@
 import { getMcpIconPath, MCP_ICON_DEFAULT_ID } from '@novu/shared';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { cn } from '@/utils/ui';
 
 type McpIconProps = {
   mcpId: string | undefined | null;
+  fallbackUrl?: string;
   className?: string;
 };
 
-export function McpIcon({ mcpId, className }: McpIconProps) {
-  const [src, setSrc] = useState(() => getMcpIconPath(mcpId || MCP_ICON_DEFAULT_ID));
+export function McpIcon({ mcpId, fallbackUrl, className }: McpIconProps) {
+  const sources = useMemo(() => {
+    const defaultSrc = getMcpIconPath(MCP_ICON_DEFAULT_ID);
+    const candidates = [getMcpIconPath(mcpId || MCP_ICON_DEFAULT_ID), fallbackUrl, defaultSrc].filter(
+      (value): value is string => Boolean(value)
+    );
+
+    return Array.from(new Set(candidates));
+  }, [mcpId, fallbackUrl]);
+
+  const sourcesKey = sources.join('|');
+  const [index, setIndex] = useState(0);
+  const [trackedKey, setTrackedKey] = useState(sourcesKey);
+
+  if (trackedKey !== sourcesKey) {
+    setTrackedKey(sourcesKey);
+    setIndex(0);
+  }
 
   return (
     <img
-      src={src}
+      src={sources[index]}
       alt=""
       aria-hidden
       className={cn('size-5 shrink-0 object-contain', className)}
       onError={() => {
-        if (src !== getMcpIconPath(MCP_ICON_DEFAULT_ID)) {
-          setSrc(getMcpIconPath(MCP_ICON_DEFAULT_ID));
-        }
+        setIndex((current) => (current < sources.length - 1 ? current + 1 : current));
       }}
     />
   );

--- a/apps/dashboard/src/components/agents/provider-cards.tsx
+++ b/apps/dashboard/src/components/agents/provider-cards.tsx
@@ -127,12 +127,28 @@ function LockedBadge() {
   );
 }
 
-function ConnectPill({ loading, comingSoon, locked }: { loading: boolean; comingSoon: boolean; locked: boolean }) {
+function ProviderPill({
+  loading,
+  comingSoon,
+  locked,
+  connected,
+  connecting,
+}: {
+  loading: boolean;
+  comingSoon: boolean;
+  locked: boolean;
+  connected: boolean;
+  connecting: boolean;
+}) {
   let label: string;
   if (comingSoon) {
     label = 'Coming soon';
   } else if (locked) {
     label = 'Upgrade';
+  } else if (connected) {
+    label = 'Connected';
+  } else if (connecting) {
+    label = 'Connecting...';
   } else {
     label = 'Connect';
   }
@@ -155,17 +171,6 @@ function ConnectPill({ loading, comingSoon, locked }: { loading: boolean; coming
       ) : (
         <RiArrowRightSLine className="size-4 shrink-0 text-text-soft" aria-hidden />
       )}
-    </div>
-  );
-}
-
-function SelectedPill({ loading, connected }: { loading: boolean; connected: boolean }) {
-  const label = connected ? 'Connected' : 'Connecting...';
-
-  return (
-    <div className="bg-bg-weak flex w-full items-center justify-center gap-1 rounded-[4px] p-1">
-      <span className="px-1 text-label-xs text-text-soft font-medium leading-4">{label}</span>
-      {loading ? <RiLoader4Line className="text-text-soft size-4 shrink-0 animate-spin" aria-hidden /> : null}
     </div>
   );
 }
@@ -290,11 +295,13 @@ function ProviderCard({
           <span className="text-label-xs text-text-sub font-medium leading-4">{item.displayName}</span>
         </div>
 
-        {isActive ? (
-          <SelectedPill loading={isLoading} connected={isConnected} />
-        ) : (
-          <ConnectPill loading={isLoading} comingSoon={item.comingSoon} locked={isLocked} />
-        )}
+        <ProviderPill
+          loading={isLoading}
+          comingSoon={item.comingSoon}
+          locked={isLocked}
+          connected={isConnected}
+          connecting={isActive && !isConnected}
+        />
       </div>
     </button>
   );

--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -117,12 +117,12 @@ export function SetupStep({
 }) {
   return (
     <div className="relative flex flex-col gap-4 pl-6">
-      <div className={cn('absolute -left-[20px] flex w-5 justify-center', sectionLabel ? 'top-6' : 'top-0')}>
+      <div className={cn('absolute -left-[20px] flex w-5 justify-center', sectionLabel ? 'top-6' : 'top-[3px]')}>
         <StepIndicator status={status} index={index} />
       </div>
       <div
         className={cn(
-          'flex flex-col gap-4 transition-opacity duration-300 ease-out md:flex-row md:gap-20',
+          'flex flex-col gap-4 transition-opacity duration-300 ease-out md:flex-row md:gap-20 pt-[3px]',
           dimmed && 'pointer-events-none opacity-30'
         )}
       >

--- a/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
@@ -1,3 +1,4 @@
+import { MCP_SERVERS } from '@novu/shared';
 import { useMemo } from 'react';
 import { type AgentTemplate, type McpServerPreview } from '@/components/agents/create-agent-fields';
 import { McpIcon } from '@/components/agents/mcp-icon';
@@ -7,6 +8,10 @@ import { cn } from '@/utils/ui';
 
 const VISIBLE_INTEGRATION_ICONS = 2;
 const PILL_FADE_WIDTH_PX = 24;
+
+function resolveMcpName(server: McpServerPreview): string {
+  return server.name ?? MCP_SERVERS.find((entry) => entry.id === server.id)?.name ?? server.id;
+}
 
 type AgentSuggestionPillsProps = {
   suggestions: AgentTemplate[];
@@ -41,13 +46,17 @@ type SuggestionPillProps = {
 };
 
 function SuggestionPill({ suggestion, disabled, onSelect }: SuggestionPillProps) {
-  const { visibleIcons, overflowCount } = useMemo(() => {
+  const { visibleIcons, overflowServers } = useMemo(() => {
     const servers: McpServerPreview[] = suggestion.mcpServers ?? suggestion.suggestedMcpServers.map((id) => ({ id }));
-    const visible = servers.slice(0, VISIBLE_INTEGRATION_ICONS);
-    const overflow = Math.max(0, servers.length - VISIBLE_INTEGRATION_ICONS);
 
-    return { visibleIcons: visible, overflowCount: overflow };
+    return {
+      visibleIcons: servers.slice(0, VISIBLE_INTEGRATION_ICONS),
+      overflowServers: servers.slice(VISIBLE_INTEGRATION_ICONS),
+    };
   }, [suggestion.mcpServers, suggestion.suggestedMcpServers]);
+
+  const overflowCount = overflowServers.length;
+  const overflowTitle = overflowServers.map(resolveMcpName).join(', ');
 
   return (
     <button
@@ -68,13 +77,17 @@ function SuggestionPill({ suggestion, disabled, onSelect }: SuggestionPillProps)
           {visibleIcons.map((server) => (
             <span
               key={server.id}
+              title={resolveMcpName(server)}
               className="border-stroke-soft-100 inline-flex size-[18px] items-center justify-center rounded-[4px] border bg-[#fbfbfb]"
             >
-              <McpIcon mcpId={server.id} className="size-[14px]" />
+              <McpIcon mcpId={server.id} fallbackUrl={server.iconUrl} className="size-[14px]" />
             </span>
           ))}
           {overflowCount > 0 && (
-            <span className="border-stroke-soft-100 text-text-soft inline-flex size-[18px] items-center justify-center rounded-[4px] border bg-[#fbfbfb] text-[10px] font-medium leading-[14px]">
+            <span
+              title={overflowTitle}
+              className="border-stroke-soft-100 text-text-soft inline-flex size-[18px] items-center justify-center rounded-[4px] border bg-[#fbfbfb] text-[10px] font-medium leading-[14px]"
+            >
               +{overflowCount}
             </span>
           )}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -1,4 +1,10 @@
-import { type IIntegration, IntegrationKindEnum, slugify } from '@novu/shared';
+import {
+  filterDemoConfigurableMcpIds,
+  type IIntegration,
+  IntegrationKindEnum,
+  isProviderManagedMcp,
+  slugify,
+} from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import type { FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -209,6 +215,18 @@ export function ConnectAgentStep({
   // need to fill in.
   const useAiGeneration = isClaudeSelected && isManagedEnabled;
   const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
+  // The demo (Novu-managed Claude) integration exposes no provider vault, so provider-managed MCPs
+  // can never be configured on it. Drop them from the suggestion pills so onboarding only advertises
+  // tools the user can actually wire up; the API enforces the same filter at provision time.
+  const displayedAgentTemplates = useMemo(() => {
+    if (!isDemoProviderSelected) return agentTemplates;
+
+    return agentTemplates.map((template) => ({
+      ...template,
+      suggestedMcpServers: filterDemoConfigurableMcpIds(template.suggestedMcpServers),
+      mcpServers: template.mcpServers?.filter((server) => !isProviderManagedMcp(server.id)),
+    }));
+  }, [agentTemplates, isDemoProviderSelected]);
   const isExistingMode =
     isClaudeSelected &&
     !isDemoProviderSelected &&
@@ -284,7 +302,9 @@ export function ConnectAgentStep({
     } else if (templateSelection.kind === 'template') {
       previewName = templateSelection.template.name;
       previewInstructions = templateSelection.template.instructions;
-      previewMcpServers = templateSelection.template.suggestedMcpServers;
+      previewMcpServers = isDemoProviderSelected
+        ? filterDemoConfigurableMcpIds(templateSelection.template.suggestedMcpServers)
+        : templateSelection.template.suggestedMcpServers;
     } else if (templateSelection.kind === 'scratch') {
       previewName = trimmedName || undefined;
       previewInstructions = trimmedInstructions || undefined;
@@ -747,9 +767,14 @@ export function ConnectAgentStep({
     // the managed-Claude preview illustration) can show them. Prefer the LLM-generated payload
     // — when absent (static template / scratch), fall back to the template's suggested MCPs so
     // the preview keeps showing what the user picked.
-    const summaryMcpServers =
+    const requestedSummaryMcpServers =
       managedOverrides?.mcpServers ??
       (templateSelection.kind === 'template' ? templateSelection.template.suggestedMcpServers : []);
+    // Mirror the API's demo provisioning filter so the summary reflects the MCPs that were actually
+    // wired up — provider-managed servers are dropped on the demo integration.
+    const summaryMcpServers = isDemoProviderSelected
+      ? filterDemoConfigurableMcpIds([...requestedSummaryMcpServers])
+      : requestedSummaryMcpServers;
     const summaryTools = managedOverrides?.tools ?? [];
 
     const summary: ConnectSummary = {
@@ -876,7 +901,7 @@ export function ConnectAgentStep({
                 prompt,
                 onPromptChange: handlePromptChange,
                 promptError,
-                suggestions: agentTemplates,
+                suggestions: displayedAgentTemplates,
                 onSelectSuggestion: handleSelectSuggestion,
                 textareaRef: promptTextareaRef,
                 isGenerating: isSubmitBusy,

--- a/packages/shared/src/consts/providers/mcp-servers.spec.ts
+++ b/packages/shared/src/consts/providers/mcp-servers.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { McpConnectionAuthModeEnum } from '../../dto/agent/managed-runtime.dto';
 import {
+  filterDemoConfigurableMcpIds,
+  isProviderManagedMcp,
   MCP_SERVERS,
   type McpOAuthCatalogEntry,
   type McpServerCategory,
@@ -130,6 +132,35 @@ describe('MCP_SERVERS catalog', () => {
         'workflow',
         'codespace',
       ]);
+    });
+  });
+
+  describe('isProviderManagedMcp', () => {
+    it('returns true for a provider-managed entry', () => {
+      expect(isProviderManagedMcp('slack')).toBe(true);
+    });
+
+    it('returns false for dcr and novu-app entries', () => {
+      expect(isProviderManagedMcp('sentry')).toBe(false);
+      expect(isProviderManagedMcp('github')).toBe(false);
+    });
+
+    it('returns false for an unknown id', () => {
+      expect(isProviderManagedMcp('not-a-real-mcp')).toBe(false);
+    });
+  });
+
+  describe('filterDemoConfigurableMcpIds', () => {
+    it('drops provider-managed ids and keeps Novu-handled OAuth ids', () => {
+      expect(filterDemoConfigurableMcpIds(['sentry', 'slack', 'github', 'asana'])).toEqual(['sentry', 'github']);
+    });
+
+    it('returns an empty array when every id is provider-managed', () => {
+      expect(filterDemoConfigurableMcpIds(['slack', 'asana'])).toEqual([]);
+    });
+
+    it('preserves order and leaves a fully-configurable list untouched', () => {
+      expect(filterDemoConfigurableMcpIds(['sentry', 'datadog', 'linear'])).toEqual(['sentry', 'datadog', 'linear']);
     });
   });
 

--- a/packages/shared/src/consts/providers/mcp-servers.ts
+++ b/packages/shared/src/consts/providers/mcp-servers.ts
@@ -2557,6 +2557,34 @@ export function getMcpIconUrl(mcpId: string, baseUrl: string): string {
   return `${normalizedBase}${getMcpIconPath(mcpId)}`;
 }
 
+/**
+ * True when the catalog entry delegates its connector OAuth to the managed
+ * runtime provider's vault UI (`provider-managed`). A missing `oauth` field is
+ * treated as provider-managed to match the picker contract (see `McpServer.oauth`).
+ */
+export function isProviderManagedMcp(mcpId: string): boolean {
+  const entry = MCP_SERVERS.find((server) => server.id === mcpId);
+
+  if (!entry) {
+    return false;
+  }
+
+  return !entry.oauth || entry.oauth.mode === McpConnectionAuthModeEnum.ProviderManaged;
+}
+
+/**
+ * Keep only the MCP ids a Novu-managed demo Claude agent can actually wire up.
+ *
+ * Provider-managed MCPs finish their connector OAuth inside the runtime
+ * provider's vault UI, but the demo (NovuAnthropic) integration exposes no
+ * vault deep link — the API rejects provider-managed connections for it — so
+ * those servers can never be configured on a demo agent. Novu-handled OAuth
+ * MCPs (dcr / novu-app) connect through Novu's own flow and remain usable.
+ */
+export function filterDemoConfigurableMcpIds(mcpIds: string[]): string[] {
+  return mcpIds.filter((mcpId) => !isProviderManagedMcp(mcpId));
+}
+
 export function resolveMcpCatalogIdByName(name: string | undefined): string | undefined {
   if (!name) {
     return undefined;


### PR DESCRIPTION
### What changed? Why was the change needed?

When using Novu Demo Claude credentials the user won't have access to the managed MCPs of the agent, that is why we need to exclude those MCPs.

Fixed a few small UI issues and MCP icons fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What changed
The PR ensures Novu Demo Claude credentials do not expose provider-managed MCPs by filtering them out of UI templates, provisioning logic, and persistence so demo agents only see configurable integrations. It also adds safer MCP icon fallbacks, tightens the managed-agent description limit to 140 chars, and fixes several small UI layout/interaction issues to prevent misleading options during demo onboarding.

Affected areas
- api: Provisioning now filters requested MCP server IDs for Novu-managed Claude demo agents before resolving provider wiring and persists the filtered set to agent_mcp_server records.
- dashboard: Onboarding and agent-creation UIs hide provider-managed MCPs in demo mode, adjust layout/positioning, refine provider-card/pill behavior, and switch agent suggestion lists to the demo-filtered templates; MCP icons now attempt multiple fallback sources.
- shared: Added isProviderManagedMcp and filterDemoConfigurableMcpIds helpers and unit tests to classify and filter provider-managed MCP IDs.
- tests: New e2e test verifying demo-managed CLAUDE provisioning filters MCPs and unit tests covering the new helper functions.

Key technical decisions
- Introduced centralized helpers (isProviderManagedMcp, filterDemoConfigurableMcpIds) in shared to standardize demo filtering across API and UI.
- Provisioning now filters at runtime and persists the filtered MCP IDs so stored records reflect only accessible demo MCPs (no schema changes).
- McpIcon switched to an ordered multi-source fallback loader to avoid broken icons when provider assets are unavailable.

Testing
Added unit tests for MCP helper functions and an e2e test that validates MCP filtering during demo-managed agent provisioning; UI changes were covered by manual visual verification screenshots included in the PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="1525" height="992" alt="Screenshot 2026-06-08 at 17 07 44" src="https://github.com/user-attachments/assets/c5bf83d9-abaa-4f3f-9149-b6e019680f4c" />

<img width="1521" height="1004" alt="Screenshot 2026-06-08 at 17 09 06" src="https://github.com/user-attachments/assets/01a1c63b-9dd0-4370-ae67-db803b46219c" />


