### PR TITLE
feat(dashboard): add descriptions for system variables fixes NV-7983

### DIFF
--- a/apps/dashboard/src/components/variables/system-variable-definitions.ts
+++ b/apps/dashboard/src/components/variables/system-variable-definitions.ts
@@ -4,9 +4,20 @@ export type SystemVariableDefinition = {
   /** Typed as a template literal to catch drift when new fields are added to EnvironmentSystemVariables. */
   key: `env.${keyof EnvironmentSystemVariables}`;
   resolve: (env: IEnvironment) => string;
+  description: string;
 };
 
 export const SYSTEM_VARIABLE_DEFINITIONS: SystemVariableDefinition[] = [
-  { key: 'env.name', resolve: (env) => env.name },
-  { key: 'env.type', resolve: (env) => env.type },
+  {
+    key: 'env.name',
+    resolve: (env) => env.name,
+    description:
+      'The display name of the environment. Use it in templates as {{env.name}} to reference the current environment by name.',
+  },
+  {
+    key: 'env.type',
+    resolve: (env) => env.type,
+    description:
+      'System classification for the environment: dev or prod.\n\n• Development → dev\n• Production and custom environments (e.g. Staging) → prod\n\nNovu uses this for platform behavior — for example, content can only be edited in dev environments, and prod environments receive updates through publishing. This value is managed by Novu and cannot be changed. Create a custom variable (e.g. environmentType) if you need your own classification.',
+  },
 ];

--- a/apps/dashboard/src/components/variables/system-variable-definitions.ts
+++ b/apps/dashboard/src/components/variables/system-variable-definitions.ts
@@ -11,12 +11,13 @@ export const SYSTEM_VARIABLE_DEFINITIONS: SystemVariableDefinition[] = [
   {
     key: 'env.name',
     resolve: (env) => env.name,
-    description: "This environment's display name. In templates, use {{env.name}}.",
+    description:
+      'The display name of the environment. Use it in templates as {{env.name}} to reference the current environment by name.',
   },
   {
     key: 'env.type',
     resolve: (env) => env.type,
     description:
-      'Tells Novu if this environment is for editing (dev) or live use (prod).\n\n• Development → dev\n• Production → prod\n• Custom environments (e.g. Staging) → prod\n\nEdit workflows and content in dev only. Prod environments update when you publish.\n\nSet by Novu — not editable. Need your own label? Create a custom variable.',
+      'System classification for the environment: dev or prod.\n\n• Development → dev\n• Production and custom environments (e.g. Staging) → prod\n\nNovu uses this for platform behavior — for example, content can only be edited in dev environments, and prod environments receive updates through publishing. This value is managed by Novu and cannot be changed. Create a custom variable (e.g. environmentType) if you need your own classification.',
   },
 ];

--- a/apps/dashboard/src/components/variables/system-variable-definitions.ts
+++ b/apps/dashboard/src/components/variables/system-variable-definitions.ts
@@ -11,13 +11,12 @@ export const SYSTEM_VARIABLE_DEFINITIONS: SystemVariableDefinition[] = [
   {
     key: 'env.name',
     resolve: (env) => env.name,
-    description:
-      'The display name of the environment. Use it in templates as {{env.name}} to reference the current environment by name.',
+    description: "This environment's display name. In templates, use {{env.name}}.",
   },
   {
     key: 'env.type',
     resolve: (env) => env.type,
     description:
-      'System classification for the environment: dev or prod.\n\n• Development → dev\n• Production and custom environments (e.g. Staging) → prod\n\nNovu uses this for platform behavior — for example, content can only be edited in dev environments, and prod environments receive updates through publishing. This value is managed by Novu and cannot be changed. Create a custom variable (e.g. environmentType) if you need your own classification.',
+      'Tells Novu if this environment is for editing (dev) or live use (prod).\n\n• Development → dev\n• Production → prod\n• Custom environments (e.g. Staging) → prod\n\nEdit workflows and content in dev only. Prod environments update when you publish.\n\nSet by Novu — not editable. Need your own label? Create a custom variable.',
   },
 ];

--- a/apps/dashboard/src/components/variables/system-variable-row.tsx
+++ b/apps/dashboard/src/components/variables/system-variable-row.tsx
@@ -4,6 +4,7 @@ import { RiArrowDownSLine, RiArrowRightSLine, RiCheckLine, RiCornerDownRightLine
 import { Badge } from '@/components/primitives/badge';
 import { CopyButton } from '@/components/primitives/copy-button';
 import { EnvironmentBranchIcon } from '@/components/primitives/environment-branch-icon';
+import { HelpTooltipIndicator } from '@/components/primitives/help-tooltip-indicator';
 import { TableCell, TableRow } from '@/components/primitives/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { cn } from '@/utils/ui';
@@ -43,11 +44,12 @@ const SystemVariableSubRow = ({ environment, value }: SystemVariableSubRowProps)
 
 type SystemVariableRowProps = {
   variableKey: string;
+  description: string;
   resolve: (env: IEnvironment) => string;
   environments: IEnvironment[];
 };
 
-export const SystemVariableRow = ({ variableKey, resolve, environments }: SystemVariableRowProps) => {
+export const SystemVariableRow = ({ variableKey, description, resolve, environments }: SystemVariableRowProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const displayKey = variableKey.split('.').at(-1) ?? variableKey;
   const totalCount = environments.length;
@@ -82,6 +84,13 @@ export const SystemVariableRow = ({ variableKey, resolve, environments }: System
             <Badge variant="lighter" color="gray" size="sm">
               SYSTEM
             </Badge>
+            <span
+              className="inline-flex"
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
+            >
+              <HelpTooltipIndicator text={description} size="3" className="text-text-soft" />
+            </span>
           </div>
         </SystemVariableCell>
         <SystemVariableCell>

--- a/apps/dashboard/src/components/variables/variable-list.tsx
+++ b/apps/dashboard/src/components/variables/variable-list.tsx
@@ -129,6 +129,7 @@ export const VariableList = () => {
               <SystemVariableRow
                 key={def.key}
                 variableKey={def.key}
+                description={def.description}
                 resolve={def.resolve}
                 environments={environments ?? []}
               />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

System variables in the Variables UI were causing confusion — especially `env.type` for custom environments like Staging, which defaults to `prod` and cannot be edited.

This change adds a `?` help icon with hover tooltips next to each system variable row, explaining what the variable means and how Novu uses it.

**Changes:**
- Added `description` field to `SystemVariableDefinition` in `system-variable-definitions.ts`
- Rendered `HelpTooltipIndicator` next to the SYSTEM badge in `SystemVariableRow`
- Documented `env.name` (display name for templates) and `env.type` (dev/prod classification, platform behavior, and guidance to use a custom variable for custom classifications)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Variables UI now shows explanatory help tooltips for system variables to reduce confusion (notably that env.type defaults to prod for custom environments and cannot be edited). A required description field was added to system variable definitions and those descriptions are passed into the row renderer, which displays a HelpTooltipIndicator next to the SYSTEM badge. Tooltip interactions are isolated so they don't trigger row expansion.

## Affected areas

**dashboard**: Added a required `description` property to system variable definitions and threaded it through VariableList into SystemVariableRow; SystemVariableRow now renders a HelpTooltipIndicator with propagation stopped to avoid toggling row expansion.

## Key technical decisions

- Tooltip interactions are wrapped in a span that stops click and keydown propagation to prevent accidental expansion/collapse of the variable row.

## Testing

No automated tests were added; this is a UI copy/behavior improvement validated manually (screenshots included).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

Hovering the `?` icon on the `type` system variable shows a tooltip explaining dev vs prod classification, that custom environments default to prod, and that edits are only allowed in dev environments.

![Variables page with system variable tooltips](https://cursor.com/artifacts/c/art-053e8ed8-80fc-4334-8c41-896fb89b8e04)
![Type system variable tooltip](https://cursor.com/artifacts/c/art-21d6e9f4-f646-43b3-b56a-009bf6d7cc60)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7983](https://linear.app/novu/issue/NV-7983/add-descriptions-for-system-variables)

<div><a href="https://cursor.com/agents/bc-bcd000b1-85aa-49f2-b89e-ccc5d631bfab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcd000b1-85aa-49f2-b89e-ccc5d631bfab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds explanatory help tooltips to system variable rows in the Variables UI to reduce confusion around variables like `env.type`, which silently defaults to `prod` for custom environments. The `description` field is made required on `SystemVariableDefinition`, ensuring all future system variables must carry documentation.

- **`system-variable-definitions.ts`**: `description` is now a required field on `SystemVariableDefinition`; both `env.name` and `env.type` are populated with clear, user-facing copy explaining platform behavior and constraints.
- **`system-variable-row.tsx`**: Renders `HelpTooltipIndicator` next to the SYSTEM badge; a wrapper `span` stops click/keydown propagation so hovering or focusing the tooltip icon does not toggle row expansion.
- **`variable-list.tsx`**: Passes `def.description` through to `SystemVariableRow` — a one-line wiring change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive UI documentation change with no behavioral side effects.

The change is purely additive: a required `description` field is added to an internal type and populated for both existing entries, a tooltip is wired in with correct propagation guards, and no data-fetching, auth, or state management is touched. The event-propagation design (`stopPropagation` on the wrapper span plus the pre-existing `e.target !== e.currentTarget` guard on the row's key handler) correctly prevents tooltip interactions from toggling row expansion.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/variables/system-variable-definitions.ts | Added required `description` field to `SystemVariableDefinition` type and populated it for `env.name` and `env.type` with user-facing explanatory text. |
| apps/dashboard/src/components/variables/system-variable-row.tsx | Added `description` prop and renders `HelpTooltipIndicator` next to the SYSTEM badge; click and keydown propagation is stopped on the wrapper span to prevent inadvertent row expansion when interacting with the tooltip. |
| apps/dashboard/src/components/variables/variable-list.tsx | Passes the new `description` field from `SystemVariableDefinition` into `SystemVariableRow` — a minimal, correct wiring change. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VL as VariableList
    participant SVD as SYSTEM_VARIABLE_DEFINITIONS
    participant SVR as SystemVariableRow
    participant HTI as HelpTooltipIndicator

    VL->>SVD: iterate definitions (key, resolve, description)
    VL->>SVR: render(variableKey, description, resolve, environments)
    SVR->>SVR: render SYSTEM badge
    SVR->>HTI: "render(text=description, size="3")"
    HTI-->>SVR: Tooltip with ? icon
    Note over SVR: span wrapper stops click/keydown propagation<br/>to prevent row expand/collapse on tooltip interaction
```

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): restore original system ..."](https://github.com/novuhq/novu/commit/02a5dc6c7f906b8039bb2a21ae3d4107aae3888b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36253559)</sub>

<!-- /greptile_comment -->