### PR TITLE
fix(dashboard): restore connect claim flow after platform unification fixes NOV-7984

### DIFF
--- a/apps/dashboard/src/api/connect.ts
+++ b/apps/dashboard/src/api/connect.ts
@@ -1,0 +1,12 @@
+import { post } from './api.client';
+
+export type ClaimKeylessConnectResponse = {
+  environmentId: string;
+  agentIdentifier?: string;
+};
+
+export async function claimKeylessConnect(token: string): Promise<ClaimKeylessConnectResponse> {
+  return post<ClaimKeylessConnectResponse>('/connect/claim', {
+    body: { token },
+  });
+}

--- a/apps/dashboard/src/components/auth/create-organization.tsx
+++ b/apps/dashboard/src/components/auth/create-organization.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { OrganizationPicker } from '@/components/auth/organization-picker';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { resolvePendingCliAuthReturnUrl } from '@/utils/cli-auth-pending';
+import { resolvePendingConnectClaimReturnUrl } from '@/utils/connect-claim-pending';
 import { getPostOrgCreateRoute } from '../../utils/onboarding-redirect';
 import { ROUTES } from '../../utils/routes';
 import { UsecasePlaygroundHeader } from '../usecase-playground-header';
@@ -44,8 +45,9 @@ function OrganizationForm() {
   const clerk = useClerk();
 
   const pendingCliAuthReturnUrl = useMemo(() => resolvePendingCliAuthReturnUrl(), []);
-  const afterCreateUrl = pendingCliAuthReturnUrl ?? getPostOrgCreateRoute();
-  const afterSelectUrl = pendingCliAuthReturnUrl ?? ROUTES.ENV;
+  const pendingConnectClaimReturnUrl = useMemo(() => resolvePendingConnectClaimReturnUrl(), []);
+  const afterCreateUrl = pendingConnectClaimReturnUrl ?? pendingCliAuthReturnUrl ?? getPostOrgCreateRoute();
+  const afterSelectUrl = pendingConnectClaimReturnUrl ?? pendingCliAuthReturnUrl ?? ROUTES.ENV;
 
   const handleSignOut = useCallback(async () => {
     const fallbackUrl = ROUTES.SIGN_IN;

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -47,6 +47,7 @@ import { AgentTelegramMobileSetupPage } from './pages/agent-telegram-mobile-setu
 import { AgentsPage } from './pages/agents';
 import { AgentsSetupPage } from './pages/agents-setup-page';
 import { CliAuthPage } from './pages/cli-auth';
+import { ConnectClaimPage } from './pages/connect-claim';
 import { ContextsPage } from './pages/contexts';
 import { CreateContextPage } from './pages/create-context';
 import { CreateSubscriberPage } from './pages/create-subscriber';
@@ -100,6 +101,10 @@ const router = createBrowserRouter([
       {
         path: ROUTES.CLI_AUTH,
         element: <CliAuthPage />,
+      },
+      {
+        path: ROUTES.CONNECT_CLAIM,
+        element: <ConnectClaimPage />,
       },
       {
         // Public, unauthenticated mobile setup page for Telegram. Mounted outside

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -80,6 +80,7 @@ import { AuthRoute, CatchAllRoute, DashboardRoute, ProtectedAuthRoute, RootRoute
 import { OnboardingParentRoute } from './routes/onboarding';
 import { ProtectedRoute } from './routes/protected-route';
 import { captureAgentTemplateIdFromUrl } from './utils/agent-template-identity';
+import { captureConnectClaimTokenFromUrl } from './utils/connect-claim-pending';
 import { ROUTES } from './utils/routes';
 import { initializeSentry } from './utils/sentry';
 import { overrideZodErrorMap } from './utils/validation';
@@ -88,6 +89,8 @@ initializeSentry();
 overrideZodErrorMap();
 // Stash an incoming `?agentTemplateId=` before Clerk's auth redirects drop the query params.
 captureAgentTemplateIdFromUrl();
+// Stash an incoming connect claim token before Clerk's auth redirects drop the query params.
+captureConnectClaimTokenFromUrl();
 
 const router = createBrowserRouter([
   {

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -1,0 +1,181 @@
+import { useAuth as useClerkAuth } from '@clerk/react';
+import type { IEnvironment } from '@novu/shared';
+import { EnvironmentTypeEnum } from '@novu/shared';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RiCheckLine, RiLoader4Line } from 'react-icons/ri';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { claimKeylessConnect } from '@/api/connect';
+import { AuthLayout } from '@/components/auth-layout';
+import { PageMeta } from '@/components/page-meta';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { useAuth } from '@/context/auth/hooks';
+import { EnvironmentProvider } from '@/context/environment/environment-provider';
+import { useFetchEnvironments } from '@/context/environment/hooks';
+import { BOOTSTRAP_ORG_CACHE_KEY } from '@/context/environment/use-bootstrap-organization';
+import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
+import { clearConnectProvisioning } from '@/utils/connect';
+import {
+  clearPendingConnectClaim,
+  parseConnectClaimToken,
+  readPendingConnectClaim,
+  storePendingConnectClaim,
+} from '@/utils/connect-claim-pending';
+import { ROUTES } from '@/utils/routes';
+
+export const ConnectClaimPage = () => {
+  const { isLoaded, isSignedIn } = useClerkAuth();
+  const [searchParams] = useSearchParams();
+  const token = parseConnectClaimToken(`?${searchParams.toString()}`) ?? readPendingConnectClaim();
+
+  useEffect(() => {
+    if (token) {
+      storePendingConnectClaim(token);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    clearConnectProvisioning();
+  }, []);
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  if (!isSignedIn) {
+    const search = token ? `?token=${encodeURIComponent(token)}` : '';
+    const redirectUrl = `${ROUTES.CONNECT_CLAIM}${search}`;
+    const signUpUrl = appendRedirectUrlParam(ROUTES.SIGN_UP, redirectUrl);
+
+    return <Navigate to={signUpUrl} replace />;
+  }
+
+  return (
+    <AuthLayout>
+      <EnvironmentProvider>
+        <PageMeta title="Keep your Novu agent" />
+        <ConnectClaimContent token={token} />
+      </EnvironmentProvider>
+    </AuthLayout>
+  );
+};
+
+function hasClaimableDevelopmentEnvironment(environments?: IEnvironment[]): boolean {
+  if (!environments?.length) {
+    return false;
+  }
+
+  return Boolean(
+    environments.find((env) => env.type === EnvironmentTypeEnum.DEV && !env._parentId) ??
+      environments.find((env) => !env._parentId)
+  );
+}
+
+function ConnectClaimContent({ token }: { token: string | null }) {
+  const { currentOrganization } = useAuth();
+  const novuOrganizationId = currentOrganization?._id;
+  const [isEnvironmentReady, setIsEnvironmentReady] = useState(false);
+  const { environments } = useFetchEnvironments({
+    organizationId: novuOrganizationId || BOOTSTRAP_ORG_CACHE_KEY,
+    refetchInterval: isEnvironmentReady ? undefined : 1000,
+    showError: false,
+  });
+
+  useEffect(() => {
+    if (hasClaimableDevelopmentEnvironment(environments)) {
+      setIsEnvironmentReady(true);
+    }
+  }, [environments]);
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [didClaim, setDidClaim] = useState(false);
+  const [claimError, setClaimError] = useState<string | null>(null);
+  const hasAttemptedRef = useRef(false);
+
+  const tokenOk = Boolean(token);
+
+  const handleClaim = useCallback(async () => {
+    if (!token || hasAttemptedRef.current) {
+      return;
+    }
+
+    hasAttemptedRef.current = true;
+    setIsClaiming(true);
+    setClaimError(null);
+    try {
+      await claimKeylessConnect(token);
+      clearPendingConnectClaim();
+      setDidClaim(true);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to claim this agent';
+      showErrorToast(`Claim failed: ${message}`);
+      setClaimError(message);
+    } finally {
+      setIsClaiming(false);
+    }
+  }, [token]);
+
+  const handleRetry = () => {
+    hasAttemptedRef.current = false;
+    setClaimError(null);
+    void handleClaim();
+  };
+
+  const reason = tokenOk ? null : 'This page must be opened from the link in your chat.';
+  const canClaim = !reason && isEnvironmentReady && !isClaiming && !didClaim && !claimError;
+
+  useEffect(() => {
+    if (canClaim && !hasAttemptedRef.current) {
+      void handleClaim();
+    }
+  }, [canClaim, handleClaim]);
+
+  return (
+    <div className="flex min-h-screen w-full items-center justify-center px-4 py-8">
+      <div className="w-full max-w-[400px] rounded-lg border-[1.5px] border-black/[0.04] bg-gradient-to-b from-white/50 to-white/[0.15] px-6 py-8 shadow-sm backdrop-blur-sm">
+        <div className="mx-auto flex w-full max-w-[350px] flex-col items-center gap-6">
+          <img src="/images/novu-logo-dark.svg" className="w-24" alt="Novu" />
+
+          <div className="flex w-full flex-col items-center gap-3">
+            <h1 className="text-label-sm text-text-strong text-center font-medium tracking-[-0.084px]">
+              Keep the agent you just built
+            </h1>
+            <p className="text-label-xs text-text-sub text-center">
+              We'll move your agent, its connected channel, and your conversation into your new Development environment.
+              The agent picks the conversation back up right where it left off.
+            </p>
+          </div>
+
+          {reason ? (
+            <div className="text-text-sub flex w-full items-start gap-2 rounded-lg border border-dashed border-stroke-soft p-3 text-label-xs">
+              <span>{reason}</span>
+            </div>
+          ) : didClaim ? (
+            <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">
+              <RiCheckLine className="mt-0.5 size-4 shrink-0" />
+              <span>
+                Your agent is connected to your account. Head back to your chat — the agent is ready to continue.
+              </span>
+            </div>
+          ) : claimError ? (
+            <div className="flex w-full flex-col gap-3">
+              <div className="text-text-sub flex w-full items-start gap-2 rounded-lg border border-dashed border-stroke-soft p-3 text-label-xs">
+                <span>{claimError}</span>
+              </div>
+              <button
+                type="button"
+                className="text-label-xs text-text-strong w-full rounded-lg border border-stroke-soft px-3 py-2 font-medium"
+                onClick={handleRetry}
+              >
+                Try again
+              </button>
+            </div>
+          ) : (
+            <div className="text-text-sub flex w-full items-center justify-center gap-2 p-3 text-label-xs">
+              <RiLoader4Line className="size-4 shrink-0 animate-spin" />
+              <span>Setting up your agent…</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -22,6 +22,9 @@ import {
 } from '@/utils/connect-claim-pending';
 import { ROUTES } from '@/utils/routes';
 
+const CLAIM_FAILED_MESSAGE = 'Unable to claim this agent. Please try again or reopen the link from your chat.';
+const ENV_READY_TIMEOUT_MS = 60_000;
+
 export const ConnectClaimPage = () => {
   const { isLoaded, isSignedIn } = useClerkAuth();
   const [searchParams] = useSearchParams();
@@ -74,17 +77,35 @@ function ConnectClaimContent({ token }: { token: string | null }) {
   const { currentOrganization } = useAuth();
   const novuOrganizationId = currentOrganization?._id;
   const [isEnvironmentReady, setIsEnvironmentReady] = useState(false);
+  const [environmentSetupError, setEnvironmentSetupError] = useState<string | null>(null);
   const { environments } = useFetchEnvironments({
     organizationId: novuOrganizationId || BOOTSTRAP_ORG_CACHE_KEY,
-    refetchInterval: isEnvironmentReady ? undefined : 1000,
+    refetchInterval: isEnvironmentReady || environmentSetupError ? undefined : 1000,
     showError: false,
   });
 
   useEffect(() => {
     if (hasClaimableDevelopmentEnvironment(environments)) {
       setIsEnvironmentReady(true);
+      setEnvironmentSetupError(null);
     }
   }, [environments]);
+
+  useEffect(() => {
+    if (isEnvironmentReady || environmentSetupError) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setEnvironmentSetupError(
+        'Your development environment is taking longer than expected to set up. Please try again in a moment.'
+      );
+    }, ENV_READY_TIMEOUT_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isEnvironmentReady, environmentSetupError]);
   const [isClaiming, setIsClaiming] = useState(false);
   const [didClaim, setDidClaim] = useState(false);
   const [claimError, setClaimError] = useState<string | null>(null);
@@ -105,9 +126,9 @@ function ConnectClaimContent({ token }: { token: string | null }) {
       clearPendingConnectClaim();
       setDidClaim(true);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unable to claim this agent';
-      showErrorToast(`Claim failed: ${message}`);
-      setClaimError(message);
+      console.error('Connect claim failed', error);
+      showErrorToast(CLAIM_FAILED_MESSAGE, 'Claim failed');
+      setClaimError(CLAIM_FAILED_MESSAGE);
     } finally {
       setIsClaiming(false);
     }
@@ -120,7 +141,8 @@ function ConnectClaimContent({ token }: { token: string | null }) {
   };
 
   const reason = tokenOk ? null : 'This page must be opened from the link in your chat.';
-  const canClaim = !reason && isEnvironmentReady && !isClaiming && !didClaim && !claimError;
+  const setupError = environmentSetupError;
+  const canClaim = !reason && !setupError && isEnvironmentReady && !isClaiming && !didClaim && !claimError;
 
   useEffect(() => {
     if (canClaim && !hasAttemptedRef.current) {
@@ -147,6 +169,22 @@ function ConnectClaimContent({ token }: { token: string | null }) {
           {reason ? (
             <div className="text-text-sub flex w-full items-start gap-2 rounded-lg border border-dashed border-stroke-soft p-3 text-label-xs">
               <span>{reason}</span>
+            </div>
+          ) : setupError ? (
+            <div className="flex w-full flex-col gap-3">
+              <div className="text-text-sub flex w-full items-start gap-2 rounded-lg border border-dashed border-stroke-soft p-3 text-label-xs">
+                <span>{setupError}</span>
+              </div>
+              <button
+                type="button"
+                className="text-label-xs text-text-strong w-full rounded-lg border border-stroke-soft px-3 py-2 font-medium"
+                onClick={() => {
+                  setEnvironmentSetupError(null);
+                  setIsEnvironmentReady(false);
+                }}
+              >
+                Try again
+              </button>
             </div>
           ) : didClaim ? (
             <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -14,6 +14,11 @@ import {
   resolvePendingCliAuthReturnUrl,
   storePendingCliAuth,
 } from '@/utils/cli-auth-pending';
+import {
+  buildConnectClaimReturnUrlFromSearchParams,
+  resolvePendingConnectClaimReturnUrl,
+  storePendingConnectClaimFromRedirectUrl,
+} from '@/utils/connect-claim-pending';
 import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -30,6 +35,10 @@ export const SignInPage = () => {
     () => buildCliAuthReturnUrlFromSearchParams(searchParams) ?? resolvePendingCliAuthReturnUrl(),
     [searchParams]
   );
+  const connectClaimReturnUrl = useMemo(
+    () => buildConnectClaimReturnUrlFromSearchParams(searchParams) ?? resolvePendingConnectClaimReturnUrl(),
+    [searchParams]
+  );
 
   useEffect(() => {
     const pending = parseCliAuthReturnFromSearchParams(searchParams);
@@ -37,6 +46,8 @@ export const SignInPage = () => {
     if (pending) {
       storePendingCliAuth(pending.deviceCode, pending.name);
     }
+
+    storePendingConnectClaimFromRedirectUrl(readClerkRedirectUrlParam(searchParams));
   }, [searchParams]);
 
   useEffect(() => {
@@ -65,8 +76,14 @@ export const SignInPage = () => {
       return;
     }
 
+    if (connectClaimReturnUrl) {
+      window.location.assign(connectClaimReturnUrl);
+
+      return;
+    }
+
     void navigate(buildRoute(ROUTES.WORKFLOWS, { environmentSlug: 'default' }), { replace: true });
-  }, [isLoaded, isSignedIn, cliAuthReturnUrl, navigate]);
+  }, [isLoaded, isSignedIn, cliAuthReturnUrl, connectClaimReturnUrl, navigate]);
 
   const signUpUrlWithRedirect = useMemo(() => {
     const redirectUrl = readClerkRedirectUrlParam(searchParams);
@@ -96,7 +113,7 @@ export const SignInPage = () => {
             path={ROUTES.SIGN_IN}
             signUpUrl={signUpUrlWithRedirect}
             appearance={clerkSignupAppearance}
-            forceRedirectUrl={cliAuthReturnUrl ?? undefined}
+            forceRedirectUrl={cliAuthReturnUrl ?? connectClaimReturnUrl ?? undefined}
           />
           {!IS_SELF_HOSTED && <RegionPicker />}
         </div>

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -8,6 +8,7 @@ import { IS_SELF_HOSTED } from '@/config';
 import { useSegment } from '@/context/segment';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { appendRedirectUrlParam, readCliAuthReturnUrl } from '@/utils/cli-auth-pending';
+import { storePendingConnectClaimFromRedirectUrl } from '@/utils/connect-claim-pending';
 import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -18,9 +19,10 @@ export const SignUpPage = () => {
   const { isSignedIn, isLoaded } = useAuth();
   const [searchParams] = useSearchParams();
 
-  // Persist pending CLI auth from inbound redirect_url; org creation still runs first.
+  // Persist pending CLI auth and connect claim from inbound redirect_url; org creation still runs first.
   useEffect(() => {
     readCliAuthReturnUrl(searchParams);
+    storePendingConnectClaimFromRedirectUrl(readClerkRedirectUrlParam(searchParams));
   }, [searchParams]);
 
   useEffect(() => {

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -1,0 +1,122 @@
+import { CONNECT_CLAIM_TOKEN_PATTERN } from '@novu/shared';
+import { ROUTES } from '@/utils/routes';
+
+const STORAGE_KEY = 'pendingConnectClaim';
+
+function isValidToken(token: string | null | undefined): token is string {
+  return typeof token === 'string' && CONNECT_CLAIM_TOKEN_PATTERN.test(token);
+}
+
+export function isConnectClaimPath(pathname: string): boolean {
+  return pathname === ROUTES.CONNECT_CLAIM;
+}
+
+export function parseConnectClaimToken(search: string): string | null {
+  const token = new URLSearchParams(search).get('token');
+
+  return isValidToken(token) ? token : null;
+}
+
+export function storePendingConnectClaim(token: string): void {
+  if (typeof window === 'undefined' || !isValidToken(token)) {
+    return;
+  }
+
+  sessionStorage.setItem(STORAGE_KEY, token);
+}
+
+export function isConnectClaimReturnUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+
+    return isConnectClaimPath(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export function storePendingConnectClaimFromPath(pathname: string, search = ''): boolean {
+  if (!isConnectClaimPath(pathname)) {
+    return false;
+  }
+
+  const token = parseConnectClaimToken(search);
+
+  if (!token) {
+    return false;
+  }
+
+  storePendingConnectClaim(token);
+
+  return true;
+}
+
+export function storePendingConnectClaimFromRedirectUrl(redirectUrl: string | null | undefined): boolean {
+  if (!redirectUrl || !isConnectClaimReturnUrl(redirectUrl)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(redirectUrl, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+    const token = parseConnectClaimToken(parsed.search);
+
+    if (!token) {
+      return false;
+    }
+
+    storePendingConnectClaim(token);
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readPendingConnectClaim(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const token = sessionStorage.getItem(STORAGE_KEY);
+
+  return isValidToken(token) ? token : null;
+}
+
+export function clearPendingConnectClaim(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  sessionStorage.removeItem(STORAGE_KEY);
+}
+
+export function resolvePendingConnectClaimReturnUrl(): string | null {
+  const token = readPendingConnectClaim();
+
+  if (!token) {
+    return null;
+  }
+
+  return `${ROUTES.CONNECT_CLAIM}?token=${encodeURIComponent(token)}`;
+}
+
+export function buildConnectClaimReturnUrlFromSearchParams(searchParams?: URLSearchParams): string | null {
+  const redirectUrl = searchParams?.get('redirect_url');
+
+  if (!redirectUrl || !isConnectClaimReturnUrl(redirectUrl)) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(redirectUrl, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+    const token = parseConnectClaimToken(parsed.search);
+
+    if (!token) {
+      return null;
+    }
+
+    return `${ROUTES.CONNECT_CLAIM}?token=${encodeURIComponent(token)}`;
+  } catch {
+    return null;
+  }
+}

--- a/apps/dashboard/src/utils/connect-claim-pending.ts
+++ b/apps/dashboard/src/utils/connect-claim-pending.ts
@@ -100,6 +100,16 @@ export function resolvePendingConnectClaimReturnUrl(): string | null {
   return `${ROUTES.CONNECT_CLAIM}?token=${encodeURIComponent(token)}`;
 }
 
+// Reads the token from the current URL and persists it. Safe to call at module load on every
+// document load — only writes when the param is present.
+export function captureConnectClaimTokenFromUrl(): void {
+  try {
+    storePendingConnectClaimFromPath(window.location.pathname, window.location.search);
+  } catch {
+    // ignore — no window available
+  }
+}
+
 export function buildConnectClaimReturnUrlFromSearchParams(searchParams?: URLSearchParams): string | null {
   const redirectUrl = searchParams?.get('redirect_url');
 

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -16,6 +16,7 @@ export const ROUTES = {
   ROOT: '/',
   LOCAL_STUDIO_AUTH: '/local-studio/auth',
   CLI_AUTH: '/cli/auth',
+  CONNECT_CLAIM: '/connect/claim',
   ENV: '/env',
   SETTINGS: '/settings',
   SETTINGS_ACCOUNT: '/settings/account',


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR restores the dashboard "connect claim" flow that broke during platform unification by reintroducing the /connect/claim route, page, and client API call so keyless agent claims work again. It preserves claim tokens across Clerk auth redirects using sessionStorage, threads the claim return URL through sign-in/sign-up/org-creation, and replays the POST /connect/claim call once the user and environment are ready. The change also sanitizes error messages and adds a timeout for environment readiness polling to avoid indefinite waits.

## Affected areas

**dashboard**: Re-added ROUTES.CONNECT_CLAIM and a new ConnectClaimPage that reads/persists tokens, waits for a claimable environment, and calls claimKeylessConnect (POST /connect/claim); added an API client function claimKeylessConnect. Implemented a new connect-claim-pending utility to validate tokens, persist them in sessionStorage (SSR-safe), capture tokens at app boot, build/resolve return URLs, and clear pending state. Updated sign-in, sign-up, and create-organization flows to store and prefer the connect-claim return URL so the flow resumes after auth.

## Key technical decisions

- SessionStorage (with window/SSR guards) is used to persist claim tokens across browser redirects so the token survives Clerk auth flows.  
- The client API contract for keyless claims is restored as POST /connect/claim (claimKeylessConnect).  
- Error messages returned from the claim API are sanitized before showing to users.  
- Environment-readiness polling includes an upper timeout to prevent infinite waiting.  
- The app now captures connect-claim tokens at startup (captureConnectClaimTokenFromUrl) to avoid losing query params when auth strips them.

## Testing

Flow verified via manual/end-to-end style checks: visiting /connect/claim?token=... while signed out preserves the token through signup and org creation and returns to trigger the claim; the flow also works when already signed in. No new unit tests were added; routing/state behavior is validated through manual/E2E scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The connect/platform dashboard unification (6292b302) removed the `/connect/claim` route and the auth redirect wiring that carried the claim token through signup and org creation. As a result, keyless agent claim links stopped working and post-signup redirects to the claim page were ignored.

This PR restores:
- The `/connect/claim` route and claim page
- SessionStorage persistence for the claim token across auth
- Sign-up, sign-in, and org-create redirects back to the claim page
- The `claimKeylessConnect` dashboard API client

Linear: https://linear.app/novu/issue/NV-7984/connect-claim-flow-broken-after-platform-unification

```mermaid
sequenceDiagram
  participant User
  participant ClaimPage as /connect/claim
  participant SignUp as /auth/sign-up
  participant OrgList as /auth/organization-list
  participant API as POST /connect/claim

  User->>ClaimPage: ?token=...
  alt not signed in
    ClaimPage->>SignUp: redirect_url=/connect/claim?token=...
    SignUp->>OrgList: after signup
    OrgList->>ClaimPage: after org create
  end
  ClaimPage->>API: claim token
  API-->>User: agent claimed
```

### Screenshots

N/A — auth/claim flow fix with no visual design changes.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

Regression introduced by #11467. The backend claim endpoint was unchanged; only dashboard routing and redirect handling were removed.

</details>

## Test plan

- [ ] Open `/connect/claim?token=<valid-token>` while signed out — should redirect to sign-up with `redirect_url` preserved
- [ ] Complete sign-up and org creation — should land back on `/connect/claim` and trigger the claim API
- [ ] Open `/connect/claim?token=<valid-token>` while signed in with an org — should claim successfully and show success state
- [ ] Sign in with `redirect_url=/connect/claim?token=...` as an existing user — should resume the claim flow

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the keyless agent claim flow (`/connect/claim`) that was accidentally removed during the platform dashboard unification. It re-wires the full auth redirect chain so that an unauthenticated user landing on `/connect/claim?token=…` is routed through sign-up and org creation with the claim token preserved, then returned to complete the claim via a new API call.

- **New `ConnectClaimPage`**: handles unauthenticated redirect to sign-up, polls for environment readiness (with a 60-second timeout), and auto-triggers `claimKeylessConnect` once ready; `hasAttemptedRef` guards against double-calls.
- **SessionStorage persistence**: `captureConnectClaimTokenFromUrl()` (module load) and `storePendingConnectClaimFromRedirectUrl` (sign-up/sign-in effects) ensure the claim token survives Clerk's fixed redirects through `SIGNUP_ORGANIZATION_LIST` and org creation.
- **Org-creation priority**: `create-organization.tsx` places `pendingConnectClaimReturnUrl` ahead of `pendingCliAuthReturnUrl` for both `afterCreateUrl` and `afterSelectUrl`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused restoration of a previously working flow with no modifications to backend logic.

All changed files follow the established CLI-auth pattern closely. Token validation is delegated to the shared CONNECT_CLAIM_TOKEN_PATTERN, sessionStorage reads/writes are SSR-guarded, and the hasAttemptedRef ref prevents double claims. The 60-second environment-readiness timeout and user-visible error state cover the degraded-API path. No existing auth flows are broken; the org-creation redirect priority order (connectClaim → cliAuth → default) is intentional and safe.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/connect-claim.tsx | New ConnectClaimPage orchestrates unauthenticated redirect to sign-up with token preserved, then polls for environment readiness (with 60s timeout) before auto-claiming. hasAttemptedRef prevents double-calls and retry logic is wired correctly. |
| apps/dashboard/src/utils/connect-claim-pending.ts | New utility module for persisting and resolving pending connect-claim tokens via sessionStorage; well-validated with CONNECT_CLAIM_TOKEN_PATTERN and SSR-safe guards. Minor inconsistency: buildConnectClaimReturnUrlFromSearchParams uses searchParams.get directly instead of readClerkRedirectUrlParam, unlike the CLI-auth equivalent. |
| apps/dashboard/src/pages/sign-in.tsx | Added connectClaimReturnUrl resolved from URL params / sessionStorage, forwarded as forceRedirectUrl and in the already-signed-in redirect effect. Consistent with the existing CLI auth pattern. |
| apps/dashboard/src/pages/sign-up.tsx | Stores the pending connect-claim token from the inbound redirect_url into sessionStorage so it survives through Clerk's fixed SIGNUP_ORGANIZATION_LIST redirect. Mirrors the existing CLI auth persistence pattern. |
| apps/dashboard/src/components/auth/create-organization.tsx | Adds pendingConnectClaimReturnUrl (highest priority) alongside pendingCliAuthReturnUrl for afterCreateUrl and afterSelectUrl, correctly restoring the claim flow after org creation. |
| apps/dashboard/src/api/connect.ts | New claimKeylessConnect API client posting to /connect/claim with the token. Straightforward and correctly typed. |
| apps/dashboard/src/main.tsx | Registers ConnectClaimPage at ROUTES.CONNECT_CLAIM and calls captureConnectClaimTokenFromUrl() at module load. Route is correctly placed as a public/unauthenticated-accessible route. |
| apps/dashboard/src/utils/routes.ts | Adds CONNECT_CLAIM: '/connect/claim' to the ROUTES constant. Clean one-line addition. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as User
  participant CP as /connect/claim
  participant SU as /auth/sign-up
  participant OL as /auth/organization-list
  participant SS as sessionStorage
  participant API as POST /connect/claim

  U->>CP: "?token=abc"
  CP->>SS: captureConnectClaimTokenFromUrl() [module load]
  CP->>SU: "redirect_url=/connect/claim?token=abc"
  SU->>SS: storePendingConnectClaimFromRedirectUrl()
  Note over SU: forceRedirectUrl=SIGNUP_ORGANIZATION_LIST
  SU-->>OL: after Clerk sign-up
  OL->>SS: resolvePendingConnectClaimReturnUrl()
  OL-->>CP: "afterCreateUrl=/connect/claim?token=abc"
  CP->>SS: readPendingConnectClaim()
  CP->>API: claimKeylessConnect(token)
  API-->>U: agent claimed
  CP->>SS: clearPendingConnectClaim()
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Futils%2Fconnect-claim-pending.ts%3A113-114%0A%60buildConnectClaimReturnUrlFromSearchParams%60%20reads%20%60redirect_url%60%20via%20%60searchParams%3F.get%28'redirect_url'%29%60%20directly%2C%20while%20the%20analogous%20CLI%20auth%20function%20%28%60parseCliAuthReturnFromSearchParams%60%29%20uses%20%60readClerkRedirectUrlParam%60.%20%60readClerkRedirectUrlParam%60%20additionally%20checks%20%60window.location.search%60%20and%20hash-based%20routing%20%28%60%23%2F%3Fredirect_url%3D%E2%80%A6%60%29%2C%20which%20Clerk%20falls%20back%20to%20in%20some%20environments.%20If%20Clerk%20places%20the%20%60redirect_url%60%20in%20the%20hash%20fragment%2C%20%60buildConnectClaimReturnUrlFromSearchParams%60%20would%20return%20%60null%60%2C%20leaving%20the%20Clerk%20%60%3CSignIn%3E%60%20form%20without%20a%20%60forceRedirectUrl%60%20and%20silently%20sending%20the%20user%20to%20the%20default%20dashboard%20instead%20of%20the%20claim%20page.%0A%0A%60%60%60suggestion%0Aexport%20function%20buildConnectClaimReturnUrlFromSearchParams%28searchParams%3F%3A%20URLSearchParams%29%3A%20string%20%7C%20null%20%7B%0A%20%20const%20redirectUrl%20%3D%20readClerkRedirectUrlParam%28searchParams%29%3B%0A%60%60%60%0A%0A&pr=11475&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/utils/connect-claim-pending.ts:113-114
`buildConnectClaimReturnUrlFromSearchParams` reads `redirect_url` via `searchParams?.get('redirect_url')` directly, while the analogous CLI auth function (`parseCliAuthReturnFromSearchParams`) uses `readClerkRedirectUrlParam`. `readClerkRedirectUrlParam` additionally checks `window.location.search` and hash-based routing (`#/?redirect_url=…`), which Clerk falls back to in some environments. If Clerk places the `redirect_url` in the hash fragment, `buildConnectClaimReturnUrlFromSearchParams` would return `null`, leaving the Clerk `<SignIn>` form without a `forceRedirectUrl` and silently sending the user to the default dashboard instead of the claim page.

```suggestion
export function buildConnectClaimReturnUrlFromSearchParams(searchParams?: URLSearchParams): string | null {
  const redirectUrl = readClerkRedirectUrlParam(searchParams);
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): address connect claim re..."](https://github.com/novuhq/novu/commit/1b507a18fc3e48608d077fad8cb3a5860f78d5f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36256104)</sub>

<!-- /greptile_comment -->