### PR TITLE
feat(dashboard): add Visit Dashboard CTA on connect claim success fixes NV-7985

### DIFF
--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -3,10 +3,11 @@ import type { IEnvironment } from '@novu/shared';
 import { EnvironmentTypeEnum } from '@novu/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { RiCheckLine, RiLoader4Line } from 'react-icons/ri';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { claimKeylessConnect } from '@/api/connect';
 import { AuthLayout } from '@/components/auth-layout';
 import { PageMeta } from '@/components/page-meta';
+import { Button } from '@/components/primitives/button';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { useAuth } from '@/context/auth/hooks';
 import { EnvironmentProvider } from '@/context/environment/environment-provider';
@@ -74,6 +75,7 @@ function hasClaimableDevelopmentEnvironment(environments?: IEnvironment[]): bool
 }
 
 function ConnectClaimContent({ token }: { token: string | null }) {
+  const navigate = useNavigate();
   const { currentOrganization } = useAuth();
   const novuOrganizationId = currentOrganization?._id;
   const [isEnvironmentReady, setIsEnvironmentReady] = useState(false);
@@ -187,11 +189,23 @@ function ConnectClaimContent({ token }: { token: string | null }) {
               </button>
             </div>
           ) : didClaim ? (
-            <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">
-              <RiCheckLine className="mt-0.5 size-4 shrink-0" />
-              <span>
-                Your agent is connected to your account. Head back to your chat — the agent is ready to continue.
-              </span>
+            <div className="flex w-full flex-col gap-3">
+              <div className="flex w-full items-start gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-label-xs text-green-700">
+                <RiCheckLine className="mt-0.5 size-4 shrink-0" />
+                <span>
+                  Your agent is connected to your account. Head back to your chat — the agent is ready to continue.
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                mode="ghost"
+                size="xs"
+                className="w-full"
+                onClick={() => navigate(ROUTES.ROOT)}
+              >
+                Visit Dashboard
+              </Button>
             </div>
           ) : claimError ? (
             <div className="flex w-full flex-col gap-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a subtle "Visit Dashboard" CTA below the success message on the connect claim page, so users can continue building in the dashboard after claiming their agent.

## Changes

- Show a ghost-style button under the green success banner once claim completes
- Button navigates to the dashboard root (`/`), where the environment provider routes users into their workspace

## Test plan

- [ ] Open `/connect/claim` with a valid claim token while signed in
- [ ] After claim succeeds, confirm the success message appears with a "Visit Dashboard" button below it
- [ ] Click "Visit Dashboard" and verify navigation into the dashboard
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1780941792883129?thread_ts=1780941792.883129&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-80d53079-b369-5cbc-9f9b-09d76e419e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80d53079-b369-5cbc-9f9b-09d76e419e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Visit Dashboard" ghost-style button beneath the green success banner on the `/connect/claim` page, giving users a direct path into the dashboard after their agent claim succeeds. The change is confined to a single component and is straightforward.

- The existing success message div is wrapped in a `flex-col` container and a `<Button variant="secondary" mode="ghost">` is appended, navigating to `ROUTES.ROOT` via `useNavigate`.
- The "Try again" buttons in the error states are still plain `<button>` elements with hand-rolled Tailwind classes, creating a minor inconsistency with the new `<Button>` primitive used for the success CTA.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to a single UI file and introduces no new logic paths or side effects.

The only change is wrapping the existing success banner in a flex column and appending a navigation button. The navigation target (ROUTES.ROOT) is an existing well-used constant, and useNavigate is used correctly. No state, data fetching, or auth logic is affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/connect-claim.tsx | Adds a "Visit Dashboard" ghost button below the success banner on the connect-claim page; uses useNavigate + ROUTES.ROOT correctly. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConnectClaimContent mounts] --> B{token ok?}
    B -- No --> C[Show 'Open from chat link' message]
    B -- Yes --> D{environmentSetupError?}
    D -- Yes --> E[Show setup error + Try again button]
    D -- No --> F{isEnvironmentReady?}
    F -- No --> G[Show spinner / polling environments]
    F -- Yes --> H{didClaim?}
    H -- Yes --> I[✅ Green success banner]
    I --> J[Visit Dashboard button → navigate ROUTES.ROOT]
    H -- No --> K{claimError?}
    K -- Yes --> L[Show error + Try again button]
    K -- No --> M[Auto-call handleClaim]
    M --> H
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/pages/connect-claim.tsx`, line 180-189 ([link](https://github.com/novuhq/novu/blob/aad4e1d5201cd95a7e50e8ba8385135a4036683c/apps/dashboard/src/pages/connect-claim.tsx#L180-L189)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The error-state "Try again" buttons (both the `setupError` branch and the `claimError` branch) use a raw `<button>` with hand-rolled Tailwind classes, while the new "Visit Dashboard" button uses the `<Button>` primitive. Applying the same primitive keeps the design system consistent and avoids diverging visual behaviour if the primitive is updated later.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/pages/connect-claim.tsx
   Line: 180-189

   Comment:
   The error-state "Try again" buttons (both the `setupError` branch and the `claimError` branch) use a raw `<button>` with hand-rolled Tailwind classes, while the new "Visit Dashboard" button uses the `<Button>` primitive. Applying the same primitive keeps the design system consistent and avoids diverging visual behaviour if the primitive is updated later.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fpages%2Fconnect-claim.tsx%0ALine%3A%20180-189%0A%0AComment%3A%0AThe%20error-state%20%22Try%20again%22%20buttons%20%28both%20the%20%60setupError%60%20branch%20and%20the%20%60claimError%60%20branch%29%20use%20a%20raw%20%60%3Cbutton%3E%60%20with%20hand-rolled%20Tailwind%20classes%2C%20while%20the%20new%20%22Visit%20Dashboard%22%20button%20uses%20the%20%60%3CButton%3E%60%20primitive.%20Applying%20the%20same%20primitive%20keeps%20the%20design%20system%20consistent%20and%20avoids%20diverging%20visual%20behaviour%20if%20the%20primitive%20is%20updated%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CButton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20variant%3D%22secondary%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20mode%3D%22ghost%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20size%3D%22xs%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22w-full%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20setEnvironmentSetupError%28null%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20setIsEnvironmentReady%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Try%20again%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FButton%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11477&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fpages%2Fconnect-claim.tsx%3A180-189%0AThe%20error-state%20%22Try%20again%22%20buttons%20%28both%20the%20%60setupError%60%20branch%20and%20the%20%60claimError%60%20branch%29%20use%20a%20raw%20%60%3Cbutton%3E%60%20with%20hand-rolled%20Tailwind%20classes%2C%20while%20the%20new%20%22Visit%20Dashboard%22%20button%20uses%20the%20%60%3CButton%3E%60%20primitive.%20Applying%20the%20same%20primitive%20keeps%20the%20design%20system%20consistent%20and%20avoids%20diverging%20visual%20behaviour%20if%20the%20primitive%20is%20updated%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CButton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20variant%3D%22secondary%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20mode%3D%22ghost%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20size%3D%22xs%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22w-full%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20setEnvironmentSetupError%28null%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20setIsEnvironmentReady%28false%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Try%20again%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3C%2FButton%3E%0A%60%60%60%0A%0A&pr=11477&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/pages/connect-claim.tsx:180-189
The error-state "Try again" buttons (both the `setupError` branch and the `claimError` branch) use a raw `<button>` with hand-rolled Tailwind classes, while the new "Visit Dashboard" button uses the `<Button>` primitive. Applying the same primitive keeps the design system consistent and avoids diverging visual behaviour if the primitive is updated later.

```suggestion
              <Button
                type="button"
                variant="secondary"
                mode="ghost"
                size="xs"
                className="w-full"
                onClick={() => {
                  setEnvironmentSetupError(null);
                  setIsEnvironmentReady(false);
                }}
              >
                Try again
              </Button>
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): add Visit Dashboard CTA..."](https://github.com/novuhq/novu/commit/aad4e1d5201cd95a7e50e8ba8385135a4036683c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36269540)</sub>

<!-- /greptile_comment -->