### PR TITLE
fix(dashboard): redirect agent setup onboarding to agents page fixes NV-7986

### DIFF
--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -221,7 +221,7 @@ export function AgentsSetupPage() {
       return;
     }
 
-    void navigate(ROUTES.WORKFLOWS);
+    void navigate(buildRoute(ROUTES.AGENTS, { environmentSlug: 'default' }));
   }, [buildOnboardingCompletionProps, currentEnvironment?.slug, navigate, telemetry]);
 
   const handleNavigateToOverview = useCallback(() => {

--- a/apps/dashboard/src/utils/onboarding-redirect.ts
+++ b/apps/dashboard/src/utils/onboarding-redirect.ts
@@ -40,5 +40,5 @@ export function getPostOrgCreateRoute(): string {
 }
 
 export function getPostOnboardingRoute(environmentSlug: string): string {
-  return buildRoute(ROUTES.WORKFLOWS, { environmentSlug });
+  return buildRoute(ROUTES.AGENTS, { environmentSlug });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When users skip or complete the agent setup onboarding flow, they are now redirected to the agents list page instead of the workflows page.

## Changes

- Updated `getPostOnboardingRoute` to build the agents route (`/env/:environmentSlug/agents`)
- Updated the fallback navigation in `AgentsSetupPage` when no environment slug is available

## Why

After finishing or skipping agent onboarding, users should land on the agents page where they can continue managing their newly created agent, rather than being sent to workflows.

## Testing

- Skip setup from `/onboarding/agents/setup` → navigates to agents page
- Complete setup and click "Navigate to Dashboard" → navigates to agents page
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1780942672321189?thread_ts=1780942672.321189&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-553affb9-cf8c-5c06-a44a-3b95a802f18d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-553affb9-cf8c-5c06-a44a-3b95a802f18d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

After agent onboarding completes or is skipped, users are now redirected to the agents page (`/env/:environmentSlug/agents`) instead of the workflows page. This affects both the `getPostOnboardingRoute` utility and the no-slug fallback path inside `AgentsSetupPage`.

- **`onboarding-redirect.ts`**: `getPostOnboardingRoute` now calls `buildRoute(ROUTES.AGENTS, ...)` — a one-line swap with no side effects on other onboarding flows.
- **`agents-setup-page.tsx`**: The fallback branch in `handleSkip` (reached when `currentEnvironment?.slug` is unavailable) was also corrected from `navigate(ROUTES.WORKFLOWS)` (which would have resolved to the literal unbuilt template string `/env/:environmentSlug/workflows`) to `navigate(buildRoute(ROUTES.AGENTS, { environmentSlug: 'default' }))`, matching the pattern used in `sign-in.tsx`.

<h3>Confidence Score: 5/5</h3>

Two targeted changes that redirect post-onboarding navigation from workflows to agents; no shared utilities or other onboarding flows are affected.

Both changed lines are correct: `getPostOnboardingRoute` now builds the agents route with the caller-supplied slug, and the fallback in `handleSkip` uses `buildRoute` with the `'default'` slug convention already established by `sign-in.tsx`. The only pre-existing gap — `handleNavigateToOverview` silently doing nothing when `currentEnvironment?.slug` is absent — is unreachable in practice due to the `isDataReady` loading gate.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/onboarding-redirect.ts | Single-line change: `getPostOnboardingRoute` now builds the agents route instead of workflows, correctly pointing post-onboarding navigation to `/env/:environmentSlug/agents`. |
| apps/dashboard/src/pages/agents-setup-page.tsx | Fallback in `handleSkip` updated from navigating to the raw `ROUTES.WORKFLOWS` template string to `buildRoute(ROUTES.AGENTS, { environmentSlug: 'default' })`, consistent with how `sign-in.tsx` handles the same no-slug edge case. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AgentsSetupPage
    participant onboarding-redirect
    participant Router

    User->>AgentsSetupPage: Click Skip setup
    AgentsSetupPage->>AgentsSetupPage: handleSkip()
    alt currentEnvironment.slug available
        AgentsSetupPage->>onboarding-redirect: getPostOnboardingRoute(slug)
        onboarding-redirect-->>AgentsSetupPage: /env/slug/agents
        AgentsSetupPage->>Router: goToPostOnboardingRoute(url)
    else no slug fallback
        AgentsSetupPage->>Router: navigate /env/default/agents
    end
    User->>AgentsSetupPage: Click Navigate to Dashboard
    AgentsSetupPage->>AgentsSetupPage: handleNavigateToOverview()
    alt currentEnvironment.slug available
        AgentsSetupPage->>onboarding-redirect: getPostOnboardingRoute(slug)
        onboarding-redirect-->>AgentsSetupPage: /env/slug/agents
        AgentsSetupPage->>Router: goToPostOnboardingRoute(url)
    end
    Router-->>User: Lands on Agents page
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): redirect agent setup onb..."](https://github.com/novuhq/novu/commit/95fdcf207639ee5f88476127d55ce595fb1e54b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36272769)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Users completing or skipping the agent setup onboarding flow are now redirected to the agents list page instead of the workflows page. The post-onboarding routing destination was updated from `ROUTES.WORKFLOWS` to `ROUTES.AGENTS`, with a fallback to use the default environment slug when the current environment is unavailable.

## Affected areas

- **dashboard**: Updated `getPostOnboardingRoute()` in the onboarding redirect utility to route to the agents page post-onboarding. Updated fallback navigation in `AgentsSetupPage.handleSkip()` to navigate to the agents page when the current environment slug is unavailable.

## Testing

No tests were added in the changeset. Manual verification scenarios are documented in the PR description: skipping setup from `/onboarding/agents/setup` should navigate to the agents page, and completing setup and clicking "Navigate to Dashboard" should also navigate to the agents page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->