### PR TITLE
fix(api-service): scope integration mutations to API key environment fixes NV-7989

### DIFF
--- a/apps/api/src/app/integrations/e2e/auto-configure-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/auto-configure-integration.e2e.ts
@@ -1,0 +1,63 @@
+import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('Auto Configure Integration - /integrations/:integrationId/auto-configure (POST) #novu-v2', () => {
+  let session: UserSession;
+  const integrationRepository = new IntegrationRepository();
+  const envRepository = new EnvironmentRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid auto-configuring an integration that lives in a different environment when authenticated via API key', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
+
+      const otherEnvironmentIntegration = await integrationRepository.create({
+        name: 'OtherEnvAutoConfigure',
+        identifier: 'other-env-auto-configure-api-key',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        credentials: { apiKey: 'SG.test', secretKey: 'test' },
+        _organizationId: session.organization._id,
+        _environmentId: prodEnv!._id,
+      });
+
+      const { body } = await session.testAgent
+        .post(`/v1/integrations/${otherEnvironmentIntegration._id}/auto-configure`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send();
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+    });
+
+    it('should still allow JWT-authenticated requests to auto-configure integrations in another environment', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
+
+      const otherEnvironmentIntegration = await integrationRepository.create({
+        name: 'OtherEnvAutoConfigureJwt',
+        identifier: 'other-env-auto-configure-jwt',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        credentials: { apiKey: 'SG.test', secretKey: 'test' },
+        _organizationId: session.organization._id,
+        _environmentId: prodEnv!._id,
+      });
+
+      const res = await session.testAgent
+        .post(`/v1/integrations/${otherEnvironmentIntegration._id}/auto-configure`)
+        .send();
+
+      expect(res.status).to.not.equal(403);
+    });
+  });
+});

--- a/apps/api/src/app/integrations/e2e/remove-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/remove-integration.e2e.ts
@@ -1,5 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
-import { IntegrationRepository } from '@novu/dal';
+import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { ChannelTypeEnum, ChatProviderIdEnum, EmailProviderIdEnum, PushProviderIdEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
@@ -7,6 +7,7 @@ import { expect } from 'chai';
 describe('Delete Integration - /integration/:integrationId (DELETE) #novu-v2', () => {
   let session: UserSession;
   const integrationRepository = new IntegrationRepository();
+  const envRepository = new EnvironmentRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -269,5 +270,61 @@ describe('Delete Integration - /integration/:integrationId (DELETE) #novu-v2', (
     )[0];
 
     expect(deletedIntegration.deleted).to.equal(true);
+  });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid deleting an integration that lives in a different environment when authenticated via API key', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
+
+      const otherEnvironmentIntegration = await integrationRepository.create({
+        name: 'OtherEnvDelete',
+        identifier: 'other-env-delete-api-key',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        _organizationId: session.organization._id,
+        _environmentId: prodEnv!._id,
+      });
+
+      const { body } = await session.testAgent
+        .delete(`/v1/integrations/${otherEnvironmentIntegration._id}`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send();
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+
+      const untouched = await integrationRepository.findOne({
+        _id: otherEnvironmentIntegration._id,
+        _environmentId: prodEnv!._id,
+      });
+      expect(untouched?._id).to.equal(otherEnvironmentIntegration._id);
+    });
+
+    it('should still allow JWT-authenticated requests to delete integrations in another environment', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
+
+      const otherEnvironmentIntegration = await integrationRepository.create({
+        name: 'OtherEnvDeleteJwt',
+        identifier: 'other-env-delete-jwt',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        _organizationId: session.organization._id,
+        _environmentId: prodEnv!._id,
+      });
+
+      const res = await session.testAgent.delete(`/v1/integrations/${otherEnvironmentIntegration._id}`).send();
+
+      expect(res.status).to.equal(HttpStatus.OK);
+
+      const isDeleted = !(await integrationRepository.findOne({
+        _id: otherEnvironmentIntegration._id,
+        _environmentId: prodEnv!._id,
+      }));
+      expect(isDeleted).to.equal(true);
+    });
   });
 });

--- a/apps/api/src/app/integrations/e2e/set-itegration-as-primary.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/set-itegration-as-primary.e2e.ts
@@ -1,4 +1,4 @@
-import { IntegrationEntity, IntegrationRepository } from '@novu/dal';
+import { EnvironmentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import {
   ChannelTypeEnum,
   ChatProviderIdEnum,
@@ -12,6 +12,7 @@ import { expect } from 'chai';
 describe('Set Integration As Primary - /integrations/:integrationId/set-primary (POST) #novu-v2', () => {
   let session: UserSession;
   const integrationRepository = new IntegrationRepository();
+  const envRepository = new EnvironmentRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -502,5 +503,38 @@ describe('Set Integration As Primary - /integrations/:integrationId/set-primary 
     expect(third.primary).to.equal(false);
     expect(third.active).to.equal(false);
     expect(third.priority).to.equal(0);
+  });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid setting an integration in a different environment as primary when authenticated via API key', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
+
+      const otherEnvironmentIntegration = await integrationRepository.create({
+        name: 'OtherEnvPrimary',
+        identifier: 'other-env-primary-api-key',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: true,
+        primary: false,
+        priority: 1,
+        _organizationId: session.organization._id,
+        _environmentId: prodEnv!._id,
+      });
+
+      const { body } = await session.testAgent
+        .post(`/v1/integrations/${otherEnvironmentIntegration._id}/set-primary`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({});
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+
+      const untouched = (await integrationRepository.findOne({
+        _id: otherEnvironmentIntegration._id,
+        _environmentId: prodEnv!._id,
+      })) as IntegrationEntity;
+      expect(untouched.primary).to.equal(false);
+    });
   });
 });

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -315,7 +315,7 @@ export class IntegrationsController {
           check: body.check ?? false,
           conditions: body.conditions,
           configurations: body.configurations,
-          restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
+          restrictToUserEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
         })
       );
 
@@ -358,7 +358,7 @@ export class IntegrationsController {
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         integrationId,
-        restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
+        restrictToUserEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
 
@@ -391,7 +391,7 @@ export class IntegrationsController {
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         integrationId,
-        restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
+        restrictToUserEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
 
@@ -425,7 +425,7 @@ export class IntegrationsController {
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         integrationId,
-        restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
+        restrictToUserEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
   }

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -355,8 +355,10 @@ export class IntegrationsController {
     const result = await this.autoConfigureIntegrationUsecase.execute(
       AutoConfigureIntegrationCommand.create({
         userId: user._id,
+        environmentId: user.environmentId,
         organizationId: user.organizationId,
         integrationId,
+        restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
       })
     );
 
@@ -389,6 +391,7 @@ export class IntegrationsController {
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         integrationId,
+        restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
       })
     );
 
@@ -422,6 +425,7 @@ export class IntegrationsController {
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         integrationId,
+        restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
       })
     );
   }

--- a/apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.command.ts
@@ -1,8 +1,12 @@
-import { IsDefined, IsString } from 'class-validator';
-import { OrganizationCommand } from '../../../shared/commands/organization.command';
+import { IsBoolean, IsDefined, IsMongoId, IsOptional } from 'class-validator';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class AutoConfigureIntegrationCommand extends OrganizationCommand {
+export class AutoConfigureIntegrationCommand extends EnvironmentWithUserCommand {
   @IsDefined()
-  @IsString()
+  @IsMongoId()
   integrationId: string;
+
+  @IsOptional()
+  @IsBoolean()
+  restrictToUserEnvironment?: boolean;
 }

--- a/apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { ChannelFactory, GetDecryptedIntegrations, PinoLogger } from '@novu/application-generic';
 import { IntegrationRepository } from '@novu/dal';
 import { AutoConfigureIntegrationResponseDto } from '../../dtos/auto-configure-integration-response.dto';
+import { assertIntegrationEnvironmentScope } from '../../utils/assert-integration-environment-scope';
 import { AutoConfigureIntegrationCommand } from './auto-configure-integration.command';
 
 @Injectable()
@@ -25,6 +26,13 @@ export class AutoConfigureIntegration {
     if (!encryptedIntegration) {
       throw new NotFoundException(`Integration not found, id: ${command.integrationId}`);
     }
+
+    assertIntegrationEnvironmentScope({
+      restrictToUserEnvironment: command.restrictToUserEnvironment,
+      userEnvironmentId: command.environmentId,
+      integrationEnvironmentId: encryptedIntegration._environmentId,
+      action: 'auto-configure',
+    });
 
     const integration = GetDecryptedIntegrations.getDecryptedCredentials(encryptedIntegration);
 

--- a/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.command.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsMongoId } from 'class-validator';
+import { IsBoolean, IsDefined, IsMongoId, IsOptional } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
@@ -6,4 +6,8 @@ export class RemoveIntegrationCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   @IsMongoId()
   integrationId: string;
+
+  @IsOptional()
+  @IsBoolean()
+  restrictToUserEnvironment?: boolean;
 }

--- a/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/remove-integration/remove-integration.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException, Scope } from '@nest
 import { DalException, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import { CHANNELS_WITH_PRIMARY, ChannelTypeEnum, EmailProviderIdEnum, SmsProviderIdEnum } from '@novu/shared';
 
+import { assertIntegrationEnvironmentScope } from '../../utils/assert-integration-environment-scope';
 import { RemoveIntegrationCommand } from './remove-integration.command';
 
 @Injectable({
@@ -19,6 +20,13 @@ export class RemoveIntegration {
       if (!existingIntegration) {
         throw new NotFoundException(`Entity with id ${command.integrationId} not found`);
       }
+
+      assertIntegrationEnvironmentScope({
+        restrictToUserEnvironment: command.restrictToUserEnvironment,
+        userEnvironmentId: command.environmentId,
+        integrationEnvironmentId: existingIntegration._environmentId,
+        action: 'delete',
+      });
 
       await this.integrationRepository.delete({
         _id: existingIntegration._id,

--- a/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.command.ts
+++ b/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.command.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsMongoId } from 'class-validator';
+import { IsBoolean, IsDefined, IsMongoId, IsOptional } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
@@ -6,4 +6,8 @@ export class SetIntegrationAsPrimaryCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   @IsMongoId()
   integrationId: string;
+
+  @IsOptional()
+  @IsBoolean()
+  restrictToUserEnvironment?: boolean;
 }

--- a/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.usecase.ts
@@ -3,6 +3,7 @@ import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import { IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
 
+import { assertIntegrationEnvironmentScope } from '../../utils/assert-integration-environment-scope';
 import { SetIntegrationAsPrimaryCommand } from './set-integration-as-primary.command';
 
 @Injectable()
@@ -57,6 +58,13 @@ export class SetIntegrationAsPrimary {
     if (!existingIntegration) {
       throw new NotFoundException(`Integration with id ${command.integrationId} not found`);
     }
+
+    assertIntegrationEnvironmentScope({
+      restrictToUserEnvironment: command.restrictToUserEnvironment,
+      userEnvironmentId: command.environmentId,
+      integrationEnvironmentId: existingIntegration._environmentId,
+      action: 'set as primary',
+    });
 
     if (!existingIntegration.channel || !CHANNELS_WITH_PRIMARY.includes(existingIntegration.channel)) {
       throw new BadRequestException(`Channel ${existingIntegration.channel ?? 'unknown'} does not support primary`);

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
@@ -1,16 +1,10 @@
-import {
-  BadRequestException,
-  ConflictException,
-  ForbiddenException,
-  Inject,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { AnalyticsService, decryptCredentials, encryptCredentials, PinoLogger } from '@novu/application-generic';
 import { EnvironmentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
 import { CheckIntegrationCommand } from '../check-integration/check-integration.command';
 import { CheckIntegration } from '../check-integration/check-integration.usecase';
+import { assertIntegrationEnvironmentScope } from '../../utils/assert-integration-environment-scope';
 import { ensureNovuAgentManagedCredentials } from '../novu-agent/novu-agent-credentials.utils';
 import { ensureWhatsAppManagedCredentials } from '../whatsapp/whatsapp-credentials.utils';
 import { UpdateIntegrationCommand } from './update-integration.command';
@@ -110,13 +104,12 @@ export class UpdateIntegration {
       throw new NotFoundException(`Entity with id ${command.integrationId} not found`);
     }
 
-    if (command.restrictToUserEnvironment && existingIntegration._environmentId !== command.userEnvironmentId) {
-      throw new ForbiddenException(
-        'API key authentication is scoped to a single environment and cannot update an integration ' +
-          "that belongs to a different environment. Use an API key from the integration's environment, " +
-          'or authenticate with a session token.'
-      );
-    }
+    assertIntegrationEnvironmentScope({
+      restrictToUserEnvironment: command.restrictToUserEnvironment,
+      userEnvironmentId: command.userEnvironmentId,
+      integrationEnvironmentId: existingIntegration._environmentId,
+      action: 'update',
+    });
 
     if (command.environmentId && command.environmentId !== existingIntegration._environmentId) {
       const targetEnvironment = await this.environmentRepository.findByIdAndOrganization(

--- a/apps/api/src/app/integrations/utils/assert-integration-environment-scope.ts
+++ b/apps/api/src/app/integrations/utils/assert-integration-environment-scope.ts
@@ -1,0 +1,24 @@
+import { ForbiddenException } from '@nestjs/common';
+
+type IntegrationMutationAction = 'update' | 'delete' | 'set as primary' | 'auto-configure';
+
+export function assertIntegrationEnvironmentScope(params: {
+  restrictToUserEnvironment?: boolean;
+  userEnvironmentId: string;
+  integrationEnvironmentId: string;
+  action: IntegrationMutationAction;
+}): void {
+  if (!params.restrictToUserEnvironment) {
+    return;
+  }
+
+  if (params.integrationEnvironmentId === params.userEnvironmentId) {
+    return;
+  }
+
+  throw new ForbiddenException(
+    `API key authentication is scoped to a single environment and cannot ${params.action} an integration ` +
+      "that belongs to a different environment. Use an API key from the integration's environment, " +
+      'or authenticate with a session token.'
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

API key authentication is now scoped to the caller's environment for integration delete, set-primary, and auto-configure mutations. JWT/session auth continues to allow cross-environment management within the same organization.

## Changes

- Added `assertIntegrationEnvironmentScope` helper shared across integration mutation use cases
- Applied environment scoping to `RemoveIntegration`, `SetIntegrationAsPrimary`, and `AutoConfigureIntegration` when `restrictToUserEnvironment` is set (API key auth)
- Refactored `UpdateIntegration` to use the same helper (behavior unchanged)
- Added e2e regression tests for delete, set-primary, and auto-configure

## Behavior

| Auth | Cross-environment mutation |
|------|---------------------------|
| API key | Blocked (403) |
| JWT / session | Allowed |

## Testing

- `remove-integration.e2e.ts` — API key blocked, JWT allowed
- `set-itegration-as-primary.e2e.ts` — API key blocked
- `auto-configure-integration.e2e.ts` — API key blocked, JWT allowed
- Existing `update-integration.e2e.ts` coverage unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1780990672642799?thread_ts=1780990672.642799&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-e436d6b6-a252-5a1c-bf00-6123097ac3b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e436d6b6-a252-5a1c-bf00-6123097ac3b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Integration mutation endpoints are now scoped to the caller’s environment when authenticated via API key: delete, set-as-primary, and auto-configure operations will be blocked (403) if the target integration belongs to a different environment. JWT/session-authenticated users keep cross-environment mutation capabilities. A shared helper assertIntegrationEnvironmentScope centralizes the environment check; UpdateIntegration was refactored to use it.

## Affected areas
**api**: Integration use cases and controller wiring were updated to accept a restrictToUserEnvironment flag and (for auto-configure) the user environmentId; RemoveIntegration, SetIntegrationAsPrimary, AutoConfigureIntegration, and UpdateIntegration now call the shared assertion helper to enforce scoping for API-key auth. Command DTOs were extended (optional restrictToUserEnvironment) and AutoConfigureIntegrationCommand now extends EnvironmentWithUserCommand and validates integrationId as a MongoId. E2E test suites were added/extended to cover the scoped behavior.

## Key technical decisions
- Introduced assertIntegrationEnvironmentScope to centralize environment-scoping checks across multiple use cases.  
- AutoConfigureIntegrationCommand switched from OrganizationCommand to EnvironmentWithUserCommand to carry environmentId and scoping metadata.

## Testing
Added end-to-end tests verifying API key auth is blocked (403) and JWT auth remains allowed for cross-environment delete, set-primary, and auto-configure flows (remove-integration.e2e.ts, set-integration-as-primary.e2e.ts, auto-configure-integration.e2e.ts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes integration mutations (delete, set-primary, auto-configure) to the caller's environment when authenticated via API key, mirroring the existing guard on update. It introduces a shared `assertIntegrationEnvironmentScope` helper and wires `restrictToUserEnvironment` through three new command/usecase pairs, backed by e2e regression tests.

- `assertIntegrationEnvironmentScope` centralises the environment check, replacing an inline `ForbiddenException` in `UpdateIntegration` and adding the same guard to `RemoveIntegration`, `SetIntegrationAsPrimary`, and `AutoConfigureIntegration`.
- New e2e tests cover the API-key-blocked (403) and JWT-allowed paths for delete and set-primary; the auto-configure mutation has no corresponding test.
- `AutoConfigureIntegrationCommand` was promoted from `OrganizationCommand` to `EnvironmentWithUserCommand`; the only caller (the controller) was updated accordingly.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the auth boundary logic is correct across all four mutation paths and the shared helper eliminates the previous inline duplication.

The core guard is correct: it short-circuits on restrictToUserEnvironment = false and compares environment IDs before allowing any write. The ForbiddenException in RemoveIntegration is thrown inside a try-catch that only converts DalExceptions, so it propagates as a 403 as expected. The one gap is that auto-configure is the only mutating path without a corresponding e2e test, so a future regression there would go undetected.

apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.usecase.ts — the env-scope check is in place but has no test coverage unlike the parallel delete and set-primary paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/utils/assert-integration-environment-scope.ts | New shared utility that centralises the API-key scope check; logic is correct and clean |
| apps/api/src/app/integrations/usecases/remove-integration/remove-integration.usecase.ts | Scope check inserted before the delete; ForbiddenException correctly propagates through the catch-all block (not swallowed) |
| apps/api/src/app/integrations/usecases/set-integration-as-primary/set-integration-as-primary.usecase.ts | Scope check added after the not-found guard, before any state mutation; looks correct |
| apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.usecase.ts | Scope check added; command base class changed from OrganizationCommand to EnvironmentWithUserCommand — new field is wired in the controller, but no e2e test exercises this path |
| apps/api/src/app/integrations/integrations.controller.ts | restrictToUserEnvironment and environmentId added to three command creation sites; all three correctly derive the flag from user.scheme === API_KEY |
| apps/api/src/app/integrations/e2e/remove-integration.e2e.ts | New tests cover API-key block (403) and JWT allow path for delete; assertions on statusCode and message body are correct |
| apps/api/src/app/integrations/e2e/set-itegration-as-primary.e2e.ts | New test covers API-key block for set-primary; only the block path is tested |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Request\ndelete / set-primary / auto-configure / update] --> B{Auth scheme?}
    B -->|API key| C[restrictToUserEnvironment = true]
    B -->|JWT / session| D[restrictToUserEnvironment = false]
    C --> E[Fetch integration by id + orgId]
    D --> E
    E -->|not found| F[404 NotFoundException]
    E -->|found| G[assertIntegrationEnvironmentScope]
    G -->|restrictToUserEnvironment = false| H[Proceed with mutation]
    G -->|same environment| H
    G -->|different environment| I[403 ForbiddenException]
    H --> J[delete / setPrimary / autoConfigure / update]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fintegrations%2Fusecases%2Fauto-configure-integration%2Fauto-configure-integration.usecase.ts%3A30-35%0A**Missing%20e2e%20test%20for%20auto-configure%20scope%20enforcement**%0A%0AThe%20env-scope%20check%20was%20added%20here%20alongside%20the%20ones%20for%20%60delete%60%20and%20%60set-primary%60%2C%20but%20no%20e2e%20test%20exercises%20the%20API-key-blocked%20or%20JWT-allowed%20path%20for%20%60auto-configure%60.%20The%20other%20two%20mutations%20each%20have%20a%20dedicated%20test%20block%20%28%60remove-integration.e2e.ts%60%2C%20%60set-itegration-as-primary.e2e.ts%60%29%2C%20so%20this%20path%20is%20the%20only%20one%20left%20untested.%20A%20misconfiguration%20of%20the%20%60restrictToUserEnvironment%60%20flag%20in%20the%20controller%20%28e.g.%20forgetting%20to%20set%20it%20after%20a%20refactor%29%20would%20go%20undetected.%0A%0A&pr=11480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.usecase.ts:30-35
**Missing e2e test for auto-configure scope enforcement**

The env-scope check was added here alongside the ones for `delete` and `set-primary`, but no e2e test exercises the API-key-blocked or JWT-allowed path for `auto-configure`. The other two mutations each have a dedicated test block (`remove-integration.e2e.ts`, `set-itegration-as-primary.e2e.ts`), so this path is the only one left untested. A misconfiguration of the `restrictToUserEnvironment` flag in the controller (e.g. forgetting to set it after a refactor) would go undetected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): scope integration muta..."](https://github.com/novuhq/novu/commit/efe65cffd62f147b7027e8b1658b0cf943c811dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36396085)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->