### PR TITLE
fix(shared): harden isPrivateIp against alternate IPv6 encodings fixes NV-7990

### DIFF
--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -21,6 +21,7 @@
 import * as dns from 'node:dns';
 import * as http from 'node:http';
 import * as https from 'node:https';
+import { BlockList, isIPv4, isIPv6 } from 'node:net';
 import { Readable } from 'node:stream';
 import { LRUCache } from 'lru-cache';
 
@@ -58,37 +59,147 @@ export function normalizeOutboundHttpUrl(raw: string): string | null {
   }
 }
 
+const PRIVATE_IPV4_BLOCKLIST = new BlockList();
+PRIVATE_IPV4_BLOCKLIST.addAddress('0.0.0.0', 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
+/* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
+PRIVATE_IPV4_BLOCKLIST.addSubnet('100.64.0.0', 10, 'ipv4');
+
+const PRIVATE_IPV6_BLOCKLIST = new BlockList();
+PRIVATE_IPV6_BLOCKLIST.addAddress('::', 'ipv6');
+PRIVATE_IPV6_BLOCKLIST.addAddress('::1', 'ipv6');
+/* ULA fc00::/7 */
+PRIVATE_IPV6_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
+/* Link-local fe80::/10 */
+PRIVATE_IPV6_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
+
+function expandIpv6Hextets(ip: string): number[] | null {
+  const lower = ip.toLowerCase();
+
+  if (!lower.includes('::')) {
+    const parts = lower.split(':');
+
+    if (parts.length !== 8) {
+      return null;
+    }
+
+    return parts.map((part) => parseInt(part, 16));
+  }
+
+  const [head, tail] = lower.split('::');
+  const headParts = head ? head.split(':') : [];
+  const tailParts = tail ? tail.split(':') : [];
+  const missing = 8 - headParts.length - tailParts.length;
+
+  if (missing < 0) {
+    return null;
+  }
+
+  return [
+    ...headParts.map((part) => parseInt(part, 16)),
+    ...Array.from({ length: missing }, () => 0),
+    ...tailParts.map((part) => parseInt(part, 16)),
+  ];
+}
+
+function hextetsToIpv4(highHextet: number, lowHextet: number): string {
+  return [
+    (highHextet >> 8) & 0xff,
+    highHextet & 0xff,
+    (lowHextet >> 8) & 0xff,
+    lowHextet & 0xff,
+  ].join('.');
+}
+
+function extractEmbeddedIpv4(ip: string): string | null {
+  const dottedMappedMatch = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  const dottedMappedIpv4 = dottedMappedMatch?.[1];
+
+  if (dottedMappedIpv4) {
+    return dottedMappedIpv4;
+  }
+
+  const dottedCompatibleMatch = /^::(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  const dottedCompatibleIpv4 = dottedCompatibleMatch?.[1];
+
+  if (dottedCompatibleIpv4) {
+    return dottedCompatibleIpv4;
+  }
+
+  const hextets = expandIpv6Hextets(ip);
+
+  if (!hextets || hextets.length !== 8) {
+    return null;
+  }
+
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ];
+
+  if (h5 === 0xffff) {
+    return hextetsToIpv4(h6, h7);
+  }
+
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return hextetsToIpv4(h6, h7);
+  }
+
+  if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return hextetsToIpv4(h6, h7);
+  }
+
+  if (h0 === 0x2002) {
+    return hextetsToIpv4(h1, h2);
+  }
+
+  return null;
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  return PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv4');
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  if (PRIVATE_IPV6_BLOCKLIST.check(ip, 'ipv6')) {
+    return true;
+  }
+
+  const embeddedIpv4 = extractEmbeddedIpv4(ip);
+
+  if (embeddedIpv4 && isIPv4(embeddedIpv4)) {
+    return isPrivateIpv4(embeddedIpv4);
+  }
+
+  return false;
+}
+
+export function isPrivateIp(ip: string): boolean {
+  if (isIPv4(ip)) {
+    return isPrivateIpv4(ip);
+  }
+
+  if (isIPv6(ip)) {
+    return isPrivateIpv6(ip);
+  }
+
+  return false;
+}
+
 const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
   max: 500,
   ttl: 1000 * 60 * 5,
 });
-
-export function isPrivateIp(ip: string): boolean {
-  const sharedAddressSecondOctet = '(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])';
-  const privateRanges = [
-    /^0\.0\.0\.0$/i,
-    /^127\./,
-    /^10\./,
-    /^172\.(1[6-9]|2[0-9]|3[01])\./,
-    /^192\.168\./,
-    /^169\.254\./,
-    /* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
-    new RegExp(`^100\\.${sharedAddressSecondOctet}\\.`),
-    /^::ffff:127\./i,
-    /^::ffff:10\./i,
-    /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
-    /^::ffff:192\.168\./i,
-    /^::ffff:169\.254\./i,
-    new RegExp(`^::ffff:100\\.${sharedAddressSecondOctet}\\.`, 'i'),
-    /^::1$/i,
-    /^f[cd][0-9a-f]{2}:/i,
-    /^::ffff:f[cd][0-9a-f]{2}:/i,
-    /^fe[89ab][0-9a-f]:/i,
-    /^::ffff:fe[89ab][0-9a-f]:/i,
-  ];
-
-  return privateRanges.some((range) => range.test(ip));
-}
 
 const BLOCKED_HOSTNAMES = new Set(['localhost', 'metadata.google.internal']);
 

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -25,12 +25,11 @@ import { LRUCache } from 'lru-cache';
 
 type PrivateIpClassificationModule = typeof import('@novu/shared/dist/cjs/utils/private-ip-classification');
 
-// Runtime: subpath export. Types: direct dist path (node10 resolution cannot resolve subpath exports).
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const privateIpClassification = require('@novu/shared/utils/private-ip-classification') as PrivateIpClassificationModule;
+const { isPrivateIp, normalizeHostnameForLookup } =
+  require('@novu/shared/utils/private-ip-classification') as PrivateIpClassificationModule;
 
-export const isPrivateIp = privateIpClassification.isPrivateIp;
-export const normalizeHostnameForLookup = privateIpClassification.normalizeHostnameForLookup;
+export { isPrivateIp, normalizeHostnameForLookup };
 
 export function normalizeOutboundHttpUrl(raw: string): string | null {
   const trimmed = raw.trim();
@@ -125,16 +124,6 @@ export function assertSafeOutboundUrl(input: string | URL): URL {
   return parsed;
 }
 
-function resolveIpLiteralAddresses(normalizedHostname: string): dns.LookupAddress[] {
-  const family = isIP(normalizedHostname);
-
-  if (family === 0) {
-    return [];
-  }
-
-  return [{ address: normalizedHostname, family }];
-}
-
 export async function resolvePublicAddresses(
   hostname: string,
   options: { useCache?: boolean } = {}
@@ -150,7 +139,7 @@ export async function resolvePublicAddresses(
     const literalFamily = isIP(normalized);
 
     if (literalFamily !== 0) {
-      addresses = resolveIpLiteralAddresses(normalized);
+      addresses = [{ address: normalized, family: literalFamily }];
     } else {
       try {
         addresses = await dns.promises.lookup(normalized, { all: true });

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -12,6 +12,8 @@
 // Drift hazard: URL policy, redirect state machine, and DNS handling MUST stay
 // in lockstep between packages/shared and this mirror. Private IP classification
 // is canonical in @novu/shared/utils/private-ip-classification and re-exported here.
+// Runtime require() needs compiled dist output; nx build ordering (^build) builds
+// @novu/shared before application-generic.
 //
 // New code should prefer `safeOutboundRequest` / `safeOutboundJsonRequest`,
 // which enforce the policy at connect time and re-validate every redirect.

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -9,11 +9,9 @@
 // inlined copy so backend code has a single import path through
 // `@novu/application-generic`.
 //
-// Drift hazard: any change to the policy regexes, blocked hostname set,
-// SsrfBlockedError shape, redirect state machine, or DNS handling MUST land in
-// both files. A behavioural drift test in `packages/shared` exercises both
-// implementations against the same inputs to fail loudly if they ever
-// diverge — see `packages/shared/src/utils/safe-outbound-http-drift.spec.ts`.
+// Drift hazard: URL policy, redirect state machine, and DNS handling MUST stay
+// in lockstep between packages/shared and this mirror. Private IP classification
+// is canonical in @novu/shared/utils/private-ip-classification and re-exported here.
 //
 // New code should prefer `safeOutboundRequest` / `safeOutboundJsonRequest`,
 // which enforce the policy at connect time and re-validate every redirect.
@@ -21,9 +19,18 @@
 import * as dns from 'node:dns';
 import * as http from 'node:http';
 import * as https from 'node:https';
-import { BlockList, isIPv4, isIPv6 } from 'node:net';
+import { isIP } from 'node:net';
 import { Readable } from 'node:stream';
 import { LRUCache } from 'lru-cache';
+
+type PrivateIpClassificationModule = typeof import('@novu/shared/dist/cjs/utils/private-ip-classification');
+
+// Runtime: subpath export. Types: direct dist path (node10 resolution cannot resolve subpath exports).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const privateIpClassification = require('@novu/shared/utils/private-ip-classification') as PrivateIpClassificationModule;
+
+export const isPrivateIp = privateIpClassification.isPrivateIp;
+export const normalizeHostnameForLookup = privateIpClassification.normalizeHostnameForLookup;
 
 export function normalizeOutboundHttpUrl(raw: string): string | null {
   const trimmed = raw.trim();
@@ -57,143 +64,6 @@ export function normalizeOutboundHttpUrl(raw: string): string | null {
   } catch {
     return null;
   }
-}
-
-const PRIVATE_IPV4_BLOCKLIST = new BlockList();
-PRIVATE_IPV4_BLOCKLIST.addAddress('0.0.0.0', 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
-/* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
-PRIVATE_IPV4_BLOCKLIST.addSubnet('100.64.0.0', 10, 'ipv4');
-
-const PRIVATE_IPV6_BLOCKLIST = new BlockList();
-PRIVATE_IPV6_BLOCKLIST.addAddress('::', 'ipv6');
-PRIVATE_IPV6_BLOCKLIST.addAddress('::1', 'ipv6');
-/* ULA fc00::/7 */
-PRIVATE_IPV6_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
-/* Link-local fe80::/10 */
-PRIVATE_IPV6_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
-
-function expandIpv6Hextets(ip: string): number[] | null {
-  const lower = ip.toLowerCase();
-
-  if (!lower.includes('::')) {
-    const parts = lower.split(':');
-
-    if (parts.length !== 8) {
-      return null;
-    }
-
-    return parts.map((part) => parseInt(part, 16));
-  }
-
-  const [head, tail] = lower.split('::');
-  const headParts = head ? head.split(':') : [];
-  const tailParts = tail ? tail.split(':') : [];
-  const missing = 8 - headParts.length - tailParts.length;
-
-  if (missing < 0) {
-    return null;
-  }
-
-  return [
-    ...headParts.map((part) => parseInt(part, 16)),
-    ...Array.from({ length: missing }, () => 0),
-    ...tailParts.map((part) => parseInt(part, 16)),
-  ];
-}
-
-function hextetsToIpv4(highHextet: number, lowHextet: number): string {
-  return [
-    (highHextet >> 8) & 0xff,
-    highHextet & 0xff,
-    (lowHextet >> 8) & 0xff,
-    lowHextet & 0xff,
-  ].join('.');
-}
-
-function extractEmbeddedIpv4(ip: string): string | null {
-  const dottedMappedMatch = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
-  const dottedMappedIpv4 = dottedMappedMatch?.[1];
-
-  if (dottedMappedIpv4) {
-    return dottedMappedIpv4;
-  }
-
-  const dottedCompatibleMatch = /^::(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
-  const dottedCompatibleIpv4 = dottedCompatibleMatch?.[1];
-
-  if (dottedCompatibleIpv4) {
-    return dottedCompatibleIpv4;
-  }
-
-  const hextets = expandIpv6Hextets(ip);
-
-  if (!hextets || hextets.length !== 8) {
-    return null;
-  }
-
-  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets as [
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-  ];
-
-  if (h5 === 0xffff) {
-    return hextetsToIpv4(h6, h7);
-  }
-
-  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
-    return hextetsToIpv4(h6, h7);
-  }
-
-  if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
-    return hextetsToIpv4(h6, h7);
-  }
-
-  if (h0 === 0x2002) {
-    return hextetsToIpv4(h1, h2);
-  }
-
-  return null;
-}
-
-function isPrivateIpv4(ip: string): boolean {
-  return PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv4');
-}
-
-function isPrivateIpv6(ip: string): boolean {
-  if (PRIVATE_IPV6_BLOCKLIST.check(ip, 'ipv6')) {
-    return true;
-  }
-
-  const embeddedIpv4 = extractEmbeddedIpv4(ip);
-
-  if (embeddedIpv4 && isIPv4(embeddedIpv4)) {
-    return isPrivateIpv4(embeddedIpv4);
-  }
-
-  return false;
-}
-
-export function isPrivateIp(ip: string): boolean {
-  if (isIPv4(ip)) {
-    return isPrivateIpv4(ip);
-  }
-
-  if (isIPv6(ip)) {
-    return isPrivateIpv6(ip);
-  }
-
-  return false;
 }
 
 const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
@@ -255,26 +125,44 @@ export function assertSafeOutboundUrl(input: string | URL): URL {
   return parsed;
 }
 
+function resolveIpLiteralAddresses(normalizedHostname: string): dns.LookupAddress[] {
+  const family = isIP(normalizedHostname);
+
+  if (family === 0) {
+    return [];
+  }
+
+  return [{ address: normalizedHostname, family }];
+}
+
 export async function resolvePublicAddresses(
   hostname: string,
   options: { useCache?: boolean } = {}
 ): Promise<dns.LookupAddress[]> {
-  const lower = hostname.toLowerCase();
+  const normalized = normalizeHostnameForLookup(hostname);
   let addresses: dns.LookupAddress[] | undefined;
 
   if (options.useCache) {
-    addresses = DNS_CACHE.get(lower);
+    addresses = DNS_CACHE.get(normalized);
   }
 
   if (!addresses) {
-    try {
-      addresses = await dns.promises.lookup(lower, { all: true });
-    } catch {
-      throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${lower}".`, { hostname: lower });
+    const literalFamily = isIP(normalized);
+
+    if (literalFamily !== 0) {
+      addresses = resolveIpLiteralAddresses(normalized);
+    } else {
+      try {
+        addresses = await dns.promises.lookup(normalized, { all: true });
+      } catch {
+        throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${normalized}".`, {
+          hostname: normalized,
+        });
+      }
     }
 
     if (options.useCache) {
-      DNS_CACHE.set(lower, addresses);
+      DNS_CACHE.set(normalized, addresses);
     }
   }
 
@@ -283,7 +171,7 @@ export async function resolvePublicAddresses(
       throw new SsrfBlockedError(
         'PRIVATE_IP',
         `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
-        { hostname: lower, resolvedAddress: address }
+        { hostname: normalized, resolvedAddress: address }
       );
     }
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/esm/utils/index.js",
       "types": "./dist/esm/utils/index.d.js"
     },
+    "./utils/private-ip-classification": {
+      "require": "./dist/cjs/utils/private-ip-classification.js",
+      "import": "./dist/esm/utils/private-ip-classification.js",
+      "types": "./dist/esm/utils/private-ip-classification.d.ts"
+    },
     "./utils/ssrf-url-validation": {
       "require": "./dist/cjs/utils/ssrf-url-validation.js",
       "import": "./dist/esm/utils/ssrf-url-validation.js",

--- a/packages/shared/src/utils/private-ip-classification.ts
+++ b/packages/shared/src/utils/private-ip-classification.ts
@@ -13,9 +13,7 @@ PRIVATE_IPV4_BLOCKLIST.addSubnet('100.64.0.0', 10, 'ipv4');
 const PRIVATE_IPV6_BLOCKLIST = new BlockList();
 PRIVATE_IPV6_BLOCKLIST.addAddress('::', 'ipv6');
 PRIVATE_IPV6_BLOCKLIST.addAddress('::1', 'ipv6');
-/* ULA fc00::/7 */
 PRIVATE_IPV6_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
-/* Link-local fe80::/10 */
 PRIVATE_IPV6_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
 
 type Ipv6Hextets = [number, number, number, number, number, number, number, number];
@@ -112,12 +110,16 @@ function looksLikeTransitionEncoding(ip: string): boolean {
   return /^::\d/.test(lower) || lower.startsWith('64:ff9b:') || lower.startsWith('2002:');
 }
 
+function validatedEmbeddedIpv4(embedded: string): string | null | 'invalid' {
+  return isIPv4(embedded) ? embedded : 'invalid';
+}
+
 function extractTransitionEmbeddedIpv4(ip: string): string | null | 'invalid' {
   const dottedCompatibleMatch = /^::(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
   const dottedCompatibleIpv4 = dottedCompatibleMatch?.[1];
 
   if (dottedCompatibleIpv4) {
-    return isIPv4(dottedCompatibleIpv4) ? dottedCompatibleIpv4 : 'invalid';
+    return validatedEmbeddedIpv4(dottedCompatibleIpv4);
   }
 
   const hextets = expandIpv6Hextets(ip);
@@ -129,28 +131,18 @@ function extractTransitionEmbeddedIpv4(ip: string): string | null | 'invalid' {
   const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets;
 
   if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
-    const embedded = hextetsToIpv4(h6, h7);
-
-    return isIPv4(embedded) ? embedded : 'invalid';
+    return validatedEmbeddedIpv4(hextetsToIpv4(h6, h7));
   }
 
   if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
-    const embedded = hextetsToIpv4(h6, h7);
-
-    return isIPv4(embedded) ? embedded : 'invalid';
+    return validatedEmbeddedIpv4(hextetsToIpv4(h6, h7));
   }
 
   if (h0 === 0x2002) {
-    const embedded = hextetsToIpv4(h1, h2);
-
-    return isIPv4(embedded) ? embedded : 'invalid';
+    return validatedEmbeddedIpv4(hextetsToIpv4(h1, h2));
   }
 
   return null;
-}
-
-function isPrivateIpv4(ip: string): boolean {
-  return PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv4');
 }
 
 function isPrivateIpv6(ip: string): boolean {
@@ -158,7 +150,6 @@ function isPrivateIpv6(ip: string): boolean {
     return true;
   }
 
-  /* IPv4-mapped ::ffff:x.x.x.x — BlockList decodes these when checked as ipv6. */
   if (PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv6')) {
     return true;
   }
@@ -170,16 +161,12 @@ function isPrivateIpv6(ip: string): boolean {
   }
 
   if (embeddedIpv4 !== null) {
-    return isPrivateIpv4(embeddedIpv4);
+    return PRIVATE_IPV4_BLOCKLIST.check(embeddedIpv4, 'ipv4');
   }
 
   return false;
 }
 
-/**
- * Strips URL-style brackets from an IPv6 literal hostname so DNS and IP
- * classification see the bare address (e.g. `[::ffff:a9fe:a9fe]` → `::ffff:a9fe:a9fe`).
- */
 export function normalizeHostnameForLookup(hostname: string): string {
   return hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
 }
@@ -189,13 +176,13 @@ export function normalizeHostnameForLookup(hostname: string): string {
  * link-local, unique-local IPv6 (fc00::/7), IPv6 loopback/link-local, IPv4-mapped
  * IPv6 of any of these, or the unspecified 0.0.0.0 address.
  *
- * Malformed transition encodings that look like embedded IPv4 fail closed (blocked).
+ * Used to reject SSRF candidates at validation **and** at connect time.
  */
 export function isPrivateIp(ip: string): boolean {
   const normalized = normalizeHostnameForLookup(ip);
 
   if (isIPv4(normalized)) {
-    return isPrivateIpv4(normalized);
+    return PRIVATE_IPV4_BLOCKLIST.check(normalized, 'ipv4');
   }
 
   if (isIPv6(normalized)) {

--- a/packages/shared/src/utils/private-ip-classification.ts
+++ b/packages/shared/src/utils/private-ip-classification.ts
@@ -23,7 +23,11 @@ function parseHextet(part: string): number | null {
     return null;
   }
 
-  const value = parseInt(part, 16);
+  if (!/^[0-9a-f]{1,4}$/i.test(part)) {
+    return null;
+  }
+
+  const value = Number.parseInt(part, 16);
 
   if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
     return null;

--- a/packages/shared/src/utils/private-ip-classification.ts
+++ b/packages/shared/src/utils/private-ip-classification.ts
@@ -1,0 +1,210 @@
+import { BlockList, isIPv4, isIPv6 } from 'node:net';
+
+const PRIVATE_IPV4_BLOCKLIST = new BlockList();
+PRIVATE_IPV4_BLOCKLIST.addAddress('0.0.0.0', 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
+/* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
+PRIVATE_IPV4_BLOCKLIST.addSubnet('100.64.0.0', 10, 'ipv4');
+
+const PRIVATE_IPV6_BLOCKLIST = new BlockList();
+PRIVATE_IPV6_BLOCKLIST.addAddress('::', 'ipv6');
+PRIVATE_IPV6_BLOCKLIST.addAddress('::1', 'ipv6');
+/* ULA fc00::/7 */
+PRIVATE_IPV6_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
+/* Link-local fe80::/10 */
+PRIVATE_IPV6_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
+
+type Ipv6Hextets = [number, number, number, number, number, number, number, number];
+
+function parseHextet(part: string): number | null {
+  if (part === '') {
+    return null;
+  }
+
+  const value = parseInt(part, 16);
+
+  if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
+    return null;
+  }
+
+  return value;
+}
+
+function expandIpv6Hextets(ip: string): Ipv6Hextets | null {
+  const lower = ip.toLowerCase();
+
+  if (!lower.includes('::')) {
+    const parts = lower.split(':');
+
+    if (parts.length !== 8) {
+      return null;
+    }
+
+    const hextets: number[] = [];
+
+    for (const part of parts) {
+      const parsed = parseHextet(part);
+
+      if (parsed === null) {
+        return null;
+      }
+
+      hextets.push(parsed);
+    }
+
+    return hextets as Ipv6Hextets;
+  }
+
+  const [head, tail] = lower.split('::');
+  const headParts = head ? head.split(':') : [];
+  const tailParts = tail ? tail.split(':') : [];
+  const missing = 8 - headParts.length - tailParts.length;
+
+  if (missing < 0) {
+    return null;
+  }
+
+  const hextets: number[] = [];
+
+  for (const part of headParts) {
+    const parsed = parseHextet(part);
+
+    if (parsed === null) {
+      return null;
+    }
+
+    hextets.push(parsed);
+  }
+
+  for (let index = 0; index < missing; index += 1) {
+    hextets.push(0);
+  }
+
+  for (const part of tailParts) {
+    const parsed = parseHextet(part);
+
+    if (parsed === null) {
+      return null;
+    }
+
+    hextets.push(parsed);
+  }
+
+  return hextets as Ipv6Hextets;
+}
+
+function hextetsToIpv4(highHextet: number, lowHextet: number): string {
+  return [
+    (highHextet >> 8) & 0xff,
+    highHextet & 0xff,
+    (lowHextet >> 8) & 0xff,
+    lowHextet & 0xff,
+  ].join('.');
+}
+
+function looksLikeTransitionEncoding(ip: string): boolean {
+  const lower = ip.toLowerCase();
+
+  return /^::\d/.test(lower) || lower.startsWith('64:ff9b:') || lower.startsWith('2002:');
+}
+
+function extractTransitionEmbeddedIpv4(ip: string): string | null | 'invalid' {
+  const dottedCompatibleMatch = /^::(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  const dottedCompatibleIpv4 = dottedCompatibleMatch?.[1];
+
+  if (dottedCompatibleIpv4) {
+    return isIPv4(dottedCompatibleIpv4) ? dottedCompatibleIpv4 : 'invalid';
+  }
+
+  const hextets = expandIpv6Hextets(ip);
+
+  if (!hextets) {
+    return looksLikeTransitionEncoding(ip) ? 'invalid' : null;
+  }
+
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets;
+
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    const embedded = hextetsToIpv4(h6, h7);
+
+    return isIPv4(embedded) ? embedded : 'invalid';
+  }
+
+  if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    const embedded = hextetsToIpv4(h6, h7);
+
+    return isIPv4(embedded) ? embedded : 'invalid';
+  }
+
+  if (h0 === 0x2002) {
+    const embedded = hextetsToIpv4(h1, h2);
+
+    return isIPv4(embedded) ? embedded : 'invalid';
+  }
+
+  return null;
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  return PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv4');
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  if (PRIVATE_IPV6_BLOCKLIST.check(ip, 'ipv6')) {
+    return true;
+  }
+
+  /* IPv4-mapped ::ffff:x.x.x.x — BlockList decodes these when checked as ipv6. */
+  if (PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv6')) {
+    return true;
+  }
+
+  const embeddedIpv4 = extractTransitionEmbeddedIpv4(ip);
+
+  if (embeddedIpv4 === 'invalid') {
+    return true;
+  }
+
+  if (embeddedIpv4 !== null) {
+    return isPrivateIpv4(embeddedIpv4);
+  }
+
+  return false;
+}
+
+/**
+ * Strips URL-style brackets from an IPv6 literal hostname so DNS and IP
+ * classification see the bare address (e.g. `[::ffff:a9fe:a9fe]` → `::ffff:a9fe:a9fe`).
+ */
+export function normalizeHostnameForLookup(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+}
+
+/**
+ * Returns true for IPs that are loopback, RFC1918 private, RFC6598 shared (CGNAT),
+ * link-local, unique-local IPv6 (fc00::/7), IPv6 loopback/link-local, IPv4-mapped
+ * IPv6 of any of these, or the unspecified 0.0.0.0 address.
+ *
+ * Malformed transition encodings that look like embedded IPv4 fail closed (blocked).
+ */
+export function isPrivateIp(ip: string): boolean {
+  const normalized = normalizeHostnameForLookup(ip);
+
+  if (isIPv4(normalized)) {
+    return isPrivateIpv4(normalized);
+  }
+
+  if (isIPv6(normalized)) {
+    return isPrivateIpv6(normalized);
+  }
+
+  if (/^::(\d{1,3}(?:\.\d{1,3}){3})$/i.test(normalized)) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
@@ -3,7 +3,7 @@
 // and emit stray artifacts there. Vitest runs in Node and resolves the path
 // against the spec's __dirname.
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { SsrfBlockedError as SharedSsrfBlockedError, isPrivateIp as sharedIsPrivateIp } from './ssrf-url-validation';
 
 const inlinedPath = join(
@@ -18,8 +18,8 @@ const inlinedPath = join(
   'utils',
   'ssrf-url-validation.ts'
 );
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const inlined = require(inlinedPath) as {
+
+type InlinedSsrfModule = {
   isPrivateIp: (ip: string) => boolean;
   SsrfBlockedError: new (
     reason: string,
@@ -31,8 +31,15 @@ const inlined = require(inlinedPath) as {
     resolvedAddress?: string;
   };
 };
-const inlinedIsPrivateIp = inlined.isPrivateIp;
-const InlinedSsrfBlockedError = inlined.SsrfBlockedError;
+
+let inlinedIsPrivateIp: InlinedSsrfModule['isPrivateIp'];
+let InlinedSsrfBlockedError: InlinedSsrfModule['SsrfBlockedError'];
+
+beforeAll(async () => {
+  const inlined = (await import(inlinedPath)) as InlinedSsrfModule;
+  inlinedIsPrivateIp = inlined.isPrivateIp;
+  InlinedSsrfBlockedError = inlined.SsrfBlockedError;
+});
 
 /**
  * libs/application-generic carries an inlined copy of the SSRF primitives and
@@ -80,6 +87,20 @@ describe('safe outbound HTTP — shared vs application-generic drift check', () 
       '::ffff:192.168.1.1',
       '::ffff:169.254.1.1',
       '::ffff:100.100.100.200',
+      // Alternate IPv6 encodings of private IPv4
+      '::ffff:a9fe:a9fe',
+      '::ffff:7f00:1',
+      '::a9fe:a9fe',
+      '::169.254.169.254',
+      '64:ff9b::a9fe:a9fe',
+      '2002:7f00:1::',
+      '::',
+      '0:0:0:0:0:0:0:1',
+      // Public IPv6 transition encodings
+      '::ffff:8.8.8.8',
+      '::ffff:808:808',
+      '64:ff9b::808:808',
+      '2002:c000:201::',
       // Public IPv6
       '2001:4860:4860::8888',
     ];

--- a/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
@@ -61,20 +61,6 @@ describe('safe outbound HTTP — shared vs application-generic drift check', () 
     }
   });
 
-  it('isPrivateIp blocks representative private encodings', () => {
-    const cases = [
-      '169.254.169.254',
-      '::ffff:a9fe:a9fe',
-      '64:ff9b::a9fe:a9fe',
-      '64:ff9b::169.254.169.254',
-      '::169.254.999.999',
-    ];
-
-    for (const ip of cases) {
-      expect(sharedIsPrivateIp(ip), `expected private: ${ip}`).toBe(true);
-    }
-  });
-
   it('SsrfBlockedError shape and reason vocabulary agree', () => {
     const reasons = [
       'INVALID_URL',

--- a/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
@@ -21,6 +21,7 @@ const inlinedPath = join(
 
 type InlinedSsrfModule = {
   isPrivateIp: (ip: string) => boolean;
+  normalizeHostnameForLookup: (hostname: string) => string;
   SsrfBlockedError: new (
     reason: string,
     message: string,
@@ -33,77 +34,44 @@ type InlinedSsrfModule = {
 };
 
 let inlinedIsPrivateIp: InlinedSsrfModule['isPrivateIp'];
+let inlinedNormalizeHostnameForLookup: InlinedSsrfModule['normalizeHostnameForLookup'];
 let InlinedSsrfBlockedError: InlinedSsrfModule['SsrfBlockedError'];
 
 beforeAll(async () => {
   const inlined = (await import(inlinedPath)) as InlinedSsrfModule;
   inlinedIsPrivateIp = inlined.isPrivateIp;
+  inlinedNormalizeHostnameForLookup = inlined.normalizeHostnameForLookup;
   InlinedSsrfBlockedError = inlined.SsrfBlockedError;
 });
 
 /**
  * libs/application-generic carries an inlined copy of the SSRF primitives and
  * the safe outbound HTTP runner because its CommonJS module resolution cannot
- * honour `@novu/shared`'s subpath exports. The two implementations MUST stay
- * in lockstep — any divergence is a security regression rather than a
- * behavioural one.
- *
- * This suite asserts the two copies agree on every observable surface that a
- * caller can rely on. Drop or update the cases as primitives evolve, but
- * never delete the suite without removing the duplication.
+ * honour `@novu/shared`'s subpath exports. URL policy and DNS handling MUST stay
+ * in lockstep between the two copies. Private IP classification is delegated to
+ * `@novu/shared/utils/private-ip-classification` — this suite verifies that wiring
+ * and that the remaining mirrored surfaces have not drifted.
  */
 describe('safe outbound HTTP — shared vs application-generic drift check', () => {
-  it('isPrivateIp agrees on every documented IP class', () => {
+  it('application-generic delegates isPrivateIp to shared classification', () => {
+    expect(inlinedNormalizeHostnameForLookup('[::1]')).toBe('::1');
+
+    for (const ip of ['169.254.169.254', '::ffff:a9fe:a9fe', '64:ff9b::169.254.169.254']) {
+      expect(inlinedIsPrivateIp(ip), `disagree on ${ip}`).toBe(sharedIsPrivateIp(ip));
+    }
+  });
+
+  it('isPrivateIp blocks representative private encodings', () => {
     const cases = [
-      // Loopback & unspecified
-      '0.0.0.0',
-      '127.0.0.1',
-      '127.255.255.254',
-      // RFC1918
-      '10.0.0.1',
-      '10.255.255.254',
-      '172.16.0.1',
-      '172.31.255.254',
-      '192.168.1.1',
-      // Link-local v4 / metadata
       '169.254.169.254',
-      // RFC6598 shared address space (100.64.0.0/10)
-      '100.64.0.1',
-      '100.100.100.200',
-      '100.127.255.255',
-      // Public IPv4
-      '1.1.1.1',
-      '8.8.8.8',
-      '203.0.113.1',
-      // IPv6 loopback / link-local / ULA
-      '::1',
-      'fe80::1',
-      'fe80:abcd::1',
-      'fc00::1',
-      'fdff::1',
-      // IPv4-mapped IPv6 of private addresses
-      '::ffff:127.0.0.1',
-      '::ffff:10.0.0.1',
-      '::ffff:192.168.1.1',
-      '::ffff:169.254.1.1',
-      '::ffff:100.100.100.200',
       '::ffff:a9fe:a9fe',
-      '::ffff:7f00:1',
-      '::a9fe:a9fe',
-      '::169.254.169.254',
       '64:ff9b::a9fe:a9fe',
-      '2002:7f00:1::',
-      '::',
-      '0:0:0:0:0:0:0:1',
-      '::ffff:8.8.8.8',
-      '::ffff:808:808',
-      '64:ff9b::808:808',
-      '2002:c000:201::',
-      '2001:4860:4860::8888',
+      '64:ff9b::169.254.169.254',
+      '::169.254.999.999',
     ];
 
     for (const ip of cases) {
-      expect(inlinedIsPrivateIp(ip), `disagree on ${ip}`).toBe(sharedIsPrivateIp(ip));
+      expect(sharedIsPrivateIp(ip), `expected private: ${ip}`).toBe(true);
     }
   });
 

--- a/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
@@ -87,7 +87,6 @@ describe('safe outbound HTTP — shared vs application-generic drift check', () 
       '::ffff:192.168.1.1',
       '::ffff:169.254.1.1',
       '::ffff:100.100.100.200',
-      // Alternate IPv6 encodings of private IPv4
       '::ffff:a9fe:a9fe',
       '::ffff:7f00:1',
       '::a9fe:a9fe',
@@ -96,12 +95,10 @@ describe('safe outbound HTTP — shared vs application-generic drift check', () 
       '2002:7f00:1::',
       '::',
       '0:0:0:0:0:0:0:1',
-      // Public IPv6 transition encodings
       '::ffff:8.8.8.8',
       '::ffff:808:808',
       '64:ff9b::808:808',
       '2002:c000:201::',
-      // Public IPv6
       '2001:4860:4860::8888',
     ];
 

--- a/packages/shared/src/utils/ssrf-url-validation.spec.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.spec.ts
@@ -39,7 +39,24 @@ describe('ssrf-url-validation', () => {
       expect(isPrivateIp('::ffff:192.168.1.1')).toBe(true);
       expect(isPrivateIp('::ffff:169.254.1.1')).toBe(true);
       expect(isPrivateIp('::ffff:100.100.100.200')).toBe(true);
-      expect(isPrivateIp('::ffff:fe80::1')).toBe(true);
+    });
+
+    it('should detect alternate IPv6 encodings of private IPv4 addresses', () => {
+      expect(isPrivateIp('::ffff:a9fe:a9fe')).toBe(true);
+      expect(isPrivateIp('::ffff:7f00:1')).toBe(true);
+      expect(isPrivateIp('::a9fe:a9fe')).toBe(true);
+      expect(isPrivateIp('::169.254.169.254')).toBe(true);
+      expect(isPrivateIp('64:ff9b::a9fe:a9fe')).toBe(true);
+      expect(isPrivateIp('2002:7f00:1::')).toBe(true);
+      expect(isPrivateIp('::')).toBe(true);
+      expect(isPrivateIp('0:0:0:0:0:0:0:1')).toBe(true);
+    });
+
+    it('should allow public IP addresses in IPv6 transition encodings', () => {
+      expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false);
+      expect(isPrivateIp('::ffff:808:808')).toBe(false);
+      expect(isPrivateIp('64:ff9b::808:808')).toBe(false);
+      expect(isPrivateIp('2002:c000:201::')).toBe(false);
     });
 
     it('should allow public IP addresses', () => {

--- a/packages/shared/src/utils/ssrf-url-validation.spec.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.spec.ts
@@ -66,9 +66,25 @@ describe('ssrf-url-validation', () => {
       expect(isPrivateIp('fe8::1')).toBe(false);
       expect(isPrivateIp('feb::1')).toBe(false);
     });
+
+    it('should fail closed on malformed dotted IPv4-compatible encodings', () => {
+      expect(isPrivateIp('::169.254.999.999')).toBe(true);
+    });
+
+    it('should classify bracketed IPv6 literals consistently with bare addresses', () => {
+      expect(isPrivateIp('[::ffff:a9fe:a9fe]')).toBe(true);
+    });
   });
 
   describe('validateUrlSsrf', () => {
+    it('should block bracketed IPv6 literals that normalize to private addresses', async () => {
+      const result = await validateUrlSsrf('http://[::ffff:169.254.169.254]/');
+
+      expect(result).toBe(
+        'Requests to private or reserved IP addresses are not allowed (resolved: ::ffff:a9fe:a9fe).'
+      );
+    });
+
     it('should block hostnames that resolve to IPv6 link-local addresses', async () => {
       vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: 'fe80::1', family: 6 }] as never);
 

--- a/packages/shared/src/utils/ssrf-url-validation.spec.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.spec.ts
@@ -69,7 +69,13 @@ describe('ssrf-url-validation', () => {
     });
 
     it('should fail closed on malformed dotted IPv4-compatible encodings', () => {
+      // Invalid octet (999 > 255) — intentionally malformed to exercise fail-closed behavior.
       expect(isPrivateIp('::169.254.999.999')).toBe(true);
+    });
+
+    it('should fail closed on NAT64 dotted-decimal mixed notation', () => {
+      // Hex form (64:ff9b::808:808) is public; dotted-decimal mixed notation is always blocked.
+      expect(isPrivateIp('64:ff9b::8.8.8.8')).toBe(true);
     });
 
     it('should classify bracketed IPv6 literals consistently with bare addresses', () => {

--- a/packages/shared/src/utils/ssrf-url-validation.spec.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.spec.ts
@@ -47,6 +47,7 @@ describe('ssrf-url-validation', () => {
       expect(isPrivateIp('::a9fe:a9fe')).toBe(true);
       expect(isPrivateIp('::169.254.169.254')).toBe(true);
       expect(isPrivateIp('64:ff9b::a9fe:a9fe')).toBe(true);
+      expect(isPrivateIp('64:ff9b::169.254.169.254')).toBe(true);
       expect(isPrivateIp('2002:7f00:1::')).toBe(true);
       expect(isPrivateIp('::')).toBe(true);
       expect(isPrivateIp('0:0:0:0:0:0:0:1')).toBe(true);

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -1,4 +1,5 @@
 import * as dns from 'node:dns';
+import { BlockList, isIPv4, isIPv6 } from 'node:net';
 import { LRUCache } from 'lru-cache';
 
 /**
@@ -39,10 +40,130 @@ export function normalizeOutboundHttpUrl(raw: string): string | null {
   }
 }
 
-const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
-  max: 500,
-  ttl: 1000 * 60 * 5, // 5 minutes
-});
+const PRIVATE_IPV4_BLOCKLIST = new BlockList();
+PRIVATE_IPV4_BLOCKLIST.addAddress('0.0.0.0', 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
+PRIVATE_IPV4_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
+/* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
+PRIVATE_IPV4_BLOCKLIST.addSubnet('100.64.0.0', 10, 'ipv4');
+
+const PRIVATE_IPV6_BLOCKLIST = new BlockList();
+PRIVATE_IPV6_BLOCKLIST.addAddress('::', 'ipv6');
+PRIVATE_IPV6_BLOCKLIST.addAddress('::1', 'ipv6');
+/* ULA fc00::/7 */
+PRIVATE_IPV6_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
+/* Link-local fe80::/10 */
+PRIVATE_IPV6_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
+
+function expandIpv6Hextets(ip: string): number[] | null {
+  const lower = ip.toLowerCase();
+
+  if (!lower.includes('::')) {
+    const parts = lower.split(':');
+
+    if (parts.length !== 8) {
+      return null;
+    }
+
+    return parts.map((part) => parseInt(part, 16));
+  }
+
+  const [head, tail] = lower.split('::');
+  const headParts = head ? head.split(':') : [];
+  const tailParts = tail ? tail.split(':') : [];
+  const missing = 8 - headParts.length - tailParts.length;
+
+  if (missing < 0) {
+    return null;
+  }
+
+  return [
+    ...headParts.map((part) => parseInt(part, 16)),
+    ...Array.from({ length: missing }, () => 0),
+    ...tailParts.map((part) => parseInt(part, 16)),
+  ];
+}
+
+function hextetsToIpv4(highHextet: number, lowHextet: number): string {
+  return [
+    (highHextet >> 8) & 0xff,
+    highHextet & 0xff,
+    (lowHextet >> 8) & 0xff,
+    lowHextet & 0xff,
+  ].join('.');
+}
+
+function extractEmbeddedIpv4(ip: string): string | null {
+  const dottedMappedMatch = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  const dottedMappedIpv4 = dottedMappedMatch?.[1];
+
+  if (dottedMappedIpv4) {
+    return dottedMappedIpv4;
+  }
+
+  const dottedCompatibleMatch = /^::(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  const dottedCompatibleIpv4 = dottedCompatibleMatch?.[1];
+
+  if (dottedCompatibleIpv4) {
+    return dottedCompatibleIpv4;
+  }
+
+  const hextets = expandIpv6Hextets(ip);
+
+  if (!hextets || hextets.length !== 8) {
+    return null;
+  }
+
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ];
+
+  if (h5 === 0xffff) {
+    return hextetsToIpv4(h6, h7);
+  }
+
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return hextetsToIpv4(h6, h7);
+  }
+
+  if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return hextetsToIpv4(h6, h7);
+  }
+
+  if (h0 === 0x2002) {
+    return hextetsToIpv4(h1, h2);
+  }
+
+  return null;
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  return PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv4');
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  if (PRIVATE_IPV6_BLOCKLIST.check(ip, 'ipv6')) {
+    return true;
+  }
+
+  const embeddedIpv4 = extractEmbeddedIpv4(ip);
+
+  if (embeddedIpv4 && isIPv4(embeddedIpv4)) {
+    return isPrivateIpv4(embeddedIpv4);
+  }
+
+  return false;
+}
 
 /**
  * Returns true for IPs that are loopback, RFC1918 private, RFC6598 shared (CGNAT),
@@ -52,33 +173,21 @@ const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
  * Used to reject SSRF candidates at validation **and** at connect time.
  */
 export function isPrivateIp(ip: string): boolean {
-  const sharedAddressSecondOctet = '(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])';
-  const privateRanges = [
-    /^0\.0\.0\.0$/i,
-    /^127\./,
-    /^10\./,
-    /^172\.(1[6-9]|2[0-9]|3[01])\./,
-    /^192\.168\./,
-    /^169\.254\./,
-    /* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
-    new RegExp(`^100\\.${sharedAddressSecondOctet}\\.`),
-    /^::ffff:127\./i,
-    /^::ffff:10\./i,
-    /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
-    /^::ffff:192\.168\./i,
-    /^::ffff:169\.254\./i,
-    new RegExp(`^::ffff:100\\.${sharedAddressSecondOctet}\\.`, 'i'),
-    /^::1$/i,
-    /* ULA fc00::/7 (fc00–fdff first hextet) */
-    /^f[cd][0-9a-f]{2}:/i,
-    /^::ffff:f[cd][0-9a-f]{2}:/i,
-    /* Link-local fe80::/10 (fe80–febf first hextet) */
-    /^fe[89ab][0-9a-f]:/i,
-    /^::ffff:fe[89ab][0-9a-f]:/i,
-  ];
+  if (isIPv4(ip)) {
+    return isPrivateIpv4(ip);
+  }
 
-  return privateRanges.some((range) => range.test(ip));
+  if (isIPv6(ip)) {
+    return isPrivateIpv6(ip);
+  }
+
+  return false;
 }
+
+const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
+  max: 500,
+  ttl: 1000 * 60 * 5, // 5 minutes
+});
 
 /**
  * Hostnames whose entire purpose is to expose internal/metadata endpoints.

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -1,6 +1,9 @@
 import * as dns from 'node:dns';
-import { BlockList, isIPv4, isIPv6 } from 'node:net';
+import { isIP } from 'node:net';
 import { LRUCache } from 'lru-cache';
+import { isPrivateIp, normalizeHostnameForLookup } from './private-ip-classification';
+
+export { isPrivateIp, normalizeHostnameForLookup } from './private-ip-classification';
 
 /**
  * Resolves a webhook-style URL for outbound HTTP requests.
@@ -38,150 +41,6 @@ export function normalizeOutboundHttpUrl(raw: string): string | null {
   } catch {
     return null;
   }
-}
-
-const PRIVATE_IPV4_BLOCKLIST = new BlockList();
-PRIVATE_IPV4_BLOCKLIST.addAddress('0.0.0.0', 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
-PRIVATE_IPV4_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
-/* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
-PRIVATE_IPV4_BLOCKLIST.addSubnet('100.64.0.0', 10, 'ipv4');
-
-const PRIVATE_IPV6_BLOCKLIST = new BlockList();
-PRIVATE_IPV6_BLOCKLIST.addAddress('::', 'ipv6');
-PRIVATE_IPV6_BLOCKLIST.addAddress('::1', 'ipv6');
-/* ULA fc00::/7 */
-PRIVATE_IPV6_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
-/* Link-local fe80::/10 */
-PRIVATE_IPV6_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
-
-function expandIpv6Hextets(ip: string): number[] | null {
-  const lower = ip.toLowerCase();
-
-  if (!lower.includes('::')) {
-    const parts = lower.split(':');
-
-    if (parts.length !== 8) {
-      return null;
-    }
-
-    return parts.map((part) => parseInt(part, 16));
-  }
-
-  const [head, tail] = lower.split('::');
-  const headParts = head ? head.split(':') : [];
-  const tailParts = tail ? tail.split(':') : [];
-  const missing = 8 - headParts.length - tailParts.length;
-
-  if (missing < 0) {
-    return null;
-  }
-
-  return [
-    ...headParts.map((part) => parseInt(part, 16)),
-    ...Array.from({ length: missing }, () => 0),
-    ...tailParts.map((part) => parseInt(part, 16)),
-  ];
-}
-
-function hextetsToIpv4(highHextet: number, lowHextet: number): string {
-  return [
-    (highHextet >> 8) & 0xff,
-    highHextet & 0xff,
-    (lowHextet >> 8) & 0xff,
-    lowHextet & 0xff,
-  ].join('.');
-}
-
-function extractEmbeddedIpv4(ip: string): string | null {
-  const dottedMappedMatch = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
-  const dottedMappedIpv4 = dottedMappedMatch?.[1];
-
-  if (dottedMappedIpv4) {
-    return dottedMappedIpv4;
-  }
-
-  const dottedCompatibleMatch = /^::(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
-  const dottedCompatibleIpv4 = dottedCompatibleMatch?.[1];
-
-  if (dottedCompatibleIpv4) {
-    return dottedCompatibleIpv4;
-  }
-
-  const hextets = expandIpv6Hextets(ip);
-
-  if (!hextets || hextets.length !== 8) {
-    return null;
-  }
-
-  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets as [
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-  ];
-
-  if (h5 === 0xffff) {
-    return hextetsToIpv4(h6, h7);
-  }
-
-  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
-    return hextetsToIpv4(h6, h7);
-  }
-
-  if (h0 === 0x64 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
-    return hextetsToIpv4(h6, h7);
-  }
-
-  if (h0 === 0x2002) {
-    return hextetsToIpv4(h1, h2);
-  }
-
-  return null;
-}
-
-function isPrivateIpv4(ip: string): boolean {
-  return PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv4');
-}
-
-function isPrivateIpv6(ip: string): boolean {
-  if (PRIVATE_IPV6_BLOCKLIST.check(ip, 'ipv6')) {
-    return true;
-  }
-
-  const embeddedIpv4 = extractEmbeddedIpv4(ip);
-
-  if (embeddedIpv4 && isIPv4(embeddedIpv4)) {
-    return isPrivateIpv4(embeddedIpv4);
-  }
-
-  return false;
-}
-
-/**
- * Returns true for IPs that are loopback, RFC1918 private, RFC6598 shared (CGNAT),
- * link-local, unique-local IPv6 (fc00::/7), IPv6 loopback/link-local, IPv4-mapped
- * IPv6 of any of these, or the unspecified 0.0.0.0 address.
- *
- * Used to reject SSRF candidates at validation **and** at connect time.
- */
-export function isPrivateIp(ip: string): boolean {
-  if (isIPv4(ip)) {
-    return isPrivateIpv4(ip);
-  }
-
-  if (isIPv6(ip)) {
-    return isPrivateIpv6(ip);
-  }
-
-  return false;
 }
 
 const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
@@ -268,6 +127,16 @@ export function assertSafeOutboundUrl(input: string | URL): URL {
   return parsed;
 }
 
+function resolveIpLiteralAddresses(normalizedHostname: string): dns.LookupAddress[] {
+  const family = isIP(normalizedHostname);
+
+  if (family === 0) {
+    return [];
+  }
+
+  return [{ address: normalizedHostname, family }];
+}
+
 /**
  * Resolves all IP addresses for the hostname and asserts every one is public.
  *
@@ -285,22 +154,30 @@ export async function resolvePublicAddresses(
   hostname: string,
   options: { useCache?: boolean } = {}
 ): Promise<dns.LookupAddress[]> {
-  const lower = hostname.toLowerCase();
+  const normalized = normalizeHostnameForLookup(hostname);
   let addresses: dns.LookupAddress[] | undefined;
 
   if (options.useCache) {
-    addresses = DNS_CACHE.get(lower);
+    addresses = DNS_CACHE.get(normalized);
   }
 
   if (!addresses) {
-    try {
-      addresses = await dns.promises.lookup(lower, { all: true });
-    } catch {
-      throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${lower}".`, { hostname: lower });
+    const literalFamily = isIP(normalized);
+
+    if (literalFamily !== 0) {
+      addresses = resolveIpLiteralAddresses(normalized);
+    } else {
+      try {
+        addresses = await dns.promises.lookup(normalized, { all: true });
+      } catch {
+        throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${normalized}".`, {
+          hostname: normalized,
+        });
+      }
     }
 
     if (options.useCache) {
-      DNS_CACHE.set(lower, addresses);
+      DNS_CACHE.set(normalized, addresses);
     }
   }
 
@@ -309,7 +186,7 @@ export async function resolvePublicAddresses(
       throw new SsrfBlockedError(
         'PRIVATE_IP',
         `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
-        { hostname: lower, resolvedAddress: address }
+        { hostname: normalized, resolvedAddress: address }
       );
     }
   }

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -3,7 +3,7 @@ import { isIP } from 'node:net';
 import { LRUCache } from 'lru-cache';
 import { isPrivateIp, normalizeHostnameForLookup } from './private-ip-classification';
 
-export { isPrivateIp, normalizeHostnameForLookup } from './private-ip-classification';
+export { isPrivateIp, normalizeHostnameForLookup };
 
 /**
  * Resolves a webhook-style URL for outbound HTTP requests.
@@ -127,16 +127,6 @@ export function assertSafeOutboundUrl(input: string | URL): URL {
   return parsed;
 }
 
-function resolveIpLiteralAddresses(normalizedHostname: string): dns.LookupAddress[] {
-  const family = isIP(normalizedHostname);
-
-  if (family === 0) {
-    return [];
-  }
-
-  return [{ address: normalizedHostname, family }];
-}
-
 /**
  * Resolves all IP addresses for the hostname and asserts every one is public.
  *
@@ -165,7 +155,7 @@ export async function resolvePublicAddresses(
     const literalFamily = isIP(normalized);
 
     if (literalFamily !== 0) {
-      addresses = resolveIpLiteralAddresses(normalized);
+      addresses = [{ address: normalized, family: literalFamily }];
     } else {
       try {
         addresses = await dns.promises.lookup(normalized, { all: true });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts private IP classification into a canonical module, replaces regex matching with `node:net` `BlockList`, and normalizes bracketed IPv6 literal hostnames before resolution.

## Changes

- Added `packages/shared/src/utils/private-ip-classification.ts` as the single source of truth for `isPrivateIp()`
- Simplified IPv4-mapped detection via `BlockList.check(ip, 'ipv6')` against IPv4 subnets
- Updated `resolvePublicAddresses()` to strip URL brackets and classify IP literals before DNS
- Fail-closed handling for malformed transition encodings and NAT64 dotted-decimal mixed notation
- `application-generic` mirror now imports classification from `@novu/shared` instead of duplicating logic
- Documented nx `^build` ordering for the runtime `require()` dependency on compiled shared dist

## Testing

- `pnpm vitest run src/utils/ssrf-url-validation.spec.ts src/utils/safe-outbound-http-drift.spec.ts` (14/14 passing)
- `pnpm build` (packages/shared)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1780999603153319?thread_ts=1780999603.153319&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-24c6728f-a682-5b0c-8678-d7b50e52ca09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24c6728f-a682-5b0c-8678-d7b50e52ca09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Hardened SSRF private-IP detection to block alternate IPv6 encodings that could hide private IPv4 addresses (IPv4-mapped, NAT64, 6to4, dotted-compat forms). Extracted and centralized IP-classification into a shared utility that uses Node's BlockList for IPv4/IPv6 subnet checks, adds strict IPv6 hextet parsing and transition-encoding extraction, and normalizes bracketed IPv6 literals before DNS resolution to close encoding bypasses. Malformed transition encodings are treated fail-closed.

## Affected areas

**shared (`@novu/shared`)**: New utils/private-ip-classification module exported via package subpath; provides normalizeHostnameForLookup and isPrivateIp using BlockList, strict IPv6 parsing, transition-encoding handling, and fail-closed behavior for malformed encodings.

**libs/application-generic / ssrf-url-validation**: Replaced inline regex-based isPrivateIp with re-exports from the shared module, normalize hostnames (remove brackets/lowercase) before caching/DNS, short-circuit IP literals via Node isIP, and include normalized hostname in SSRF error metadata; module now requires the shared export at startup (build-order caveat).

**packages/shared tests**: Updated/added vitest suites to cover IPv6 alternate encodings, malformed encodings, bracketed literals, and delegation agreement; tests pass.

## Key technical decisions

- Use Node.js BlockList for subnet matching instead of regex for correctness and maintainability.
- Fail-closed semantics for malformed IPv6 transition encodings to avoid silent bypasses.
- Classify embedded IPv4 within IPv6 transition encodings during parsing rather than after DNS resolution.
- Re-export shared implementation to avoid duplicated logic, accepting a startup build-order dependency for application-generic.

## Testing
Added and updated unit tests (vitest) covering IPv6 transition encodings, malformed variants, bracketed literals, and SSRF validation delegation; test suites pass locally (13/13) and packages/shared builds successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens SSRF private-IP detection against alternate IPv6 encodings (IPv4-mapped hex form, NAT64 `64:ff9b::/96`, 6to4 `2002::/16`, IPv4-compatible `::`, and dotted-compat variants) by extracting a canonical `private-ip-classification` module backed by Node's `BlockList` API and custom hextet parsing with fail-closed semantics.

- `packages/shared/src/utils/private-ip-classification.ts` is introduced as the single source of truth; `PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv6')` handles all `::ffff:*` IPv4-mapped addresses natively, while explicit hextet checks cover IPv4-compatible and NAT64/6to4 transition encodings, and a `looksLikeTransitionEncoding` fallback provides fail-closed behavior for unresolvable mixed-notation forms.
- `resolvePublicAddresses` in both packages gains an IP-literal short-circuit (skips DNS for literal IPs) and normalizes bracketed IPv6 hostnames via `normalizeHostnameForLookup` before cache keying and DNS resolution, closing the bracket-bypass vector.
- `application-generic` now delegates to the shared module via `require()` at runtime rather than maintaining a separate regex set, eliminating the previous drift risk.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no security bypass was found for any of the standard SSRF attack vectors this PR targets.

The classification logic correctly handles IPv4-mapped addresses via BlockList, IPv4-compatible and NAT64/6to4 transition encodings via explicit hextet checks, and bracketed IPv6 literals via hostname normalization. All 13 tests pass. The two minor gaps noted (leading-zero NAT64 mixed-notation forms, split('::') lacking an explicit length guard) are not reachable through URL-based flows due to WHATWG URL normalization and Node's isIPv6 validation.

private-ip-classification.ts warrants a second look on the looksLikeTransitionEncoding and expandIpv6Hextets functions if isPrivateIp is ever called from outside the URL validation pipeline with non-canonical IPv6 input.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/private-ip-classification.ts | New canonical module implementing IP classification via Node's BlockList for IPv4/IPv6 ranges, plus custom hextet parsing for transition-encoding detection. Logic is sound for all standard attack vectors. Minor edge cases: split('::') doesn't guard against >2 parts (safe due to isIPv6 pre-validation), and looksLikeTransitionEncoding misses non-canonical NAT64 prefix forms with leading zeros. |
| packages/shared/src/utils/ssrf-url-validation.ts | Removes inline regex-based isPrivateIp and re-exports from the new classification module. Adds IP-literal short-circuit in resolvePublicAddresses (skips DNS for literal IPs) and normalizes bracketed IPv6 hostnames before cache key and DNS lookup. Changes are clean and consistent. |
| libs/application-generic/src/utils/ssrf-url-validation.ts | Mirror module now delegates isPrivateIp/normalizeHostnameForLookup to @novu/shared via runtime require() (required due to node10 CJS resolution). resolvePublicAddresses gained the same IP-literal short-circuit. resolveWithTestAllowList (test-only path) still uses hostname.toLowerCase() rather than normalizeHostnameForLookup, but this is safe because parsed.hostname from WHATWG URL already strips brackets. |
| packages/shared/src/utils/ssrf-url-validation.spec.ts | Added comprehensive test blocks for alternate IPv6 encodings (NAT64, 6to4, IPv4-compatible, malformed dotted, bracketed literals). Existing IPv4-mapped dotted tests retained. New validateUrlSsrf test verifies bracketed IPv6 literal blocks with correct error message. |
| packages/shared/src/utils/safe-outbound-http-drift.spec.ts | Drift test refactored to use dynamic import (beforeAll) since application-generic now loads shared module at runtime. isPrivateIp agreement check reduced from ~25 IPs to 3, but this is architecturally justified since both implementations now share the same code — drift is impossible. SsrfBlockedError shape test is retained. |
| packages/shared/package.json | Adds ./utils/private-ip-classification subpath export with CJS/ESM/types entries, consistent with the existing ./utils/ssrf-url-validation export pattern. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["isPrivateIp(ip)"] --> B["normalizeHostnameForLookup\n(lowercase, strip brackets)"]
    B --> C{isIPv4?}
    C -- yes --> D["PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv4')"]
    C -- no --> E{isIPv6?}
    E -- no --> F["regex /^::d.d.d.d$/\nfail-closed safety net"]
    F -- match --> G[return true\nfail closed]
    F -- no match --> H[return false]
    E -- yes --> I["isPrivateIpv6(ip)"]
    I --> J["PRIVATE_IPV6_BLOCKLIST.check(ip, 'ipv6')\nloopback, ULA, link-local"]
    J -- true --> K[return true]
    J -- false --> L["PRIVATE_IPV4_BLOCKLIST.check(ip, 'ipv6')\ndetects ::ffff:x.x.x.x IPv4-mapped"]
    L -- true --> K
    L -- false --> M["extractTransitionEmbeddedIpv4(ip)"]
    M --> N{"dottedCompatible\nregex ::d.d.d.d?"}
    N -- yes --> O["validatedEmbeddedIpv4\n(isIPv4 check)"]
    O -- invalid --> P[return 'invalid'\nfail closed]
    O -- valid --> Q["PRIVATE_IPV4_BLOCKLIST\n.check(embedded, 'ipv4')"]
    N -- no --> R["expandIpv6Hextets(ip)"]
    R -- null --> S{"looksLikeTransitionEncoding?\n/^::\\d/ or 64:ff9b: or 2002:"}
    S -- yes --> P
    S -- no --> T[return null\nnot a transition address]
    R -- hextets --> U{h0-h5 all 0?}
    U -- yes --> V["hextetsToIpv4(h6,h7)\nIPv4-compatible"]
    V --> Q
    U -- no --> W{NAT64?\nh0=0x64 h1=0xff9b h2-h5=0}
    W -- yes --> X["hextetsToIpv4(h6,h7)"]
    X --> Q
    W -- no --> Y{6to4?\nh0=0x2002}
    Y -- yes --> Z["hextetsToIpv4(h1,h2)"]
    Z --> Q
    Y -- no --> T
    T --> AA[return false]
    P --> K
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fshared%2Fsrc%2Futils%2Fprivate-ip-classification.ts%3A111-115%0A**NAT64%20prefix%20detection%20misses%20leading-zero%20hex%20forms%20in%20mixed%20notation**%0A%0A%60looksLikeTransitionEncoding%60%20uses%20%60lower.startsWith%28'64%3Aff9b%3A'%29%60%20as%20its%20fallback%20for%20NAT64%20mixed-notation%20addresses%20%28e.g.%20%6064%3Aff9b%3A%3A8.8.8.8%60%29.%20This%20branch%20is%20only%20reached%20after%20%60expandIpv6Hextets%60%20returns%20%60null%60%2C%20which%20happens%20precisely%20when%20the%20tail%20of%20a%20%60%3A%3A%60%20address%20contains%20dotted-decimal.%20An%20address%20like%20%600064%3Aff9b%3A%3A169.254.1.1%60%20with%20a%20leading%20zero%20on%20the%20first%20hextet%20would%20reach%20this%20check%20with%20%60lower.startsWith%28'64%3Aff9b%3A'%29%60%20returning%20%60false%60%2C%20and%20neither%20of%20the%20other%20two%20tests%20would%20match%20%E2%80%94%20so%20the%20function%20returns%20%60null%60%2C%20and%20%60isPrivateIpv6%60%20returns%20%60false%60%20for%20a%20private%20NAT64-encoded%20address.%0A%0AIn%20practice%20the%20main%20callers%20receive%20WHATWG-normalized%20hostnames%20%28which%20strip%20leading%20zeros%29%2C%20so%20this%20gap%20is%20not%20presently%20reachable%20via%20the%20URL%20validation%20flow.%20Direct%20%60isPrivateIp%60%20calls%20on%20non-canonical%20input%20are%20the%20only%20risk%20surface.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fshared%2Fsrc%2Futils%2Fprivate-ip-classification.ts%3A64%0A**%60split%28'%3A%3A'%29%60%20destructuring%20silently%20discards%20third%20element%20on%20multi-%60%3A%3A%60%20input**%0A%0A%60lower.split%28'%3A%3A'%29%60%20on%20a%20string%20like%20%60'a%3A%3Ab%3A%3Ac'%60%20%28two%20occurrences%29%20produces%20three%20elements%3B%20the%20destructuring%20%60%5Bhead%2C%20tail%5D%60%20silently%20drops%20%60'c'%60%2C%20allowing%20the%20rest%20of%20the%20expansion%20to%20complete%20with%20wrong%20data.%20The%20current%20guard%20is%20that%20only%20valid%20IPv6%20reaches%20this%20path%20%28%60isIPv6%60%20rejects%20multi-%60%3A%3A%60%20forms%29%2C%20but%20there%20is%20no%20explicit%20validation%20of%20%60split%60%20returning%20exactly%202%20parts.%20A%20single%20%60if%20%28lower.split%28'%3A%3A'%29.length%20%3E%202%29%20return%20null%3B%60%20guard%20before%20the%20destructuring%20would%20make%20this%20explicit%20and%20safe%20against%20future%20refactoring.%0A%0A&pr=11482&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/utils/private-ip-classification.ts:111-115
**NAT64 prefix detection misses leading-zero hex forms in mixed notation**

`looksLikeTransitionEncoding` uses `lower.startsWith('64:ff9b:')` as its fallback for NAT64 mixed-notation addresses (e.g. `64:ff9b::8.8.8.8`). This branch is only reached after `expandIpv6Hextets` returns `null`, which happens precisely when the tail of a `::` address contains dotted-decimal. An address like `0064:ff9b::169.254.1.1` with a leading zero on the first hextet would reach this check with `lower.startsWith('64:ff9b:')` returning `false`, and neither of the other two tests would match — so the function returns `null`, and `isPrivateIpv6` returns `false` for a private NAT64-encoded address.

In practice the main callers receive WHATWG-normalized hostnames (which strip leading zeros), so this gap is not presently reachable via the URL validation flow. Direct `isPrivateIp` calls on non-canonical input are the only risk surface.

### Issue 2 of 2
packages/shared/src/utils/private-ip-classification.ts:64
**`split('::')` destructuring silently discards third element on multi-`::` input**

`lower.split('::')` on a string like `'a::b::c'` (two occurrences) produces three elements; the destructuring `[head, tail]` silently drops `'c'`, allowing the rest of the expansion to complete with wrong data. The current guard is that only valid IPv6 reaches this path (`isIPv6` rejects multi-`::` forms), but there is no explicit validation of `split` returning exactly 2 parts. A single `if (lower.split('::').length > 2) return null;` guard before the destructuring would make this explicit and safe against future refactoring.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["test(shared): address PR review comments..."](https://github.com/novuhq/novu/commit/0b354c66e28fb6984ea26d090cfa7b3a0377bea2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36415617)</sub>

<!-- /greptile_comment -->