### PR TITLE
fix(api-service): provision Novu Email demo provider for keyless envs fixes NV-7994

### DIFF
--- a/apps/api/src/app/inbox/usecases/session/session.spec.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.spec.ts
@@ -31,6 +31,7 @@ import sinon from 'sinon';
 import { AuthService } from '../../../auth/services/auth.service';
 import { GenerateUniqueApiKey } from '../../../environments-v1/usecases/generate-unique-api-key/generate-unique-api-key.usecase';
 import { CreateNovuIntegrations } from '../../../integrations/usecases/create-novu-integrations/create-novu-integrations.usecase';
+import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
 import { GetOrganizationSettings } from '../../../organization/usecases/get-organization-settings/get-organization-settings.usecase';
 import { SubscriberSessionResponseDto } from '../../dtos/subscriber-session-response.dto';
 import { AnalyticsEventsEnum } from '../../utils';
@@ -87,6 +88,7 @@ describe('Session', () => {
   let messageRepository: sinon.SinonStubbedInstance<MessageRepository>;
   let getSubscriberSchedule: sinon.SinonStubbedInstance<GetSubscriberSchedule>;
   let updatePreferencesUsecase: sinon.SinonStubbedInstance<UpdatePreferences>;
+  let keylessAbuseGuard: sinon.SinonStubbedInstance<KeylessAbuseGuardService>;
 
   beforeEach(() => {
     environmentRepository = sinon.createStubInstance(EnvironmentRepository);
@@ -112,6 +114,7 @@ describe('Session', () => {
     messageRepository = sinon.createStubInstance(MessageRepository);
     getSubscriberSchedule = sinon.createStubInstance(GetSubscriberSchedule);
     updatePreferencesUsecase = sinon.createStubInstance(UpdatePreferences);
+    keylessAbuseGuard = sinon.createStubInstance(KeylessAbuseGuardService);
 
     session = new Session(
       environmentRepository as any,
@@ -136,7 +139,8 @@ describe('Session', () => {
       logger as any,
       featureFlagsService as any,
       getSubscriberSchedule as any,
-      updatePreferencesUsecase as any
+      updatePreferencesUsecase as any,
+      keylessAbuseGuard as any
     );
 
     messageRepository.getCountBySeverity.resolves(mockSeverityCounts);

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -41,6 +41,7 @@ import {
   ContextPayload,
   ControlValuesLevelEnum,
   CustomDataType,
+  EnvironmentEnum,
   EnvironmentTypeEnum,
   FeatureFlagsKeysEnum,
   FeatureNameEnum,
@@ -509,9 +510,10 @@ export class Session {
         environmentId: environment._id,
         organizationId: environment._organizationId,
         userId: user._id,
-        name: 'Keyless Integration',
-        channels: [ChannelTypeEnum.IN_APP],
+        name: EnvironmentEnum.DEVELOPMENT,
+        channels: [ChannelTypeEnum.IN_APP, ChannelTypeEnum.EMAIL],
         includeManagedClaude: true,
+        environmentType: EnvironmentTypeEnum.DEV,
       })
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Keyless environments created during `npx novu connect` only provisioned in-app integrations. When the connect flow later tries to add an agent email integration, `NovuEmailProvisioningService` fails with a 409 because no outbound Novu Email demo provider exists in the environment.

This aligns keyless environment creation with the new-org Development flow by seeding the bundled Novu Email demo integration alongside the existing in-app and managed Claude provisioning.

## Root cause

`Session.processKeyless()` called `CreateNovuIntegrations` with:

- `channels: [IN_APP]` only (EMAIL excluded)
- `name: 'Keyless Integration'` (email demo seeding only runs for `EnvironmentEnum.DEVELOPMENT`)

## Fix

Pass `EnvironmentEnum.DEVELOPMENT`, include `ChannelTypeEnum.EMAIL`, and set `environmentType: DEV` when provisioning integrations for keyless environments.

```mermaid
flowchart LR
  A[npx novu connect] --> B[Session.processKeyless]
  B --> C[CreateNovuIntegrations]
  C --> D[In-App integration]
  C --> E[Novu Email demo integration]
  C --> F[Managed Claude optional]
  E --> G[Agent email integration can resolve outbound sender]
```

## Test plan

- [x] Existing `Session` unit tests pass
- [ ] Manual: run `npx novu connect` against a keyless-enabled deployment and verify `POST /v1/agents/:id/integrations` with Novu Email succeeds (no 409)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1781011001828439?thread_ts=1781011001.828439&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-c8734195-f2d7-5a22-92a3-844cfa6ca24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8734195-f2d7-5a22-92a3-844cfa6ca24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The `Session.processKeyless()` method now provisions the bundled Novu Email demo provider alongside in-app and managed Claude integrations when creating keyless environments. The method was updated to pass `EnvironmentEnum.DEVELOPMENT` as the integration name, include `ChannelTypeEnum.EMAIL` in the provisioning channels, and explicitly set `environmentType: EnvironmentTypeEnum.DEV`.

## Affected areas
**api** – Updated keyless environment provisioning in the `Session` use case to seed the Novu Email demo integration, aligning behavior with the new-organization Development environment flow.

## Testing
Existing `Session` unit tests pass. Manual verification of the `POST /v1/agents/:id/integrations` endpoint with Novu Email (expecting success without 409 errors) is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes keyless environment provisioning so that the Novu Email demo integration is seeded alongside the in-app integration when `npx novu connect` creates a keyless environment, preventing a 409 when the agent email integration is later added.

- Changes `processKeyless` to pass `name: EnvironmentEnum.DEVELOPMENT`, `channels: [IN_APP, EMAIL]`, and `environmentType: EnvironmentTypeEnum.DEV` to `CreateNovuIntegrationsCommand`, which satisfies the name-gate check in `createEmailIntegration` and triggers its execution.
- Adds the missing `KeylessAbuseGuardService` stub to the `Session` unit-test constructor to align the test harness with the existing constructor signature.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; it adds email integration provisioning to keyless environments with minimal blast radius — idempotently guarded by an existing count check, scoped only to keyless flow creation.

The three-line parameter change in `processKeyless` is correct and self-contained, but the accompanying test only adds the missing stub without asserting the new provisioning values, leaving the fix uncovered at the unit-test level. The runtime behavior is gated by `areNovuEmailCredentialsSet()`, which is a deployment-time concern rather than a code risk.

The test file `session.spec.ts` would benefit from a test case verifying the exact arguments passed to `createNovuIntegrationsUsecase.execute` inside `processKeyless`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/inbox/usecases/session/session.usecase.ts | Passes `name: EnvironmentEnum.DEVELOPMENT`, adds `ChannelTypeEnum.EMAIL`, and sets `environmentType: EnvironmentTypeEnum.DEV` so keyless environments receive the Novu Email demo integration alongside in-app; logic is correct and consistent with how new-org dev environments are provisioned. |
| apps/api/src/app/inbox/usecases/session/session.spec.ts | Adds the missing `KeylessAbuseGuardService` stub to the `Session` constructor in tests, but no new assertions cover the changed provisioning arguments in `processKeyless`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processKeyless] --> B[CreateNovuIntegrationsCommand]
    B --> C{command.channels includes EMAIL?}
    C -- Yes --> D[createEmailIntegration]
    D --> E{areNovuEmailCredentialsSet AND\nname === EnvironmentEnum.DEVELOPMENT?}
    E -- Yes --> F[Create Novu Email integration\nSet as primary]
    E -- No --> G[return early - no email provisioned]
    B --> H[createInAppIntegration]
    H --> I{environmentType === PROD?}
    I -- No DEV --> J[Create Novu In-App\nHMAC off]
    B --> K[createManagedClaudeIntegration\nincludeManagedClaude=true]
    K --> L[Create Novu Managed Claude\nif feature flag enabled]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Finbox%2Fusecases%2Fsession%2Fsession.spec.ts%3A143%0A**Missing%20assertion%20for%20updated%20provisioning%20parameters**%0A%0AThe%20spec%20file%20only%20adds%20the%20%60keylessAbuseGuard%60%20stub%20to%20make%20the%20constructor%20happy%20but%20doesn't%20add%20any%20test%20asserting%20that%20%60createNovuIntegrationsUsecase.execute%60%20is%20now%20called%20with%20%60name%3A%20EnvironmentEnum.DEVELOPMENT%60%2C%20%60channels%60%20containing%20%60EMAIL%60%2C%20and%20%60environmentType%3A%20EnvironmentTypeEnum.DEV%60.%20Without%20this%2C%20a%20future%20accidental%20revert%20of%20those%20three%20values%20would%20go%20undetected%20at%20the%20unit-test%20level.%0A%0A&pr=11485&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/inbox/usecases/session/session.spec.ts:143
**Missing assertion for updated provisioning parameters**

The spec file only adds the `keylessAbuseGuard` stub to make the constructor happy but doesn't add any test asserting that `createNovuIntegrationsUsecase.execute` is now called with `name: EnvironmentEnum.DEVELOPMENT`, `channels` containing `EMAIL`, and `environmentType: EnvironmentTypeEnum.DEV`. Without this, a future accidental revert of those three values would go undetected at the unit-test level.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): provision Novu Email d..."](https://github.com/novuhq/novu/commit/31221e71b67a41dde58468cfc87399b08fd6ae37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36446522)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->