### PR TITLE
feat(api-service,dashboard): agent suggestions based on org domain and industry fixes NV-7992

### DIFF
--- a/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
@@ -1,7 +1,13 @@
 import { Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { AnalyticsService, InstrumentUsecase, PinoLogger } from '@novu/application-generic';
-import { ApiAuthSchemeEnum, CLAUDE_ANTHROPIC_SKILLS, CLAUDE_BUILTIN_TOOLS, CLAUDE_DEFAULT_TOOL_TYPES, MCP_SERVERS } from '@novu/shared';
+import {
+  ApiAuthSchemeEnum,
+  CLAUDE_ANTHROPIC_SKILLS,
+  CLAUDE_BUILTIN_TOOLS,
+  CLAUDE_DEFAULT_TOOL_TYPES,
+  MCP_SERVERS,
+} from '@novu/shared';
 
 import { KeylessAbuseGuardService } from '../../../../keyless/keyless-abuse-guard.service';
 import { GenerateManagedAgentCommand } from './generate-managed-agent.command';
@@ -85,6 +91,9 @@ Pick a clear human name, derive a kebab-case identifier, and write a system prom
 ## System prompt
 The \`systemPrompt\` is sent verbatim to the agent. Address the agent in second person ("You are a…"), describe its role, scope, tone, and the workflow it should follow when invoked. Do not reference Anthropic-specific tools, MCPs or skills — the runtime is custom.
 
+## Language
+ALL output (\`name\`, \`description\`, \`identifier\`, and \`systemPrompt\`) MUST be written in English only. Use plain ASCII characters — no non-English words, no transliterations, and no non-ASCII characters (no accented letters, emoji, or other scripts). Even if the user's description is written in another language, translate everything to English.
+
 Return a JSON object matching the provided schema. Do not include any commentary outside the schema.`;
 }
 
@@ -120,6 +129,9 @@ The \`systemPrompt\` is sent verbatim to Claude. Address the agent in second per
 
 ## Identifier
 The \`identifier\` MUST be a kebab-case slug of the \`name\` (lowercase, hyphen-separated, ASCII only).
+
+## Language
+ALL output (\`name\`, \`description\`, \`identifier\`, and \`systemPrompt\`) MUST be written in English only. Use plain ASCII characters — no non-English words, no transliterations, and no non-ASCII characters (no accented letters, emoji, or other scripts). Even if the user's description is written in another language, translate everything to English.
 
 ## Catalogs
 Available built-in tool types:

--- a/apps/api/src/app/agents/management/usecases/generate-managed-agent/managed-agent-generation.schema.ts
+++ b/apps/api/src/app/agents/management/usecases/generate-managed-agent/managed-agent-generation.schema.ts
@@ -24,23 +24,23 @@ export { MAX_GENERATED_MCP_SERVERS, MAX_GENERATED_SKILLS };
 export const managedAgentGenerationSchema = z.object({
   name: z
     .string()
-    .min(1)
+    .min(5)
     .max(MANAGED_AGENT_NAME_MAX_LENGTH)
     .describe('Human readable agent name. Title case, 2–4 words (e.g., "PR Security Reviewer").'),
   identifier: z
     .string()
-    .min(1)
+    .min(5)
     .max(MANAGED_AGENT_IDENTIFIER_MAX_LENGTH)
     .regex(/^[a-z0-9-]+$/, 'Identifier must be lowercase kebab-case')
     .describe('Stable kebab-case identifier derived from the name (e.g., "pr-security-reviewer").'),
   description: z
     .string()
-    .min(1)
+    .min(10)
     .max(140) // max length for the description field, enforced by provider specific limits, for example: Slack
     .describe("Agent description. A short, human-readable summary of the agent's purpose and capabilities."),
   systemPrompt: z
     .string()
-    .min(1)
+    .min(20)
     .max(MANAGED_AGENT_SYSTEM_PROMPT_MAX_LENGTH)
     .describe(
       'The full system prompt sent to Claude. Speak in second person to the agent ("You are…"). Describe role, scope, tone, and the workflow it should follow. Reference the available tools/MCPs/skills naturally without hard-coding them.'

--- a/apps/dashboard/src/api/ai.ts
+++ b/apps/dashboard/src/api/ai.ts
@@ -161,6 +161,29 @@ export async function fetchWorkflowSuggestions({
   return responseData;
 }
 
+export type AgentSuggestionResponse = {
+  id: string;
+  name: string;
+  prompt: string;
+};
+
+export async function fetchAgentSuggestions({
+  environment,
+  refresh,
+}: {
+  environment: IEnvironment;
+  refresh?: boolean;
+}): Promise<AgentSuggestionResponse[]> {
+  if (!IS_AI_FEATURES_ENABLED) return [];
+
+  const endpoint = refresh ? '/ai/agent-suggestions?refresh=true' : '/ai/agent-suggestions';
+  const { data: responseData } = await getV2<{ data: AgentSuggestionResponse[] }>(endpoint, {
+    environment,
+  });
+
+  return responseData;
+}
+
 export async function cancelStream({
   environment,
   chatId,

--- a/apps/dashboard/src/components/agents/agent-preview-skeleton.tsx
+++ b/apps/dashboard/src/components/agents/agent-preview-skeleton.tsx
@@ -1,0 +1,78 @@
+import { Skeleton } from '@/components/primitives/skeleton';
+import { SetupStep } from './setup-guide-primitives';
+
+const BRAIN_STEP_TITLE = 'What should your agent do?';
+const BRAIN_STEP_DESCRIPTION =
+  "We'll provide demo Claude credentials so you can set up an agent without bringing your own keys. Later, you can replace it with your own agent and credentials.";
+
+function PreviewSectionSkeleton({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-text-soft text-code-xs font-normal uppercase leading-4 tracking-[0.4px]">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function AgentCardSkeleton() {
+  return (
+    <div className="bg-bg-weak border-stroke-weak flex flex-col gap-1 rounded-[8px] border p-1">
+      <div className="border-stroke-soft bg-bg-white relative overflow-hidden rounded-lg border shadow-[0_1px_2px_rgba(16,24,40,0.04)]">
+        <div className="bg-bg-weak flex h-8 items-center justify-between px-2">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Skeleton className="size-4 shrink-0 rounded-full" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+          <Skeleton className="h-4 w-16 rounded-full" />
+        </div>
+
+        <div className="flex flex-col gap-5 px-2 pb-3 pt-2">
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+
+          <PreviewSectionSkeleton label="MCPs">
+            <div className="flex flex-wrap gap-1.5">
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="h-5 w-24 rounded-full" />
+            </div>
+          </PreviewSectionSkeleton>
+
+          <PreviewSectionSkeleton label="Tools">
+            <div className="flex flex-wrap gap-1.5">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="h-5 w-14 rounded-full" />
+            </div>
+          </PreviewSectionSkeleton>
+
+          <PreviewSectionSkeleton label="Instructions">
+            <div className="flex flex-col gap-1.5">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-4/5" />
+            </div>
+          </PreviewSectionSkeleton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Loading placeholder shown while an agent is provisioned directly from a deep-linked template
+ * (marketing website). Mirrors the brain-step `SetupStep` + `AgentCard` layout so the swap into the
+ * real `ManagedAgentRecap` preview reads as an in-place reveal rather than a layout shift.
+ */
+export function AgentPreviewSkeleton() {
+  return (
+    <SetupStep
+      index={1}
+      status="current"
+      title={BRAIN_STEP_TITLE}
+      description={BRAIN_STEP_DESCRIPTION}
+      fullWidthContent={<AgentCardSkeleton />}
+    />
+  );
+}

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -1,6 +1,13 @@
-import { DirectionEnum, EnvironmentTypeEnum, PermissionsEnum } from '@novu/shared';
+import {
+  DirectionEnum,
+  EnvironmentTypeEnum,
+  filterDemoConfigurableMcpIds,
+  type IIntegration,
+  PermissionsEnum,
+  slugify,
+} from '@novu/shared';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowRightSLine, RiRobot2Line } from 'react-icons/ri';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import {
@@ -11,12 +18,18 @@ import {
   listAgents,
 } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
+import { AgentPreviewSkeleton } from '@/components/agents/agent-preview-skeleton';
 import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsProductionEmptyState } from '@/components/agents/agents-production-empty-state';
 import { AgentsTable } from '@/components/agents/agents-table';
+import {
+  getPreferredClaudeManagedIntegration,
+  resolveClaudeManagedProviderId,
+} from '@/components/agents/connectors/claude-managed-integrations';
 import { CreateAgentDialog, CreateAgentForm } from '@/components/agents/create-agent-dialog';
-import { findAgentTemplateById } from '@/components/agents/create-agent-fields';
+import { type AgentTemplate, findAgentTemplateById } from '@/components/agents/create-agent-fields';
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
+import { isDemoIntegration } from '@/components/integrations/components/utils/helpers';
 import { ListNoResults } from '@/components/list-no-results';
 import { Button } from '@/components/primitives/button';
 import { FacetedFormFilter } from '@/components/primitives/form/faceted-filter/facated-form-filter';
@@ -27,6 +40,7 @@ import { requireEnvironment, useEnvironment } from '@/context/environment/hooks'
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useAgentTemplates } from '@/hooks/use-agent-templates';
 import { useCreateAgentMutation } from '@/hooks/use-create-agent-mutation';
+import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { AGENTS_DOCS_PROVIDERS_URL } from '@/utils/agent-docs';
@@ -62,45 +76,15 @@ export function AgentsList() {
     prompt?: string;
   }>({});
   const [agentToDelete, setAgentToDelete] = useState<AgentResponse | null>(null);
+  // True while an agent is being provisioned directly from a deep-linked template (marketing
+  // website). Shows a preview skeleton until we navigate to the created agent's detail page.
+  const [isAutoProvisioningFromTemplate, setIsAutoProvisioningFromTemplate] = useState(false);
+  // Guards the deep-link template handling so it runs at most once per template id.
+  const appliedTemplateIdRef = useRef<string | undefined>(undefined);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const { templates: agentTemplates } = useAgentTemplates();
-
-  // Allow external links (e.g. connect dashboard) to open the create dialog with prefilled values
-  // via `?create=1&name=...&description=...`, or a Sanity-backed template via `?agentTemplateId=...`
-  // (also picked up from sessionStorage when it survived the auth flow). Consume once and strip the
-  // params from the URL.
-  useEffect(() => {
-    const hasCreate = searchParams.get('create') === '1';
-    const templateId = readActiveAgentTemplateId(searchParams.get(AGENT_TEMPLATE_ID_PARAM));
-
-    if (!hasCreate && !templateId) return;
-
-    let nextName = searchParams.get('name') ?? undefined;
-    let nextDescription = searchParams.get('description') ?? undefined;
-    let nextPrompt: string | undefined;
-
-    if (templateId) {
-      const template = findAgentTemplateById(agentTemplates, templateId);
-      // Templates may still be loading — wait for the match before consuming the id.
-      if (!template) return;
-
-      nextName = nextName ?? template.name;
-      nextDescription = nextDescription ?? template.instructions;
-      nextPrompt = template.instructions;
-      clearPersistedAgentTemplateId();
-    }
-
-    setInitialCreateValues({ name: nextName, description: nextDescription, prompt: nextPrompt });
-    setCreateOpen(true);
-
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.delete('create');
-    nextParams.delete('name');
-    nextParams.delete('description');
-    nextParams.delete(AGENT_TEMPLATE_ID_PARAM);
-    setSearchParams(nextParams, { replace: true });
-  }, [searchParams, setSearchParams, agentTemplates]);
+  const { integrations } = useFetchIntegrations();
 
   const handleCreateOpenChange = useCallback((next: boolean) => {
     setCreateOpen(next);
@@ -163,10 +147,7 @@ export function AgentsList() {
       setAgentToDelete(null);
       showSuccessToast('Agent deleted', 'The agent was removed.');
 
-      track(
-        TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD,
-        { agentIdentifier: identifier }
-      );
+      track(TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD, { agentIdentifier: identifier });
 
       const environment = requireEnvironment(currentEnvironment, 'No environment selected');
       const listKey = getAgentsListQueryKey(environment._id, {
@@ -265,6 +246,120 @@ export function AgentsList() {
     },
     [submitCreateAgent, track, currentEnvironment, agentRoutes.detailsTab, location.search, navigate]
   );
+
+  // Provision an agent directly from a deep-linked Sanity template (no dialog, no LLM): apply the
+  // template's name, instructions, and MCP servers as managed-runtime overrides on an existing
+  // managed Claude integration, then navigate to the created agent's detail page (the "preview").
+  const handleAutoProvisionFromTemplate = useCallback(
+    async (template: AgentTemplate, integration: IIntegration) => {
+      setIsAutoProvisioningFromTemplate(true);
+
+      const providerId = resolveClaudeManagedProviderId(integration);
+      const isDemo = isDemoIntegration(integration.providerId);
+      const requestedMcpServers = isDemo
+        ? filterDemoConfigurableMcpIds([...template.suggestedMcpServers])
+        : template.suggestedMcpServers;
+
+      await submitCreateAgent(
+        {
+          name: template.name,
+          identifier: slugify(template.name),
+          description: template.instructions,
+          instructions: template.instructions,
+          apiKey: '',
+          runtime: 'claude',
+          isExistingMode: false,
+          providerId,
+          integrationId: integration._id,
+          managedOverrides: {
+            systemPrompt: template.instructions,
+            mcpServers: requestedMcpServers,
+          },
+        },
+        {
+          onSuccess: (createdAgent) => {
+            track(TelemetryEvent.AGENT_CREATED_FROM_DASHBOARD, {
+              agentIdentifier: createdAgent.identifier,
+              active: createdAgent.active,
+            });
+
+            const environment = requireEnvironment(currentEnvironment, 'No environment selected');
+            const agentDetailsPath = `${buildRoute(agentRoutes.detailsTab, {
+              environmentSlug: environment.slug ?? '',
+              agentIdentifier: encodeURIComponent(createdAgent.identifier),
+              agentTab: AGENT_DETAILS_DEFAULT_TAB,
+            })}${location.search}`;
+
+            navigate(agentDetailsPath);
+          },
+          onError: (err) => {
+            setIsAutoProvisioningFromTemplate(false);
+            const message = err instanceof NovuApiError ? err.message : 'Could not create agent.';
+            showErrorToast(message, 'Create failed');
+          },
+        }
+      );
+    },
+    [submitCreateAgent, track, currentEnvironment, agentRoutes.detailsTab, location.search, navigate]
+  );
+
+  // Allow external links (e.g. connect dashboard) to open the create dialog with prefilled values
+  // via `?create=1&name=...&description=...`, or a Sanity-backed template via `?agentTemplateId=...`
+  // (also picked up from sessionStorage when it survived the auth flow). When a template matches and a
+  // managed Claude integration exists, provision the agent directly; otherwise fall back to opening
+  // the prefilled dialog. Consume once and strip the params from the URL.
+  useEffect(() => {
+    const hasCreate = searchParams.get('create') === '1';
+    const templateId = readActiveAgentTemplateId(searchParams.get(AGENT_TEMPLATE_ID_PARAM));
+
+    if (!hasCreate && !templateId) return;
+
+    const stripParams = () => {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.delete('create');
+      nextParams.delete('name');
+      nextParams.delete('description');
+      nextParams.delete(AGENT_TEMPLATE_ID_PARAM);
+      setSearchParams(nextParams, { replace: true });
+    };
+
+    let nextName = searchParams.get('name') ?? undefined;
+    let nextDescription = searchParams.get('description') ?? undefined;
+    let nextPrompt: string | undefined;
+
+    if (templateId) {
+      if (appliedTemplateIdRef.current === templateId) return;
+
+      const template = findAgentTemplateById(agentTemplates, templateId);
+      // Templates may still be loading — wait for the match before consuming the id.
+      if (!template) return;
+
+      // Integrations may still be loading — wait before deciding between auto-provision and dialog.
+      if (integrations === undefined) return;
+
+      const integration = getPreferredClaudeManagedIntegration(integrations);
+      if (integration) {
+        appliedTemplateIdRef.current = templateId;
+        clearPersistedAgentTemplateId();
+        stripParams();
+        void handleAutoProvisionFromTemplate(template, integration);
+
+        return;
+      }
+
+      // No managed Claude integration available — fall back to the prefilled create dialog so the
+      // user can supply credentials.
+      appliedTemplateIdRef.current = templateId;
+      nextName = nextName ?? template.name;
+      nextDescription = nextDescription ?? template.instructions;
+      nextPrompt = template.instructions;
+      clearPersistedAgentTemplateId();
+    }
+
+    setInitialCreateValues({ name: nextName, description: nextDescription, prompt: nextPrompt });
+    setCreateOpen(true);
+    stripParams();
+  }, [searchParams, setSearchParams, agentTemplates, integrations, handleAutoProvisionFromTemplate]);
 
   if (!canReadAgents) {
     return (
@@ -382,6 +477,14 @@ export function AgentsList() {
       </div>
     );
   };
+
+  if (isAutoProvisioningFromTemplate) {
+    return (
+      <div className="relative py-6 pl-6">
+        <AgentPreviewSkeleton />
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -898,6 +898,8 @@ export function CreateAgentDialog({
                       isLoading={isFetchingAgentTemplates}
                     />
                     <Button
+                      aria-label="Regenerate suggestions"
+                      title="Regenerate suggestions"
                       className="h-6 shrink-0 [&_svg]:size-2.5"
                       variant="secondary"
                       mode="ghost"

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -10,7 +10,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import type { FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { RiArrowRightSLine, RiArrowRightUpLine, RiCloseLine } from 'react-icons/ri';
+import { RiArrowRightSLine, RiArrowRightUpLine, RiCloseLine, RiLoopLeftLine } from 'react-icons/ri';
 import type { GeneratedManagedAgent } from '@/api/agents';
 import { BroomSparkle } from '@/components/icons/broom-sparkle';
 import { Button } from '@/components/primitives/button';
@@ -23,7 +23,7 @@ import {
 } from '@/components/primitives/segmented-control';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { useEnvironment } from '@/context/environment/hooks';
-import { useAgentTemplates } from '@/hooks/use-agent-templates';
+import { useAgentSuggestions } from '@/hooks/use-agent-suggestions';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
@@ -161,7 +161,11 @@ export function CreateAgentDialog({
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
   const { integrations } = useFetchIntegrations();
-  const { templates: agentTemplates } = useAgentTemplates();
+  const {
+    templates: agentTemplates,
+    isFetching: isFetchingAgentTemplates,
+    refresh: refreshAgentTemplates,
+  } = useAgentSuggestions();
   const verifyMutation = useVerifyManagedCredentials();
   const { mutateAsync: createIntegration, isPending: isSavingIntegration } = useCreateIntegration();
 
@@ -885,11 +889,24 @@ export function CreateAgentDialog({
                 </div>
 
                 {generationMode === 'prompt' && (
-                  <AgentSuggestionPills
-                    suggestions={displayedAgentTemplates}
-                    onSelect={handleSelectAiSuggestion}
-                    disabled={isSubmitBusy}
-                  />
+                  <div className="flex min-w-0 items-center gap-2">
+                    <AgentSuggestionPills
+                      className="min-w-0 flex-1"
+                      suggestions={displayedAgentTemplates}
+                      onSelect={handleSelectAiSuggestion}
+                      disabled={isSubmitBusy}
+                      isLoading={isFetchingAgentTemplates}
+                    />
+                    <Button
+                      className="h-6 shrink-0 [&_svg]:size-2.5"
+                      variant="secondary"
+                      mode="ghost"
+                      size="2xs"
+                      trailingIcon={RiLoopLeftLine}
+                      disabled={isSubmitBusy || isFetchingAgentTemplates}
+                      onClick={refreshAgentTemplates}
+                    />
+                  </div>
                 )}
               </div>
             ) : (

--- a/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
@@ -3,11 +3,13 @@ import { useMemo } from 'react';
 import { type AgentTemplate, type McpServerPreview } from '@/components/agents/create-agent-fields';
 import { McpIcon } from '@/components/agents/mcp-icon';
 import { OrbIcon } from '@/components/icons/orb';
+import { Skeleton } from '@/components/primitives/skeleton';
 import { buildEdgeFadeMask, useHorizontalScrollEdges } from '@/hooks/use-horizontal-scroll-edges';
 import { cn } from '@/utils/ui';
 
 const VISIBLE_INTEGRATION_ICONS = 2;
 const PILL_FADE_WIDTH_PX = 24;
+const SKELETON_PILL_WIDTHS = ['w-28', 'w-36', 'w-24', 'w-32', 'w-20'];
 
 function resolveMcpName(server: McpServerPreview): string {
   return server.name ?? MCP_SERVERS.find((entry) => entry.id === server.id)?.name ?? server.id;
@@ -17,12 +19,30 @@ type AgentSuggestionPillsProps = {
   suggestions: AgentTemplate[];
   onSelect: (suggestion: AgentTemplate) => void;
   disabled?: boolean;
+  /** When true, render animated skeleton pills instead of the suggestions (loading / refreshing). */
+  isLoading?: boolean;
   className?: string;
 };
 
-export function AgentSuggestionPills({ suggestions, onSelect, disabled, className }: AgentSuggestionPillsProps) {
+export function AgentSuggestionPills({
+  suggestions,
+  onSelect,
+  disabled,
+  isLoading,
+  className,
+}: AgentSuggestionPillsProps) {
   const { ref: scrollRef, canScrollLeft, canScrollRight } = useHorizontalScrollEdges<HTMLDivElement>();
   const maskImage = buildEdgeFadeMask(canScrollLeft, canScrollRight, PILL_FADE_WIDTH_PX);
+
+  if (isLoading) {
+    return (
+      <div className={cn('flex min-w-0 items-center gap-2 overflow-hidden', className)}>
+        {SKELETON_PILL_WIDTHS.map((width) => (
+          <Skeleton key={width} className={cn('h-[26px] shrink-0 rounded-full', width)} />
+        ))}
+      </div>
+    );
+  }
 
   if (!suggestions.length) return null;
 

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -284,6 +284,8 @@ export function ConnectAgentForm({
                 />
                 {aiGeneration.onRegenerateSuggestions && (
                   <Button
+                    aria-label="Regenerate suggestions"
+                    title="Regenerate suggestions"
                     className="h-6 shrink-0 [&_svg]:size-2.5"
                     variant="secondary"
                     mode="ghost"

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -1,7 +1,7 @@
 import { AgentRuntimeProviderIdEnum, type IIntegration } from '@novu/shared';
 import { motion } from 'motion/react';
 import type { ReactNode } from 'react';
-import { RiArrowRightSLine, RiCloseLine, RiInformation2Line } from 'react-icons/ri';
+import { RiArrowRightSLine, RiCloseLine, RiInformation2Line, RiLoopLeftLine } from 'react-icons/ri';
 import {
   ConnectorIntegrationDropdown,
   type ConnectorIntegrationStatus,
@@ -36,6 +36,10 @@ export type AgentGenerationBindings = {
   promptError?: string;
   suggestions: AgentTemplate[];
   onSelectSuggestion: (suggestion: AgentTemplate) => void;
+  /** Regenerates the suggestion pills on the server. When omitted, the regenerate button is hidden. */
+  onRegenerateSuggestions?: () => void;
+  /** When true, the pills show a loading skeleton and the regenerate button is disabled. */
+  isRegeneratingSuggestions?: boolean;
   textareaRef?: React.Ref<HTMLTextAreaElement>;
   /**
    * When true, the prompt textarea becomes read-only and the rotating status animation +
@@ -276,7 +280,23 @@ export function ConnectAgentForm({
                   suggestions={aiGeneration.suggestions}
                   onSelect={aiGeneration.onSelectSuggestion}
                   disabled={disabled || (aiGeneration.isGenerating ?? false)}
+                  isLoading={aiGeneration.isRegeneratingSuggestions ?? false}
                 />
+                {aiGeneration.onRegenerateSuggestions && (
+                  <Button
+                    className="h-6 shrink-0 [&_svg]:size-2.5"
+                    variant="secondary"
+                    mode="ghost"
+                    size="2xs"
+                    trailingIcon={RiLoopLeftLine}
+                    disabled={
+                      disabled ||
+                      (aiGeneration.isGenerating ?? false) ||
+                      (aiGeneration.isRegeneratingSuggestions ?? false)
+                    }
+                    onClick={aiGeneration.onRegenerateSuggestions}
+                  />
+                )}
               </div>
             )}
             {/*
@@ -701,11 +721,26 @@ function renderExtraContent({
 }: ExtraContentArgs) {
   if (usePromptUi && aiGeneration && aiMode === 'prompt') {
     return (
-      <AgentSuggestionPills
-        suggestions={aiGeneration.suggestions}
-        onSelect={aiGeneration.onSelectSuggestion}
-        disabled={disabled}
-      />
+      <div className="flex min-w-0 items-center gap-2">
+        <AgentSuggestionPills
+          className="min-w-0 flex-1"
+          suggestions={aiGeneration.suggestions}
+          onSelect={aiGeneration.onSelectSuggestion}
+          disabled={disabled}
+          isLoading={aiGeneration.isRegeneratingSuggestions ?? false}
+        />
+        {aiGeneration.onRegenerateSuggestions && (
+          <Button
+            className="h-6 shrink-0 [&_svg]:size-2.5"
+            variant="secondary"
+            mode="ghost"
+            size="2xs"
+            trailingIcon={RiLoopLeftLine}
+            disabled={disabled || (aiGeneration.isRegeneratingSuggestions ?? false)}
+            onClick={aiGeneration.onRegenerateSuggestions}
+          />
+        )}
+      </div>
     );
   }
 

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowRightSLine } from 'react-icons/ri';
 import type { AgentResponse, GeneratedManagedAgent } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
+import { AgentPreviewSkeleton } from '@/components/agents/agent-preview-skeleton';
 import {
   getClaudeManagedAgentIntegrations,
   isDemoManagedClaudeIntegrationSelected,
@@ -38,6 +39,7 @@ import { ClaudeIcon } from '@/components/icons/claude';
 import { Button } from '@/components/primitives/button';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useAgentSuggestions } from '@/hooks/use-agent-suggestions';
 import { useAgentTemplates } from '@/hooks/use-agent-templates';
 import { useCreateAgentMutation } from '@/hooks/use-create-agent-mutation';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
@@ -143,7 +145,15 @@ export function ConnectAgentStep({
   const { currentEnvironment } = useEnvironment();
   const { submit, isPending } = useCreateAgentMutation();
   const { integrations } = useFetchIntegrations();
-  const { templates: agentTemplates } = useAgentTemplates();
+  const {
+    templates: agentSuggestions,
+    isFetching: isFetchingAgentSuggestions,
+    refresh: refreshAgentSuggestions,
+  } = useAgentSuggestions();
+  // Sanity-backed templates are used only to resolve a deep-linked `agentTemplateId` (marketing
+  // website) into a concrete template for direct provisioning — kept separate from the AI
+  // suggestion pills above.
+  const { templates: sanityAgentTemplates, isLoading: isLoadingSanityTemplates } = useAgentTemplates();
   const verifyMutation = useVerifyManagedCredentials();
   const { mutateAsync: createIntegration, isPending: isSavingIntegration } = useCreateIntegration();
 
@@ -162,6 +172,10 @@ export function ConnectAgentStep({
   // animation flickers off in between `isGenerating` and `isPending` and reveals the
   // submit button momentarily.
   const [isPromptSubmitInFlight, setIsPromptSubmitInFlight] = useState(false);
+  // True while an agent is being provisioned directly from a deep-linked template (marketing
+  // website). Swaps the brain form for a preview skeleton until `onAgentCreated` morphs the parent
+  // into the real agent preview.
+  const [isAutoProvisioningFromTemplate, setIsAutoProvisioningFromTemplate] = useState(false);
   // Set when the user cancels generation, so the in-flight submit bails before creating the agent
   // even if the aborted request's promise resolves (or settles late) instead of rejecting.
   const generationCancelledRef = useRef(false);
@@ -219,14 +233,14 @@ export function ConnectAgentStep({
   // can never be configured on it. Drop them from the suggestion pills so onboarding only advertises
   // tools the user can actually wire up; the API enforces the same filter at provision time.
   const displayedAgentTemplates = useMemo(() => {
-    if (!isDemoProviderSelected) return agentTemplates;
+    if (!isDemoProviderSelected) return agentSuggestions;
 
-    return agentTemplates.map((template) => ({
+    return agentSuggestions.map((template) => ({
       ...template,
       suggestedMcpServers: filterDemoConfigurableMcpIds(template.suggestedMcpServers),
       mcpServers: template.mcpServers?.filter((server) => !isProviderManagedMcp(server.id)),
     }));
-  }, [agentTemplates, isDemoProviderSelected]);
+  }, [agentSuggestions, isDemoProviderSelected]);
   const isExistingMode =
     isClaudeSelected &&
     !isDemoProviderSelected &&
@@ -254,30 +268,140 @@ export function ConnectAgentStep({
     onRuntimeChange?.(runtime);
   }, [runtime, onRuntimeChange]);
 
-  // Deep-link prefill: when an `agentTemplateId` matches a fetched template, drop into prompt mode
-  // with the prompt + agent fields filled in. Runs once per id (templates may load asynchronously),
-  // then clears the persisted id so a refresh doesn't re-apply it.
+  const dropdownStatus = dropdownStatusFor(verifyStatus, Boolean(selectedIntegrationId));
+  const isSubmitBusy = isPending || isGenerating || isPromptSubmitInFlight || isAutoProvisioningFromTemplate;
+
+  // Provision an agent directly from a deep-linked Sanity template — no LLM prompt step. The
+  // template's name, instructions, and MCP servers are applied as managed-runtime overrides so the
+  // agent is created with exactly what the marketing-site template advertised.
+  const provisionAgentFromTemplate = useCallback(
+    async (template: AgentTemplate) => {
+      setIsAutoProvisioningFromTemplate(true);
+
+      const effectiveName = template.name;
+      const effectiveIdentifier = slugify(template.name);
+      const effectiveInstructions = template.instructions;
+      const requestedMcpServers = isDemoProviderSelected
+        ? filterDemoConfigurableMcpIds([...template.suggestedMcpServers])
+        : template.suggestedMcpServers;
+
+      const managedOverrides: ManagedAgentRuntimeOverrides = {
+        systemPrompt: template.instructions,
+        mcpServers: requestedMcpServers,
+      };
+
+      const summary: ConnectSummary = {
+        connectorId,
+        templateSelection,
+        name: effectiveName,
+        identifier: effectiveIdentifier,
+        instructions: effectiveInstructions,
+        apiKey,
+        externalAgentId,
+        externalEnvironmentId,
+        externalWorkspaceId,
+        region: region.trim() || undefined,
+        selectedIntegrationId,
+        integrationName,
+        mcpServers: requestedMcpServers,
+        tools: [],
+      };
+
+      await submit(
+        {
+          name: effectiveName.trim(),
+          identifier: effectiveIdentifier.trim(),
+          instructions: effectiveInstructions.trim(),
+          description: effectiveInstructions.trim(),
+          apiKey: apiKey.trim(),
+          runtime,
+          isExistingMode: false,
+          providerId: selectedConnector?.providerId,
+          externalAgentId: externalAgentId.trim(),
+          externalEnvironmentId: externalEnvironmentId.trim(),
+          externalWorkspaceId: externalWorkspaceId.trim() || undefined,
+          region: region.trim() || undefined,
+          integrationId: selectedIntegrationId,
+          integrationName: integrationName.trim() || undefined,
+          managedOverrides,
+        },
+        {
+          onSuccess: (agent) => {
+            telemetry(TelemetryEvent.ONBOARDING_CONNECT_AGENT_CREATED, {
+              runtime,
+              connectorId,
+              mode: 'template',
+              templateKind: 'template',
+              agentIdentifier: agent.identifier,
+              isExistingMode: false,
+            });
+            onAgentCreated(agent, summary);
+          },
+          onError: (err) => {
+            setIsAutoProvisioningFromTemplate(false);
+            const message = err instanceof NovuApiError ? err.message : 'Could not create agent.';
+            showErrorToast(message, 'Create failed');
+          },
+        }
+      );
+    },
+    [
+      connectorId,
+      templateSelection,
+      apiKey,
+      externalAgentId,
+      externalEnvironmentId,
+      externalWorkspaceId,
+      region,
+      selectedIntegrationId,
+      integrationName,
+      runtime,
+      selectedConnector?.providerId,
+      isDemoProviderSelected,
+      submit,
+      telemetry,
+      onAgentCreated,
+    ]
+  );
+
+  // Deep-link auto-provision: when an `agentTemplateId` matches a fetched Sanity template, create the
+  // agent straight from the template (name + instructions + MCPs) once the managed runtime and a
+  // credential are ready. Runs once per id, then clears the persisted id so a refresh doesn't re-run.
   useEffect(() => {
     if (!agentTemplateId) return;
     if (appliedTemplateIdRef.current === agentTemplateId) return;
+    if (!currentEnvironment) return;
+    if (!isClaudeSelected || !isManagedEnabled) return;
+    if (!selectedIntegrationId) return;
 
-    const template = findAgentTemplateById(agentTemplates, agentTemplateId);
+    const template = findAgentTemplateById(sanityAgentTemplates, agentTemplateId);
     if (!template) return;
 
     appliedTemplateIdRef.current = agentTemplateId;
-    setGenerationMode('prompt');
-    setPrompt(template.instructions);
-    setPromptError(undefined);
-    setName(template.name);
-    if (!isIdentifierTouched) {
-      setIdentifier(slugify(template.name));
-    }
-    setInstructions(template.instructions);
     clearPersistedAgentTemplateId();
-  }, [agentTemplateId, agentTemplates, isIdentifierTouched]);
+    void provisionAgentFromTemplate(template);
+  }, [
+    agentTemplateId,
+    sanityAgentTemplates,
+    currentEnvironment,
+    isClaudeSelected,
+    isManagedEnabled,
+    selectedIntegrationId,
+    provisionAgentFromTemplate,
+  ]);
 
-  const dropdownStatus = dropdownStatusFor(verifyStatus, Boolean(selectedIntegrationId));
-  const isSubmitBusy = isPending || isGenerating || isPromptSubmitInFlight;
+  // A deep-linked template (marketing website) bypasses the brain form entirely: show the agent
+  // preview skeleton from the first render — while integrations/templates load and the agent is
+  // provisioned — instead of briefly flashing the suggestion pills + prompt. Fall back to the form
+  // only once we can prove there's nothing to provision (managed runtime unavailable, or the id
+  // resolves to no known Sanity template), so the user is never stranded on the skeleton.
+  const deepLinkTemplateUnresolvable =
+    Boolean(agentTemplateId) &&
+    !isLoadingSanityTemplates &&
+    !findAgentTemplateById(sanityAgentTemplates, agentTemplateId ?? '');
+  const showTemplateProvisioningSkeleton =
+    isAutoProvisioningFromTemplate ||
+    (Boolean(agentTemplateId) && isManagedEnabled && isClaudeSelected && !deepLinkTemplateUnresolvable);
 
   // Build a preview snapshot for the right-side illustration. Pulls instructions / MCPs from
   // the active template (or the manual form fields when "Start from scratch" is picked) so the
@@ -864,6 +988,20 @@ export function ConnectAgentStep({
     </Button>
   );
 
+  if (showTemplateProvisioningSkeleton) {
+    return (
+      <div className="relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-3 md:pr-6">
+        <div
+          className="absolute bottom-0 left-[22px] top-0 w-px"
+          style={{
+            background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+          }}
+        />
+        <AgentPreviewSkeleton />
+      </div>
+    );
+  }
+
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-10 py-6 pb-3 pl-8 pr-3 md:pr-6">
       <div
@@ -903,6 +1041,8 @@ export function ConnectAgentStep({
                 promptError,
                 suggestions: displayedAgentTemplates,
                 onSelectSuggestion: handleSelectSuggestion,
+                onRegenerateSuggestions: refreshAgentSuggestions,
+                isRegeneratingSuggestions: isFetchingAgentSuggestions,
                 textareaRef: promptTextareaRef,
                 isGenerating: isSubmitBusy,
                 generationSteps: GENERATION_STEPS,

--- a/apps/dashboard/src/hooks/use-agent-suggestions.ts
+++ b/apps/dashboard/src/hooks/use-agent-suggestions.ts
@@ -1,0 +1,58 @@
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useRef } from 'react';
+import { AgentSuggestionResponse, fetchAgentSuggestions } from '@/api/ai';
+import { AGENT_TEMPLATES, type AgentTemplate } from '@/components/agents/create-agent-fields';
+import { IS_AI_FEATURES_ENABLED } from '@/config';
+import { useEnvironment } from '@/context/environment/hooks';
+import { useFeatureFlag } from './use-feature-flag';
+
+const QUERY_KEY = 'agent-suggestions';
+
+function mapSuggestionToTemplate(suggestion: AgentSuggestionResponse): AgentTemplate {
+  return {
+    templateId: suggestion.id,
+    label: suggestion.name,
+    name: suggestion.name,
+    instructions: suggestion.prompt,
+    suggestedMcpServers: [],
+    mcpServers: [],
+  };
+}
+
+/**
+ * Fetches AI agent suggestions tailored to the organization industry/domain for the
+ * onboarding/create-agent suggestion pills. Falls back to the hardcoded `AGENT_TEMPLATES` when the
+ * feature is disabled or the endpoint returns nothing. `refresh()` regenerates the suggestions on
+ * the server.
+ */
+export function useAgentSuggestions() {
+  const isManagedAgentRuntimeEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED);
+  const { currentEnvironment } = useEnvironment();
+  const refreshRef = useRef(false);
+
+  const { data, isLoading, isFetching, refetch } = useQuery({
+    queryKey: [QUERY_KEY, currentEnvironment?._id],
+    queryFn: async () => {
+      if (!currentEnvironment) throw new Error('Environment not loaded');
+
+      const shouldRefresh = refreshRef.current;
+      refreshRef.current = false;
+
+      const result = await fetchAgentSuggestions({ environment: currentEnvironment, refresh: shouldRefresh });
+
+      return result.map(mapSuggestionToTemplate);
+    },
+    enabled: isManagedAgentRuntimeEnabled && IS_AI_FEATURES_ENABLED && !!currentEnvironment,
+    staleTime: 24 * 60 * 60 * 1000,
+  });
+
+  const refresh = useCallback(() => {
+    refreshRef.current = true;
+    refetch();
+  }, [refetch]);
+
+  const templates = data && data.length > 0 ? data : AGENT_TEMPLATES;
+
+  return { templates, isLoading, isFetching, refresh };
+}

--- a/apps/dashboard/src/hooks/use-agent-templates.ts
+++ b/apps/dashboard/src/hooks/use-agent-templates.ts
@@ -42,7 +42,7 @@ function mapSanityTemplate(template: SanityAgentTemplate): AgentTemplate | null 
   return {
     templateId: template.id,
     label: template.name,
-    name: template.agentName || template.name,
+    name: template.name ?? template.agentName,
     instructions: template.systemPrompt || '',
     suggestedMcpServers: mcpServers.map((server) => server.id),
     mcpServers,
@@ -50,8 +50,10 @@ function mapSanityTemplate(template: SanityAgentTemplate): AgentTemplate | null 
 }
 
 /**
- * Fetches agent templates from Sanity for the onboarding/create-agent pills. Falls back to the
- * hardcoded `AGENT_TEMPLATES` when Sanity is unavailable or returns nothing.
+ * Fetches agent templates from Sanity. Used to resolve a deep-linked `agentTemplateId` (from the
+ * marketing website) into a concrete template — name, instructions, and MCP servers — so the agent
+ * can be provisioned directly. Falls back to the hardcoded `AGENT_TEMPLATES` when Sanity is
+ * unavailable or returns nothing.
  */
 export function useAgentTemplates() {
   const { data, isLoading } = useQuery({

--- a/apps/dashboard/src/hooks/use-horizontal-scroll-edges.ts
+++ b/apps/dashboard/src/hooks/use-horizontal-scroll-edges.ts
@@ -28,11 +28,18 @@ export function buildEdgeFadeMask(
  * changes so the edges stay accurate when content reflows.
  */
 export function useHorizontalScrollEdges<T extends HTMLElement>() {
-  const ref = useRef<T | null>(null);
+  const nodeRef = useRef<T | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
   const [edges, setEdges] = useState({ canScrollLeft: false, canScrollRight: false });
 
-  useEffect(() => {
-    const node = ref.current;
+  // Callback ref so the observers (re)attach whenever the node mounts — including when the
+  // container is rendered after a loading/skeleton state. A plain effect would only run once on
+  // mount, missing the later attach and leaving the edge fade permanently disabled.
+  const ref = useCallback((node: T | null) => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+    nodeRef.current = node;
+
     if (!node) return;
 
     const update = () => {
@@ -66,15 +73,17 @@ export function useHorizontalScrollEdges<T extends HTMLElement>() {
     });
     mutationObserver.observe(node, { childList: true });
 
-    return () => {
+    cleanupRef.current = () => {
       node.removeEventListener('scroll', update);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
     };
   }, []);
 
+  useEffect(() => () => cleanupRef.current?.(), []);
+
   const scrollBy = useCallback((direction: 'left' | 'right') => {
-    const node = ref.current;
+    const node = nodeRef.current;
     if (!node) return;
 
     const delta = Math.max(node.clientWidth * 0.8, 160);

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -6,6 +6,7 @@ export enum AiConversationStatusEnum {
 
 export enum AiResourceTypeEnum {
   WORKFLOW = 'workflow',
+  AGENT = 'agent',
 }
 
 export enum AiAgentTypeEnum {
@@ -22,6 +23,7 @@ export enum SnapshotSourceTypeEnum {
   AI_CHAT = 'ai-chat',
   ONBOARDING_WORKFLOWS = 'onboarding-workflows',
   WORKFLOW_SUGGESTIONS = 'workflow-suggestions',
+  AGENT_SUGGESTIONS = 'agent-suggestions',
 }
 
 export enum AiWorkflowToolsEnum {


### PR DESCRIPTION
### What changed? Why was the change needed?

**Related EE repo PR: https://github.com/novuhq/packages-enterprise/pull/461**

Agents:
- agent suggestions based on org domain and industry
- improved marketing templates to dashboard flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Implemented AI-powered agent suggestions and deep-link provisioning to recommend and auto-provision agents based on an organization’s domain and industry, improving onboarding and agent management flows. The change adds suggestion fetching, UI loading states, stronger generation validation, and managed-agent prompt constraints to ensure consistent, English/ASCII agent metadata.

## Affected areas

**api**: Added server-side support for agent suggestion responses and updated managed-agent generation logic and schema validation (stricter min lengths and language/ASCII constraints for name, identifier, description, systemPrompt).  
**dashboard**: Added suggestion discovery and provisioning UX: `useAgentSuggestions` hook, fetching via new AI endpoint, `AgentPreviewSkeleton` loading UI, regenerate/refresh controls, and deep-link auto-provisioning from Sanity templates with managed-runtime MCP filtering.  
**shared**: Introduced AiResourceTypeEnum.AGENT and SnapshotSourceTypeEnum.AGENT_SUGGESTIONS to model the new resource types.  
**enterprise**: Related EE package updated (submodule pointer / EE PR referenced) to align enterprise features.

## Key technical decisions

- Server respects feature gate (IS_AI_FEATURES_ENABLED) and supports a refresh query param to regenerate suggestions.  
- Deep-link provisioning can bypass the prompt step when a valid Sanity template and managed provider are available.  
- Zod validation and system prompts enforce English-only, plain ASCII outputs and increased minimum lengths to improve data consistency.

## Testing

Manual verification for onboarding flows and agent provisioning was added; suggestion fetching and deep-link flows should be covered by integration/e2e tests. No new npm dependencies introduced in this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots


https://github.com/user-attachments/assets/3506937e-d8f0-4339-909c-f75a3d6ad8df


https://github.com/user-attachments/assets/2272eb1b-c99f-4450-a485-396d54af22c9

<img width="1528" height="994" alt="Screenshot 2026-06-09 at 13 49 27" src="https://github.com/user-attachments/assets/070c1514-9c59-41b4-8f1b-6bfb0acb9646" />

<img width="1528" height="995" alt="Screenshot 2026-06-09 at 13 49 04" src="https://github.com/user-attachments/assets/6e97c6cb-749f-4afc-b742-ca416766dc43" />

