### PR TITLE
fix(novu): harden keyless session bootstrap and CI handoff events

### DIFF
--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import {
   AnalyticsService,
+  areNovuManagedClaudeCredentialsSet,
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
   encryptApiKey,
@@ -477,6 +478,24 @@ export class Session {
 
     if (!isKeylessEnabled) {
       throw new BadRequestException('Keyless environment creation is currently disabled.');
+    }
+
+    if (!areNovuManagedClaudeCredentialsSet()) {
+      throw new BadRequestException(
+        'Keyless Connect requires NOVU_MANAGED_CLAUDE_API_KEY to be configured on the API server.'
+      );
+    }
+
+    const isDemoManagedClaudeEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_DEMO_MANAGED_CLAUDE_ENABLED,
+      defaultValue: false,
+      organization,
+    });
+
+    if (!isDemoManagedClaudeEnabled) {
+      throw new BadRequestException(
+        'Keyless Connect requires the IS_DEMO_MANAGED_CLAUDE_ENABLED feature flag to be enabled on the API server.'
+      );
     }
 
     const user = await this.communityUserRepository.findByEmail(process.env.KEYLESS_USER_EMAIL!);

--- a/packages/novu/src/commands/connect/api/keyless-session.spec.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.spec.ts
@@ -14,14 +14,20 @@ vi.mock('../../shared/novu-http', () => ({
   },
 }));
 
-vi.mock('./client', () => ({
-  createConnectApiClient: vi.fn(() => ({ axios: {} })),
-}));
+vi.mock('./client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./client')>();
+
+  return {
+    ...actual,
+    createConnectApiClient: vi.fn(() => ({ axios: {} })),
+  };
+});
 
 vi.mock('./integrations', () => ({
   listIntegrations: (...args: unknown[]) => listIntegrations(...args),
 }));
 
+import { NovuApiError } from './client';
 import { bootstrapKeylessSession } from './keyless-session';
 
 const apiUrl = 'http://localhost:3000';
@@ -115,11 +121,61 @@ describe('bootstrapKeylessSession', () => {
     expect(post.mock.calls[0][1]).toEqual({});
   });
 
+  it('starts a fresh session when the stored keyless session is no longer authorized', async () => {
+    post
+      .mockResolvedValueOnce(sessionResponse(storedIdentifier))
+      .mockResolvedValueOnce(sessionResponse(freshIdentifier));
+    listIntegrations
+      .mockRejectedValueOnce(new NovuApiError('Unauthorized', 401, 'GET /v1/integrations', {}))
+      .mockResolvedValueOnce([demoIntegration()]);
+
+    const result = await bootstrapKeylessSession(apiUrl, storedIdentifier);
+
+    expect(result).toEqual({
+      applicationIdentifier: freshIdentifier,
+      recoveredFromStaleSession: true,
+    });
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(post.mock.calls[1][1]).toEqual({});
+    expect(listIntegrations).toHaveBeenCalledTimes(2);
+  });
+
   it('propagates integration-list failures instead of treating them as stale sessions', async () => {
     post.mockResolvedValueOnce(sessionResponse(storedIdentifier));
     listIntegrations.mockRejectedValueOnce(new Error('network down'));
 
     await expect(bootstrapKeylessSession(apiUrl, storedIdentifier)).rejects.toThrow('network down');
     expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('explains when a fresh keyless session has no demo agent integration', async () => {
+    post.mockResolvedValueOnce(sessionResponse(freshIdentifier));
+    listIntegrations.mockResolvedValueOnce([]);
+
+    await expect(bootstrapKeylessSession(apiUrl)).rejects.toThrow(
+      'The keyless environment has no integrations — the API likely omitted the demo agent integration during provisioning.'
+    );
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(listIntegrations).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces API errors from inbox session creation', async () => {
+    post.mockResolvedValueOnce({
+      status: 400,
+      data: { message: 'Keyless Connect requires NOVU_MANAGED_CLAUDE_API_KEY to be configured on the API server.' },
+    });
+
+    await expect(bootstrapKeylessSession(apiUrl)).rejects.toThrow('NOVU_MANAGED_CLAUDE_API_KEY');
+  });
+
+  it('surfaces community edition rejection from inbox session creation', async () => {
+    post.mockResolvedValueOnce({
+      status: 400,
+      data: { message: 'Keyless is not supported in community edition' },
+    });
+
+    await expect(bootstrapKeylessSession(apiUrl)).rejects.toThrow(
+      'Keyless is not supported in community edition (POST http://localhost:3000/v1/inbox/session returned 400)'
+    );
   });
 });

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -1,5 +1,5 @@
 import { createNovuAxios, extractNovuApiMessage } from '../../shared/novu-http';
-import { createConnectApiClient } from './client';
+import { createConnectApiClient, NovuApiError } from './client';
 import { findActiveDemoAgentIntegration } from './demo-agent-integration';
 import { listIntegrations } from './integrations';
 
@@ -30,8 +30,12 @@ export async function bootstrapKeylessSession(
     attemptedStoredSession = true;
     const restored = await requestKeylessSession(apiUrl, trimmedStored);
 
-    if (restored && (await isKeylessEnvironmentReadyForConnect(apiUrl, restored.applicationIdentifier))) {
-      return { ...restored, recoveredFromStaleSession: false };
+    if (restored) {
+      const readiness = await checkKeylessEnvironmentReadyForConnect(apiUrl, restored.applicationIdentifier);
+
+      if (readiness.ready) {
+        return { ...restored, recoveredFromStaleSession: false };
+      }
     }
   }
 
@@ -41,19 +45,16 @@ export async function bootstrapKeylessSession(
     throw new Error('Failed to start a keyless session.');
   }
 
-  if (!(await isKeylessEnvironmentReadyForConnect(apiUrl, fresh.applicationIdentifier))) {
-    throw new Error(
-      'Keyless mode is not available on this Novu deployment. Re-run with `--secret-key <key>` to use an existing environment.'
-    );
+  const readiness = await checkKeylessEnvironmentReadyForConnect(apiUrl, fresh.applicationIdentifier);
+
+  if (!readiness.ready) {
+    throw new Error(describeKeylessEnvironmentNotReady(fresh.applicationIdentifier, readiness, apiUrl));
   }
 
   return { ...fresh, recoveredFromStaleSession: attemptedStoredSession };
 }
 
-async function requestKeylessSession(
-  apiUrl: string,
-  applicationIdentifier?: string
-): Promise<KeylessSession | null> {
+async function requestKeylessSession(apiUrl: string, applicationIdentifier?: string): Promise<KeylessSession | null> {
   const axios = createNovuAxios({ apiUrl });
   const body = applicationIdentifier ? { applicationIdentifier } : {};
 
@@ -66,7 +67,7 @@ async function requestKeylessSession(
       return null;
     }
 
-    throw new Error(describeKeylessSessionFailure(res.status, res.data));
+    throw new Error(describeKeylessSessionFailure(res.status, res.data, apiUrl));
   }
 
   const responseBody = res.data;
@@ -93,29 +94,100 @@ function isRecoverableKeylessSessionFailure(status: number, body: unknown): bool
   return false;
 }
 
-function describeKeylessSessionFailure(status: number, body: unknown): string {
-  if (status === 400) {
-    const message = extractNovuApiMessage(body);
-
-    if (message?.includes('Keyless environment creation is currently disabled')) {
-      return message;
-    }
-
-    return 'Keyless mode is not available on this Novu deployment. Re-run with `--secret-key <key>` to use an existing environment.';
-  }
-
-  const message = extractNovuApiMessage(body);
-
-  return message ? `Failed to start a keyless session (${status}): ${message}` : `Failed to start a keyless session (${status}).`;
+interface KeylessEnvironmentReadiness {
+  ready: boolean;
+  reason: string;
+  integrationCount: number;
+  agentIntegrationCount: number;
 }
 
-async function isKeylessEnvironmentReadyForConnect(apiUrl: string, applicationIdentifier: string): Promise<boolean> {
-  const client = createConnectApiClient({ apiUrl, keylessApplicationIdentifier: applicationIdentifier });
-  const integrations = await listIntegrations(client);
+function describeKeylessSessionFailure(status: number, body: unknown, apiUrl: string): string {
+  const message = extractNovuApiMessage(body);
 
-  return findActiveDemoAgentIntegration(integrations) != null;
+  if (status === 400) {
+    if (message) {
+      return `${message} (POST ${apiUrl}/v1/inbox/session returned 400)`;
+    }
+
+    return `Failed to start a keyless session (POST ${apiUrl}/v1/inbox/session returned 400 with no error message). Re-run with \`--secret-key <key>\` to use an existing environment.`;
+  }
+
+  return message
+    ? `Failed to start a keyless session (${status} at ${apiUrl}/v1/inbox/session): ${message}`
+    : `Failed to start a keyless session (${status} at ${apiUrl}/v1/inbox/session).`;
+}
+
+function describeKeylessEnvironmentNotReady(
+  applicationIdentifier: string,
+  readiness: KeylessEnvironmentReadiness,
+  apiUrl: string
+): string {
+  const serverFix =
+    'On the API server, set NOVU_MANAGED_CLAUDE_API_KEY and enable IS_DEMO_MANAGED_CLAUDE_ENABLED, then restart the API.';
+  const bypass = 'Alternatively, re-run with `--secret-key <key>` to use an existing environment.';
+
+  return [
+    'Keyless session was created, but Connect could not find the demo agent integration required to create agents.',
+    readiness.reason,
+    serverFix,
+    bypass,
+    `Application identifier: ${applicationIdentifier}.`,
+    `Integrations found: ${readiness.integrationCount} total, ${readiness.agentIntegrationCount} agent.`,
+    `API: ${apiUrl}.`,
+  ].join(' ');
+}
+
+async function checkKeylessEnvironmentReadyForConnect(
+  apiUrl: string,
+  applicationIdentifier: string
+): Promise<KeylessEnvironmentReadiness> {
+  const client = createConnectApiClient({ apiUrl, keylessApplicationIdentifier: applicationIdentifier });
+  let integrations;
+
+  try {
+    integrations = await listIntegrations(client);
+  } catch (err) {
+    if (err instanceof NovuApiError && err.status === 401) {
+      return {
+        ready: false,
+        reason: 'The stored keyless session is no longer authorized for Connect.',
+        integrationCount: 0,
+        agentIntegrationCount: 0,
+      };
+    }
+
+    throw err;
+  }
+
+  const demoIntegration = findActiveDemoAgentIntegration(integrations);
+  const agentIntegrations = integrations.filter((integration) => integration.kind === 'agent');
+
+  if (demoIntegration) {
+    return {
+      ready: true,
+      reason: '',
+      integrationCount: integrations.length,
+      agentIntegrationCount: agentIntegrations.length,
+    };
+  }
+
+  let reason = 'The keyless environment is missing an active Novu Anthropic demo agent integration.';
+
+  if (integrations.length === 0) {
+    reason =
+      'The keyless environment has no integrations — the API likely omitted the demo agent integration during provisioning.';
+  } else if (agentIntegrations.length === 0) {
+    reason = 'The keyless environment has integrations, but none are agent integrations.';
+  }
+
+  return {
+    ready: false,
+    reason,
+    integrationCount: integrations.length,
+    agentIntegrationCount: agentIntegrations.length,
+  };
 }
 
 export function isKeylessIdentifier(value: string | undefined | null): boolean {
-  return Boolean(value && value.startsWith(KEYLESS_ENVIRONMENT_PREFIX));
+  return Boolean(value?.startsWith(KEYLESS_ENVIRONMENT_PREFIX));
 }

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -150,7 +150,7 @@ async function checkKeylessEnvironmentReadyForConnect(
     if (err instanceof NovuApiError && err.status === 401) {
       return {
         ready: false,
-        reason: 'The stored keyless session is no longer authorized for Connect.',
+        reason: 'The keyless session is no longer authorized for Connect.',
         integrationCount: 0,
         agentIntegrationCount: 0,
       };

--- a/packages/novu/src/commands/connect/api/keyless-session.ts
+++ b/packages/novu/src/commands/connect/api/keyless-session.ts
@@ -134,7 +134,7 @@ function describeKeylessEnvironmentNotReady(
     `Application identifier: ${applicationIdentifier}.`,
     `Integrations found: ${readiness.integrationCount} total, ${readiness.agentIntegrationCount} agent.`,
     `API: ${apiUrl}.`,
-  ].join(' ');
+  ].join('\n');
 }
 
 async function checkKeylessEnvironmentReadyForConnect(

--- a/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
+++ b/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '../../../services';
-import { resolveAuth, type ResolveAuthOptions } from '../../wizard/auth/resolve-auth';
+import { type ResolveAuthOptions, resolveAuth } from '../../wizard/auth/resolve-auth';
 import type { ResolvedAuth, WizardCommandOptions } from '../../wizard/types';
 import { bootstrapKeylessSession } from '../api/keyless-session';
 import type { ConnectCommandOptions } from '../types';
@@ -30,9 +30,7 @@ export async function resolveConnectAuth(
   const config = new ConfigService();
   const stored = config.getValue(KEYLESS_CONFIG_KEY);
 
-  resolveOptions.onStatus?.(
-    stored ? 'Restoring your keyless workspace…' : 'Setting up a temporary keyless workspace…'
-  );
+  resolveOptions.onStatus?.(stored ? 'Restoring your keyless workspace…' : 'Setting up a temporary keyless workspace…');
 
   const session = await bootstrapKeylessSession(options.apiUrl, stored);
 

--- a/packages/novu/src/commands/connect/ui/handoff-events.spec.ts
+++ b/packages/novu/src/commands/connect/ui/handoff-events.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logEmailHandoffEvents, logSlackHandoffEvents } from './handoff-events';
+
+describe('handoff-events', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs email handoff sentinel lines', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    logEmailHandoffEvents({
+      inboundAddress: 'agent-abc@dev.agentconnect.sh',
+      mailtoUrl: 'mailto:agent-abc@dev.agentconnect.sh?subject=Hi',
+      sendFromEmail: 'user@example.com',
+    });
+
+    expect(log).toHaveBeenCalledWith('NOVU_CONNECT_INBOUND_ADDRESS=agent-abc@dev.agentconnect.sh');
+    expect(log).toHaveBeenCalledWith('NOVU_CONNECT_MAILTO=mailto:agent-abc@dev.agentconnect.sh?subject=Hi');
+    expect(log).toHaveBeenCalledWith('NOVU_CONNECT_SEND_FROM_EMAIL=user@example.com');
+  });
+
+  it('omits send-from line when not provided', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    logEmailHandoffEvents({
+      inboundAddress: 'agent-abc@dev.agentconnect.sh',
+      mailtoUrl: 'mailto:agent-abc@dev.agentconnect.sh',
+    });
+
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining('SEND_FROM_EMAIL'));
+  });
+
+  it('logs slack authorize sentinel line', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    logSlackHandoffEvents({ authorizeUrl: 'https://slack.com/oauth/v2/authorize?client_id=abc' });
+
+    expect(log).toHaveBeenCalledWith(
+      'NOVU_CONNECT_SLACK_AUTHORIZE_URL=https://slack.com/oauth/v2/authorize?client_id=abc'
+    );
+  });
+});

--- a/packages/novu/src/commands/connect/ui/handoff-events.ts
+++ b/packages/novu/src/commands/connect/ui/handoff-events.ts
@@ -1,0 +1,18 @@
+/** Machine-readable handoff lines for `--ci` / logging mode. Agents grep stdout for these. */
+const HANDOFF_PREFIX = 'NOVU_CONNECT_';
+
+export function logEmailHandoffEvents(opts: {
+  inboundAddress: string;
+  mailtoUrl: string;
+  sendFromEmail?: string;
+}): void {
+  console.log(`${HANDOFF_PREFIX}INBOUND_ADDRESS=${opts.inboundAddress}`);
+  console.log(`${HANDOFF_PREFIX}MAILTO=${opts.mailtoUrl}`);
+  if (opts.sendFromEmail) {
+    console.log(`${HANDOFF_PREFIX}SEND_FROM_EMAIL=${opts.sendFromEmail}`);
+  }
+}
+
+export function logSlackHandoffEvents(opts: { authorizeUrl: string }): void {
+  console.log(`${HANDOFF_PREFIX}SLACK_AUTHORIZE_URL=${opts.authorizeUrl}`);
+}

--- a/packages/novu/src/commands/connect/ui/logging-ui.ts
+++ b/packages/novu/src/commands/connect/ui/logging-ui.ts
@@ -5,6 +5,7 @@ import { SEND_FROM_ACCOUNT_LABEL } from '../copy/email-onboarding';
 import { channelDisplayName } from '../dashboard-urls';
 import type { AgentSummary } from '../types';
 import { resolveGeneratedAgentSpecLabels } from './agent-spec-labels';
+import { logEmailHandoffEvents, logSlackHandoffEvents } from './handoff-events';
 import type { ConnectUI, GeneratedAgentPreviewResult, PickResult } from './ui';
 
 export function createLoggingUI(): ConnectUI {
@@ -169,6 +170,7 @@ export function createLoggingUI(): ConnectUI {
         console.log(`${chalk.cyan('→')} ${SEND_FROM_ACCOUNT_LABEL} ${chalk.bold(sendFromEmail)}`);
       }
       console.log(`${chalk.cyan('→')} Open in your mail client: ${chalk.underline(mailtoUrl)}`);
+      logEmailHandoffEvents({ inboundAddress, mailtoUrl, sendFromEmail });
       // Non-interactive: nothing to await — the user will copy/paste the
       // address themselves. Resolve immediately so the pipeline can move on
       // to polling.
@@ -224,6 +226,7 @@ export function createLoggingUI(): ConnectUI {
         console.log(`${chalk.green('✓')} Slack app created successfully.`);
       }
       console.log(`${chalk.cyan('→')} Authorize Slack here: ${chalk.underline(authorizeUrl)}`);
+      logSlackHandoffEvents({ authorizeUrl });
 
       return Promise.resolve();
     },


### PR DESCRIPTION
## Summary

- **API:** Fail fast in `processKeyless()` when `NOVU_MANAGED_CLAUDE_API_KEY` is unset or `IS_DEMO_MANAGED_CLAUDE_ENABLED` is off, so keyless environments are not provisioned without demo agent support.
- **CLI:** Improve keyless session bootstrap — recover from stale stored sessions (401 on integration list), surface actionable API error messages, and explain missing demo agent integrations with integration counts.
- **CLI (`--ci` / logging UI):** Emit machine-readable `NOVU_CONNECT_*` sentinel lines for email and Slack handoffs so onboarding agents can grep stdout.

```mermaid
sequenceDiagram
  participant CLI as novu connect
  participant API as POST /v1/inbox/session
  participant Int as GET /v1/integrations

  CLI->>API: keyless session (stored or fresh)
  API-->>CLI: applicationIdentifier or 400 (config/flag)
  CLI->>Int: list integrations (keyless auth)
  alt demo agent integration active
    Int-->>CLI: integrations
    CLI-->>CLI: proceed + log NOVU_CONNECT_* handoffs
  else 401 unauthorized
    Int-->>CLI: 401
    CLI->>API: fresh keyless session
  else missing demo integration
    Int-->>CLI: no agent integration
    CLI-->>CLI: throw detailed remediation message
  end
```

## Test plan

- [x] `pnpm exec vitest run src/commands/connect/api/keyless-session.spec.ts src/commands/connect/ui/handoff-events.spec.ts` (12 tests)
- [x] `pnpm --filter @novu/api-service build`
- [ ] Manual: run `npx novu@rc connect … --ci` against local stack with/without `NOVU_MANAGED_CLAUDE_API_KEY` and verify error messages
- [ ] Manual: confirm `NOVU_CONNECT_INBOUND_ADDRESS` / `NOVU_CONNECT_SLACK_AUTHORIZE_URL` appear in `--ci` stdout during email/Slack handoff

## Linear

> **Action needed:** No Linear ticket was linked — please create one and update the PR title to `fixes NV-XXXX`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR hardens keyless session bootstrapping and CI onboarding: the API now blocks creating keyless environments unless managed Claude credentials and the demo-agent flag are enabled; the CLI detects and recovers stale keyless sessions (401), returns structured readiness diagnostics for environments missing demo integrations, surfaces clearer actionable error messages on session/create failures, and emits machine-readable NOVU_CONNECT_* handoff lines for email and Slack during non-interactive/CI flows.

## Affected areas

**api**: Server-side validation in the session usecase ensures NOVU_MANAGED_CLAUDE_API_KEY is set and IS_DEMO_MANAGED_CLAUDE_ENABLED is enabled before provisioning keyless environments, preventing unsupported provisioning.  
**js**: CLI keyless session logic now computes and returns a KeylessEnvironmentReadiness object, treats 401 from integrations as stale-session to retry with a fresh session, formats richer error diagnostics, and replaces simple logging with new handoff helpers that emit NOVU_CONNECT_* sentinel lines.  
**js (tests)**: Added/updated Vitest specs covering stale-session recovery, demo-integration validation, and handoff-event logging; test mocks adjusted to preserve original module exports when overriding the Connect API client.

## Key technical decisions

- Treat 401 from the integrations endpoint as a stale-session signal and retry by bootstrapping a fresh keyless session.  
- Return a structured KeylessEnvironmentReadiness (ready, reason, integration counts) to produce actionable, newline-separated diagnostics.  
- Emit machine-readable NOVU_CONNECT_* sentinel lines for CI/non-interactive onboarding to allow downstream automation to parse inbound addresses, mailto links, send-from emails, and Slack authorize URLs.

## Testing

Unit tests (Vitest) were added/updated for keyless-session recovery, demo integration checks, and handoff-event logging; CI/manual verification recommended for the CLI --ci flow to confirm NOVU_CONNECT_* lines appear in stdout and behavior with/without NOVU_MANAGED_CLAUDE_API_KEY.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the keyless session bootstrap on both the API and CLI sides: the API now fails fast when `NOVU_MANAGED_CLAUDE_API_KEY` is unset or `IS_DEMO_MANAGED_CLAUDE_ENABLED` is off, while the CLI recovers from stale sessions (401 on integration list), surfaces richer error messages, and emits machine-readable `NOVU_CONNECT_*` sentinel lines for CI/agent-driven onboarding.

- **API (`session.usecase.ts`):** Two new guard clauses added to `processKeyless()` — one checking server credentials via `areNovuManagedClaudeCredentialsSet()`, one checking the feature flag — so environments are never provisioned in unsupported configurations.
- **CLI (`keyless-session.ts`):** `isKeylessEnvironmentReadyForConnect` replaced with `checkKeylessEnvironmentReadyForConnect` returning a structured `KeylessEnvironmentReadiness` object; 401 responses on integration list now trigger a fresh-session retry instead of a hard failure.
- **CLI (`handoff-events.ts`, `logging-ui.ts`):** New `logEmailHandoffEvents` / `logSlackHandoffEvents` helpers emit `NOVU_CONNECT_*` lines to stdout from the logging UI, backed by three new unit tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive fail-fast guards and improved error messaging with no regressions to existing paths.

The server-side guards are correctly ordered and only fire on the new-environment creation path, leaving the restore path untouched. The stale-session 401 recovery logic is straightforward and well-tested. Handoff-event sentinel lines are confined to the non-interactive logging UI. All new branches have corresponding unit tests and the existing test suite structure is improved with importOriginal mocking.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/inbox/usecases/session/session.usecase.ts | Two new guard clauses before environment provisioning: credentials check (synchronous) then feature flag check (async). Both throw 400 with clear messages that the CLI now surfaces verbatim. |
| packages/novu/src/commands/connect/api/keyless-session.ts | Refactored readiness check returns a structured object with diagnostic fields; 401 on integration list now returns not-ready instead of throwing, allowing fall-through to fresh session. Error messages are now newline-separated and include actionable server-fix hints. |
| packages/novu/src/commands/connect/api/keyless-session.spec.ts | Adds four new tests covering: stale-session 401 recovery, no-integration fresh session, API 400 with CLAUDE key message, and community-edition rejection. Mock refactored to importOriginal so NovuApiError instanceof checks work correctly. |
| packages/novu/src/commands/connect/ui/handoff-events.ts | New module emitting machine-readable NOVU_CONNECT_* sentinel lines to stdout; sendFromEmail is correctly optional and guarded before logging. |
| packages/novu/src/commands/connect/ui/handoff-events.spec.ts | Three unit tests covering email sentinel lines (with/without sendFromEmail) and Slack authorize URL. Straightforward and complete. |
| packages/novu/src/commands/connect/ui/logging-ui.ts | Calls logEmailHandoffEvents and logSlackHandoffEvents after existing console.log statements in awaitEmailOpen and awaitSlackOAuthOpen; sentinel lines are only emitted from this non-interactive logging UI, not the interactive path. |
| packages/novu/src/commands/connect/auth/resolve-connect-auth.ts | Minor cleanup: import reordering (alphabetical) and collapsing multi-line onStatus call to one line. No functional changes. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant CLI as novu connect (CLI)
  participant API as POST /v1/inbox/session
  participant Int as GET /v1/integrations

  CLI->>API: keyless session (stored identifier)
  API-->>CLI: 200 applicationIdentifier
  CLI->>Int: list integrations (stored auth)
  alt 401 Unauthorized (stale session)
    Int-->>CLI: 401
    CLI->>API: fresh keyless session (no identifier)
    API-->>CLI: 400 (missing CLAUDE key or flag disabled)
    note over CLI: throw descriptive error
  else integrations missing demo agent
    Int-->>CLI: integrations (no demo agent)
    CLI->>API: fresh keyless session (no identifier)
    API-->>CLI: 200 fresh applicationIdentifier
    CLI->>Int: list integrations (fresh auth)
    Int-->>CLI: integrations with demo agent
    CLI-->>CLI: return recoveredFromStaleSession true
  else demo agent found
    Int-->>CLI: integrations with demo agent
    CLI-->>CLI: return recoveredFromStaleSession false
  end
  CLI-->>CLI: logEmailHandoffEvents / logSlackHandoffEvents (logging-ui only)
```

<sub>Reviews (2): Last reviewed commit: ["fix(connect): clarify keyless session au..."](https://github.com/novuhq/novu/commit/c8aa370b94c23f2bbb3aca0db03bb091dec09699) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36530593)</sub>

<!-- /greptile_comment -->