### PR TITLE
fix(api-service): resolve MCP always-allow stuck on multi-tool approval fixes NV-7998

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase.ts
@@ -124,7 +124,12 @@ export class HandlePlanProgress {
 
     const tasks = this.collectTasks(existingActivities);
 
-    await this.postOrEditPlan(command, activePlanMessageId, this.toModel('awaiting-approval', tasks, false), 'awaiting-approval');
+    await this.postOrEditPlan(
+      command,
+      activePlanMessageId,
+      this.toModel('awaiting-approval', tasks, false),
+      'awaiting-approval'
+    );
   }
 
   private async handleVerdictUpdate(
@@ -256,10 +261,12 @@ export class HandlePlanProgress {
   }
 
   private toModel(phase: PlanPhase, tasks: Map<string, ToolTask>, isFinalized: boolean): PlanModel {
+    const terminalStatus: PlanTaskStatus = phase === 'failed' ? 'error' : 'complete';
+
     const planTasks = [...tasks.values()].map((t) => ({
       id: t.toolUseId,
       title: t.mcpServerName ? `${t.mcpServerName}: ${t.toolName}` : t.toolName,
-      status: t.status,
+      status: isFinalized && t.status !== 'complete' && t.status !== 'error' ? terminalStatus : t.status,
       ...(t.details ? { details: { markdown: t.details } } : {}),
     }));
 

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/confirm-tool-approval.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/confirm-tool-approval.usecase.ts
@@ -1,16 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
-import {
-  AgentMcpServerRepository,
-  ConversationRepository,
-  McpConnectionRepository,
-  SubscriberRepository,
-} from '@novu/dal';
+import { AgentMcpServerRepository, McpConnectionRepository, SubscriberRepository } from '@novu/dal';
 import { OutboundGateway } from '../../conversation-runtime/egress/outbound.gateway';
 import { HandlePlanProgressCommand } from '../../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.command';
 import { HandlePlanProgress } from '../../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase';
 import { ManagedAgentService } from '../managed-agent.service';
-import { ManagedAgentProviderFactory } from '../managed-agent-provider-factory.service';
 import { type ParsedToolApprovalAction } from './approval-card.builder';
 import { ConfirmToolApprovalCommand } from './confirm-tool-approval.command';
 import { mergeToolTrustPatch, resolveTrustForPendingTool } from './tool-trust.helper';
@@ -21,8 +15,6 @@ export class ConfirmToolApproval {
     private readonly subscriberRepository: SubscriberRepository,
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
     private readonly mcpConnectionRepository: McpConnectionRepository,
-    private readonly conversationRepository: ConversationRepository,
-    private readonly providerFactory: ManagedAgentProviderFactory,
     private readonly managedAgentService: ManagedAgentService,
     private readonly outboundGateway: OutboundGateway,
     private readonly handlePlanProgress: HandlePlanProgress,
@@ -36,8 +28,6 @@ export class ConfirmToolApproval {
 
     await this.persistTrustIfNeeded(command, parsed);
 
-    const toolUseIds = await this.resolveConfirmationToolUseIds(command, parsed);
-
     await this.managedAgentService.resumeWithToolResults({
       conversationId: command.conversationId,
       environmentId: command.environmentId,
@@ -46,7 +36,7 @@ export class ConfirmToolApproval {
       integrationIdentifier: command.integrationIdentifier,
       subscriberId: command.subscriberId,
       platform: command.platform,
-      toolUseIds,
+      toolUseIds: parsed.toolUseIds,
       approved: parsed.approved,
     });
 
@@ -101,61 +91,6 @@ export class ConfirmToolApproval {
         toolName,
       }),
     });
-  }
-
-  private async resolveConfirmationToolUseIds(
-    command: ConfirmToolApprovalCommand,
-    parsed: ParsedToolApprovalAction
-  ): Promise<string[]> {
-    if (parsed.persistScope !== 'server' || !parsed.mcpServerName) {
-      return parsed.toolUseIds;
-    }
-
-    const sessionId = await this.getExternalSessionId(command);
-
-    if (!sessionId) {
-      return parsed.toolUseIds;
-    }
-
-    const runtimeProvider = await this.providerFactory.tryGetByAgentIdentifier(
-      command.agentIdentifier,
-      command.environmentId
-    );
-
-    if (!runtimeProvider) {
-      return parsed.toolUseIds;
-    }
-
-    try {
-      const pendingTools = await runtimeProvider.getAllPendingToolApprovals(sessionId);
-      const mcpToolUseIds = pendingTools
-        .filter((tool) => tool.mcpServerName === parsed.mcpServerName)
-        .map((tool) => tool.toolUseId);
-
-      if (mcpToolUseIds.length > 0) {
-        return mcpToolUseIds;
-      }
-    } catch (err) {
-      this.logger.warn(
-        { err: err instanceof Error ? err.message : String(err), conversationId: command.conversationId },
-        'getAllPendingToolApprovals failed; confirming clicked tool only'
-      );
-    }
-
-    return parsed.toolUseIds;
-  }
-
-  private async getExternalSessionId(command: ConfirmToolApprovalCommand): Promise<string | undefined> {
-    const conversation = await this.conversationRepository.findOne(
-      {
-        _id: command.conversationId,
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-      },
-      ['externalSessionId']
-    );
-
-    return conversation?.externalSessionId;
   }
 
   private deleteApprovalCard(command: ConfirmToolApprovalCommand): void {

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
@@ -406,11 +406,11 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
     for await (const event of iterator) {
       const stopReason = event?.stop_reason as { type?: string; event_ids?: string[] } | undefined;
 
-      if (stopReason?.type !== 'requires_action') {
-        return [];
+      if (stopReason?.type === 'requires_action') {
+        return (stopReason.event_ids ?? []).filter(
+          (toolUseId): toolUseId is string => typeof toolUseId === 'string' && toolUseId.length > 0
+        );
       }
-
-      return (stopReason.event_ids ?? []).filter(Boolean);
     }
 
     return [];

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
@@ -384,46 +384,73 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
     const client = await this.getClient();
 
     try {
-      const iterator = (client as any).beta.sessions.events.list(sessionId, {
-        order: 'asc',
-        types: ['agent.mcp_tool_use', 'agent.tool_use', 'user.tool_confirmation'],
-      });
+      const toolUseIds = await this.getRequiresActionToolUseIds(client, sessionId);
 
-      const pendingById = new Map<string, PendingToolApproval>();
-
-      for await (const event of iterator) {
-        if (event?.type === 'user.tool_confirmation') {
-          const confirmedToolUseId = event.tool_use_id as string | undefined;
-          if (confirmedToolUseId) {
-            pendingById.delete(confirmedToolUseId);
-          }
-
-          continue;
-        }
-
-        if (event?.evaluated_permission !== 'ask') {
-          continue;
-        }
-
-        const toolUseId = event.id as string | undefined;
-        const toolName = (event.name as string | undefined) ?? 'unknown_tool';
-
-        if (!toolUseId) {
-          continue;
-        }
-
-        pendingById.set(toolUseId, {
-          toolUseId,
-          toolName,
-          mcpServerName: event.type === 'agent.mcp_tool_use' ? (event.mcp_server_name as string) : undefined,
-          input: (event.input as Record<string, unknown> | undefined) ?? undefined,
-        });
+      if (toolUseIds.length === 0) {
+        return [];
       }
 
-      return [...pendingById.values()];
+      return this.resolvePendingToolApprovals(client, sessionId, toolUseIds);
     } catch (err) {
       this.normaliseError(err);
     }
+  }
+
+  /** Tool-use ids Anthropic is blocked on in the latest session pause. */
+  private async getRequiresActionToolUseIds(client: AnthropicCompatibleClient, sessionId: string): Promise<string[]> {
+    const iterator = (client as any).beta.sessions.events.list(sessionId, {
+      order: 'desc',
+      types: ['session.status_idle', 'session.thread_status_idle'],
+    });
+
+    for await (const event of iterator) {
+      const stopReason = event?.stop_reason as { type?: string; event_ids?: string[] } | undefined;
+
+      if (stopReason?.type !== 'requires_action') {
+        return [];
+      }
+
+      return (stopReason.event_ids ?? []).filter(Boolean);
+    }
+
+    return [];
+  }
+
+  private async resolvePendingToolApprovals(
+    client: AnthropicCompatibleClient,
+    sessionId: string,
+    toolUseIds: string[]
+  ): Promise<PendingToolApproval[]> {
+    const pendingIds = new Set(toolUseIds);
+    const tools = new Map<string, PendingToolApproval>();
+
+    const iterator = (client as any).beta.sessions.events.list(sessionId, {
+      order: 'asc',
+      types: ['agent.mcp_tool_use', 'agent.tool_use'],
+    });
+
+    for await (const event of iterator) {
+      const toolUseId = event?.id as string | undefined;
+
+      if (!toolUseId || !pendingIds.has(toolUseId)) {
+        continue;
+      }
+
+      tools.set(toolUseId, {
+        toolUseId,
+        toolName: (event.name as string | undefined) ?? 'unknown_tool',
+        mcpServerName: event.type === 'agent.mcp_tool_use' ? (event.mcp_server_name as string) : undefined,
+        input: (event.input as Record<string, unknown> | undefined) ?? undefined,
+      });
+
+      if (tools.size === pendingIds.size) {
+        break;
+      }
+    }
+
+    return toolUseIds
+      .map((toolUseId) => tools.get(toolUseId))
+      .filter((tool): tool is PendingToolApproval => tool !== undefined);
   }
 
   async createVault(input: CreateVaultInput): Promise<CreateVaultResult> {


### PR DESCRIPTION
## Summary

- Stop batch-expanding "Always allow [MCP]" into all pending tool IDs from that server — send only the clicked tool so each approval turn is observed by Thalamus sequentially
- Coerce non-terminal plan task statuses to `complete`/`error` when the plan card is finalized (prevents spinners under "Finished thinking")
- Resolve pending tool approvals from Anthropic `stop_reason.event_ids` on the latest `requires_action` idle event, then hydrate tool metadata (fixes follow-up webhooks where `actionsRequired` is empty)

## Root cause

Batching multiple tool confirmations in one `provider.send` caused Anthropic to process them across turns while the observer only watched one. By the time the webhook arrived, pending tools were already confirmed and the final turn was never observed — leaving the session stuck on "Approved, Resuming…".

```mermaid
sequenceDiagram
    participant User
    participant API
    participant Observer
    participant Anthropic

    User->>API: Always allow Attio (tool 1)
    API->>Anthropic: toolResults [tool1]
    Observer->>API: requires-action webhook
    API->>API: auto-confirm tool 2 (trusted)
    API->>Anthropic: toolResults [tool2]
    Observer->>API: stop webhook
    API->>User: final reply + plan finalized
```

## Linear

https://linear.app/novu/issue/NV-7998

## Test plan

- [ ] Connect Attio MCP, send "Find Monday in Attio" (triggers 2 `search-records` calls)
- [ ] Click **Always allow Attio** on the approval card
- [ ] Verify agent responds with data
- [ ] Verify plan card shows **Finished thinking** with checkmarks (no stuck spinners)
- [ ] Repeat once to confirm stability


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR fixes managed-agent sessions getting stuck after "Always allow [MCP]" on multi-tool approvals by stopping batch confirmation of all pending tools in one event — the system now sends only the clicked tool ID so Anthropic observes each approval turn sequentially. It also forces non-terminal plan task statuses to a terminal state (complete or error) when a plan card is finalized, and resolves pending tool approvals using the latest Anthropic `requires_action` stop_reason event IDs so tool metadata and follow-up webhooks are correctly hydrated.

## Affected areas

**api** — Plan progress handling now coerces non-terminal task statuses to terminal values during finalization to avoid lingering spinners; the managed-runtime tool approval handler was simplified to use tool IDs from the parsed request instead of resolving them via runtime-provider/session lookups.

**application-generic** — The Anthropic agent runtime now extracts tool-use IDs from the most recent `requires_action` stop_reason and resolves pending approvals only for those IDs, returning approvals ordered to match the requested list and avoiding stale or cross-turn confirmations.

## Key technical decisions

- Send a single tool ID per approval action (sequential per-tool approvals) to ensure Anthropic and the observer stay in sync across turns.
- Replace session-scoped batching and runtime-provider lookups with direct parsed tool IDs and stop_reason-driven resolution to reduce indirection and race conditions.
- Scan session events in the correct order and stop once requested tool approvals are resolved to avoid over-scanning and to preserve tool metadata context.

## Testing

Manual verification: connect Attio MCP, trigger two tool calls, click "Always allow" and confirm the agent returns data and the plan card shows "Finished thinking" with checkmarks (no stuck spinners); repeat to confirm stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->