### PR TITLE
fix(shared): use ClickHouse command() to drain response streams fixes NV-7999

### DIFF
--- a/apps/api/e2e/setup.ts
+++ b/apps/api/e2e/setup.ts
@@ -129,7 +129,7 @@ async function truncateClickHouseTable(databaseName: string, tableName: string):
     const conn = await getClickHouseConnection();
     if (!conn) return;
 
-    await conn.exec({ query: `TRUNCATE TABLE IF EXISTS ${databaseName}.${tableName}` });
+    await conn.command({ query: `TRUNCATE TABLE IF EXISTS ${databaseName}.${tableName}` });
     logInfo(`Successfully cleaned table ${tableName}`);
   } catch (error) {
     logInfo(`Failed to clean table ${tableName}:`, error.message);

--- a/apps/worker/e2e/setup.ts
+++ b/apps/worker/e2e/setup.ts
@@ -46,7 +46,7 @@ async function truncateClickHouseTable(databaseName: string, tableName: string):
     const conn = await getClickHouseConnection();
     if (!conn) return;
 
-    await conn.exec({ query: `TRUNCATE TABLE IF EXISTS ${databaseName}.${tableName}` });
+    await conn.command({ query: `TRUNCATE TABLE IF EXISTS ${databaseName}.${tableName}` });
     console.log(`Successfully cleaned table ${tableName}`);
   } catch (error) {
     console.log(`Failed to clean table ${tableName}:`, error.message);

--- a/libs/application-generic/src/services/analytic-logs/clickhouse.service.ts
+++ b/libs/application-generic/src/services/analytic-logs/clickhouse.service.ts
@@ -34,7 +34,7 @@ export class ClickHouseService implements BeforeApplicationShutdown {
       });
 
       try {
-        await defaultClient.query({
+        await defaultClient.command({
           query: `CREATE DATABASE IF NOT EXISTS \`${process.env.CLICK_HOUSE_DATABASE}\``,
         });
         if (!process.env.CI) {
@@ -138,7 +138,7 @@ export class ClickHouseService implements BeforeApplicationShutdown {
       return;
     }
 
-    await this._client.exec({
+    await this._client.command({
       query,
       query_params: params,
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After upgrading `@clickhouse/client` to 1.20.0, WARN logs appeared for `Exec` operations:

> socket was closed or ended before the response was fully read

This happens because `client.exec()` returns a response stream that must be fully consumed or destroyed. Our code used `exec()` for fire-and-forget SQL (DDL, TRUNCATE, OPTIMIZE) without draining the stream, which can corrupt keep-alive sockets and lead to intermittent `ECONNRESET` errors.

## Changes

- Switch `ClickHouseService.exec()` to use `client.command()` instead of `client.exec()`
- Switch local `CREATE DATABASE` bootstrap to use `command()` instead of `query()`
- Update e2e setup helpers (API + worker) to use `conn.command()` for `TRUNCATE`

`command()` drains the response stream internally — the correct API for statements that don't return row data.

```mermaid
flowchart LR
  A[DDL / TRUNCATE / OPTIMIZE] --> B{Client method}
  B -->|Before| C[exec - stream not consumed]
  B -->|After| D[command - stream drained]
  C --> E[WARN logs + socket pool risk]
  D --> F[Clean connection reuse]
```

## Test plan

- [x] `pnpm --filter @novu/application-generic build` passes
- [ ] WARN logs for `Exec: socket was closed...` no longer appear during local/test ClickHouse operations
- [ ] E2E tests that call `clickHouseService.exec()` (OPTIMIZE TABLE) continue to pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4208b1df-5948-47b9-ba49-ec38501d20b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4208b1df-5948-47b9-ba49-ec38501d20b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

After upgrading `@clickhouse/client` to 1.20.0, WARN logs appeared for Exec operations: "socket was closed or ended before the response was fully read." This issue occurred because `client.exec()` was used for fire-and-forget SQL statements (DDL, TRUNCATE, OPTIMIZE) without draining the returned response stream, which can corrupt keep-alive sockets and cause intermittent ECONNRESET errors. The fix replaces all uses of `client.exec()` with `client.command()`, which internally drains the response stream and is the correct API for statements that don't return row data.

## Affected areas

- **api**: E2E setup helper `truncateClickHouseTable` now uses `conn.command()` instead of `conn.exec()` for TRUNCATE operations.
- **worker**: E2E setup helper updated to use `conn.command()` instead of `conn.exec()` for ClickHouse table truncation.
- **application-generic**: `ClickHouseService` refactored to use `client.command()` in the `exec()` method and for the "create database if not exists" initialization step in local/test environments.

## Key technical decisions

- `client.command()` is the correct API for DDL and utility statements that don't return row data, as it properly drains response streams internally and prevents socket corruption.

## Testing

- Build verification: `pnpm --filter `@novu/application-generic` build` passes.
- Pending: Verification that WARN logs no longer appear and E2E tests using `clickHouseService.exec()` for OPTIMIZE TABLE operations continue to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches ClickHouse DDL and fire-and-forget SQL calls from `exec()`/`query()` to `command()`, which drains the response stream internally and prevents socket pool corruption after upgrading `@clickhouse/client` to 1.20.0.

- `ClickHouseService.exec()` now delegates to `client.command()`, and the local `CREATE DATABASE` bootstrap in `init()` is likewise updated — both are correct.
- The `truncateClickHouseTable` helpers in the API and worker e2e setups are correctly switched to `command()`, but the `ensureClickHouseDatabase` helpers in both files still call `client.query()` for `CREATE DATABASE IF NOT EXISTS`, leaving the same unconsumed-stream problem on that code path.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core production fix in `clickhouse.service.ts` is correct and complete; the remaining `query()` calls for DDL are only in test setup helpers.

The production service change is solid and directly addresses the root cause. The two e2e setup files each have one `ensureClickHouseDatabase` helper that still calls `client.query()` for a `CREATE DATABASE` DDL statement — the unconsumed stream issue the PR is fixing — so WARN logs will persist on that specific test-setup code path.

`apps/api/e2e/setup.ts` and `apps/worker/e2e/setup.ts` — their `ensureClickHouseDatabase` functions were not updated alongside `truncateClickHouseTable`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/analytic-logs/clickhouse.service.ts | Core service fix: switches both `CREATE DATABASE` bootstrap and the public `exec()` method from `exec()`/`query()` to `command()`, correctly draining response streams for all DDL and fire-and-forget SQL. |
| apps/api/e2e/setup.ts | `truncateClickHouseTable` correctly switched to `command()`, but `ensureClickHouseDatabase` still uses `client.query()` for a DDL statement — the same unconsumed-stream pattern being fixed elsewhere. |
| apps/worker/e2e/setup.ts | `truncateClickHouseTable` correctly switched to `command()`, but `ensureClickHouseDatabase` still uses `client.query()` for a DDL statement — same incomplete fix as the API setup file. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DDL / TRUNCATE / OPTIMIZE] --> B{Which call site?}
    B -->|ClickHouseService.exec| C[command ✅]
    B -->|clickhouse.service.ts init CREATE DATABASE| D[command ✅]
    B -->|e2e truncateClickHouseTable API + Worker| E[command ✅]
    B -->|e2e ensureClickHouseDatabase API + Worker| F[query ⚠️ stream not consumed]
    C --> G[Stream drained — clean socket reuse]
    D --> G
    E --> G
    F --> H[WARN: socket closed before response fully read]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/api/e2e/setup.ts`, line 98-100 ([link](https://github.com/novuhq/novu/blob/0310cd55b055fba0535c390a58008b600a0b16c2/apps/api/e2e/setup.ts#L98-L100)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `ensureClickHouseDatabase` helper still uses `client.query()` for a `CREATE DATABASE` DDL statement — the same pattern this PR fixes elsewhere. `query()` returns a result stream that is never consumed here, which will still produce the same `socket was closed or ended` WARN logs the PR is trying to eliminate.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/e2e/setup.ts
   Line: 98-100

   Comment:
   The `ensureClickHouseDatabase` helper still uses `client.query()` for a `CREATE DATABASE` DDL statement — the same pattern this PR fixes elsewhere. `query()` returns a result stream that is never consumed here, which will still produce the same `socket was closed or ended` WARN logs the PR is trying to eliminate.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fe2e%2Fsetup.ts%0ALine%3A%2098-100%0A%0AComment%3A%0AThe%20%60ensureClickHouseDatabase%60%20helper%20still%20uses%20%60client.query%28%29%60%20for%20a%20%60CREATE%20DATABASE%60%20DDL%20statement%20%E2%80%94%20the%20same%20pattern%20this%20PR%20fixes%20elsewhere.%20%60query%28%29%60%20returns%20a%20result%20stream%20that%20is%20never%20consumed%20here%2C%20which%20will%20still%20produce%20the%20same%20%60socket%20was%20closed%20or%20ended%60%20WARN%20logs%20the%20PR%20is%20trying%20to%20eliminate.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20client.command%28%7B%0A%20%20%20%20%20%20query%3A%20%60CREATE%20DATABASE%20IF%20NOT%20EXISTS%20%24%7BdatabaseName%7D%60%2C%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `apps/worker/e2e/setup.ts`, line 23-25 ([link](https://github.com/novuhq/novu/blob/0310cd55b055fba0535c390a58008b600a0b16c2/apps/worker/e2e/setup.ts#L23-L25)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same missed conversion as in the API setup: `ensureClickHouseDatabase` calls `client.query()` for a `CREATE DATABASE` DDL statement. The response stream is never drained, which will continue to trigger the WARN logs this PR targets.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/worker/e2e/setup.ts
   Line: 23-25

   Comment:
   Same missed conversion as in the API setup: `ensureClickHouseDatabase` calls `client.query()` for a `CREATE DATABASE` DDL statement. The response stream is never drained, which will continue to trigger the WARN logs this PR targets.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fworker%2Fe2e%2Fsetup.ts%0ALine%3A%2023-25%0A%0AComment%3A%0ASame%20missed%20conversion%20as%20in%20the%20API%20setup%3A%20%60ensureClickHouseDatabase%60%20calls%20%60client.query%28%29%60%20for%20a%20%60CREATE%20DATABASE%60%20DDL%20statement.%20The%20response%20stream%20is%20never%20drained%2C%20which%20will%20continue%20to%20trigger%20the%20WARN%20logs%20this%20PR%20targets.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20client.command%28%7B%0A%20%20%20%20%20%20query%3A%20%60CREATE%20DATABASE%20IF%20NOT%20EXISTS%20%24%7BdatabaseName%7D%60%2C%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fe2e%2Fsetup.ts%3A98-100%0AThe%20%60ensureClickHouseDatabase%60%20helper%20still%20uses%20%60client.query%28%29%60%20for%20a%20%60CREATE%20DATABASE%60%20DDL%20statement%20%E2%80%94%20the%20same%20pattern%20this%20PR%20fixes%20elsewhere.%20%60query%28%29%60%20returns%20a%20result%20stream%20that%20is%20never%20consumed%20here%2C%20which%20will%20still%20produce%20the%20same%20%60socket%20was%20closed%20or%20ended%60%20WARN%20logs%20the%20PR%20is%20trying%20to%20eliminate.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20client.command%28%7B%0A%20%20%20%20%20%20query%3A%20%60CREATE%20DATABASE%20IF%20NOT%20EXISTS%20%24%7BdatabaseName%7D%60%2C%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fworker%2Fe2e%2Fsetup.ts%3A23-25%0ASame%20missed%20conversion%20as%20in%20the%20API%20setup%3A%20%60ensureClickHouseDatabase%60%20calls%20%60client.query%28%29%60%20for%20a%20%60CREATE%20DATABASE%60%20DDL%20statement.%20The%20response%20stream%20is%20never%20drained%2C%20which%20will%20continue%20to%20trigger%20the%20WARN%20logs%20this%20PR%20targets.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20client.command%28%7B%0A%20%20%20%20%20%20query%3A%20%60CREATE%20DATABASE%20IF%20NOT%20EXISTS%20%24%7BdatabaseName%7D%60%2C%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A&pr=11493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/e2e/setup.ts:98-100
The `ensureClickHouseDatabase` helper still uses `client.query()` for a `CREATE DATABASE` DDL statement — the same pattern this PR fixes elsewhere. `query()` returns a result stream that is never consumed here, which will still produce the same `socket was closed or ended` WARN logs the PR is trying to eliminate.

```suggestion
    await client.command({
      query: `CREATE DATABASE IF NOT EXISTS ${databaseName}`,
    });
```

### Issue 2 of 2
apps/worker/e2e/setup.ts:23-25
Same missed conversion as in the API setup: `ensureClickHouseDatabase` calls `client.query()` for a `CREATE DATABASE` DDL statement. The response stream is never drained, which will continue to trigger the WARN logs this PR targets.

```suggestion
    await client.command({
      query: `CREATE DATABASE IF NOT EXISTS ${databaseName}`,
    });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): use ClickHouse command() to..."](https://github.com/novuhq/novu/commit/0310cd55b055fba0535c390a58008b600a0b16c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36666078)</sub>

<!-- /greptile_comment -->