### PR TITLE
fix(framework): apply controllerDecorators in NovuModule.registerAsync fixes NV-7543

### DIFF
--- a/packages/framework/src/servers/nest.ts
+++ b/packages/framework/src/servers/nest.ts
@@ -19,3 +19,4 @@ export * from './nest/nest.handler';
 export * from './nest/nest.interface';
 export * from './nest/nest.module';
 export * from './nest/nest.register-api-path';
+export * from './nest/nest.register-controller-decorators';

--- a/packages/framework/src/servers/nest/nest.constants.ts
+++ b/packages/framework/src/servers/nest/nest.constants.ts
@@ -1,2 +1,3 @@
 export const REGISTER_API_PATH = 'REGISTER_API_PATH';
+export const REGISTER_CONTROLLER_DECORATORS = 'REGISTER_CONTROLLER_DECORATORS';
 export { NOVU_OPTIONS } from './nest.module-definition';

--- a/packages/framework/src/servers/nest/nest.module.test.ts
+++ b/packages/framework/src/servers/nest/nest.module.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { REGISTER_CONTROLLER_DECORATORS } from './nest.constants';
+import { NovuModule } from './nest.module';
+import { registerControllerDecorators } from './nest.register-controller-decorators';
+
+describe('NovuModule', () => {
+  it('should include registerControllerDecorators provider in registerAsync', () => {
+    const dynamicModule = NovuModule.registerAsync({
+      useFactory: () => ({
+        apiPath: '/novu/bridge',
+        workflows: [],
+      }),
+    });
+
+    expect(dynamicModule.controllers).toEqual(expect.arrayContaining([expect.any(Function)]));
+    expect(dynamicModule.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provide: REGISTER_CONTROLLER_DECORATORS,
+          useFactory: registerControllerDecorators.useFactory,
+        }),
+      ])
+    );
+  });
+});

--- a/packages/framework/src/servers/nest/nest.module.ts
+++ b/packages/framework/src/servers/nest/nest.module.ts
@@ -4,6 +4,7 @@ import { NovuController } from './nest.controller';
 import { NovuHandler } from './nest.handler';
 import { ASYNC_OPTIONS_TYPE, NovuBaseModule, OPTIONS_TYPE } from './nest.module-definition';
 import { registerApiPath } from './nest.register-api-path';
+import { registerControllerDecorators } from './nest.register-controller-decorators';
 import { applyDecorators } from './nest.utils';
 
 /**
@@ -62,7 +63,13 @@ export class NovuModule extends NovuBaseModule {
     const superModule = NovuBaseModule.registerAsync(options);
 
     superModule.controllers = [NovuController];
-    superModule.providers?.push(registerApiPath, NovuClient, NovuHandler, ...(customProviders || []));
+    superModule.providers?.push(
+      registerApiPath,
+      registerControllerDecorators,
+      NovuClient,
+      NovuHandler,
+      ...(customProviders || [])
+    );
     superModule.exports = [NovuClient, NovuHandler];
 
     return superModule;

--- a/packages/framework/src/servers/nest/nest.register-controller-decorators.test.ts
+++ b/packages/framework/src/servers/nest/nest.register-controller-decorators.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { NovuController } from './nest.controller';
+import { registerControllerDecorators } from './nest.register-controller-decorators';
+
+describe('registerControllerDecorators', () => {
+  it('should apply controller decorators from async module options', () => {
+    const metadataKey = Symbol('novu-test-controller-decorator');
+    const testDecorator =
+      (): ClassDecorator =>
+      (target) => {
+        Reflect.defineMetadata(metadataKey, true, target);
+      };
+
+    registerControllerDecorators.useFactory({
+      apiPath: '/novu/bridge',
+      workflows: [],
+      controllerDecorators: [testDecorator()],
+    });
+
+    expect(Reflect.getMetadata(metadataKey, NovuController)).toBe(true);
+  });
+
+  it('should no-op when controllerDecorators is omitted', () => {
+    expect(() =>
+      registerControllerDecorators.useFactory({
+        apiPath: '/novu/bridge',
+        workflows: [],
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/framework/src/servers/nest/nest.register-controller-decorators.test.ts
+++ b/packages/framework/src/servers/nest/nest.register-controller-decorators.test.ts
@@ -20,6 +20,31 @@ describe('registerControllerDecorators', () => {
     expect(Reflect.getMetadata(metadataKey, NovuController)).toBe(true);
   });
 
+  it('should chain decorator return values onto NovuController', () => {
+    const firstKey = Symbol('novu-async-first-decorator');
+    const secondKey = Symbol('novu-async-second-decorator');
+    const firstDecorator =
+      (): ClassDecorator =>
+      (target) => {
+        Reflect.defineMetadata(firstKey, 'first', target);
+
+        return class extends (target as typeof NovuController) {};
+      };
+    const secondDecorator =
+      (): ClassDecorator =>
+      (target) => {
+        Reflect.defineMetadata(secondKey, 'second', target);
+      };
+
+    registerControllerDecorators.useFactory({
+      apiPath: '/novu/bridge',
+      workflows: [],
+      controllerDecorators: [firstDecorator(), secondDecorator()],
+    });
+
+    expect(Reflect.getMetadata(secondKey, NovuController)).toBe('second');
+  });
+
   it('should no-op when controllerDecorators is omitted', () => {
     expect(() =>
       registerControllerDecorators.useFactory({

--- a/packages/framework/src/servers/nest/nest.register-controller-decorators.ts
+++ b/packages/framework/src/servers/nest/nest.register-controller-decorators.ts
@@ -1,0 +1,23 @@
+import { FactoryProvider } from '@nestjs/common';
+import { NOVU_OPTIONS, REGISTER_CONTROLLER_DECORATORS } from './nest.constants';
+import { NovuController } from './nest.controller';
+import { OPTIONS_TYPE } from './nest.module-definition';
+
+/**
+ * Apply controller decorators resolved from async module options.
+ *
+ * A custom provider is necessary because `controllerDecorators` are only
+ * available after the async options factory runs, while NestJS requires
+ * controllers to be declared when the dynamic module is created.
+ *
+ * This mirrors the `registerApiPath` pattern used for dynamic controller paths.
+ */
+export const registerControllerDecorators: FactoryProvider = {
+  provide: REGISTER_CONTROLLER_DECORATORS,
+  useFactory: (options: typeof OPTIONS_TYPE) => {
+    for (const decorator of options.controllerDecorators ?? []) {
+      decorator(NovuController);
+    }
+  },
+  inject: [NOVU_OPTIONS],
+};

--- a/packages/framework/src/servers/nest/nest.register-controller-decorators.ts
+++ b/packages/framework/src/servers/nest/nest.register-controller-decorators.ts
@@ -2,6 +2,7 @@ import { FactoryProvider } from '@nestjs/common';
 import { NOVU_OPTIONS, REGISTER_CONTROLLER_DECORATORS } from './nest.constants';
 import { NovuController } from './nest.controller';
 import { OPTIONS_TYPE } from './nest.module-definition';
+import { applyDecoratorsInPlace } from './nest.utils';
 
 /**
  * Apply controller decorators resolved from async module options.
@@ -15,9 +16,7 @@ import { OPTIONS_TYPE } from './nest.module-definition';
 export const registerControllerDecorators: FactoryProvider = {
   provide: REGISTER_CONTROLLER_DECORATORS,
   useFactory: (options: typeof OPTIONS_TYPE) => {
-    for (const decorator of options.controllerDecorators ?? []) {
-      decorator(NovuController);
-    }
+    applyDecoratorsInPlace(NovuController, options.controllerDecorators ?? []);
   },
   inject: [NOVU_OPTIONS],
 };

--- a/packages/framework/src/servers/nest/nest.utils.test.ts
+++ b/packages/framework/src/servers/nest/nest.utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { NovuController } from './nest.controller';
+import { applyDecorators, applyDecoratorsInPlace } from './nest.utils';
+
+describe('applyDecorators', () => {
+  it('should chain decorator return values', () => {
+    const firstKey = Symbol('novu-first-decorator');
+    const secondKey = Symbol('novu-second-decorator');
+    const firstDecorator =
+      (): ClassDecorator =>
+      (target) => {
+        Reflect.defineMetadata(firstKey, 'first', target);
+
+        return class extends (target as typeof NovuController) {};
+      };
+    const secondDecorator =
+      (): ClassDecorator =>
+      (target) => {
+        Reflect.defineMetadata(secondKey, 'second', target);
+      };
+
+    const decoratedClass = applyDecorators(NovuController, [firstDecorator(), secondDecorator()]);
+
+    expect(decoratedClass).not.toBe(NovuController);
+    expect(Reflect.getMetadata(secondKey, decoratedClass)).toBe('second');
+  });
+});
+
+describe('applyDecoratorsInPlace', () => {
+  it('should copy metadata from class-replacing decorators onto the base controller', () => {
+    const metadataKey = Symbol('novu-replaced-class-decorator');
+    const replacingDecorator =
+      (): ClassDecorator =>
+      (target) => {
+        const replacedClass = class extends (target as typeof NovuController) {};
+
+        Reflect.defineMetadata(metadataKey, 'replaced', replacedClass);
+
+        return replacedClass;
+      };
+
+    applyDecoratorsInPlace(NovuController, [replacingDecorator()]);
+
+    expect(Reflect.getMetadata(metadataKey, NovuController)).toBe('replaced');
+  });
+});

--- a/packages/framework/src/servers/nest/nest.utils.ts
+++ b/packages/framework/src/servers/nest/nest.utils.ts
@@ -4,6 +4,6 @@ export function applyDecorators<T>(baseClass: Type<T>, decorators: Array<ClassDe
   return decorators.reduce((decoratedClass, decorator) => {
     const result = decorator(decoratedClass);
 
-    return result as Type<T>;
+    return (result ?? decoratedClass) as Type<T>;
   }, baseClass);
 }

--- a/packages/framework/src/servers/nest/nest.utils.ts
+++ b/packages/framework/src/servers/nest/nest.utils.ts
@@ -7,3 +7,24 @@ export function applyDecorators<T>(baseClass: Type<T>, decorators: Array<ClassDe
     return (result ?? decoratedClass) as Type<T>;
   }, baseClass);
 }
+
+function copyReflectMetadata(from: object, to: object): void {
+  for (const key of Reflect.getMetadataKeys(from) ?? []) {
+    Reflect.defineMetadata(key, Reflect.getMetadata(key, from), to);
+  }
+}
+
+/**
+ * Apply class decorators while keeping `baseClass` as the registered controller.
+ *
+ * Async module registration cannot swap the controller class after the dynamic
+ * module is created, so any decorator that returns a subclass has its metadata
+ * copied back onto `baseClass`.
+ */
+export function applyDecoratorsInPlace<T>(baseClass: Type<T>, decorators: Array<ClassDecorator> = []): void {
+  const decoratedClass = applyDecorators(baseClass, decorators);
+
+  if (decoratedClass !== baseClass) {
+    copyReflectMetadata(decoratedClass, baseClass);
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`NovuModule.registerAsync()` accepted `controllerDecorators` in its TypeScript types but never applied them at runtime. This PR fixes that by applying decorators during module initialization using the same NestJS factory-provider pattern already used for dynamic `apiPath` configuration.

## Problem

- `NovuModule.register()` correctly applies `controllerDecorators` via `applyDecorators()` when building the dynamic module.
- `NovuModule.registerAsync()` declared the option in types but registered the raw `NovuController` without applying decorators.

## Solution

Added a `registerControllerDecorators` factory provider that:

1. Injects resolved options from `NOVU_OPTIONS` (provided by `ConfigurableModuleBuilder`).
2. Applies each `controllerDecorators` entry to `NovuController` during application bootstrap.

This mirrors the existing `registerApiPath` provider, which solves the same class of problem for async-only controller configuration.

```mermaid
sequenceDiagram
    participant App as Nest App Bootstrap
    participant Module as NovuModule.registerAsync
    participant Options as NOVU_OPTIONS factory
    participant Decorators as registerControllerDecorators
    participant Controller as NovuController

    App->>Module: create dynamic module
    Module->>Options: resolve async options
    Options-->>Decorators: inject resolved options
    Decorators->>Controller: apply controllerDecorators
```

## Additional change

- Hardened `applyDecorators()` to keep the previous class when a decorator returns `undefined` (common for metadata-only NestJS decorators).

## Testing

- Added unit tests for `registerControllerDecorators` and `NovuModule.registerAsync` provider wiring.
- `pnpm exec vitest run src/servers/nest/nest.register-controller-decorators.test.ts src/servers/nest/nest.module.test.ts`
- `pnpm build` in `packages/framework`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7543](https://linear.app/novu/issue/NV-7543/bug-report-novumoduleregisterasync-silently-ignores)

<div><a href="https://cursor.com/agents/bc-f069e770-6df2-4e5d-a1c0-fde1a1dfa132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f069e770-6df2-4e5d-a1c0-fde1a1dfa132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

registerAsync previously accepted controllerDecorators in types but did not apply them at runtime. This PR adds a registerControllerDecorators factory provider that resolves async NOVU_OPTIONS and applies configured class decorators to NovuController during bootstrap, matching the behavior of the synchronous register() path. applyDecorators was hardened to preserve the original class when a decorator returns undefined to support metadata-only NestJS decorators.

## Affected areas

**framework**: Added a registerControllerDecorators FactoryProvider and re-export, updated NovuModule.registerAsync to include the provider, introduced applyDecoratorsInPlace helper and hardened applyDecorators, and added unit tests covering decorator chaining, in-place application, and provider wiring.

## Key technical decisions

- Use a factory provider (patterned after registerApiPath) to apply controller decorators only after async options resolve.
- When decorators replace a class, copy Reflect metadata back onto the original class so the module can continue to register the original controller class while preserving decorator metadata.
- applyDecorators now falls back to the previous class if a decorator returns undefined, accommodating metadata-only decorators.

## Testing

Added Vitest unit tests for applyDecorators and applyDecoratorsInPlace behaviors, registerControllerDecorators behavior (including chaining and no-op), and NovuModule.registerAsync provider wiring. Test/run instructions are provided in the PR description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a long-standing gap where `NovuModule.registerAsync()` accepted `controllerDecorators` in its TypeScript types but silently ignored them at runtime. The fix follows the same factory-provider pattern already used by `registerApiPath`.

- Adds `registerControllerDecorators`, a `FactoryProvider` that injects `NOVU_OPTIONS` and calls `applyDecoratorsInPlace(NovuController, options.controllerDecorators)` during bootstrap.
- Introduces `applyDecoratorsInPlace`, which chains decorators via the existing `applyDecorators` helper and copies reflect metadata from the final decorated class back onto the original `NovuController` (necessary because NestJS requires the controller class to be declared before async options are resolved).
- Hardens `applyDecorators` to return `result ?? decoratedClass` when a decorator returns `undefined`, fixing a pre-existing bug where the next decorator in a chain would receive `undefined` as its target.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, mirrors an established pattern in the same module, and is covered by unit tests for all three code paths.

The new `registerControllerDecorators` provider, `applyDecoratorsInPlace`, and the `applyDecorators` null-safety fix are all correct. The only observation is that the module-level test omits the `inject` field from its matcher, leaving DI wiring partially untested, but this doesn't affect runtime correctness given the lower-level tests cover the factory logic directly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/servers/nest/nest.utils.ts | Added `applyDecoratorsInPlace` which chains decorators via `applyDecorators` and copies reflect metadata from the final decorated class back onto the base class; also hardened `applyDecorators` to return `result ?? decoratedClass` when a decorator returns undefined. |
| packages/framework/src/servers/nest/nest.register-controller-decorators.ts | New factory provider that injects `NOVU_OPTIONS` and calls `applyDecoratorsInPlace(NovuController, options.controllerDecorators)` — correctly mirrors the existing `registerApiPath` pattern. |
| packages/framework/src/servers/nest/nest.module.ts | Registers `registerControllerDecorators` in the `registerAsync` providers list, closing the parity gap with the synchronous `register()` path. |
| packages/framework/src/servers/nest/nest.module.test.ts | New test verifies the provider appears in `registerAsync`'s providers array; only asserts `provide` and `useFactory` but not `inject`, leaving DI wiring partially untested. |
| packages/framework/src/servers/nest/nest.register-controller-decorators.test.ts | Tests directly invoke `useFactory` to verify metadata-only decorators, class-replacing decorator chaining, and the no-op path when no decorators are supplied. |
| packages/framework/src/servers/nest/nest.utils.test.ts | New tests for `applyDecorators` (decorator return-value chaining) and `applyDecoratorsInPlace` (metadata copy-back to base class). |
| packages/framework/src/servers/nest/nest.constants.ts | Adds the `REGISTER_CONTROLLER_DECORATORS` injection token constant. |
| packages/framework/src/servers/nest.ts | Re-exports the new `nest.register-controller-decorators` module from the top-level barrel. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as NestJS Bootstrap
    participant Module as NovuModule.registerAsync
    participant Options as NOVU_OPTIONS Factory
    participant Decorators as registerControllerDecorators
    participant Utils as applyDecoratorsInPlace
    participant Controller as NovuController

    App->>Module: create dynamic module
    Module->>Options: register async options factory
    Module->>Decorators: register as provider (inject: NOVU_OPTIONS)
    App->>Options: resolve async options
    Options-->>Decorators: inject resolved options
    Decorators->>Utils: applyDecoratorsInPlace(NovuController, decorators)
    Utils->>Controller: decorator(target) × N (chained)
    Utils->>Controller: copyReflectMetadata(decoratedClass → NovuController)
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fframework%2Fsrc%2Fservers%2Fnest%2Fnest.module.test.ts%3A16-23%0A**Module%20test%20doesn't%20assert%20%60inject%60%20wiring**%0A%0AThe%20%60objectContaining%60%20matcher%20checks%20%60provide%60%20and%20%60useFactory%60%20but%20not%20%60inject%60.%20If%20%60inject%3A%20%5BNOVU_OPTIONS%5D%60%20were%20accidentally%20dropped%20or%20changed%2C%20the%20factory%20would%20receive%20%60undefined%60%20as%20its%20argument%20and%20%60options.controllerDecorators%60%20would%20throw%20at%20runtime%20%E2%80%94%20but%20this%20test%20would%20still%20pass.%20Adding%20%60inject%3A%20registerControllerDecorators.inject%60%20to%20the%20matcher%20would%20close%20that%20gap.%0A%0A&pr=11497&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/framework/src/servers/nest/nest.module.test.ts:16-23
**Module test doesn't assert `inject` wiring**

The `objectContaining` matcher checks `provide` and `useFactory` but not `inject`. If `inject: [NOVU_OPTIONS]` were accidentally dropped or changed, the factory would receive `undefined` as its argument and `options.controllerDecorators` would throw at runtime — but this test would still pass. Adding `inject: registerControllerDecorators.inject` to the matcher would close that gap.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(framework): chain controllerDecorato..."](https://github.com/novuhq/novu/commit/8ed845441846ee8464e984a1053e72dd877fa1bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36717761)</sub>

<!-- /greptile_comment -->