### PR TITLE
fix(api-service): add ThrottleStepUpsertDto to UpdateWorkflowDto fixes NV-7995

### DIFF
--- a/apps/api/src/app/workflows-v2/dtos/update-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/update-workflow.dto.ts
@@ -14,6 +14,7 @@ import {
   InAppStepUpsertDto,
   PushStepUpsertDto,
   SmsStepUpsertDto,
+  ThrottleStepUpsertDto,
 } from './create-step.dto';
 import { PreferencesRequestDto } from './preferences.request.dto';
 
@@ -25,6 +26,7 @@ import { PreferencesRequestDto } from './preferences.request.dto';
   ChatStepUpsertDto,
   DelayStepUpsertDto,
   DigestStepUpsertDto,
+  ThrottleStepUpsertDto,
   CustomStepUpsertDto,
   HttpRequestStepUpsertDto
 )
@@ -48,6 +50,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
         { $ref: getSchemaPath(ChatStepUpsertDto) },
         { $ref: getSchemaPath(DelayStepUpsertDto) },
         { $ref: getSchemaPath(DigestStepUpsertDto) },
+        { $ref: getSchemaPath(ThrottleStepUpsertDto) },
         { $ref: getSchemaPath(CustomStepUpsertDto) },
         { $ref: getSchemaPath(HttpRequestStepUpsertDto) },
       ],
@@ -61,6 +64,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
           [StepTypeEnum.CHAT]: getSchemaPath(ChatStepUpsertDto),
           [StepTypeEnum.DELAY]: getSchemaPath(DelayStepUpsertDto),
           [StepTypeEnum.DIGEST]: getSchemaPath(DigestStepUpsertDto),
+          [StepTypeEnum.THROTTLE]: getSchemaPath(ThrottleStepUpsertDto),
           [StepTypeEnum.CUSTOM]: getSchemaPath(CustomStepUpsertDto),
           [StepTypeEnum.HTTP_REQUEST]: getSchemaPath(HttpRequestStepUpsertDto),
         },
@@ -80,6 +84,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
         { name: StepTypeEnum.CHAT, value: ChatStepUpsertDto },
         { name: StepTypeEnum.DELAY, value: DelayStepUpsertDto },
         { name: StepTypeEnum.DIGEST, value: DigestStepUpsertDto },
+        { name: StepTypeEnum.THROTTLE, value: ThrottleStepUpsertDto },
         { name: StepTypeEnum.CUSTOM, value: CustomStepUpsertDto },
         { name: StepTypeEnum.HTTP_REQUEST, value: HttpRequestStepUpsertDto },
       ],
@@ -94,6 +99,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
     | ChatStepUpsertDto
     | DelayStepUpsertDto
     | DigestStepUpsertDto
+    | ThrottleStepUpsertDto
     | CustomStepUpsertDto
     | HttpRequestStepUpsertDto
   )[];

--- a/libs/internal-sdk/src/models/components/updateworkflowdto.ts
+++ b/libs/internal-sdk/src/models/components/updateworkflowdto.ts
@@ -61,6 +61,11 @@ import {
   SmsStepUpsertDto$Outbound,
   SmsStepUpsertDto$outboundSchema,
 } from "./smsstepupsertdto.js";
+import {
+  ThrottleStepUpsertDto,
+  ThrottleStepUpsertDto$Outbound,
+  ThrottleStepUpsertDto$outboundSchema,
+} from "./throttlestepupsertdto.js";
 
 export type UpdateWorkflowDtoSteps =
   | InAppStepUpsertDto
@@ -70,6 +75,7 @@ export type UpdateWorkflowDtoSteps =
   | ChatStepUpsertDto
   | DelayStepUpsertDto
   | DigestStepUpsertDto
+  | ThrottleStepUpsertDto
   | CustomStepUpsertDto
   | HttpRequestStepUpsertDto;
 
@@ -117,6 +123,7 @@ export type UpdateWorkflowDto = {
     | ChatStepUpsertDto
     | DelayStepUpsertDto
     | DigestStepUpsertDto
+    | ThrottleStepUpsertDto
     | CustomStepUpsertDto
     | HttpRequestStepUpsertDto
   >;
@@ -143,6 +150,7 @@ export type UpdateWorkflowDtoSteps$Outbound =
   | ChatStepUpsertDto$Outbound
   | DelayStepUpsertDto$Outbound
   | DigestStepUpsertDto$Outbound
+  | ThrottleStepUpsertDto$Outbound
   | CustomStepUpsertDto$Outbound
   | HttpRequestStepUpsertDto$Outbound;
 
@@ -159,6 +167,7 @@ export const UpdateWorkflowDtoSteps$outboundSchema: z.ZodType<
   ChatStepUpsertDto$outboundSchema,
   DelayStepUpsertDto$outboundSchema,
   DigestStepUpsertDto$outboundSchema,
+  ThrottleStepUpsertDto$outboundSchema,
   CustomStepUpsertDto$outboundSchema,
   HttpRequestStepUpsertDto$outboundSchema,
 ]);
@@ -189,6 +198,7 @@ export type UpdateWorkflowDto$Outbound = {
     | ChatStepUpsertDto$Outbound
     | DelayStepUpsertDto$Outbound
     | DigestStepUpsertDto$Outbound
+    | ThrottleStepUpsertDto$Outbound
     | CustomStepUpsertDto$Outbound
     | HttpRequestStepUpsertDto$Outbound
   >;
@@ -220,6 +230,7 @@ export const UpdateWorkflowDto$outboundSchema: z.ZodType<
       ChatStepUpsertDto$outboundSchema,
       DelayStepUpsertDto$outboundSchema,
       DigestStepUpsertDto$outboundSchema,
+      ThrottleStepUpsertDto$outboundSchema,
       CustomStepUpsertDto$outboundSchema,
       HttpRequestStepUpsertDto$outboundSchema,
     ]),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

`UpdateWorkflowDto` for `PUT /v2/workflows/{workflowId}` was missing `ThrottleStepUpsertDto` in its OpenAPI discriminator, while `CreateWorkflowDto` already supported throttle steps. This prevented `@novu/api` consumers from using `type: 'throttle'` when calling `Workflows.update()`.

This PR aligns `UpdateWorkflowDto` with `CreateWorkflowDto` by adding `ThrottleStepUpsertDto` to:

- `@ApiExtraModels`
- OpenAPI `oneOf` and discriminator mapping
- class-transformer discriminator `subTypes`
- TypeScript step union type

The `@novu/api` SDK types were updated to match the regenerated OpenAPI schema.

### Screenshots

N/A — API schema/type fix only.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7995](https://linear.app/novu/issue/NV-7995/bug-report-throttlestepupsertdto-missing-in-updateworkflowdto)

<div><a href="https://cursor.com/agents/bc-2b91ae77-6d4e-46f4-a429-197b6e53512a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b91ae77-6d4e-46f4-a429-197b6e53512a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

`UpdateWorkflowDto` for the `PUT /v2/workflows/{workflowId}` endpoint now supports `ThrottleStepUpsertDto`, matching the existing support in `CreateWorkflowDto`. The fix threads `ThrottleStepUpsertDto` through OpenAPI documentation, class-transformer discriminators, and TypeScript type unions. This enables `@novu/api` SDK consumers to use `type: 'throttle'` when calling `Workflows.update()`.

## Affected areas

**api**: Updated `UpdateWorkflowDto` to include `ThrottleStepUpsertDto` in `@ApiExtraModels`, OpenAPI discriminator mapping, and `steps` union type.

**internal-sdk**: Regenerated SDK types to reflect the OpenAPI schema changes, extending `UpdateWorkflowDtoSteps` union and Zod validation schemas to accept `ThrottleStepUpsertDto`.

## Key technical decisions

- No breaking changes—this adds missing support to align two existing DTOs (`CreateWorkflowDto` already had throttle step support).
- Changes are purely additive to the discriminator mappings and type unions.
- No new dependencies or database schema changes.

## Testing

No new tests added. This is a schema/type alignment fix that corrects missing discriminator mappings. The change is covered by existing API contract tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a parity gap between `CreateWorkflowDto` and `UpdateWorkflowDto` by adding `ThrottleStepUpsertDto` to the update path, enabling `PUT /v2/workflows/{workflowId}` to accept throttle steps just like the create endpoint already did.

- **`update-workflow.dto.ts`**: `ThrottleStepUpsertDto` is wired into all four required registration points — `@ApiExtraModels`, OpenAPI `oneOf`, the discriminator mapping, and the class-transformer `subTypes` — mirroring the existing pattern in `create-workflow.dto.ts`.
- **`updateworkflowdto.ts` (SDK)**: The generated SDK file adds `ThrottleStepUpsertDto` to the type unions and the outbound Zod schema, keeping the SDK in sync with the updated OpenAPI spec.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive, tightly scoped, and directly mirror the existing pattern in CreateWorkflowDto.

Every registration point in update-workflow.dto.ts and the generated SDK file has been updated consistently, the referenced ThrottleStepUpsertDto already exists, and there are no logic changes — only additions that bring the update path in line with the create path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/workflows-v2/dtos/update-workflow.dto.ts | Adds ThrottleStepUpsertDto to all four registration sites (ApiExtraModels, oneOf, discriminator mapping, subTypes) and the steps union type, matching CreateWorkflowDto exactly. |
| libs/internal-sdk/src/models/components/updateworkflowdto.ts | Generated SDK file updated to add ThrottleStepUpsertDto import, type union entries, and outbound Zod schema member — consistent with the parallel createworkflowdto.ts. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PUT /v2/workflows/{workflowId}"] --> B["UpdateWorkflowDto"]
    B --> C["steps: StepUpsertDto[]"]
    C --> D["OneOf discriminator (type)"]
    D --> E["InAppStepUpsertDto"]
    D --> F["EmailStepUpsertDto"]
    D --> G["SmsStepUpsertDto"]
    D --> H["PushStepUpsertDto"]
    D --> I["ChatStepUpsertDto"]
    D --> J["DelayStepUpsertDto"]
    D --> K["DigestStepUpsertDto"]
    D --> L["ThrottleStepUpsertDto NEW"]
    D --> M["CustomStepUpsertDto"]
    D --> N["HttpRequestStepUpsertDto"]
```

<sub>Reviews (1): Last reviewed commit: ["chore(internal-sdk): add ThrottleStepUps..."](https://github.com/novuhq/novu/commit/4a3dd3571aea597a7313824d94bdedfc6571456d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36718188)</sub>

<!-- /greptile_comment -->