### PR TITLE
feat(dashboard): improve agents onboarding flow fixes NV-8005

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -238,6 +238,7 @@ export function ManagedAgentRecap({
       displayName={agent.name}
       isPlaceholderName={false}
       description={agent.description}
+      identifier={agent.identifier}
       instructions={agent.managedRuntime?.systemPrompt ?? summary.instructions}
       mcpServers={serverMcpIds ?? summary.mcpServers ?? []}
       tools={serverToolIds ?? summary.tools ?? []}

--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -10,7 +10,7 @@ import {
   listAgentIntegrations,
   sendAgentWelcomeMessage,
 } from '@/api/agents';
-import { AgentCard, type ManagedConnectorKind } from '@/components/onboarding/claude-agent-preview-illustration';
+import { AgentCard, type AgentCardConnectorKind } from '@/components/onboarding/claude-agent-preview-illustration';
 import { ConnectAgentForm } from '@/components/onboarding/connect-agent/connect-agent-form';
 import {
   type ConnectSummary,
@@ -220,8 +220,12 @@ export function ManagedAgentRecap({
    */
   hideHeader?: boolean;
 }) {
-  const connector: ManagedConnectorKind =
+  const isManagedAgent = agent.runtime === 'managed';
+  const managedConnector: AgentCardConnectorKind =
     agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.AnthropicAws ? 'aws' : 'anthropic';
+  // Custom-code (self-hosted) agents render the trimmed card variant: custom-code icon + footer,
+  // no status badge, and no MCPs/tools/instructions (those live in the user's own code).
+  const connector: AgentCardConnectorKind = isManagedAgent ? managedConnector : 'custom';
   const serverMcpIds = agent.managedRuntime?.mcpServers?.map((m) => m.externalId);
   const serverToolIds = agent.managedRuntime?.tools?.map((t) => t.externalId);
 

--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -207,11 +207,49 @@ const BRAIN_STEP_TITLE = 'What should your agent do?';
 const BRAIN_STEP_DESCRIPTION =
   "We'll provide demo Claude credentials so you can set up an agent without bringing your own keys. Later, you can replace it with your own agent and credentials.";
 
-export function ManagedAgentRecap({ agent, summary }: { agent: AgentResponse; summary: ConnectSummary }) {
+export function ManagedAgentRecap({
+  agent,
+  summary,
+  hideHeader,
+}: {
+  agent: AgentResponse;
+  summary: ConnectSummary;
+  /**
+   * When true, the step title/description are omitted and only the agent preview card is rendered
+   * next to the completed-step indicator (onboarding "Agent preview" step).
+   */
+  hideHeader?: boolean;
+}) {
   const connector: ManagedConnectorKind =
     agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.AnthropicAws ? 'aws' : 'anthropic';
   const serverMcpIds = agent.managedRuntime?.mcpServers?.map((m) => m.externalId);
   const serverToolIds = agent.managedRuntime?.tools?.map((t) => t.externalId);
+
+  const agentCard = (
+    <AgentCard
+      connector={connector}
+      isDemoCredential={agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic}
+      status="connected"
+      agentCreated
+      displayName={agent.name}
+      isPlaceholderName={false}
+      description={agent.description}
+      instructions={agent.managedRuntime?.systemPrompt ?? summary.instructions}
+      mcpServers={serverMcpIds ?? summary.mcpServers ?? []}
+      tools={serverToolIds ?? summary.tools ?? []}
+    />
+  );
+
+  if (hideHeader) {
+    return (
+      <div className="relative flex flex-col pl-6">
+        <div className="absolute -left-[20px] top-[3px] flex w-5 justify-center">
+          <CompletedStepIndicator />
+        </div>
+        {agentCard}
+      </div>
+    );
+  }
 
   return (
     <SetupStep
@@ -219,20 +257,7 @@ export function ManagedAgentRecap({ agent, summary }: { agent: AgentResponse; su
       status="completed"
       title={BRAIN_STEP_TITLE}
       description={BRAIN_STEP_DESCRIPTION}
-      fullWidthContent={
-        <AgentCard
-          connector={connector}
-          isDemoCredential={agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic}
-          status="connected"
-          agentCreated
-          displayName={agent.name}
-          isPlaceholderName={false}
-          description={agent.description}
-          instructions={agent.managedRuntime?.systemPrompt ?? summary.instructions}
-          mcpServers={serverMcpIds ?? summary.mcpServers ?? []}
-          tools={serverToolIds ?? summary.tools ?? []}
-        />
-      }
+      fullWidthContent={agentCard}
     />
   );
 }

--- a/apps/dashboard/src/components/onboarding/agent-usecase-preview-illustration.tsx
+++ b/apps/dashboard/src/components/onboarding/agent-usecase-preview-illustration.tsx
@@ -177,7 +177,7 @@ export function AgentUsecasePreviewIllustration() {
       <g mask="url(#D)">
         <path
           fill="#000"
-          fill-opacity=".3"
+          fillOpacity=".3"
           d="M309.803 180.736a2.408 2.408 0 1 1 4.816-.084l.023 1.294a2.903 2.903 0 0 1-2.853 2.954l-1.913.034z"
         />
       </g>

--- a/apps/dashboard/src/components/onboarding/claude-agent-preview-illustration.tsx
+++ b/apps/dashboard/src/components/onboarding/claude-agent-preview-illustration.tsx
@@ -7,7 +7,7 @@ import {
   getMcpIconPath,
 } from '@novu/shared';
 import { AnimatePresence, motion } from 'motion/react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { RiFileCodeLine } from 'react-icons/ri';
 import { AwsIcon } from '@/components/icons/aws';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
@@ -189,20 +189,13 @@ export function AgentCard({
           ) : null}
 
           {isCustomCode ? (
-            <>
-              {identifier ? (
-                <PreviewSection label="Identifier">
-                  <AnimatedField enabled={agentCreated} signature={identifier}>
-                    <span className="text-text-sub font-mono text-[12px] leading-4" title={identifier}>
-                      {identifier}
-                    </span>
-                  </AnimatedField>
-                </PreviewSection>
-              ) : null}
-              <div className="flex max-w-full justify-center overflow-hidden">
-                <AgentUsecasePreviewIllustration />
-              </div>
-            </>
+            identifier && (
+              <PreviewSection label="Identifier">
+                <span className="text-text-sub font-mono text-[12px] leading-4" title={identifier}>
+                  {identifier}
+                </span>
+              </PreviewSection>
+            )
           ) : (
             <>
               <PreviewSection label="MCPs">
@@ -457,10 +450,13 @@ type McpTagProps = {
 function McpTag({ id }: McpTagProps) {
   const iconPath = getMcpIconPath(id);
   const label = formatMcpLabel(id);
+  const [hasIconError, setHasIconError] = useState(false);
 
   return (
     <span className="border border-stroke-soft bg-bg-weak inline-flex h-5 items-center gap-1 rounded px-1 py-0.5">
-      {iconPath ? <img src={iconPath} alt={label} className="size-3.5" aria-hidden /> : null}
+      {iconPath && !hasIconError ? (
+        <img src={iconPath} alt={label} className="size-3.5" aria-hidden onError={() => setHasIconError(true)} />
+      ) : null}
       <span className="text-text-sub text-[12px] font-medium leading-4">{label}</span>
     </span>
   );

--- a/apps/dashboard/src/components/onboarding/claude-agent-preview-illustration.tsx
+++ b/apps/dashboard/src/components/onboarding/claude-agent-preview-illustration.tsx
@@ -8,12 +8,20 @@ import {
 } from '@novu/shared';
 import { AnimatePresence, motion } from 'motion/react';
 import { useMemo } from 'react';
+import { RiFileCodeLine } from 'react-icons/ri';
 import { AwsIcon } from '@/components/icons/aws';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { LogoCircle } from '../icons/logo-circle';
 import { AnthropicAsteriskIcon } from './agent-flow-illustration-shared';
 
 export type ManagedConnectorKind = 'anthropic' | 'aws';
+
+/**
+ * Connector kinds renderable by {@link AgentCard}. Custom-code (self-hosted) agents reuse the
+ * card with a trimmed-down look: no status badge and no MCPs/Tools/Instructions sections, since
+ * those are wired up in the user's own code rather than a managed runtime.
+ */
+export type AgentCardConnectorKind = ManagedConnectorKind | 'custom';
 
 export type ManagedAgentPreviewStatus = 'idle' | 'connecting' | 'connected';
 
@@ -112,7 +120,7 @@ function ClaudeAgentPreviewIllustration({
 }
 
 export type AgentCardProps = {
-  connector: ManagedConnectorKind;
+  connector: AgentCardConnectorKind;
   isDemoCredential: boolean;
   status: ManagedAgentPreviewStatus;
   /**
@@ -142,6 +150,10 @@ export function AgentCard({
   mcpServers,
   tools,
 }: AgentCardProps) {
+  // Custom-code agents host MCPs/tools/instructions in the user's own code and have no managed
+  // connection status — the card collapses to the header + description with a "Custom code" footer.
+  const isCustomCode = connector === 'custom';
+
   return (
     <div className="flex flex-col gap-1 p-1 bg-bg-weak rounded-[8px] border border-stroke-weak">
       <div className="border-stroke-soft bg-bg-white relative overflow-hidden rounded-lg border shadow-[0_1px_2px_rgba(16,24,40,0.04)]">
@@ -159,36 +171,42 @@ export function AgentCard({
               </span>
             </AnimatedField>
           </div>
-          <StatusBadge status={status} />
+          {!isCustomCode && <StatusBadge status={status} />}
         </div>
 
-        <div className="flex flex-col gap-5 px-2 pb-3 pt-2">
-          {description ? (
-            <AnimatedField enabled={agentCreated} signature={description}>
-              <p className="text-label-xs font-normal text-text-soft line-clamp-2 leading-4" title={description}>
-                {description}
-              </p>
-            </AnimatedField>
-          ) : null}
+        {isCustomCode && !description ? null : (
+          <div className="flex flex-col gap-5 px-2 pb-3 pt-2">
+            {description ? (
+              <AnimatedField enabled={agentCreated} signature={description}>
+                <p className="text-label-xs font-normal text-text-soft line-clamp-2 leading-4" title={description}>
+                  {description}
+                </p>
+              </AnimatedField>
+            ) : null}
 
-          <PreviewSection label="MCPs">
-            <AnimatedField enabled={agentCreated} signature={mcpServers.join('|')}>
-              {mcpServers.length > 0 ? <McpTagRow ids={mcpServers} /> : <NotConfiguredLabel />}
-            </AnimatedField>
-          </PreviewSection>
+            {!isCustomCode && (
+              <>
+                <PreviewSection label="MCPs">
+                  <AnimatedField enabled={agentCreated} signature={mcpServers.join('|')}>
+                    {mcpServers.length > 0 ? <McpTagRow ids={mcpServers} /> : <NotConfiguredLabel />}
+                  </AnimatedField>
+                </PreviewSection>
 
-          <PreviewSection label="Tools">
-            <AnimatedField enabled={agentCreated} signature={tools.join('|')}>
-              {tools.length > 0 ? <ToolTagRow tools={tools} /> : <NotConfiguredLabel />}
-            </AnimatedField>
-          </PreviewSection>
+                <PreviewSection label="Tools">
+                  <AnimatedField enabled={agentCreated} signature={tools.join('|')}>
+                    {tools.length > 0 ? <ToolTagRow tools={tools} /> : <NotConfiguredLabel />}
+                  </AnimatedField>
+                </PreviewSection>
 
-          <PreviewSection label="Instructions">
-            <AnimatedField enabled={agentCreated} signature={instructions ?? ''}>
-              {instructions?.trim() ? <InstructionsBlock value={instructions} /> : <NotConfiguredLabel />}
-            </AnimatedField>
-          </PreviewSection>
-        </div>
+                <PreviewSection label="Instructions">
+                  <AnimatedField enabled={agentCreated} signature={instructions ?? ''}>
+                    {instructions?.trim() ? <InstructionsBlock value={instructions} /> : <NotConfiguredLabel />}
+                  </AnimatedField>
+                </PreviewSection>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       <ConnectorFooter connector={connector} isDemoCredential={isDemoCredential} />
@@ -253,13 +271,21 @@ function AnimatedField({ enabled, signature, as = 'div', children }: AnimatedFie
 }
 
 type ConnectorBrandIconProps = {
-  connector: ManagedConnectorKind;
+  connector: AgentCardConnectorKind;
   className?: string;
 };
 
 function ConnectorBrandIcon({ connector, className }: ConnectorBrandIconProps) {
   if (connector === 'aws') {
     return <AwsIcon className={className} />;
+  }
+
+  if (connector === 'custom') {
+    return (
+      <span className={`bg-bg-weak text-text-sub flex items-center justify-center rounded-full ${className ?? ''}`}>
+        <RiFileCodeLine className="size-3" />
+      </span>
+    );
   }
 
   return <AnthropicAsteriskIcon className={className} />;
@@ -499,12 +525,18 @@ function InstructionsBlock({ value }: InstructionsBlockProps) {
 }
 
 type ConnectorFooterProps = {
-  connector: ManagedConnectorKind;
+  connector: AgentCardConnectorKind;
   isDemoCredential: boolean;
 };
 
+const CONNECTOR_FOOTER_LABELS: Record<AgentCardConnectorKind, string> = {
+  anthropic: 'Claude Managed',
+  aws: 'AWS Claude Managed',
+  custom: 'Custom code',
+};
+
 function ConnectorFooter({ connector, isDemoCredential }: ConnectorFooterProps) {
-  const label = connector === 'aws' ? 'AWS Claude Managed' : 'Claude Managed';
+  const label = CONNECTOR_FOOTER_LABELS[connector];
 
   return (
     <div className="flex h-7 items-center gap-1 px-1">

--- a/apps/dashboard/src/components/onboarding/claude-agent-preview-illustration.tsx
+++ b/apps/dashboard/src/components/onboarding/claude-agent-preview-illustration.tsx
@@ -13,6 +13,7 @@ import { AwsIcon } from '@/components/icons/aws';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { LogoCircle } from '../icons/logo-circle';
 import { AnthropicAsteriskIcon } from './agent-flow-illustration-shared';
+import { AgentUsecasePreviewIllustration } from './agent-usecase-preview-illustration';
 
 export type ManagedConnectorKind = 'anthropic' | 'aws';
 
@@ -133,6 +134,8 @@ export type AgentCardProps = {
   displayName: string;
   isPlaceholderName: boolean;
   description?: string;
+  /** Agent identifier, rendered under the description in the custom-code card variant. */
+  identifier?: string;
   instructions?: string;
   mcpServers: ReadonlyArray<string>;
   tools: ReadonlyArray<string>;
@@ -146,12 +149,14 @@ export function AgentCard({
   displayName,
   isPlaceholderName,
   description,
+  identifier,
   instructions,
   mcpServers,
   tools,
 }: AgentCardProps) {
   // Custom-code agents host MCPs/tools/instructions in the user's own code and have no managed
-  // connection status — the card collapses to the header + description with a "Custom code" footer.
+  // connection status — the card shows the description + identifier with a usecase illustration
+  // and a "Custom code" footer instead.
   const isCustomCode = connector === 'custom';
 
   return (
@@ -174,39 +179,52 @@ export function AgentCard({
           {!isCustomCode && <StatusBadge status={status} />}
         </div>
 
-        {isCustomCode && !description ? null : (
-          <div className="flex flex-col gap-5 px-2 pb-3 pt-2">
-            {description ? (
-              <AnimatedField enabled={agentCreated} signature={description}>
-                <p className="text-label-xs font-normal text-text-soft line-clamp-2 leading-4" title={description}>
-                  {description}
-                </p>
-              </AnimatedField>
-            ) : null}
+        <div className="flex flex-col gap-5 px-2 pb-3 pt-2">
+          {description ? (
+            <AnimatedField enabled={agentCreated} signature={description}>
+              <p className="text-label-xs font-normal text-text-soft line-clamp-2 leading-4" title={description}>
+                {description}
+              </p>
+            </AnimatedField>
+          ) : null}
 
-            {!isCustomCode && (
-              <>
-                <PreviewSection label="MCPs">
-                  <AnimatedField enabled={agentCreated} signature={mcpServers.join('|')}>
-                    {mcpServers.length > 0 ? <McpTagRow ids={mcpServers} /> : <NotConfiguredLabel />}
+          {isCustomCode ? (
+            <>
+              {identifier ? (
+                <PreviewSection label="Identifier">
+                  <AnimatedField enabled={agentCreated} signature={identifier}>
+                    <span className="text-text-sub font-mono text-[12px] leading-4" title={identifier}>
+                      {identifier}
+                    </span>
                   </AnimatedField>
                 </PreviewSection>
+              ) : null}
+              <div className="flex max-w-full justify-center overflow-hidden">
+                <AgentUsecasePreviewIllustration />
+              </div>
+            </>
+          ) : (
+            <>
+              <PreviewSection label="MCPs">
+                <AnimatedField enabled={agentCreated} signature={mcpServers.join('|')}>
+                  {mcpServers.length > 0 ? <McpTagRow ids={mcpServers} /> : <NotConfiguredLabel />}
+                </AnimatedField>
+              </PreviewSection>
 
-                <PreviewSection label="Tools">
-                  <AnimatedField enabled={agentCreated} signature={tools.join('|')}>
-                    {tools.length > 0 ? <ToolTagRow tools={tools} /> : <NotConfiguredLabel />}
-                  </AnimatedField>
-                </PreviewSection>
+              <PreviewSection label="Tools">
+                <AnimatedField enabled={agentCreated} signature={tools.join('|')}>
+                  {tools.length > 0 ? <ToolTagRow tools={tools} /> : <NotConfiguredLabel />}
+                </AnimatedField>
+              </PreviewSection>
 
-                <PreviewSection label="Instructions">
-                  <AnimatedField enabled={agentCreated} signature={instructions ?? ''}>
-                    {instructions?.trim() ? <InstructionsBlock value={instructions} /> : <NotConfiguredLabel />}
-                  </AnimatedField>
-                </PreviewSection>
-              </>
-            )}
-          </div>
-        )}
+              <PreviewSection label="Instructions">
+                <AnimatedField enabled={agentCreated} signature={instructions ?? ''}>
+                  {instructions?.trim() ? <InstructionsBlock value={instructions} /> : <NotConfiguredLabel />}
+                </AnimatedField>
+              </PreviewSection>
+            </>
+          )}
+        </div>
       </div>
 
       <ConnectorFooter connector={connector} isDemoCredential={isDemoCredential} />

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -2,6 +2,7 @@ import { AgentRuntimeProviderIdEnum, type IIntegration } from '@novu/shared';
 import { motion } from 'motion/react';
 import type { ReactNode } from 'react';
 import { RiArrowRightSLine, RiCloseLine, RiInformation2Line, RiLoopLeftLine } from 'react-icons/ri';
+import { isDemoManagedClaudeIntegrationSelected } from '@/components/agents/connectors/claude-managed-integrations';
 import {
   ConnectorIntegrationDropdown,
   type ConnectorIntegrationStatus,
@@ -264,13 +265,71 @@ export function ConnectAgentForm({
   simplifiedDemo,
 }: ConnectAgentFormProps) {
   if (simplifiedDemo && aiGeneration) {
+    const demoSelectedConnector = getConnectorById(connectorId);
+    const showDemoCredentialsSection =
+      isClaudeSelected && credentialsPanelVisible && Boolean(demoSelectedConnector?.providerId);
+    const isDemoCredentialSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
+
     return (
-      <SetupStep
-        index={1}
-        status="current"
-        title="What should your agent do?"
-        description="We'll provide demo Claude credentials so you can set up an agent without bringing your own keys. Later, you can replace it with your own agent and credentials."
-        fullWidthContent={
+      <>
+        <SetupStep
+          index={1}
+          status={selectedIntegrationId ? 'completed' : 'current'}
+          sectionLabel="2/7 SETUP AGENT BRAIN"
+          title="Choose your connector"
+          description="Your Connector is the LLM runtime where the agent is hosted and executed. Novu connects to your Connector to bring your agents to where you work"
+          fullWidthContent={
+            <div className="mt-1 flex w-full max-w-[500px] flex-col gap-2">
+              <ConnectorIntegrationDropdown
+                selectedConnectorId={connectorId}
+                selectedIntegrationId={selectedIntegrationId}
+                integrations={integrations}
+                status={dropdownStatus}
+                showStatusBadge={showSavedBadge}
+                disabled={disabled}
+                onSelectConnector={onConnectorChange}
+                onSelectIntegration={onSelectIntegration}
+                onRequestSetupCredentials={onRequestSetupCredentials}
+              />
+              <p className="text-text-soft text-label-xs flex items-center gap-1 font-normal leading-4">
+                <RiInformation2Line className="size-3.5" aria-hidden /> The platform that hosts and runs your agent.
+              </p>
+              {showDemoCredentialsSection && demoSelectedConnector?.providerId ? (
+                <ConfigureCredentialsSection
+                  providerId={demoSelectedConnector.providerId as AgentRuntimeProviderIdEnum}
+                  providerLabel={demoSelectedConnector.providerLabel ?? 'Provider'}
+                  integrationName={integrationName}
+                  apiKey={apiKey}
+                  externalWorkspaceId={externalWorkspaceId}
+                  region={region}
+                  errors={errors}
+                  disabled={disabled}
+                  status={verifyStatus}
+                  statusMessage={verifyMessage}
+                  isSaving={isSavingIntegration}
+                  expanded={credentialsPanelExpanded}
+                  onExpandedChange={onCredentialsExpandedChange}
+                  onIntegrationNameChange={onIntegrationNameChange}
+                  onApiKeyChange={onApiKeyChange}
+                  onExternalWorkspaceIdChange={onExternalWorkspaceIdChange}
+                  onRegionChange={onRegionChange}
+                  onVerify={onVerify}
+                  onSave={onSaveIntegration}
+                />
+              ) : null}
+            </div>
+          }
+        />
+        <SetupStep
+          index={2}
+          status="current"
+          title="What should your agent do?"
+          description={
+            isDemoCredentialSelected
+              ? "We'll provide demo Claude credentials so you can set up an agent without bringing your own keys. Later, you can replace it with your own agent and credentials."
+              : 'Describe what your agent should do — we configure the tools, MCPs, skills, and system prompt for you.'
+          }
+          fullWidthContent={
           <div className="flex flex-col gap-3 mt-5 max-w-[500px]">
             {aiGeneration.suggestions.length > 0 && (
               <div className="flex min-w-0 items-center gap-2">
@@ -313,7 +372,11 @@ export function ConnectAgentForm({
               disabled={disabled || (aiGeneration.isGenerating ?? false)}
               errorMessage={aiGeneration.promptError}
               textareaRef={aiGeneration.textareaRef}
-              helperText="Using Demo credentials for Claude Managed Agents for onboarding"
+              helperText={
+                isDemoCredentialSelected
+                  ? 'Using Demo credentials for Claude Managed Agents for onboarding'
+                  : 'You can always edit the agent once created'
+              }
             />
             {/*
              * Render the cancel/submit toggle as different element types (button vs a wrapping
@@ -350,8 +413,9 @@ export function ConnectAgentForm({
               </motion.div>
             )}
           </div>
-        }
-      />
+          }
+        />
+      </>
     );
   }
 

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -264,62 +264,103 @@ export function ConnectAgentForm({
   submitSlot,
   simplifiedDemo,
 }: ConnectAgentFormProps) {
-  if (simplifiedDemo && aiGeneration) {
+  if (simplifiedDemo && (aiGeneration || isScratchRuntime)) {
     const demoSelectedConnector = getConnectorById(connectorId);
     const showDemoCredentialsSection =
       isClaudeSelected && credentialsPanelVisible && Boolean(demoSelectedConnector?.providerId);
     const isDemoCredentialSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
+    // Custom-code connectors carry no credential to set up, so picking one completes the step.
+    const isConnectorStepCompleted = isScratchRuntime || Boolean(selectedIntegrationId);
+
+    const demoConnectorStep = (
+      <SetupStep
+        index={1}
+        status={isConnectorStepCompleted ? 'completed' : 'current'}
+        sectionLabel="2/7 SETUP AGENT BRAIN"
+        title="Choose your connector"
+        description="Your Connector is the LLM runtime where the agent is hosted and executed. Novu connects to your Connector to bring your agents to where you work"
+        fullWidthContent={
+          <div className="mt-1 flex w-full max-w-[500px] flex-col gap-2">
+            <ConnectorIntegrationDropdown
+              selectedConnectorId={connectorId}
+              selectedIntegrationId={selectedIntegrationId}
+              integrations={integrations}
+              status={dropdownStatus}
+              showStatusBadge={showSavedBadge}
+              disabled={disabled}
+              onSelectConnector={onConnectorChange}
+              onSelectIntegration={onSelectIntegration}
+              onRequestSetupCredentials={onRequestSetupCredentials}
+            />
+            <p className="text-text-soft text-label-xs flex items-center gap-1 font-normal leading-4">
+              <RiInformation2Line className="size-3.5" aria-hidden /> The platform that hosts and runs your agent.
+            </p>
+            {showDemoCredentialsSection && demoSelectedConnector?.providerId ? (
+              <ConfigureCredentialsSection
+                providerId={demoSelectedConnector.providerId as AgentRuntimeProviderIdEnum}
+                providerLabel={demoSelectedConnector.providerLabel ?? 'Provider'}
+                integrationName={integrationName}
+                apiKey={apiKey}
+                externalWorkspaceId={externalWorkspaceId}
+                region={region}
+                errors={errors}
+                disabled={disabled}
+                status={verifyStatus}
+                statusMessage={verifyMessage}
+                isSaving={isSavingIntegration}
+                expanded={credentialsPanelExpanded}
+                onExpandedChange={onCredentialsExpandedChange}
+                onIntegrationNameChange={onIntegrationNameChange}
+                onApiKeyChange={onApiKeyChange}
+                onExternalWorkspaceIdChange={onExternalWorkspaceIdChange}
+                onRegionChange={onRegionChange}
+                onVerify={onVerify}
+                onSave={onSaveIntegration}
+              />
+            ) : null}
+          </div>
+        }
+      />
+    );
+
+    // Custom-code (scratch) connectors keep the same stepped layout: the connector step stays in
+    // place and the prompt step swaps for the manual agent form. The created agent then follows
+    // the regular custom-code flow (channel selection + bridge setup).
+    if (isScratchRuntime || !aiGeneration) {
+      return (
+        <>
+          {demoConnectorStep}
+          <SetupStep
+            index={2}
+            status="current"
+            title="Configure your agent"
+            description="Give your agent a name, identifier, and description. Wire up your own tools, MCPs, and integrations in code."
+            fullWidthContent={
+              <div className="mt-5 flex max-w-[500px] flex-col gap-3">
+                <ScratchAgentFields
+                  name={name}
+                  identifier={identifier}
+                  instructions={instructions}
+                  errors={errors}
+                  isIdentifierTouched={isIdentifierTouched}
+                  isClaudeSelected={false}
+                  disabled={disabled}
+                  onNameChange={onNameChange}
+                  onIdentifierChange={onIdentifierChange}
+                  onIdentifierTouched={onIdentifierTouched}
+                  onInstructionsChange={onInstructionsChange}
+                />
+                {submitSlot}
+              </div>
+            }
+          />
+        </>
+      );
+    }
 
     return (
       <>
-        <SetupStep
-          index={1}
-          status={selectedIntegrationId ? 'completed' : 'current'}
-          sectionLabel="2/7 SETUP AGENT BRAIN"
-          title="Choose your connector"
-          description="Your Connector is the LLM runtime where the agent is hosted and executed. Novu connects to your Connector to bring your agents to where you work"
-          fullWidthContent={
-            <div className="mt-1 flex w-full max-w-[500px] flex-col gap-2">
-              <ConnectorIntegrationDropdown
-                selectedConnectorId={connectorId}
-                selectedIntegrationId={selectedIntegrationId}
-                integrations={integrations}
-                status={dropdownStatus}
-                showStatusBadge={showSavedBadge}
-                disabled={disabled}
-                onSelectConnector={onConnectorChange}
-                onSelectIntegration={onSelectIntegration}
-                onRequestSetupCredentials={onRequestSetupCredentials}
-              />
-              <p className="text-text-soft text-label-xs flex items-center gap-1 font-normal leading-4">
-                <RiInformation2Line className="size-3.5" aria-hidden /> The platform that hosts and runs your agent.
-              </p>
-              {showDemoCredentialsSection && demoSelectedConnector?.providerId ? (
-                <ConfigureCredentialsSection
-                  providerId={demoSelectedConnector.providerId as AgentRuntimeProviderIdEnum}
-                  providerLabel={demoSelectedConnector.providerLabel ?? 'Provider'}
-                  integrationName={integrationName}
-                  apiKey={apiKey}
-                  externalWorkspaceId={externalWorkspaceId}
-                  region={region}
-                  errors={errors}
-                  disabled={disabled}
-                  status={verifyStatus}
-                  statusMessage={verifyMessage}
-                  isSaving={isSavingIntegration}
-                  expanded={credentialsPanelExpanded}
-                  onExpandedChange={onCredentialsExpandedChange}
-                  onIntegrationNameChange={onIntegrationNameChange}
-                  onApiKeyChange={onApiKeyChange}
-                  onExternalWorkspaceIdChange={onExternalWorkspaceIdChange}
-                  onRegionChange={onRegionChange}
-                  onVerify={onVerify}
-                  onSave={onSaveIntegration}
-                />
-              ) : null}
-            </div>
-          }
-        />
+        {demoConnectorStep}
         <SetupStep
           index={2}
           status="current"

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -7,12 +7,7 @@ import { TelemetryEvent } from '@/utils/telemetry';
  * spin up from the "What should your agent do?" step, so copying it (or opening it in Cursor)
  * gets them to a working agent description without typing anything.
  */
-const PREBUILT_AGENT_PROMPT = `You are Support Agent, a docs-powered support agent that answers questions from your product documentation and knowledge base.
-
-For each inbound question:
-1. Search the product docs and knowledge base for an answer. Quote the relevant passage and link to the source — never paraphrase policy from memory.
-2. If the docs don't cover it, say so clearly and offer to escalate the conversation to a human.
-3. Keep replies short, friendly, and actionable.`;
+const PREBUILT_AGENT_PROMPT = `Add an agent to my app following instructions from this web page https://novu.co/agents.md`;
 
 function safeCursorEncode(text: string): string {
   return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -43,7 +43,7 @@ export function PrebuiltPromptBanner() {
     <div className="border-stroke-weak bg-bg-weak rounded-lg border p-1">
       <div className="bg-bg-white flex items-center gap-2 rounded-md border border-[rgba(255,132,71,0.1)] py-1.5 pl-2 pr-1.5">
         <div className="bg-text-soft h-7 w-1 shrink-0 self-stretch rounded-full" />
-        <p className="text-text-strong min-w-0 flex-1 text-sm font-medium leading-5 tracking-[-0.084px]">
+        <p className="text-text-strong text-label-sm min-w-0 flex-1 font-normal">
           Use this pre-built prompt to get started faster.
         </p>
         <div className="flex shrink-0 items-center gap-2.5">
@@ -51,7 +51,9 @@ export function PrebuiltPromptBanner() {
             href={CURSOR_DEEP_LINK}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => telemetry(TelemetryEvent.AI_PROMPT_COPIED, { source: 'agents-onboarding', method: 'cursor-deeplink' })}
+            onClick={() =>
+              telemetry(TelemetryEvent.AI_PROMPT_COPIED, { source: 'agents-onboarding', method: 'cursor-deeplink' })
+            }
             className="text-text-sub inline-flex h-7 cursor-pointer items-center gap-1 rounded-md p-1.5 text-xs font-medium shadow-[0px_1px_3px_0px_rgba(14,18,27,0.12),0px_0px_0px_1px_#e1e4ea] transition-colors hover:bg-neutral-50"
             style={{
               backgroundImage:

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useTelemetry } from '@/hooks/use-telemetry';
+import { TelemetryEvent } from '@/utils/telemetry';
+
+/**
+ * Starter prompt surfaced in the onboarding banner. Mirrors the demo support-agent the user can
+ * spin up from the "What should your agent do?" step, so copying it (or opening it in Cursor)
+ * gets them to a working agent description without typing anything.
+ */
+const PREBUILT_AGENT_PROMPT = `You are Support Agent, a docs-powered support agent that answers questions from your product documentation and knowledge base.
+
+For each inbound question:
+1. Search the product docs and knowledge base for an answer. Quote the relevant passage and link to the source — never paraphrase policy from memory.
+2. If the docs don't cover it, say so clearly and offer to escalate the conversation to a human.
+3. Keep replies short, friendly, and actionable.`;
+
+function safeCursorEncode(text: string): string {
+  return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+const CURSOR_DEEP_LINK = `https://cursor.com/link/prompt?text=${safeCursorEncode(PREBUILT_AGENT_PROMPT)}`;
+
+/**
+ * Inline tip rendered above the agent-brain steps during onboarding: a pre-built agent prompt the
+ * user can copy to their clipboard or open directly in Cursor via the prompt deep link.
+ */
+export function PrebuiltPromptBanner() {
+  const telemetry = useTelemetry();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(PREBUILT_AGENT_PROMPT);
+      setCopied(true);
+      telemetry(TelemetryEvent.AI_PROMPT_COPIED, { source: 'agents-onboarding' });
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard access denied — nothing actionable for the user beyond retrying.
+    }
+  };
+
+  return (
+    <div className="border-stroke-weak bg-bg-weak rounded-lg border p-1">
+      <div className="bg-bg-white flex items-center gap-2 rounded-md border border-[rgba(255,132,71,0.1)] py-1.5 pl-2 pr-1.5">
+        <div className="bg-text-soft h-7 w-1 shrink-0 self-stretch rounded-full" />
+        <p className="text-text-strong min-w-0 flex-1 text-sm font-medium leading-5 tracking-[-0.084px]">
+          Use this pre-built prompt to get started faster.
+        </p>
+        <div className="flex shrink-0 items-center gap-2.5">
+          <a
+            href={CURSOR_DEEP_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => telemetry(TelemetryEvent.AI_PROMPT_COPIED, { source: 'agents-onboarding', method: 'cursor-deeplink' })}
+            className="text-text-sub inline-flex h-7 cursor-pointer items-center gap-1 rounded-md p-1.5 text-xs font-medium shadow-[0px_1px_3px_0px_rgba(14,18,27,0.12),0px_0px_0px_1px_#e1e4ea] transition-colors hover:bg-neutral-50"
+            style={{
+              backgroundImage:
+                'linear-gradient(180deg, transparent 30%, rgba(0,0,0,0.02) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
+            }}
+          >
+            <img src="/images/cursor-icon.svg" alt="" className="size-4" />
+            <span className="px-1">Open in Cursor</span>
+          </a>
+          <button
+            type="button"
+            onClick={handleCopyPrompt}
+            className="text-static-white inline-flex h-7 cursor-pointer items-center rounded-md py-1.5 pl-2 pr-1.5 text-xs font-medium shadow-[0px_1px_2px_0px_rgba(27,28,29,0.48),0px_0px_0px_1px_#242628] transition-[background] duration-150"
+            style={{
+              backgroundImage: copied
+                ? 'linear-gradient(180deg, rgba(255,255,255,0.28) 0%, rgba(255,255,255,0.12) 100%), linear-gradient(90deg, #151a22 0%, #151a22 100%)'
+                : 'linear-gradient(180deg, rgba(255,255,255,0.16) 0%, rgba(255,255,255,0) 100%), linear-gradient(90deg, #0e121b 0%, #0e121b 100%)',
+            }}
+          >
+            <span className="px-1">{copied ? 'Copied!' : 'Copy prompt'}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -5,10 +5,10 @@ import { RiArrowLeftSLine, RiArrowRightSLine, RiExpandUpDownLine } from 'react-i
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
 import { AgentSetupSteps, ManagedAgentRecap } from '@/components/agents/agent-setup-steps';
-import { ProviderCards } from '@/components/agents/provider-cards';
-import { CompletedStepIndicator, SetupStep } from '@/components/agents/setup-guide-primitives';
+import { CompletedStepIndicator } from '@/components/agents/setup-guide-primitives';
 import { ConnectAgentStep, type ConnectSummary } from '@/components/onboarding/connect-agent/connect-agent-step';
 import { getConnectorById } from '@/components/onboarding/connect-agent/connector-options';
+import { PrebuiltPromptBanner } from '@/components/onboarding/connect-agent/prebuilt-prompt-banner';
 import { OnboardingLoader } from '@/components/onboarding/onboarding-loader';
 import { OnboardingShell } from '@/components/onboarding/onboarding-shell';
 import { PageMeta } from '@/components/page-meta';
@@ -74,32 +74,6 @@ function SkipBanner({ onSkip }: SkipBannerProps) {
 }
 
 /**
- * Dimmed, non-interactive preview of the channel step shown during the connect phase, so the
- * user can see what comes next while still authoring the agent. Mirrors the
- * `AgentSetupSteps` channel step layout/rail; activates for real once the agent is created.
- */
-function ChannelStepPreview() {
-  return (
-    <div className="pointer-events-none relative flex select-none flex-col gap-10 pl-8 pr-3 opacity-60 md:pr-6">
-      <div
-        className="absolute bottom-0 left-[22px] top-0 w-px"
-        style={{
-          background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
-        }}
-      />
-      <SetupStep
-        index={2}
-        status="upcoming"
-        dimmed
-        title="Choose where your agent can talk"
-        description="Connect a channel so users can message the agent and receive replies."
-        fullWidthContent={<ProviderCards agentIdentifier="" onSelect={() => {}} disabled dimmed />}
-      />
-    </div>
-  );
-}
-
-/**
  * Collapsed marker for the completed agent-brain + channel-selection steps. Toggling it reveals or
  * hides the agent preview and channel cards while the channel setup guide stays visible.
  */
@@ -158,7 +132,7 @@ export function AgentsSetupPage() {
     () => readActiveAgentTemplateId(searchParams.get(AGENT_TEMPLATE_ID_PARAM)),
     [searchParams]
   );
-  const pageTitle = 'Connect your first agent';
+  const pageTitle = 'Connect your agent to where your users are';
 
   // Org bootstrap (poll Novu envs + reload Clerk after org creation) lives in EnvironmentProvider.
   // Here we only gate on Novu's org id + the resolved environment, like the inbox onboarding page.
@@ -279,9 +253,28 @@ export function AgentsSetupPage() {
 
       <h1 className="text-foreground text-lg font-medium tracking-[-0.27px]">{pageTitle}</h1>
       <p className="text-text-soft mt-1 text-xs font-normal leading-4 w-1/2">
-        Start with a Claude demo agent, connect channels, and see how conversations flow. You can bring your own agent
-        later.
+        Choose a starting point to see how your agent handles your users’ conversations. You can replace it with your
+        own agent and credentials later.
       </p>
+
+      {/* Pre-built prompt tip: only relevant while the user is authoring the agent brain. It
+       * collapses away once the agent is created and the page morphs into the agent preview. */}
+      <AnimatePresence initial={false}>
+        {!createdAgent ? (
+          <motion.div
+            key="prebuilt-prompt-banner"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div className="mt-6">
+              <PrebuiltPromptBanner />
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
 
       {/*
        * The user stays on one screen. Step 1 crossfades the brain form into the created-agent
@@ -289,7 +282,7 @@ export function AgentsSetupPage() {
        * interactive channel step in place. Keyed on `createdAgent` — the back arrow returns to the
        * brain form.
        */}
-      <div className="relative mt-12">
+      <div className="relative mt-8">
         {/* Single continuous rail line behind every step segment. Each segment also draws its own
          * gradient line, but those fade to transparent at their edges and pinch where segments meet;
          * this same-colored line sits underneath and fills those gaps so the toggle, brain step, and
@@ -355,7 +348,7 @@ export function AgentsSetupPage() {
                       'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
                   }}
                 />
-                <ManagedAgentRecap agent={createdAgent} summary={connectSummary} />
+                <ManagedAgentRecap agent={createdAgent} summary={connectSummary} hideHeader />
               </div>
             </motion.div>
           ) : (
@@ -386,9 +379,7 @@ export function AgentsSetupPage() {
             onChannelGuideActiveChange={setChannelGuideActive}
             connectSummary={connectSummary}
           />
-        ) : (
-          <ChannelStepPreview />
-        )}
+        ) : null}
       </div>
 
       {/* Footer actions live outside the rail so the continuous line ends at the last step. */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The agents onboarding flow at `/onboarding/agents/setup` was redesigned to align with Conversational Agents Figma designs. Key additions include a new `PrebuiltPromptBanner` component with "Open in Cursor" and "Copy prompt" buttons (with telemetry tracking), a connector selection step using `ConnectorIntegrationDropdown`, custom code connector support with a stepped layout instead of the legacy two-column view, a custom code agent preview variant in `AgentCard`, and repositioning of provider channels to appear only in the post-creation "Agent preview" step. Page copy updated to "Connect your agent to where your users are".

## Affected areas

**dashboard**: Updated agents onboarding components to implement the new stepped flow, including `ManagedAgentRecap` (added optional `hideHeader` prop for compact layout), `ConnectAgentForm` (refactored simplified demo flow to support connector selection and conditional credentials configuration), new `PrebuiltPromptBanner` component (with Cursor deep link generation and clipboard copy functionality), `AgentsSetupPage` (updated copy, added animated banner, removed channel preview, and passed `hideHeader` to recap), and `claude-agent-preview-illustration.tsx` (added `AgentCardConnectorKind` type supporting 'custom' variant, updated `AgentCard` to render custom code layout without status badge, and enhanced `McpTag` with image load error handling).

## Key technical decisions

- Introduced `AgentCardConnectorKind` type to extend connector support beyond managed connectors to include custom code agents
- `ManagedAgentRecap` gained a compact rendering mode for use in post-creation preview without repeating step header information
- Pre-built prompt deep linking uses URL-encoded prompt content with custom escape handling to support Cursor IDE integration
- Simplified demo flow now conditionally renders credential configuration only for Claude managed agent selection

## Testing

No automated tests were added with this change; testing was performed via manual verification with the Custom Scaffold connector and end-to-end demo recording. The local test environment was noted as lacking demo Claude integration and LLM keys for full integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Aligns the agents onboarding flow (`/onboarding/agents/setup`) with the [Conversational Agents Figma designs](https://www.figma.com/design/NxgfvPgzVGLukGARqSvtSm/Conversational-Agents?node-id=8134-36172):

- **Pre-built prompt banner** — new `PrebuiltPromptBanner` ("Use this pre-built prompt to get started faster.") with **Open in Cursor** (cursor.com prompt deep link) and **Copy prompt** buttons, shown while authoring the agent brain and collapsing once the agent is created.
- **Connector step in the demo flow** — the simplified demo brain form now renders a "Choose your connector" step using `ConnectorIntegrationDropdown`, including the inline create-credentials form (`ConfigureCredentialsSection`) and the connect-existing integrations list, matching the [setup step design](https://www.figma.com/design/NxgfvPgzVGLukGARqSvtSm/Conversational-Agents?node-id=8220-134188).
- **Custom code connector keeps the stepped layout** — selecting "Custom code" in the connector dropdown no longer switches to the legacy two-column view: the "Choose your connector" step stays in place and the prompt step swaps for the "Configure your agent" form (`ScratchAgentFields` + Setup agent button); the created agent then follows the regular custom-code flow (channel selection, provider guide, bridge setup).
- **Custom code agent preview variant** — `AgentCard` gained a `custom` connector kind: custom-code icon in the header, no CONNECTED badge, no MCPs/Tools/Instructions sections, and a "Custom code" footer. The body shows the description, an "Identifier" field, and the `AgentUsecasePreviewIllustration` diagram. `ManagedAgentRecap` picks this variant for non-managed agents.
- **Agent preview step** — provider channels now only appear in the post-creation "Agent preview" step (the dimmed `ChannelStepPreview` was removed from step 1), and `ManagedAgentRecap` gained a `hideHeader` variant so the preview card renders next to the completed-step indicator per the [agent preview design](https://www.figma.com/design/NxgfvPgzVGLukGARqSvtSm/Conversational-Agents?node-id=8220-150870).
- **Collapsed state** — picking a channel still collapses the preview + channel cards behind "Show all instructions", matching the [collapsed design](https://www.figma.com/design/NxgfvPgzVGLukGARqSvtSm/Conversational-Agents?node-id=8220-159884).
- Page copy updated to "Connect your agent to where your users are" per the designs.

### Screenshots
<img width="1525" height="996" alt="Screenshot 2026-06-10 at 18 37 40" src="https://github.com/user-attachments/assets/f98dfb1a-900c-473f-9f9d-f2c4bcc50fc1" />

<img width="1527" height="997" alt="Screenshot 2026-06-10 at 18 37 52" src="https://github.com/user-attachments/assets/2bcb09cb-6803-4819-8d4c-774342d94319" />

<img width="1530" height="994" alt="Screenshot 2026-06-10 at 18 39 08" src="https://github.com/user-attachments/assets/acae11a0-f0df-4749-93bf-de38b485a886" />
<img width="1526" height="996" alt="Screenshot 2026-06-10 at 18 39 18" src="https://github.com/user-attachments/assets/7d1dd9f2-5961-492b-9f92-771ad9ba8f8c" />
<img width="1525" height="995" alt="Screenshot 2026-06-10 at 18 39 39" src="https://github.com/user-attachments/assets/f5638f82-afa9-408e-a206-94502368472d" />

https://github.com/user-attachments/assets/8008e284-770e-46be-9324-6984b85e49cd


https://github.com/user-attachments/assets/1ce9e62d-1cfd-4e23-9d3b-83341f4ffab3

https://github.com/user-attachments/assets/8610c277-e82d-4bdf-8000-56d0f55b27e8


