### PR TITLE
feat(dashboard): show personalizing suggestions shimmer for agent suggestion pills fixes NV-8006

### DIFF
--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -8,6 +8,7 @@ import {
   slugify,
 } from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
+import { AnimatePresence, motion } from 'motion/react';
 import type { FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowRightSLine, RiArrowRightUpLine, RiCloseLine, RiLoopLeftLine } from 'react-icons/ri';
@@ -889,7 +890,7 @@ export function CreateAgentDialog({
                 </div>
 
                 {generationMode === 'prompt' && (
-                  <div className="flex min-w-0 items-center gap-2">
+                  <div className="flex min-w-0 items-center">
                     <AgentSuggestionPills
                       className="min-w-0 flex-1"
                       suggestions={displayedAgentTemplates}
@@ -897,17 +898,30 @@ export function CreateAgentDialog({
                       disabled={isSubmitBusy}
                       isLoading={isFetchingAgentTemplates}
                     />
-                    <Button
-                      aria-label="Regenerate suggestions"
-                      title="Regenerate suggestions"
-                      className="h-6 shrink-0 [&_svg]:size-2.5"
-                      variant="secondary"
-                      mode="ghost"
-                      size="2xs"
-                      trailingIcon={RiLoopLeftLine}
-                      disabled={isSubmitBusy || isFetchingAgentTemplates}
-                      onClick={refreshAgentTemplates}
-                    />
+                    <AnimatePresence initial={false}>
+                      {!isFetchingAgentTemplates && (
+                        <motion.div
+                          key="regenerate-suggestions"
+                          initial={{ opacity: 0, maxWidth: 0, marginLeft: 0 }}
+                          animate={{ opacity: 1, maxWidth: 24, marginLeft: 8 }}
+                          exit={{ opacity: 0, maxWidth: 0, marginLeft: 0 }}
+                          transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+                          className="shrink-0 overflow-hidden"
+                        >
+                          <Button
+                            aria-label="Regenerate suggestions"
+                            title="Regenerate suggestions"
+                            className="h-6 shrink-0 [&_svg]:size-2.5"
+                            variant="secondary"
+                            mode="ghost"
+                            size="2xs"
+                            trailingIcon={RiLoopLeftLine}
+                            disabled={isSubmitBusy}
+                            onClick={refreshAgentTemplates}
+                          />
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
                   </div>
                 )}
               </div>

--- a/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
@@ -1,15 +1,30 @@
 import { MCP_SERVERS } from '@novu/shared';
+import type { Variants } from 'motion/react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useMemo } from 'react';
 import { type AgentTemplate, type McpServerPreview } from '@/components/agents/create-agent-fields';
 import { McpIcon } from '@/components/agents/mcp-icon';
+import { Shimmer } from '@/components/ai-elements/shimmer';
+import { Broom } from '@/components/icons/broom';
 import { OrbIcon } from '@/components/icons/orb';
-import { Skeleton } from '@/components/primitives/skeleton';
 import { buildEdgeFadeMask, useHorizontalScrollEdges } from '@/hooks/use-horizontal-scroll-edges';
+import { itemVariants } from '@/utils/animation';
 import { cn } from '@/utils/ui';
 
 const VISIBLE_INTEGRATION_ICONS = 2;
 const PILL_FADE_WIDTH_PX = 24;
-const SKELETON_PILL_WIDTHS = ['w-28', 'w-36', 'w-24', 'w-32', 'w-20'];
+// Matches the rendered pill height (py-1 + 18px content) so the loading shimmer and the loaded
+// pills occupy the exact same vertical space — swapping states never shifts the layout.
+const ROW_HEIGHT_CLASS = 'h-[26px]';
+
+const pillsRowVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.05,
+    },
+  },
+};
 
 function resolveMcpName(server: McpServerPreview): string {
   return server.name ?? MCP_SERVERS.find((entry) => entry.id === server.id)?.name ?? server.id;
@@ -19,7 +34,7 @@ type AgentSuggestionPillsProps = {
   suggestions: AgentTemplate[];
   onSelect: (suggestion: AgentTemplate) => void;
   disabled?: boolean;
-  /** When true, render animated skeleton pills instead of the suggestions (loading / refreshing). */
+  /** When true, render the "Personalizing suggestions" shimmer instead of the pills (loading / refreshing). */
   isLoading?: boolean;
   className?: string;
 };
@@ -34,27 +49,42 @@ export function AgentSuggestionPills({
   const { ref: scrollRef, canScrollLeft, canScrollRight } = useHorizontalScrollEdges<HTMLDivElement>();
   const maskImage = buildEdgeFadeMask(canScrollLeft, canScrollRight, PILL_FADE_WIDTH_PX);
 
-  if (isLoading) {
-    return (
-      <div className={cn('flex min-w-0 items-center gap-2 overflow-hidden', className)}>
-        {SKELETON_PILL_WIDTHS.map((width) => (
-          <Skeleton key={width} className={cn('h-[26px] shrink-0 rounded-full', width)} />
-        ))}
-      </div>
-    );
-  }
-
-  if (!suggestions.length) return null;
+  if (!isLoading && !suggestions.length) return null;
 
   return (
-    <div
-      ref={scrollRef}
-      className={cn('nv-no-scrollbar flex min-w-0 items-center gap-2 overflow-x-auto', className)}
-      style={maskImage ? { maskImage, WebkitMaskImage: maskImage } : undefined}
-    >
-      {suggestions.map((suggestion) => (
-        <SuggestionPill key={suggestion.label} suggestion={suggestion} disabled={disabled} onSelect={onSelect} />
-      ))}
+    <div className={cn(ROW_HEIGHT_CLASS, 'min-w-0', className)}>
+      <AnimatePresence mode="wait" initial={false}>
+        {isLoading ? (
+          <motion.div
+            key="personalizing-suggestions"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6, scale: 0.98, filter: 'blur(4px)' }}
+            transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+            className={cn(ROW_HEIGHT_CLASS, 'flex min-w-0 items-center gap-1')}
+          >
+            <Broom fill="#525866" className="text-text-sub h-3 w-3 shrink-0 animate-pulse" />
+            <Shimmer className="text-label-xs">Personalizing suggestions</Shimmer>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="suggestion-pills"
+            ref={scrollRef}
+            initial="hidden"
+            animate="visible"
+            exit={{ opacity: 0, transition: { duration: 0.15 } }}
+            variants={pillsRowVariants}
+            className={cn(ROW_HEIGHT_CLASS, 'nv-no-scrollbar flex min-w-0 items-center gap-2 overflow-x-auto')}
+            style={maskImage ? { maskImage, WebkitMaskImage: maskImage } : undefined}
+          >
+            {suggestions.map((suggestion) => (
+              <motion.div key={suggestion.label} variants={itemVariants} className="flex shrink-0">
+                <SuggestionPill suggestion={suggestion} disabled={disabled} onSelect={onSelect} />
+              </motion.div>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -274,7 +274,15 @@ export function ConnectAgentForm({
           <div className="flex flex-col gap-3 mt-5 max-w-[500px]">
             {aiGeneration.suggestions.length > 0 && (
               <div className="flex min-w-0 items-center gap-2">
-                <span className="text-text-soft text-label-xs shrink-0 font-medium leading-4">Try:</span>
+                {/* Fades (not unmounts) while the shimmer is shown so the row geometry never shifts. */}
+                <span
+                  className={cn(
+                    'text-text-soft text-label-xs shrink-0 font-medium leading-4 transition-opacity duration-200',
+                    aiGeneration.isRegeneratingSuggestions && 'opacity-0'
+                  )}
+                >
+                  Try:
+                </span>
                 <AgentSuggestionPills
                   className="min-w-0 flex-1"
                   suggestions={aiGeneration.suggestions}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -1,5 +1,5 @@
 import { AgentRuntimeProviderIdEnum, type IIntegration } from '@novu/shared';
-import { motion } from 'motion/react';
+import { AnimatePresence, motion } from 'motion/react';
 import type { ReactNode } from 'react';
 import { RiArrowRightSLine, RiCloseLine, RiInformation2Line, RiLoopLeftLine } from 'react-icons/ri';
 import {
@@ -273,16 +273,21 @@ export function ConnectAgentForm({
         fullWidthContent={
           <div className="flex flex-col gap-3 mt-5 max-w-[500px]">
             {aiGeneration.suggestions.length > 0 && (
-              <div className="flex min-w-0 items-center gap-2">
-                {/* Fades (not unmounts) while the shimmer is shown so the row geometry never shifts. */}
-                <span
-                  className={cn(
-                    'text-text-soft text-label-xs shrink-0 font-medium leading-4 transition-opacity duration-200',
-                    aiGeneration.isRegeneratingSuggestions && 'opacity-0'
+              <div className="flex min-w-0 items-center">
+                <AnimatePresence initial={false}>
+                  {!aiGeneration.isRegeneratingSuggestions && (
+                    <motion.span
+                      key="try-label"
+                      initial={{ opacity: 0, maxWidth: 0, marginRight: 0 }}
+                      animate={{ opacity: 1, maxWidth: 36, marginRight: 8 }}
+                      exit={{ opacity: 0, maxWidth: 0, marginRight: 0 }}
+                      transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+                      className="text-text-soft text-label-xs shrink-0 overflow-hidden font-medium leading-4 whitespace-nowrap"
+                    >
+                      Try:
+                    </motion.span>
                   )}
-                >
-                  Try:
-                </span>
+                </AnimatePresence>
                 <AgentSuggestionPills
                   className="min-w-0 flex-1"
                   suggestions={aiGeneration.suggestions}
@@ -291,21 +296,30 @@ export function ConnectAgentForm({
                   isLoading={aiGeneration.isRegeneratingSuggestions ?? false}
                 />
                 {aiGeneration.onRegenerateSuggestions && (
-                  <Button
-                    aria-label="Regenerate suggestions"
-                    title="Regenerate suggestions"
-                    className="h-6 shrink-0 [&_svg]:size-2.5"
-                    variant="secondary"
-                    mode="ghost"
-                    size="2xs"
-                    trailingIcon={RiLoopLeftLine}
-                    disabled={
-                      disabled ||
-                      (aiGeneration.isGenerating ?? false) ||
-                      (aiGeneration.isRegeneratingSuggestions ?? false)
-                    }
-                    onClick={aiGeneration.onRegenerateSuggestions}
-                  />
+                  <AnimatePresence initial={false}>
+                    {!aiGeneration.isRegeneratingSuggestions && (
+                      <motion.div
+                        key="regenerate-suggestions"
+                        initial={{ opacity: 0, maxWidth: 0, marginLeft: 0 }}
+                        animate={{ opacity: 1, maxWidth: 24, marginLeft: 8 }}
+                        exit={{ opacity: 0, maxWidth: 0, marginLeft: 0 }}
+                        transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+                        className="shrink-0 overflow-hidden"
+                      >
+                        <Button
+                          aria-label="Regenerate suggestions"
+                          title="Regenerate suggestions"
+                          className="h-6 shrink-0 [&_svg]:size-2.5"
+                          variant="secondary"
+                          mode="ghost"
+                          size="2xs"
+                          trailingIcon={RiLoopLeftLine}
+                          disabled={disabled || (aiGeneration.isGenerating ?? false)}
+                          onClick={aiGeneration.onRegenerateSuggestions}
+                        />
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
                 )}
               </div>
             )}
@@ -731,7 +745,7 @@ function renderExtraContent({
 }: ExtraContentArgs) {
   if (usePromptUi && aiGeneration && aiMode === 'prompt') {
     return (
-      <div className="flex min-w-0 items-center gap-2">
+      <div className="flex min-w-0 items-center">
         <AgentSuggestionPills
           className="min-w-0 flex-1"
           suggestions={aiGeneration.suggestions}
@@ -740,15 +754,30 @@ function renderExtraContent({
           isLoading={aiGeneration.isRegeneratingSuggestions ?? false}
         />
         {aiGeneration.onRegenerateSuggestions && (
-          <Button
-            className="h-6 shrink-0 [&_svg]:size-2.5"
-            variant="secondary"
-            mode="ghost"
-            size="2xs"
-            trailingIcon={RiLoopLeftLine}
-            disabled={disabled || (aiGeneration.isRegeneratingSuggestions ?? false)}
-            onClick={aiGeneration.onRegenerateSuggestions}
-          />
+          <AnimatePresence initial={false}>
+            {!aiGeneration.isRegeneratingSuggestions && (
+              <motion.div
+                key="regenerate-suggestions"
+                initial={{ opacity: 0, maxWidth: 0, marginLeft: 0 }}
+                animate={{ opacity: 1, maxWidth: 24, marginLeft: 8 }}
+                exit={{ opacity: 0, maxWidth: 0, marginLeft: 0 }}
+                transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
+                className="shrink-0 overflow-hidden"
+              >
+                <Button
+                  aria-label="Regenerate suggestions"
+                  title="Regenerate suggestions"
+                  className="h-6 shrink-0 [&_svg]:size-2.5"
+                  variant="secondary"
+                  mode="ghost"
+                  size="2xs"
+                  trailingIcon={RiLoopLeftLine}
+                  disabled={disabled}
+                  onClick={aiGeneration.onRegenerateSuggestions}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
         )}
       </div>
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent suggestion pills now show the "Personalizing suggestions" shimmer with a broom icon during loading instead of a generic skeleton; loading and loaded states are animated with AnimatePresence inside a fixed h-[26px] wrapper to prevent layout shift. The simplified demo/onboarding flow also fades the "Try:" label while regenerating suggestions so row geometry remains stable. Regenerate controls were converted to conditionally mounted motion elements to avoid disabled-but-present buttons during loading.

## Affected areas

**dashboard**: Replaced skeleton loading UI for agent suggestion pills (create-agent dialog and agents setup/onboarding) with the existing personalizing shimmer and broom icon, added AnimatePresence/motion transitions and fixed-height wrappers to prevent layout shifts, and updated regenerate-suggestion controls and the demo "Try:" label to use conditional motion-based mounting/fading.

## Testing

Manual verification was performed and screenshots were added to confirm the shimmer animation, layout stability, and regenerate-button behavior during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The agent suggestion pills in the create-agent dialog and the agents setup (onboarding) page showed a generic skeleton animation while suggestions were loading. This replaces the skeleton with the "Personalizing suggestions" shimmer treatment already used on the workflows page, and crossfades into the suggestion pills (with a subtle stagger) once they load.

- `agent-suggestion-pills.tsx`: the loading state now renders the animated `Broom` icon + `Shimmer` "Personalizing suggestions" text; loading and loaded states are swapped via `AnimatePresence` inside a fixed `h-[26px]` wrapper (matches the pill height) so there is no layout shift.
- `connect-agent-form.tsx` (simplified demo / onboarding step): the "Try:" label fades out (without unmounting) while the shimmer is shown, so the row geometry stays stable.

### Screenshots


https://github.com/user-attachments/assets/daa317a8-62ce-4c8b-99df-e2751a7acc89


https://github.com/user-attachments/assets/4d6ae01e-d1db-417d-918b-9f7b5c34ce4c

