### PR TITLE
feat(novu): agent-optimized connect --help fixes NV-8007

### DIFF
--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -5,7 +5,7 @@ Examples (non-interactive / agent / CI):
     npx novu connect "A support assistant for Acme's customers that answers billing questions." \\
       --ci \\
       --channel slack \\
-      --slack-config-token "xoxe.xoxp-..."
+      --slack-config-token "xoxe.xoxp-…"
 
   Keyless Email:
     npx novu connect "An onboarding assistant for Acme's new members." \\
@@ -34,7 +34,7 @@ Examples (non-interactive / agent / CI):
       --ci \\
       --secret-key "$NOVU_SECRET_KEY" \\
       --channel slack \\
-      --slack-config-token "xoxe.xoxp-..."
+      --slack-config-token "xoxe.xoxp-…"
 
 Non-interactive (agent / CI) contract:
 

--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -32,14 +32,14 @@ Examples (non-interactive / agent / CI):
   Existing Novu account (instead of keyless):
     npx novu connect "A support assistant for Acme's customers." \\
       --ci \\
-      --secret-key "NOVU_SECRET_KEY" \\
+      --secret-key "$NOVU_SECRET_KEY" \\
       --channel slack \\
       --slack-config-token "xoxe.xoxp-..."
 
 Non-interactive (agent / CI) contract:
 
   Required for --ci mode:
-    - Pass the agent description as the positional <prompt> argument (or --prompt).
+    - Pass the agent description as the positional <prompt> argument or --prompt.
     - Pass --channel <slack|email|telegram|skip>.
 
   Channel-specific flags:

--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -1,0 +1,89 @@
+export const CONNECT_HELP_TEXT = `
+Examples (non-interactive / agent / CI):
+
+  Keyless Slack (default — no Novu account required):
+    npx novu connect "A support assistant for Acme's customers that answers billing questions." \\
+      --ci \\
+      --channel slack \\
+      --slack-config-token "xoxe.xoxp-..."
+
+  Keyless Email:
+    npx novu connect "An onboarding assistant for Acme's new members." \\
+      --ci \\
+      --channel email
+
+  Keyless Telegram:
+    npx novu connect "A concierge for Acme's shoppers that helps with orders." \\
+      --ci \\
+      --channel telegram \\
+      --telegram-bot-token "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+
+  Agent only (no channel):
+    npx novu connect "An inventory assistant for Acme's ops staff." \\
+      --ci \\
+      --channel skip
+
+  EU region:
+    npx novu connect "A support assistant for Acme's EU customers." \\
+      --ci \\
+      --region eu \\
+      --channel email
+
+  Existing Novu account (instead of keyless):
+    npx novu connect "A support assistant for Acme's customers." \\
+      --ci \\
+      --secret-key "NOVU_SECRET_KEY" \\
+      --channel slack \\
+      --slack-config-token "xoxe.xoxp-..."
+
+Non-interactive (agent / CI) contract:
+
+  Required for --ci mode:
+    - Pass the agent description as the positional <prompt> argument (or --prompt).
+    - Pass --channel <slack|email|telegram|skip>.
+
+  Channel-specific flags:
+    - --channel slack    → requires --slack-config-token (xoxe.xoxp-…)
+    - --channel telegram → requires --telegram-bot-token (from @BotFather)
+    - --channel email    → no extra flags
+    - --channel skip     → no extra flags (agent only, no channel)
+
+  Defaults (do not pass unless needed):
+    - Keyless mode: omit --secret-key (creates a temporary agent; user claims via in-channel sign-up link)
+    - Demo runtime: omit --runtime (shared Claude runtime, ~5 free replies in keyless mode)
+    - US region: omit --region (use --region eu for EU Novu Cloud)
+
+  Not supported headlessly:
+    - whatsapp and teams → use the Novu dashboard instead; do not pass --channel whatsapp or --channel teams
+
+  One run = one new agent + one channel. Re-running creates another agent.
+
+Machine-readable stdout (plain text, no ANSI — watch these in --ci mode):
+
+  Slack:
+    NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>
+
+  Email:
+    NOVU_CONNECT_INBOUND_ADDRESS=<address>
+    NOVU_CONNECT_MAILTO=<mailto-url>
+    NOVU_CONNECT_SEND_FROM_EMAIL=<email>   (only when present)
+
+  Telegram:
+    NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=<url>
+    NOVU_CONNECT_TELEGRAM_BOT_USERNAME=<name>
+
+  Success:
+    ✓ Your agent is live.
+
+Behavior & exit codes:
+
+  - For slack, email, and telegram: the CLI blocks and polls for the handoff (up to ~5 min).
+  - Exit 0 on success (prints "✓ Your agent is live." with agent identifier and dashboard URL).
+  - Non-zero exit on failure (prints "✗ ..." with an error message).
+  - Safe to re-run on Slack OAuth timeout or "Failed to create Slack app" (the Slack app is reused).
+
+  Do not redirect stdout to a log file — read output from the shell session directly.
+
+Full end-to-end agent onboarding guide:
+  https://github.com/novuhq/novu/blob/main/packages/shared/docs/agent-onboarding.md
+`;

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -188,7 +188,7 @@ program
   )
   .option(
     '--ci',
-    'Non-interactive mode (no Ink TUI). Requires positional <prompt> and --channel; see examples below',
+    'Non-interactive mode (no Ink TUI). Requires a prompt (positional <prompt> or --prompt) and --channel; see examples below',
     false
   )
   .addHelpText('after', CONNECT_HELP_TEXT)
@@ -203,6 +203,25 @@ program
     });
     // Positional `prompt` wins over `--prompt` (the positional form is the
     // primary surface; the flag exists for parity with `--ci` workflows).
+    if (options.ci) {
+      const prompt = (positionalPrompt ?? options.prompt)?.trim();
+      const channel = options.skipSlack ? 'skip' : options.channel;
+
+      if (!prompt) {
+        console.error(
+          'Non-interactive mode requires a prompt (positional <prompt> or --prompt).\n(run `novu connect --help` for the non-interactive contract and examples)'
+        );
+        process.exit(1);
+      }
+
+      if (!channel) {
+        console.error(
+          'Non-interactive mode requires --channel <slack|email|telegram|skip>.\n(run `novu connect --help` for the non-interactive contract and examples)'
+        );
+        process.exit(1);
+      }
+    }
+
     if (options.channel && !(CHANNEL_CHOICES as readonly string[]).includes(options.channel)) {
       console.error(`Invalid --channel value: "${options.channel}". Expected one of: ${CHANNEL_CHOICES.join(', ')}.`);
       process.exit(1);

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -220,6 +220,20 @@ program
         );
         process.exit(1);
       }
+
+      if (channel === 'slack' && !options.slackConfigToken?.trim()) {
+        console.error(
+          'Non-interactive mode with --channel slack requires --slack-config-token (xoxe.xoxp-…).\n(run `novu connect --help` for the non-interactive contract and examples)'
+        );
+        process.exit(1);
+      }
+
+      if (channel === 'telegram' && !options.telegramBotToken?.trim()) {
+        console.error(
+          'Non-interactive mode with --channel telegram requires --telegram-bot-token (from @BotFather).\n(run `novu connect --help` for the non-interactive contract and examples)'
+        );
+        process.exit(1);
+      }
     }
 
     if (options.channel && !(CHANNEL_CHOICES as readonly string[]).includes(options.channel)) {

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { v4 as uuidv4 } from 'uuid';
 import { DevCommandOptions, devCommand } from './commands';
 import { connectCommand } from './commands/connect';
+import { CONNECT_HELP_TEXT } from './commands/connect/help-text';
 import type { ConnectCommandInput } from './commands/connect/resolve-options';
 import { resolveConnectCommandOptions } from './commands/connect/resolve-options';
 import {
@@ -137,9 +138,18 @@ program
 
 program
   .command('connect')
-  .description('Create a managed agent and connect it to Slack from the CLI')
-  .argument('[prompt]', 'Agent description. When provided, skips the picker and creates a new agent from this prompt.')
-  .option('-s, --secret-key <secret-key>', 'Skip browser auth and use this Novu Secret Key')
+  .description(
+    `Create a managed agent and connect it to a channel (keyless by default; use --ci for non-interactive agent/CI runs)`
+  )
+  .usage('[prompt] [--ci] [--channel <name>] [options]')
+  .argument(
+    '[prompt]',
+    'Agent description. Required in --ci mode. When provided, skips the picker and creates a new agent from this prompt.'
+  )
+  .option(
+    '-s, --secret-key <secret-key>',
+    'Use an existing Novu account instead of keyless mode (omit for keyless — the default)'
+  )
   .option('-a, --api-url <url>', 'Override the Novu API URL (default follows --region)')
   .option('-d, --dashboard-url <url>', 'Override the Novu Dashboard URL (default follows --region)')
   .option(
@@ -147,10 +157,13 @@ program
     'Override the Connect browser-auth URL (default follows --region, e.g. dashboard.novu.co)'
   )
   .option('--region <region>', `Novu region (${Object.values(CloudRegionEnum).join(' | ')})`, CloudRegionEnum.US)
-  .option('--prompt <text>', 'Pre-fill the agent description (skips the input screen)')
+  .option(
+    '--prompt <text>',
+    'Pre-fill the agent description (alternative to positional <prompt>; positional wins when both are set)'
+  )
   .option(
     '--runtime <runtime>',
-    `Agent runtime for new agents (${AGENT_RUNTIME_CHOICES.join(' | ')}). Defaults to demo in interactive mode.`
+    `Agent runtime for new agents (${AGENT_RUNTIME_CHOICES.join(' | ')}). Defaults to demo — omit in --ci keyless runs`
   )
   .option(
     '--agent-integration-id <id>',
@@ -162,18 +175,24 @@ program
   .option('--aws-claude-workspace-id <id>', 'AWS Claude workspace ID for --runtime claude-aws')
   .option(
     '--channel <name>',
-    `Channel to connect (skips the picker). One of: ${CHANNEL_CHOICES.join(', ')}. "slack" and "telegram" are implemented today.`
+    `Channel to connect (required in --ci mode). One of: ${CHANNEL_CHOICES.join(', ')}. whatsapp/teams are dashboard-only — do not pass them in --ci mode`
   )
   .option('--skip-slack', 'Create the agent and exit; do not connect any channel (equivalent to --channel skip)', false)
   .option(
     '--slack-config-token <token>',
-    'Slack App Configuration Token (xoxe.xoxp-…) used to provision Slack OAuth credentials non-interactively'
+    'Slack App Configuration Token (xoxe.xoxp-…). Required with --channel slack in --ci mode'
   )
   .option(
     '--telegram-bot-token <token>',
-    'Telegram bot token from @BotFather (123456:ABC-…). The CLI stores it on the integration, skipping the mobile-link handoff'
+    'Telegram bot token from @BotFather (123456:ABC-…). Required with --channel telegram in --ci mode'
   )
-  .option('--ci', 'Force non-interactive logging mode (no Ink TUI)', false)
+  .option(
+    '--ci',
+    'Non-interactive mode (no Ink TUI). Requires positional <prompt> and --channel; see examples below',
+    false
+  )
+  .addHelpText('after', CONNECT_HELP_TEXT)
+  .showHelpAfterError('(run `novu connect --help` for the non-interactive contract and examples)')
   .action(async (positionalPrompt: string | undefined, options: ConnectCommandInput) => {
     analytics.track({
       identity: {

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -302,6 +302,8 @@ Extract the **agent identifier** and **Dashboard URL**, then tell the user:
 
 ## Command flag reference (the subset this flow uses)
 
+Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI) contract, machine-readable stdout markers, and exit-code semantics. Keep that help text in sync when changing connect flags or behavior.
+
 | Flag | Purpose |
 |---|---|
 | `connect "<description>"` | Positional agent description (required in `--ci`). |


### PR DESCRIPTION
## Summary

- Enrich `novu connect --help` with copy-paste examples for each channel (slack, email, telegram, skip, EU, existing account)
- Document the non-interactive (agent/CI) contract: required flags, channel pairings, defaults, and unsupported channels
- Add machine-readable stdout markers (`NOVU_CONNECT_*`), exit-code semantics, and polling behavior
- Cross-reference the help contract from `packages/shared/docs/agent-onboarding.md`

## Why

AI agents running `--help` previously saw only a flat flag list. They had no way to know that `--ci` requires the positional description, which flags pair with which `--channel`, or what stdout markers to watch. That knowledge lived only in the separate onboarding doc.

## Test plan

- [x] `pnpm --filter novu build`
- [x] `node packages/novu/dist/src/index.js connect --help` — examples, contract, markers, and exit semantics render in piped mode
- [x] `node packages/novu/dist/src/index.js connect --bogus-flag` — shows self-correct hint via `showHelpAfterError`

## Linear

https://linear.app/novu/issue/NV-8007/agent-optimized-novu-connect-help

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Improves the `novu connect` CLI to be agent- and CI-friendly by adding a comprehensive, copy-pasteable help text that documents the non-interactive contract (required flags per channel, channel pairings, defaults, unsupported channels), machine-readable stdout markers (`NOVU_CONNECT_*`), exit-code semantics, and polling behavior. The CLI now enforces the `--ci` contract at runtime (fail-fast when `--ci` is used without a prompt or valid channel) and validates channel-specific tokens (e.g., Slack and Telegram) to prevent ambiguous agent runs.

## Affected areas
**novu (js)**: Introduced a new `CONNECT_HELP_TEXT` constant and appended it to `novu connect` help via Commander `.addHelpText('after', …)` and `.showHelpAfterError(…)`; improved command usage and option descriptions; added runtime CI-mode guards that validate presence of prompt/channel and channel-specific tokens and emit consistent machine-readable stdout markers and exit codes.  
**shared**: Updated `packages/shared/docs/agent-onboarding.md` to reference the CLI help and require keeping the non-interactive/agent contract and machine-readable markers in sync with documentation.

## Key technical decisions
- Fail fast in `--ci` mode to surface missing inputs immediately and avoid ambiguous/incomplete agent runs.  
- Expose machine-readable stdout markers and deterministic exit semantics in the CLI help so integrations can reliably parse outcomes.  
- Use Commander’s help hooks (`addHelpText` and `showHelpAfterError`) to keep guidance and self-correcting hints close to the command implementation.

## Testing
Manual verification: built `novu` (pnpm --filter novu build); confirmed `connect --help` renders examples, contract text, markers, and exit semantics in piped mode; validated fail-fast behavior and token checks for Slack/Telegram and that invalid flags show the help hint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `novu connect --help` agent- and CI-friendly by embedding copy-paste examples, a non-interactive contract, machine-readable stdout markers, and exit-code semantics directly in the CLI output. It also adds fail-fast validation in `--ci` mode and cross-references the help text from the shared onboarding doc.

- **`help-text.ts`**: New file exporting `CONNECT_HELP_TEXT` with examples for all supported channels, the CI contract, stdout markers, and behavior/exit-code semantics.
- **`index.ts`**: Wires `CONNECT_HELP_TEXT` into Commander via `.addHelpText`, adds early-exit guards when `--ci` is used without a prompt, without `--channel`, or without channel-specific tokens (`--slack-config-token`, `--telegram-bot-token`); sharpens option descriptions.
- **`agent-onboarding.md`**: Adds a one-line cross-reference to `novu connect --help` with a sync reminder.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one follow-up: the whatsapp/teams headless guard is missing from the CI validation block.

The CI validation block correctly guards prompt, channel presence, and channel-specific tokens for slack and telegram. However, it does not reject --channel whatsapp or --channel teams in --ci mode, even though the help text explicitly documents them as unsupported headlessly. Both values pass all current guards and reach connectCommand, producing a late and opaque error rather than the fail-fast behavior this PR introduces.

The CI validation block in packages/novu/src/index.ts (lines 206–237) needs guards for whatsapp and teams.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/help-text.ts | New file exporting CONNECT_HELP_TEXT constant with copy-paste examples, non-interactive contract, machine-readable stdout markers, and exit-code semantics; content is well-structured and accurate. |
| packages/novu/src/index.ts | Added fail-fast CI validation block and wired help text into Commander; missing guard for --channel whatsapp/teams in --ci mode, which the help text explicitly documents as unsupported headlessly. |
| packages/shared/docs/agent-onboarding.md | Added cross-reference to novu connect --help and a sync reminder; doc-only change, no issues. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[novu connect --ci ...] --> B{prompt present?}
    B -- No --> E1[error + exit 1]
    B -- Yes --> C{channel present?}
    C -- No --> E2[error + exit 1]
    C -- Yes --> D{channel value}
    D -- slack --> F{slackConfigToken?}
    F -- No --> E3[error + exit 1]
    F -- Yes --> OK[connectCommand]
    D -- telegram --> G{telegramBotToken?}
    G -- No --> E4[error + exit 1]
    G -- Yes --> OK
    D -- email/skip --> OK
    D -- whatsapp/teams --> H{CHANNEL_CHOICES check}
    H -- passes --> LATE[connectCommand — late failure ⚠️]
    H -- fails --> E5[error + exit 1]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnovu%2Fsrc%2Findex.ts%3A224-236%0A**%60whatsapp%60%20and%20%60teams%60%20pass%20all%20CI%20guards%20and%20reach%20%60connectCommand%60**%0A%0AThe%20help%20text%20explicitly%20states%20%22%60whatsapp%60%20and%20%60teams%60%20%E2%86%92%20use%20the%20Novu%20dashboard%20instead%3B%20do%20not%20pass%20them%20in%20%60--ci%60%20mode%22%2C%20but%20the%20CI%20validation%20block%20only%20guards%20%60slack%60%20and%20%60telegram%60.%20Passing%20%60--ci%20--channel%20whatsapp%60%20%28or%20%60teams%60%29%20satisfies%20the%20prompt%20check%2C%20the%20channel-presence%20check%2C%20and%20the%20%60CHANNEL_CHOICES%60%20inclusion%20check%20at%20line%20239%20%E2%80%94%20then%20%60connectCommand%60%20is%20called%20with%20a%20channel%20it%20cannot%20handle%20headlessly%2C%20producing%20a%20late%20and%20opaque%20error%20rather%20than%20the%20documented%20fail-fast%20behavior%20this%20PR%20specifically%20introduces.%0A%0A&pr=11504&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/novu/src/index.ts:224-236
**`whatsapp` and `teams` pass all CI guards and reach `connectCommand`**

The help text explicitly states "`whatsapp` and `teams` → use the Novu dashboard instead; do not pass them in `--ci` mode", but the CI validation block only guards `slack` and `telegram`. Passing `--ci --channel whatsapp` (or `teams`) satisfies the prompt check, the channel-presence check, and the `CHANNEL_CHOICES` inclusion check at line 239 — then `connectCommand` is called with a channel it cannot handle headlessly, producing a late and opaque error rather than the documented fail-fast behavior this PR specifically introduces.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(novu): validate channel tokens in --..."](https://github.com/novuhq/novu/commit/510e769cb76580f9519234ad1dec3ea389448fb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36775444)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->