### PR TITLE
feat(novu): telegram QR PNG handoff and --ci channel guard fixes NV-8007

### DIFF
--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -71,6 +71,7 @@ Machine-readable stdout (plain text, no ANSI — watch these in --ci mode):
   Telegram:
     NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=<url>
     NOVU_CONNECT_TELEGRAM_BOT_USERNAME=<name>
+    NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   (only when present)
 
   Success:
     ✓ Your agent is live.

--- a/packages/novu/src/commands/connect/ui/handoff-events.spec.ts
+++ b/packages/novu/src/commands/connect/ui/handoff-events.spec.ts
@@ -4,6 +4,7 @@ import {
   logSlackHandoffEvents,
   logTelegramBotfatherHandoffEvent,
   logTelegramDeepLinkHandoffEvents,
+  logTelegramDeepLinkQrPngHandoffEvent,
   logTelegramMobileLinkHandoffEvent,
 } from './handoff-events';
 
@@ -75,5 +76,13 @@ describe('handoff-events', () => {
 
     expect(log).toHaveBeenCalledWith('NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=https://t.me/mybot?start=abc');
     expect(log).toHaveBeenCalledWith('NOVU_CONNECT_TELEGRAM_BOT_USERNAME=mybot');
+  });
+
+  it('logs the QR PNG path sentinel line', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    logTelegramDeepLinkQrPngHandoffEvent({ deepLinkQrPngPath: '/tmp/novu-connect-qr-abc123.png' });
+
+    expect(log).toHaveBeenCalledWith('NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=/tmp/novu-connect-qr-abc123.png');
   });
 });

--- a/packages/novu/src/commands/connect/ui/handoff-events.ts
+++ b/packages/novu/src/commands/connect/ui/handoff-events.ts
@@ -29,3 +29,7 @@ export function logTelegramDeepLinkHandoffEvents(opts: { deepLinkUrl: string; bo
   console.log(`${HANDOFF_PREFIX}TELEGRAM_DEEPLINK_URL=${opts.deepLinkUrl}`);
   console.log(`${HANDOFF_PREFIX}TELEGRAM_BOT_USERNAME=${opts.botUsername}`);
 }
+
+export function logTelegramDeepLinkQrPngHandoffEvent(opts: { deepLinkQrPngPath: string }): void {
+  console.log(`${HANDOFF_PREFIX}TELEGRAM_DEEPLINK_QR_PNG=${opts.deepLinkQrPngPath}`);
+}

--- a/packages/novu/src/commands/connect/ui/logging-ui.ts
+++ b/packages/novu/src/commands/connect/ui/logging-ui.ts
@@ -10,7 +10,9 @@ import {
   logSlackHandoffEvents,
   logTelegramBotfatherHandoffEvent,
   logTelegramDeepLinkHandoffEvents,
+  logTelegramDeepLinkQrPngHandoffEvent,
 } from './handoff-events';
+import { renderQRPngFile } from './qr';
 import type { ConnectUI, GeneratedAgentPreviewResult, PickResult } from './ui';
 
 export function createLoggingUI(): ConnectUI {
@@ -210,6 +212,9 @@ export function createLoggingUI(): ConnectUI {
       stop();
       console.log(`${chalk.cyan('→')} Open Telegram and tap Start on @${botUsername}: ${chalk.underline(deepLinkUrl)}`);
       logTelegramDeepLinkHandoffEvents({ deepLinkUrl, botUsername });
+      void renderQRPngFile(deepLinkUrl)
+        .then((deepLinkQrPngPath) => logTelegramDeepLinkQrPngHandoffEvent({ deepLinkQrPngPath }))
+        .catch(() => undefined);
     },
     telegramConnected() {
       succeed('Telegram connected');

--- a/packages/novu/src/commands/connect/ui/qr.ts
+++ b/packages/novu/src/commands/connect/ui/qr.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import QRCode from 'qrcode';
@@ -15,6 +16,7 @@ import QRCode from 'qrcode';
 export async function renderQRPngFile(text: string): Promise<string> {
   const filePath = join(tmpdir(), `novu-connect-qr-${randomBytes(6).toString('hex')}.png`);
   await QRCode.toFile(filePath, text, { type: 'png', width: 480, margin: 2 });
+  await chmod(filePath, 0o600);
 
   return filePath;
 }

--- a/packages/novu/src/commands/connect/ui/qr.ts
+++ b/packages/novu/src/commands/connect/ui/qr.ts
@@ -1,4 +1,23 @@
+import { randomBytes } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import QRCode from 'qrcode';
+
+/**
+ * Render a QR code to a PNG file in the OS temp directory and return its
+ * absolute path.
+ *
+ * Used in `--ci` / logging mode where the consumer is an AI agent driving a
+ * chat UI: ASCII QR art breaks there (code blocks add line-height gaps that
+ * slice the modules, and dark themes invert the polarity), while a PNG path
+ * can be embedded inline as a markdown image.
+ */
+export async function renderQRPngFile(text: string): Promise<string> {
+  const filePath = join(tmpdir(), `novu-connect-qr-${randomBytes(6).toString('hex')}.png`);
+  await QRCode.toFile(filePath, text, { type: 'png', width: 480, margin: 2 });
+
+  return filePath;
+}
 
 /**
  * Half-block ASCII QR for terminal rendering.

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -234,6 +234,13 @@ program
         );
         process.exit(1);
       }
+
+      if (channel === 'whatsapp' || channel === 'teams') {
+        console.error(
+          'Non-interactive mode does not support --channel whatsapp or --channel teams. Use the Novu dashboard instead.\n(run `novu connect --help` for the non-interactive contract and examples)'
+        );
+        process.exit(1);
+      }
     }
 
     if (options.channel && !(CHANNEL_CHOICES as readonly string[]).includes(options.channel)) {

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { v4 as uuidv4 } from 'uuid';
 import { DevCommandOptions, devCommand } from './commands';
 import { connectCommand } from './commands/connect';
+import { isDashboardOnlyChannel } from './commands/connect/dashboard-urls';
 import { CONNECT_HELP_TEXT } from './commands/connect/help-text';
 import type { ConnectCommandInput } from './commands/connect/resolve-options';
 import { resolveConnectCommandOptions } from './commands/connect/resolve-options';
@@ -235,7 +236,7 @@ program
         process.exit(1);
       }
 
-      if (channel === 'whatsapp' || channel === 'teams') {
+      if (isDashboardOnlyChannel(channel as ChannelChoice)) {
         console.error(
           'Non-interactive mode does not support --channel whatsapp or --channel teams. Use the Novu dashboard instead.\n(run `novu connect --help` for the non-interactive contract and examples)'
         );

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -236,7 +236,7 @@ program
         process.exit(1);
       }
 
-      if (isDashboardOnlyChannel(channel as ChannelChoice)) {
+      if (options.channel && isDashboardOnlyChannel(options.channel as ChannelChoice)) {
         console.error(
           'Non-interactive mode does not support --channel whatsapp or --channel teams. Use the Novu dashboard instead.\n(run `novu connect --help` for the non-interactive contract and examples)'
         );

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -258,7 +258,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
   NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   # only when present
   ```
 
-  When they appear, embed the **QR code image** inline with markdown — `![Scan with your phone](<absolute png path>)` using the path from `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=` — so the user can scan it from their phone. Never render the QR as ASCII/Unicode art in a code block (chat markdown breaks it and it won't scan). Also give the deep link as a clickable fallback. Ask them to open the bot and tap **Start** on `@<botUsername>` in Telegram. The CLI polls until `/start` is received (~5 min).
+  When they appear, embed the **QR code image** inline with Markdown — `![Scan with your phone](<absolute png path>)` using the path from `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=` — so the user can scan it from their phone. Never render the QR as ASCII/Unicode art in a code block (chat Markdown breaks it and it won't scan). Also give the deep link as a clickable fallback. Ask them to open the bot and tap **Start** on `@<botUsername>` in Telegram. The CLI polls until `/start` is received (~5 min).
 
   Then wait for the CLI poll to finish — the process exits on its own once they tap Start. If it times out (~5 min), **re-run the same command** with the same `--telegram-bot-token`.
 

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -255,9 +255,10 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
   ```
   NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=<url>
   NOVU_CONNECT_TELEGRAM_BOT_USERNAME=<name>
+  NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   # only when present
   ```
 
-  When they appear, give the user the deep link and ask them to open it and tap **Start** on `@<botUsername>` in Telegram. The CLI polls until `/start` is received (~5 min).
+  When they appear, embed the **QR code image** inline with markdown — `![Scan with your phone](<absolute png path>)` using the path from `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=` — so the user can scan it from their phone. Never render the QR as ASCII/Unicode art in a code block (chat markdown breaks it and it won't scan). Also give the deep link as a clickable fallback. Ask them to open the bot and tap **Start** on `@<botUsername>` in Telegram. The CLI polls until `/start` is received (~5 min).
 
   Then wait for the CLI poll to finish — the process exits on its own once they tap Start. If it times out (~5 min), **re-run the same command** with the same `--telegram-bot-token`.
 


### PR DESCRIPTION
## Summary

- Reject `--channel whatsapp` and `--channel teams` in `novu connect --ci` mode via `isDashboardOnlyChannel()`, directing agents to the Novu dashboard instead.
- Emit `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute path>` in logging/`--ci` mode so agents can embed a scannable QR image in chat (ASCII QR art breaks in markdown code blocks).
- Document the new sentinel in `connect --help`, `agent-onboarding.md`, and unit tests.

```mermaid
sequenceDiagram
  participant Agent
  participant CLI as novu connect --ci
  participant LogUI as logging-ui
  participant FS as temp PNG

  Agent->>CLI: --channel telegram --telegram-bot-token ...
  CLI->>LogUI: showTelegramTest(deepLinkUrl)
  LogUI->>Agent: NOVU_CONNECT_TELEGRAM_DEEPLINK_URL
  LogUI->>Agent: NOVU_CONNECT_TELEGRAM_BOT_USERNAME
  LogUI->>FS: renderQRPngFile(deepLinkUrl)
  FS-->>LogUI: /tmp/novu-connect-qr-*.png
  LogUI->>Agent: NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG
  Agent->>Agent: ![Scan](path) in chat UI
```

## Test plan

- [ ] `novu connect "test" --ci --channel whatsapp` exits non-zero with dashboard-only message
- [ ] `novu connect "test" --ci --channel teams` exits non-zero with dashboard-only message
- [ ] `novu connect "test" --ci --channel telegram --telegram-bot-token "<token>"` prints `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=/tmp/novu-connect-qr-….png`
- [ ] `pnpm --filter novu exec vitest run src/commands/connect/ui/handoff-events.spec.ts` passes
- [ ] `pnpm --filter novu build` passes

Linear: [NV-8007](https://linear.app/novu/issue/NV-8007)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The CLI's non-interactive (--ci) connect flow now fail-fast rejects dashboard-only channels (whatsapp, teams) by checking the raw channel option early, preventing bypass via flags like --skip-slack. The Telegram flow now generates a 480×480 PNG deep-link QR in the OS temp directory (random filename, chmod 0o600) and emits a machine-readable sentinel line (NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute path>) to stdout for CI consumers. QR generation runs asynchronously and errors are swallowed so the CLI is not blocked.

## Affected areas

**js** — packages/novu: Added an early isDashboardOnlyChannel guard in the non-interactive connect flow; wired Telegram deep-link flow to an async renderQRPngFile(text) helper that writes a randomized, permission-hardened PNG to tmpdir and logs a CI handoff sentinel; updated logging/UI to emit the sentinel non-blockingly; updated CLI help text.

**shared** — docs: Updated agent-onboarding and connect help docs to document the NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG sentinel and guidance for embedding the provided PNG path.

## Key technical decisions

- Reject dashboard-only channels early using the existing isDashboardOnlyChannel helper to keep non-interactive behavior deterministic and prevent flag-based bypasses.
- Produce QR as a temp PNG with a randomized filename and strict file perms (0o600), emit only the absolute path as the CI handoff, and render fire-and-forget (suppressing errors) to avoid blocking the CLI.

## Testing

Added a unit test validating the Telegram QR PNG handoff logger prints the sentinel; updated relevant tests and help-text checks. Manual/build verification covered --ci rejection for whatsapp/teams and the QR sentinel output. No DB, API contract, enterprise changes, or new npm dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two features to the `novu connect --ci` flow: an early-rejection guard for dashboard-only channels (`whatsapp`, `teams`) using the shared `isDashboardOnlyChannel()` helper, and a Telegram QR PNG handoff that writes a temp PNG and emits a machine-readable `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<path>` sentinel for agents to embed as a scannable image.

- **Dashboard-only channel guard** (`index.ts`): checks `options.channel` directly (not the coerced `channel` variable), correctly blocking the `--skip-slack --channel whatsapp` bypass. Guard fires before `resolveConnectCommandOptions`.
- **QR PNG generation** (`qr.ts`, `logging-ui.ts`): `renderQRPngFile` writes a collision-safe temp PNG (randomised hex suffix, `chmod 0o600`); called fire-and-forget inside `showTelegramTest` so it doesn't block the CLI's Telegram polling loop; errors are swallowed by design.
- **Docs & tests** (`help-text.ts`, `agent-onboarding.md`, `handoff-events.spec.ts`): sentinel documented with an "(only when present)" caveat; unit test and help text updated to match.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to a CI-mode channel guard and async PNG generation for the Telegram handoff path; neither touches auth, data persistence, or shared state.

The guard correctly tests `options.channel` directly, closing the previously noted `--skip-slack` bypass. The QR PNG generation is fire-and-forget with all errors explicitly caught, so it cannot crash or block the CLI. The only concerns are a brief TOCTOU window between file creation and `chmod`, and temp PNGs never being cleaned up — both minor and unlikely to affect users in practice.

packages/novu/src/commands/connect/ui/qr.ts — the chmod race window and absence of cleanup are worth a second look if file-system hygiene on shared CI machines matters.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/ui/qr.ts | Adds renderQRPngFile helper that writes a collision-safe PNG to tmpdir; has a brief TOCTOU window between toFile and chmod, and temp files are never cleaned up. |
| packages/novu/src/index.ts | Adds isDashboardOnlyChannel guard for whatsapp/teams in --ci mode; guard correctly checks options.channel directly to prevent bypass via --skip-slack. |
| packages/novu/src/commands/connect/ui/logging-ui.ts | Wires fire-and-forget renderQRPngFile call inside showTelegramTest, emitting the QR path sentinel asynchronously after the deep link sentinels; errors are intentionally swallowed. |
| packages/novu/src/commands/connect/ui/handoff-events.ts | Adds logTelegramDeepLinkQrPngHandoffEvent, a simple console.log wrapper for the new NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG sentinel line. |
| packages/novu/src/commands/connect/ui/handoff-events.spec.ts | Adds a unit test asserting the new QR PNG path sentinel is logged correctly; follows the existing test pattern. |
| packages/novu/src/commands/connect/help-text.ts | Documents the new NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG sentinel in the --help output with a clear "only when present" caveat. |
| packages/shared/docs/agent-onboarding.md | Updates agent-onboarding guide to document the QR PNG sentinel and instruct agents to embed it as a Markdown image instead of ASCII art. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Agent
  participant CLI as novu connect --ci
  participant Guard as isDashboardOnlyChannel
  participant LogUI as logging-ui
  participant FS as tmpdir PNG

  Agent->>CLI: --ci --channel whatsapp/teams
  CLI->>Guard: isDashboardOnlyChannel(options.channel)
  Guard-->>CLI: true
  CLI-->>Agent: exit(1) + dashboard redirect message

  Agent->>CLI: --ci --channel telegram --telegram-bot-token ...
  CLI->>LogUI: showTelegramTest(deepLinkUrl, botUsername)
  LogUI->>Agent: NOVU_CONNECT_TELEGRAM_DEEPLINK_URL (sync)
  LogUI->>Agent: NOVU_CONNECT_TELEGRAM_BOT_USERNAME (sync)
  LogUI->>FS: renderQRPngFile(deepLinkUrl) [fire-and-forget]
  Note over FS: QRCode.toFile then chmod 0o600
  FS-->>LogUI: "/tmp/novu-connect-qr-*.png"
  LogUI->>Agent: NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG (async)
  Agent->>Agent: embed Scan image in chat UI
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fui%2Fqr.ts%3A18-19%0A**Brief%20TOCTOU%20window%20between%20file%20creation%20and%20permission%20hardening**%0A%0A%60QRCode.toFile%60%20creates%20the%20file%20with%20default%20permissions%20derived%20from%20the%20process%20umask%20%28typically%20%600o644%60%20on%20Linux%2C%20allowing%20world-read%29%2C%20and%20%60chmod%280o600%29%60%20is%20only%20applied%20afterwards.%20There%20is%20a%20small%20window%20between%20the%20two%20%60await%60%20calls%20where%20another%20process%20on%20the%20same%20machine%20could%20read%20the%20file.%20For%20a%20Telegram%20deep%20link%20this%20is%20low%20risk%2C%20but%20if%20stricter%20hygiene%20is%20wanted%2C%20one%20option%20is%20to%20open%20a%20%60FileHandle%60%20with%20mode%20%600o600%60%20first%20and%20then%20pass%20the%20file%20descriptor%20to%20a%20manual%20write%20%E2%80%94%20or%20to%20set%20a%20restrictive%20umask%20around%20the%20%60toFile%60%20call.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fui%2Fqr.ts%3A16-22%0A**Temp%20PNG%20files%20are%20never%20cleaned%20up**%0A%0AEach%20call%20to%20%60renderQRPngFile%60%20writes%20a%20new%20%60novu-connect-qr-*.png%60%20to%20%60tmpdir%28%29%60%20with%20no%20deletion%20on%20process%20exit%20or%20success%2Ffailure.%20Repeated%20%60--ci%20--channel%20telegram%60%20runs%20accumulate%20files.%20Since%20%60chmod%280o600%29%60%20prevents%20OS%20temp-sweeping%20tools%20from%20deleting%20other-user%20files%20on%20shared%20machines%2C%20the%20files%20will%20persist%20until%20the%20owning%20user%20clears%20them.%20If%20cleanup%20is%20not%20desired%20%28the%20agent%20needs%20the%20file%20to%20stay%20for%20embedding%29%2C%20this%20is%20acceptable%20%E2%80%94%20but%20it%20is%20worth%20documenting%20that%20the%20file%20is%20intentionally%20left%20on%20disk.%0A%0A&pr=11505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/novu/src/commands/connect/ui/qr.ts:18-19
**Brief TOCTOU window between file creation and permission hardening**

`QRCode.toFile` creates the file with default permissions derived from the process umask (typically `0o644` on Linux, allowing world-read), and `chmod(0o600)` is only applied afterwards. There is a small window between the two `await` calls where another process on the same machine could read the file. For a Telegram deep link this is low risk, but if stricter hygiene is wanted, one option is to open a `FileHandle` with mode `0o600` first and then pass the file descriptor to a manual write — or to set a restrictive umask around the `toFile` call.

### Issue 2 of 2
packages/novu/src/commands/connect/ui/qr.ts:16-22
**Temp PNG files are never cleaned up**

Each call to `renderQRPngFile` writes a new `novu-connect-qr-*.png` to `tmpdir()` with no deletion on process exit or success/failure. Repeated `--ci --channel telegram` runs accumulate files. Since `chmod(0o600)` prevents OS temp-sweeping tools from deleting other-user files on shared machines, the files will persist until the owning user clears them. If cleanup is not desired (the agent needs the file to stay for embedding), this is acceptable — but it is worth documenting that the file is intentionally left on disk.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(shared): capitalize Markdown in age..."](https://github.com/novuhq/novu/commit/0fb6c8dac3012e70f29fcd397e8eb9b294705c08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36781531)</sub>

<!-- /greptile_comment -->