### PR TITLE
feat(novu): secure setup links for Slack/Telegram secrets fixes NV-8008

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import {
   CalculateDemoClaudeQuota,
   CalculateLimitNovuIntegration,
@@ -23,6 +23,7 @@ import { AuthModule } from '../auth/auth.module';
 import { ChannelEndpointsModule } from '../channel-endpoints/channel-endpoints.module';
 import { ConnectModule } from '../connect/connect.module';
 import { EventsModule } from '../events/events.module';
+import { IntegrationModule } from '../integrations/integrations.module';
 import { KeylessModule } from '../keyless/keyless.module';
 import { SharedModule } from '../shared/shared.module';
 import { AgentConfigResolver } from './channels/agent-config-resolver.service';
@@ -66,7 +67,15 @@ import { AgentRuntimeExceptionFilter } from './shared/agent-runtime-exception.fi
 import { USE_CASES } from './usecases';
 
 @Module({
-  imports: [SharedModule, AuthModule, EventsModule, ChannelEndpointsModule, ConnectModule, KeylessModule],
+  imports: [
+    SharedModule,
+    AuthModule,
+    EventsModule,
+    ChannelEndpointsModule,
+    ConnectModule,
+    KeylessModule,
+    forwardRef(() => IntegrationModule),
+  ],
   controllers: [
     AgentsController,
     AgentIntegrationsController,

--- a/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
+++ b/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
@@ -48,6 +48,7 @@ import {
 } from '../../shared/dtos';
 import { ConfigureTelegramWebhookResponseDto } from '../../shared/dtos/configure-telegram-webhook-response.dto';
 import { ConfigureWhatsAppWebhookResponseDto } from '../../shared/dtos/configure-whatsapp-webhook-response.dto';
+import { IssueSlackSetupLinkResponseDto } from '../../shared/dtos/issue-slack-setup-link-response.dto';
 import { IssueTelegramMobileLinkRequestDto } from '../../shared/dtos/issue-telegram-mobile-link-request.dto';
 import { IssueTelegramMobileLinkResponseDto } from '../../shared/dtos/issue-telegram-mobile-link-response.dto';
 import { IssueTelegramSubscriberLinkRequestDto } from '../../shared/dtos/issue-telegram-subscriber-link-request.dto';
@@ -58,6 +59,8 @@ import {
   SendWhatsAppTestTemplateRequestDto,
   SendWhatsAppTestTemplateResponseDto,
 } from '../../shared/dtos/send-whatsapp-test-template.dto';
+import { IssueSlackSetupLinkCommand } from '../slack-linking/issue-slack-setup-link/issue-slack-setup-link.command';
+import { IssueSlackSetupLink } from '../slack-linking/issue-slack-setup-link/issue-slack-setup-link.usecase';
 import { ConfigureTelegramAgentWebhookCommand } from '../telegram/configure-telegram-agent-webhook/configure-telegram-agent-webhook.command';
 import { ConfigureTelegramAgentWebhook } from '../telegram/configure-telegram-agent-webhook/configure-telegram-agent-webhook.usecase';
 import { IssueTelegramMobileLinkCommand } from '../telegram-linking/issue-telegram-mobile-link/issue-telegram-mobile-link.command';
@@ -95,6 +98,7 @@ export class AgentIntegrationsController {
     private readonly sendWhatsAppTestTemplateUsecase: SendWhatsAppTestTemplate,
     private readonly configureTelegramAgentWebhookUsecase: ConfigureTelegramAgentWebhook,
     private readonly issueTelegramMobileLinkUsecase: IssueTelegramMobileLink,
+    private readonly issueSlackSetupLinkUsecase: IssueSlackSetupLink,
     private readonly issueTelegramSubscriberLinkUsecase: IssueTelegramSubscriberLink,
     private readonly updateAgentInboxSharedUsecase: UpdateAgentInboxShared
   ) {}
@@ -420,6 +424,37 @@ export class AgentIntegrationsController {
         agentIdentifier: identifier,
         integrationId,
         subscriberId: body?.subscriberId,
+      })
+    );
+  }
+
+  @Post('/:identifier/integrations/:integrationId/slack/setup-link')
+  @ExternalApiAccessible()
+  @KeylessAccessible()
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse(IssueSlackSetupLinkResponseDto, 200)
+  @ApiOperation({
+    summary: 'Issue a short-lived Slack setup link',
+    description:
+      'Issues a signed, single-use link (TTL = 5 minutes) that can be opened to paste a Slack App ' +
+      'Configuration Token without re-authenticating. Slack-only.',
+  })
+  @ApiNotFoundResponse({
+    description: 'The agent, integration, or agent-integration link was not found.',
+  })
+  @RequirePermissions(PermissionsEnum.AGENT_WRITE)
+  createSlackSetupLink(
+    @UserSession() user: UserSessionData,
+    @Param('identifier') identifier: string,
+    @Param('integrationId') integrationId: string
+  ): Promise<IssueSlackSetupLinkResponseDto> {
+    return this.issueSlackSetupLinkUsecase.execute(
+      IssueSlackSetupLinkCommand.create({
+        userId: user._id,
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        agentIdentifier: identifier,
+        integrationId,
       })
     );
   }

--- a/apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.command.ts
+++ b/apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.command.ts
@@ -1,0 +1,12 @@
+import { BaseCommand } from '@novu/application-generic';
+import { IsDefined, IsString } from 'class-validator';
+
+export class ConsumeSlackSetupLinkCommand extends BaseCommand {
+  @IsDefined()
+  @IsString()
+  token: string;
+
+  @IsDefined()
+  @IsString()
+  configToken: string;
+}

--- a/apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase.ts
+++ b/apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase.ts
@@ -1,0 +1,118 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { AgentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+import { SlackQuickSetupCommand } from '../../../../integrations/usecases/slack-quick-setup/slack-quick-setup.command';
+import { SlackQuickSetup } from '../../../../integrations/usecases/slack-quick-setup/slack-quick-setup.usecase';
+import {
+  InvalidTelegramMobileTokenError,
+  SlackAgentSetupLinkPayload,
+  TelegramMobileLinkTokenService,
+} from '../../telegram-linking/telegram-mobile-link-token.service';
+import { ConsumeSlackSetupLinkCommand } from './consume-slack-setup-link.command';
+
+export interface ConsumeSlackSetupLinkResult {
+  success: true;
+}
+
+@Injectable()
+export class ConsumeSlackSetupLink {
+  constructor(
+    private readonly tokenService: TelegramMobileLinkTokenService,
+    private readonly agentRepository: AgentRepository,
+    private readonly integrationRepository: IntegrationRepository,
+    private readonly slackQuickSetupUsecase: SlackQuickSetup,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async execute(command: ConsumeSlackSetupLinkCommand): Promise<ConsumeSlackSetupLinkResult> {
+    const claimed = await this.claimToken(command.token);
+    const payload = claimed.payload as SlackAgentSetupLinkPayload;
+
+    try {
+      const agent = await this.agentRepository.findOne(
+        {
+          identifier: payload.aid,
+          _environmentId: payload.env,
+          _organizationId: payload.org,
+        },
+        ['_id']
+      );
+
+      if (!agent) {
+        throw new NotFoundException('Agent referenced by this link no longer exists.');
+      }
+
+      const integration = await this.integrationRepository.findOne(
+        {
+          _id: payload.iid,
+          _environmentId: payload.env,
+          _organizationId: payload.org,
+        },
+        '_id providerId'
+      );
+
+      if (!integration) {
+        throw new NotFoundException('Integration referenced by this link no longer exists.');
+      }
+
+      if (integration.providerId !== ChatProviderIdEnum.Slack) {
+        throw new BadRequestException('This link is not a Slack setup link.');
+      }
+
+      await this.slackQuickSetupUsecase.execute(
+        SlackQuickSetupCommand.create({
+          userId: 'slack-setup-link',
+          environmentId: payload.env,
+          organizationId: payload.org,
+          integrationId: integration._id,
+          agentId: agent._id,
+          configToken: command.configToken,
+        })
+      );
+
+      return { success: true };
+    } catch (err) {
+      try {
+        await this.tokenService.release(command.token, claimed);
+      } catch (releaseErr) {
+        this.logger.error(`Slack setup token rollback failed: ${(releaseErr as Error).message}`);
+      }
+      this.logger.warn(`Slack setup consume failed: ${(err as Error).message}`);
+      throw err;
+    }
+  }
+
+  private async claimToken(token: string) {
+    try {
+      return await this.tokenService.claim(token, 'slack-agent-setup');
+    } catch (err) {
+      if (err instanceof InvalidTelegramMobileTokenError) {
+        if (err.reason === 'used') {
+          throw new ConflictException({
+            code: 'token_already_used',
+            message: 'This setup link has already been used. Generate a new one from your dashboard.',
+          });
+        }
+
+        throw new UnauthorizedException({
+          code: err.reason === 'expired' ? 'token_expired' : 'token_invalid',
+          message:
+            err.reason === 'expired'
+              ? 'This setup link has expired. Generate a new one from your dashboard.'
+              : 'This setup link is invalid.',
+        });
+      }
+
+      throw err;
+    }
+  }
+}

--- a/apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase.ts
+++ b/apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase.ts
@@ -21,6 +21,12 @@ export interface ConsumeSlackSetupLinkResult {
   success: true;
 }
 
+/**
+ * Sentinel userId for Slack quick-setup invoked from the public setup page.
+ * Satisfies OrganizationCommand validation; not a real Novu user.
+ */
+const SYNTHETIC_USER_ID = 'slack-setup-link';
+
 @Injectable()
 export class ConsumeSlackSetupLink {
   constructor(
@@ -70,7 +76,7 @@ export class ConsumeSlackSetupLink {
 
       await this.slackQuickSetupUsecase.execute(
         SlackQuickSetupCommand.create({
-          userId: 'slack-setup-link',
+          userId: SYNTHETIC_USER_ID,
           environmentId: payload.env,
           organizationId: payload.org,
           integrationId: integration._id,

--- a/apps/api/src/app/agents/channels/slack-linking/get-slack-setup-link-status/get-slack-setup-link-status.command.ts
+++ b/apps/api/src/app/agents/channels/slack-linking/get-slack-setup-link-status/get-slack-setup-link-status.command.ts
@@ -1,0 +1,8 @@
+import { BaseCommand } from '@novu/application-generic';
+import { IsDefined, IsString } from 'class-validator';
+
+export class GetSlackSetupLinkStatusCommand extends BaseCommand {
+  @IsDefined()
+  @IsString()
+  token: string;
+}

--- a/apps/api/src/app/agents/channels/slack-linking/get-slack-setup-link-status/get-slack-setup-link-status.usecase.ts
+++ b/apps/api/src/app/agents/channels/slack-linking/get-slack-setup-link-status/get-slack-setup-link-status.usecase.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import { AgentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+
+import {
+  InvalidTelegramMobileTokenError,
+  SlackAgentSetupLinkPayload,
+  TelegramMobileLinkTokenService,
+} from '../../telegram-linking/telegram-mobile-link-token.service';
+import { GetSlackSetupLinkStatusCommand } from './get-slack-setup-link-status.command';
+
+export type GetSlackSetupLinkStatusResult =
+  | { valid: true; agentName: string; providerName: 'slack' }
+  | { valid: false; reason: 'expired' | 'used' | 'invalid' };
+
+@Injectable()
+export class GetSlackSetupLinkStatus {
+  constructor(
+    private readonly tokenService: TelegramMobileLinkTokenService,
+    private readonly agentRepository: AgentRepository,
+    private readonly integrationRepository: IntegrationRepository
+  ) {}
+
+  async execute(command: GetSlackSetupLinkStatusCommand): Promise<GetSlackSetupLinkStatusResult> {
+    let payload: SlackAgentSetupLinkPayload;
+    try {
+      payload = await this.tokenService.verifySlackAgentSetup(command.token);
+    } catch (err) {
+      if (err instanceof InvalidTelegramMobileTokenError) {
+        return { valid: false, reason: err.reason };
+      }
+
+      throw err;
+    }
+
+    const integration = await this.integrationRepository.findOne(
+      {
+        _id: payload.iid,
+        _environmentId: payload.env,
+        _organizationId: payload.org,
+      },
+      '_id providerId'
+    );
+
+    if (!integration || integration.providerId !== ChatProviderIdEnum.Slack) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    const agent = await this.agentRepository.findOne(
+      {
+        identifier: payload.aid,
+        _environmentId: payload.env,
+        _organizationId: payload.org,
+      },
+      ['name']
+    );
+
+    if (!agent) {
+      return { valid: false, reason: 'invalid' };
+    }
+
+    return { valid: true, agentName: agent.name, providerName: 'slack' };
+  }
+}

--- a/apps/api/src/app/agents/channels/slack-linking/issue-slack-setup-link/issue-slack-setup-link.command.ts
+++ b/apps/api/src/app/agents/channels/slack-linking/issue-slack-setup-link/issue-slack-setup-link.command.ts
@@ -1,0 +1,13 @@
+import { IsDefined, IsMongoId, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../../shared/commands/project.command';
+
+export class IssueSlackSetupLinkCommand extends EnvironmentWithUserCommand {
+  @IsDefined()
+  @IsString()
+  agentIdentifier: string;
+
+  @IsDefined()
+  @IsMongoId()
+  integrationId: string;
+}

--- a/apps/api/src/app/agents/channels/slack-linking/issue-slack-setup-link/issue-slack-setup-link.usecase.ts
+++ b/apps/api/src/app/agents/channels/slack-linking/issue-slack-setup-link/issue-slack-setup-link.usecase.ts
@@ -1,0 +1,94 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+
+import { TelegramMobileLinkTokenService } from '../../telegram-linking/telegram-mobile-link-token.service';
+import { IssueSlackSetupLinkCommand } from './issue-slack-setup-link.command';
+
+export interface IssueSlackSetupLinkResult {
+  token: string;
+  /** Absolute URL the user can open to paste their Slack App Configuration Token. */
+  url: string;
+  /** ISO timestamp when the link expires. */
+  expiresAt: string;
+}
+
+const SLACK_SETUP_PATH = '/agents/slack/connect';
+
+@Injectable()
+export class IssueSlackSetupLink {
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly integrationRepository: IntegrationRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly tokenService: TelegramMobileLinkTokenService
+  ) {}
+
+  async execute(command: IssueSlackSetupLinkCommand): Promise<IssueSlackSetupLinkResult> {
+    const agent = await this.agentRepository.findOne(
+      {
+        identifier: command.agentIdentifier,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      ['_id', 'identifier']
+    );
+
+    if (!agent) {
+      throw new NotFoundException(`Agent with identifier "${command.agentIdentifier}" was not found.`);
+    }
+
+    const integration = await this.integrationRepository.findOne(
+      {
+        _id: command.integrationId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      '_id providerId'
+    );
+
+    if (!integration) {
+      throw new NotFoundException(`Integration ${command.integrationId} not found`);
+    }
+
+    if (integration.providerId !== ChatProviderIdEnum.Slack) {
+      throw new BadRequestException('Slack setup link is only available for Slack integrations.');
+    }
+
+    const link = await this.agentIntegrationRepository.findOne(
+      {
+        _agentId: agent._id,
+        _integrationId: integration._id,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      ['_id']
+    );
+
+    if (!link) {
+      throw new NotFoundException('Integration is not linked to this agent');
+    }
+
+    const { token, expiresAt } = await this.tokenService.issueForSlackAgentSetup({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      agentIdentifier: agent.identifier,
+      integrationId: integration._id,
+    });
+
+    return {
+      token,
+      expiresAt,
+      url: this.buildSetupUrl(token),
+    };
+  }
+
+  private buildSetupUrl(token: string): string {
+    const base = (process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL || 'https://dashboard.novu.co').replace(
+      /\/$/,
+      ''
+    );
+
+    return `${base}${SLACK_SETUP_PATH}/${token}`;
+  }
+}

--- a/apps/api/src/app/agents/channels/telegram-linking/agents-public.controller.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/agents-public.controller.ts
@@ -5,10 +5,22 @@ import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { ThrottlerCategory } from '../../../rate-limiting/guards';
 import { ApiCommonResponses, ApiResponse } from '../../../shared/framework/response.decorator';
 import {
+  ConsumeSlackSetupLinkRequestDto,
+  ConsumeSlackSetupLinkResponseDto,
+} from '../../shared/dtos/consume-slack-setup-link.dto';
+import {
   ConsumeTelegramMobileLinkRequestDto,
   ConsumeTelegramMobileLinkResponseDto,
 } from '../../shared/dtos/consume-telegram-mobile-link.dto';
+import { SlackSetupLinkStatusResponseDto } from '../../shared/dtos/slack-setup-link-status-response.dto';
 import { TelegramMobileLinkStatusResponseDto } from '../../shared/dtos/telegram-mobile-link-status-response.dto';
+import { ConsumeSlackSetupLinkCommand } from '../slack-linking/consume-slack-setup-link/consume-slack-setup-link.command';
+import { ConsumeSlackSetupLink } from '../slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase';
+import { GetSlackSetupLinkStatusCommand } from '../slack-linking/get-slack-setup-link-status/get-slack-setup-link-status.command';
+import {
+  GetSlackSetupLinkStatus,
+  type GetSlackSetupLinkStatusResult,
+} from '../slack-linking/get-slack-setup-link-status/get-slack-setup-link-status.usecase';
 import { ConsumeTelegramMobileLinkCommand } from './consume-telegram-mobile-link/consume-telegram-mobile-link.command';
 import { ConsumeTelegramMobileLink } from './consume-telegram-mobile-link/consume-telegram-mobile-link.usecase';
 import { GetTelegramMobileLinkStatusCommand } from './get-telegram-mobile-link-status/get-telegram-mobile-link-status.command';
@@ -19,7 +31,7 @@ import {
 
 /**
  * Public, unauthenticated agent endpoints (no session). Add provider-specific
- * route groups under this controller — today only Telegram mobile configure.
+ * route groups under this controller (Telegram mobile configure, Slack setup).
  *
  * Telegram: authorization is an opaque, single-use, short-lived token stored in
  * Redis; the dashboard issues it via authed
@@ -35,7 +47,9 @@ import {
 export class AgentsPublicController {
   constructor(
     private readonly getTelegramMobileLinkStatusUsecase: GetTelegramMobileLinkStatus,
-    private readonly consumeTelegramMobileLinkUsecase: ConsumeTelegramMobileLink
+    private readonly consumeTelegramMobileLinkUsecase: ConsumeTelegramMobileLink,
+    private readonly getSlackSetupLinkStatusUsecase: GetSlackSetupLinkStatus,
+    private readonly consumeSlackSetupLinkUsecase: ConsumeSlackSetupLink
   ) {}
 
   @Get('telegram/mobile-configure/status')
@@ -71,5 +85,36 @@ export class AgentsPublicController {
     );
 
     return result;
+  }
+
+  @Get('slack/setup/status')
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse(SlackSetupLinkStatusResponseDto, 200)
+  @ApiOperation({
+    summary: 'Check the status of a Slack setup link',
+    description:
+      'Returns whether a Slack setup token is still usable. Designed to be called from the ' +
+      'setup landing page before showing the credentials form.',
+  })
+  async getSlackSetupStatus(@Query('token') token: string): Promise<GetSlackSetupLinkStatusResult> {
+    return this.getSlackSetupLinkStatusUsecase.execute(GetSlackSetupLinkStatusCommand.create({ token: token ?? '' }));
+  }
+
+  @Post('slack/setup')
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse(ConsumeSlackSetupLinkResponseDto, 200)
+  @ApiOperation({
+    summary: 'Consume a Slack setup link',
+    description:
+      'Validates the setup token, runs Slack quick-setup with the supplied App Configuration Token, ' +
+      'and creates the Slack app from the Novu manifest. The token becomes invalid after a successful call.',
+  })
+  async consumeSlackSetup(@Body() body: ConsumeSlackSetupLinkRequestDto): Promise<ConsumeSlackSetupLinkResponseDto> {
+    return this.consumeSlackSetupLinkUsecase.execute(
+      ConsumeSlackSetupLinkCommand.create({
+        token: body.token,
+        configToken: body.configToken,
+      })
+    );
   }
 }

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
@@ -55,7 +55,7 @@ redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
 redis.call('DEL', KEYS[2])
 `;
 
-export type TelegramMobileLinkKind = 'agent' | 'integration-store';
+export type TelegramMobileLinkKind = 'agent' | 'integration-store' | 'slack-agent-setup';
 
 export interface TelegramMobileLinkTokenPayload {
   kind: 'agent';
@@ -82,7 +82,20 @@ export interface IntegrationStoreTelegramMobileLinkPayload {
   org: string;
 }
 
-type StoredPayload = TelegramMobileLinkTokenPayload | IntegrationStoreTelegramMobileLinkPayload;
+export interface SlackAgentSetupLinkPayload {
+  kind: 'slack-agent-setup';
+  env: string;
+  org: string;
+  /** Agent external identifier. */
+  aid: string;
+  /** Integration id (internal Mongo `_id`). */
+  iid: string;
+}
+
+type StoredPayload =
+  | TelegramMobileLinkTokenPayload
+  | IntegrationStoreTelegramMobileLinkPayload
+  | SlackAgentSetupLinkPayload;
 
 interface StoredEntry {
   payload: StoredPayload;
@@ -158,6 +171,23 @@ export class TelegramMobileLinkTokenService {
     return this.mint(payload);
   }
 
+  async issueForSlackAgentSetup(params: {
+    environmentId: string;
+    organizationId: string;
+    agentIdentifier: string;
+    integrationId: string;
+  }): Promise<IssuedTelegramMobileLink> {
+    const payload: SlackAgentSetupLinkPayload = {
+      kind: 'slack-agent-setup',
+      env: params.environmentId,
+      org: params.organizationId,
+      aid: params.agentIdentifier,
+      iid: params.integrationId,
+    };
+
+    return this.mint(payload);
+  }
+
   /**
    * Reads the stored payload without consuming the token (safe for status/prefetch).
    */
@@ -167,6 +197,10 @@ export class TelegramMobileLinkTokenService {
 
   async verifyIntegrationStore(token: string): Promise<IntegrationStoreTelegramMobileLinkPayload> {
     return this.peek(token, 'integration-store') as Promise<IntegrationStoreTelegramMobileLinkPayload>;
+  }
+
+  async verifySlackAgentSetup(token: string): Promise<SlackAgentSetupLinkPayload> {
+    return this.peek(token, 'slack-agent-setup') as Promise<SlackAgentSetupLinkPayload>;
   }
 
   /** Returns whether a token was already consumed (used marker present). */
@@ -319,6 +353,11 @@ export class TelegramMobileLinkTokenService {
       if (!agentPayload.env || !agentPayload.org || !agentPayload.aid || !agentPayload.iid) {
         throw new InvalidTelegramMobileTokenError('invalid');
       }
+    } else if (entry.payload.kind === 'slack-agent-setup') {
+      const slackPayload = entry.payload;
+      if (!slackPayload.env || !slackPayload.org || !slackPayload.aid || !slackPayload.iid) {
+        throw new InvalidTelegramMobileTokenError('invalid');
+      }
     } else if (!entry.payload.env || !entry.payload.org) {
       throw new InvalidTelegramMobileTokenError('invalid');
     }
@@ -334,7 +373,7 @@ export class TelegramMobileLinkTokenService {
       }
 
       const payload = parsed.payload;
-      if (payload.kind !== 'agent' && payload.kind !== 'integration-store') {
+      if (payload.kind !== 'agent' && payload.kind !== 'integration-store' && payload.kind !== 'slack-agent-setup') {
         return null;
       }
 

--- a/apps/api/src/app/agents/shared/dtos/consume-slack-setup-link.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/consume-slack-setup-link.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+const SLACK_CONFIG_TOKEN_PATTERN = /^xoxe\.xoxp-/;
+
+export class ConsumeSlackSetupLinkRequestDto {
+  @ApiProperty({ type: String, description: 'Signed Slack setup token issued by the connect CLI' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Slack App Configuration Token (xoxe.xoxp-…) from api.slack.com/apps',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(SLACK_CONFIG_TOKEN_PATTERN, {
+    message: 'configToken must be a Slack App Configuration Token (xoxe.xoxp-…)',
+  })
+  configToken: string;
+}
+
+export class ConsumeSlackSetupLinkResponseDto {
+  @ApiProperty({ type: Boolean })
+  success: boolean;
+}

--- a/apps/api/src/app/agents/shared/dtos/issue-slack-setup-link-response.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/issue-slack-setup-link-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IssueSlackSetupLinkResponseDto {
+  @ApiProperty({ type: String, description: 'Opaque setup token identifying this setup session' })
+  token: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Absolute URL the user opens to paste their Slack App Configuration Token',
+  })
+  url: string;
+
+  @ApiProperty({ type: String, description: 'ISO-8601 expiry timestamp' })
+  expiresAt: string;
+}

--- a/apps/api/src/app/agents/shared/dtos/slack-setup-link-status-response.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/slack-setup-link-status-response.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SlackSetupLinkStatusResponseDto {
+  @ApiProperty({ type: Boolean })
+  valid: boolean;
+
+  @ApiPropertyOptional({
+    type: String,
+    enum: ['expired', 'used', 'invalid'],
+    description: 'Populated when valid is false',
+  })
+  reason?: 'expired' | 'used' | 'invalid';
+
+  @ApiPropertyOptional({ type: String, description: 'Display name of the agent being configured' })
+  agentName?: string;
+
+  @ApiPropertyOptional({ type: String, description: 'Provider being configured (always "slack")' })
+  providerName?: string;
+}

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -2,6 +2,9 @@ import { AddAgentIntegration } from '../channels/integrations/add-agent-integrat
 import { ListAgentIntegrations } from '../channels/integrations/list-agent-integrations/list-agent-integrations.usecase';
 import { RemoveAgentIntegration } from '../channels/integrations/remove-agent-integration/remove-agent-integration.usecase';
 import { UpdateAgentIntegration } from '../channels/integrations/update-agent-integration/update-agent-integration.usecase';
+import { ConsumeSlackSetupLink } from '../channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase';
+import { GetSlackSetupLinkStatus } from '../channels/slack-linking/get-slack-setup-link-status/get-slack-setup-link-status.usecase';
+import { IssueSlackSetupLink } from '../channels/slack-linking/issue-slack-setup-link/issue-slack-setup-link.usecase';
 import { ConfigureTelegramAgentWebhook } from '../channels/telegram/configure-telegram-agent-webhook/configure-telegram-agent-webhook.usecase';
 import { ConsumeTelegramMobileLink } from '../channels/telegram-linking/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase';
 import { GetTelegramMobileLinkStatus } from '../channels/telegram-linking/get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase';
@@ -47,8 +50,11 @@ import { ListAgentEmoji } from '../shared/emoji/list-agent-emoji/list-agent-emoj
 
 export {
   ConfigureTelegramAgentWebhook,
+  ConsumeSlackSetupLink,
   ConsumeTelegramMobileLink,
+  GetSlackSetupLinkStatus,
   GetTelegramMobileLinkStatus,
+  IssueSlackSetupLink,
   IssueTelegramMobileLink,
   IssueTelegramSubscriberLink,
   LinkTelegramChatToSubscriber,
@@ -57,9 +63,11 @@ export {
 export const USE_CASES = [
   CreateAgent,
   ConfigureTelegramAgentWebhook,
+  ConsumeSlackSetupLink,
   ConsumeTelegramMobileLink,
   GetAgent,
   GetAgentRuntimeConfig,
+  GetSlackSetupLinkStatus,
   GetTelegramMobileLinkStatus,
   ListAgents,
   UpdateAgent,
@@ -70,6 +78,7 @@ export const USE_CASES = [
   AddAgentIntegration,
   ConfigureWhatsAppWebhook,
   GenerateManagedAgent,
+  IssueSlackSetupLink,
   IssueTelegramMobileLink,
   IssueTelegramSubscriberLink,
   LinkTelegramChatToSubscriber,

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -913,6 +913,68 @@ export async function submitTelegramMobileCredentials(
   return unwrapEnvelope(data) as SubmitTelegramMobileCredentialsResult;
 }
 
+export type SlackSetupLinkStatus =
+  | { valid: true; agentName: string; providerName: string }
+  | { valid: false; reason: 'expired' | 'used' | 'invalid' };
+
+export async function getSlackSetupStatus(token: string, signal?: AbortSignal): Promise<SlackSetupLinkStatus> {
+  const url = `${getApiBaseUrl()}/v1/agents/public/slack/setup/status?token=${encodeURIComponent(token)}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    signal,
+  });
+
+  const data = await safeJson(response);
+
+  if (!response.ok) {
+    throw new NovuApiError(extractErrorMessage(data) ?? 'Failed to load setup link', response.status, data);
+  }
+
+  return unwrapEnvelope(data) as SlackSetupLinkStatus;
+}
+
+export type SubmitSlackSetupCredentialsResult = {
+  success: true;
+};
+
+export type SubmitSlackSetupCredentialsError = {
+  code: 'token_invalid' | 'token_expired' | 'token_already_used' | 'unknown';
+  message: string;
+};
+
+export class SlackSetupSubmitError extends Error {
+  constructor(
+    public readonly code: SubmitSlackSetupCredentialsError['code'],
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+  }
+}
+
+export async function submitSlackSetupCredentials(
+  token: string,
+  configToken: string
+): Promise<SubmitSlackSetupCredentialsResult> {
+  const url = `${getApiBaseUrl()}/v1/agents/public/slack/setup`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, configToken }),
+  });
+
+  const data = await safeJson(response);
+
+  if (!response.ok) {
+    const code = extractErrorCode(data) as SubmitSlackSetupCredentialsError['code'];
+    const message = extractErrorMessage(data) ?? 'Failed to configure Slack';
+    throw new SlackSetupSubmitError(code, message, response.status);
+  }
+
+  return unwrapEnvelope(data) as SubmitSlackSetupCredentialsResult;
+}
+
 async function safeJson(response: Response): Promise<unknown> {
   try {
     return await response.json();

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -43,6 +43,7 @@ import { ChannelPreferences } from './components/workflow-editor/channel-prefere
 import { IS_ENTERPRISE, IS_SELF_HOSTED } from './config';
 import { FeatureFlagsProvider } from './context/feature-flags-provider';
 import { AgentDetailsPage } from './pages/agent-details';
+import { AgentSlackSetupPage } from './pages/agent-slack-setup-page';
 import { AgentTelegramMobileSetupPage } from './pages/agent-telegram-mobile-setup-page';
 import { AgentsPage } from './pages/agents';
 import { AgentsSetupPage } from './pages/agents-setup-page';
@@ -108,6 +109,12 @@ const router = createBrowserRouter([
       {
         path: ROUTES.CONNECT_CLAIM,
         element: <ConnectClaimPage />,
+      },
+      {
+        // Public, unauthenticated setup page for Slack. Mounted outside
+        // AuthRoute so unauthenticated visitors are not redirected to sign-in.
+        path: ROUTES.AGENT_SLACK_SETUP,
+        element: <AgentSlackSetupPage />,
       },
       {
         // Public, unauthenticated mobile setup page for Telegram. Mounted outside

--- a/apps/dashboard/src/pages/agent-slack-setup-page.tsx
+++ b/apps/dashboard/src/pages/agent-slack-setup-page.tsx
@@ -1,0 +1,262 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { motion } from 'motion/react';
+import { useState } from 'react';
+import { RiCheckLine, RiErrorWarningLine, RiTimeLine } from 'react-icons/ri';
+import { useParams } from 'react-router-dom';
+import {
+  getSlackSetupStatus,
+  type SlackSetupLinkStatus,
+  SlackSetupSubmitError,
+  type SubmitSlackSetupCredentialsResult,
+  submitSlackSetupCredentials,
+} from '@/api/agents';
+import { Button } from '@/components/primitives/button';
+import { Input } from '@/components/primitives/input';
+import { cn } from '@/utils/ui';
+
+const SLACK_CONFIG_TOKEN_PREFIX = 'xoxe.xoxp-';
+
+function isValidSlackConfigToken(value: string): boolean {
+  return value.trim().startsWith(SLACK_CONFIG_TOKEN_PREFIX) && value.trim().length > SLACK_CONFIG_TOKEN_PREFIX.length;
+}
+
+export function AgentSlackSetupPage() {
+  const { token = '' } = useParams<{ token: string }>();
+
+  const statusQuery = useQuery<SlackSetupLinkStatus>({
+    queryKey: ['slack-setup-status', token],
+    queryFn: ({ signal }) => getSlackSetupStatus(token, signal),
+    enabled: token.length > 0,
+    retry: false,
+    refetchOnWindowFocus: false,
+    meta: { showError: false },
+  });
+
+  return (
+    <PageShell>
+      {!token && <InactiveLinkCard reason="invalid" />}
+      {token && statusQuery.isLoading && <LoadingCard />}
+      {token && statusQuery.data && !statusQuery.data.valid && <InactiveLinkCard reason={statusQuery.data.reason} />}
+      {token && statusQuery.isError && <InactiveLinkCard reason="invalid" />}
+      {token && statusQuery.data?.valid && <SetupForm token={token} agentName={statusQuery.data.agentName} />}
+    </PageShell>
+  );
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-bg-weak flex min-h-dvh flex-col items-center justify-between px-4 py-8">
+      <div className="w-full max-w-md flex-1 pt-[max(env(safe-area-inset-top),0px)]">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+        >
+          {children}
+        </motion.div>
+      </div>
+      <PoweredByNovu />
+    </div>
+  );
+}
+
+function LoadingCard() {
+  return (
+    <Card>
+      <div className="flex flex-col items-center gap-3 py-6">
+        <div
+          className="border-stroke-soft border-t-text-strong size-7 animate-spin rounded-full border-2"
+          aria-label="Loading"
+        />
+        <p className="text-text-soft text-paragraph-xs">Checking your setup link…</p>
+      </div>
+    </Card>
+  );
+}
+
+type SetupFormProps = {
+  token: string;
+  agentName: string;
+};
+
+function SetupForm({ token, agentName }: SetupFormProps) {
+  const [configToken, setConfigToken] = useState('');
+  const trimmedToken = configToken.trim();
+  const tokenValid = isValidSlackConfigToken(trimmedToken);
+
+  const submitMutation = useMutation<
+    SubmitSlackSetupCredentialsResult,
+    SlackSetupSubmitError | Error,
+    { configToken: string }
+  >({
+    mutationFn: ({ configToken: value }) => submitSlackSetupCredentials(token, value),
+  });
+
+  if (submitMutation.data?.success) {
+    return <SuccessCard agentName={agentName} />;
+  }
+
+  if (submitMutation.error instanceof SlackSetupSubmitError) {
+    const code = submitMutation.error.code;
+    if (code === 'token_already_used') return <InactiveLinkCard reason="used" />;
+    if (code === 'token_expired') return <InactiveLinkCard reason="expired" />;
+    if (code === 'token_invalid') return <InactiveLinkCard reason="invalid" />;
+  }
+
+  const errorMessage = submitMutation.error instanceof Error ? submitMutation.error.message : null;
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-1">
+        <p className="text-text-soft text-label-xs uppercase tracking-wide">Connect Slack</p>
+        <h1 className="text-text-strong text-paragraph-md font-medium leading-snug">
+          Finish setup for <span className="text-text-strong font-semibold">{agentName}</span>
+        </h1>
+        <p className="text-text-soft text-paragraph-xs leading-5">
+          Paste your Slack App Configuration Token here. Novu uses it once to create the Slack app from a manifest, then
+          discards it — your terminal will continue automatically.
+        </p>
+      </div>
+
+      <div className="mt-5 flex flex-col gap-2">
+        <label htmlFor="slack-config-token" className="text-label-xs text-text-strong font-medium">
+          Slack App Configuration Token
+        </label>
+        <ol className="text-text-soft text-label-xs ml-4 list-decimal space-y-1 leading-4">
+          <li>
+            Open{' '}
+            <a
+              href="https://api.slack.com/apps"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-text-strong underline"
+            >
+              api.slack.com/apps
+            </a>
+          </li>
+          <li>Scroll to &quot;Your App Configuration Tokens&quot;</li>
+          <li>Generate a token and copy the access token (starts with xoxe.xoxp-)</li>
+        </ol>
+        <Input
+          id="slack-config-token"
+          value={configToken}
+          onChange={(event) => setConfigToken(event.target.value)}
+          placeholder="xoxe.xoxp-…"
+          className={cn('font-mono text-xs', tokenValid && 'border-success-base ring-success-base/40 ring-1')}
+          autoFocus
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+        />
+      </div>
+
+      {errorMessage && (
+        <div className="border-error-base bg-error-base/5 text-error-base mt-4 flex items-start gap-2 rounded-md border p-2.5">
+          <RiErrorWarningLine className="mt-0.5 size-4 shrink-0" />
+          <p className="text-paragraph-xs leading-5">{errorMessage}</p>
+        </div>
+      )}
+
+      <Button
+        variant="primary"
+        mode="filled"
+        size="md"
+        className="mt-5 w-full"
+        isLoading={submitMutation.isPending}
+        disabled={!tokenValid || submitMutation.isPending}
+        onClick={() => {
+          if (tokenValid) submitMutation.mutate({ configToken: trimmedToken });
+        }}
+      >
+        Connect Slack
+      </Button>
+    </Card>
+  );
+}
+
+function SuccessCard({ agentName }: { agentName: string }) {
+  return (
+    <Card>
+      <div className="flex flex-col items-center gap-3 text-center">
+        <div className="bg-success-base/10 text-success-base flex size-12 items-center justify-center rounded-full">
+          <RiCheckLine className="size-6" />
+        </div>
+        <h1 className="text-text-strong text-paragraph-md font-semibold">Slack app created</h1>
+        <p className="text-text-soft text-paragraph-xs leading-5">
+          Your Slack app is ready for <span className="text-text-strong font-medium">{agentName}</span>. Return to your
+          terminal — the connect command will open Slack authorization next.
+        </p>
+      </div>
+      <p className="text-text-soft text-label-xs mt-5 text-center">You can safely close this tab.</p>
+    </Card>
+  );
+}
+
+type InactiveReason = 'expired' | 'used' | 'invalid';
+
+function InactiveLinkCard({ reason }: { reason: InactiveReason }) {
+  const copy = reasonCopy(reason);
+
+  return (
+    <Card>
+      <div className="flex flex-col items-center gap-3 text-center">
+        <div className="bg-warning-base/10 text-warning-base flex size-12 items-center justify-center rounded-full">
+          <RiTimeLine className="size-6" />
+        </div>
+        <h1 className="text-text-strong text-paragraph-md font-semibold">{copy.title}</h1>
+        <p className="text-text-soft text-paragraph-xs leading-5">{copy.description}</p>
+      </div>
+    </Card>
+  );
+}
+
+function reasonCopy(reason: InactiveReason): { title: string; description: string } {
+  switch (reason) {
+    case 'expired':
+      return {
+        title: 'This setup link has expired',
+        description:
+          'Setup links are valid for 5 minutes. Re-run `npx novu connect` in your terminal to get a fresh link.',
+      };
+    case 'used':
+      return {
+        title: 'This setup link has already been used',
+        description:
+          'For security, each link works only once. Re-run `npx novu connect` if you need to configure Slack again.',
+      };
+    case 'invalid':
+    default:
+      return {
+        title: 'This setup link is no longer valid',
+        description: 'The link may be broken or for a different agent. Re-run `npx novu connect` to continue.',
+      };
+  }
+}
+
+function Card({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'border-stroke-soft bg-bg-white shadow-regular-xs flex w-full flex-col rounded-xl border p-5',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function PoweredByNovu() {
+  return (
+    <a
+      href="https://novu.co"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-text-soft hover:text-text-strong mt-8 inline-flex items-center gap-2 text-label-xs transition"
+      aria-label="Powered by Novu"
+    >
+      <span>Powered by</span>
+      <img src="/images/novu-logo-dark.svg" alt="Novu" className="h-3.5" />
+    </a>
+  );
+}

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -84,6 +84,7 @@ export const ROUTES = {
     '/env/:environmentSlug/agents/:agentIdentifier/integrations/:integrationIdentifier',
   AGENT_DETAILS_TAB: '/env/:environmentSlug/agents/:agentIdentifier/:agentTab',
   AGENT_TELEGRAM_MOBILE_SETUP: '/agents/telegram/connect/:token',
+  AGENT_SLACK_SETUP: '/agents/slack/connect/:token',
   INTEGRATION_TELEGRAM_MOBILE_SETUP: '/integrations/telegram/connect/:token',
 } as const;
 

--- a/packages/novu/src/commands/connect/api/agents.ts
+++ b/packages/novu/src/commands/connect/api/agents.ts
@@ -252,9 +252,8 @@ export interface ConsumeTelegramMobileLinkResult {
 /**
  * Public endpoint — the opaque setup token authenticates the request. Persists
  * the BotFather token onto the linked Telegram integration and registers the
- * webhook. This is what the dashboard mobile-setup page calls; the CLI calls
- * it directly when the user supplies `--telegram-bot-token`, so keyless users
- * (who cannot sign in to the dashboard) never need the mobile page.
+ * webhook. The dashboard setup page and the CLI (via `--telegram-bot-token`
+ * for headless CI) both call this endpoint.
  */
 export async function consumeTelegramMobileLink(
   client: ConnectApiClient,
@@ -267,6 +266,48 @@ export async function consumeTelegramMobileLink(
   const body = res.data;
 
   return 'data' in body && body.data ? body.data : (body as ConsumeTelegramMobileLinkResult);
+}
+
+export interface SlackSetupLinkResult {
+  token: string;
+  url: string;
+  expiresAt: string;
+}
+
+export interface SlackSetupLinkStatus {
+  valid: boolean;
+  reason?: 'expired' | 'used' | 'invalid';
+  agentName?: string;
+  providerName?: string;
+}
+
+export async function issueSlackSetupLink(
+  client: ConnectApiClient,
+  agentIdentifier: string,
+  integrationId: string
+): Promise<SlackSetupLinkResult> {
+  const res = await client.axios.post<{ data?: SlackSetupLinkResult } | SlackSetupLinkResult>(
+    `/v1/agents/${encodeURIComponent(agentIdentifier)}/integrations/${encodeURIComponent(integrationId)}/slack/setup-link`,
+    {}
+  );
+  const body = res.data;
+
+  return 'data' in body && body.data ? body.data : (body as SlackSetupLinkResult);
+}
+
+/**
+ * Public endpoint — needs no auth header (the opaque setup token in the query string
+ * authenticates the request). Poll this to detect when the user has pasted their
+ * Slack App Configuration Token on the secure setup page.
+ */
+export async function getSlackSetupLinkStatus(client: ConnectApiClient, token: string): Promise<SlackSetupLinkStatus> {
+  const res = await client.axios.get<{ data?: SlackSetupLinkStatus } | SlackSetupLinkStatus>(
+    '/v1/agents/public/slack/setup/status',
+    { params: { token } }
+  );
+  const body = res.data;
+
+  return 'data' in body && body.data ? body.data : (body as SlackSetupLinkStatus);
 }
 
 export async function issueTelegramSubscriberLink(

--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -4,8 +4,7 @@ Examples (non-interactive / agent / CI):
   Keyless Slack (default — no Novu account required):
     npx novu connect "A support assistant for Acme's customers that answers billing questions." \\
       --ci \\
-      --channel slack \\
-      --slack-config-token "xoxe.xoxp-…"
+      --channel slack
 
   Keyless Email:
     npx novu connect "An onboarding assistant for Acme's new members." \\
@@ -15,8 +14,7 @@ Examples (non-interactive / agent / CI):
   Keyless Telegram:
     npx novu connect "A concierge for Acme's shoppers that helps with orders." \\
       --ci \\
-      --channel telegram \\
-      --telegram-bot-token "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+      --channel telegram
 
   Agent only (no channel):
     npx novu connect "An inventory assistant for Acme's ops staff." \\
@@ -33,8 +31,7 @@ Examples (non-interactive / agent / CI):
     npx novu connect "A support assistant for Acme's customers." \\
       --ci \\
       --secret-key "$NOVU_SECRET_KEY" \\
-      --channel slack \\
-      --slack-config-token "xoxe.xoxp-…"
+      --channel slack
 
 Non-interactive (agent / CI) contract:
 
@@ -43,10 +40,14 @@ Non-interactive (agent / CI) contract:
     - Pass --channel <slack|email|telegram|skip>.
 
   Channel-specific flags:
-    - --channel slack    → requires --slack-config-token (xoxe.xoxp-…)
-    - --channel telegram → requires --telegram-bot-token (from @BotFather)
+    - --channel slack    → no extra flags (CLI prints a secure setup link for the Slack config token)
+    - --channel telegram → no extra flags (CLI prints a secure setup link for the BotFather token)
     - --channel email    → no extra flags
     - --channel skip     → no extra flags (agent only, no channel)
+
+  Optional CI-only escape hatches (secrets injected via env — never paste in chat):
+    - --slack-config-token "xoxe.xoxp-…"    → skip the setup page; pass token directly
+    - --telegram-bot-token "123456:ABC-…"   → skip the setup page; pass token directly
 
   Defaults (do not pass unless needed):
     - Keyless mode: omit --secret-key (creates a temporary agent; user claims via in-channel sign-up link)
@@ -61,6 +62,7 @@ Non-interactive (agent / CI) contract:
 Machine-readable stdout (plain text, no ANSI — watch these in --ci mode):
 
   Slack:
+    NOVU_CONNECT_SLACK_SETUP_URL=<url>
     NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>
 
   Email:
@@ -69,6 +71,9 @@ Machine-readable stdout (plain text, no ANSI — watch these in --ci mode):
     NOVU_CONNECT_SEND_FROM_EMAIL=<email>   (only when present)
 
   Telegram:
+    NOVU_CONNECT_TELEGRAM_BOTFATHER_URL=<url>             (only when present)
+    NOVU_CONNECT_TELEGRAM_SETUP_URL=<url>
+    NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG=<absolute png path>  (only when present)
     NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=<url>
     NOVU_CONNECT_TELEGRAM_BOT_USERNAME=<name>
     NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   (only when present)

--- a/packages/novu/src/commands/connect/pipeline/channels/slack.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/slack.ts
@@ -141,17 +141,37 @@ async function runSlackQuickSetup(
   const setupLink = await issueSlackSetupLink(client, agent.identifier, slackIntegration._id);
   ui.showSlackSetupLink({ setupUrl: setupLink.url });
 
+  let setupLinkFailure: 'expired' | 'invalid' | undefined;
+
   const tokenSaved = await pollUntil(
     async () => {
       const status = await getSlackSetupLinkStatus(client, setupLink.token);
       if (!status.valid && status.reason === 'used') return 'done';
-      if (!status.valid) return 'failed';
+      if (!status.valid && status.reason === 'expired') {
+        setupLinkFailure = 'expired';
+
+        return 'failed';
+      }
+      if (!status.valid) {
+        setupLinkFailure = 'invalid';
+
+        return 'failed';
+      }
 
       return 'pending';
     },
     { intervalMs: CHANNEL_POLL_INTERVAL_MS, timeoutMs: CHANNEL_POLL_TIMEOUT_MS }
   );
   if (!tokenSaved) {
+    if (setupLinkFailure === 'expired') {
+      throw new Error(
+        'The Slack setup link expired before you could paste your App Configuration Token. Re-run `npx novu connect` to get a fresh link.'
+      );
+    }
+    if (setupLinkFailure === 'invalid') {
+      throw new Error('The Slack setup link is no longer valid. Re-run `npx novu connect` to get a fresh link.');
+    }
+
     throw new Error(
       `The Slack App Configuration Token wasn't saved within ${Math.round(CHANNEL_POLL_TIMEOUT_MS / 1000)} seconds. ` +
         'Re-run `npx novu connect` to get a fresh setup link.'

--- a/packages/novu/src/commands/connect/pipeline/channels/slack.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/slack.ts
@@ -1,5 +1,6 @@
 import open from 'open';
 import { CONNECT_EVENTS } from '../../analytics/events';
+import { getSlackSetupLinkStatus, issueSlackSetupLink } from '../../api/agents';
 import type { ConnectApiClient } from '../../api/client';
 import { NovuApiError } from '../../api/client';
 import {
@@ -122,17 +123,40 @@ async function runSlackQuickSetup(
   slackIntegration: IntegrationRecord,
   ui: ConnectUI,
   options: ConnectCommandOptions,
-  flags: { retry: boolean }
+  _flags: { retry: boolean }
 ): Promise<void> {
-  const configToken = options.slackConfigToken?.trim()
-    ? options.slackConfigToken.trim()
-    : await ui.promptForSlackConfigToken({ retry: flags.retry });
+  const configToken = options.slackConfigToken?.trim();
 
-  ui.runningSlackQuickSetup();
-  await slackQuickSetup(client, slackIntegration._id, {
-    configToken,
-    agentId: agent.id,
-  });
+  if (configToken) {
+    // Optional escape hatch for headless CI: the caller supplies the token directly.
+    ui.runningSlackQuickSetup();
+    await slackQuickSetup(client, slackIntegration._id, {
+      configToken,
+      agentId: agent.id,
+    });
+
+    return;
+  }
+
+  const setupLink = await issueSlackSetupLink(client, agent.identifier, slackIntegration._id);
+  ui.showSlackSetupLink({ setupUrl: setupLink.url });
+
+  const tokenSaved = await pollUntil(
+    async () => {
+      const status = await getSlackSetupLinkStatus(client, setupLink.token);
+      if (!status.valid && status.reason === 'used') return 'done';
+      if (!status.valid) return 'failed';
+
+      return 'pending';
+    },
+    { intervalMs: CHANNEL_POLL_INTERVAL_MS, timeoutMs: CHANNEL_POLL_TIMEOUT_MS }
+  );
+  if (!tokenSaved) {
+    throw new Error(
+      `The Slack App Configuration Token wasn't saved within ${Math.round(CHANNEL_POLL_TIMEOUT_MS / 1000)} seconds. ` +
+        'Re-run `npx novu connect` to get a fresh setup link.'
+    );
+  }
 }
 
 function isMissingSlackCredentialsError(err: unknown): boolean {

--- a/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
@@ -83,17 +83,37 @@ export async function connectTelegramForAgent(
     const mobileQr = await renderQR(mobileLink.url);
     ui.showTelegramLinkToken({ mobileQr, mobileUrl: mobileLink.url });
 
+    let setupLinkFailure: 'expired' | 'invalid' | undefined;
+
     const tokenSaved = await pollUntil(
       async () => {
         const status = await getTelegramMobileLinkStatus(client, mobileLink.token);
         if (!status.valid && status.reason === 'used') return 'done';
-        if (!status.valid) return 'failed';
+        if (!status.valid && status.reason === 'expired') {
+          setupLinkFailure = 'expired';
+
+          return 'failed';
+        }
+        if (!status.valid) {
+          setupLinkFailure = 'invalid';
+
+          return 'failed';
+        }
 
         return 'pending';
       },
       { intervalMs: CHANNEL_POLL_INTERVAL_MS, timeoutMs: CHANNEL_POLL_TIMEOUT_MS }
     );
     if (!tokenSaved) {
+      if (setupLinkFailure === 'expired') {
+        throw new Error(
+          'The Telegram setup link expired before you could paste your bot token. Re-run `npx novu connect` to get a fresh link.'
+        );
+      }
+      if (setupLinkFailure === 'invalid') {
+        throw new Error('The Telegram setup link is no longer valid. Re-run `npx novu connect` to get a fresh link.');
+      }
+
       throw new Error(
         `The bot token wasn't saved within ${Math.round(CHANNEL_POLL_TIMEOUT_MS / 1000)} seconds. ` +
           'Re-run `npx novu connect` to get a fresh setup link.'

--- a/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
@@ -54,9 +54,8 @@ export async function connectTelegramForAgent(
   let prefetchedSubscriberLink: TelegramSubscriberLinkResult | undefined;
 
   if (botToken) {
-    // The user already created the bot and pasted its token (e.g. collected
-    // by an AI agent in chat). Save it directly — keyless users cannot open
-    // the dashboard mobile-link page.
+    // Optional escape hatch for headless CI: the caller supplies the token
+    // directly instead of routing the user through the secure setup page.
     ui.savingTelegramBotToken();
     const mobileLink = await issueTelegramMobileLink(client, agent.identifier, integration._id, subscriberId);
     try {

--- a/packages/novu/src/commands/connect/ui/handoff-events.spec.ts
+++ b/packages/novu/src/commands/connect/ui/handoff-events.spec.ts
@@ -2,10 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   logEmailHandoffEvents,
   logSlackHandoffEvents,
+  logSlackSetupLinkHandoffEvent,
   logTelegramBotfatherHandoffEvent,
   logTelegramDeepLinkHandoffEvents,
   logTelegramDeepLinkQrPngHandoffEvent,
-  logTelegramMobileLinkHandoffEvent,
+  logTelegramSetupLinkHandoffEvent,
+  logTelegramSetupLinkQrPngHandoffEvent,
 } from './handoff-events';
 
 describe('handoff-events', () => {
@@ -48,6 +50,16 @@ describe('handoff-events', () => {
     );
   });
 
+  it('logs slack setup link sentinel lines', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    logSlackSetupLinkHandoffEvent({ setupUrl: 'https://dashboard.novu.co/agents/slack/connect/abc123' });
+
+    expect(log).toHaveBeenCalledWith(
+      'NOVU_CONNECT_SLACK_SETUP_URL=https://dashboard.novu.co/agents/slack/connect/abc123'
+    );
+  });
+
   it('logs telegram botfather sentinel line', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
@@ -56,14 +68,22 @@ describe('handoff-events', () => {
     expect(log).toHaveBeenCalledWith('NOVU_CONNECT_TELEGRAM_BOTFATHER_URL=https://t.me/botfather');
   });
 
-  it('logs telegram mobile link sentinel line', () => {
+  it('logs telegram setup link sentinel lines', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
-    logTelegramMobileLinkHandoffEvent({ mobileUrl: 'https://dashboard.novu.co/telegram/mobile/abc123' });
+    logTelegramSetupLinkHandoffEvent({ setupUrl: 'https://dashboard.novu.co/agents/telegram/connect/abc123' });
 
     expect(log).toHaveBeenCalledWith(
-      'NOVU_CONNECT_TELEGRAM_MOBILE_LINK_URL=https://dashboard.novu.co/telegram/mobile/abc123'
+      'NOVU_CONNECT_TELEGRAM_SETUP_URL=https://dashboard.novu.co/agents/telegram/connect/abc123'
     );
+  });
+
+  it('logs telegram setup QR png sentinel line', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    logTelegramSetupLinkQrPngHandoffEvent({ setupQrPngPath: '/tmp/novu-connect-qr-abc123.png' });
+
+    expect(log).toHaveBeenCalledWith('NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG=/tmp/novu-connect-qr-abc123.png');
   });
 
   it('logs telegram deep link and bot username sentinel lines', () => {

--- a/packages/novu/src/commands/connect/ui/handoff-events.ts
+++ b/packages/novu/src/commands/connect/ui/handoff-events.ts
@@ -21,8 +21,16 @@ export function logTelegramBotfatherHandoffEvent(opts: { botfatherUrl: string })
   console.log(`${HANDOFF_PREFIX}TELEGRAM_BOTFATHER_URL=${opts.botfatherUrl}`);
 }
 
-export function logTelegramMobileLinkHandoffEvent(opts: { mobileUrl: string }): void {
-  console.log(`${HANDOFF_PREFIX}TELEGRAM_MOBILE_LINK_URL=${opts.mobileUrl}`);
+export function logTelegramSetupLinkHandoffEvent(opts: { setupUrl: string }): void {
+  console.log(`${HANDOFF_PREFIX}TELEGRAM_SETUP_URL=${opts.setupUrl}`);
+}
+
+export function logTelegramSetupLinkQrPngHandoffEvent(opts: { setupQrPngPath: string }): void {
+  console.log(`${HANDOFF_PREFIX}TELEGRAM_SETUP_QR_PNG=${opts.setupQrPngPath}`);
+}
+
+export function logSlackSetupLinkHandoffEvent(opts: { setupUrl: string }): void {
+  console.log(`${HANDOFF_PREFIX}SLACK_SETUP_URL=${opts.setupUrl}`);
 }
 
 export function logTelegramDeepLinkHandoffEvents(opts: { deepLinkUrl: string; botUsername: string }): void {

--- a/packages/novu/src/commands/connect/ui/index.tsx
+++ b/packages/novu/src/commands/connect/ui/index.tsx
@@ -225,6 +225,9 @@ function createUiController(store: ConnectStore, shutdown: () => Promise<number>
         store.phase.set({ kind: 'paste-slack-token', retry, resolve, reject });
       });
     },
+    showSlackSetupLink({ setupUrl }) {
+      store.phase.set({ kind: 'slack-setup-link', setupUrl });
+    },
     runningSlackQuickSetup() {
       store.phase.set({ kind: 'running-slack-quick-setup' });
     },

--- a/packages/novu/src/commands/connect/ui/logging-ui.ts
+++ b/packages/novu/src/commands/connect/ui/logging-ui.ts
@@ -8,9 +8,12 @@ import { resolveGeneratedAgentSpecLabels } from './agent-spec-labels';
 import {
   logEmailHandoffEvents,
   logSlackHandoffEvents,
+  logSlackSetupLinkHandoffEvent,
   logTelegramBotfatherHandoffEvent,
   logTelegramDeepLinkHandoffEvents,
   logTelegramDeepLinkQrPngHandoffEvent,
+  logTelegramSetupLinkHandoffEvent,
+  logTelegramSetupLinkQrPngHandoffEvent,
 } from './handoff-events';
 import { renderQRPngFile } from './qr';
 import type { ConnectUI, GeneratedAgentPreviewResult, PickResult } from './ui';
@@ -199,11 +202,13 @@ export function createLoggingUI(): ConnectUI {
 
       return Promise.resolve();
     },
-    showTelegramLinkToken(_opts) {
+    showTelegramLinkToken({ mobileUrl }) {
       stop();
-      throw new Error(
-        'Telegram mobile-link setup is not available in CI mode. Pass --telegram-bot-token "<token>" so the CLI can configure Telegram without the dashboard mobile page.'
-      );
+      console.log(`${chalk.cyan('→')} Paste your BotFather token on this secure page: ${chalk.underline(mobileUrl)}`);
+      logTelegramSetupLinkHandoffEvent({ setupUrl: mobileUrl });
+      void renderQRPngFile(mobileUrl)
+        .then((setupQrPngPath) => logTelegramSetupLinkQrPngHandoffEvent({ setupQrPngPath }))
+        .catch(() => undefined);
     },
     savingTelegramBotToken() {
       start('Saving your Telegram bot token…');
@@ -222,12 +227,19 @@ export function createLoggingUI(): ConnectUI {
     addingSlackIntegration() {
       start('Linking Slack to your agent…');
     },
+    showSlackSetupLink({ setupUrl }) {
+      stop();
+      console.log(
+        `${chalk.cyan('→')} Paste your Slack App Configuration Token on this secure page: ${chalk.underline(setupUrl)}`
+      );
+      logSlackSetupLinkHandoffEvent({ setupUrl });
+    },
     promptForSlackConfigToken(_opts) {
       stop();
 
       return Promise.reject(
         new Error(
-          'Slack integration has no OAuth credentials. Pass --slack-config-token "xoxe.xoxp-…" to run the Slack quick-setup unattended, or run interactively to paste it.'
+          'Slack integration has no OAuth credentials. Omit --slack-config-token to use the secure setup page, or pass the token for headless CI.'
         )
       );
     },

--- a/packages/novu/src/commands/connect/ui/orb/orb-tint.ts
+++ b/packages/novu/src/commands/connect/ui/orb/orb-tint.ts
@@ -62,6 +62,7 @@ export function computeOrbTint(
       return hoveredChannel ? CHANNEL_TINTS[hoveredChannel] : DEFAULT_ORB_COLOR;
     case 'adding-slack':
     case 'paste-slack-token':
+    case 'slack-setup-link':
     case 'running-slack-quick-setup':
     case 'slack-oauth-ready':
     case 'waiting-slack':
@@ -105,6 +106,7 @@ export function computeOrbLabel(
       return hoveredChannel ? CHANNEL_LABELS[hoveredChannel] : undefined;
     case 'adding-slack':
     case 'paste-slack-token':
+    case 'slack-setup-link':
     case 'running-slack-quick-setup':
     case 'slack-oauth-ready':
     case 'waiting-slack':

--- a/packages/novu/src/commands/connect/ui/phase-content.tsx
+++ b/packages/novu/src/commands/connect/ui/phase-content.tsx
@@ -241,6 +241,21 @@ export function PhaseContent({
     case 'running-slack-quick-setup':
       return <Text color="cyan">Creating Slack app from manifest…</Text>;
 
+    case 'slack-setup-link':
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Text bold color="cyan">
+            Paste your Slack App Configuration Token
+          </Text>
+          <Text dimColor>
+            Open the link below to paste your token on a secure page. We'll create the Slack app from a manifest — the
+            token never passes through this terminal.
+          </Text>
+          <CopyableLink url={phase.setupUrl} hint="Open this link:" />
+          <Text dimColor>Waiting for your Slack App Configuration Token…</Text>
+        </Box>
+      );
+
     case 'slack-oauth-ready':
       return (
         <SlackOAuthReadyContent

--- a/packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts
+++ b/packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts
@@ -6,6 +6,7 @@ export function phaseHasCopyableUrl(phase: Phase): boolean {
     case 'auth':
       return Boolean(phase.dashboardUrl);
     case 'waiting-slack':
+    case 'slack-setup-link':
     case 'telegram-link-token':
     case 'telegram-test':
     case 'dashboard-channel-ready':

--- a/packages/novu/src/commands/connect/ui/store.ts
+++ b/packages/novu/src/commands/connect/ui/store.ts
@@ -60,6 +60,10 @@ export type Phase =
       resolve: (token: string) => void;
       reject: (reason: Error) => void;
     }
+  | {
+      kind: 'slack-setup-link';
+      setupUrl: string;
+    }
   | { kind: 'running-slack-quick-setup' }
   | {
       kind: 'slack-oauth-ready';

--- a/packages/novu/src/commands/connect/ui/ui.ts
+++ b/packages/novu/src/commands/connect/ui/ui.ts
@@ -102,7 +102,7 @@ export interface ConnectUI {
    */
   showTelegramIntro(opts: { botfatherQr: string; botfatherUrl: string }): Promise<void>;
   /**
-   * Step 2: render the mobile-link QR. Fire-and-forget — the pipeline owns
+   * Render the signed mobile-link QR. Fire-and-forget — the pipeline owns
    * the polling loop and transitions away from this phase when the bot token
    * lands on the integration.
    */
@@ -127,8 +127,16 @@ export interface ConnectUI {
    * because the chosen Slack integration has no OAuth client credentials
    * configured yet. `retry` is true when this prompt is following an earlier
    * failed quick-setup (so the UI can hint at the cause).
+   *
+   * @deprecated Prefer {@link showSlackSetupLink} — the secure setup page keeps
+   * tokens out of the terminal and agent chat.
    */
   promptForSlackConfigToken(opts: { retry: boolean }): Promise<string>;
+  /**
+   * Show the signed Slack setup-link URL. Fire-and-forget — the pipeline
+   * polls until the user pastes their config token on the secure page.
+   */
+  showSlackSetupLink(opts: { setupUrl: string }): void;
   runningSlackQuickSetup(): void;
   /**
    * Consent gate before opening Slack OAuth. When `appCreated` is true, confirms

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -181,11 +181,11 @@ program
   .option('--skip-slack', 'Create the agent and exit; do not connect any channel (equivalent to --channel skip)', false)
   .option(
     '--slack-config-token <token>',
-    'Slack App Configuration Token (xoxe.xoxp-…). Required with --channel slack in --ci mode'
+    'Slack App Configuration Token (xoxe.xoxp-…). CI-only escape hatch — omit to use the secure setup page'
   )
   .option(
     '--telegram-bot-token <token>',
-    'Telegram bot token from @BotFather (123456:ABC-…). Required with --channel telegram in --ci mode'
+    'Telegram bot token from @BotFather (123456:ABC-…). CI-only escape hatch — omit to use the secure setup page'
   )
   .option(
     '--ci',
@@ -218,20 +218,6 @@ program
       if (!channel) {
         console.error(
           'Non-interactive mode requires --channel <slack|email|telegram|skip>.\n(run `novu connect --help` for the non-interactive contract and examples)'
-        );
-        process.exit(1);
-      }
-
-      if (channel === 'slack' && !options.slackConfigToken?.trim()) {
-        console.error(
-          'Non-interactive mode with --channel slack requires --slack-config-token (xoxe.xoxp-…).\n(run `novu connect --help` for the non-interactive contract and examples)'
-        );
-        process.exit(1);
-      }
-
-      if (channel === 'telegram' && !options.telegramBotToken?.trim()) {
-        console.error(
-          'Non-interactive mode with --channel telegram requires --telegram-bot-token (from @BotFather).\n(run `novu connect --help` for the non-interactive contract and examples)'
         );
         process.exit(1);
       }

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -13,7 +13,8 @@ Your job, end to end: collect a couple of inputs, infer the agent's purpose from
 These govern every step. When in doubt, follow these over any specific instruction below.
 
 - **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5.
-- **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1), the purpose confirmation (Step 2), and — for `telegram` — the bot token (after Step 2) require the user. Default on everything else (region, runtime) unless the user raises it.
+- **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime) unless the user raises it.
+- **Never collect secrets in chat.** Slack App Configuration Tokens and Telegram bot tokens must **never** be pasted into the agent chat window. The CLI prints a secure one-time setup link; the user pastes the secret directly on that page.
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
 - **One Connect shell, no log watchers.** Run the Step 3 connect command in a single Shell session. Read stdout from that session (or **Await** its shell id). Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path.
 - **The CLI validates handoffs.** For `slack`/`email`, that Shell blocks and polls until OAuth or inbound email completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion.
@@ -32,7 +33,7 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 **Use the picker for:** Step 1 (channel) and Step 2 (approve / edit description).
 
-**Do not use the picker for:** free-text values (e.g. Slack config token, Telegram bot token, edited agent description prose) — ask in chat normally.
+**Do not use the picker for:** free-text values (e.g. edited agent description prose) — ask in chat normally. **Never** ask the user to paste Slack config tokens or Telegram bot tokens in chat — those go on the secure setup page the CLI prints.
 
 **If the tool is unavailable:** number options (`a1`, `a2`, …) and ask for a reply like `q1a2`.
 
@@ -54,10 +55,10 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 ## Flow overview
 
-1. **Channel** — ask which channel; collect channel-specific inputs. If the user picks WhatsApp / MS Teams, the flow ends here with a **dashboard redirect** — Steps 2–5 do not run.
-2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user. If channel is `telegram`, collect the bot token here (after approval) before running connect.
+1. **Channel** — ask which channel. If the user picks WhatsApp / MS Teams, the flow ends here with a **dashboard redirect** — Steps 2–5 do not run.
+2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user.
 3. **Run** — connect command from Step 3 (keyless, `--ci`), streamed.
-4. **Handoff** — read stdout; give the user the channel-specific next step; let the CLI poll (`slack`/`email`/`telegram`).
+4. **Handoff** — read stdout; give the user the channel-specific next step (secure setup link, OAuth link, email, or Telegram deep link); let the CLI poll (`slack`/`email`/`telegram`).
 5. **Report** — relay the CLI's success or error; explain the demo limit → claim.
 
 ---
@@ -70,9 +71,9 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 | Option id | Label | What the user must do |
 |---|---|---|
-| `slack` | Slack | Provide a **Slack App Configuration Token** (`xoxe.xoxp-…`), then click an OAuth link to approve the install. |
+| `slack` | Slack | Open the secure setup link the CLI prints to paste a Slack App Configuration Token, then click an OAuth link to approve the install. |
 | `email` | Email | Nothing up front. The CLI prints an inbound email address; the user sends one email to it. |
-| `telegram` | Telegram | After the description is approved, create a bot via @BotFather, paste the **bot token** in chat, then tap **Start** on the new bot in Telegram after connect. |
+| `telegram` | Telegram | Create a bot via @BotFather, paste the token on the secure setup link the CLI prints, then tap **Start** on the bot in Telegram. |
 | `dashboard` | WhatsApp / MS Teams | Not supported in the CLI — sign in to the Novu dashboard and continue onboarding there. |
 
 **If they pick `dashboard`:** stop — do **not** run connect and do **not** generate an agent. WhatsApp and Microsoft Teams are not supported in this CLI flow. Give the user the dashboard URL — **<https://dashboard.novu.co>** (or <https://eu.dashboard.novu.co> if they asked for the EU region) — and tell them to **sign in (or sign up) and continue the onboarding from the dashboard**, where they can set up WhatsApp or Microsoft Teams. Steps 2–5 do not apply; you are done once you've delivered the link.
@@ -81,9 +82,7 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 **Collect after they choose:**
 
-- **slack** → the **Slack App Configuration Token** (`xoxe.xoxp-…`, required). The CLI uses it once; it is never stored. The user generates it at <https://api.slack.com/apps> under **"Your App Configuration Tokens"** (see <https://api.slack.com/authentication/config-tokens>); copy the **access token** (`xoxe.xoxp-…`), which is short-lived (~12h).
-- **telegram** → no extra input here — the **bot token** is collected after Step 2 once the description is approved; see [Telegram bot token (after Step 2)](#telegram-bot-token-after-step-2).
-- **email / skip** → no extra input.
+- **slack / telegram / email / skip** → no extra input up front. Secrets and channel-specific actions happen on the secure setup page or via the CLI handoff links printed during Step 4.
 - **dashboard (WhatsApp / MS Teams)** → no extra input; the flow already ended with the dashboard redirect above.
 
 **Runtime:** always use the **demo runtime** — do not ask for an Anthropic API key and do not pass `--runtime` or `--anthropic-api-key`.
@@ -150,25 +149,6 @@ Show the draft and briefly note the inferred audience (e.g. "this agent will ser
 
 If they pick **edit**, ask for their revised text in chat (not the picker), update the draft, and ask again until they pick **approve**. If their revision drops a service name, warn once that the agent will lose that integration — but their wording wins. **Never run the command until they approve.**
 
-### Telegram bot token (after Step 2)
-
-**When:** channel is `telegram` and the user has approved the agent description. Do **not** run connect until you have the token.
-
-**Goal:** walk the user through creating a bot with @BotFather and pasting the HTTP API token in chat.
-
-Open with context — e.g. "**Telegram** is chosen and the description is approved." Then tell them you still need their **Telegram bot token** before you can run connect, and give these steps:
-
-1. Open Telegram (phone or desktop) and start a chat with **@BotFather** — <https://t.me/botfather>
-2. Send `/newbot`
-3. Follow BotFather's prompts: choose a **display name** for your bot (what users see in chats), then a **username** that ends in `bot` (e.g. `MyShopAssistantBot`)
-4. BotFather replies with a message that includes your bot's **HTTP API token** — a string like `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`
-5. **Copy** the full token from that BotFather message
-6. **Paste** it here in the chat
-
-Wait for the user to paste the token. Pass it to the CLI via `--telegram-bot-token`; the CLI stores it on the integration. Keyless users cannot use the dashboard mobile-link page, so the token must be collected here. After connect runs, they will also tap **Start** on the bot in Telegram (Step 4 handoff).
-
-**Do not** run Step 3 until the token is pasted.
-
 ---
 
 ## Step 3 — Run connect (keyless, non-interactive)
@@ -193,23 +173,20 @@ Never pass `--channel whatsapp` or `--channel teams` — those channels are hand
 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
-export SLACK_CONFIG_TOKEN='<xoxe.xoxp-...>'
 
 npx novu connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
-  --channel slack \
-  --slack-config-token "$SLACK_CONFIG_TOKEN"
+  --channel slack
 ```
 
 **How to run the Connect shell** — pick one path; never combine with log redirection or a second watch command:
 
-- **If channel is `slack`, `email`, or `telegram`:** Shell with `block_until_ms: 0` (background). Use **Await** on that shell id to read output as it arrives (e.g. pattern `NOVU_CONNECT_SLACK_AUTHORIZE_URL=`, `NOVU_CONNECT_INBOUND_ADDRESS=`, or `NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=`). When the user finishes the handoff, **Await** again until `✓ Your agent is live` or a `✗` error. Do not use Monitor, `tail -f`, `grep`, Read on log files, or ask for permission to watch logs.
+- **If channel is `slack`, `email`, or `telegram`:** Shell with `block_until_ms: 0` (background). Use **Await** on that shell id to read output as it arrives (e.g. pattern `NOVU_CONNECT_SLACK_SETUP_URL=`, `NOVU_CONNECT_TELEGRAM_SETUP_URL=`, `NOVU_CONNECT_INBOUND_ADDRESS=`, or `NOVU_CONNECT_SLACK_AUTHORIZE_URL=` / `NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=`). When the user finishes the handoff, **Await** again until `✓ Your agent is live` or a `✗` error. Do not use Monitor, `tail -f`, `grep`, Read on log files, or ask for permission to watch logs.
 - **If channel is `skip`:** a normal foreground Shell is enough — the CLI exits quickly after printing the success block.
 
 Conditional flags — apply each only when its condition holds:
 
-- **If channel is `slack`:** also pass `--slack-config-token "$SLACK_CONFIG_TOKEN"` (set the token in the shell environment first).
-- **If channel is `telegram`:** also pass `--telegram-bot-token "$TELEGRAM_BOT_TOKEN"` (collected after Step 2 — see [Telegram bot token (after Step 2)](#telegram-bot-token-after-step-2)). `--ci` is required (no prompts, no TUI).
+- **Do not** pass `--slack-config-token` or `--telegram-bot-token` in the agent flow — the CLI issues secure setup links instead. Only use those flags for genuine headless CI where secrets are injected via environment variables.
 - **Runtime:** do not pass `--runtime` or `--anthropic-api-key` — the **demo runtime** is always used.
 - **Region:** pass `--region eu` only when the user explicitly asks; otherwise the default is **US** Novu Cloud.
 
@@ -225,15 +202,27 @@ Always required: the positional description (in `--ci` mode).
 
 **If channel is `slack`, `email`, or `telegram`:** deliver the handoff from the Connect shell stdout, then **Await** the same shell until the **CLI poll** finishes. Do not start a separate watch process, read log files, or validate OAuth/email/Telegram yourself.
 
+**Always paste the literal URL — never a placeholder.** Every handoff link must be the full resolved value copied verbatim from the matching `NOVU_CONNECT_*` line (everything after the `=`). **Never** send a message that refers to "the secure link below", "the setup link", or "the link above" without the actual `https://…` URL in that same message. If you have not yet captured the URL from stdout, **Await** the matching pattern (e.g. `NOVU_CONNECT_SLACK_SETUP_URL=`) **before** sending any handoff message — do not announce the handoff until you have the real URL in hand.
+
 Read Connect shell stdout (via **Await**, not log files) and act based on the chosen channel:
 
-- **slack** — connection can't be automated. Watch for the machine-readable line:
+- **slack** — two user actions. First, **Await** the secure setup link line and copy its value:
+
+  ```
+  NOVU_CONNECT_SLACK_SETUP_URL=<url>
+  ```
+
+  Paste that exact `<url>` into chat as a clickable link. Then tell them to:
+  1. Open <https://api.slack.com/apps> and generate an **App Configuration Token** (access token starting with `xoxe.xoxp-`)
+  2. Open the setup link and paste the token there — **not in this chat**
+
+  The CLI polls until the token is saved (~5 min). Then **Await** the OAuth handoff line and copy its value:
 
   ```
   NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>
   ```
 
-  Parse the URL after `=`. Give it to the user and ask them to approve the install **within 5 minutes**. Then wait for the CLI poll to finish — the process exits on its own once they authorize. If it times out (~5 min), it prints an error; **re-run the same command** (the Slack app is reused).
+  Paste that exact `<url>` into chat and ask them to approve the install within 5 minutes. **Await** until the CLI poll finishes. Re-run on timeout (the Slack app is reused).
 
 - **email** — watch for these machine-readable lines (plain stdout, no ANSI):
 
@@ -250,7 +239,17 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
   Then wait for the **CLI poll** — the process completes once the email arrives; on timeout, re-run after they've sent it.
 
-- **telegram** — the bot token was collected after Step 2 and passed via `--telegram-bot-token`, so the CLI saves it itself — there is no BotFather or mobile-link handoff here. Watch for these machine-readable lines (plain stdout, no ANSI):
+- **telegram** — two user actions. First, watch for the BotFather hint and secure setup link:
+
+  ```
+  NOVU_CONNECT_TELEGRAM_BOTFATHER_URL=<url>              # only when present
+  NOVU_CONNECT_TELEGRAM_SETUP_URL=<url>
+  NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG=<absolute png path>   # only when present
+  ```
+
+  Tell the user to create a bot with @BotFather (<https://t.me/botfather>, send `/newbot`), then open the **setup link** and paste the BotFather confirmation message there — **not in this chat**. The CLI polls until the bot token is saved (~5 min).
+
+  Then watch for the deep-link handoff:
 
   ```
   NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=<url>
@@ -258,9 +257,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
   NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   # only when present
   ```
 
-  When they appear, embed the **QR code image** inline with Markdown — `![Scan with your phone](<absolute png path>)` using the path from `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=` — so the user can scan it from their phone. Never render the QR as ASCII/Unicode art in a code block (chat Markdown breaks it and it won't scan). Also give the deep link as a clickable fallback. Ask them to open the bot and tap **Start** on `@<botUsername>` in Telegram. The CLI polls until `/start` is received (~5 min).
-
-  Then wait for the CLI poll to finish — the process exits on its own once they tap Start. If it times out (~5 min), **re-run the same command** with the same `--telegram-bot-token`.
+  Embed the QR PNG inline when present. Ask them to open the bot and tap **Start** on `@<botUsername>`. **Await** until the CLI poll finishes. Re-run on timeout with the same command.
 
 - **skip** — nothing to hand off; the agent is created without a channel.
 
@@ -291,12 +288,13 @@ Extract the **agent identifier** and **Dashboard URL**, then tell the user:
 | Symptom | Fix |
 |---|---|
 | `…requires --prompt "<agent description>"` | You didn't pass the positional description — re-run Step 3 with it. |
-| `…--slack-config-token "xoxe.xoxp-…"` | Ask the user for the Slack App Configuration Token (Step 1) and pass it. |
+| `The Slack App Configuration Token wasn't saved within … seconds` | User didn't paste the token on the setup page in time — re-run the same command for a fresh link. |
 | `Failed to create Slack app: …` (e.g. timeout) | Transient — Slack's app-create can be slow on a cold call. Silently re-run the same command once; only surface if it fails again. |
 | `Slack OAuth was not completed within … seconds` | User didn't approve in time — re-run the same command (the Slack app is reused). |
 | `We didn't see your email at … within …s` | User hasn't emailed the inbound address yet — re-run after they send it. |
-| `Telegram didn't accept the bot token: …` | The pasted token is wrong or revoked — ask the user to re-copy it from @BotFather (`/token`) and re-run with the new value. |
-| `We didn't see a /start message on @… within … seconds` | User didn't tap Start on the bot in time — re-run the same command (same `--telegram-bot-token`). |
+| `The bot token wasn't saved within … seconds` | User didn't paste the BotFather token on the setup page in time — re-run for a fresh link. |
+| `Telegram didn't accept the bot token: …` | Wrong or revoked token on the setup page — have the user re-copy from @BotFather and re-run. |
+| `We didn't see a /start message on @… within … seconds` | User didn't tap Start on the bot in time — re-run the same command. |
 | `Keyless environment creation is currently disabled` / no demo integration | Target API isn't configured for keyless/demo — confirm the right `--region`, or have the user provide `--secret-key` for their existing account. |
 
 ---
@@ -311,8 +309,8 @@ Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI
 | `--ci` | Non-interactive mode (required for all channels in this flow). |
 | `--region <us\|eu>` | Target Novu Cloud region (default: `us`). |
 | `--channel <slack\|email\|telegram\|skip>` | Which channel to connect. Never pass `whatsapp`/`teams` — those are handled by the dashboard redirect, not the CLI. |
-| `--slack-config-token <xoxe.xoxp-…>` | Create the Slack app headlessly (slack only). |
-| `--telegram-bot-token <123456:ABC…>` | Bot token from @BotFather; the CLI stores it on the integration (telegram only, required in this flow). |
+| `--slack-config-token <xoxe.xoxp-…>` | CI-only escape hatch: pass the Slack config token directly instead of using the secure setup page. |
+| `--telegram-bot-token <123456:ABC…>` | CI-only escape hatch: pass the BotFather token directly instead of using the secure setup page. |
 | `--secret-key <key>` | Optional — use an existing Novu account instead of keyless. |
 
 ---
@@ -320,7 +318,8 @@ Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI
 ## Limitations to keep in mind
 
 - **One run = one new agent + one channel.** Re-running `connect` creates another agent; there is no "add a channel to the existing agent" in this non-interactive flow yet.
-- **Channel support is uneven headlessly:** `slack` and `email` complete with one user action; `telegram` requires two user actions (create the bot + paste its token in chat after description approval, then tap Start after connect); `whatsapp` and `teams` are **not supported in the CLI** — the user signs in to the Novu dashboard and continues onboarding there (no agent is generated by this flow).
+- **Channel support is uneven headlessly:** `slack` and `telegram` each require two user actions (paste a secret on the secure setup page, then OAuth or tap Start); `email` completes with one user action; `whatsapp` and `teams` are **not supported in the CLI** — the user signs in to the Novu dashboard and continues onboarding there (no agent is generated by this flow).
+- **Never paste Slack or Telegram tokens in the agent chat.** The CLI prints one-time setup links (`NOVU_CONNECT_SLACK_SETUP_URL`, `NOVU_CONNECT_TELEGRAM_SETUP_URL`) that work without signing in to the dashboard — including in keyless mode.
 - Keyless data is temporary until the user claims it via the in-channel sign-up link.
 - The CLI stores keyless credentials **per API URL**, so switching `--region` between runs does not require clearing `~/.config/configstore/novu-cli.json`.
 
@@ -332,7 +331,7 @@ Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI
 
 You are done when:
 
-1. The user picked a channel and you collected its required inputs.
+1. The user picked a channel (no secrets collected in chat).
 2. The user confirmed the agent description.
 3. You delivered the handoff (link / address) — or noted `skip`.
 4. The Connect shell printed `✓ Your agent is live.` (exit `0`). You never used Monitor, log files, or a separate watch command; for `slack`/`email`/`telegram`, the **CLI poll** validated the handoff.


### PR DESCRIPTION
## Summary
- Add Slack setup-link flow (issue → dashboard paste → consume) mirroring the existing Telegram mobile-link pattern
- CLI prints `NOVU_CONNECT_SLACK_SETUP_URL` and `NOVU_CONNECT_TELEGRAM_SETUP_URL`, then polls until secrets are saved on the secure page
- `--slack-config-token` / `--telegram-bot-token` remain CI-only escape hatches; agent onboarding docs and connect help text updated accordingly

## Architecture

```mermaid
sequenceDiagram
  participant CLI as novu connect
  participant API as API (authed)
  participant Page as Dashboard setup page
  participant Pub as API (public)

  CLI->>API: POST .../slack/setup-link
  API-->>CLI: setup URL + token
  CLI->>CLI: print NOVU_CONNECT_SLACK_SETUP_URL
  Page->>Pub: GET /agents/public/slack/setup/status
  Page->>Pub: POST /agents/public/slack/setup (configToken)
  CLI->>Pub: poll status until used
  CLI->>CLI: continue OAuth handoff
```

## Test plan
- [ ] `npx novu connect --ci --channel slack` → setup URL printed → paste token on page → OAuth proceeds
- [ ] Expired/used/invalid links show correct inactive states on `/agents/slack/connect/:token`
- [ ] `--slack-config-token` still works headlessly for CI
- [ ] `--ci --channel whatsapp` still rejected fast
- [ ] Telegram setup link handoff still works (`NOVU_CONNECT_TELEGRAM_SETUP_URL`)

Linear: https://linear.app/novu/issue/NV-8008/secure-setup-links-for-slacktelegram-secrets-in-novu-connect

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR adds a secure setup-link flow for Slack in Novu Connect that mirrors the Telegram mobile-link pattern: the CLI issues a setup URL (printed to stdout), users paste their Slack App Configuration Token on a secure dashboard page, finish OAuth, and the CLI polls a public status endpoint until the secret is saved. This prevents collecting secrets in chat; existing token flags remain as CI-only escape hatches for headless automation.

## Affected areas

**api**: New Slack setup-link use cases (IssueSlackSetupLink, GetSlackSetupLinkStatus, ConsumeSlackSetupLink), controller endpoints, DTOs, and public unauthenticated routes; TelegramMobileLinkTokenService extended with a new `slack-agent-setup` kind and token verification/issuance methods.

**dashboard**: New public AgentSlackSetupPage and routes to accept/validate Slack config tokens, plus API clients (getSlackSetupStatus, submitSlackSetupCredentials) and UX for expired/used/invalid link states.

**js (packages/novu CLI)**: CLI issues Slack setup links, prints machine-readable markers (e.g., NOVU_CONNECT_SLACK_SETUP_URL), polls status every 2s, and integrates the slack-setup-link phase across UI, handoff logging, and pipeline code; help text and docs updated to treat token flags as CI-only.

**shared**: Agent onboarding docs updated to reflect secure setup pages for Slack and Telegram and to advise against pasting tokens in chat.

## Key technical decisions

- Reuse TelegramMobileLinkTokenService for Slack by adding a `slack-agent-setup` token kind and payload shape to avoid a second token subsystem.  
- Public, unauthenticated dashboard endpoints allow keyless token validation/consumption while keeping tokens single-use and time-limited (short TTL and GETDEL claim/restore semantics).  
- CLI emits machine-readable stdout markers for automation (NOVU_CONNECT_*), and preserves token flags as optional CI escape hatches.

## Testing

Updated tests include handoff-events.spec.ts to assert Slack URL logging; the PR also defines a manual/interactive test plan covering CLI+dashboard flows, CI escape hatch behavior, and expired/used/invalid link states. Core use-case unit tests were not added in this change; verification is expected via the documented interactive and CI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a secure setup-link flow for Slack (and improves Telegram's error handling), mirroring the existing Telegram mobile-link pattern. Instead of collecting sensitive tokens in the agent chat, the CLI now issues a signed, single-use, 5-minute setup link, prints it as `NOVU_CONNECT_SLACK_SETUP_URL`, and polls until the user pastes their Slack App Configuration Token on the secure dashboard page.

- **API**: Three new use cases (`IssueSlackSetupLink`, `ConsumeSlackSetupLink`, `GetSlackSetupLinkStatus`) added with public endpoints; `TelegramMobileLinkTokenService` extended with a new `slack-agent-setup` token kind.
- **Dashboard**: New `AgentSlackSetupPage` component and corresponding public route added outside the auth guard; dashboard API helpers for getting status and submitting credentials.
- **CLI**: `runSlackQuickSetup` now issues a setup link and polls (token passed via `--slack-config-token` remains a CI escape hatch); Telegram polling gains the same `expired`/`invalid` differentiation.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new setup-link flow is well-structured, token lifecycle (issue → claim → rollback or commit) mirrors the proven Telegram pattern, and the public endpoints are guarded by the existing controller-level rate limiter.

The core path — issuing, polling, and consuming the single-use Slack setup token — is logically sound and consistent with the Telegram precedent. Two edge cases worth noting: the hardcoded dashboard.novu.co fallback in buildSetupUrl silently produces wrong URLs for self-hosted deployments without DASHBOARD_URL set, and a very unlikely Redis failure between token claim and rollback could cause the CLI to misread setup completion. Neither is reachable in normal operation.

issue-slack-setup-link.usecase.ts (hardcoded dashboard URL fallback) and consume-slack-setup-link.usecase.ts (best-effort rollback edge case)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase.ts | Core consume usecase: claims token, runs SlackQuickSetup, rolls back token on failure. Rollback is best-effort and a Redis crash between claim and release could leave the CLI incorrectly inferring success (token marked "used" but setup incomplete). |
| apps/api/src/app/agents/channels/slack-linking/issue-slack-setup-link/issue-slack-setup-link.usecase.ts | Validates agent/integration ownership before issuing a token; buildSetupUrl reads process.env directly with a hardcoded novu.co fallback that would produce wrong URLs in self-hosted deployments without DASHBOARD_URL set. |
| apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts | Extended with slack-agent-setup token kind; new issueForSlackAgentSetup, verifySlackAgentSetup methods, and validatePayload branch all follow the existing Telegram pattern correctly. |
| apps/api/src/app/agents/channels/telegram-linking/agents-public.controller.ts | Two new public Slack endpoints (GET status, POST consume) added alongside existing Telegram endpoints; inherits controller-level throttling and auth bypass correctly. |
| apps/dashboard/src/pages/agent-slack-setup-page.tsx | New public setup page with proper loading/error/success states; correctly handles all error codes from the API and prevents form re-submission on terminal states. |
| packages/novu/src/commands/connect/pipeline/channels/slack.ts | Refactored to use setup-link flow; polling differentiates expired/invalid/timeout correctly (previous expired-message bug is fixed); CI escape hatch via --slack-config-token preserved. |
| packages/novu/src/index.ts | Removed the --ci validation guards that required --slack-config-token and --telegram-bot-token; flag descriptions updated to clarify CI-only escape-hatch role. |
| packages/shared/docs/agent-onboarding.md | Comprehensive update removing secret-collection-in-chat instructions and replacing with secure setup-link handoff guidance for both Slack and Telegram. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as novu connect (CLI)
    participant API as API (authed)
    participant Page as Dashboard setup page
    participant Pub as API (public)
    participant Slack as Slack API

    CLI->>API: POST /:id/integrations/:iid/slack/setup-link
    API-->>CLI: "{ token, url, expiresAt }"
    CLI->>CLI: "print NOVU_CONNECT_SLACK_SETUP_URL=url"

    loop poll every 3s (max 300s)
        CLI->>Pub: "GET /agents/public/slack/setup/status?token="
        Pub-->>CLI: "{ valid: true } or { valid: false, reason }"
    end

    Note over Page: User opens setup URL
    Page->>Pub: "GET /agents/public/slack/setup/status?token="
    Pub-->>Page: "{ valid: true, agentName }"

    Page->>Pub: "POST /agents/public/slack/setup { token, configToken }"
    Pub->>Slack: SlackQuickSetup (create app from manifest)
    Slack-->>Pub: OK
    Pub-->>Page: "{ success: true }"
    Note over Page: Token marked used in Redis

    CLI->>Pub: poll - reason: used - done
    CLI->>CLI: continue OAuth handoff
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/novu/src/commands/connect/pipeline/channels/slack.ts`, line 80-116 ([link](https://github.com/novuhq/novu/blob/15896aece3c143853fc1cf9daf07067c3e60d4fe/packages/novu/src/commands/connect/pipeline/channels/slack.ts#L80-L116)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Two setup-link prompts on retry path**

   `getAuthorizeUrlWithQuickSetupFallback` calls `runSlackQuickSetup` twice (line 102 and line 111). With the new flow, each call issues a fresh setup link and blocks the process waiting for user interaction on the setup page. If the first call completes (token consumed, Slack app created) but `buildUrl()` still fails again with `isMissingSlackCredentialsError`, the user is silently issued a second setup link and asked to paste their Slack config token again. The `_flags: { retry: boolean }` parameter is now unused — the retry context is no longer surfaced in the UI — so users get no hint that they're repeating the step or why. Consider propagating the failure reason from `buildUrl()` on the second failure and throwing rather than re-entering the setup-link loop.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/novu/src/commands/connect/pipeline/channels/slack.ts
   Line: 80-116

   Comment:
   **Two setup-link prompts on retry path**

   `getAuthorizeUrlWithQuickSetupFallback` calls `runSlackQuickSetup` twice (line 102 and line 111). With the new flow, each call issues a fresh setup link and blocks the process waiting for user interaction on the setup page. If the first call completes (token consumed, Slack app created) but `buildUrl()` still fails again with `isMissingSlackCredentialsError`, the user is silently issued a second setup link and asked to paste their Slack config token again. The `_flags: { retry: boolean }` parameter is now unused — the retry context is no longer surfaced in the UI — so users get no hint that they're repeating the step or why. Consider propagating the failure reason from `buildUrl()` on the second failure and throwing rather than re-entering the setup-link loop.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fpipeline%2Fchannels%2Fslack.ts%0ALine%3A%2080-116%0A%0AComment%3A%0A**Two%20setup-link%20prompts%20on%20retry%20path**%0A%0A%60getAuthorizeUrlWithQuickSetupFallback%60%20calls%20%60runSlackQuickSetup%60%20twice%20%28line%20102%20and%20line%20111%29.%20With%20the%20new%20flow%2C%20each%20call%20issues%20a%20fresh%20setup%20link%20and%20blocks%20the%20process%20waiting%20for%20user%20interaction%20on%20the%20setup%20page.%20If%20the%20first%20call%20completes%20%28token%20consumed%2C%20Slack%20app%20created%29%20but%20%60buildUrl%28%29%60%20still%20fails%20again%20with%20%60isMissingSlackCredentialsError%60%2C%20the%20user%20is%20silently%20issued%20a%20second%20setup%20link%20and%20asked%20to%20paste%20their%20Slack%20config%20token%20again.%20The%20%60_flags%3A%20%7B%20retry%3A%20boolean%20%7D%60%20parameter%20is%20now%20unused%20%E2%80%94%20the%20retry%20context%20is%20no%20longer%20surfaced%20in%20the%20UI%20%E2%80%94%20so%20users%20get%20no%20hint%20that%20they're%20repeating%20the%20step%20or%20why.%20Consider%20propagating%20the%20failure%20reason%20from%20%60buildUrl%28%29%60%20on%20the%20second%20failure%20and%20throwing%20rather%20than%20re-entering%20the%20setup-link%20loop.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11506&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fchannels%2Fslack-linking%2Fissue-slack-setup-link%2Fissue-slack-setup-link.usecase.ts%3A86-93%0AHardcoded%20dashboard%20fallback%20breaks%20self-hosted%20deployments.%20%60buildSetupUrl%60%20falls%20back%20to%20%60https%3A%2F%2Fdashboard.novu.co%60%20when%20neither%20%60DASHBOARD_URL%60%20nor%20%60FRONT_BASE_URL%60%20is%20set.%20Any%20self-hosted%20instance%20that%20hasn't%20explicitly%20configured%20one%20of%20these%20env%20vars%20will%20generate%20setup%20URLs%20pointing%20at%20the%20cloud%20dashboard%20rather%20than%20their%20own%20instance%2C%20causing%20the%20setup%20page%20to%20404.%20The%20existing%20%60IssueTelegramMobileLink%60%20usecase%20should%20be%20checked%20for%20the%20same%20pattern%20and%20fixed%20consistently.%0A%0A%60%60%60suggestion%0A%20%20private%20buildSetupUrl%28token%3A%20string%29%3A%20string%20%7B%0A%20%20%20%20const%20dashboardUrl%20%3D%20process.env.DASHBOARD_URL%20%7C%7C%20process.env.FRONT_BASE_URL%3B%0A%20%20%20%20if%20%28!dashboardUrl%29%20%7B%0A%20%20%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%20%20'DASHBOARD_URL%20%28or%20FRONT_BASE_URL%29%20must%20be%20set%20to%20issue%20Slack%20setup%20links.%20'%20%2B%0A%20%20%20%20%20%20%20%20%20%20'Configure%20it%20in%20your%20environment%20and%20restart%20the%20API.'%0A%20%20%20%20%20%20%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20const%20base%20%3D%20dashboardUrl.replace%28%2F%5C%2F%24%2F%2C%20''%29%3B%0A%0A%20%20%20%20return%20%60%24%7Bbase%7D%24%7BSLACK_SETUP_PATH%7D%2F%24%7Btoken%7D%60%3B%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fchannels%2Fslack-linking%2Fconsume-slack-setup-link%2Fconsume-slack-setup-link.usecase.ts%3A215-223%0ABest-effort%20rollback%20can%20leave%20CLI%20in%20a%20misleading%20%22done%22%20state.%20If%20%60slackQuickSetupUsecase.execute%28%29%60%20throws%20and%20the%20subsequent%20%60tokenService.release%28%29%60%20call%20also%20fails%20%28e.g.%20transient%20Redis%20error%29%2C%20the%20token%20stays%20in%20the%20%22claimed%2Fused%22%20state%20in%20Redis.%20The%20CLI's%20%60pollUntil%60%20probe%20treats%20%60status.reason%20%3D%3D%3D%20'used'%60%20as%20confirmation%20that%20setup%20completed%20successfully%2C%20so%20it%20would%20return%20%60'done'%60%20and%20proceed%20to%20the%20Slack%20OAuth%20step%20%E2%80%94%20even%20though%20no%20Slack%20app%20was%20created.%20The%20result%20is%20an%20OAuth%20URL%20that%20leads%20nowhere%2C%20with%20no%20actionable%20error%20message.%20Consider%20emitting%20a%20structured%20log%20entry%20at%20WARN%20level%20that%20includes%20the%20setup%20token%20when%20release%20fails%2C%20so%20on-call%20engineers%20can%20identify%20and%20manually%20invalidate%20orphaned%20tokens.%0A%0A&pr=11506&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/agents/channels/slack-linking/issue-slack-setup-link/issue-slack-setup-link.usecase.ts:86-93
Hardcoded dashboard fallback breaks self-hosted deployments. `buildSetupUrl` falls back to `https://dashboard.novu.co` when neither `DASHBOARD_URL` nor `FRONT_BASE_URL` is set. Any self-hosted instance that hasn't explicitly configured one of these env vars will generate setup URLs pointing at the cloud dashboard rather than their own instance, causing the setup page to 404. The existing `IssueTelegramMobileLink` usecase should be checked for the same pattern and fixed consistently.

```suggestion
  private buildSetupUrl(token: string): string {
    const dashboardUrl = process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL;
    if (!dashboardUrl) {
      throw new Error(
        'DASHBOARD_URL (or FRONT_BASE_URL) must be set to issue Slack setup links. ' +
          'Configure it in your environment and restart the API.'
      );
    }

    const base = dashboardUrl.replace(/\/$/, '');

    return `${base}${SLACK_SETUP_PATH}/${token}`;
  }
```

### Issue 2 of 2
apps/api/src/app/agents/channels/slack-linking/consume-slack-setup-link/consume-slack-setup-link.usecase.ts:215-223
Best-effort rollback can leave CLI in a misleading "done" state. If `slackQuickSetupUsecase.execute()` throws and the subsequent `tokenService.release()` call also fails (e.g. transient Redis error), the token stays in the "claimed/used" state in Redis. The CLI's `pollUntil` probe treats `status.reason === 'used'` as confirmation that setup completed successfully, so it would return `'done'` and proceed to the Slack OAuth step — even though no Slack app was created. The result is an OAuth URL that leads nowhere, with no actionable error message. Consider emitting a structured log entry at WARN level that includes the setup token when release fails, so on-call engineers can identify and manually invalidate orphaned tokens.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(connect): clarify setup-link poll fa..."](https://github.com/novuhq/novu/commit/c2f74833f9ec60846fa83fcc67299e50a328f6a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36811484)</sub>

<!-- /greptile_comment -->