### PR TITLE
feat(root): add PORTLESS URLS mprocs tab fixes NV-8010

### DIFF
--- a/apps/api/src/.example.env
+++ b/apps/api/src/.example.env
@@ -127,7 +127,7 @@ SCHEDULER_CALLBACK_API_KEY=
 # Local dev preferences: `.novu-dev.local.json` (gitignored, created on first `pnpm dev:portless`)
 # Reconfigure: `pnpm dev:config` or mprocs → DEV CONFIG
 # Ngrok for agent webhooks/OAuth is configured there (random URL or reserved domain)
-# Public URL when ngrok is on: mprocs `API PUBLIC URL` tab, or `pnpm portless:ngrok:url`
+# Public URL when ngrok is on: mprocs `PORTLESS URLS` tab, or `pnpm portless:ngrok:url`
 # One-off overrides: PORTLESS_NGROK=1|0  PORTLESS_NGROK_DOMAIN=https://my-api.ngrok.app
 #
 # Run `PORTLESS=0 pnpm start:api:dev` to bypass the proxy without uninstalling.

--- a/scripts/mprocs-dev.mjs
+++ b/scripts/mprocs-dev.mjs
@@ -15,20 +15,15 @@ import { configExists, loadConfig, resolveNgrokEnv } from './novu-dev-local.mjs'
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const baseConfigPath = join(root, 'mprocs.yaml');
 
-const NGROK_URL_PROC = `
-  "API PUBLIC URL":
-    shell: node scripts/portless-ngrok.mjs watch api.novu
+const PORTLESS_URLS_PROC = `
+  "PORTLESS URLS":
+    shell: node scripts/portless-urls.mjs watch
 `;
 
-function buildConfigPath(ngrokEnabled) {
+function buildConfigPath() {
   const base = readFileSync(baseConfigPath, 'utf8');
-
-  if (!ngrokEnabled) {
-    return baseConfigPath;
-  }
-
-  const merged = base.replace(/^scrollback:/m, `${NGROK_URL_PROC}scrollback:`);
-  const generatedPath = join(tmpdir(), 'novu-mprocs-ngrok.yaml');
+  const merged = base.replace(/^scrollback:/m, `${PORTLESS_URLS_PROC}scrollback:`);
+  const generatedPath = join(tmpdir(), 'novu-mprocs-portless.yaml');
 
   writeFileSync(generatedPath, merged);
 
@@ -57,11 +52,11 @@ async function main() {
   }
 
   const config = loadConfig();
-  const { enabled, resolved } = resolveNgrokEnv(config);
+  const { resolved } = resolveNgrokEnv(config);
 
   applyResolvedEnv(resolved);
 
-  const configPath = buildConfigPath(enabled);
+  const configPath = buildConfigPath();
   const child = spawn('pnpm', ['exec', 'mprocs', '-c', configPath], {
     cwd: root,
     stdio: 'inherit',

--- a/scripts/portless-ngrok.mjs
+++ b/scripts/portless-ngrok.mjs
@@ -57,8 +57,8 @@ export function readRoutes() {
   }
 }
 
-export function findServiceRoute(serviceName = API_SERVICE) {
-  for (const route of readRoutes()) {
+export function findServiceRoute(serviceName = API_SERVICE, routes = readRoutes()) {
+  for (const route of routes) {
     if (!route?.hostname || !route?.port) {
       continue;
     }
@@ -71,8 +71,8 @@ export function findServiceRoute(serviceName = API_SERVICE) {
   return undefined;
 }
 
-export function findPortlessNgrokUrl(serviceName = API_SERVICE) {
-  for (const route of readRoutes()) {
+export function findPortlessNgrokUrl(serviceName = API_SERVICE, routes = readRoutes()) {
+  for (const route of routes) {
     if (!route?.ngrokUrl || !route?.hostname) {
       continue;
     }
@@ -214,14 +214,14 @@ function formatTunnelBanner(url) {
   ].join('\n');
 }
 
-function resolveTunnelUrl(serviceName) {
+export function resolveTunnelUrl(serviceName = API_SERVICE, routes = readRoutes()) {
   const reserved = normalizeNgrokDomain(process.env.PORTLESS_NGROK_DOMAIN);
 
-  if (reserved && findServiceRoute(serviceName)) {
+  if (reserved && findServiceRoute(serviceName, routes)) {
     return reserved;
   }
 
-  return findPortlessNgrokUrl(serviceName);
+  return findPortlessNgrokUrl(serviceName, routes);
 }
 
 function watchTunnel(serviceName) {

--- a/scripts/portless-ngrok.mjs
+++ b/scripts/portless-ngrok.mjs
@@ -41,7 +41,7 @@ export function isNgrokMode() {
   return process.env.PORTLESS_NGROK === '1' || Boolean(normalizeNgrokDomain(process.env.PORTLESS_NGROK_DOMAIN));
 }
 
-function readRoutes() {
+export function readRoutes() {
   const routesPath = getRoutesPath();
 
   if (!existsSync(routesPath)) {

--- a/scripts/portless-urls.mjs
+++ b/scripts/portless-urls.mjs
@@ -6,12 +6,10 @@
  */
 import { fileURLToPath } from 'node:url';
 import {
-  findPortlessNgrokUrl,
-  findServiceRoute,
   hostnameMatchesService,
   isNgrokMode,
-  normalizeNgrokDomain,
   readRoutes,
+  resolveTunnelUrl,
 } from './portless-ngrok.mjs';
 
 const API_SERVICE = 'api.novu';
@@ -47,18 +45,12 @@ function isNovuRoute(route) {
   return false;
 }
 
-function resolveApiPublicUrl() {
+function resolveApiPublicUrl(routes) {
   if (!isNgrokMode()) {
     return undefined;
   }
 
-  const reserved = normalizeNgrokDomain(process.env.PORTLESS_NGROK_DOMAIN);
-
-  if (reserved && findServiceRoute(API_SERVICE)) {
-    return reserved;
-  }
-
-  return findPortlessNgrokUrl(API_SERVICE);
+  return resolveTunnelUrl(API_SERVICE, routes);
 }
 
 function formatRouteLine(route) {
@@ -93,10 +85,20 @@ function formatBanner(routes, apiPublicUrl) {
   return lines.join('\n');
 }
 
-function collectNovuRoutes() {
-  const routes = readRoutes().filter(isNovuRoute);
+function serviceOrder(hostname) {
+  for (let index = 0; index < NOVU_SERVICES.length; index++) {
+    if (hostnameMatchesService(hostname, NOVU_SERVICES[index].name)) {
+      return index;
+    }
+  }
 
-  routes.sort((a, b) => serviceLabel(a.hostname).localeCompare(serviceLabel(b.hostname)));
+  return NOVU_SERVICES.length;
+}
+
+function collectNovuRoutes(allRoutes) {
+  const routes = allRoutes.filter(isNovuRoute);
+
+  routes.sort((a, b) => serviceOrder(a.hostname) - serviceOrder(b.hostname));
 
   return routes;
 }
@@ -107,8 +109,9 @@ function watchUrls() {
   let lastBanner = '';
 
   const tick = () => {
-    const routes = collectNovuRoutes();
-    const apiPublicUrl = resolveApiPublicUrl();
+    const allRoutes = readRoutes();
+    const routes = collectNovuRoutes(allRoutes);
+    const apiPublicUrl = resolveApiPublicUrl(allRoutes);
     const banner = formatBanner(routes, apiPublicUrl);
 
     if (banner !== lastBanner) {

--- a/scripts/portless-urls.mjs
+++ b/scripts/portless-urls.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Watch and print Novu portless service URLs from ~/.portless/routes.json.
+ *
+ * Usage: node scripts/portless-urls.mjs watch
+ */
+import { fileURLToPath } from 'node:url';
+import {
+  findPortlessNgrokUrl,
+  findServiceRoute,
+  hostnameMatchesService,
+  isNgrokMode,
+  normalizeNgrokDomain,
+  readRoutes,
+} from './portless-ngrok.mjs';
+
+const API_SERVICE = 'api.novu';
+
+const NOVU_SERVICES = [
+  { name: 'api.novu', label: 'API' },
+  { name: 'dashboard.novu', label: 'Dashboard' },
+  { name: 'ws.novu', label: 'WebSocket' },
+  { name: 'playground.novu', label: 'Playground' },
+];
+
+function serviceLabel(hostname) {
+  for (const { name, label } of NOVU_SERVICES) {
+    if (hostnameMatchesService(hostname, name)) {
+      return label;
+    }
+  }
+
+  return hostname;
+}
+
+function isNovuRoute(route) {
+  if (!route?.hostname) {
+    return false;
+  }
+
+  for (const { name } of NOVU_SERVICES) {
+    if (hostnameMatchesService(route.hostname, name)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function resolveApiPublicUrl() {
+  if (!isNgrokMode()) {
+    return undefined;
+  }
+
+  const reserved = normalizeNgrokDomain(process.env.PORTLESS_NGROK_DOMAIN);
+
+  if (reserved && findServiceRoute(API_SERVICE)) {
+    return reserved;
+  }
+
+  return findPortlessNgrokUrl(API_SERVICE);
+}
+
+function formatRouteLine(route) {
+  const url = `https://${route.hostname}`;
+  const portSuffix = route.port ? `  (proxy → 127.0.0.1:${route.port})` : '';
+  const ngrokSuffix = route.ngrokUrl ? `  ngrok: ${route.ngrokUrl}` : '';
+
+  return `  ${serviceLabel(route.hostname)}  ${url}${portSuffix}${ngrokSuffix}`;
+}
+
+function formatBanner(routes, apiPublicUrl) {
+  const lines = ['', '  Portless URLs', ''];
+
+  if (apiPublicUrl) {
+    lines.push('  API public (ngrok) — AGENT_API_HOSTNAME', `  ${apiPublicUrl}`, '');
+  }
+
+  if (routes.length === 0) {
+    lines.push('  Waiting for portless routes…', '  Start api / dashboard / ws / playground with start:portless', '');
+  } else {
+    for (const route of routes) {
+      lines.push(formatRouteLine(route));
+    }
+
+    lines.push('');
+  }
+
+  if (apiPublicUrl || isNgrokMode()) {
+    lines.push('  Copy API public URL: pnpm portless:ngrok:url', '');
+  }
+
+  return lines.join('\n');
+}
+
+function collectNovuRoutes() {
+  const routes = readRoutes().filter(isNovuRoute);
+
+  routes.sort((a, b) => serviceLabel(a.hostname).localeCompare(serviceLabel(b.hostname)));
+
+  return routes;
+}
+
+function watchUrls() {
+  process.stdout.write('[portless-urls] watching ~/.portless/routes.json …\n');
+
+  let lastBanner = '';
+
+  const tick = () => {
+    const routes = collectNovuRoutes();
+    const apiPublicUrl = resolveApiPublicUrl();
+    const banner = formatBanner(routes, apiPublicUrl);
+
+    if (banner !== lastBanner) {
+      lastBanner = banner;
+      process.stdout.write(banner);
+    }
+  };
+
+  tick();
+  setInterval(tick, 1000);
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isCli) {
+  const command = process.argv[2];
+
+  if (command === 'watch') {
+    watchUrls();
+  } else {
+    console.error('[portless-urls] usage: node scripts/portless-urls.mjs watch');
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the ngrok-only **API PUBLIC URL** mprocs tab with a **PORTLESS URLS** tab that is always available during `pnpm dev:portless`.
- Poll `~/.portless/routes.json` and list all Novu portless services (API, Dashboard, WebSocket, Playground) with their HTTPS URLs and local proxy ports.
- When ngrok is enabled, also show the API public URL used for `AGENT_API_HOSTNAME` / OAuth webhooks.

## How it works

```mermaid
flowchart LR
  mprocs["mprocs PORTLESS URLS tab"] --> watch["portless-urls.mjs watch"]
  watch --> routes["~/.portless/routes.json"]
  routes --> list["HTTPS URL + proxy port per service"]
  watch --> ngrok["ngrok URL when PORTLESS_NGROK=1"]
```

## Test plan

- [ ] Run `pnpm dev:portless` and open the **PORTLESS URLS** tab in mprocs
- [ ] Confirm API and Dashboard URLs appear with proxy ports after those services start
- [ ] With ngrok enabled (`pnpm dev:config`), confirm API public URL appears at the top
- [ ] Run `node scripts/portless-urls.mjs watch` standalone and verify output updates as services start/stop

## Linear

https://linear.app/novu/issue/NV-8010/show-all-portless-urls-with-proxy-ports-in-mprocs-dev-tab

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

A new "PORTLESS URLS" mprocs tab was added and is now injected during dev to show all Novu portless service URLs (API, Dashboard, WebSocket, Playground) with HTTPS endpoints and local proxy ports; this replaces the prior ngrok-only "API PUBLIC URL" tab. A new watcher CLI (scripts/portless-urls.mjs) polls ~/.portless/routes.json and renders a live banner of service URLs, and when ngrok mode is enabled it also surfaces the API public ngrok URL. The change centralizes visibility of all portless services and their proxy ports for local development.

## Affected areas

- **root**: Added scripts/portless-urls.mjs (watcher/CLI) to poll and format portless routes; simplified scripts/mprocs-dev.mjs to always inject the PORTLESS URLS tab into the generated mprocs YAML; exported readRoutes() from scripts/portless-ngrok.mjs for reuse.  
- **api**: Updated a comment in apps/api/src/.example.env to reference the new mprocs PORTLESS URLS tab.

## Key technical decisions

- Implemented a 1s polling watcher on ~/.portless/routes.json to provide live updates without adding runtime dependencies.  
- Consolidated tunnel-route reads and deduplicated tunnel URL resolution so each watcher tick performs a single read, avoiding inconsistent snapshots.  
- No new npm packages or runtime API/DB/schema changes were introduced.

## Testing

No automated tests were added; manual verification is expected: run pnpm dev:portless and confirm the PORTLESS URLS mprocs tab lists expected HTTPS URLs and proxy ports, enable ngrok (PORTLESS_NGROK=1) to confirm the API public ngrok URL appears, or run node scripts/portless-urls.mjs watch standalone to observe updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the conditional ngrok-only "API PUBLIC URL" mprocs tab with a permanent "PORTLESS URLS" tab that always appears during `pnpm dev:portless`. It adds a new `portless-urls.mjs` watcher script and refactors `portless-ngrok.mjs` to export `readRoutes`, `resolveTunnelUrl`, and related helpers so the new script can reuse them.

- **`scripts/portless-urls.mjs`** (new): polls `~/.portless/routes.json` every second and prints a live banner of all four Novu services (API, Dashboard, WebSocket, Playground) with HTTPS URLs and proxy ports; surfaces the ngrok API public URL when `PORTLESS_NGROK=1`.
- **`scripts/portless-ngrok.mjs`**: exports `readRoutes` and `resolveTunnelUrl`, and adds an optional `routes` parameter to `findServiceRoute`, `findPortlessNgrokUrl`, and `resolveTunnelUrl` to allow callers to share a single file-read snapshot per tick — cleanly addressing the multiple-reads concern from the prior review.
- **`scripts/mprocs-dev.mjs`**: `buildConfigPath` now unconditionally injects the `PORTLESS URLS` process, removing the ngrok-enabled conditional entirely.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are dev-tooling only and do not affect any production code paths.

The change is entirely confined to local development scripts and a .example.env comment. The new watcher correctly shares a single readRoutes() snapshot per tick, the sort order follows the NOVU_SERVICES declaration, and the duplicated tunnel-URL logic has been replaced with the now-exported resolveTunnelUrl. No production code, tests, or data flows are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/portless-urls.mjs | New watcher script; reads routes once per tick and threads the snapshot through all helpers, fixing the multi-read issue from the previous review. Logic is correct and consistent with existing portless patterns. |
| scripts/portless-ngrok.mjs | Exports readRoutes and resolveTunnelUrl; adds optional routes parameter to findServiceRoute, findPortlessNgrokUrl, and resolveTunnelUrl so callers can share a single snapshot. Backward-compatible — all defaults preserved. |
| scripts/mprocs-dev.mjs | Simplified: buildConfigPath now always injects the PORTLESS URLS process unconditionally; the enabled flag from resolveNgrokEnv is correctly dropped since it is no longer needed. |
| apps/api/src/.example.env | Single-line comment update to reference the new PORTLESS URLS tab name. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm dev:portless\n(mprocs-dev.mjs)"] --> B["buildConfigPath()\nalways injects PORTLESS URLS proc"]
    B --> C["mprocs.yaml + PORTLESS URLS tab"]
    C --> D["node scripts/portless-urls.mjs watch"]
    D --> E["watchUrls()\nsetInterval 1s"]
    E --> F["readRoutes()\n~/.portless/routes.json\none read per tick"]
    F --> G["collectNovuRoutes(allRoutes)\nsort by NOVU_SERVICES order"]
    F --> H["resolveApiPublicUrl(allRoutes)\nreuses same snapshot"]
    G --> I["formatBanner(routes, apiPublicUrl)"]
    H --> I
    I -->|banner changed| J["process.stdout.write(banner)"]
    H --> K{isNgrokMode?}
    K -->|yes| L["resolveTunnelUrl(API_SERVICE, routes)\nreserved domain or ngrokUrl"]
    K -->|no| M["return undefined"]
    L --> I
```

<sub>Reviews (2): Last reviewed commit: ["fix(root): dedupe tunnel URL resolution ..."](https://github.com/novuhq/novu/commit/a901bfd22b6c7a48a8aaca1d9057f262d899db1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36915539)</sub>

<!-- /greptile_comment -->