### PR TITLE
fix(dashboard): redirect 'Navigate to Dashboard' to created agent after onboarding

### DIFF
--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -24,7 +24,7 @@ import { AGENT_TEMPLATE_ID_PARAM, readActiveAgentTemplateId } from '@/utils/agen
 import { isAbsoluteUrl } from '@/utils/apps';
 import { clearPersistedCliOnboardingSessionId } from '@/utils/cli-onboarding-identity';
 import { getPostOnboardingRoute, withOnboardingSource } from '@/utils/onboarding-redirect';
-import { buildRoute, ROUTES } from '@/utils/routes';
+import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 function goToPostOnboardingRoute(target: string, navigate: (path: string) => void) {
@@ -203,10 +203,19 @@ export function AgentsSetupPage() {
     telemetry(TelemetryEvent.ONBOARDING_REDIRECT, { from: 'complete' });
     clearPersistedCliOnboardingSessionId();
 
-    if (currentEnvironment?.slug) {
+    if (!currentEnvironment?.slug) return;
+
+    if (createdAgent) {
+      const agentPath = buildRoute(agentRoutes.detailsTab, {
+        environmentSlug: currentEnvironment.slug,
+        agentIdentifier: encodeURIComponent(createdAgent.identifier),
+        agentTab: AGENT_DETAILS_DEFAULT_TAB,
+      });
+      goToPostOnboardingRoute(agentPath, navigate);
+    } else {
       goToPostOnboardingRoute(getPostOnboardingRoute(currentEnvironment.slug), navigate);
     }
-  }, [buildOnboardingCompletionProps, currentEnvironment?.slug, navigate, telemetry]);
+  }, [agentRoutes.detailsTab, buildOnboardingCompletionProps, createdAgent, currentEnvironment?.slug, navigate, telemetry]);
 
   const handleSetupAnotherChannel = useCallback(() => {
     if (!currentEnvironment?.slug || !createdAgent) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

After completing the agent onboarding flow, the "Navigate to Dashboard" button was incorrectly redirecting users to the `/agents` list page. Users expect to be taken to the agent they just created, not to the generic list.

**Fix:** Updated `handleNavigateToOverview` in `agents-setup-page.tsx` to navigate to the newly created agent's overview page (`/env/:slug/agents/:identifier/overview`) when `createdAgent` is available. Falls back to the agents list route if no created agent exists.

This mirrors the existing pattern used by `handleSetupAnotherChannel` which already navigates to the created agent.

### Screenshots

N/A — routing change only, no visual UI change.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1781164772182039?thread_ts=1781164772.182039&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-76256eea-46bd-590d-9223-5a4e034da73a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76256eea-46bd-590d-9223-5a4e034da73a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

After completing agent onboarding, the "Navigate to Dashboard" button now routes users to the newly created agent's overview page instead of the generic agents list. The `handleNavigateToOverview` function in agents-setup-page.tsx was updated to check for a created agent and navigate to its details page when available, falling back to the agents list if needed. This ensures users see their newly created agent immediately after onboarding.

## Affected areas

- **dashboard**: Updated the post-onboarding redirect logic in agents-setup-page.tsx to route to the newly created agent's overview page using the agent identifier and default details tab, with a fallback to the agents list.

## Testing

No new tests were added. This is a routing fix that mirrors existing navigation patterns in the codebase. Manual verification through the onboarding flow would validate the redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the post-onboarding "Navigate to Dashboard" button so it redirects to the newly created agent's overview page (`/env/:slug/agents/:identifier/overview`) instead of the generic agents list. The fix follows the exact same pattern already used by `handleSetupAnotherChannel`.

- `handleNavigateToOverview` now builds the agent detail route using `buildRoute(agentRoutes.detailsTab, ...)` with `AGENT_DETAILS_DEFAULT_TAB` (`'overview'`), consistent with the sibling handler.
- Falls back to `getPostOnboardingRoute` when no `createdAgent` is present, which is a safe defensive path since the button is only rendered when `createdAgent && setupComplete`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-function routing fix with a well-tested fallback path.

The change is small, touches only one callback, mirrors a pattern already in production in the same file, and the affected button is only rendered when both `createdAgent` and `setupComplete` are truthy, making the new branch the only one that will ever fire in practice.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/agents-setup-page.tsx | handleNavigateToOverview now routes to the created agent's detail/overview page when createdAgent is available, falling back to the generic post-onboarding route. Pattern is consistent with handleSetupAnotherChannel. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks 'Navigate to Dashboard'] --> B{currentEnvironment?.slug?}
    B -- No --> C[Return early / no navigation]
    B -- Yes --> D{createdAgent?}
    D -- Yes --> E["Build agent path\n/env/:slug/agents/:identifier/overview"]
    D -- No --> F["getPostOnboardingRoute(slug)\n(generic fallback)"]
    E --> G[goToPostOnboardingRoute\nwithOnboardingSource + navigate]
    F --> G
```

<sub>Reviews (1): Last reviewed commit: ["fix: redirect &#39;Navigate to Dashboard&#39; to..."](https://github.com/novuhq/novu/commit/012438d6fd03e3415f323ec2a3a20df51bc1750d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36921539)</sub>

<!-- /greptile_comment -->