### PR TITLE
fix(dashboard): remove API key edit link from agent overview sidebar

### DIFF
--- a/apps/dashboard/src/components/agents/connector-section.tsx
+++ b/apps/dashboard/src/components/agents/connector-section.tsx
@@ -1,15 +1,13 @@
 import { AGENT_RUNTIME_PROVIDERS, isClaudePlatformConsoleProvider } from '@novu/shared';
 import { useMutation } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
-import { RiEditLine, RiInformationFill, RiLoopRightLine } from 'react-icons/ri';
-import { Link } from 'react-router-dom';
+import { RiInformationFill, RiLoopRightLine } from 'react-icons/ri';
 import { type AgentResponse, getAgentRuntimeConfig } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
 import { AnimatedBadgeDot, Badge } from '@/components/primitives/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
-import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 import { ClaudeIcon } from '../icons/claude';
 
@@ -77,12 +75,6 @@ export function ConnectorSection({ agent }: ConnectorSectionProps) {
     return integrations?.find((item) => item._id === managed.integrationId);
   }, [integrations, managed?.integrationId]);
 
-  const integrationUpdateRoute = useMemo(() => {
-    if (!managed?.integrationId) return undefined;
-
-    return buildRoute(ROUTES.INTEGRATIONS_UPDATE, { integrationId: managed.integrationId });
-  }, [managed?.integrationId]);
-
   const testConnectionMutation = useMutation({
     mutationFn: () =>
       getAgentRuntimeConfig(requireEnvironment(currentEnvironment, 'No environment selected'), agent.identifier),
@@ -114,15 +106,6 @@ export function ConnectorSection({ agent }: ConnectorSectionProps) {
         <span className="text-text-sub min-w-0 truncate text-label-xs font-medium">
           {integration?.name ?? 'Loading…'}
         </span>
-        {integrationUpdateRoute ? (
-          <Link
-            to={integrationUpdateRoute}
-            aria-label="Edit integration"
-            className="text-text-soft hover:text-text-sub inline-flex shrink-0 items-center rounded-sm transition-colors"
-          >
-            <RiEditLine className="size-3.5" />
-          </Link>
-        ) : null}
       </Row>
 
       <Row label="Workspace ID">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the edit/pencil icon link next to the "API key" field in the agent overview sidebar. Clicking that icon used to navigate to the Integration Store page, but since there is no dedicated tab for non-channel integrations yet, the link was confusing.

## Changes

- Removed the `<Link>` component (with `RiEditLine` icon) from the "API key" row in `ConnectorSection`
- Cleaned up unused imports (`RiEditLine`, `Link`, `buildRoute`, `ROUTES`)
- Removed the now-unused `integrationUpdateRoute` memoized variable

## Before / After

**Before:** The API key row shows the integration name with an edit icon that redirects to the Integration Store.

**After:** The API key row shows only the integration name as plain text — no clickable icon.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1781164935531639?thread_ts=1781164935.531639&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-7714b9fe-b18c-5a1e-a5ab-68ed704e115c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7714b9fe-b18c-5a1e-a5ab-68ed704e115c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the edit/pencil icon link from the "API key" row in the agent overview sidebar's `ConnectorSection` component, along with its associated imports and memoized route variable.

- The `<Link>` with `RiEditLine` icon is removed from the API key row; the integration name now renders as plain text only.
- All now-unused imports (`RiEditLine`, `Link`, `buildRoute`, `ROUTES`) and the `integrationUpdateRoute` `useMemo` are cleaned up correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused UI removal with no logic side effects.

All removed code (icon, Link, imports, memo) was exclusively wiring the edit navigation; nothing else depended on it. The remaining render path is unchanged and the cleanup is complete.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/connector-section.tsx | Removes the edit icon link and its supporting code from the API key row; remaining code is correct and all removed imports are genuinely unused after the change. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConnectorSection renders] --> B[API key Row]
    B --> C["integration?.name ?? 'Loading…'"]
    C --> D[Plain text — no link]

    subgraph Removed
        E["integrationUpdateRoute (useMemo)"] --> F["<Link to=integrationUpdateRoute>"]
        F --> G["<RiEditLine icon>"]
        G --> H[Navigated to Integration Store]
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): remove API key edit link..."](https://github.com/novuhq/novu/commit/b32caa65002381b1a6fbae50ada1f8c0ed305ccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36924352)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The agent overview sidebar's connector section no longer displays an edit icon link next to the API key field. The icon previously navigated to the Integration Store page but was confusing because there's no dedicated tab for managing non-channel integrations. The API key field now shows only the integration name as plain text, removing this unnecessary UI affordance.

## Affected areas

**dashboard**: Removed the edit link from the API key row in the connector section component, including unused routing imports (`Link`, `buildRoute`, `ROUTES`), the edit icon import (`RiEditLine`), and the `integrationUpdateRoute` memoized variable.

## Testing

No new tests were added. The change is a UI simplification that likely benefits from manual verification in the agent overview sidebar to confirm the edit icon is removed while the API key field remains functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->