### PR TITLE
fix(api): reduce keyless demo reply cap to 3 messages fixes NV-8014

### DIFF
--- a/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@novu/dal';
 import { EmailProviderIdEnum } from '@novu/shared';
 import type { WellKnownEmoji } from 'chat';
+import { isKeylessOrganization } from '../../keyless/keyless-organization.helpers';
 import { trackAgentIntegrationFirstWebhook } from '../shared/analytics/agent-analytics';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
 import { AgentInactiveException } from '../shared/errors/agent-inactive.exception';
@@ -248,7 +249,7 @@ export class AgentConfigResolver {
       connectionAccessToken,
       environmentId,
       organizationId,
-      isKeyless: Boolean(process.env.KEYLESS_ORGANIZATION_ID && organizationId === process.env.KEYLESS_ORGANIZATION_ID),
+      isKeyless: isKeylessOrganization(organizationId),
       isManaged: !!agent.managedRuntime,
       agentId: agent._id,
       agentIdentifier: agent.identifier,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -15,7 +15,7 @@ import type { CardElement, EmojiValue, Message, Thread } from 'chat';
 import { ConnectClaimTokenService } from '../../../connect/services/connect-claim-token.service';
 import { parsePositiveIntEnv } from '../../../keyless/keyless-abuse.constants';
 import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
-import { buildConnectClaimUrl, buildKeylessSignupCard } from '../../../keyless/keyless-signup.helpers';
+import { buildConnectClaimUrl, buildKeylessSignupCard, toReplyCard } from '../../../keyless/keyless-signup.helpers';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { LinkTelegramChatToSubscriberCommand } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
 import { LinkTelegramChatToSubscriber } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
@@ -730,7 +730,7 @@ export class AgentInboundHandler implements OnModuleInit {
       const claimUrl = buildConnectClaimUrl(token);
 
       await this.outboundGateway.replyOnThread(thread, {
-        card: buildKeylessSignupCard(claimUrl) as unknown as Record<string, unknown>,
+        card: toReplyCard(buildKeylessSignupCard(claimUrl)),
       });
 
       await this.connectClaimTokenService.tryMarkSignupCtaPosted(conversationId);

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -15,6 +15,7 @@ import type { CardElement, EmojiValue, Message, Thread } from 'chat';
 import { ConnectClaimTokenService } from '../../../connect/services/connect-claim-token.service';
 import { parsePositiveIntEnv } from '../../../keyless/keyless-abuse.constants';
 import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.service';
+import { buildConnectClaimUrl, buildKeylessSignupCard } from '../../../keyless/keyless-signup.helpers';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { LinkTelegramChatToSubscriberCommand } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
 import { LinkTelegramChatToSubscriber } from '../../channels/telegram-linking/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
@@ -86,46 +87,6 @@ const SUBSCRIBER_LINK_WRONG_BOT_REPLY =
 const NOVU_PRICING_URL = 'https://novu.co/pricing';
 
 const KEYLESS_DEMO_REPLY_CAP = parsePositiveIntEnv(process.env.KEYLESS_DEMO_REPLY_CAP, 3);
-
-function resolveConnectClaimBaseUrl(): string {
-  for (const candidate of [process.env.DASHBOARD_URL, process.env.FRONT_BASE_URL]) {
-    const trimmed = candidate?.trim();
-
-    if (!trimmed || trimmed.startsWith('^')) {
-      continue;
-    }
-
-    return trimmed.replace(/\/$/, '');
-  }
-
-  return 'https://dashboard.novu.co';
-}
-
-function buildKeylessSignupCard(claimUrl: string): CardElement {
-  return {
-    type: 'card',
-    children: [
-      {
-        type: 'text',
-        content:
-          "You've reached the limit of this free demo. Sign up for a free Novu account to keep this agent — your " +
-          'conversation and setup carry over, and the agent picks up right where it left off.',
-      },
-      { type: 'divider' },
-      {
-        type: 'actions',
-        children: [
-          {
-            type: 'link-button',
-            label: 'Sign up & keep this agent',
-            url: claimUrl,
-            style: 'primary',
-          },
-        ],
-      },
-    ],
-  };
-}
 
 /**
  * Workspace-label copy keyed by every platform in `AUTO_PROVISION_PLATFORMS`.
@@ -766,7 +727,7 @@ export class AgentInboundHandler implements OnModuleInit {
         env: config.environmentId,
         org: config.organizationId,
       });
-      const claimUrl = `${resolveConnectClaimBaseUrl()}/connect/claim?token=${encodeURIComponent(token)}`;
+      const claimUrl = buildConnectClaimUrl(token);
 
       await this.outboundGateway.replyOnThread(thread, {
         card: buildKeylessSignupCard(claimUrl) as unknown as Record<string, unknown>,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -85,7 +85,7 @@ const SUBSCRIBER_LINK_WRONG_BOT_REPLY =
 
 const NOVU_PRICING_URL = 'https://novu.co/pricing';
 
-const KEYLESS_DEMO_REPLY_CAP = parsePositiveIntEnv(process.env.KEYLESS_DEMO_REPLY_CAP, 5);
+const KEYLESS_DEMO_REPLY_CAP = parsePositiveIntEnv(process.env.KEYLESS_DEMO_REPLY_CAP, 3);
 
 function resolveConnectClaimBaseUrl(): string {
   for (const candidate of [process.env.DASHBOARD_URL, process.env.FRONT_BASE_URL]) {

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
@@ -6,14 +6,15 @@ import {
   ConversationParticipantTypeEnum,
   IntegrationRepository,
 } from '@novu/dal';
+import type { CardElement } from 'chat';
 import { ConnectClaimTokenService } from '../../../../connect/services/connect-claim-token.service';
+import { isKeylessOrganization } from '../../../../keyless/keyless-organization.helpers';
 import {
   buildConnectClaimUrl,
   buildKeylessWelcomeCard,
-  getKeylessWelcomeText,
-  isKeylessOrganization,
+  toReplyCard,
 } from '../../../../keyless/keyless-signup.helpers';
-import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
+import { getWelcomeText } from '../../../shared/util/agent-welcome-text';
 import { PLATFORM_ENDPOINT_CONFIG } from '../../../shared/util/platform-endpoint-config';
 import { resolveAgentPlatform } from '../../../shared/util/provider-to-platform';
 import { AgentConversationService } from '../../conversation/agent-conversation.service';
@@ -97,13 +98,15 @@ export class SendAgentWelcomeMessage {
     }
 
     try {
-      const welcomeText = getKeylessWelcomeText(platform);
-      const keylessWelcome = await this.buildKeylessWelcomeDelivery(command, platform, welcomeText);
+      const welcomeText = getWelcomeText(platform);
+      const keylessWelcomeCard = await this.resolveKeylessWelcomeCard(command, welcomeText);
+      const welcomeReplyCard = keylessWelcomeCard ? toReplyCard(keylessWelcomeCard) : undefined;
+      const welcomeContent = welcomeReplyCard ? { card: welcomeReplyCard } : { markdown: welcomeText };
       const sent = await this.outboundGateway.sendDirectMessage(
         agent._id,
         command.integrationIdentifier,
         platformUserId,
-        keylessWelcome?.content ?? { markdown: welcomeText }
+        welcomeContent
       );
 
       const { platformThreadId } = sent;
@@ -129,7 +132,7 @@ export class SendAgentWelcomeMessage {
         platformMessageId: sent.messageId,
         agentIdentifier: command.agentIdentifier,
         content: welcomeText,
-        richContent: keylessWelcome?.richContent,
+        richContent: welcomeReplyCard ? { card: welcomeReplyCard } : undefined,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
       });
@@ -150,11 +153,10 @@ export class SendAgentWelcomeMessage {
     }
   }
 
-  private async buildKeylessWelcomeDelivery(
+  private async resolveKeylessWelcomeCard(
     command: SendAgentWelcomeMessageCommand,
-    platform: AgentPlatformEnum,
     welcomeText: string
-  ): Promise<{ content: { card: Record<string, unknown> }; richContent: Record<string, unknown> } | null> {
+  ): Promise<CardElement | null> {
     if (!isKeylessOrganization(command.organizationId)) {
       return null;
     }
@@ -165,12 +167,8 @@ export class SendAgentWelcomeMessage {
         org: command.organizationId,
       });
       const claimUrl = buildConnectClaimUrl(token);
-      const card = buildKeylessWelcomeCard(welcomeText, claimUrl);
 
-      return {
-        content: { card: card as unknown as Record<string, unknown> },
-        richContent: { card: card as unknown as Record<string, unknown> },
-      };
+      return buildKeylessWelcomeCard(welcomeText, claimUrl);
     } catch (err) {
       this.logger.warn(
         err,

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
@@ -6,27 +6,19 @@ import {
   ConversationParticipantTypeEnum,
   IntegrationRepository,
 } from '@novu/dal';
+import { ConnectClaimTokenService } from '../../../../connect/services/connect-claim-token.service';
+import {
+  buildConnectClaimUrl,
+  buildKeylessWelcomeCard,
+  getKeylessWelcomeText,
+  isKeylessOrganization,
+} from '../../../../keyless/keyless-signup.helpers';
 import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
 import { PLATFORM_ENDPOINT_CONFIG } from '../../../shared/util/platform-endpoint-config';
 import { resolveAgentPlatform } from '../../../shared/util/provider-to-platform';
 import { AgentConversationService } from '../../conversation/agent-conversation.service';
 import { OutboundGateway } from '../../egress/outbound.gateway';
 import { SendAgentWelcomeMessageCommand } from './send-agent-welcome-message.command';
-
-function getWelcomeText(platform: AgentPlatformEnum): string {
-  switch (platform) {
-    case AgentPlatformEnum.SLACK:
-      return 'Your Slack app is connected! Send me a message to try it out.';
-    case AgentPlatformEnum.TEAMS:
-      return 'Your Teams app is connected! Send me a message to try it out.';
-    case AgentPlatformEnum.WHATSAPP:
-      return 'Connected! Send me a message to try it out.';
-    case AgentPlatformEnum.EMAIL:
-      return 'Connected! Reply to this email to try it out.';
-    default:
-      return 'Connected! Send me a message to try it out.';
-  }
-}
 
 @Injectable()
 export class SendAgentWelcomeMessage {
@@ -37,6 +29,7 @@ export class SendAgentWelcomeMessage {
     private readonly conversationService: AgentConversationService,
     private readonly analyticsService: AnalyticsService,
     private readonly outboundGateway: OutboundGateway,
+    private readonly connectClaimTokenService: ConnectClaimTokenService,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -104,12 +97,13 @@ export class SendAgentWelcomeMessage {
     }
 
     try {
-      const welcomeText = getWelcomeText(platform);
+      const welcomeText = getKeylessWelcomeText(platform);
+      const keylessWelcome = await this.buildKeylessWelcomeDelivery(command, platform, welcomeText);
       const sent = await this.outboundGateway.sendDirectMessage(
         agent._id,
         command.integrationIdentifier,
         platformUserId,
-        { markdown: welcomeText }
+        keylessWelcome?.content ?? { markdown: welcomeText }
       );
 
       const { platformThreadId } = sent;
@@ -135,6 +129,7 @@ export class SendAgentWelcomeMessage {
         platformMessageId: sent.messageId,
         agentIdentifier: command.agentIdentifier,
         content: welcomeText,
+        richContent: keylessWelcome?.richContent,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
       });
@@ -152,6 +147,37 @@ export class SendAgentWelcomeMessage {
       this.logger.warn(err, `Failed to send welcome message for agent "${command.agentIdentifier}"`);
 
       return { sent: false };
+    }
+  }
+
+  private async buildKeylessWelcomeDelivery(
+    command: SendAgentWelcomeMessageCommand,
+    platform: AgentPlatformEnum,
+    welcomeText: string
+  ): Promise<{ content: { card: Record<string, unknown> }; richContent: Record<string, unknown> } | null> {
+    if (!isKeylessOrganization(command.organizationId)) {
+      return null;
+    }
+
+    try {
+      const { token } = await this.connectClaimTokenService.issueOrGetForEnvironment({
+        env: command.environmentId,
+        org: command.organizationId,
+      });
+      const claimUrl = buildConnectClaimUrl(token);
+      const card = buildKeylessWelcomeCard(welcomeText, claimUrl);
+
+      return {
+        content: { card: card as unknown as Record<string, unknown> },
+        richContent: { card: card as unknown as Record<string, unknown> },
+      };
+    } catch (err) {
+      this.logger.warn(
+        err,
+        `Failed to build keyless welcome signup link for agent "${command.agentIdentifier}" — sending plain welcome`
+      );
+
+      return null;
     }
   }
 

--- a/apps/api/src/app/agents/shared/util/agent-welcome-text.ts
+++ b/apps/api/src/app/agents/shared/util/agent-welcome-text.ts
@@ -1,0 +1,16 @@
+import { AgentPlatformEnum } from '../enums/agent-platform.enum';
+
+export function getWelcomeText(platform: AgentPlatformEnum): string {
+  switch (platform) {
+    case AgentPlatformEnum.SLACK:
+      return 'Your Slack app is connected! Send me a message to try it out.';
+    case AgentPlatformEnum.TEAMS:
+      return 'Your Teams app is connected! Send me a message to try it out.';
+    case AgentPlatformEnum.WHATSAPP:
+      return 'Connected! Send me a message to try it out.';
+    case AgentPlatformEnum.EMAIL:
+      return 'Connected! Reply to this email to try it out.';
+    default:
+      return 'Connected! Send me a message to try it out.';
+  }
+}

--- a/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
+++ b/apps/api/src/app/keyless/keyless-abuse-guard.service.ts
@@ -9,6 +9,7 @@ import {
   KEYLESS_GENERATE_CAP_PER_IP_PER_DAY,
   KEYLESS_MAX_AGENTS_PER_ENV,
 } from './keyless-abuse.constants';
+import { isKeylessOrganization } from './keyless-organization.helpers';
 
 const ENV_CREATE_LIMIT_MESSAGE =
   'Daily keyless demo limit reached. Sign up for a free Novu account or try again tomorrow.';
@@ -45,7 +46,7 @@ export class KeylessAbuseGuardService {
   }
 
   async isKeylessAgentAiEnabled(organizationId: string): Promise<boolean> {
-    if (!this.isKeylessOrganization(organizationId)) {
+    if (!isKeylessOrganization(organizationId)) {
       return true;
     }
 
@@ -65,7 +66,7 @@ export class KeylessAbuseGuardService {
   }
 
   async assertManagedAgentCap(environmentId: string, organizationId: string): Promise<void> {
-    if (KEYLESS_MAX_AGENTS_PER_ENV === 0 || !this.isKeylessOrganization(organizationId)) {
+    if (KEYLESS_MAX_AGENTS_PER_ENV === 0 || !isKeylessOrganization(organizationId)) {
       return;
     }
 
@@ -98,12 +99,6 @@ export class KeylessAbuseGuardService {
     if (nextCount > cap) {
       throw new HttpException(limitMessage, HttpStatus.TOO_MANY_REQUESTS);
     }
-  }
-
-  private isKeylessOrganization(organizationId: string): boolean {
-    const keylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
-
-    return Boolean(keylessOrgId && organizationId === keylessOrgId);
   }
 
   private dailyCounterKey(kind: 'env_create' | 'generate', clientIp: string): string {

--- a/apps/api/src/app/keyless/keyless-organization.helpers.spec.ts
+++ b/apps/api/src/app/keyless/keyless-organization.helpers.spec.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { isKeylessOrganization } from './keyless-organization.helpers';
+
+describe('keyless-organization.helpers', () => {
+  const originalKeylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
+
+  afterEach(() => {
+    if (originalKeylessOrgId === undefined) {
+      delete process.env.KEYLESS_ORGANIZATION_ID;
+    } else {
+      process.env.KEYLESS_ORGANIZATION_ID = originalKeylessOrgId;
+    }
+  });
+
+  it('isKeylessOrganization returns true only for the configured org', () => {
+    process.env.KEYLESS_ORGANIZATION_ID = 'org-keyless';
+
+    expect(isKeylessOrganization('org-keyless')).to.equal(true);
+    expect(isKeylessOrganization('org-other')).to.equal(false);
+  });
+});

--- a/apps/api/src/app/keyless/keyless-organization.helpers.ts
+++ b/apps/api/src/app/keyless/keyless-organization.helpers.ts
@@ -1,0 +1,5 @@
+export function isKeylessOrganization(organizationId: string): boolean {
+  const keylessOrganizationId = process.env.KEYLESS_ORGANIZATION_ID;
+
+  return Boolean(keylessOrganizationId && organizationId === keylessOrganizationId);
+}

--- a/apps/api/src/app/keyless/keyless-signup.helpers.spec.ts
+++ b/apps/api/src/app/keyless/keyless-signup.helpers.spec.ts
@@ -1,40 +1,63 @@
 import { expect } from 'chai';
+import { getWelcomeText } from '../agents/shared/util/agent-welcome-text';
 import { AgentPlatformEnum } from '../agents/shared/enums/agent-platform.enum';
 import {
   buildConnectClaimUrl,
   buildKeylessSignupCard,
   buildKeylessWelcomeCard,
-  getKeylessWelcomeText,
-  isKeylessOrganization,
+  resolveConnectClaimBaseUrl,
 } from './keyless-signup.helpers';
 
 describe('keyless-signup.helpers', () => {
-  const originalKeylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
+  const originalDashboardUrl = process.env.DASHBOARD_URL;
+  const originalFrontBaseUrl = process.env.FRONT_BASE_URL;
 
   afterEach(() => {
-    if (originalKeylessOrgId === undefined) {
-      delete process.env.KEYLESS_ORGANIZATION_ID;
+    if (originalDashboardUrl === undefined) {
+      delete process.env.DASHBOARD_URL;
     } else {
-      process.env.KEYLESS_ORGANIZATION_ID = originalKeylessOrgId;
+      process.env.DASHBOARD_URL = originalDashboardUrl;
+    }
+
+    if (originalFrontBaseUrl === undefined) {
+      delete process.env.FRONT_BASE_URL;
+    } else {
+      process.env.FRONT_BASE_URL = originalFrontBaseUrl;
     }
   });
 
-  it('isKeylessOrganization returns true only for the configured org', () => {
-    process.env.KEYLESS_ORGANIZATION_ID = 'org-keyless';
+  it('resolveConnectClaimBaseUrl prefers DASHBOARD_URL over FRONT_BASE_URL', () => {
+    process.env.DASHBOARD_URL = 'https://dashboard.example.com/';
+    process.env.FRONT_BASE_URL = 'https://front.example.com';
 
-    expect(isKeylessOrganization('org-keyless')).to.equal(true);
-    expect(isKeylessOrganization('org-other')).to.equal(false);
+    expect(resolveConnectClaimBaseUrl()).to.equal('https://dashboard.example.com');
+  });
+
+  it('resolveConnectClaimBaseUrl falls back to FRONT_BASE_URL when DASHBOARD_URL is unset', () => {
+    delete process.env.DASHBOARD_URL;
+    process.env.FRONT_BASE_URL = 'https://front.example.com/';
+
+    expect(resolveConnectClaimBaseUrl()).to.equal('https://front.example.com');
+  });
+
+  it('resolveConnectClaimBaseUrl skips regex-shaped env values and uses the default', () => {
+    process.env.DASHBOARD_URL = '^https://.*\\.example\\.com$';
+    delete process.env.FRONT_BASE_URL;
+
+    expect(resolveConnectClaimBaseUrl()).to.equal('https://dashboard.novu.co');
   });
 
   it('buildConnectClaimUrl encodes the token in the claim URL', () => {
-    const claimUrl = buildConnectClaimUrl('abc+token');
+    process.env.DASHBOARD_URL = 'https://dashboard.example.com';
+    delete process.env.FRONT_BASE_URL;
 
-    expect(claimUrl).to.include('/connect/claim?token=abc%2Btoken');
-    expect(claimUrl.startsWith('http://') || claimUrl.startsWith('https://')).to.equal(true);
+    expect(buildConnectClaimUrl('abc+token')).to.equal(
+      'https://dashboard.example.com/connect/claim?token=abc%2Btoken'
+    );
   });
 
   it('buildKeylessWelcomeCard includes welcome text and a subtle signup link', () => {
-    const welcomeText = getKeylessWelcomeText(AgentPlatformEnum.SLACK);
+    const welcomeText = getWelcomeText(AgentPlatformEnum.SLACK);
     const card = buildKeylessWelcomeCard(welcomeText, 'https://example.com/claim');
 
     expect(card.children?.[0]).to.deep.equal({ type: 'text', content: welcomeText });

--- a/apps/api/src/app/keyless/keyless-signup.helpers.spec.ts
+++ b/apps/api/src/app/keyless/keyless-signup.helpers.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { AgentPlatformEnum } from '../agents/shared/enums/agent-platform.enum';
+import {
+  buildConnectClaimUrl,
+  buildKeylessSignupCard,
+  buildKeylessWelcomeCard,
+  getKeylessWelcomeText,
+  isKeylessOrganization,
+} from './keyless-signup.helpers';
+
+describe('keyless-signup.helpers', () => {
+  const originalKeylessOrgId = process.env.KEYLESS_ORGANIZATION_ID;
+
+  afterEach(() => {
+    if (originalKeylessOrgId === undefined) {
+      delete process.env.KEYLESS_ORGANIZATION_ID;
+    } else {
+      process.env.KEYLESS_ORGANIZATION_ID = originalKeylessOrgId;
+    }
+  });
+
+  it('isKeylessOrganization returns true only for the configured org', () => {
+    process.env.KEYLESS_ORGANIZATION_ID = 'org-keyless';
+
+    expect(isKeylessOrganization('org-keyless')).to.equal(true);
+    expect(isKeylessOrganization('org-other')).to.equal(false);
+  });
+
+  it('buildConnectClaimUrl encodes the token in the claim URL', () => {
+    const claimUrl = buildConnectClaimUrl('abc+token');
+
+    expect(claimUrl).to.include('/connect/claim?token=abc%2Btoken');
+    expect(claimUrl.startsWith('http://') || claimUrl.startsWith('https://')).to.equal(true);
+  });
+
+  it('buildKeylessWelcomeCard includes welcome text and a subtle signup link', () => {
+    const welcomeText = getKeylessWelcomeText(AgentPlatformEnum.SLACK);
+    const card = buildKeylessWelcomeCard(welcomeText, 'https://example.com/claim');
+
+    expect(card.children?.[0]).to.deep.equal({ type: 'text', content: welcomeText });
+    expect(card.children?.[2]).to.deep.equal({
+      type: 'link',
+      label: 'Sign up free',
+      url: 'https://example.com/claim',
+    });
+  });
+
+  it('buildKeylessSignupCard includes a primary signup button', () => {
+    const card = buildKeylessSignupCard('https://example.com/claim');
+    const actions = card.children?.find((child) => child.type === 'actions');
+
+    expect(actions?.children?.[0]).to.deep.equal({
+      type: 'link-button',
+      label: 'Sign up & keep this agent',
+      url: 'https://example.com/claim',
+      style: 'primary',
+    });
+  });
+});

--- a/apps/api/src/app/keyless/keyless-signup.helpers.ts
+++ b/apps/api/src/app/keyless/keyless-signup.helpers.ts
@@ -1,16 +1,10 @@
 import type { CardElement } from 'chat';
-import { AgentPlatformEnum } from '../agents/shared/enums/agent-platform.enum';
-
-export function isKeylessOrganization(organizationId: string): boolean {
-  const keylessOrganizationId = process.env.KEYLESS_ORGANIZATION_ID;
-
-  return Boolean(keylessOrganizationId && organizationId === keylessOrganizationId);
-}
 
 export function resolveConnectClaimBaseUrl(): string {
   for (const candidate of [process.env.DASHBOARD_URL, process.env.FRONT_BASE_URL]) {
     const trimmed = candidate?.trim();
 
+    // Some deployments store CORS-style regex patterns in these vars; skip them for URL building.
     if (!trimmed || trimmed.startsWith('^')) {
       continue;
     }
@@ -25,19 +19,8 @@ export function buildConnectClaimUrl(token: string): string {
   return `${resolveConnectClaimBaseUrl()}/connect/claim?token=${encodeURIComponent(token)}`;
 }
 
-export function getKeylessWelcomeText(platform: AgentPlatformEnum): string {
-  switch (platform) {
-    case AgentPlatformEnum.SLACK:
-      return 'Your Slack app is connected! Send me a message to try it out.';
-    case AgentPlatformEnum.TEAMS:
-      return 'Your Teams app is connected! Send me a message to try it out.';
-    case AgentPlatformEnum.WHATSAPP:
-      return 'Connected! Send me a message to try it out.';
-    case AgentPlatformEnum.EMAIL:
-      return 'Connected! Reply to this email to try it out.';
-    default:
-      return 'Connected! Send me a message to try it out.';
-  }
+export function toReplyCard(card: CardElement): Record<string, unknown> {
+  return card as unknown as Record<string, unknown>;
 }
 
 export function buildKeylessWelcomeCard(welcomeText: string, claimUrl: string): CardElement {

--- a/apps/api/src/app/keyless/keyless-signup.helpers.ts
+++ b/apps/api/src/app/keyless/keyless-signup.helpers.ts
@@ -1,0 +1,85 @@
+import type { CardElement } from 'chat';
+import { AgentPlatformEnum } from '../agents/shared/enums/agent-platform.enum';
+
+export function isKeylessOrganization(organizationId: string): boolean {
+  const keylessOrganizationId = process.env.KEYLESS_ORGANIZATION_ID;
+
+  return Boolean(keylessOrganizationId && organizationId === keylessOrganizationId);
+}
+
+export function resolveConnectClaimBaseUrl(): string {
+  for (const candidate of [process.env.DASHBOARD_URL, process.env.FRONT_BASE_URL]) {
+    const trimmed = candidate?.trim();
+
+    if (!trimmed || trimmed.startsWith('^')) {
+      continue;
+    }
+
+    return trimmed.replace(/\/$/, '');
+  }
+
+  return 'https://dashboard.novu.co';
+}
+
+export function buildConnectClaimUrl(token: string): string {
+  return `${resolveConnectClaimBaseUrl()}/connect/claim?token=${encodeURIComponent(token)}`;
+}
+
+export function getKeylessWelcomeText(platform: AgentPlatformEnum): string {
+  switch (platform) {
+    case AgentPlatformEnum.SLACK:
+      return 'Your Slack app is connected! Send me a message to try it out.';
+    case AgentPlatformEnum.TEAMS:
+      return 'Your Teams app is connected! Send me a message to try it out.';
+    case AgentPlatformEnum.WHATSAPP:
+      return 'Connected! Send me a message to try it out.';
+    case AgentPlatformEnum.EMAIL:
+      return 'Connected! Reply to this email to try it out.';
+    default:
+      return 'Connected! Send me a message to try it out.';
+  }
+}
+
+export function buildKeylessWelcomeCard(welcomeText: string, claimUrl: string): CardElement {
+  return {
+    type: 'card',
+    children: [
+      { type: 'text', content: welcomeText },
+      {
+        type: 'text',
+        content: 'This is a free demo — sign up anytime to keep this agent and your conversation.',
+      },
+      {
+        type: 'link',
+        label: 'Sign up free',
+        url: claimUrl,
+      },
+    ],
+  };
+}
+
+export function buildKeylessSignupCard(claimUrl: string): CardElement {
+  return {
+    type: 'card',
+    children: [
+      {
+        type: 'text',
+        content:
+          "You've reached the limit of this free demo. Sign up for a free Novu account to keep this agent — your " +
+          'conversation and setup carry over, and the agent picks up right where it left off.',
+      },
+      { type: 'divider' },
+      {
+        type: 'actions',
+        children: [
+          {
+            type: 'link-button',
+            label: 'Sign up & keep this agent',
+            url: claimUrl,
+            style: 'primary',
+          },
+        ],
+      },
+    ],
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves keyless demo conversion by surfacing signup earlier, while keeping the hard block at the demo cap.

## Changes

1. **Demo cap:** Default `KEYLESS_DEMO_REPLY_CAP` is **3** persisted agent messages. On the next inbound user message, a hard signup CTA card is posted and AI stops.

2. **Subtle welcome signup (keyless only):** The first `/welcome-message` sends a card with normal welcome copy, a short demo note, and a subtle `link` ("Sign up free") to the connect claim URL.

3. **Shared helpers (consolidated):**
   - `keyless-organization.helpers.ts` — canonical `isKeylessOrganization` (used by abuse guard, config resolver, welcome flow)
   - `keyless-signup.helpers.ts` — claim URL + card builders + `toReplyCard`
   - `agent-welcome-text.ts` — generic platform welcome copy (not keyless-specific)

## User experience (cap = 3)

| Step | What happens |
|---|---|
| Connect | Welcome card with subtle signup link (agent msg #1) |
| User msg #1 | AI reply (#2) |
| User msg #2 | AI reply (#3) |
| User msg #3 | Hard signup CTA — no further AI |

## Testing

- `pnpm test -- --grep 'keyless-(signup|organization).helpers'` — 7 passing
- `pnpm test -- --grep 'KeylessAbuseGuardService'` — 10 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a59cdd5d-c698-402c-8e90-9593aacf336f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a59cdd5d-c698-402c-8e90-9593aacf336f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Lowered the default keyless demo reply cap from 5 to 3 so a hard signup CTA appears sooner in keyless/demo conversations (KEYLESS_DEMO_REPLY_CAP remains overridable via env). The welcome flow now sends a persisted welcome card in keyless mode with normal welcome copy, a short demo note, and a subtle “Sign up free” link to a connect-claim URL; when the reply cap is exceeded, the next inbound message posts a richer signup CTA card and AI replies stop. Helpers were consolidated to centralize claim-URL and card construction.

## Affected areas

**api**: Conversation runtime now defaults KEYLESS_DEMO_REPLY_CAP to 3 and uses shared keyless helpers; SendAgentWelcomeMessage issues/connects claim tokens, may persist a rich welcome card, and uses helper-built claim URLs and cards; abuse guard and agent config resolver now use a shared isKeylessOrganization helper; new agent welcome text util added.  
**tests**: New unit tests for keyless-signup helpers and keyless-organization detection were added.

## Key technical decisions

- Centralized claim-URL resolution and card builders in a new keyless-signup helpers module to ensure consistent UX across welcome and cap flows.  
- Introduced isKeylessOrganization as a shared helper to standardize keyless detection across services.  
- Welcome delivery now optionally persists richContent (card) when sent in keyless mode.

## Testing

Added unit tests covering connect-claim base URL resolution, token encoding, card structure, and keyless-organization detection; related test suites report passing. No DB/schema or external dependency changes; behavior remains configurable via environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces the keyless demo reply cap from 5 to 3 and improves conversion by adding a subtle signup link to the first welcome message. It also consolidates shared keyless helpers (`isKeylessOrganization`, URL builder, card builders) to eliminate code duplication across the abuse guard, config resolver, and welcome flow.

- **Cap change:** `KEYLESS_DEMO_REPLY_CAP` default drops from 5 → 3, producing the sequence: welcome card (counts as agent msg #1) → user msg #1 → AI reply (#2) → user msg #2 → AI reply (#3) → user msg #3 → hard signup CTA.
- **Welcome card:** For keyless orgs, `SendAgentWelcomeMessage` now issues a claim token and sends a rich card containing the platform welcome text, a demo note, and a subtle `link`-type "Sign up free" CTA; falls back silently to plain markdown if token issuance fails.
- **Helper extraction:** `isKeylessOrganization`, `buildConnectClaimUrl`, `resolveConnectClaimBaseUrl`, and both card builders moved to dedicated modules (`keyless-organization.helpers.ts` / `keyless-signup.helpers.ts`) with unit tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the cap change is a one-line default, the helper extraction is a pure refactor, and the welcome card flow falls back gracefully to plain markdown if token issuance fails.

The cap reduction from 5 to 3 is intentional and correct; the welcome card is persisted via `persistAgentMessage` so it counts against the cap exactly as the PR description states. `ConnectClaimTokenService` was already provided in `AgentsModule` via `ConnectModule`, so the new injection in `SendAgentWelcomeMessage` requires no module changes. `issueOrGetForEnvironment` is idempotent, ensuring the claim URL in the welcome card and the hard CTA card is always the same token. The only gap is a missing unit test for the undefined-env-var edge case in the helper spec.

No files require special attention. The only nit is the missing test case in `keyless-organization.helpers.spec.ts`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/keyless/keyless-signup.helpers.ts | New helpers file centralising claim URL building and card construction; logic is correct and well-tested. |
| apps/api/src/app/keyless/keyless-organization.helpers.ts | Extracted `isKeylessOrganization` helper; implementation is identical to the removed private method in KeylessAbuseGuardService. |
| apps/api/src/app/keyless/keyless-organization.helpers.spec.ts | Has one test covering the positive and one-negative case; missing coverage for when KEYLESS_ORGANIZATION_ID is undefined. |
| apps/api/src/app/keyless/keyless-signup.helpers.spec.ts | Thorough tests for URL building, env-var fallback logic, and card structure; covers the regex-pattern skip edge case. |
| apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts | Added ConnectClaimTokenService injection and resolveKeylessWelcomeCard for keyless orgs; graceful fallback to plain markdown on token failure. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Cap default reduced 5→3; local helpers removed and replaced with shared imports; logic unchanged. |
| apps/api/src/app/keyless/keyless-abuse-guard.service.ts | Private isKeylessOrganization removed and replaced with shared helper; behaviour unchanged. |
| apps/api/src/app/agents/channels/agent-config-resolver.service.ts | Inline isKeyless boolean replaced with shared helper call; semantics identical. |
| apps/api/src/app/agents/shared/util/agent-welcome-text.ts | Extracted getWelcomeText from SendAgentWelcomeMessage into a shared utility; logic unchanged. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant W as SendAgentWelcomeMessage
    participant CT as ConnectClaimTokenService
    participant DB as ConversationActivity (DB)
    participant IH as AgentInboundHandler
    participant AI as AI Runtime

    U->>W: /welcome-message (connect)
    W->>CT: issueOrGetForEnvironment()
    CT-->>W: token
    W->>W: buildKeylessWelcomeCard(welcomeText, claimUrl)
    W->>U: "sendDirectMessage(card) — agent msg #1"
    W->>DB: "persistAgentMessage() → count=1"

    U->>IH: "inbound msg #1"
    IH->>DB: countAgentMessages() → 1
    Note over IH: 1 < 3 — proceed
    IH->>AI: dispatch turn
    AI->>U: "reply — agent msg #2"
    AI->>DB: "persistAgentMessage() → count=2"

    U->>IH: "inbound msg #2"
    IH->>DB: countAgentMessages() → 2
    Note over IH: 2 < 3 — proceed
    IH->>AI: dispatch turn
    AI->>U: "reply — agent msg #3"
    AI->>DB: "persistAgentMessage() → count=3"

    U->>IH: "inbound msg #3"
    IH->>DB: countAgentMessages() → 3
    Note over IH: 3 >= 3 — cap reached
    IH->>CT: issueOrGetForEnvironment() (same token)
    IH->>U: replyOnThread(buildKeylessSignupCard) — hard CTA
    IH->>DB: tryMarkSignupCtaPosted()
```

<sub>Reviews (3): Last reviewed commit: ["refactor(api): consolidate keyless signu..."](https://github.com/novuhq/novu/commit/ffc4442aafc0ba4bb748da389de5e77562dd6fff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36942528)</sub>

<!-- /greptile_comment -->