### PR TITLE
feat(dashboard): agent-onboarding prompt fixes NV-8013

### DIFF
--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -1,25 +1,19 @@
-// Bundled at build time from the canonical agent-onboarding guide in `@novu/shared/docs`
-// (see the `@shared-docs` alias in vite.config.ts). Keeping a single source of truth means the
-// banner prompt always matches the instructions we ship for the keyless `novu connect` flow.
-import agentOnboardingPrompt from '@shared-docs/agent-onboarding.md?raw';
 import { useState } from 'react';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 /**
- * Starter prompt surfaced in the onboarding banner. This is the full agent-onboarding guide, so
- * copying it (or opening it in Cursor) hands the user's coding agent everything it needs to create
- * a managed agent and connect a channel without the user typing anything.
+ * Starter prompt surfaced in the onboarding banner. Mirrors the demo support-agent the user can
+ * spin up from the "What should your agent do?" step, so copying it (or opening it in Cursor)
+ * gets them to a working agent description without typing anything.
  */
-const PREBUILT_AGENT_PROMPT = agentOnboardingPrompt.trim();
-// The URL has the length limitation thats why we tell to follow the instructions from the markdown file
-const CURSOR_AGENT_PROMPT = `Add an agent to my app following instructions from this markdown file: https://github.com/novuhq/novu/blob/next/packages/shared/docs/agent-onboarding.md`;
+const PREBUILT_AGENT_PROMPT = `Add an agent to my app following instructions from this markdown file: https://github.com/novuhq/novu/blob/next/packages/shared/docs/agent-onboarding.md`;
 
 function safeCursorEncode(text: string): string {
   return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 }
 
-const CURSOR_DEEP_LINK = `https://cursor.com/link/prompt?text=${safeCursorEncode(CURSOR_AGENT_PROMPT)}`;
+const CURSOR_DEEP_LINK = `https://cursor.com/link/prompt?text=${safeCursorEncode(PREBUILT_AGENT_PROMPT)}`;
 
 /**
  * Inline tip rendered above the agent-brain steps during onboarding: a pre-built agent prompt the

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -7,7 +7,7 @@ import { TelemetryEvent } from '@/utils/telemetry';
  * spin up from the "What should your agent do?" step, so copying it (or opening it in Cursor)
  * gets them to a working agent description without typing anything.
  */
-const PREBUILT_AGENT_PROMPT = `Add an agent to my app following instructions from this markdown file: https://github.com/novuhq/novu/blob/next/packages/shared/docs/agent-onboarding.md`;
+const PREBUILT_AGENT_PROMPT = `Add an agent to my app following instructions from this markdown file: https://github.com/novuhq/novu/blob/main/packages/shared/docs/agent-onboarding.md`;
 
 function safeCursorEncode(text: string): string {
   return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -1,13 +1,17 @@
+// Bundled at build time from the canonical agent-onboarding guide in `@novu/shared/docs`
+// (see the `@shared-docs` alias in vite.config.ts). Keeping a single source of truth means the
+// banner prompt always matches the instructions we ship for the keyless `novu connect` flow.
+import agentOnboardingPrompt from '@shared-docs/agent-onboarding.md?raw';
 import { useState } from 'react';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 /**
- * Starter prompt surfaced in the onboarding banner. Mirrors the demo support-agent the user can
- * spin up from the "What should your agent do?" step, so copying it (or opening it in Cursor)
- * gets them to a working agent description without typing anything.
+ * Starter prompt surfaced in the onboarding banner. This is the full agent-onboarding guide, so
+ * copying it (or opening it in Cursor) hands the user's coding agent everything it needs to create
+ * a managed agent and connect a channel without the user typing anything.
  */
-const PREBUILT_AGENT_PROMPT = `Add an agent to my app following instructions from this web page https://novu.co/agents.md`;
+const PREBUILT_AGENT_PROMPT = agentOnboardingPrompt.trim();
 
 function safeCursorEncode(text: string): string {
   return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -12,12 +12,14 @@ import { TelemetryEvent } from '@/utils/telemetry';
  * a managed agent and connect a channel without the user typing anything.
  */
 const PREBUILT_AGENT_PROMPT = agentOnboardingPrompt.trim();
+// The URL has the length limitation thats why we tell to follow the instructions from the markdown file
+const CURSOR_AGENT_PROMPT = `Add an agent to my app following instructions from this markdown file: https://github.com/novuhq/novu/blob/next/packages/shared/docs/agent-onboarding.md`;
 
 function safeCursorEncode(text: string): string {
   return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 }
 
-const CURSOR_DEEP_LINK = `https://cursor.com/link/prompt?text=${safeCursorEncode(PREBUILT_AGENT_PROMPT)}`;
+const CURSOR_DEEP_LINK = `https://cursor.com/link/prompt?text=${safeCursorEncode(CURSOR_AGENT_PROMPT)}`;
 
 /**
  * Inline tip rendered above the agent-brain steps during onboarding: a pre-built agent prompt the

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -106,9 +106,6 @@ export default defineConfig(({ mode }) => {
               }
             : {}),
         '@': path.resolve(__dirname, './src'),
-        // Canonical agent-onboarding docs live in @novu/shared/docs (not part of the package's
-        // published `exports`), so alias the source directory to bundle the markdown via `?raw`.
-        '@shared-docs': path.resolve(__dirname, '../../packages/shared/docs'),
         // Explicitly map prettier imports to browser-compatible versions
         'prettier/standalone': path.resolve(__dirname, './node_modules/prettier/standalone.js'),
         'prettier/plugins/html': path.resolve(__dirname, './node_modules/prettier/plugins/html.js'),

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -106,6 +106,9 @@ export default defineConfig(({ mode }) => {
               }
             : {}),
         '@': path.resolve(__dirname, './src'),
+        // Canonical agent-onboarding docs live in @novu/shared/docs (not part of the package's
+        // published `exports`), so alias the source directory to bundle the markdown via `?raw`.
+        '@shared-docs': path.resolve(__dirname, '../../packages/shared/docs'),
         // Explicitly map prettier imports to browser-compatible versions
         'prettier/standalone': path.resolve(__dirname, './node_modules/prettier/standalone.js'),
         'prettier/plugins/html': path.resolve(__dirname, './node_modules/prettier/plugins/html.js'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why
Instead of bundling the agents prompt we build the simpler version with a reference link that the agent should follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The prebuilt agent onboarding prompt was simplified to reference the repository's canonical agent onboarding markdown instead of an external page. The dashboard now embeds a prompt string pointing to packages/shared/docs/agent-onboarding.md and uses that text when copying the prompt or opening it via the Cursor deep link, ensuring users receive the authoritative, in-repo instructions.

## Affected areas
- dashboard — Updated the onboarding banner component to use the in-repo agent onboarding markdown URL for the prebuilt prompt and the Cursor deep link payload.
- shared — The repository's agent onboarding document (packages/shared/docs/agent-onboarding.md) is now the canonical guide referenced by the dashboard prompt.

## Testing
Manual verification: the onboarding banner renders correctly and both "Copy prompt" and "Open in Cursor" actions produce the updated prompt content; no automated tests were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->