### PR TITLE
docs(shared): document secure token delivery fallback in agent-onboarding fixes NV-8015

### DIFF
--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -12,7 +12,7 @@ Your job, end to end: collect a couple of inputs, infer the agent's purpose from
 
 These govern every step. When in doubt, follow these over any specific instruction below.
 
-- **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5.
+- **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5, or the Step 4 `in_chat` token fallback re-run (after killing the first Connect shell).
 - **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime) unless the user raises it.
 - **Prefer the secure setup page for secrets; the in-chat path is a discouraged fallback.** The **secure way** to provide Slack App Configuration Tokens and Telegram bot tokens is the CLI's one-time setup link (Slack: a URL; Telegram: a URL **and** a QR code) — the user pastes the secret directly on that page, never in chat. Always offer this first and recommend it. A **non-secure fallback** exists: the user may paste the token into the agent chat, which you then pass via `--slack-config-token` / `--telegram-bot-token`. Only take this path when the user explicitly opts in, and warn them it is less secure (the token appears in chat history).
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
@@ -191,6 +191,18 @@ Conditional flags — apply each only when its condition holds:
 - **Runtime:** do not pass `--runtime` or `--anthropic-api-key` — the **demo runtime** is always used.
 - **Region:** pass `--region eu` only when the user explicitly asks; otherwise the default is **US** Novu Cloud.
 
+**Example — Step 4 Slack re-run (`in_chat` path):**
+
+```bash
+export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
+export SLACK_CONFIG_TOKEN='<xoxe.xoxp-...>'
+
+npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+  --ci \
+  --channel slack \
+  --slack-config-token "$SLACK_CONFIG_TOKEN"
+```
+
 Always required: the positional description (in `--ci` mode).
 
 **Safe retry — Slack only:** if the run fails with `Failed to create Slack app: …` (Slack's app-create can be slow on a cold first call), **silently re-run the exact same command once** before reporting anything — the step is safe to repeat. Only surface an error if the second attempt also fails.
@@ -209,7 +221,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
 - **slack** — the connect run defaulted to the secure path, so first **Await** the secure setup link line and copy its value:
 
-  ```
+  ```text
   NOVU_CONNECT_SLACK_SETUP_URL=<url>
   ```
 
@@ -223,17 +235,17 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
   The CLI polls until the token is saved (~5 min). Then **Await** the OAuth handoff line and copy its value:
 
-  ```
+  ```text
   NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>
   ```
 
   Paste that exact `<url>` into chat and ask them to approve the install within 5 minutes. **Await** until the CLI poll finishes. Re-run on timeout (the Slack app is reused).
 
-  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **re-run the Step 3 connect command once with `--slack-config-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_SLACK_SETUP_URL` handoff and goes straight to OAuth. **Await** the `NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>` line, paste that exact URL into chat, and ask them to approve the install within 5 minutes.
+  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **kill the first Connect shell** (the Step 3 process still polling the secure setup page) and **re-run the Step 3 connect command once with `--slack-config-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_SLACK_SETUP_URL` handoff and goes straight to OAuth. **Await** the `NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>` line, paste that exact URL into chat, and ask them to approve the install within 5 minutes.
 
 - **email** — watch for these machine-readable lines (plain stdout, no ANSI):
 
-  ```
+  ```text
   NOVU_CONNECT_INBOUND_ADDRESS=<address>
   NOVU_CONNECT_MAILTO=<mailto-url>
   NOVU_CONNECT_SEND_FROM_EMAIL=<email>   # only when present
@@ -248,7 +260,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
 - **telegram** — the connect run defaulted to the secure path. First, watch for the BotFather hint and secure setup link:
 
-  ```
+  ```text
   NOVU_CONNECT_TELEGRAM_BOTFATHER_URL=<url>              # only when present
   NOVU_CONNECT_TELEGRAM_SETUP_URL=<url>
   NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG=<absolute png path>   # only when present
@@ -260,11 +272,11 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
   **If they pick `secure` (or skip the choice):** open the **setup link** and paste the BotFather confirmation message there — **not in this chat**. **Embed the secure-setup QR PNG (`NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG`) inline when present** so the user can scan the secure link on their phone — do not just describe it. Always paste the literal `NOVU_CONNECT_TELEGRAM_SETUP_URL` value alongside the QR. The CLI polls until the bot token is saved (~5 min).
 
-  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **re-run the Step 3 connect command once with `--telegram-bot-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_TELEGRAM_SETUP_URL`/QR handoff and goes straight to the deep-link step below.
+  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **kill the first Connect shell** (the Step 3 process still polling the secure setup page) and **re-run the Step 3 connect command once with `--telegram-bot-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_TELEGRAM_SETUP_URL`/QR handoff and goes straight to the deep-link step below.
 
   Then watch for the deep-link handoff:
 
-  ```
+  ```text
   NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=<url>
   NOVU_CONNECT_TELEGRAM_BOT_USERNAME=<name>
   NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   # only when present
@@ -284,7 +296,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
 On success the CLI exits `0` and prints a block like:
 
-```
+```text
 ✓ Your agent is live.
   Agent: <name> (<identifier>)
   → Check <Channel> — your agent just messaged you.      # connected channels (slack/email)
@@ -330,7 +342,7 @@ Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI
 
 ## Limitations to keep in mind
 
-- **One run = one new agent + one channel.** Re-running `connect` creates another agent; there is no "add a channel to the existing agent" in this non-interactive flow yet.
+- **One run = one new agent + one channel.** Re-running `connect` creates another agent; there is no "add a channel to the existing agent" in this non-interactive flow yet. The Step 4 `in_chat` re-run is the one deliberate exception — it still creates a second agent (the first, from the secure-path attempt, is left unconnected). Prefer the secure path to avoid duplicates.
 - **Channel support is uneven headlessly:** `slack` and `telegram` each require two user actions (paste a secret on the secure setup page, then OAuth or tap Start); `email` completes with one user action; `whatsapp` and `teams` are **not supported in the CLI** — the user signs in to the Novu dashboard and continues onboarding there (no agent is generated by this flow).
 - **Prefer the secure setup page for Slack/Telegram tokens.** The CLI prints one-time setup links (`NOVU_CONNECT_SLACK_SETUP_URL`, `NOVU_CONNECT_TELEGRAM_SETUP_URL`; Telegram also a QR) that work without signing in to the dashboard — including in keyless mode. A non-secure fallback (paste the token in chat → `--slack-config-token` / `--telegram-bot-token`) is available only when the user explicitly opts in; warn them the token then lives in chat history.
 - Keyless data is temporary until the user claims it via the in-channel sign-up link.

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -14,7 +14,7 @@ These govern every step. When in doubt, follow these over any specific instructi
 
 - **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5.
 - **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime) unless the user raises it.
-- **Never collect secrets in chat.** Slack App Configuration Tokens and Telegram bot tokens must **never** be pasted into the agent chat window. The CLI prints a secure one-time setup link; the user pastes the secret directly on that page.
+- **Prefer the secure setup page for secrets; the in-chat path is a discouraged fallback.** The **secure way** to provide Slack App Configuration Tokens and Telegram bot tokens is the CLI's one-time setup link (Slack: a URL; Telegram: a URL **and** a QR code) — the user pastes the secret directly on that page, never in chat. Always offer this first and recommend it. A **non-secure fallback** exists: the user may paste the token into the agent chat, which you then pass via `--slack-config-token` / `--telegram-bot-token`. Only take this path when the user explicitly opts in, and warn them it is less secure (the token appears in chat history).
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
 - **One Connect shell, no log watchers.** Run the Step 3 connect command in a single Shell session. Read stdout from that session (or **Await** its shell id). Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path.
 - **The CLI validates handoffs.** For `slack`/`email`, that Shell blocks and polls until OAuth or inbound email completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion.
@@ -31,9 +31,9 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 - **Cursor:** `AskQuestion` with 2–4 `options` (short `label` per option). 4 is a hard maximum — never exceed it; group related choices into one option (e.g. WhatsApp / MS Teams).
 - **Claude Code:** `AskUserQuestion` with the same shape (`label` + optional `description`).
 
-**Use the picker for:** Step 1 (channel) and Step 2 (approve / edit description).
+**Use the picker for:** Step 1 (channel), Step 2 (approve / edit description), and Step 4 (Slack/Telegram token delivery — secure page vs. paste in chat, presented inline only when the token is actually needed).
 
-**Do not use the picker for:** free-text values (e.g. edited agent description prose) — ask in chat normally. **Never** ask the user to paste Slack config tokens or Telegram bot tokens in chat — those go on the secure setup page the CLI prints.
+**Do not use the picker for:** free-text values (e.g. edited agent description prose) — ask in chat normally. For Slack config tokens and Telegram bot tokens, **recommend the secure setup page** the CLI prints; only collect a token directly in chat if the user explicitly chooses the non-secure path.
 
 **If the tool is unavailable:** number options (`a1`, `a2`, …) and ask for a reply like `q1a2`.
 
@@ -58,7 +58,7 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 1. **Channel** — ask which channel. If the user picks WhatsApp / MS Teams, the flow ends here with a **dashboard redirect** — Steps 2–5 do not run.
 2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user.
 3. **Run** — connect command from Step 3 (keyless, `--ci`), streamed.
-4. **Handoff** — read stdout; give the user the channel-specific next step (secure setup link, OAuth link, email, or Telegram deep link); let the CLI poll (`slack`/`email`/`telegram`).
+4. **Handoff** — read stdout; give the user the channel-specific next step (secure setup link, OAuth link, email, or Telegram deep link). For Slack/Telegram, present the inline secure-page-vs-paste-in-chat token choice here — only when the token is actually needed. Let the CLI poll (`slack`/`email`/`telegram`).
 5. **Report** — relay the CLI's success or error; explain the demo limit → claim.
 
 ---
@@ -71,9 +71,9 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 | Option id | Label | What the user must do |
 |---|---|---|
-| `slack` | Slack | Open the secure setup link the CLI prints to paste a Slack App Configuration Token, then click an OAuth link to approve the install. |
+| `slack` | Slack | **Recommended (secure):** open the setup link the CLI prints and paste a Slack App Configuration Token there, then click an OAuth link to approve the install. **Non-secure fallback:** paste the token in chat instead and you pass it via `--slack-config-token`. |
 | `email` | Email | Nothing up front. The CLI prints an inbound email address; the user sends one email to it. |
-| `telegram` | Telegram | Create a bot via @BotFather, paste the token on the secure setup link the CLI prints, then tap **Start** on the bot in Telegram. |
+| `telegram` | Telegram | Create a bot via @BotFather. **Recommended (secure):** open the setup link/QR the CLI prints and paste the token there. **Non-secure fallback:** paste the token in chat instead and you pass it via `--telegram-bot-token`. Then tap **Start** on the bot in Telegram. |
 | `dashboard` | WhatsApp / MS Teams | Not supported in the CLI — sign in to the Novu dashboard and continue onboarding there. |
 
 **If they pick `dashboard`:** stop — do **not** run connect and do **not** generate an agent. WhatsApp and Microsoft Teams are not supported in this CLI flow. Give the user the dashboard URL — **<https://dashboard.novu.co>** (or <https://eu.dashboard.novu.co> if they asked for the EU region) — and tell them to **sign in (or sign up) and continue the onboarding from the dashboard**, where they can set up WhatsApp or Microsoft Teams. Steps 2–5 do not apply; you are done once you've delivered the link.
@@ -82,7 +82,8 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 **Collect after they choose:**
 
-- **slack / telegram / email / skip** → no extra input up front. Secrets and channel-specific actions happen on the secure setup page or via the CLI handoff links printed during Step 4.
+- **slack / telegram** → collect **nothing** up front, and do **not** ask about token delivery yet — it is too early. Default the Step 3 connect run to the **secure path** (omit `--slack-config-token` / `--telegram-bot-token`). The secure-page-vs-paste-in-chat choice is presented **inline in Step 4**, lazily, at the exact moment the user must provide the token.
+- **email / skip** → no extra input up front. Channel-specific actions happen via the CLI handoff links printed during Step 4.
 - **dashboard (WhatsApp / MS Teams)** → no extra input; the flow already ended with the dashboard redirect above.
 
 **Runtime:** always use the **demo runtime** — do not ask for an Anthropic API key and do not pass `--runtime` or `--anthropic-api-key`.
@@ -186,7 +187,7 @@ npx novu connect "$NOVU_AGENT_DESCRIPTION" \
 
 Conditional flags — apply each only when its condition holds:
 
-- **Do not** pass `--slack-config-token` or `--telegram-bot-token` in the agent flow — the CLI issues secure setup links instead. Only use those flags for genuine headless CI where secrets are injected via environment variables.
+- **Prefer the secure setup links** over `--slack-config-token` / `--telegram-bot-token`. The **first** connect run always omits those flags so the CLI issues a secure setup page (URL for Slack; URL + QR for Telegram). Pass `--slack-config-token` / `--telegram-bot-token` **only** on a Step 4 re-run, after the user explicitly chose the non-secure in-chat path at the inline token prompt (or for genuine headless CI where secrets are injected via environment variables). When you do pass a token, set it via an environment variable first — never paste the raw secret into the command line.
 - **Runtime:** do not pass `--runtime` or `--anthropic-api-key` — the **demo runtime** is always used.
 - **Region:** pass `--region eu` only when the user explicitly asks; otherwise the default is **US** Novu Cloud.
 
@@ -206,13 +207,17 @@ Always required: the positional description (in `--ci` mode).
 
 Read Connect shell stdout (via **Await**, not log files) and act based on the chosen channel:
 
-- **slack** — two user actions. First, **Await** the secure setup link line and copy its value:
+- **slack** — the connect run defaulted to the secure path, so first **Await** the secure setup link line and copy its value:
 
   ```
   NOVU_CONNECT_SLACK_SETUP_URL=<url>
   ```
 
-  Paste that exact `<url>` into chat as a clickable link. Then tell them to:
+  This is the moment the user must provide the token, so **now** present the token-delivery choice inline — call `AskQuestion` / `AskUserQuestion` with two options and recommend `secure`:
+  - `secure` — **Secure setup page (recommended)** — paste the token on the page the CLI printed; it never enters chat.
+  - `in_chat` — **Paste token in chat (less secure)** — the token then lives in chat history.
+
+  **If they pick `secure` (or skip the choice):** paste that exact `<url>` into chat as a clickable link. Then tell them to:
   1. Open <https://api.slack.com/apps> and generate an **App Configuration Token** (access token starting with `xoxe.xoxp-`)
   2. Open the setup link and paste the token there — **not in this chat**
 
@@ -223,6 +228,8 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
   ```
 
   Paste that exact `<url>` into chat and ask them to approve the install within 5 minutes. **Await** until the CLI poll finishes. Re-run on timeout (the Slack app is reused).
+
+  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **re-run the Step 3 connect command once with `--slack-config-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_SLACK_SETUP_URL` handoff and goes straight to OAuth. **Await** the `NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>` line, paste that exact URL into chat, and ask them to approve the install within 5 minutes.
 
 - **email** — watch for these machine-readable lines (plain stdout, no ANSI):
 
@@ -239,7 +246,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
   Then wait for the **CLI poll** — the process completes once the email arrives; on timeout, re-run after they've sent it.
 
-- **telegram** — two user actions. First, watch for the BotFather hint and secure setup link:
+- **telegram** — the connect run defaulted to the secure path. First, watch for the BotFather hint and secure setup link:
 
   ```
   NOVU_CONNECT_TELEGRAM_BOTFATHER_URL=<url>              # only when present
@@ -247,7 +254,13 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
   NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG=<absolute png path>   # only when present
   ```
 
-  Tell the user to create a bot with @BotFather (<https://t.me/botfather>, send `/newbot`), then open the **setup link** and paste the BotFather confirmation message there — **not in this chat**. The CLI polls until the bot token is saved (~5 min).
+  Tell the user to create a bot with @BotFather (<https://t.me/botfather>, send `/newbot`). The bot token is needed next, so **now** present the token-delivery choice inline — call `AskQuestion` / `AskUserQuestion` with two options and recommend `secure`:
+  - `secure` — **Secure setup page (recommended)** — paste the token on the page/QR the CLI printed; it never enters chat.
+  - `in_chat` — **Paste token in chat (less secure)** — the token then lives in chat history.
+
+  **If they pick `secure` (or skip the choice):** open the **setup link** and paste the BotFather confirmation message there — **not in this chat**. **Embed the secure-setup QR PNG (`NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG`) inline when present** so the user can scan the secure link on their phone — do not just describe it. Always paste the literal `NOVU_CONNECT_TELEGRAM_SETUP_URL` value alongside the QR. The CLI polls until the bot token is saved (~5 min).
+
+  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **re-run the Step 3 connect command once with `--telegram-bot-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_TELEGRAM_SETUP_URL`/QR handoff and goes straight to the deep-link step below.
 
   Then watch for the deep-link handoff:
 
@@ -309,8 +322,8 @@ Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI
 | `--ci` | Non-interactive mode (required for all channels in this flow). |
 | `--region <us\|eu>` | Target Novu Cloud region (default: `us`). |
 | `--channel <slack\|email\|telegram\|skip>` | Which channel to connect. Never pass `whatsapp`/`teams` — those are handled by the dashboard redirect, not the CLI. |
-| `--slack-config-token <xoxe.xoxp-…>` | CI-only escape hatch: pass the Slack config token directly instead of using the secure setup page. |
-| `--telegram-bot-token <123456:ABC…>` | CI-only escape hatch: pass the BotFather token directly instead of using the secure setup page. |
+| `--slack-config-token <xoxe.xoxp-…>` | Non-secure alternative (or headless CI): pass the Slack config token directly instead of using the secure setup page. Use only when the user opts in. |
+| `--telegram-bot-token <123456:ABC…>` | Non-secure alternative (or headless CI): pass the BotFather token directly instead of using the secure setup page. Use only when the user opts in. |
 | `--secret-key <key>` | Optional — use an existing Novu account instead of keyless. |
 
 ---
@@ -319,7 +332,7 @@ Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI
 
 - **One run = one new agent + one channel.** Re-running `connect` creates another agent; there is no "add a channel to the existing agent" in this non-interactive flow yet.
 - **Channel support is uneven headlessly:** `slack` and `telegram` each require two user actions (paste a secret on the secure setup page, then OAuth or tap Start); `email` completes with one user action; `whatsapp` and `teams` are **not supported in the CLI** — the user signs in to the Novu dashboard and continues onboarding there (no agent is generated by this flow).
-- **Never paste Slack or Telegram tokens in the agent chat.** The CLI prints one-time setup links (`NOVU_CONNECT_SLACK_SETUP_URL`, `NOVU_CONNECT_TELEGRAM_SETUP_URL`) that work without signing in to the dashboard — including in keyless mode.
+- **Prefer the secure setup page for Slack/Telegram tokens.** The CLI prints one-time setup links (`NOVU_CONNECT_SLACK_SETUP_URL`, `NOVU_CONNECT_TELEGRAM_SETUP_URL`; Telegram also a QR) that work without signing in to the dashboard — including in keyless mode. A non-secure fallback (paste the token in chat → `--slack-config-token` / `--telegram-bot-token`) is available only when the user explicitly opts in; warn them the token then lives in chat history.
 - Keyless data is temporary until the user claims it via the in-channel sign-up link.
 - The CLI stores keyless credentials **per API URL**, so switching `--region` between runs does not require clearing `~/.config/configstore/novu-cli.json`.
 
@@ -331,7 +344,7 @@ Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI
 
 You are done when:
 
-1. The user picked a channel (no secrets collected in chat).
+1. The user picked a channel (secrets went through the secure setup page unless the user explicitly opted into the non-secure in-chat path).
 2. The user confirmed the agent description.
 3. You delivered the handoff (link / address) — or noted `skip`.
 4. The Connect shell printed `✓ Your agent is live.` (exit `0`). You never used Monitor, log files, or a separate watch command; for `slack`/`email`/`telegram`, the **CLI poll** validated the handoff.


### PR DESCRIPTION
## Summary

- Update `packages/shared/docs/agent-onboarding.md` to prefer the secure setup page for Slack/Telegram tokens (URL for Slack; URL + QR for Telegram).
- Document the inline Step 4 token-delivery picker (`secure` vs `in_chat`) and the non-secure fallback via `--slack-config-token` / `--telegram-bot-token` when users explicitly opt in.
- Clarify that the first connect run always omits token flags; a re-run is only needed when the user chooses the in-chat path.

Follow-up to NV-8008 — keeps production Cloud defaults (`npx novu connect`, `dashboard.novu.co`); no local-dev overrides.

## Flow (Slack/Telegram token delivery)

```mermaid
sequenceDiagram
  participant Agent as AI agent
  participant CLI as novu connect
  participant User as User

  Agent->>CLI: connect --ci (no token flags)
  CLI-->>Agent: NOVU_CONNECT_*_SETUP_URL (+ QR for Telegram)
  Agent->>User: AskQuestion: secure page vs paste in chat
  alt secure (default)
    Agent->>User: Share setup link / QR
    User->>CLI: Paste token on secure page
    CLI-->>Agent: Continue to OAuth / deep link
  else in_chat (explicit opt-in)
    User->>Agent: Paste token in chat
    Agent->>CLI: Re-run connect with --*-token flag
    CLI-->>Agent: Skip setup page; OAuth / deep link
  end
```

## Test plan

- [x] Verified diff contains only production onboarding guidance (no local-dev CLI/URL overrides)
- [ ] Spot-check Step 4 Slack/Telegram sections read coherently end-to-end
- [ ] Confirm flag reference table matches `novu connect --help`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What changed

Updated the agent onboarding documentation to introduce a dual-path token-delivery model for Slack and Telegram: the CLI's one-time secure setup page (Slack: URL; Telegram: URL + QR) is now the default, while an explicit, opt-in non-secure fallback lets users paste tokens in chat and re-run connect with the corresponding token flag. This clarifies CLI behavior (first connect run omits token flags), operational steps for re-running (terminate the first Connect shell), and the impact on duplicate-agent creation; sequence diagrams and a manual test checklist were added.

Affected areas

shared — packages/shared/docs/agent-onboarding.md: Rewrote onboarding guidance to prefer secure setup links for Slack/Telegram, added an inline Step 4 picker (secure vs in_chat), documented that the initial connect run omits --slack-config-token/--telegram-bot-token, added instructions to terminate the first Connect shell before any in_chat re-run, clarified duplicate-agent implications and other limitations, updated the flag reference table, Operating Principles, Flow Overview, Definition of Done, included sequence diagrams, and added a manual test-plan checklist.

Key technical decisions

- The first npx novu connect invocation intentionally omits token flags to force the secure setup page by default; token flags are only supported on an explicit Step 4 in_chat re-run or for headless CI via env vars.  
- Re-running with a token requires terminating the original Connect shell first to avoid conflicting sessions; re-running the CLI in this flow creates a second agent (the original secure-path attempt may remain), so the docs recommend the secure path to avoid duplicates.

Testing

Documentation-only change — no code or automated tests. The PR adds a manual verification checklist (spot-check Step 4 picker wording, confirm production-only guidance, and verify the flag table matches novu connect --help) for reviewers to validate the updated flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the agent-onboarding docs to replace the hard "never paste tokens in chat" rule with a dual-path model: the CLI's one-time secure setup link (URL for Slack, URL + QR for Telegram) is the recommended default, while an explicit opt-in `in_chat` fallback lets users paste tokens in chat and re-run `novu connect` with `--slack-config-token` / `--telegram-bot-token`.

- Adds the Step 4 inline token-delivery picker (`secure` vs `in_chat`) that is shown lazily, only at the moment the token is actually needed.
- Documents the first-run-always-omits-token-flags rule, the kill-first-shell requirement before any in_chat re-run, and the duplicate-agent implication of the in_chat path.
- Provides a concrete bash example for the Slack `in_chat` re-run and updates the flag reference table, Operating Principles, Limitations, and Definition of Done to be internally consistent.

<h3>Confidence Score: 4/5</h3>

Documentation-only change; safe to merge after addressing the missing Await instruction in the Slack in_chat path.

The three issues flagged in the previous review round (operating-principle conflict, missing shell-kill step, and the Limitations contradiction) are all fixed. One new gap remains: the Slack in_chat path ends after telling the agent to paste the OAuth URL without the explicit 'Await until the CLI poll finishes' instruction that the secure path carries. An agent following the in_chat branch literally would move on to Step 5 without having received the success/failure output from the re-run shell, so it cannot extract the agent identifier or Dashboard URL.

packages/shared/docs/agent-onboarding.md — specifically the Slack in_chat branch at line 244 where the post-OAuth Await instruction is absent.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/docs/agent-onboarding.md | Adds a dual-path (secure page vs. in-chat fallback) Slack/Telegram token-delivery model; previously-flagged issues around the operating-principle conflict, shell-kill order, and limitations text have all been addressed, but the Slack in_chat path is missing the explicit 'Await until the CLI poll finishes' instruction that the secure path carries. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Agent as AI Agent
  participant Shell1 as Connect Shell (1st run)
  participant Shell2 as Connect Shell (re-run)
  participant User as User

  Agent->>Shell1: npx novu connect --ci --channel slack/telegram
  Shell1-->>Agent: "NOVU_CONNECT_*_SETUP_URL (+ QR for Telegram)"
  Agent->>User: AskQuestion: secure (recommended) vs in_chat
  alt secure (default)
    User-->>Agent: secure
    Agent->>User: Share setup URL (+ QR for Telegram)
    User->>Shell1: Paste token on secure setup page
    Shell1-->>Agent: NOVU_CONNECT_SLACK_AUTHORIZE_URL / TELEGRAM_DEEPLINK_URL
    Agent->>User: Share OAuth / deep-link
    Shell1-->>Agent: Your agent is live
  else in_chat (explicit opt-in)
    User-->>Agent: in_chat
    Agent->>User: Ask for token (warn: lives in chat history)
    User-->>Agent: Paste token in chat
    Agent->>Shell1: Kill (stop polling secure page)
    Agent->>Shell2: npx novu connect --ci --channel slack --slack-config-token / --telegram-bot-token
    Shell2-->>Agent: NOVU_CONNECT_SLACK_AUTHORIZE_URL / TELEGRAM_DEEPLINK_URL
    Agent->>User: Share OAuth / deep-link
    Shell2-->>Agent: Your agent is live (2nd agent created)
  end
  Agent->>User: Report result + claim path
```

<sub>Reviews (3): Last reviewed commit: ["Revert accidental .source submodule bump..."](https://github.com/novuhq/novu/commit/4c57e3d3756b19adb19cb4f47a6549727ae62f93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36952578)</sub>

<!-- /greptile_comment -->