### PR TITLE
docs(shared): document host-aware Telegram QR delivery in agent-onboarding fixes NV-8015

### DIFF
--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -217,10 +217,12 @@ Always required: the positional description (in `--ci` mode).
 
 **Always paste the literal URL — never a placeholder.** Every handoff link must be the full resolved value copied verbatim from the matching `NOVU_CONNECT_*` line (everything after the `=`). **Never** send a message that refers to "the secure link below", "the setup link", or "the link above" without the actual `https://…` URL in that same message. If you have not yet captured the URL from stdout, **Await** the matching pattern (e.g. `NOVU_CONNECT_SLACK_SETUP_URL=`) **before** sending any handoff message — do not announce the handoff until you have the real URL in hand.
 
-**Showing the QR code (host-aware).** The Telegram QR PNGs (`NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG`, `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG`) are a phone-scan convenience — the literal URL is the primary handoff and must appear in the same message regardless. **Never deliver a QR by only Read-ing the PNG file:** in most hosts a file-read tool call renders collapsed (e.g. Claude Code shows just "Read 1 file"), so the user never sees the QR. Pick the path that matches what your host can render:
+### Showing the QR code (host-aware)
 
-- **Chat UI that renders markdown images inline (e.g. Cursor):** embed the PNG in your reply text with `![Scan to open the secure setup page](<absolute png path>)` — an image in your own message, not a tool call.
-- **Terminal host that cannot render images (e.g. Claude Code or other CLIs):** open the PNG in the OS image viewer — `open "<png path>"` (macOS) or `xdg-open "<png path>"` (Linux) — and tell the user a QR window just opened that they can scan with their phone. If the open command fails or the session is headless/remote, skip the QR entirely and present only the clickable URL — never leave the user hunting through collapsed tool output.
+The Telegram QR PNGs (`NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG`, `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG`) are a phone-scan convenience — the literal URL is the primary handoff and must appear in the same message regardless. **Never deliver a QR by only Read-ing the PNG file:** in most hosts a file-read tool call renders collapsed (e.g. Claude Code shows just "Read 1 file"), so the user never sees the QR. Pick the path that matches what your host can render:
+
+- **Chat UI that renders Markdown images inline (e.g. Cursor):** embed the PNG in your reply text with `![Scan the QR code with your phone](<absolute png path>)` — an image in your own message, not a tool call.
+- **Terminal host that cannot render images (e.g. Claude Code or other CLIs):** open the PNG in the OS image viewer — `open "<png path>"` (macOS), `xdg-open "<png path>"` (Linux), or `start "" "<png path>"` (Windows) — and tell the user a QR window just opened that they can scan with their phone. If the open command fails or the session is headless/remote, skip the QR entirely and present only the clickable URL — never leave the user hunting through collapsed tool output.
 
 Read Connect shell stdout (via **Await**, not log files) and act based on the chosen channel:
 

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -217,6 +217,11 @@ Always required: the positional description (in `--ci` mode).
 
 **Always paste the literal URL — never a placeholder.** Every handoff link must be the full resolved value copied verbatim from the matching `NOVU_CONNECT_*` line (everything after the `=`). **Never** send a message that refers to "the secure link below", "the setup link", or "the link above" without the actual `https://…` URL in that same message. If you have not yet captured the URL from stdout, **Await** the matching pattern (e.g. `NOVU_CONNECT_SLACK_SETUP_URL=`) **before** sending any handoff message — do not announce the handoff until you have the real URL in hand.
 
+**Showing the QR code (host-aware).** The Telegram QR PNGs (`NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG`, `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG`) are a phone-scan convenience — the literal URL is the primary handoff and must appear in the same message regardless. **Never deliver a QR by only Read-ing the PNG file:** in most hosts a file-read tool call renders collapsed (e.g. Claude Code shows just "Read 1 file"), so the user never sees the QR. Pick the path that matches what your host can render:
+
+- **Chat UI that renders markdown images inline (e.g. Cursor):** embed the PNG in your reply text with `![Scan to open the secure setup page](<absolute png path>)` — an image in your own message, not a tool call.
+- **Terminal host that cannot render images (e.g. Claude Code or other CLIs):** open the PNG in the OS image viewer — `open "<png path>"` (macOS) or `xdg-open "<png path>"` (Linux) — and tell the user a QR window just opened that they can scan with their phone. If the open command fails or the session is headless/remote, skip the QR entirely and present only the clickable URL — never leave the user hunting through collapsed tool output.
+
 Read Connect shell stdout (via **Await**, not log files) and act based on the chosen channel:
 
 - **slack** — the connect run defaulted to the secure path, so first **Await** the secure setup link line and copy its value:
@@ -270,7 +275,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
   - `secure` — **Secure setup page (recommended)** — paste the token on the page/QR the CLI printed; it never enters chat.
   - `in_chat` — **Paste token in chat (less secure)** — the token then lives in chat history.
 
-  **If they pick `secure` (or skip the choice):** open the **setup link** and paste the BotFather confirmation message there — **not in this chat**. **Embed the secure-setup QR PNG (`NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG`) inline when present** so the user can scan the secure link on their phone — do not just describe it. Always paste the literal `NOVU_CONNECT_TELEGRAM_SETUP_URL` value alongside the QR. The CLI polls until the bot token is saved (~5 min).
+  **If they pick `secure` (or skip the choice):** paste the literal `NOVU_CONNECT_TELEGRAM_SETUP_URL` value into chat as a clickable link and tell them to paste the BotFather confirmation message on that page — **not in this chat**. When `NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG` is present, also show the QR following [Showing the QR code (host-aware)](#showing-the-qr-code-host-aware) — never via a bare file read. The CLI polls until the bot token is saved (~5 min).
 
   **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **kill the first Connect shell** (the Step 3 process still polling the secure setup page) and **re-run the Step 3 connect command once with `--telegram-bot-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_TELEGRAM_SETUP_URL`/QR handoff and goes straight to the deep-link step below.
 
@@ -282,7 +287,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
   NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   # only when present
   ```
 
-  Embed the QR PNG inline when present. Ask them to open the bot and tap **Start** on `@<botUsername>`. **Await** until the CLI poll finishes. Re-run on timeout with the same command.
+  When `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG` is present, show the QR following [Showing the QR code (host-aware)](#showing-the-qr-code-host-aware). Ask them to open the bot and tap **Start** on `@<botUsername>`. **Await** until the CLI poll finishes. Re-run on timeout with the same command.
 
 - **skip** — nothing to hand off; the agent is created without a channel.
 


### PR DESCRIPTION
## Summary

Follow-up to #11518 (NV-8015): documents how agents should deliver Telegram setup/deep-link QR PNGs based on the host environment.

- Adds a **Showing the QR code (host-aware)** section explaining why bare file-read tool calls fail in most hosts (e.g. Claude Code collapses to "Read 1 file")
- **Cursor / markdown-capable chat UIs:** embed the PNG inline via `![...](<absolute path>)` in the agent's reply
- **Terminal / non-image hosts:** open the PNG with `open` / `xdg-open` and tell the user to scan; fall back to URL-only on headless/remote sessions
- Updates Telegram secure-setup and deep-link steps to reference the shared section instead of duplicating inline-embed instructions

```mermaid
flowchart TD
  A[CLI prints QR PNG path] --> B{Host renders markdown images?}
  B -->|Yes e.g. Cursor| C[Embed PNG in reply message]
  B -->|No e.g. Claude Code| D[open / xdg-open PNG in OS viewer]
  D --> E{Open succeeded?}
  E -->|Yes| F[Tell user to scan QR window]
  E -->|No / headless| G[URL-only handoff — never bare file read]
  C --> H[Always include literal URL in same message]
  F --> H
  G --> H
```

## Test plan

- [ ] Read updated `packages/shared/docs/agent-onboarding.md` Step 4 Telegram sections
- [ ] Confirm anchor link `#showing-the-qr-code-host-aware` resolves correctly
- [ ] No code changes — docs only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added host-aware documentation for delivering Telegram QR PNGs in agent onboarding: a shared "Showing the QR code (host-aware)" section explains when to embed the PNG inline (markdown-capable chat UIs), when to open it with the OS image viewer (terminal/non-image hosts), and when to fall back to URL-only handoff (headless/remote). The Telegram secure-setup and deep-link steps now reference this shared guidance and include a decision flowchart and explicit OS-open commands.

## Affected areas

**shared**: packages/shared/docs/agent-onboarding.md — added the host-aware QR section, updated Telegram secure-setup and deep-link steps to reference the shared guidance, and fixed the QR subsection anchor and image alt text.

## Testing

Docs-only change; no code or tests added. Manual verification: review Step 4 Telegram sections and confirm the `#showing-the-qr-code-host-aware` anchor resolves and instructions (including `open`, `xdg-open`, `start`) are correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds a `### Showing the QR code (host-aware)` section to `packages/shared/docs/agent-onboarding.md` that consolidates guidance on how AI agents should deliver Telegram QR PNGs based on the rendering capabilities of the host environment. The two Telegram handoff steps (secure-setup and deep-link) are updated to reference this shared section instead of duplicating inline-embed instructions.

- **New shared section** at `### Showing the QR code (host-aware)` (proper heading, so the `#showing-the-qr-code-host-aware` anchor is valid): explains three delivery paths — inline Markdown image embedding for chat UIs like Cursor, OS image-viewer launch (`open`/`xdg-open`/`start`) for terminal hosts, and URL-only fallback for headless/remote sessions.
- **Telegram secure-setup step** (line 280): reworded to use the shared section reference and clarifies that the literal `NOVU_CONNECT_TELEGRAM_SETUP_URL` must be pasted as a clickable link alongside any QR.
- **Telegram deep-link step** (line 292): similarly updated to reference the shared section for `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG`.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no code, schema, or runtime behavior is modified.

The single changed file is a Markdown documentation guide for AI agents. The new section uses a proper ### heading so the cross-reference anchors resolve correctly, covers all three major OS open commands (macOS, Linux, Windows), and uses neutral alt text applicable to both QR types. All three issues called out in the previous review round have been addressed. No logic, APIs, or runtime paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/docs/agent-onboarding.md | Adds a proper ###-level heading for the host-aware QR section (valid anchor), includes OS-open commands for macOS/Linux/Windows, and uses generic alt text; previous review findings are all addressed. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A["CLI prints QR PNG path\n(NOVU_CONNECT_TELEGRAM_*_QR_PNG)"] --> B{Host renders\nMarkdown images?}
  B -->|"Yes — e.g. Cursor"| C["Embed PNG inline in reply\n![Scan the QR code with your phone](path)"]
  B -->|"No — e.g. Claude Code / CLI"| D["Launch OS image viewer\nopen / xdg-open / start"]
  D --> E{Open command\nsucceeded?}
  E -->|Yes| F["Tell user a QR window\njust opened — scan with phone"]
  E -->|"No / headless / remote"| G["Skip QR entirely\n(URL-only handoff)"]
  C --> H["Always include literal URL\nin the same message"]
  F --> H
  G --> H
```

<sub>Reviews (2): Last reviewed commit: ["docs(shared): fix host-aware QR section ..."](https://github.com/novuhq/novu/commit/1bd1ccafb66457d10ec5d1f2aed2713712b4b37f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36966572)</sub>

<!-- /greptile_comment -->