### PR TITLE
fix(dashboard): equalize padding in agent dialog segmented control

### DIFF
--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -804,7 +804,7 @@ export function CreateAgentDialog({
               >
                 <SegmentedControlList
                   className="rounded-[5px] bg-bg-muted p-1"
-                  floatingBgClassName="rounded-[4px]"
+                  floatingBgClassName="rounded-[1px]"
                 >
                   <SegmentedControlTrigger value="create" className="text-label-xs" disabled={isSubmitBusy}>
                     Create new agent

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -802,7 +802,10 @@ export function CreateAgentDialog({
                 value={scope}
                 onValueChange={(v) => handleGenerationModeChange(v === 'existing' ? 'existing' : 'prompt')}
               >
-                <SegmentedControlList className="rounded-[5px] bg-bg-muted p-px">
+                <SegmentedControlList
+                  className="rounded-[5px] bg-bg-muted p-1"
+                  floatingBgClassName="rounded-[4px]"
+                >
                   <SegmentedControlTrigger value="create" className="text-label-xs" disabled={isSubmitBusy}>
                     Create new agent
                   </SegmentedControlTrigger>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Fixed uneven padding in the "Create new agent / Connect existing agent" segmented control inside the Add Agent dialog.

The `SegmentedControlList` container had `p-px` (1px) padding while the floating background indicator uses `inset-y-1` (4px vertical inset). This created a visual mismatch — 4px gap between the active indicator and container border vertically, but only ~1px horizontally.

**Changes:**
- Container padding: `p-px` → `p-1` (4px all sides), matching the floating background's `inset-y-1`
- Added `floatingBgClassName="rounded-[1px]"` for geometrically correct inner corner radius relative to the container's `rounded-[5px]` (5px − 4px gap = 1px), per Greptile review feedback

### Review feedback addressed

- **Greptile (inline):** Updated `floatingBgClassName` from `rounded-[4px]` to `rounded-[1px]` in commit 7e6b975589 — matches the `outer_radius - gap` formula used by the default SegmentedControlList (`rounded-[10px]` + `p-1` → `rounded-[6px]`).

### Screenshots

See Slack thread screenshot for the "before" state showing the uneven padding.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

This is a CSS-only change. The fix ensures equal visual spacing between the tab triggers and the segmented control container border on all four sides.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1781183834138089?thread_ts=1781183834.138089&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-1a939d87-d643-539e-9047-d0e8a6836051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a939d87-d643-539e-9047-d0e8a6836051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What changed
Fixed a visual mismatch in the Add Agent dialog’s segmented control by making the container padding and the floating background indicator use the same spacing and corner geometry. The container padding was changed from p-px (1px) to p-1 (4px) to match the floating indicator’s inset-y-1, and the inner floating indicator’s corner radius was adjusted to a geometrically correct value so the highlight sits evenly on all four sides. This is a CSS-only visual polish.

Affected areas
dashboard: Updated the SegmentedControl styling in the Add Agent dialog (padding and floating-background rounding) to equalize spacing and corner radii for the “Create new agent / Connect existing agent” segmented control.

Testing
Styling-only change — requires manual visual verification in the dashboard UI to confirm even padding and correct indicator rounding; no unit or e2e tests were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visual mismatch in the Add Agent dialog's segmented control by aligning the container padding with the floating background indicator's inset, and updating the inner corner radius to be geometrically correct.

- Changes container padding from `p-px` (1px) to `p-1` (4px) so all four sides match the floating indicator's `inset-y-1` (4px) offset, eliminating the uneven spacing.
- Adds `floatingBgClassName=\"rounded-[1px]\"` to override the default `rounded-[6px]`, following the `outer_radius − gap` formula (5px − 4px = 1px); this is correctly resolved by `tailwind-merge` in the project's `cn` utility.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a visual CSS tweak with no logic or API changes.

The change touches only two Tailwind class values on a single UI component. The p-1 / inset-y-1 alignment is correct, the rounded-[1px] inner radius follows the standard outer_radius − gap formula, and the project's cn utility (tailwind-merge) will properly resolve the class override. No runtime behaviour, data flow, or API surface is affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/create-agent-dialog.tsx | CSS-only fix: container padding changed from `p-px` to `p-1` and `floatingBgClassName` set to `rounded-[1px]` to equalize spacing and corner radii in the segmented control. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SegmentedControlList container\nrounded-[5px] · p-1 (4px)"] --> B["SegmentedControlTrigger\n'Create new agent'"]
    A --> C["SegmentedControlTrigger\n'Connect existing agent'"]
    A --> D["Floating bg indicator\ninset-y-1 (4px) · rounded-[1px]\ntranslate3d(offsetLeft, 0, 0)\nwidth = offsetWidth"]

    style A fill:#f0f0f0,stroke:#888
    style D fill:#ffffff,stroke:#aaa,stroke-dasharray:4 2
```

<sub>Reviews (3): Last reviewed commit: ["chore: retrigger CI after flaky E2E shar..."](https://github.com/novuhq/novu/commit/c2233a7ee0e7f99e1f4840ffc04b17bf38180b2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36975210)</sub>

<!-- /greptile_comment -->