### PR TITLE
feat(api, dal): implement agent integration disconnection handling and revival logic fixes NV-8019

### DIFF
--- a/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
@@ -20,6 +20,7 @@ import { isKeylessOrganization } from '../../keyless/keyless-organization.helper
 import { trackAgentIntegrationFirstWebhook } from '../shared/analytics/agent-analytics';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
 import { AgentInactiveException } from '../shared/errors/agent-inactive.exception';
+import { AgentIntegrationDisconnectedException } from '../shared/errors/agent-integration-disconnected.exception';
 import { esmImport } from '../shared/util/esm-import';
 import { resolveAgentPlatform } from '../shared/util/provider-to-platform';
 
@@ -147,6 +148,29 @@ export class AgentConfigResolver {
       '*'
     );
     if (!agentIntegration) {
+      // A tombstoned link means the user deliberately disconnected this channel.
+      // Reject instead of consulting the heal, so a still-registered platform
+      // webhook cannot resurrect the link. The explicit `disconnectedAt`
+      // condition bypasses the schema-level tombstone exclusion.
+      const disconnectedLink = await this.agentIntegrationRepository.findOne(
+        {
+          _environmentId: environmentId,
+          _organizationId: organizationId,
+          _agentId: agentId,
+          _integrationId: integration._id,
+          disconnectedAt: { $ne: null },
+        },
+        ['_id']
+      );
+
+      if (disconnectedLink) {
+        this.logger.info(
+          { agentId, integrationIdentifier },
+          'Rejecting resolve for an integration that was deliberately disconnected from the agent'
+        );
+        throw new AgentIntegrationDisconnectedException(agentId, integrationIdentifier);
+      }
+
       agentIntegration = await this.tryHealMissingAgentIntegrationLink({
         agentId,
         agentIdentifier: agent.identifier,

--- a/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
@@ -144,11 +144,13 @@ export class AddAgentIntegration {
       throw new ConflictException('This integration is already linked to the agent.');
     }
 
-    const link = await this.agentIntegrationRepository.create({
-      _agentId: agent._id,
-      _integrationId: integration._id,
-      _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
+    // Revives a tombstoned (disconnected) link when one exists for this pair —
+    // a plain create would violate the unique (_agentId, _integrationId) index.
+    const link = await this.agentIntegrationRepository.createOrReviveLink({
+      agentId: agent._id,
+      integrationId: integration._id,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
     });
 
     const response = toAgentIntegrationResponse(link, integration, agent);

--- a/apps/api/src/app/agents/channels/integrations/remove-agent-integration/remove-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/remove-agent-integration/remove-agent-integration.usecase.ts
@@ -33,17 +33,18 @@ export class RemoveAgentIntegration {
     }
 
     await this.agentIntegrationRepository.withTransaction(async (session) => {
-      const deleted = await this.agentIntegrationRepository.findOneAndDelete(
-        {
-          _id: command.agentIntegrationId,
-          _agentId: agent._id,
-          _environmentId: command.environmentId,
-          _organizationId: command.organizationId,
-        },
-        { session }
-      );
+      // Soft delete: the tombstoned link lets the inbound-webhook heal distinguish
+      // a deliberate disconnect from a never-linked orphan, so platform webhooks
+      // that still target this integration cannot resurrect the channel.
+      const disconnected = await this.agentIntegrationRepository.softDisconnect({
+        agentIntegrationId: command.agentIntegrationId,
+        agentId: agent._id,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        session,
+      });
 
-      if (!deleted) {
+      if (!disconnected) {
         throw new NotFoundException(
           `Agent-integration link "${command.agentIntegrationId}" was not found for this agent.`
         );
@@ -51,7 +52,7 @@ export class RemoveAgentIntegration {
 
       await this.cleanupNovuEmail.cleanupForIntegration(
         agent._id,
-        deleted._integrationId,
+        disconnected._integrationId,
         command.environmentId,
         command.organizationId,
         session

--- a/apps/api/src/app/agents/channels/integrations/update-agent-integration/update-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/update-agent-integration/update-agent-integration.usecase.ts
@@ -73,6 +73,17 @@ export class UpdateAgentIntegration {
       throw new ConflictException('This integration is already linked to the agent.');
     }
 
+    // The duplicate check above only sees active links; a tombstoned (disconnected)
+    // link for the target integration would still trip the unique
+    // (_agentId, _integrationId) index when the update re-points this link.
+    await this.agentIntegrationRepository.delete({
+      _agentId: agent._id,
+      _integrationId: targetIntegration._id,
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+      disconnectedAt: { $ne: null },
+    });
+
     await this.agentIntegrationRepository.updateOne(
       {
         _id: command.agentIntegrationId,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/agent-inbound.controller.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/agent-inbound.controller.ts
@@ -4,6 +4,7 @@ import { PinoLogger } from '@novu/application-generic';
 import { Request, Response } from 'express';
 import type { AgentConfigResolveSource } from '../../channels/agent-config-resolver.service';
 import { AgentInactiveException } from '../../shared/errors/agent-inactive.exception';
+import { AgentIntegrationDisconnectedException } from '../../shared/errors/agent-integration-disconnected.exception';
 import { InboundDispatcher } from './inbound.dispatcher';
 
 @Controller('/agents')
@@ -47,7 +48,7 @@ export class AgentInboundController {
     try {
       await this.inboundDispatcher.handleWebhook(agentId, integrationIdentifier, req, res, { source });
     } catch (err) {
-      if (err instanceof AgentInactiveException) {
+      if (err instanceof AgentInactiveException || err instanceof AgentIntegrationDisconnectedException) {
         // Return 200 to avoid retries by the delivery provider
         res.status(HttpStatus.OK).json({});
 

--- a/apps/api/src/app/agents/e2e/agent-integration-disconnect.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-integration-disconnect.e2e.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression coverage for the "disconnected channel resurrects itself" bug:
+ * disconnecting an integration on the Agent Channels page tombstones the
+ * agent-integration link (soft delete). A Slack webhook that still targets the
+ * old URL must NOT re-create the link via tryHealMissingAgentIntegrationLink —
+ * the heal only applies to never-linked (mid-setup orphan) integrations.
+ */
+import { encryptCredentials } from '@novu/application-generic';
+import {
+  AgentIntegrationRepository,
+  AgentRepository,
+  ChannelConnectionRepository,
+  IntegrationRepository,
+} from '@novu/dal';
+import { ChannelTypeEnum, ChatProviderIdEnum } from '@novu/shared';
+import { testServer } from '@novu/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ChatInstanceRegistry } from '../conversation-runtime/ingress/chat-instance.registry';
+import { AgentExecutionParams, BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
+import { AgentTestContext, setupAgentTestContext } from './helpers/agent-test-setup';
+import { buildSlackAppMention, signSlackRequest } from './helpers/providers/slack';
+import {
+  findEmulatorChannel,
+  findEmulatorUser,
+  type SlackChannelSummary,
+  type SlackUserSummary,
+  startSlackEmulator,
+} from './helpers/slack-emulator';
+
+const agentRepository = new AgentRepository();
+const agentIntegrationRepository = new AgentIntegrationRepository();
+const integrationRepository = new IntegrationRepository();
+const channelConnectionRepository = new ChannelConnectionRepository();
+
+describe('Agent integration disconnect tombstone #novu-v2', () => {
+  let ctx: AgentTestContext;
+  let bridgeCalls: AgentExecutionParams[];
+  let slackChannel: SlackChannelSummary;
+  let slackUser: SlackUserSummary;
+
+  before(async () => {
+    process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
+    const emulator = await startSlackEmulator();
+    slackChannel = await findEmulatorChannel(emulator.url, 'incidents');
+    slackUser = await findEmulatorUser(emulator.url, 'e2e@novu.test');
+  });
+
+  beforeEach(async () => {
+    ctx = await setupAgentTestContext();
+
+    // The Slack emulator returns 404 for assistant.threads.setStatus; awaiting
+    // acknowledgeOnReceived can block inbound processing long enough to flake.
+    await agentRepository.update(
+      { _id: ctx.agentId, _environmentId: ctx.session.environment._id },
+      { $set: { 'behavior.acknowledgeOnReceived': false } }
+    );
+
+    bridgeCalls = [];
+    const bridgeExecutor = testServer.getService(BridgeExecutorService);
+    sinon.stub(bridgeExecutor, 'execute').callsFake(async (params: AgentExecutionParams) => {
+      bridgeCalls.push(params);
+    });
+  });
+
+  afterEach(async () => {
+    const registry = testServer.getService(ChatInstanceRegistry);
+    await registry.onModuleDestroy();
+    sinon.restore();
+  });
+
+  async function postSlackWebhook(integrationIdentifier: string, signingSecret: string) {
+    const body = JSON.stringify(
+      buildSlackAppMention({
+        userId: slackUser.id,
+        channel: slackChannel.id,
+        threadTs: `${Math.floor(Date.now() / 1000)}.${`${Date.now() % 1000000}`.padStart(6, '0')}`,
+      })
+    );
+    const timestamp = Math.floor(Date.now() / 1000);
+    const headers = signSlackRequest(signingSecret, timestamp, body);
+
+    return ctx.session.testAgent
+      .post(`/v1/agents/${ctx.agentId}/webhook/${integrationIdentifier}`)
+      .set(headers)
+      .set('content-type', 'application/json')
+      .send(body);
+  }
+
+  async function getLinkId(): Promise<string> {
+    const listRes = await ctx.session.testAgent.get(`/v1/agents/${ctx.agentIdentifier}/integrations`);
+    expect(listRes.status).to.equal(200);
+    expect(listRes.body.data.length).to.equal(1);
+
+    return listRes.body.data[0]._id as string;
+  }
+
+  async function disconnectLink(linkId: string): Promise<void> {
+    const removeRes = await ctx.session.testAgent.delete(`/v1/agents/${ctx.agentIdentifier}/integrations/${linkId}`);
+    expect(removeRes.status).to.equal(204);
+  }
+
+  function activeLinkQuery() {
+    return {
+      _agentId: ctx.agentId,
+      _integrationId: ctx.integrationId,
+      _environmentId: ctx.session.environment._id,
+      _organizationId: ctx.session.organization._id,
+    };
+  }
+
+  it('does not resurrect a deliberately disconnected link when a webhook arrives', async () => {
+    const linkId = await getLinkId();
+    await disconnectLink(linkId);
+
+    const webhookRes = await postSlackWebhook(ctx.integrationIdentifier, ctx.signingSecret);
+
+    // 200 (not 4xx) so Slack stops retrying the still-registered webhook URL
+    expect(webhookRes.status).to.equal(200);
+    expect(bridgeCalls.length).to.equal(0);
+
+    // No active link came back — the heal must not have run
+    const activeLink = await agentIntegrationRepository.findOne(activeLinkQuery(), ['_id']);
+    expect(activeLink).to.equal(null);
+
+    // The tombstone is still there, marking the deliberate disconnect
+    const tombstone = await agentIntegrationRepository.findOne(
+      { ...activeLinkQuery(), disconnectedAt: { $ne: null } },
+      '*'
+    );
+    if (!tombstone) throw new Error('Expected a tombstoned link to remain after disconnect');
+    expect(tombstone._id).to.equal(linkId);
+    expect(tombstone.disconnectedAt).to.exist;
+
+    // And the Channels page list stays empty
+    const listRes = await ctx.session.testAgent.get(`/v1/agents/${ctx.agentIdentifier}/integrations`);
+    expect(listRes.body.data.length).to.equal(0);
+  });
+
+  it('still heals a never-linked orphan integration on first inbound webhook', async () => {
+    const orphanSigningSecret = 'orphan-slack-signing-secret';
+    const orphanIntegration = await integrationRepository.create({
+      _environmentId: ctx.session.environment._id,
+      _organizationId: ctx.session.organization._id,
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      credentials: encryptCredentials({ signingSecret: orphanSigningSecret }),
+      active: true,
+      name: 'Slack Orphan E2E',
+      identifier: `slack-orphan-e2e-${Date.now()}`,
+      priority: 1,
+      primary: false,
+      deleted: false,
+    });
+
+    await channelConnectionRepository.create({
+      identifier: `conn-orphan-e2e-${Date.now()}`,
+      _environmentId: ctx.session.environment._id,
+      _organizationId: ctx.session.organization._id,
+      integrationIdentifier: orphanIntegration.identifier,
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      contextKeys: [],
+      workspace: { id: 'W_TEAM', name: 'Test Workspace' },
+      auth: { accessToken: 'xoxb-fake-bot-token-for-e2e' },
+    });
+
+    const webhookRes = await postSlackWebhook(orphanIntegration.identifier, orphanSigningSecret);
+
+    expect(webhookRes.status).to.equal(200);
+
+    const healedLink = await agentIntegrationRepository.findOne(
+      {
+        _agentId: ctx.agentId,
+        _integrationId: orphanIntegration._id,
+        _environmentId: ctx.session.environment._id,
+        _organizationId: ctx.session.organization._id,
+      },
+      '*'
+    );
+    if (!healedLink) throw new Error('Orphan integration should be auto-linked by the heal');
+    expect(healedLink.disconnectedAt ?? null).to.equal(null);
+  });
+
+  it('revives the tombstoned link when the integration is re-added', async () => {
+    const linkId = await getLinkId();
+    await disconnectLink(linkId);
+
+    const addRes = await ctx.session.testAgent
+      .post(`/v1/agents/${ctx.agentIdentifier}/integrations`)
+      .send({ integrationIdentifier: ctx.integrationIdentifier });
+
+    expect(addRes.status).to.equal(201);
+    // Same row revived, not a duplicate
+    expect(addRes.body.data._id).to.equal(linkId);
+
+    const revived = await agentIntegrationRepository.findOne(activeLinkQuery(), '*');
+    if (!revived) throw new Error('Expected the link to be active again after re-adding the integration');
+    expect(revived._id).to.equal(linkId);
+    expect(revived.disconnectedAt ?? null).to.equal(null);
+    expect(revived.connectedAt ?? null).to.equal(null);
+
+    // The channel works again end to end
+    const webhookRes = await postSlackWebhook(ctx.integrationIdentifier, ctx.signingSecret);
+    expect(webhookRes.status).to.equal(200);
+
+    const reconnected = await agentIntegrationRepository.findOne(activeLinkQuery(), '*');
+    if (!reconnected) throw new Error('Expected the revived link to still exist after the webhook');
+    expect(reconnected.connectedAt, 'first webhook after revive should re-mark the link connected').to.exist;
+  });
+});

--- a/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.service.ts
+++ b/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.service.ts
@@ -301,15 +301,15 @@ export class NovuEmailProvisioningService {
       throw new ConflictException('This integration is already linked to the agent.');
     }
 
-    const link = await this.agentIntegrationRepository.create(
-      {
-        _agentId: agentId,
-        _integrationId: integration._id,
-        _environmentId: environmentId,
-        _organizationId: organizationId,
-      },
-      { session }
-    );
+    // Revives a tombstoned (disconnected) link when one exists for this pair —
+    // a plain create would violate the unique (_agentId, _integrationId) index.
+    const link = await this.agentIntegrationRepository.createOrReviveLink({
+      agentId,
+      integrationId: integration._id,
+      environmentId,
+      organizationId,
+      session,
+    });
 
     return toAgentIntegrationResponse(link, integration, agent);
   }

--- a/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.spec.ts
+++ b/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.spec.ts
@@ -33,7 +33,7 @@ describe('NovuEmailProvisioningService', () => {
   let agentIntegrationRepo: {
     find: sinon.SinonStub;
     findOne: sinon.SinonStub;
-    create: sinon.SinonStub;
+    createOrReviveLink: sinon.SinonStub;
     withTransaction: sinon.SinonStub;
   };
   let organizationRepo: {
@@ -73,7 +73,7 @@ describe('NovuEmailProvisioningService', () => {
     agentIntegrationRepo = {
       find: stub().resolves([]),
       findOne: stub().resolves(null),
-      create: stub().resolves({
+      createOrReviveLink: stub().resolves({
         _id: 'link-id',
         _agentId: AGENT_ID,
         _integrationId: 'novu-agent-int-id',

--- a/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
+++ b/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
@@ -76,7 +76,7 @@ describe('SyncAgentToEnvironment usecase', () => {
   };
   let agentIntegrationRepo: {
     find: sinon.SinonStub;
-    create: sinon.SinonStub;
+    createOrReviveLink: sinon.SinonStub;
     delete: sinon.SinonStub;
   };
   let integrationRepo: {
@@ -92,7 +92,7 @@ describe('SyncAgentToEnvironment usecase', () => {
 
   beforeEach(() => {
     agentRepo = { findOne: stub(), create: stub(), update: stub().resolves() };
-    agentIntegrationRepo = { find: stub(), create: stub().resolves(), delete: stub().resolves() };
+    agentIntegrationRepo = { find: stub(), createOrReviveLink: stub().resolves(), delete: stub().resolves() };
     integrationRepo = { find: stub(), findOne: stub(), create: stub(), delete: stub().resolves() };
   });
 
@@ -157,11 +157,11 @@ describe('SyncAgentToEnvironment usecase', () => {
       expect(stubArg._environmentId).to.equal(TARGET_ENV);
       expect(stubArg.active).to.equal(true);
 
-      expect(agentIntegrationRepo.create.calledOnce).to.equal(true);
-      const linkArg = agentIntegrationRepo.create.firstCall.args[0];
-      expect(linkArg._agentId).to.equal('target-agent-id');
-      expect(linkArg._integrationId).to.equal('stub-id');
-      expect(linkArg._environmentId).to.equal(TARGET_ENV);
+      expect(agentIntegrationRepo.createOrReviveLink.calledOnce).to.equal(true);
+      const linkArg = agentIntegrationRepo.createOrReviveLink.firstCall.args[0];
+      expect(linkArg.agentId).to.equal('target-agent-id');
+      expect(linkArg.integrationId).to.equal('stub-id');
+      expect(linkArg.environmentId).to.equal(TARGET_ENV);
     });
   });
 
@@ -213,7 +213,7 @@ describe('SyncAgentToEnvironment usecase', () => {
       await buildUsecase().execute(baseCommand());
 
       expect(integrationRepo.create.called).to.equal(false);
-      expect(agentIntegrationRepo.create.called).to.equal(false);
+      expect(agentIntegrationRepo.createOrReviveLink.called).to.equal(false);
     });
   });
 

--- a/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -127,12 +127,14 @@ export class SyncAgentToEnvironment {
         });
       }
 
-      await this.agentIntegrationRepository.create({
-        _agentId: targetAgent._id,
-        _integrationId: stubIntegration._id,
-        connectedAt: null,
-        _environmentId: targetEnvironmentId,
-        _organizationId: organizationId,
+      // Revives a tombstoned (disconnected) target link when one exists for this
+      // pair — a plain create would violate the unique (_agentId, _integrationId)
+      // index. Both paths leave connectedAt as null.
+      await this.agentIntegrationRepository.createOrReviveLink({
+        agentId: targetAgent._id,
+        integrationId: stubIntegration._id,
+        environmentId: targetEnvironmentId,
+        organizationId,
       });
     }
 

--- a/apps/api/src/app/agents/shared/errors/agent-integration-disconnected.exception.ts
+++ b/apps/api/src/app/agents/shared/errors/agent-integration-disconnected.exception.ts
@@ -1,0 +1,12 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+
+/**
+ * Raised when a webhook or outbound flow targets an integration whose link to
+ * the agent was deliberately disconnected (tombstoned). The inbound controller
+ * maps this to a 200 response so chat platforms stop retrying delivery.
+ */
+export class AgentIntegrationDisconnectedException extends UnprocessableEntityException {
+  constructor(agentId: string, integrationIdentifier: string) {
+    super(`Integration ${integrationIdentifier} is disconnected from agent ${agentId}`);
+  }
+}

--- a/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
@@ -114,11 +114,13 @@ export class SlackQuickSetup {
       throw new ConflictException('Integration is already linked to a different agent');
     }
 
-    await this.agentIntegrationRepository.create({
-      _agentId: command.agentId,
-      _integrationId: command.integrationId,
-      _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
+    // Revives a tombstoned (disconnected) link when one exists for this pair —
+    // a plain create would violate the unique (_agentId, _integrationId) index.
+    await this.agentIntegrationRepository.createOrReviveLink({
+      agentId: command.agentId,
+      integrationId: command.integrationId,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
     });
   }
 

--- a/libs/dal/src/repositories/agent-integration/agent-integration.entity.ts
+++ b/libs/dal/src/repositories/agent-integration/agent-integration.entity.ts
@@ -15,6 +15,13 @@ export class AgentIntegrationEntity {
 
   connectedAt?: string | null;
 
+  /**
+   * Tombstone marker. Set when the user deliberately disconnects the integration
+   * from an agent. Tombstoned links are excluded from reads by default via schema
+   * pre-hooks; query with an explicit `disconnectedAt` condition to see them.
+   */
+  disconnectedAt?: string | null;
+
   createdAt: string;
 
   updatedAt: string;

--- a/libs/dal/src/repositories/agent-integration/agent-integration.repository.ts
+++ b/libs/dal/src/repositories/agent-integration/agent-integration.repository.ts
@@ -2,6 +2,7 @@ import { DirectionEnum } from '@novu/shared';
 import { ClientSession, FilterQuery } from 'mongoose';
 
 import type { EnforceEnvOrOrgIds } from '../../types';
+import { isDuplicateKeyError } from '../../types/error.enum';
 import { SortOrder } from '../../types/sort-order';
 import { BaseRepositoryV2 } from '../base-repository-v2';
 import { AgentIntegrationDBModel, AgentIntegrationEntity } from './agent-integration.entity';
@@ -82,15 +83,44 @@ export class AgentIntegrationRepository extends BaseRepositoryV2<
       return revived;
     }
 
-    return this.create(
-      {
-        _agentId: agentId,
-        _integrationId: integrationId,
-        _environmentId: environmentId,
-        _organizationId: organizationId,
-      },
-      { session }
-    );
+    try {
+      return await this.create(
+        {
+          _agentId: agentId,
+          _integrationId: integrationId,
+          _environmentId: environmentId,
+          _organizationId: organizationId,
+        },
+        { session }
+      );
+    } catch (error) {
+      if (!isDuplicateKeyError(error)) {
+        throw error;
+      }
+
+      /*
+       * Race loser against the (_agentId, _integrationId, _environmentId)
+       * unique index: a concurrent caller created the link between our revive
+       * lookup and the insert. Re-read the winner's active row (the schema
+       * pre-hook scopes findOne to disconnectedAt: null) and return it.
+       */
+      const existing = await this.findOne(
+        {
+          _agentId: agentId,
+          _integrationId: integrationId,
+          _environmentId: environmentId,
+          _organizationId: organizationId,
+        },
+        '*',
+        { session }
+      );
+
+      if (existing) {
+        return existing;
+      }
+
+      throw error;
+    }
   }
 
   async findLinksForAgents({

--- a/libs/dal/src/repositories/agent-integration/agent-integration.repository.ts
+++ b/libs/dal/src/repositories/agent-integration/agent-integration.repository.ts
@@ -1,5 +1,5 @@
 import { DirectionEnum } from '@novu/shared';
-import { FilterQuery } from 'mongoose';
+import { ClientSession, FilterQuery } from 'mongoose';
 
 import type { EnforceEnvOrOrgIds } from '../../types';
 import { SortOrder } from '../../types/sort-order';
@@ -14,6 +14,83 @@ export class AgentIntegrationRepository extends BaseRepositoryV2<
 > {
   constructor() {
     super(AgentIntegration, AgentIntegrationEntity);
+  }
+
+  /**
+   * Tombstones an active link instead of deleting it, so the inbound-webhook
+   * heal can tell a deliberate disconnect apart from a never-linked orphan.
+   * Returns the link as it was before the update, or null when no active link matched.
+   */
+  async softDisconnect({
+    agentIntegrationId,
+    agentId,
+    environmentId,
+    organizationId,
+    session,
+  }: {
+    agentIntegrationId: string;
+    agentId: string;
+    environmentId: string;
+    organizationId: string;
+    session?: ClientSession | null;
+  }): Promise<AgentIntegrationEntity | null> {
+    return this.findOneAndUpdate(
+      {
+        _id: agentIntegrationId,
+        _agentId: agentId,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        disconnectedAt: null,
+      },
+      { $set: { disconnectedAt: new Date() } },
+      { session }
+    );
+  }
+
+  /**
+   * Revives a tombstoned link for the same (agent, integration) pair when one
+   * exists — the unique index makes a plain create fail — otherwise creates a
+   * fresh link. `connectedAt` is reset on revival so the first inbound webhook
+   * after reconnecting marks the link as connected again.
+   */
+  async createOrReviveLink({
+    agentId,
+    integrationId,
+    environmentId,
+    organizationId,
+    session,
+  }: {
+    agentId: string;
+    integrationId: string;
+    environmentId: string;
+    organizationId: string;
+    session?: ClientSession | null;
+  }): Promise<AgentIntegrationEntity> {
+    const revived = await this.findOneAndUpdate(
+      {
+        _agentId: agentId,
+        _integrationId: integrationId,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        disconnectedAt: { $ne: null },
+      },
+      { $set: { disconnectedAt: null, connectedAt: null } },
+      { new: true, session }
+    );
+
+    if (revived) {
+      return revived;
+    }
+
+    return this.create(
+      {
+        _agentId: agentId,
+        _integrationId: integrationId,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      { session }
+    );
   }
 
   async findLinksForAgents({

--- a/libs/dal/src/repositories/agent-integration/agent-integration.schema.ts
+++ b/libs/dal/src/repositories/agent-integration/agent-integration.schema.ts
@@ -3,12 +3,20 @@ import mongoose, { FilterQuery, Query, Schema } from 'mongoose';
 import { schemaOptions } from '../schema-default.options';
 import { AgentIntegrationDBModel } from './agent-integration.entity';
 
-function referencesDisconnectedAt(filter: FilterQuery<AgentIntegrationDBModel>): boolean {
-  if ('disconnectedAt' in filter) return true;
+function referencesDisconnectedAt(filter: unknown): boolean {
+  if (!filter || typeof filter !== 'object') return false;
 
-  const nestedClauses = [...(filter.$and ?? []), ...(filter.$or ?? [])];
+  if (Array.isArray(filter)) {
+    return filter.some(referencesDisconnectedAt);
+  }
 
-  return nestedClauses.some((clause) => clause && typeof clause === 'object' && 'disconnectedAt' in clause);
+  const filterQuery = filter as FilterQuery<AgentIntegrationDBModel>;
+
+  if ('disconnectedAt' in filterQuery) return true;
+
+  const nestedClauses = [...(filterQuery.$and ?? []), ...(filterQuery.$or ?? []), ...(filterQuery.$nor ?? [])];
+
+  return nestedClauses.some(referencesDisconnectedAt);
 }
 
 function excludeDisconnected(this: Query<unknown, AgentIntegrationDBModel>) {

--- a/libs/dal/src/repositories/agent-integration/agent-integration.schema.ts
+++ b/libs/dal/src/repositories/agent-integration/agent-integration.schema.ts
@@ -1,7 +1,21 @@
-import mongoose, { Schema } from 'mongoose';
+import mongoose, { FilterQuery, Query, Schema } from 'mongoose';
 
 import { schemaOptions } from '../schema-default.options';
 import { AgentIntegrationDBModel } from './agent-integration.entity';
+
+function referencesDisconnectedAt(filter: FilterQuery<AgentIntegrationDBModel>): boolean {
+  if ('disconnectedAt' in filter) return true;
+
+  const nestedClauses = [...(filter.$and ?? []), ...(filter.$or ?? [])];
+
+  return nestedClauses.some((clause) => clause && typeof clause === 'object' && 'disconnectedAt' in clause);
+}
+
+function excludeDisconnected(this: Query<unknown, AgentIntegrationDBModel>) {
+  if (!referencesDisconnectedAt(this.getFilter())) {
+    this.where({ disconnectedAt: null });
+  }
+}
 
 const agentIntegrationSchema = new Schema<AgentIntegrationDBModel>(
   {
@@ -26,9 +40,16 @@ const agentIntegrationSchema = new Schema<AgentIntegrationDBModel>(
       required: false,
       default: null,
     },
+    disconnectedAt: {
+      type: Date,
+      required: false,
+      default: null,
+    },
   },
   schemaOptions
 );
+
+agentIntegrationSchema.pre(['find', 'findOne', 'countDocuments'], excludeDisconnected);
 
 agentIntegrationSchema.index(
   {


### PR DESCRIPTION


### What changed? Why was the change needed?
- Added `AgentIntegrationDisconnectedException` to handle cases where a webhook targets a deliberately disconnected integration.
- Updated `agent-config-resolver.service.ts` to reject resolutions for disconnected integrations.
- Introduced `createOrReviveLink` method in `agent-integration.repository.ts` to manage revival of tombstoned links.
- Modified various use cases to utilize the new revival logic instead of direct creation.
- Implemented soft disconnect functionality to mark integrations as disconnected without deletion.
- Added regression tests to ensure disconnected integrations do not resurrect on webhook events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Implemented soft-disconnect for agent integrations so channels can be tombstoned (marked disconnected) instead of deleted, preventing webhook events from unintentionally resurrecting deliberately disconnected links; introduced revival logic to re-enable tombstoned links when re-added via the API. Added a specific exception to reject webhook resolutions against disconnected integrations and ensure webhook handlers return 200 to avoid provider retries.

## Affected areas

- **api**: Rejects agent-config resolutions for deliberately disconnected integrations, treats disconnected integrations like inactive agents in webhook handling (HTTP 200), and updated add/remove/update/sync/quick-setup use cases to use revival logic rather than blind create/delete.
- **dal**: Added `disconnectedAt` to agent integration entity, implemented `softDisconnect` to tombstone links and `createOrReviveLink` to atomically revive or create links, and added a Mongoose pre-hook to exclude disconnected records from reads by default.
- **agents (tests/e2e)**: Added regression e2e tests covering prevention of resurrection from webhooks, auto-heal for never-linked integrations, and proper revival behavior when re-adding integrations.

## Key technical decisions

- Tombstone via `disconnectedAt` timestamp (soft disconnect) instead of hard deletion to preserve webhook healing semantics and allow controlled revival.
- `createOrReviveLink` attempts to atomically revive a disconnected link then falls back to create, with duplicate-key handling to avoid unique-index races on (_agentId, _integrationId).
- Schema-level query middleware filters out disconnected records unless explicitly requested, preventing accidental resurrection.
- New `AgentIntegrationDisconnectedException` (extends UnprocessableEntityException) signals deliberate disconnects and is mapped to 200 responses in webhook paths to prevent retries.

## Testing

Added an e2e regression suite that verifies: webhooks do not resurrect deliberately disconnected links, orphan integrations auto-heal on first webhook, and re-adding an integration revives the tombstoned row; additional unit/test updates mock the new repository APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="1154" height="90" alt="Screenshot 2026-06-11 at 19 17 55" src="https://github.com/user-attachments/assets/b48847d8-07b8-4493-9723-f569955ea8c5" />

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
