### PR TITLE
feat(dashboard): welcome page ui updated to cover inbox and agents usecase fixes NV-8018

### DIFF
--- a/apps/dashboard/src/components/welcome/home/setup-steps-card.tsx
+++ b/apps/dashboard/src/components/welcome/home/setup-steps-card.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from 'react';
+import type { IconType } from 'react-icons';
+import { RiArrowRightSLine, RiBookMarkedLine, RiCheckLine } from 'react-icons/ri';
+import { cn } from '@/utils/ui';
+import { Button } from '../../primitives/button';
+
+export type WelcomeStepStatus = 'completed' | 'pending';
+
+export type WelcomeSetupStep = {
+  id: string;
+  title: ReactNode;
+  description: ReactNode;
+  status: WelcomeStepStatus;
+  ctaLabel?: string;
+  ctaTrailingIcon?: IconType;
+  ctaDisabled?: boolean;
+  onCtaClick?: () => void;
+};
+
+function StepIndicator({ status, index }: { status: WelcomeStepStatus; index: number }) {
+  if (status === 'completed') {
+    return (
+      <div className="relative z-10 flex size-6 items-center justify-center rounded-full border-2 border-[#E1E4EA]">
+        <div className="m-px flex size-[18px] min-w-[18px] items-center justify-center rounded-full border-[#5EC269] bg-[#77DB89] p-1 text-static-white">
+          <RiCheckLine className="h-full min-w-full" aria-hidden />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative z-10 flex size-6 items-center justify-center rounded-full border-2 border-[#E1E4EA]">
+      <div className="text-text-strong text-label-xs bg-bg-muted m-px flex size-[22px] items-center justify-center rounded-full">
+        {index}
+      </div>
+    </div>
+  );
+}
+
+function StepRow({
+  step,
+  index,
+  isFirst,
+  isLast,
+}: {
+  step: WelcomeSetupStep;
+  index: number;
+  isFirst: boolean;
+  isLast: boolean;
+}) {
+  const isCompleted = step.status === 'completed';
+  const TrailingIcon = step.ctaTrailingIcon ?? RiArrowRightSLine;
+
+  return (
+    <li className="flex items-stretch gap-4">
+      <div className="flex w-5 shrink-0 flex-col items-center self-stretch">
+        <div className={cn('h-2 w-px', isFirst ? 'bg-transparent' : 'bg-stroke-soft')} />
+        <StepIndicator status={step.status} index={index} />
+        <div className={cn('w-px flex-1', isLast ? 'bg-transparent' : 'bg-stroke-soft')} />
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-start gap-4 py-2.5">
+        <div className="flex min-w-0 max-w-88 flex-col gap-0.5">
+          <h3
+            className={cn('text-label-sm leading-5', isCompleted ? 'text-text-soft line-through' : 'text-text-strong')}
+          >
+            {step.title}
+          </h3>
+          <p className="text-text-soft text-paragraph-xs mt-1 leading-4">{step.description}</p>
+        </div>
+
+        {!isCompleted && step.ctaLabel ? (
+          <div className="ml-2 flex shrink-0 flex-col items-start gap-1.5 pt-0.5 lg:ml-10">
+            <Button
+              variant="secondary"
+              mode="outline"
+              size="2xs"
+              trailingIcon={TrailingIcon}
+              onClick={step.onCtaClick}
+              disabled={step.ctaDisabled}
+            >
+              {step.ctaLabel}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+type SetupStepsCardProps = {
+  steps: WelcomeSetupStep[];
+  onLearnMore: () => void;
+};
+
+export function SetupStepsCard({ steps, onLearnMore }: SetupStepsCardProps) {
+  return (
+    <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
+      <div className="flex items-center justify-between px-2 py-1.5">
+        <span className="text-text-soft text-code-xs font-code font-medium uppercase leading-4 tracking-wider">
+          Set things up
+        </span>
+        <button
+          type="button"
+          onClick={onLearnMore}
+          className="text-text-sub hover:text-text-strong text-paragraph-xs cursor-pointer transition-colors"
+        >
+          How it works?
+        </button>
+      </div>
+
+      <div className="bg-bg-white rounded-md p-5 shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
+        <ol className="flex flex-col">
+          {steps.map((step, idx) => (
+            <StepRow key={step.id} step={step} index={idx + 1} isFirst={idx === 0} isLast={idx === steps.length - 1} />
+          ))}
+        </ol>
+
+        <div className="mt-3 flex items-center gap-2">
+          <RiBookMarkedLine className="text-text-sub size-3.5 shrink-0" aria-hidden />
+          <button
+            type="button"
+            onClick={onLearnMore}
+            className="text-text-sub hover:text-text-strong text-paragraph-xs cursor-pointer underline underline-offset-2 transition-colors"
+          >
+            Learn more in docs
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/welcome/home/use-welcome-setup.ts
+++ b/apps/dashboard/src/components/welcome/home/use-welcome-setup.ts
@@ -1,0 +1,288 @@
+import { useOrganization } from '@clerk/react';
+import {
+  ChannelTypeEnum,
+  DirectionEnum,
+  FeatureFlagsKeysEnum,
+  type IIntegration,
+  ProductUseCasesEnum,
+} from '@novu/shared';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { RiAddLine } from 'react-icons/ri';
+import { useNavigate } from 'react-router-dom';
+import {
+  type AgentResponse,
+  getAgentIntegrationsQueryKey,
+  getAgentsListQueryKey,
+  listAgentIntegrations,
+  listAgents,
+} from '@/api/agents';
+import { docsUrl } from '@/components/header-navigation/support-drawer-constants';
+import { IS_EU, IS_SELF_HOSTED, ONBOARDING_DEMO_WORKFLOW_ID } from '@/config';
+import { useAuth } from '@/context/auth/hooks';
+import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
+import { useFetchWorkflows } from '@/hooks/use-fetch-workflows';
+import { useTelemetry } from '@/hooks/use-telemetry';
+import { AGENTS_DOCS_OVERVIEW_URL } from '@/utils/agent-docs';
+import { buildRoute, ROUTES } from '@/utils/routes';
+import { TelemetryEvent } from '@/utils/telemetry';
+import type { WelcomeSetupStep } from './setup-steps-card';
+
+export type WelcomeVariant = 'agents' | 'standard';
+
+export type UseWelcomeSetupResult = {
+  variant: WelcomeVariant;
+  steps: WelcomeSetupStep[];
+  isLoading: boolean;
+  /** Agents view: nudge to set up Workflows when none exist. */
+  showWorkflowsBanner: boolean;
+  /** Standard view: nudge to set up Agents when none exist (and agents are available). */
+  showAgentsBanner: boolean;
+  goToWorkflows: () => void;
+  goToAgentsSetup: () => void;
+  openDocs: () => void;
+};
+
+const AGENTS_PEEK_PARAMS = { after: undefined, before: undefined, limit: 2, identifier: '' };
+
+function hasInboxIntegration(integrations: IIntegration[] | undefined): boolean {
+  return Boolean(
+    integrations?.some(
+      (integration) =>
+        integration.channel === ChannelTypeEnum.IN_APP &&
+        !integration.providerId.startsWith('novu-') &&
+        !!integration.connected
+    )
+  );
+}
+
+export function useWelcomeSetup(): UseWelcomeSetupResult {
+  const navigate = useNavigate();
+  const telemetry = useTelemetry();
+  const { currentEnvironment } = useEnvironment();
+  const { currentOrganization } = useAuth();
+  const { organization } = useOrganization();
+
+  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const agentsAvailable = isAgentsEnabled && !IS_EU;
+  const pickedAgents = Boolean(currentOrganization?.productUseCases?.[ProductUseCasesEnum.AGENTS]);
+  const variant: WelcomeVariant = pickedAgents && agentsAvailable ? 'agents' : 'standard';
+
+  const environmentSlug = currentEnvironment?.slug ?? '';
+
+  const agentsQuery = useQuery({
+    queryKey: getAgentsListQueryKey(currentEnvironment?._id, AGENTS_PEEK_PARAMS),
+    queryFn: () =>
+      listAgents({
+        environment: requireEnvironment(currentEnvironment, 'No environment selected'),
+        limit: 2,
+        orderBy: 'updatedAt',
+        orderDirection: DirectionEnum.DESC,
+      }),
+    enabled: !!currentEnvironment && agentsAvailable,
+  });
+
+  const workflowsQuery = useFetchWorkflows({ limit: 12 });
+  const { integrations } = useFetchIntegrations();
+
+  const agents: AgentResponse[] = agentsQuery.data?.data ?? [];
+  const hasAgent = agents.length > 0;
+  const onlyAgent = agents.length === 1 ? agents[0] : undefined;
+
+  const agentIntegrationsQuery = useQuery({
+    queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, onlyAgent?.identifier),
+    queryFn: () =>
+      listAgentIntegrations({
+        environment: requireEnvironment(currentEnvironment, 'No environment selected'),
+        agentIdentifier: onlyAgent?.identifier ?? '',
+        limit: 50,
+      }),
+    enabled: !!currentEnvironment && agentsAvailable && !!onlyAgent,
+  });
+
+  const hasConnectedChannel = useMemo(
+    () => (agentIntegrationsQuery.data?.data ?? []).some((link) => Boolean(link.connectedAt)),
+    [agentIntegrationsQuery.data?.data]
+  );
+
+  const hasWorkflow = useMemo(
+    () =>
+      (workflowsQuery.data?.workflows ?? []).filter((workflow) => workflow.workflowId !== ONBOARDING_DEMO_WORKFLOW_ID)
+        .length > 0,
+    [workflowsQuery.data?.workflows]
+  );
+
+  const hasInbox = useMemo(() => hasInboxIntegration(integrations), [integrations]);
+  const hasTeam = (organization?.membersCount ?? 0) > 1;
+
+  const goToWorkflowsCreate = useCallback(() => {
+    if (!environmentSlug) return;
+
+    void navigate(buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug }));
+  }, [environmentSlug, navigate]);
+
+  const goToAgentsSetup = useCallback(() => {
+    void navigate(ROUTES.AGENTS_SETUP);
+  }, [navigate]);
+
+  const goToInbox = useCallback(() => {
+    void navigate(ROUTES.INBOX_EMBED);
+  }, [navigate]);
+
+  const goToTeam = useCallback(() => {
+    void navigate(ROUTES.SETTINGS_TEAM);
+  }, [navigate]);
+
+  const goToAgentChannel = useCallback(() => {
+    if (onlyAgent && environmentSlug) {
+      void navigate(
+        buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+          environmentSlug,
+          agentIdentifier: encodeURIComponent(onlyAgent.identifier),
+          agentTab: 'integrations',
+        })
+      );
+
+      return;
+    }
+
+    void navigate(ROUTES.AGENTS_SETUP);
+  }, [environmentSlug, navigate, onlyAgent]);
+
+  const openDocs = useCallback(() => {
+    const url = variant === 'agents' ? AGENTS_DOCS_OVERVIEW_URL : docsUrl('/platform/quickstart');
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }, [variant]);
+
+  const trackCta = useCallback(
+    (stepId: string) => {
+      telemetry(TelemetryEvent.WELCOME_STEP_CLICKED, { stepId, variant });
+    },
+    [telemetry, variant]
+  );
+
+  const isLoading =
+    (agentsAvailable && agentsQuery.isLoading) || workflowsQuery.isLoading || integrations === undefined;
+
+  const steps = useMemo<WelcomeSetupStep[]>(() => {
+    const accountStep: WelcomeSetupStep = {
+      id: 'account-creation',
+      title: 'Account creation',
+      description: "We know it's not always easy — take a moment to celebrate!",
+      status: 'completed',
+    };
+
+    const inviteStep: WelcomeSetupStep = {
+      id: 'invite-team',
+      title: 'Invite a team member',
+      description:
+        'Invite teammates to collaborate on agents and let them add their own custom agents for internal use.',
+      status: hasTeam ? 'completed' : 'pending',
+      ctaLabel: 'Invite teammates',
+      onCtaClick: () => {
+        trackCta('invite-team');
+        goToTeam();
+      },
+    };
+
+    if (variant === 'agents') {
+      const agentSteps: WelcomeSetupStep[] = [
+        accountStep,
+        {
+          id: 'add-agent',
+          title: 'Add an agent',
+          description: 'Give it a name, a system prompt, and pick the tools it can use.',
+          status: hasAgent ? 'completed' : 'pending',
+          ctaLabel: 'Add an agent',
+          ctaTrailingIcon: RiAddLine,
+          ctaDisabled: isLoading,
+          onCtaClick: () => {
+            trackCta('add-agent');
+            goToAgentsSetup();
+          },
+        },
+        {
+          id: 'connect-channel',
+          title: 'Connect a channel',
+          description:
+            'Slack, Teams, WhatsApp, or Email. Pick where your agent lives. You can add more channels later.',
+          status: hasConnectedChannel ? 'completed' : 'pending',
+          ctaLabel: 'Setup agent',
+          ctaDisabled: isLoading,
+          onCtaClick: () => {
+            trackCta('connect-channel');
+            goToAgentChannel();
+          },
+        },
+        inviteStep,
+      ];
+
+      return IS_SELF_HOSTED ? agentSteps.filter((step) => step.id !== 'invite-team') : agentSteps;
+    }
+
+    const standardSteps: WelcomeSetupStep[] = [
+      accountStep,
+      {
+        id: 'embed-inbox',
+        title: 'Add <Inbox/> to your product',
+        description:
+          'Give users a place to receive workflow notifications, manage preferences, and reopen conversations with your agents.',
+        status: hasInbox ? 'completed' : 'pending',
+        ctaLabel: 'Embed Inbox',
+        ctaDisabled: isLoading,
+        onCtaClick: () => {
+          trackCta('embed-inbox');
+          goToInbox();
+        },
+      },
+      {
+        id: 'create-workflow',
+        title: 'Create a workflow',
+        description:
+          'Start with events like payment failed, or task assigned, then let users ask the agent what happened and what to do next.',
+        status: hasWorkflow ? 'completed' : 'pending',
+        ctaLabel: 'Create a workflow',
+        ctaTrailingIcon: RiAddLine,
+        ctaDisabled: isLoading,
+        onCtaClick: () => {
+          trackCta('create-workflow');
+          goToWorkflowsCreate();
+        },
+      },
+      inviteStep,
+    ];
+
+    return IS_SELF_HOSTED ? standardSteps.filter((step) => step.id !== 'invite-team') : standardSteps;
+  }, [
+    goToAgentChannel,
+    goToAgentsSetup,
+    goToInbox,
+    goToTeam,
+    goToWorkflowsCreate,
+    hasAgent,
+    hasConnectedChannel,
+    hasInbox,
+    hasTeam,
+    hasWorkflow,
+    isLoading,
+    trackCta,
+    variant,
+  ]);
+
+  const hasAnyWorkflow = (workflowsQuery.data?.totalCount ?? 0) > 0;
+  const showWorkflowsBanner = variant === 'agents' && !workflowsQuery.isLoading && !hasAnyWorkflow;
+  const showAgentsBanner = variant === 'standard' && agentsAvailable && !agentsQuery.isLoading && !hasAgent;
+
+  return {
+    variant,
+    steps,
+    isLoading,
+    showWorkflowsBanner,
+    showAgentsBanner,
+    goToWorkflows: goToWorkflowsCreate,
+    goToAgentsSetup,
+    openDocs,
+  };
+}

--- a/apps/dashboard/src/components/welcome/home/welcome-banner.tsx
+++ b/apps/dashboard/src/components/welcome/home/welcome-banner.tsx
@@ -1,0 +1,225 @@
+import { SVGProps, useId } from 'react';
+import type { IconType } from 'react-icons';
+import { RiArrowRightSLine, RiArrowRightUpLine } from 'react-icons/ri';
+import { Button } from '../../primitives/button';
+
+export type WelcomeBannerProps = {
+  badgeLabel: string;
+  badgeIcon: IconType;
+  /** Tailwind text color class for the badge (controls icon + label tint). */
+  badgeColorClassName: string;
+  /** Tailwind background tint class for the badge pill. */
+  badgeBackgroundClassName: string;
+  title: string;
+  description: string;
+  ctaLabel: string;
+  onCtaClick: () => void;
+  learnMore?: { onClick: () => void };
+};
+
+const BackgroundSvg = (props: SVGProps<SVGSVGElement>) => {
+  const uid = useId();
+  const id = (name: string) => `${uid}-${name}`;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 790 116" preserveAspectRatio="none" {...props}>
+      <g filter={`url(#${id('a')})`} opacity=".4">
+        <g clipPath={`url(#${id('b')})`}>
+          <path fill="#fff" d="M0-50h790v170H0z" />
+          <g filter={`url(#${id('c')})`} opacity=".1">
+            <ellipse
+              cx="159.754"
+              cy="67.234"
+              fill="#ffba33"
+              rx="159.754"
+              ry="67.234"
+              transform="matrix(.96907 .2468 -.6364 .77136 182.556 44.563)"
+            />
+          </g>
+          <g filter={`url(#${id('d')})`} opacity=".1">
+            <ellipse
+              cx="292.491"
+              cy="100.85"
+              fill="#ff006a"
+              rx="292.491"
+              ry="100.85"
+              transform="matrix(.96907 .2468 -.6364 .77136 224.028 -66.844)"
+            />
+          </g>
+          <g filter={`url(#${id('e')})`} opacity=".1">
+            <ellipse
+              cx="286.618"
+              cy="117.249"
+              fill="#e300bd"
+              rx="286.618"
+              ry="117.249"
+              transform="matrix(.96907 .2468 -.6364 .77136 357.87 -148.062)"
+            />
+          </g>
+          <path fill={`url(#${id('f')})`} d="M0-31h811v275H0z" />
+        </g>
+      </g>
+      <defs>
+        <filter
+          id={id('a')}
+          width="804"
+          height="184"
+          x="-7"
+          y="-57"
+          colorInterpolationFilters="sRGB"
+          filterUnits="userSpaceOnUse"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feGaussianBlur result="effect1_foregroundBlur_8136_186653" stdDeviation="3.5" />
+        </filter>
+        <filter
+          id={id('c')}
+          width="376.474"
+          height="185.457"
+          x="106.344"
+          y="43.123"
+          colorInterpolationFilters="sRGB"
+          filterUnits="userSpaceOnUse"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feGaussianBlur result="effect1_foregroundBlur_8136_186653" stdDeviation="13.79" />
+        </filter>
+        <filter
+          id={id('d')}
+          width="636.524"
+          height="267.418"
+          x="125.028"
+          y="-50.572"
+          colorInterpolationFilters="sRGB"
+          filterUnits="userSpaceOnUse"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feGaussianBlur result="effect1_foregroundBlur_8136_186653" stdDeviation="13.79" />
+        </filter>
+        <filter
+          id={id('e')}
+          width="630.503"
+          height="284.816"
+          x="245.753"
+          y="-129.291"
+          colorInterpolationFilters="sRGB"
+          filterUnits="userSpaceOnUse"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feGaussianBlur result="effect1_foregroundBlur_8136_186653" stdDeviation="13.79" />
+        </filter>
+        <linearGradient id={id('f')} x1="405.5" x2="405.5" y1="-31" y2="244" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#fafafa" />
+          <stop offset=".5" stopColor="#fafafa" stopOpacity="0" />
+        </linearGradient>
+        <clipPath id={id('b')}>
+          <path fill="#fff" d="M0-50h790v170H0z" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+const BackgroundMastSvg = (props: SVGProps<SVGSVGElement>) => {
+  const uid = useId();
+  const maskId = `${uid}-mask`;
+  const gradientId = `${uid}-gradient`;
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 283 116" {...props}>
+      <mask id={maskId} width="283" height="153" x="0" y="-16" maskUnits="userSpaceOnUse" style={{ maskType: 'alpha' }}>
+        <path fill={`url(#${gradientId})`} d="M0 137h153v283H0z" transform="rotate(-90 0 137)" />
+      </mask>
+      <g mask={`url(#${maskId})`}>
+        <path
+          stroke="#b2adbe"
+          strokeWidth=".3"
+          d="M6 132v-21h21v21zM6 111V90h21v21zM6 90V69h21v21zM6 69V48h21v21zM6 48V27h21v21zM6 27V6h21v21zM-15 132v-21H6v21zM-15 111V90H6v21zM-15 90V69H6v21zM-15 69V48H6v21zM-15 48V27H6v21zM-15 27V6H6v21zM-15 6v-21H6V6zM48 132v-21h21v21zM48 111V90h21v21zM48 90V69h21v21zM48 69V48h21v21zM48 48V27h21v21zM48 27V6h21v21zM48 6v-21h21V6zM27 132v-21h21v21zM27 111V90h21v21zM27 90V69h21v21zM27 48V27h21v21z"
+        />
+        <path fill="#ff30b7" fillOpacity=".2" stroke="#e300bd" strokeWidth=".3" d="M27 69V48h21v21z" />
+        <path stroke="#b2adbe" strokeWidth=".3" d="M27 27V6h21v21zM27 6v-21h21V6z" />
+        <path fill="#ffb661" fillOpacity=".2" stroke="#ffba33" strokeWidth=".3" d="M6 6v-21h21V6z" />
+        <path
+          stroke="#b2adbe"
+          strokeWidth=".3"
+          d="M69 132v-21h21v21zM69 111V90h21v21zM69 90V69h21v21zM69 69V48h21v21zM69 48V27h21v21zM69 27V6h21v21zM69 6v-21h21V6zM90 132v-21h21v21zM90 111V90h21v21zM90 90V69h21v21zM90 69V48h21v21zM90 48V27h21v21zM90 27V6h21v21zM90 6v-21h21V6zM111 132v-21h21v21zM111 111V90h21v21zM111 90V69h21v21zM111 69V48h21v21zM111 48V27h21v21zM111 27V6h21v21zM111 6v-21h21V6zM132 132v-21h21v21zM132 111V90h21v21zM132 90V69h21v21zM132 69V48h21v21zM132 48V27h21v21zM132 6v-21h21V6zM153 132v-21h21v21zM153 111V90h21v21zM153 90V69h21v21zM153 69V48h21v21zM153 48V27h21v21zM153 27V6h21v21zM153 6v-21h21V6zM174 132v-21h21v21zM174 111V90h21v21zM174 90V69h21v21zM174 69V48h21v21zM174 48V27h21v21zM174 27V6h21v21zM174 6v-21h21V6z"
+        />
+        <path fill="#ff006a" fillOpacity=".2" stroke="#ff006a" strokeWidth=".3" d="M132 27V6h21v21z" />
+        <circle cx="90.001" cy="48" r="1" fill="#6b6382" transform="rotate(-90 90 48)" />
+      </g>
+      <defs>
+        <radialGradient
+          id={gradientId}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="matrix(0 141.5 -76.5 0 76.5 278.5)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#d9d9d9" stopOpacity=".4" />
+          <stop offset="1" stopColor="#d9d9d9" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+    </svg>
+  );
+};
+
+export function WelcomeBanner({
+  badgeLabel,
+  badgeIcon: BadgeIcon,
+  badgeColorClassName,
+  badgeBackgroundClassName,
+  title,
+  description,
+  ctaLabel,
+  onCtaClick,
+  learnMore,
+}: WelcomeBannerProps) {
+  return (
+    <div className="border-stroke-soft relative isolate overflow-hidden rounded-[10px] border p-4">
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden>
+        <BackgroundSvg className="absolute inset-0 size-full" />
+        <BackgroundMastSvg
+          className="absolute inset-y-0 left-1/3 -translate-x-1/3 h-full w-auto"
+          preserveAspectRatio="xMinYMid meet"
+        />
+      </div>
+
+      <div className="flex items-start justify-between gap-3">
+        <span
+          className={`inline-flex items-center gap-1 rounded-[4px] py-0.5 pl-[3px] pr-[5px] ${badgeBackgroundClassName} ${badgeColorClassName}`}
+        >
+          <BadgeIcon className="size-3.5" aria-hidden />
+          <span className="font-code text-code-xs font-medium uppercase leading-4 tracking-wider">{badgeLabel}</span>
+        </span>
+
+        <Button variant="secondary" mode="outline" size="2xs" trailingIcon={RiArrowRightSLine} onClick={onCtaClick}>
+          {ctaLabel}
+        </Button>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-1">
+        <p className="text-text-strong text-label-sm font-medium leading-5">{title}</p>
+        <p className="text-text-soft text-paragraph-xs leading-4">
+          {description}
+          {learnMore ? (
+            <>
+              {' '}
+              <button
+                type="button"
+                onClick={learnMore.onClick}
+                className="text-text-sub hover:text-text-strong inline-flex cursor-pointer items-center gap-0.5 font-medium transition-colors"
+              >
+                Learn more
+                <RiArrowRightUpLine className="size-3.5" aria-hidden />
+              </button>
+            </>
+          ) : null}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/welcome/home/welcome-heading.tsx
+++ b/apps/dashboard/src/components/welcome/home/welcome-heading.tsx
@@ -1,0 +1,14 @@
+import { useAuth } from '@/context/auth/hooks';
+
+export function WelcomeHeading() {
+  const { currentUser } = useAuth();
+  const firstName = currentUser?.firstName?.trim();
+  const title = firstName ? `Welcome, ${firstName}.` : 'Welcome.';
+
+  return (
+    <div className="flex items-center px-2 py-2">
+      <h1 className="text-text-strong text-label-lg text-nowrap leading-6">{title}</h1>
+      <span className="text-text-soft text-label-lg ml-1 text-nowrap font-normal">Let's get this setup.</span>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/welcome/home/welcome-sidebar.tsx
+++ b/apps/dashboard/src/components/welcome/home/welcome-sidebar.tsx
@@ -1,0 +1,100 @@
+import type { IconType } from 'react-icons';
+import {
+  RiArrowRightUpLine,
+  RiBookletFill,
+  RiBookletLine,
+  RiBuildingLine,
+  RiCalendarScheduleLine,
+  RiCodeSSlashLine,
+  RiDatabase2Line,
+  RiGithubLine,
+  RiGroup2Fill,
+} from 'react-icons/ri';
+import { BOOK_DEMO_URL, docsUrl } from '@/components/header-navigation/support-drawer-constants';
+import { BotIcon } from '@/components/icons/bot';
+import { LinkIcon } from '@/components/icons/link';
+import { useTelemetry } from '@/hooks/use-telemetry';
+import { AGENTS_DOCS_OVERVIEW_URL } from '@/utils/agent-docs';
+import { TelemetryEvent } from '@/utils/telemetry';
+
+type SidebarLink = {
+  label: string;
+  href: string;
+  icon: IconType;
+};
+
+const QUICK_LINKS: SidebarLink[] = [
+  { label: 'Join our community', href: 'https://discord.novu.co', icon: RiGroup2Fill },
+  { label: 'Book a demo (Yes, with a human)', href: BOOK_DEMO_URL, icon: RiCalendarScheduleLine },
+  { label: 'Read documentation', href: docsUrl(), icon: RiBookletLine },
+  { label: 'See our code on GitHub', href: 'https://github.com/novuhq/novu', icon: RiGithubLine },
+];
+
+const LEARN_LINKS: SidebarLink[] = [
+  { label: 'Agents', href: AGENTS_DOCS_OVERVIEW_URL, icon: BotIcon },
+  { label: 'Environments', href: docsUrl('/platform/concepts/environments'), icon: RiDatabase2Line },
+  {
+    label: 'Contexts',
+    href: docsUrl('/platform/workflow/advanced-features/contexts/contexts-in-workflows'),
+    icon: RiBuildingLine,
+  },
+  { label: 'Framework', href: docsUrl('/framework/overview'), icon: RiCodeSSlashLine },
+];
+
+function SidebarSection({
+  title,
+  titleIcon: TitleIcon,
+  links,
+}: {
+  title: string;
+  titleIcon: IconType;
+  links: SidebarLink[];
+}) {
+  const telemetry = useTelemetry();
+
+  return (
+    <div className="flex flex-col rounded-[10px] p-1">
+      <div className="flex items-center gap-1 px-2 py-1.5">
+        <TitleIcon className="text-text-soft size-4" aria-hidden />
+        <span className="text-text-soft text-code-xs font-code font-medium uppercase leading-4 tracking-wider">
+          {title}
+        </span>
+      </div>
+      <ul className="bg-bg-white divide-stroke-soft flex flex-col divide-y rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
+        {links.map((link) => {
+          const Icon = link.icon;
+
+          return (
+            <li key={link.label} className="first:rounded-t-md last:rounded-b-md">
+              <a
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() =>
+                  telemetry(TelemetryEvent.RESOURCE_CLICKED, { title: link.label, url: link.href, section: title })
+                }
+                className="hover:bg-bg-weak focus-visible:bg-bg-weak focus-visible:ring-stroke-strong group flex w-full items-center gap-2 rounded-md px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2"
+              >
+                <Icon className="text-text-sub size-4 shrink-0" aria-hidden />
+                <span className="text-text-sub text-label-sm flex-1 truncate font-medium">{link.label}</span>
+                <RiArrowRightUpLine
+                  className="text-text-soft size-4 shrink-0 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+                  aria-hidden
+                />
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function WelcomeSidebar() {
+  return (
+    <aside className="flex flex-col gap-2.5">
+      <SidebarSection title="Quick links" titleIcon={LinkIcon} links={QUICK_LINKS} />
+      <SidebarSection title="Learn" titleIcon={RiBookletFill} links={LEARN_LINKS} />
+    </aside>
+  );
+}

--- a/apps/dashboard/src/hooks/use-update-product-use-cases.ts
+++ b/apps/dashboard/src/hooks/use-update-product-use-cases.ts
@@ -1,9 +1,17 @@
+import { useOrganization } from '@clerk/react';
 import type { ProductUseCases } from '@novu/shared';
 import { useMutation } from '@tanstack/react-query';
 import { updateExternalOrganization } from '@/api/organization';
 
 export function useUpdateProductUseCases() {
+  const { organization } = useOrganization();
+
   return useMutation<unknown, Error, ProductUseCases>({
     mutationFn: async (productUseCases) => updateExternalOrganization({ productUseCases }),
+    onSuccess: async () => {
+      // The org's productUseCases live in Clerk's publicMetadata, which the API just updated.
+      // Reload the Clerk resource so useAuth().currentOrganization reflects the change.
+      await organization?.reload();
+    },
   });
 }

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -216,7 +216,7 @@ export function AgentsSetupPage() {
       return;
     }
 
-    void navigate(buildRoute(ROUTES.AGENTS, { environmentSlug: 'default' }));
+    void navigate(buildRoute(ROUTES.WELCOME, { environmentSlug: 'default' }));
   }, [buildOnboardingCompletionProps, currentEnvironment?.slug, navigate, telemetry]);
 
   const handleNavigateToOverview = useCallback(() => {

--- a/apps/dashboard/src/pages/usecase-select-page.tsx
+++ b/apps/dashboard/src/pages/usecase-select-page.tsx
@@ -319,7 +319,7 @@ function UsecaseSelector({ selected, onSelect }: { selected: UsecaseId; onSelect
 
     if (selected === 'inbox') {
       // Persist the picked usecase on the org (fire-and-forget — navigation continues regardless).
-      updateProductUseCases.mutate({ [ProductUseCasesEnum.IN_APP]: true });
+      updateProductUseCases.mutate({ [ProductUseCasesEnum.IN_APP]: true, [ProductUseCasesEnum.AGENTS]: false });
       // Restart the provisioning loader so it plays a full cycle (with the inbox/notification copy)
       // while the destination page boots, instead of flickering off as soon as data resolves.
       beginOnboardingProvisioning('platform');
@@ -329,7 +329,7 @@ function UsecaseSelector({ selected, onSelect }: { selected: UsecaseId; onSelect
     }
 
     if (selected === 'agents') {
-      updateProductUseCases.mutate({ [ProductUseCasesEnum.AGENTS]: true });
+      updateProductUseCases.mutate({ [ProductUseCasesEnum.AGENTS]: true, [ProductUseCasesEnum.IN_APP]: false });
       beginOnboardingProvisioning('agents');
       void navigate(ROUTES.AGENTS_SETUP);
     }

--- a/apps/dashboard/src/pages/welcome-page.tsx
+++ b/apps/dashboard/src/pages/welcome-page.tsx
@@ -74,7 +74,7 @@ export function WelcomePage(): ReactElement {
                     badgeIcon={RiChat3Line}
                     badgeColorClassName="text-[#7d52f4]"
                     badgeBackgroundClassName="bg-[rgba(125,82,244,0.1)]"
-                    title="Setup agents to let your users respond the notifications."
+                    title="Setup agents to let your users respond to the notifications."
                     description="Workflows can notify users when something happens, and with agents, your users can respond to those notifications and get a response back or take action."
                     ctaLabel="Setup agents"
                     onCtaClick={goToAgentsSetup}

--- a/apps/dashboard/src/pages/welcome-page.tsx
+++ b/apps/dashboard/src/pages/welcome-page.tsx
@@ -1,113 +1,93 @@
 import { motion } from 'motion/react';
 import { ReactElement, useEffect } from 'react';
-import { RiBookletFill, RiBookmark2Fill } from 'react-icons/ri';
+import { RiChat3Line, RiNotification3Line } from 'react-icons/ri';
 import { DashboardLayout } from '../components/dashboard-layout';
 import { PageMeta } from '../components/page-meta';
-import { ProgressSection } from '../components/welcome/progress-section';
-import { Resource, ResourcesList } from '../components/welcome/resources-list';
+import { SetupStepsCard } from '../components/welcome/home/setup-steps-card';
+import { useWelcomeSetup } from '../components/welcome/home/use-welcome-setup';
+import { WelcomeBanner } from '../components/welcome/home/welcome-banner';
+import { WelcomeHeading } from '../components/welcome/home/welcome-heading';
+import { WelcomeSidebar } from '../components/welcome/home/welcome-sidebar';
 import { useTelemetry } from '../hooks/use-telemetry';
 import { TelemetryEvent } from '../utils/telemetry';
 
-const helpfulResources: Resource[] = [
-  {
-    title: 'Documentation',
-    image: 'blog.svg',
-    url: 'https://docs.novu.co/',
+const sectionVariants = {
+  hidden: { opacity: 0, y: 12 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: [0.16, 1, 0.3, 1] },
   },
-  {
-    title: 'Install Novu MCP',
-    image: 'mcp.svg',
-    url: 'https://docs.novu.co/platform/additional-resources/mcp',
-  },
-  {
-    title: 'See our code on GitHub',
-    image: 'git.svg',
-    url: 'https://github.com/novuhq/novu',
-  },
-  {
-    title: 'Security & Compliance',
-    image: 'security.svg',
-    url: 'https://trust.novu.co/',
-  },
-];
+};
 
-const learnResources: Resource[] = [
-  {
-    title: 'Manage Subscribers',
-    duration: '4m read',
-    image: 'subscribers.svg',
-    url: 'https://docs.novu.co/platform/concepts/subscribers?utm_source=novu.co&utm_medium=welcome-page',
+const pageVariants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.08, delayChildren: 0.05 },
   },
-  {
-    title: 'Topics',
-    duration: '5m read',
-    image: 'topics.svg',
-    url: 'https://docs.novu.co/platform/concepts/topics?utm_source=novu.co&utm_medium=welcome-page',
-  },
-  {
-    title: 'Code First Workflows',
-    duration: '4m read',
-    image: 'code-first.svg',
-    url: 'https://docs.novu.co/framework/introduction?utm_source=novu.co&utm_medium=welcome-page',
-  },
-  {
-    title: 'Digest Engine',
-    duration: '3m read',
-    image: 'digest engine-1.svg',
-    url: 'https://docs.novu.co/platform/workflow/digest?utm_source=novu.co&utm_medium=welcome-page',
-  },
-];
+};
 
 export function WelcomePage(): ReactElement {
   const telemetry = useTelemetry();
+  const { variant, steps, showWorkflowsBanner, showAgentsBanner, goToWorkflows, goToAgentsSetup, openDocs } =
+    useWelcomeSetup();
 
   useEffect(() => {
-    telemetry(TelemetryEvent.WELCOME_PAGE_VIEWED);
-  }, [telemetry]);
-
-  const pageVariants = {
-    hidden: { opacity: 0 },
-    show: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.2,
-        delayChildren: 0.1,
-      },
-    },
-  };
-
-  const sectionVariants = {
-    hidden: { opacity: 0, y: 20 },
-    show: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.5,
-        ease: [0.16, 1, 0.3, 1],
-      },
-    },
-  };
+    telemetry(TelemetryEvent.WELCOME_PAGE_VIEWED, { variant });
+  }, [telemetry, variant]);
 
   return (
     <>
       <PageMeta title="Get Started with Novu" />
       <DashboardLayout>
-        <motion.div className="flex flex-col gap-6 p-4 pt-2 md:gap-8 md:p-9 md:pt-4" variants={pageVariants} initial="hidden" animate="show">
+        <motion.div className="flex flex-col gap-2.5 p-2.5" variants={pageVariants} initial="hidden" animate="show">
           <motion.div variants={sectionVariants}>
-            <ProgressSection />
+            <WelcomeHeading />
           </motion.div>
 
-          <motion.div variants={sectionVariants}>
-            <ResourcesList
-              title="Helpful resources"
-              icon={<RiBookmark2Fill className="h-4 w-4" />}
-              resources={helpfulResources}
-            />
-          </motion.div>
+          <div className="grid grid-cols-1 gap-2.5 lg:grid-cols-[minmax(0,1fr)_375px]">
+            <div className="flex min-w-0 flex-col gap-2.5">
+              <motion.div variants={sectionVariants}>
+                <SetupStepsCard steps={steps} onLearnMore={openDocs} />
+              </motion.div>
 
-          <motion.div variants={sectionVariants}>
-            <ResourcesList title="Learn" icon={<RiBookletFill className="h-4 w-4" />} resources={learnResources} />
-          </motion.div>
+              {showWorkflowsBanner ? (
+                <motion.div variants={sectionVariants}>
+                  <WelcomeBanner
+                    badgeLabel="Notifications"
+                    badgeIcon={RiNotification3Line}
+                    badgeColorClassName="text-[#fb3748]"
+                    badgeBackgroundClassName="bg-primary-alpha-10"
+                    title="Send transactional notifications with Workflows"
+                    description="Trigger product events, orchestrate delivery across channels, and optionally connect notifications to your agents for follow-up conversations."
+                    ctaLabel="Setup workflows"
+                    onCtaClick={goToWorkflows}
+                  />
+                </motion.div>
+              ) : null}
+
+              {showAgentsBanner ? (
+                <motion.div variants={sectionVariants}>
+                  <WelcomeBanner
+                    badgeLabel="Conversations"
+                    badgeIcon={RiChat3Line}
+                    badgeColorClassName="text-[#7d52f4]"
+                    badgeBackgroundClassName="bg-[rgba(125,82,244,0.1)]"
+                    title="Setup agents to let your users respond the notifications."
+                    description="Workflows can notify users when something happens, and with agents, your users can respond to those notifications and get a response back or take action."
+                    ctaLabel="Setup agents"
+                    onCtaClick={goToAgentsSetup}
+                    learnMore={{ onClick: openDocs }}
+                  />
+                </motion.div>
+              ) : null}
+            </div>
+
+            <motion.div variants={sectionVariants}>
+              <WelcomeSidebar />
+            </motion.div>
+          </div>
         </motion.div>
       </DashboardLayout>
     </>

--- a/apps/dashboard/src/utils/onboarding-redirect.ts
+++ b/apps/dashboard/src/utils/onboarding-redirect.ts
@@ -47,5 +47,5 @@ export function getPostOrgCreateRoute(productType?: ProductType | null): string 
 }
 
 export function getPostOnboardingRoute(environmentSlug: string): string {
-  return buildRoute(ROUTES.AGENTS, { environmentSlug });
+  return buildRoute(ROUTES.WELCOME, { environmentSlug });
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard: updated the Welcome page (aka getting started guides) to cover both product usecases inbox and agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The dashboard welcome page was redesigned into a guided setup experience that supports two onboarding variants—agents and inbox—so users see variant-specific steps, banners, and CTAs. The change centralizes onboarding logic into a hook and new UI components, letting the page compute step completion from live data (agents, integrations, workflows) and guide users to the correct setup flows.

## Affected areas

**dashboard**: Reworked the WelcomePage to use a new useWelcomeSetup hook and new components (SetupStepsCard, WelcomeBanner, WelcomeHeading, WelcomeSidebar) to render variant-aware setup steps, contextual banners, and sidebar links; telemetry now includes the active welcome variant. Redirect logic and onboarding routing were adjusted (agents setup skip fallback now points to welcome; post-onboarding route uses ROUTES.WELCOME). The usecase selection page now persists both IN_APP and AGENTS flags explicitly. useUpdateProductUseCases now reloads the Clerk organization after updating product use cases so auth/publicMetadata stays in sync.

## Key technical decisions

- Introduced a two-variant pattern ('agents' | 'standard') driven by a single hook to avoid duplicating page logic while supporting different onboarding flows.  
- The useWelcomeSetup hook aggregates agents, integrations, and workflow queries to determine step completion and to expose navigation handlers and docs selection.  
- Clerk organization is reloaded after updating product use cases to ensure the auth context reflects changes immediately.  
- Self-hosted deployments omit the team-invite step to respect deployment constraints.

## Testing

No automated tests were added; changes are UI-focused and rely on existing data hooks. Manual verification is recommended to confirm both agents and inbox onboarding flows, step completion logic, and the updated redirect/usecase persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="1531" height="999" alt="Screenshot 2026-06-11 at 17 44 55" src="https://github.com/user-attachments/assets/0961b7a9-a9da-4a12-8565-7ecf75749816" />
<img width="1528" height="995" alt="Screenshot 2026-06-11 at 17 41 22" src="https://github.com/user-attachments/assets/a6364859-e8e5-4651-bd03-659241f60816" />

https://github.com/user-attachments/assets/532b80ed-5f94-4f89-80cf-113c86da4c25


https://github.com/user-attachments/assets/300b3f79-9c02-4fc6-acab-89a0fff99652


