### PR TITLE
feat(dashboard): update agents list icons and row actions (fixes NV-8017)

### DIFF
--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -16,6 +16,7 @@ import {
   deleteAgent,
   getAgentsListQueryKey,
   listAgents,
+  updateAgent,
 } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
 import { AgentPreviewSkeleton } from '@/components/agents/agent-preview-skeleton';
@@ -184,6 +185,31 @@ export function AgentsList() {
       showErrorToast(message, 'Delete failed');
     },
   });
+
+  const toggleActiveMutation = useMutation({
+    mutationFn: ({ identifier, active }: { identifier: string; active: boolean }) =>
+      updateAgent(requireEnvironment(currentEnvironment, 'No environment selected'), identifier, { active }),
+    onSuccess: async (updatedAgent) => {
+      showSuccessToast(
+        updatedAgent.active ? 'The agent is now active.' : 'The agent is now paused.',
+        updatedAgent.active ? 'Agent activated' : 'Agent paused'
+      );
+
+      await queryClient.invalidateQueries({ queryKey: [AGENTS_LIST_QUERY_KEY] });
+    },
+    onError: (err: Error) => {
+      const message = err instanceof NovuApiError ? err.message : 'Could not update agent.';
+
+      showErrorToast(message, 'Update failed');
+    },
+  });
+
+  const handleToggleActive = useCallback(
+    (agent: AgentResponse) => {
+      toggleActiveMutation.mutate({ identifier: agent.identifier, active: !agent.active });
+    },
+    [toggleActiveMutation]
+  );
 
   const handleNextPage = useCallback(() => {
     const next = listQuery.data?.next;
@@ -460,6 +486,8 @@ export function AgentsList() {
             agents={agents}
             isLoading={isLoading}
             onRequestDelete={setAgentToDelete}
+            onToggleActive={handleToggleActive}
+            togglingAgentId={toggleActiveMutation.isPending ? toggleActiveMutation.variables?.identifier : null}
             paginationProps={{
               pageSize: limit,
               pageSizeOptions: PAGE_SIZE_OPTIONS,

--- a/apps/dashboard/src/components/agents/agents-table.tsx
+++ b/apps/dashboard/src/components/agents/agents-table.tsx
@@ -6,8 +6,8 @@ import {
   RiDeleteBinLine,
   RiForbidFill,
   RiMore2Fill,
-  RiPlayCircleLine,
   RiPauseCircleLine,
+  RiPlayCircleLine,
   RiRobot2Line,
 } from 'react-icons/ri';
 import { SiAmazonwebservices, SiAnthropic } from 'react-icons/si';
@@ -41,6 +41,8 @@ import { useHasPermission } from '@/hooks/use-has-permission';
 import { formatDateSimple } from '@/utils/format-date';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
+import { AwsIcon } from '../icons/aws';
+import { ClaudeIcon } from '../icons/claude';
 
 type AgentsTableProps = {
   agents: AgentResponse[];
@@ -93,12 +95,12 @@ function AgentIcon({ agent }: { agent: AgentResponse }) {
   let icon = <RiRobot2Line className="size-3.5" aria-hidden />;
 
   if (managedProviderId === AgentRuntimeProviderIdEnum.AnthropicAws) {
-    icon = <SiAmazonwebservices className="size-3.5 text-[#FF9900]" aria-hidden />;
+    icon = <AwsIcon className="size-3.5" aria-hidden />;
   } else if (
     managedProviderId === AgentRuntimeProviderIdEnum.Anthropic ||
     managedProviderId === AgentRuntimeProviderIdEnum.NovuAnthropic
   ) {
-    icon = <SiAnthropic className="size-3.5 text-[#D97757]" aria-hidden />;
+    icon = <ClaudeIcon className="size-3.5" aria-hidden />;
   }
 
   return (
@@ -209,7 +211,7 @@ export function AgentsTable({
     <Table isLoading={isLoading} loadingRowsCount={5} loadingRow={<AgentsTableSkeletonRow />}>
       <TableHeader>
         <TableRow>
-          <TableHead className="h-11 px-3 py-2.5">Agent</TableHead>
+          <TableHead className="h-11 px-3 py-2.5">Agents</TableHead>
           <TableHead className="h-11 px-3 py-2.5">Status</TableHead>
           <TableHead className="h-11 px-3 py-2.5">Integrations</TableHead>
           <TableHead className="h-11 px-3 py-2.5">Last updated</TableHead>

--- a/apps/dashboard/src/components/agents/agents-table.tsx
+++ b/apps/dashboard/src/components/agents/agents-table.tsx
@@ -1,7 +1,17 @@
-import { providers as novuProviders, PermissionsEnum } from '@novu/shared';
+import { AgentRuntimeProviderIdEnum, providers as novuProviders, PermissionsEnum } from '@novu/shared';
 import { ComponentProps } from 'react';
-import { RiCheckboxCircleFill, RiForbidFill, RiMore2Fill, RiRobot2Line } from 'react-icons/ri';
-import { Link, useLocation } from 'react-router-dom';
+import {
+  RiChat3Line,
+  RiCheckboxCircleFill,
+  RiDeleteBinLine,
+  RiForbidFill,
+  RiMore2Fill,
+  RiPlayCircleLine,
+  RiPauseCircleLine,
+  RiRobot2Line,
+} from 'react-icons/ri';
+import { SiAmazonwebservices, SiAnthropic } from 'react-icons/si';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { CompactButton } from '@/components/primitives/button-compact';
@@ -9,6 +19,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/primitives/dropdown-menu';
 import { Skeleton } from '@/components/primitives/skeleton';
@@ -28,13 +39,15 @@ import { useEnvironment } from '@/context/environment/hooks';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { formatDateSimple } from '@/utils/format-date';
-import { buildRoute } from '@/utils/routes';
+import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 
 type AgentsTableProps = {
   agents: AgentResponse[];
   isLoading: boolean;
   onRequestDelete: (agent: AgentResponse) => void;
+  onToggleActive: (agent: AgentResponse) => void;
+  togglingAgentId?: string | null;
   paginationProps: {
     pageSize: number;
     pageSizeOptions?: number[];
@@ -70,6 +83,29 @@ const MAX_VISIBLE_INTEGRATION_ICONS = 3;
 
 function getProviderDisplayName(providerId: string): string {
   return novuProviders.find((p) => p.id === providerId)?.displayName ?? providerId;
+}
+
+// Renders an icon reflecting the agent's runtime: the managed provider's brand
+// (Claude/Anthropic, AWS) when managed, or a generic robot for custom self-hosted code.
+function AgentIcon({ agent }: { agent: AgentResponse }) {
+  const managedProviderId = agent.runtime === 'managed' ? agent.managedRuntime?.providerId : undefined;
+
+  let icon = <RiRobot2Line className="size-3.5" aria-hidden />;
+
+  if (managedProviderId === AgentRuntimeProviderIdEnum.AnthropicAws) {
+    icon = <SiAmazonwebservices className="size-3.5 text-[#FF9900]" aria-hidden />;
+  } else if (
+    managedProviderId === AgentRuntimeProviderIdEnum.Anthropic ||
+    managedProviderId === AgentRuntimeProviderIdEnum.NovuAnthropic
+  ) {
+    icon = <SiAnthropic className="size-3.5 text-[#D97757]" aria-hidden />;
+  }
+
+  return (
+    <span className="text-text-sub flex size-5 shrink-0 items-center justify-center" aria-hidden>
+      {icon}
+    </span>
+  );
 }
 
 function AgentIntegrationsCell({ agent }: { agent: AgentResponse }) {
@@ -154,11 +190,19 @@ function AgentsTableSkeletonRow() {
   );
 }
 
-export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProps }: AgentsTableProps) {
+export function AgentsTable({
+  agents,
+  isLoading,
+  onRequestDelete,
+  onToggleActive,
+  togglingAgentId,
+  paginationProps,
+}: AgentsTableProps) {
   const has = useHasPermission();
   const canWrite = has({ permission: PermissionsEnum.AGENT_WRITE });
   const { currentEnvironment, readOnly } = useEnvironment();
   const location = useLocation();
+  const navigate = useNavigate();
   const agentRoutes = useAgentRoutes();
 
   return (
@@ -183,13 +227,17 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
               agentTab: 'overview',
             })}${location.search}`;
 
+            const conversationsPath = `${buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, {
+              environmentSlug: currentEnvironment?.slug ?? '',
+            })}?agentId=${encodeURIComponent(agent.identifier)}`;
+
+            const isToggling = togglingAgentId === agent.identifier;
+
             return (
               <TableRow key={agent._id} className="group relative isolate cursor-pointer">
                 <AgentNavTableCell to={agentDetailsPath} className="p-3 align-middle">
                   <div className="flex min-h-[41px] items-center gap-4">
-                    <span className="text-text-sub flex size-5 shrink-0 items-center justify-center" aria-hidden>
-                      <RiRobot2Line className="size-3.5" />
-                    </span>
+                    <AgentIcon agent={agent} />
                     <div className="flex min-w-0 flex-col gap-0.5">
                       <span className="text-text-strong text-label-sm font-medium leading-5 tracking-tight">
                         {agent.name}
@@ -237,12 +285,37 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
                         <DropdownMenuItem
+                          className="cursor-pointer"
+                          onClick={() => {
+                            navigate(conversationsPath);
+                          }}
+                        >
+                          <RiChat3Line className="text-text-sub size-4" />
+                          View conversations
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="cursor-pointer"
+                          disabled={isToggling}
+                          onClick={() => {
+                            onToggleActive(agent);
+                          }}
+                        >
+                          {agent.active ? (
+                            <RiPauseCircleLine className="text-text-sub size-4" />
+                          ) : (
+                            <RiPlayCircleLine className="text-text-sub size-4" />
+                          )}
+                          {agent.active ? 'Pause agent' : 'Activate agent'}
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
                           className="text-destructive cursor-pointer"
                           onClick={() => {
                             setTimeout(() => onRequestDelete(agent), 0);
                           }}
                         >
-                          Delete
+                          <RiDeleteBinLine className="size-4" />
+                          Delete agent
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Updates the Agents list page (`agents-table.tsx` / `agents-list.tsx`) per the [Conversational Agents designs](https://www.figma.com/design/NxgfvPgzVGLukGARqSvtSm/Conversational-Agents?node-id=8136-189586&m=dev):

- **Agent icon by runtime/provider** — the left column icon now reflects the agent's managed provider or custom code instead of a single generic robot:
  - `anthropic` / `novu-anthropic` → Anthropic (Claude) logo
  - `anthropic-aws` → AWS logo
  - `self-hosted` (custom code) → generic robot icon
- **Row actions** — the `…` menu now includes the actions that are already implementable, matching the design:
  - **View conversations** — navigates to the conversations activity feed filtered by `agentId` (reuses the existing pattern from the agent sidebar widget).
  - **Pause agent / Activate agent** — toggles `active` via the existing `updateAgent` endpoint; label flips based on current state, with success/error toasts and list invalidation.
  - **Delete agent** — existing action, now labeled "Delete agent" with a trash icon to match the design.

Actions shown in the design but without an existing implementation (Duplicate agent, Publish changes) were intentionally left out, matching the ticket ("add those that are already implemented").

### Screenshots
<img width="1534" height="1002" alt="Screenshot 2026-06-12 at 00 05 10" src="https://github.com/user-attachments/assets/98583c6d-89e2-4a7c-91ba-16261f86f5ec" />

https://github.com/user-attachments/assets/4e03258f-b3f8-4839-aa8e-c19fccc4a83b



### Special notes for your reviewer

- Icons use `react-icons` (`SiAnthropic`, `SiAmazonwebservices`, `RiRobot2Line`) which is already a dashboard dependency; no new packages added.
- Tested manually by seeding agents of each runtime/provider in the dev DB and temporarily enabling the conversational-agents flag locally (reverted; not part of the diff). The seeded agents remain in the dev environment for further manual testing.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c064407-fdce-4125-b283-9c45c5387abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c064407-fdce-4125-b283-9c45c5387abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Agents list UI was updated to match Conversational Agents designs: agent icons now reflect the managed provider (Anthropic/Claude, anthropic-aws → AWS) or show a generic robot for self-hosted/custom code, and row actions were expanded to include "View conversations", a Pause/Activate toggle (calls existing updateAgent endpoint, shows toasts, invalidates the list), and a relabeled "Delete agent". Duplicate/Publish actions from designs were intentionally omitted.

## Affected areas

**dashboard** — Updated agents list/table components to render provider-specific icons, add a Pause/Activate toggle wired to the existing updateAgent mutation, include "View conversations" navigation, adjust row action labels/icons, and disable toggle while mutation is in-flight.

## Key technical decisions

- Reused react-icons (SiAnthropic, SiAmazonwebservices, RiRobot2Line) — no new dependencies added.  
- Toggle action uses existing updateAgent API with payload { active: !agent.active }, preserving API contract.  
- Parent component manages the toggle mutation and query invalidation so the table updates after changes.  
- Design actions without existing implementations (Duplicate agent, Publish changes) were omitted intentionally.

## Testing

Manual verification performed by seeding agents for each runtime/provider behind a temporary feature flag; no new unit or e2e tests were added because changes are UI-focused and rely on existing API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->