### PR TITLE
feat(dashboard): redesign Workflows empty state for development env fixes NV-8021

### DIFF
--- a/apps/dashboard/src/components/workflow-list-empty.tsx
+++ b/apps/dashboard/src/components/workflow-list-empty.tsx
@@ -1,11 +1,26 @@
 import { PermissionsEnum } from '@novu/shared';
-import { RiBookMarkedLine, RiRouteFill } from 'react-icons/ri';
+import { ComponentType, ReactNode } from 'react';
+import {
+  RiAddLine,
+  RiArrowRightSLine,
+  RiBookMarkedLine,
+  RiBuildingLine,
+  RiCellphoneFill,
+  RiChatThreadFill,
+  RiDiscussLine,
+  RiRouteFill,
+  RiTranslate2,
+} from 'react-icons/ri';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { VersionControlDev } from '@/components/icons/version-control-dev';
+import { LogoCircle } from '@/components/icons/logo-circle';
+import { Mail3Fill } from '@/components/icons/mail-3-fill';
+import { Notification5Fill } from '@/components/icons/notification-5-fill';
+import { Sms } from '@/components/icons/sms';
 import { VersionControlProd } from '@/components/icons/version-control-prod';
 import { Button } from '@/components/primitives/button';
 import { PermissionButton } from '@/components/primitives/permission-button';
 import { useEnvironment } from '@/context/environment/hooks';
+import { cn } from '@/utils/ui';
 import { buildRoute, ROUTES } from '../utils/routes';
 import { ListNoResults } from './list-no-results';
 import { LinkButton } from './primitives/button-link';
@@ -60,39 +75,155 @@ const WorkflowListEmptyProd = ({ switchToDev }: { switchToDev: () => void }) => 
   </div>
 );
 
+const CheckIcon = ({ className }: { className?: string }) => (
+  <svg viewBox="0 0 9 6.5" fill="none" className={className} xmlns="http://www.w3.org/2000/svg">
+    <path d="M8.5 0.5L3 6L0.5 3.5" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+type EmptyStateTag = {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  className?: string;
+  rotate?: string;
+};
+
+const CHANNEL_TAGS: EmptyStateTag[] = [
+  { label: 'In-app', icon: Notification5Fill, className: 'border-stable/10 bg-stable/10 text-stable/60', rotate: 'rotate-1' },
+  {
+    label: 'Email',
+    icon: Mail3Fill,
+    className: 'border-information/10 bg-information/10 text-information/60',
+    rotate: '-rotate-1',
+  },
+  { label: 'Chat', icon: RiChatThreadFill, className: 'border-feature/10 bg-feature/10 text-feature/60' },
+  {
+    label: 'Push',
+    icon: RiCellphoneFill,
+    className: 'border-verified/10 bg-verified/10 text-verified/60',
+    rotate: 'rotate-1',
+  },
+  {
+    label: 'SMS',
+    icon: Sms,
+    className: 'border-error-base/10 bg-error-base/10 text-error-base/60',
+    rotate: '-rotate-1',
+  },
+];
+
+const SCALE_TAGS: EmptyStateTag[] = [
+  { label: 'Translations', icon: RiTranslate2, rotate: 'rotate-1' },
+  { label: 'Contexts', icon: RiBuildingLine, rotate: 'rotate-1' },
+  { label: 'Topics', icon: RiDiscussLine, rotate: '-rotate-1' },
+];
+
+const ColoredTag = ({ label, icon: Icon, className, rotate }: EmptyStateTag) => (
+  <span
+    className={cn(
+      'inline-flex items-center gap-0.5 rounded border px-1 py-0.5 text-label-xs leading-4',
+      className,
+      rotate
+    )}
+  >
+    <Icon className="size-3.5 shrink-0" />
+    {label}
+  </span>
+);
+
+const NeutralTag = ({ label, icon: Icon, rotate }: EmptyStateTag) => (
+  <span
+    className={cn(
+      'inline-flex items-center gap-1 rounded border border-stroke-soft bg-bg-weak px-1 py-0.5 text-label-xs leading-4 text-text-strong',
+      rotate
+    )}
+  >
+    <Icon className="size-3.5 shrink-0 text-text-sub" />
+    {label}
+  </span>
+);
+
+const EmptyListRow = ({ children }: { children: ReactNode }) => (
+  <div className="flex min-h-6 items-center gap-1.5">
+    <CheckIcon className="size-3 shrink-0 text-text-soft" />
+    <div className="flex flex-wrap items-center gap-1 text-label-xs text-text-sub">{children}</div>
+  </div>
+);
+
 const WorkflowListEmptyDev = () => {
   const navigate = useNavigate();
   const { environmentSlug } = useParams();
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-6">
-      <VersionControlDev />
-      <div className="flex flex-col items-center gap-2 text-center">
-        <span className="text-foreground-900 block font-medium">Create your first workflow to send notifications</span>
-        <p className="text-foreground-400 max-w-[60ch] text-sm">
-          Workflows handle notifications across multiple channels in a single, version-controlled flow, with the ability
-          to manage preference for each subscriber.
-        </p>
-      </div>
+    <div className="flex h-full w-full flex-col items-center justify-center">
+      <div className="flex flex-col gap-12">
+        <div className="flex flex-col items-start">
+          <div className="flex h-[46px] w-[136px] flex-col rounded-lg border border-primary-base p-1">
+            <div className="bg-bg-white border-primary-alpha-24 flex flex-1 items-center justify-center rounded-md border p-3">
+              <RiRouteFill className="text-primary-base size-4" />
+            </div>
+          </div>
+          <div className="border-stroke-sub ml-[68px] h-[30px] border-l border-dashed" />
+          <div className="border-stroke-sub flex h-[46px] w-[136px] flex-col rounded-lg border border-dashed p-1">
+            <div className="bg-bg-white border-stroke-weak flex flex-1 items-center justify-center rounded-md border p-3">
+              <RiAddLine className="text-text-soft size-2.5" />
+            </div>
+          </div>
+        </div>
 
-      <div className="flex items-center justify-center gap-6">
-        <Link to={'https://docs.novu.co/platform/concepts/workflows'} target="_blank">
-          <LinkButton variant="gray" trailingIcon={RiBookMarkedLine}>
-            View docs
-          </LinkButton>
-        </Link>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <p className="text-text-strong text-label-md font-medium">
+              Send transactional notifications with Workflows
+            </p>
+            <p className="text-text-soft max-w-[500px] text-label-sm font-medium">
+              Trigger product events, orchestrate delivery across channels, and optionally connect notifications to your
+              agents for follow-up conversations.
+            </p>
+          </div>
 
-        <PermissionButton
-          permission={PermissionsEnum.WORKFLOW_WRITE}
-          variant="primary"
-          leadingIcon={RiRouteFill}
-          className="gap-2"
-          onClick={() => {
-            navigate(buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug: environmentSlug || '' }));
-          }}
-        >
-          Create workflow
-        </PermissionButton>
+          <div className="flex flex-col gap-1 py-3">
+            <EmptyListRow>
+              <span>Send notifications across</span>
+              {CHANNEL_TAGS.map((tag) => (
+                <ColoredTag key={tag.label} {...tag} />
+              ))}
+              <span>with one API</span>
+            </EmptyListRow>
+            <EmptyListRow>
+              <span>Orchestrate delivery with workflows (conditions, delays, digests, fallbacks)</span>
+            </EmptyListRow>
+            <EmptyListRow>
+              <span>Scale notifications with</span>
+              {SCALE_TAGS.map((tag) => (
+                <NeutralTag key={tag.label} {...tag} />
+              ))}
+              <span>and a lot more.</span>
+            </EmptyListRow>
+            <EmptyListRow>
+              <span>Embed</span>
+              <span className="border-stroke-soft bg-bg-weak text-text-strong inline-flex items-center gap-0.5 rounded border px-1 py-0.5 text-label-xs leading-4">
+                <LogoCircle className="size-4 shrink-0" />
+                {'<Inbox />'}
+              </span>
+              <span>with preferences, notification history, and agent handoff</span>
+            </EmptyListRow>
+          </div>
+
+          <div className="flex">
+            <PermissionButton
+              permission={PermissionsEnum.WORKFLOW_WRITE}
+              variant="secondary"
+              mode="gradient"
+              size="xs"
+              trailingIcon={RiArrowRightSLine}
+              onClick={() => {
+                navigate(buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug: environmentSlug || '' }));
+              }}
+            >
+              Create your first workflow
+            </PermissionButton>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/workflow-list-empty.tsx
+++ b/apps/dashboard/src/components/workflow-list-empty.tsx
@@ -1,5 +1,5 @@
 import { PermissionsEnum } from '@novu/shared';
-import { ComponentType, ReactNode } from 'react';
+import { ComponentType, ReactNode, SVGProps } from 'react';
 import {
   RiAddLine,
   RiArrowRightSLine,
@@ -89,7 +89,12 @@ type EmptyStateTag = {
 };
 
 const CHANNEL_TAGS: EmptyStateTag[] = [
-  { label: 'In-app', icon: Notification5Fill, className: 'border-stable/10 bg-stable/10 text-stable/60', rotate: 'rotate-1' },
+  {
+    label: 'In-app',
+    icon: Notification5Fill,
+    className: 'border-stable/10 bg-stable/10 text-stable/60',
+    rotate: 'rotate-1',
+  },
   {
     label: 'Email',
     icon: Mail3Fill,
@@ -149,26 +154,33 @@ const EmptyListRow = ({ children }: { children: ReactNode }) => (
   </div>
 );
 
+const WorkflowsIllustration = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 136 125" {...props}>
+      <rect width="135" height="45" x=".5" y="79.5" stroke="#cacfd8" strokeDasharray="5 3" rx="7.5" />
+      <rect width="127" height="37" x="4.5" y="83.5" fill="#fff" rx="5.5" />
+      <rect width="127" height="37" x="4.5" y="83.5" stroke="#f2f5f8" rx="5.5" />
+      <path fill="#99a0ae" d="M67.625 101.625v-2.25h.75v2.25h2.25v.75h-2.25v2.25h-.75v-2.25h-2.25v-.75z" />
+      <rect width="135" height="45" x=".5" y=".5" stroke="#dd2450" rx="7.5" />
+      <rect width="128" height="38" x="4" y="4" fill="#fff" rx="6" />
+      <rect width="127" height="37" x="4.5" y="4.5" stroke="#fb3748" strokeOpacity=".24" rx="5.5" />
+      <path
+        fill="#d82651"
+        d="M63.2 24.802v-3.9a2.7 2.7 0 0 1 5.4 0v4.2a1.5 1.5 0 1 0 3 0V21.1a1.8 1.8 0 1 1 1.2 0v4.002a2.7 2.7 0 0 1-5.4 0v-4.2a1.5 1.5 0 1 0-3 0v3.9h1.8l-2.4 3-2.4-3z"
+      />
+      <path stroke="#cacfd8" strokeDasharray="5 3" strokeLinejoin="bevel" strokeWidth="1.33" d="M68 49.164v26.67" />
+    </svg>
+  );
+};
+
 const WorkflowListEmptyDev = () => {
   const navigate = useNavigate();
   const { environmentSlug } = useParams();
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center">
-      <div className="flex flex-col gap-12">
-        <div className="flex flex-col items-start">
-          <div className="flex h-[46px] w-[136px] flex-col rounded-lg border border-primary-base p-1">
-            <div className="bg-bg-white border-primary-alpha-24 flex flex-1 items-center justify-center rounded-md border p-3">
-              <RiRouteFill className="text-primary-base size-4" />
-            </div>
-          </div>
-          <div className="border-stroke-sub ml-[68px] h-[30px] border-l border-dashed" />
-          <div className="border-stroke-sub flex h-[46px] w-[136px] flex-col rounded-lg border border-dashed p-1">
-            <div className="bg-bg-white border-stroke-weak flex flex-1 items-center justify-center rounded-md border p-3">
-              <RiAddLine className="text-text-soft size-2.5" />
-            </div>
-          </div>
-        </div>
+    <div className="flex h-full w-full flex-col items-start justify-center">
+      <div className="flex flex-col gap-12 translate-x-1/4">
+        <WorkflowsIllustration className="w-34" />
 
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Redesigns the development-environment Workflows empty state (`WorkflowListEmptyDev` in `apps/dashboard/src/components/workflow-list-empty.tsx`) to match the latest Figma design.

Figma: https://www.figma.com/design/NxgfvPgzVGLukGARqSvtSm/Conversational-Agents?node-id=8139-48851&m=dev

## Changes

- New illustration: a primary-bordered card with a route icon connected by a dashed connector to a dashed card with a plus icon.
- New heading "Send transactional notifications with Workflows" and supporting copy.
- Feature bullet list with grey checkmarks and:
  - Colored channel tags: In-app (teal), Email (blue), Chat (purple), Push (sky), SMS (red).
  - Neutral capability tags: Translations, Contexts, Topics.
  - An `<Inbox />` tag with the colorful Novu logo.
- Dark gradient "Create your first workflow" CTA with a chevron, keeping the existing `WORKFLOW_WRITE` permission gate and navigation to the create-workflow route.

All styling uses existing design-system tokens and channel icons; no new dependencies or shared-component changes. The production empty state and the no-search-results state are unchanged.

## Distribution

Dashboard-only UI change. Community / Cloud / On-prem behavior is unaffected.

## Walkthrough
<img width="1532" height="1002" alt="Screenshot 2026-06-11 at 23 53 34" src="https://github.com/user-attachments/assets/97ed93ca-9573-486c-b7cd-17b10bf07e6d" />




## Testing

- `tsc --noEmit` (dashboard) passes.
- `biome lint` on the file passes (one pre-existing nursery `noFloatingPromises` warning on the unchanged `navigate(...)` call).
- Manually verified in the running dashboard (Development env) by rendering the empty state; all elements render cleanly and match the Figma design.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b4a7bb1-cf6b-4edb-abf4-528a7fefec18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b4a7bb1-cf6b-4edb-abf4-528a7fefec18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Workflows empty state shown in the Development environment was redesigned to match Figma (NV-8021). The new Dev empty state replaces the previous content with a visual illustration (card + dashed connector to a dashed add card), a new heading and descriptive copy, a feature checklist with colored channel tags (In-app, Email, Chat, Push, SMS), neutral scaling tags (Translations, Contexts, Topics), an Inbox tag, and a dark gradient CTA "Create your first workflow" that navigates to the create-workflow route. The change is visual only and aims to improve clarity and match design.

## Affected areas

- dashboard: Updated apps/dashboard/src/components/workflow-list-empty.tsx to implement the new Development empty state UI, adding small presentational helpers (CheckIcon, ColoredTag, NeutralTag, EmptyListRow), tag definitions for channels and scale features, and a new WorkflowsIllustration; preserved WORKFLOW_WRITE permission gating and existing navigation behavior. Production and no-search-results empty states remain unchanged.

## Key technical decisions

- No new dependencies or shared-component changes were introduced; styling uses existing design-system tokens and icons.
- The change is component-local to the dashboard and does not affect Community/Cloud/On-prem flows.

## Testing

TypeScript compilation (tsc --noEmit for dashboard) and biome linting pass (one pre-existing lint warning unchanged); manual verification in a running dashboard (Development env) confirms visual parity with Figma. No automated tests were added because the PR is a UI-only redesign with no functional/API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->