### PR TITLE
feat(dashboard): hide provider-managed MCPs for demo Anthropic agents

### DIFF
--- a/apps/dashboard/src/components/agents/mcps-sheet.tsx
+++ b/apps/dashboard/src/components/agents/mcps-sheet.tsx
@@ -1,4 +1,11 @@
-import { FeatureFlagsKeysEnum, MCP_SERVERS, McpConnectionAuthModeEnum, type McpServer } from '@novu/shared';
+import {
+  AgentRuntimeProviderIdEnum,
+  FeatureFlagsKeysEnum,
+  isProviderManagedMcp,
+  MCP_SERVERS,
+  McpConnectionAuthModeEnum,
+  type McpServer,
+} from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RiAddLine, RiArrowRightUpLine, RiCloseLine, RiLoader4Line, RiSearchLine } from 'react-icons/ri';
@@ -207,18 +214,30 @@ export function McpsSheet({ agent, isOpen, onOpenChange, enabledServers, console
     return false;
   }, [stagedIds, initialEnabledIds]);
 
+  // The demo (Novu-managed Claude / NovuAnthropic) integration exposes no
+  // provider vault, so provider-managed MCPs can never be configured on it —
+  // the API rejects them at connect time. Drop them from the picker so the
+  // catalog only advertises the Novu-handled OAuth modes (dcr / novu-app) the
+  // user can actually wire up, matching the onboarding + provision filters.
+  const isDemoProviderAgent = agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic;
+
+  const catalogMcps = useMemo(
+    () => (isDemoProviderAgent ? MCP_SERVERS.filter((entry) => !isProviderManagedMcp(entry.id)) : MCP_SERVERS),
+    [isDemoProviderAgent]
+  );
+
   const filteredMcps = useMemo(() => {
     const query = search.trim().toLowerCase();
 
-    if (!query) return MCP_SERVERS;
+    if (!query) return catalogMcps;
 
-    return MCP_SERVERS.filter(
+    return catalogMcps.filter(
       (entry) =>
         entry.name.toLowerCase().includes(query) ||
         entry.description.toLowerCase().includes(query) ||
         entry.id.toLowerCase().includes(query)
     );
-  }, [search]);
+  }, [search, catalogMcps]);
 
   const { enabledList, availableList } = useMemo(() => {
     const enabled: McpServer[] = [];

--- a/apps/dashboard/src/components/agents/mcps-sheet.tsx
+++ b/apps/dashboard/src/components/agents/mcps-sheet.tsx
@@ -160,6 +160,21 @@ function buildSaveMcpIds(stagedIds: Set<string>): string[] {
   return [...stagedIds];
 }
 
+/**
+ * Seed the staged enablement set from the server's enabled list. For demo
+ * (NovuAnthropic) agents we additionally drop provider-managed ids: they are
+ * already hidden from the catalog and can never be connected, so leaving a
+ * stale one in `stagedIds` would silently re-send it on the next Save and
+ * trigger an unrelated partial-failure toast.
+ */
+function seedStagedIds(servers: AgentMcpServerEnablement[], isDemoProviderAgent: boolean): Set<string> {
+  return new Set(
+    servers
+      .filter((server) => !isDemoProviderAgent || !isProviderManagedMcp(server.mcpId))
+      .map((server) => server.mcpId)
+  );
+}
+
 function formatPartialFailureMessage(failures: SetAgentMcpServersFailure[]): string {
   const labels = failures
     .map((f) => f.mcpId)
@@ -180,11 +195,16 @@ export function McpsSheet({ agent, isOpen, onOpenChange, enabledServers, console
   // never gets a chance to fire and 403.
   const providerManagedEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_MCP_PROVIDER_MANAGED_ENABLED);
   const badgeKindOptions = useMemo<McpBadgeKindOptions>(() => ({ providerManagedEnabled }), [providerManagedEnabled]);
+  // The demo (Novu-managed Claude / NovuAnthropic) integration exposes no
+  // provider vault, so provider-managed MCPs can never be configured on it —
+  // the API rejects them at connect time. We use this both to hide them from
+  // the catalog and to keep them out of the staged save set.
+  const isDemoProviderAgent = agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic;
   // Staged enablement set. Mirrors `enabledServers` whenever the sheet opens
   // and is then driven entirely by the in-sheet Add / Remove actions until
   // the user clicks "Save changes" (which commits the diff against the
   // initial snapshot) or discards via the Unsaved changes dialog.
-  const [stagedIds, setStagedIds] = useState<Set<string>>(() => new Set(enabledServers.map((s) => s.mcpId)));
+  const [stagedIds, setStagedIds] = useState<Set<string>>(() => seedStagedIds(enabledServers, isDemoProviderAgent));
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
 
   const initialEnabledIds = useMemo(() => new Set(enabledServers.map((server) => server.mcpId)), [enabledServers]);
@@ -198,11 +218,11 @@ export function McpsSheet({ agent, isOpen, onOpenChange, enabledServers, console
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {
       setSearch('');
-      setStagedIds(new Set(enabledServersRef.current.map((s) => s.mcpId)));
+      setStagedIds(seedStagedIds(enabledServersRef.current, isDemoProviderAgent));
       setShowUnsavedDialog(false);
     }
     wasOpenRef.current = isOpen;
-  }, [isOpen]);
+  }, [isOpen, isDemoProviderAgent]);
 
   const hasUnsavedChanges = useMemo(() => {
     if (stagedIds.size !== initialEnabledIds.size) return true;
@@ -214,13 +234,9 @@ export function McpsSheet({ agent, isOpen, onOpenChange, enabledServers, console
     return false;
   }, [stagedIds, initialEnabledIds]);
 
-  // The demo (Novu-managed Claude / NovuAnthropic) integration exposes no
-  // provider vault, so provider-managed MCPs can never be configured on it —
-  // the API rejects them at connect time. Drop them from the picker so the
+  // Drop provider-managed entries from the picker for demo agents so the
   // catalog only advertises the Novu-handled OAuth modes (dcr / novu-app) the
   // user can actually wire up, matching the onboarding + provision filters.
-  const isDemoProviderAgent = agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic;
-
   const catalogMcps = useMemo(
     () => (isDemoProviderAgent ? MCP_SERVERS.filter((entry) => !isProviderManagedMcp(entry.id)) : MCP_SERVERS),
     [isDemoProviderAgent]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

When an agent uses the **demo Anthropic** runtime provider (`novu-anthropic` / Novu-managed Claude), the "Configure external Claude MCPs" picker (`McpsSheet`) now filters out **provider-managed** MCPs, rendering only the Novu-handled OAuth modes (`dcr` and `novu-app`).

The demo (`NovuAnthropic`) integration exposes no provider vault, so provider-managed MCPs can never be wired up on it — the API already rejects them at connect time (`ensure-provider-managed-vault`) and strips them at provision time (`provision-managed-agent`). The picker was the remaining gap: it still surfaced "Add from Claude" rows that would 4xx for demo agents. This change closes that gap and keeps the dashboard consistent with the existing onboarding/provision filters by reusing `isProviderManagedMcp` from `@novu/shared`.

Standard providers (e.g. `anthropic`, `anthropic-aws`) are unaffected and still show provider-managed ("Add from Claude") rows.

```mermaid
flowchart TD
  A[Open MCP picker] --> B{agent.managedRuntime.providerId === novu-anthropic?}
  B -- yes --> C[Catalog = MCP_SERVERS minus provider-managed<br/>only dcr / novu-app render]
  B -- no --> D[Catalog = full MCP_SERVERS<br/>provider-managed rows show 'Add from Claude']
```

### Screenshots

Demo vs. standard agent comparison:

<a href="https://cursor.com/agents/bc-abd9a039-70bf-4302-a7e8-19a21c734c74/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_anthropic_mcp_filter_demo_vs_standard.mp4"><img src="https://cursor.com/artifacts/c/art-7e14b2c1-acf5-4ca8-ae5d-f7cdd4d5114f" alt="demo_anthropic_mcp_filter_demo_vs_standard.mp4" /></a>

Demo agent — only `OAuth` rows, no "Add from Claude":
![Demo agent MCP list only OAuth](https://cursor.com/artifacts/c/art-5f1155be-98c4-47fe-ace9-850b47415ba0)

Demo agent — searching "slack" returns no provider-managed Slack:
![Demo agent slack search absent](https://cursor.com/artifacts/c/art-306b0e23-80a5-4bdf-ba82-c6f3d343836e)

Standard agent — "Add from Claude" rows still present:
![Standard agent Add from Claude badges](https://cursor.com/artifacts/c/art-d7fa0041-81c2-45f7-ae4c-b605af00170a)

Standard agent — searching "slack" returns Slack with "Add from Claude":
![Standard agent slack search present](https://cursor.com/artifacts/c/art-03b98832-5ec2-407f-b30c-416084430792)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Scope limited to `apps/dashboard/src/components/agents/mcps-sheet.tsx`; reuses the existing shared helper `isProviderManagedMcp`.
- No catalog entry currently uses the `user-app` mode, so filtering provider-managed is equivalent to "render only `dcr` and `novu-app`".
- Follow-up commit addresses review feedback: the staged-save seed (`seedStagedIds`) now also strips provider-managed ids for demo agents, so a stale enabled provider-managed id can't silently ride into a Save payload and produce an unrelated partial-failure toast.
- A Linear ticket could not be created automatically — the Linear MCP requires authentication in this environment.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abd9a039-70bf-4302-a7e8-19a21c734c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abd9a039-70bf-4302-a7e8-19a21c734c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The MCP picker for demo Anthropic agents (Novu-managed Claude) now hides provider-managed MCPs ("Add from Claude") and prevents them from being seeded into the staged-save set. This avoids showing options that would 4xx because demo integrations expose no provider vault and the backend rejects provider-managed MCPs, improving the UX and preventing invalid Save payloads.

## Affected areas

**dashboard**: Updated the McpsSheet component to detect demo Anthropic agents, filter the MCP catalog to exclude provider-managed entries for those agents, thread the filtered catalog through search and UI lists, and defensively strip provider-managed MCP IDs from the initial stagedIds seed.

## Key technical decisions

- Reuses isProviderManagedMcp from `@novu/shared` to identify provider-managed MCPs so frontend filtering matches backend validation.
- Keeps standard providers (anthropic, anthropic-aws) unchanged; this is a demo-only UI filter and not a backend contract change.

## Testing

No automated tests were added; this is a UI-level filtering change that prevents known invalid workflows already rejected by the API. Manual verification via the dashboard (screenshots included) is sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR filters provider-managed MCPs ("Add from Claude") out of the `McpsSheet` picker for demo Anthropic agents (`novu-anthropic`), where the backend already rejects such MCPs. It also introduces `seedStagedIds` to strip stale provider-managed IDs from the initial staged set on sheet open, directly addressing the concern raised in the previous review thread.

- **Catalog filtering**: a new `catalogMcps` memo uses `isProviderManagedMcp` from `@novu/shared` to exclude provider-managed entries for demo agents, keeping the UI consistent with backend validation.
- **Stale-ID fix**: `seedStagedIds` replaces the previous inline `new Set(enabledServers.map(...))` in both the `useState` initializer and the `isOpen` effect, preventing ghost IDs from silently riding along on the next Save payload.
- **Standard providers unaffected**: agents backed by `anthropic` or `anthropic-aws` see the full catalog unchanged.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to UI filtering for a specific provider variant and the backend continues to enforce the same restrictions.

The stale-ID fix in `seedStagedIds` is correct and addresses the prior review concern. There is a small gap: `initialEnabledIds` is derived without applying the same provider-managed filter, which can cause a false "unsaved changes" state on sheet open if any stale provider-managed IDs exist in `enabledServers`. The practical impact is limited (a spuriously enabled Save button that, if clicked, just removes stale data), but it is an inconsistency in the seeding logic worth closing.

apps/dashboard/src/components/agents/mcps-sheet.tsx — the `initialEnabledIds` derivation on line 210 should mirror the `seedStagedIds` filter for full consistency.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/mcps-sheet.tsx | Adds `isDemoProviderAgent` flag and `seedStagedIds`/`catalogMcps` filtering to hide provider-managed MCPs for NovuAnthropic agents; correctly addresses the stale-stagedIds issue from the prior thread. Minor: `initialEnabledIds` is not filtered in the same way, which can produce a false "unsaved changes" state on sheet open for demo agents with stale provider-managed data. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[McpsSheet opens] --> B{isDemoProviderAgent?}
    B -- yes --> C[seedStagedIds: filter provider-managed IDs from enabledServers]
    B -- no --> D[seedStagedIds: keep all IDs from enabledServers]
    C --> E[stagedIds — no provider-managed entries]
    D --> F[stagedIds — all entries]
    B -- yes --> G[catalogMcps = MCP_SERVERS filtered by isProviderManagedMcp]
    B -- no --> H[catalogMcps = full MCP_SERVERS]
    G --> I[filteredMcps — only dcr / novu-app rows]
    H --> J[filteredMcps — all rows incl. Add from Claude]
    E --> K[Save sends no provider-managed IDs]
    F --> L[Save may include provider-managed IDs]
```

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): strip provider-managed M..."](https://github.com/novuhq/novu/commit/3665f397e8cecad63a9f18ba5cb1b410d07defe6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37084248)</sub>

<!-- /greptile_comment -->