### PR TITLE
feat(dashboard): onboarding cli agent creation polling and success view fixes NV-8016

### DIFF
--- a/apps/dashboard/src/components/onboarding/connect-agent/agent-cli-success-view.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/agent-cli-success-view.tsx
@@ -1,0 +1,164 @@
+import { AgentRuntimeProviderIdEnum, providers as novuProviders } from '@novu/shared';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import ReactConfetti from 'react-confetti';
+import { createPortal } from 'react-dom';
+import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
+import { CompletedStepIndicator } from '@/components/agents/setup-guide-primitives';
+import { ProviderIcon } from '@/components/integrations/components/provider-icon';
+import { AgentCard, type AgentCardConnectorKind } from '@/components/onboarding/claude-agent-preview-illustration';
+
+type AgentCliSuccessViewProps = {
+  agent: AgentResponse;
+  connectedLink: AgentIntegrationLink;
+};
+
+function resolveConnector(agent: AgentResponse): AgentCardConnectorKind {
+  if (agent.runtime !== 'managed') return 'custom';
+
+  return agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.AnthropicAws ? 'aws' : 'anthropic';
+}
+
+function formatLastEvent(connectedAt: string | null | undefined, now: number): string {
+  if (!connectedAt) return 'just now';
+
+  const diffInSeconds = Math.floor((now - new Date(connectedAt).getTime()) / 1000);
+
+  if (diffInSeconds < 5) return 'just now';
+
+  if (diffInSeconds < 60) {
+    const rounded = Math.round(diffInSeconds / 5) * 5;
+
+    return `${rounded} seconds ago`;
+  }
+
+  if (diffInSeconds < 3600) {
+    const minutes = Math.floor(diffInSeconds / 60);
+
+    return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
+  }
+
+  const hours = Math.floor(diffInSeconds / 3600);
+
+  return `${hours} hour${hours > 1 ? 's' : ''} ago`;
+}
+
+function ConnectedStatusPill({ connectedAt }: { connectedAt: string | null | undefined }) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 5000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const lastEvent = formatLastEvent(connectedAt, now);
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-[#e0faec] px-1.5 py-[2px]">
+        <span className="relative inline-block size-[5px] rounded-full bg-[#1fc16b] shadow-[0_0_0_2px_rgba(31,193,107,0.18)]" />
+        <span
+          className="text-[9px] font-medium uppercase leading-3 tracking-[0.54px] text-[#1fc16b]"
+          style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}
+        >
+          CONNECTED
+        </span>
+      </span>
+      <span className="text-text-soft text-label-xs font-normal leading-4">
+        Last event received <span className="text-text-strong font-medium">{lastEvent}</span>
+      </span>
+    </div>
+  );
+}
+
+/** One-shot confetti burst, fired the first time the success view mounts. */
+function SuccessConfetti() {
+  const [show, setShow] = useState(true);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    timeoutRef.current = window.setTimeout(() => setShow(false), 10_000);
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  if (!show) return null;
+
+  return createPortal(
+    <ReactConfetti
+      width={window.innerWidth}
+      height={window.innerHeight}
+      recycle={false}
+      numberOfPieces={1000}
+      style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 10000 }}
+    />,
+    document.body
+  );
+}
+
+/**
+ * Success view shown once a CLI-created agent (Open in Cursor / Copy prompt) has a channel
+ * connected. Mirrors the onboarding agent-preview step (a checked agent card on the rail),
+ * followed by the connected-channel row and a live "last event received" status pill.
+ */
+export function AgentCliSuccessView({ agent, connectedLink }: AgentCliSuccessViewProps) {
+  const connector = resolveConnector(agent);
+  const isDemoCredential = agent.managedRuntime?.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic;
+  const mcpServers = useMemo(
+    () => agent.managedRuntime?.mcpServers?.map((server) => server.externalId) ?? [],
+    [agent.managedRuntime?.mcpServers]
+  );
+  const tools = useMemo(
+    () => agent.managedRuntime?.tools?.map((tool) => tool.externalId) ?? [],
+    [agent.managedRuntime?.tools]
+  );
+
+  const providerId = connectedLink.integration.providerId;
+  const providerMeta = novuProviders.find((provider) => provider.id === providerId);
+  const channelName = providerMeta?.displayName ?? connectedLink.integration.name;
+
+  return (
+    <div className="relative flex flex-col gap-10 py-6 pl-8 pr-3 md:pr-6">
+      <SuccessConfetti />
+      <div
+        className="absolute bottom-0 left-[22px] top-0 w-px"
+        style={{
+          background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+        }}
+      />
+
+      <div className="relative flex flex-col pl-6">
+        <div className="absolute left-[-20px] top-[3px] flex w-5 justify-center">
+          <CompletedStepIndicator />
+        </div>
+        <AgentCard
+          connector={connector}
+          isDemoCredential={isDemoCredential}
+          status="connected"
+          agentCreated
+          displayName={agent.name}
+          isPlaceholderName={false}
+          description={agent.description}
+          identifier={agent.identifier}
+          instructions={agent.managedRuntime?.systemPrompt}
+          mcpServers={mcpServers}
+          tools={tools}
+        />
+      </div>
+
+      <div className="relative flex flex-col gap-3 pl-6">
+        <div className="absolute left-[-20px] top-[3px] flex w-5 justify-center">
+          <CompletedStepIndicator />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-text-strong text-label-sm font-medium leading-5">Connected to</span>
+          <ProviderIcon providerId={providerId} providerDisplayName={channelName} className="size-4 shrink-0" />
+          <span className="text-text-strong text-label-sm font-medium leading-5">{channelName}</span>
+        </div>
+        <ConnectedStatusPill connectedAt={connectedLink.connectedAt} />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/hooks/use-agent-cli-connection-poll.ts
+++ b/apps/dashboard/src/hooks/use-agent-cli-connection-poll.ts
@@ -1,0 +1,128 @@
+import { DirectionEnum, EmailProviderIdEnum } from '@novu/shared';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import {
+  type AgentIntegrationLink,
+  type AgentResponse,
+  getAgentIntegrationsQueryKey,
+  getAgentsListQueryKey,
+  listAgentIntegrations,
+  listAgents,
+} from '@/api/agents';
+import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+
+const POLL_INTERVAL_MS = 5000;
+
+// Mirrors the param shape baked into `getAgentsListQueryKey` so the polling query key stays stable.
+const LATEST_AGENT_PARAMS = { after: undefined, before: undefined, limit: 1, identifier: '' };
+
+export type CliConnectionResult = {
+  connectedAgentIdentifier: string;
+  connectedLink: AgentIntegrationLink;
+};
+
+type Baseline = {
+  latestAgentId: string | undefined;
+  hadConnectedChannel: boolean;
+};
+
+/**
+ * A "real" connected channel is a link with `connectedAt` stamped whose provider is not the
+ * auto-provisioned Novu email integration — the same exclusion used across the agent setup UI.
+ */
+function findConnectedChannelLink(links: AgentIntegrationLink[] | undefined): AgentIntegrationLink | undefined {
+  return links?.find(
+    (link) => Boolean(link.connectedAt) && link.integration.providerId !== EmailProviderIdEnum.NovuAgent
+  );
+}
+
+/**
+ * Polls for an agent connected via the CLI path (Open in Cursor / Copy prompt). The poll watches
+ * the most recently created agent and its channel links; when a non-email channel becomes
+ * connected it returns the agent identifier + connected link so the page can render the success
+ * view.
+ *
+ * The baseline is session-only: it's captured on the first resolved poll so a returning user who
+ * already has a connected agent is never shown the success view — only a connection that appears
+ * while the page is open triggers it. Polling stops as soon as `enabled` flips to false (the user
+ * created an agent from the UI) or a connection is detected.
+ */
+export function useAgentCliConnectionPoll({ enabled }: { enabled: boolean }): CliConnectionResult | null {
+  const { currentEnvironment } = useEnvironment();
+  const baselineRef = useRef<Baseline | null>(null);
+  const [detected, setDetected] = useState<CliConnectionResult | null>(null);
+
+  const pollingActive = enabled && !detected;
+
+  const latestAgentQuery = useQuery({
+    queryKey: getAgentsListQueryKey(currentEnvironment?._id, LATEST_AGENT_PARAMS),
+    queryFn: () =>
+      listAgents({
+        environment: requireEnvironment(currentEnvironment, 'No environment selected'),
+        limit: 1,
+        orderBy: 'createdAt',
+        orderDirection: DirectionEnum.DESC,
+      }),
+    enabled: pollingActive && Boolean(currentEnvironment),
+    refetchInterval: pollingActive ? POLL_INTERVAL_MS : false,
+  });
+
+  const latestAgent: AgentResponse | undefined = latestAgentQuery.data?.data?.[0];
+
+  const integrationsQuery = useQuery({
+    queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, latestAgent?.identifier),
+    queryFn: () =>
+      listAgentIntegrations({
+        environment: requireEnvironment(currentEnvironment, 'No environment selected'),
+        agentIdentifier: latestAgent?.identifier ?? '',
+        limit: 100,
+      }),
+    enabled: pollingActive && Boolean(currentEnvironment && latestAgent?.identifier),
+    refetchInterval: pollingActive ? POLL_INTERVAL_MS : false,
+  });
+
+  useEffect(() => {
+    if (!pollingActive) return;
+    // Wait for the latest-agent fetch so the baseline reflects the real starting state.
+    if (!latestAgentQuery.isSuccess) return;
+
+    // No agents yet (fresh onboarding) — record an empty baseline and keep polling. Any agent that
+    // later appears connected will read as a new agent and trigger the success view.
+    if (!latestAgent) {
+      if (!baselineRef.current) {
+        baselineRef.current = { latestAgentId: undefined, hadConnectedChannel: false };
+      }
+
+      return;
+    }
+
+    if (!integrationsQuery.isSuccess) return;
+
+    const connectedLink = findConnectedChannelLink(integrationsQuery.data?.data);
+    const hasConnectedChannel = Boolean(connectedLink);
+
+    if (!baselineRef.current) {
+      baselineRef.current = { latestAgentId: latestAgent._id, hadConnectedChannel: hasConnectedChannel };
+
+      return;
+    }
+
+    if (!connectedLink) return;
+
+    const baseline = baselineRef.current;
+    const isNewAgent = latestAgent._id !== baseline.latestAgentId;
+    const baselineAgentNewlyConnected = latestAgent._id === baseline.latestAgentId && !baseline.hadConnectedChannel;
+
+    if (isNewAgent || baselineAgentNewlyConnected) {
+      setDetected({ connectedAgentIdentifier: latestAgent.identifier, connectedLink });
+    }
+  }, [
+    pollingActive,
+    latestAgentQuery.isSuccess,
+    integrationsQuery.isSuccess,
+    integrationsQuery.data?.data,
+    latestAgent,
+  ]);
+
+  return detected;
+}

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -1,11 +1,14 @@
 import { FeatureFlagsKeysEnum, ProductUseCasesEnum } from '@novu/shared';
+import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowLeftSLine, RiArrowRightSLine, RiExpandUpDownLine } from 'react-icons/ri';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
-import type { AgentResponse } from '@/api/agents';
+import { type AgentResponse, getAgent, getAgentDetailQueryKey } from '@/api/agents';
+import { AgentPreviewSkeleton } from '@/components/agents/agent-preview-skeleton';
 import { AgentSetupSteps, ManagedAgentRecap } from '@/components/agents/agent-setup-steps';
 import { CompletedStepIndicator } from '@/components/agents/setup-guide-primitives';
+import { AgentCliSuccessView } from '@/components/onboarding/connect-agent/agent-cli-success-view';
 import { ConnectAgentStep, type ConnectSummary } from '@/components/onboarding/connect-agent/connect-agent-step';
 import { getConnectorById } from '@/components/onboarding/connect-agent/connector-options';
 import { PrebuiltPromptBanner } from '@/components/onboarding/connect-agent/prebuilt-prompt-banner';
@@ -15,7 +18,8 @@ import { PageMeta } from '@/components/page-meta';
 import { Button } from '@/components/primitives/button';
 import { IS_EU } from '@/config';
 import { useAuth } from '@/context/auth/hooks';
-import { useEnvironment } from '@/context/environment/hooks';
+import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAgentCliConnectionPoll } from '@/hooks/use-agent-cli-connection-poll';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useOnboardingProvisioningActive, useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
@@ -180,16 +184,54 @@ export function AgentsSetupPage() {
 
   const [connectedProviderId, setConnectedProviderId] = useState<string | undefined>(undefined);
 
+  // Watch for an agent connected via the CLI path (Open in Cursor / Copy prompt). Polling stops the
+  // moment the user creates an agent from the UI form (`createdAgent` is set).
+  const cliConnection = useAgentCliConnectionPoll({ enabled: !createdAgent });
+  const cliConnected = Boolean(cliConnection) && !createdAgent;
+
+  // The list/poll response doesn't hydrate the managed-runtime details, so fetch the full agent to
+  // populate the preview card once a CLI connection is detected.
+  const cliAgentQuery = useQuery({
+    queryKey: getAgentDetailQueryKey(currentEnvironment?._id, cliConnection?.connectedAgentIdentifier),
+    queryFn: () =>
+      getAgent(
+        requireEnvironment(currentEnvironment, 'No environment selected'),
+        cliConnection?.connectedAgentIdentifier ?? ''
+      ),
+    enabled: Boolean(currentEnvironment && cliConnection?.connectedAgentIdentifier),
+  });
+  const cliAgent = cliAgentQuery.data;
+
+  // The agent driving the footer CTAs: the UI-created agent, or the CLI-detected one.
+  const activeAgent = createdAgent ?? (cliConnected ? cliAgent : undefined);
+
+  const cliPhaseTrackedRef = useRef(false);
+  useEffect(() => {
+    if (!cliConnection || cliPhaseTrackedRef.current) return;
+
+    cliPhaseTrackedRef.current = true;
+    telemetry(TelemetryEvent.ONBOARDING_PHASE_VIEWED, {
+      phase: 'details',
+      source: 'cli',
+      agentIdentifier: cliConnection.connectedAgentIdentifier,
+    });
+    telemetry(TelemetryEvent.ONBOARDING_CHANNEL_CONNECTED, {
+      agentIdentifier: cliConnection.connectedAgentIdentifier,
+      providerId: cliConnection.connectedLink.integration.providerId,
+      source: 'cli',
+    });
+  }, [cliConnection, telemetry]);
+
   const buildOnboardingCompletionProps = useCallback(() => {
     return {
       usecase: 'agents' as const,
-      setupComplete,
+      setupComplete: setupComplete || cliConnected,
       runtime: connectSummary ? (getConnectorById(connectSummary.connectorId)?.runtime ?? 'scratch') : undefined,
       connectorId: connectSummary?.connectorId,
-      providerId: connectedProviderId,
-      source: 'web' as const,
+      providerId: connectedProviderId ?? cliConnection?.connectedLink.integration.providerId,
+      source: cliConnected ? ('cli' as const) : ('web' as const),
     };
-  }, [connectSummary?.connectorId, connectedProviderId, setupComplete]);
+  }, [cliConnected, cliConnection, connectSummary, connectedProviderId, setupComplete]);
 
   const handleAgentCreated = useCallback(
     (agent: AgentResponse, summary: ConnectSummary) => {
@@ -226,10 +268,10 @@ export function AgentsSetupPage() {
 
     if (!currentEnvironment?.slug) return;
 
-    if (createdAgent) {
+    if (activeAgent) {
       const agentPath = buildRoute(agentRoutes.detailsTab, {
         environmentSlug: currentEnvironment.slug,
-        agentIdentifier: encodeURIComponent(createdAgent.identifier),
+        agentIdentifier: encodeURIComponent(activeAgent.identifier),
         agentTab: AGENT_DETAILS_DEFAULT_TAB,
       });
       goToPostOnboardingRoute(agentPath, navigate);
@@ -237,25 +279,25 @@ export function AgentsSetupPage() {
       goToPostOnboardingRoute(getPostOnboardingRoute(currentEnvironment.slug), navigate);
     }
   }, [
+    activeAgent,
     agentRoutes.detailsTab,
     buildOnboardingCompletionProps,
-    createdAgent,
     currentEnvironment?.slug,
     navigate,
     telemetry,
   ]);
 
   const handleSetupAnotherChannel = useCallback(() => {
-    if (!currentEnvironment?.slug || !createdAgent) return;
+    if (!currentEnvironment?.slug || !activeAgent) return;
 
     void navigate(
       buildRoute(agentRoutes.detailsTab, {
         environmentSlug: currentEnvironment.slug,
-        agentIdentifier: encodeURIComponent(createdAgent.identifier),
+        agentIdentifier: encodeURIComponent(activeAgent.identifier),
         agentTab: 'integrations',
       })
     );
-  }, [agentRoutes.detailsTab, createdAgent, currentEnvironment?.slug, navigate]);
+  }, [activeAgent, agentRoutes.detailsTab, currentEnvironment?.slug, navigate]);
 
   const handleBackStep = useCallback(() => {
     void navigate(ROUTES.USECASE_SELECT);
@@ -283,6 +325,10 @@ export function AgentsSetupPage() {
   // expands "Show all instructions".
   const collapsePreview = channelGuideActive && !instructionsExpanded;
 
+  const showFooterActions = Boolean((createdAgent && setupComplete) || (cliConnected && cliAgent));
+  // During the CLI success state the skip banner is suppressed even while the agent preview hydrates.
+  const showSkipBanner = !showFooterActions && !cliConnected;
+
   const leftContent = (
     <>
       <PageMeta title={pageTitle} />
@@ -294,133 +340,160 @@ export function AgentsSetupPage() {
         own agent and credentials later.
       </p>
 
-      {/* Pre-built prompt tip: only relevant while the user is authoring the agent brain. It
-       * collapses away once the agent is created and the page morphs into the agent preview. */}
-      <AnimatePresence initial={false}>
-        {!createdAgent ? (
-          <motion.div
-            key="prebuilt-prompt-banner"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
-            style={{ overflow: 'hidden' }}
-          >
-            <div className="mt-6">
-              <PrebuiltPromptBanner />
+      {cliConnected ? (
+        <div className="relative mt-8">
+          <div
+            className="absolute bottom-0 left-[22px] top-0 w-px"
+            style={{
+              background:
+                'linear-gradient(to bottom, transparent 0, #E1E4EA 24px, #E1E4EA calc(100% - 24px), transparent 100%)',
+            }}
+          />
+          {cliAgent && cliConnection ? (
+            <AgentCliSuccessView agent={cliAgent} connectedLink={cliConnection.connectedLink} />
+          ) : (
+            <div className="relative py-6 pl-8 pr-3 md:pr-6">
+              <div
+                className="absolute bottom-0 left-[22px] top-0 w-px"
+                style={{
+                  background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+                }}
+              />
+              <AgentPreviewSkeleton />
             </div>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
+          )}
+        </div>
+      ) : (
+        <>
+          {/* Pre-built prompt tip: only relevant while the user is authoring the agent brain. It
+           * collapses away once the agent is created and the page morphs into the agent preview. */}
+          <AnimatePresence initial={false}>
+            {!createdAgent ? (
+              <motion.div
+                key="prebuilt-prompt-banner"
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+                style={{ overflow: 'hidden' }}
+              >
+                <div className="mt-6">
+                  <PrebuiltPromptBanner />
+                </div>
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
 
-      {/*
-       * The user stays on one screen. Step 1 crossfades the brain form into the created-agent
-       * preview card; step 2 (channels) crossfades from the dimmed/disabled preview into the live,
-       * interactive channel step in place. Keyed on `createdAgent` — the back arrow returns to the
-       * brain form.
-       */}
-      <div className="relative mt-8">
-        {/* Single continuous rail line behind every step segment. Each segment also draws its own
-         * gradient line, but those fade to transparent at their edges and pinch where segments meet;
-         * this same-colored line sits underneath and fills those gaps so the toggle, brain step, and
-         * channel steps read as one unbroken vertical timeline. */}
-        <div
-          className="absolute bottom-0 left-[22px] top-0 w-px"
-          style={{
-            background:
-              'linear-gradient(to bottom, transparent 0, #E1E4EA 24px, #E1E4EA calc(100% - 24px), transparent 100%)',
-          }}
-        />
+          {/*
+           * The user stays on one screen. Step 1 crossfades the brain form into the created-agent
+           * preview card; step 2 (channels) crossfades from the dimmed/disabled preview into the live,
+           * interactive channel step in place. Keyed on `createdAgent` — the back arrow returns to the
+           * brain form.
+           */}
+          <div className="relative mt-8">
+            {/* Single continuous rail line behind every step segment. Each segment also draws its own
+             * gradient line, but those fade to transparent at their edges and pinch where segments meet;
+             * this same-colored line sits underneath and fills those gaps so the toggle, brain step, and
+             * channel steps read as one unbroken vertical timeline. */}
+            <div
+              className="absolute bottom-0 left-[22px] top-0 w-px"
+              style={{
+                background:
+                  'linear-gradient(to bottom, transparent 0, #E1E4EA 24px, #E1E4EA calc(100% - 24px), transparent 100%)',
+              }}
+            />
 
-        {/* Once a channel is picked, the completed agent-brain + channel-selection steps collapse
-         * behind this toggle so only the channel setup guide remains visible. It animates in
-         * (height + opacity) in sync with the collapsing preview so the whole transition is one beat. */}
-        <AnimatePresence initial={false}>
-          {createdAgent && channelGuideActive ? (
+            {/* Once a channel is picked, the completed agent-brain + channel-selection steps collapse
+             * behind this toggle so only the channel setup guide remains visible. It animates in
+             * (height + opacity) in sync with the collapsing preview so the whole transition is one beat. */}
+            <AnimatePresence initial={false}>
+              {createdAgent && channelGuideActive ? (
+                <motion.div
+                  key="show-all-instructions"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: 'auto', opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+                  style={{ clipPath: 'inset(0 -100% -100% -100%)', overflow: 'hidden' }}
+                >
+                  <ShowAllInstructionsToggle
+                    expanded={instructionsExpanded}
+                    onToggle={() => setInstructionsExpanded((prev) => !prev)}
+                  />
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+
+            {/*
+             * Step 1: the brain form crossfades into the created-agent preview card, overlapping in the
+             * same grid cell so the swap reads as an in-place morph. Collapses to height 0 once a
+             * channel guide is active (unless the user expands "Show all instructions").
+             */}
             <motion.div
-              key="show-all-instructions"
-              initial={{ height: 0, opacity: 0 }}
-              animate={{ height: 'auto', opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
+              initial={false}
+              animate={{
+                height: collapsePreview ? 0 : 'auto',
+                opacity: collapsePreview ? 0 : 1,
+              }}
               transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
               style={{ clipPath: 'inset(0 -100% -100% -100%)', overflow: 'hidden' }}
             >
-              <ShowAllInstructionsToggle
-                expanded={instructionsExpanded}
-                onToggle={() => setInstructionsExpanded((prev) => !prev)}
-              />
+              {/* The brain form unmounts instantly when the agent is created (no overlap → no ghosting)
+               * and the preview fades/rises in. There's no crossfade or animated height, so the section
+               * height changes exactly once — the scrollbar can't flick on/off mid-transition. */}
+              {createdAgent && connectSummary ? (
+                <motion.div
+                  key="agent-preview"
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+                >
+                  <div className="relative py-6 pl-8 pr-3 md:pr-6">
+                    <div
+                      className="absolute bottom-0 left-[22px] top-0 w-px"
+                      style={{
+                        background:
+                          'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+                      }}
+                    />
+                    <ManagedAgentRecap agent={createdAgent} summary={connectSummary} hideHeader />
+                  </div>
+                </motion.div>
+              ) : (
+                <div className="relative pb-12">
+                  <ConnectAgentStep
+                    onAgentCreated={handleAgentCreated}
+                    isManagedEnabled={isManagedEnabled}
+                    agentTemplateId={agentTemplateId}
+                    simplifiedDemo
+                  />
+                </div>
+              )}
             </motion.div>
-          ) : null}
-        </AnimatePresence>
 
-        {/*
-         * Step 1: the brain form crossfades into the created-agent preview card, overlapping in the
-         * same grid cell so the swap reads as an in-place morph. Collapses to height 0 once a
-         * channel guide is active (unless the user expands "Show all instructions").
-         */}
-        <motion.div
-          initial={false}
-          animate={{
-            height: collapsePreview ? 0 : 'auto',
-            opacity: collapsePreview ? 0 : 1,
-          }}
-          transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
-          style={{ clipPath: 'inset(0 -100% -100% -100%)', overflow: 'hidden' }}
-        >
-          {/* The brain form unmounts instantly when the agent is created (no overlap → no ghosting)
-           * and the preview fades/rises in. There's no crossfade or animated height, so the section
-           * height changes exactly once — the scrollbar can't flick on/off mid-transition. */}
-          {createdAgent && connectSummary ? (
-            <motion.div
-              key="agent-preview"
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
-            >
-              <div className="relative py-6 pl-8 pr-3 md:pr-6">
-                <div
-                  className="absolute bottom-0 left-[22px] top-0 w-px"
-                  style={{
-                    background:
-                      'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
-                  }}
-                />
-                <ManagedAgentRecap agent={createdAgent} summary={connectSummary} hideHeader />
-              </div>
-            </motion.div>
-          ) : (
-            <div className="relative pb-12">
-              <ConnectAgentStep
-                onAgentCreated={handleAgentCreated}
-                isManagedEnabled={isManagedEnabled}
-                agentTemplateId={agentTemplateId}
-                simplifiedDemo
+            {/*
+             * Step 2: the channel section becomes interactive once the agent exists. When the user picks
+             * a channel its setup guide replaces the cards in place (the cards collapse via
+             * `collapseChannelSelection`).
+             */}
+            {createdAgent ? (
+              <AgentSetupSteps
+                agent={createdAgent}
+                onSetupComplete={() => setSetupComplete(true)}
+                onChannelConnected={(providerId) => setConnectedProviderId(providerId)}
+                hideAddProvider
+                hideRecap
+                collapseChannelSelection={collapsePreview}
+                onChannelGuideActiveChange={setChannelGuideActive}
+                connectSummary={connectSummary}
               />
-            </div>
-          )}
-        </motion.div>
-
-        {/*
-         * Step 2: the channel section becomes interactive once the agent exists. When the user picks
-         * a channel its setup guide replaces the cards in place (the cards collapse via
-         * `collapseChannelSelection`).
-         */}
-        {createdAgent ? (
-          <AgentSetupSteps
-            agent={createdAgent}
-            onSetupComplete={() => setSetupComplete(true)}
-            onChannelConnected={(providerId) => setConnectedProviderId(providerId)}
-            hideAddProvider
-            hideRecap
-            collapseChannelSelection={collapsePreview}
-            onChannelGuideActiveChange={setChannelGuideActive}
-            connectSummary={connectSummary}
-          />
-        ) : null}
-      </div>
+            ) : null}
+          </div>
+        </>
+      )}
 
       {/* Footer actions live outside the rail so the continuous line ends at the last step. */}
-      {createdAgent && setupComplete ? (
+      {showFooterActions ? (
         <div className="mt-6 flex items-center gap-3 pb-10 pl-6">
           <Button
             className="text-label-xs gap-1 rounded-lg p-2"
@@ -439,9 +512,8 @@ export function AgentsSetupPage() {
             Setup another channel
           </button>
         </div>
-      ) : (
-        <SkipBanner onSkip={handleSkip} />
-      )}
+      ) : null}
+      {showSkipBanner ? <SkipBanner onSkip={handleSkip} /> : null}
     </>
   );
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard Agents Onboarding: CLI agent creation pulling and successful connection view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added CLI-driven agent connection flow to the agents onboarding experience. Users can now create agents via CLI and see a success screen when the CLI agent connects to a channel. The solution includes polling to detect when a CLI-created agent establishes a connection, displaying connection status with last-event timestamps, and routing to the correct agent details page whether the agent was created via UI or CLI.

## Affected areas

**dashboard**: Added `AgentCliSuccessView` component to display a success screen with agent details, connected channel status, and navigation actions. Added `useAgentCliConnectionPoll` hook to poll for newly created CLI agents and detect successful connections. Updated `AgentsSetupPage` to support parallel flows for both UI-created and CLI-created agents, including fetching full agent details, managing completion state, and adjusting visibility of skip/footer actions based on the active flow.

## Key technical decisions

- **Polling with baseline detection**: The connection poll captures an initial baseline to avoid false positives when already-connected channels exist on page load; it only detects new connections established while the page is open.
- **Isolated confetti rendering**: Success view renders confetti using `createPortal` into a fixed, non-interactive canvas overlay to keep effects contained and non-blocking.
- **Connector type resolution**: Agent display derives connector info from `agent.runtime` and managed provider metadata to show correct channel and credential information.

## Testing

No test files were added. The changes implement UI flows and polling logic that would benefit from manual verification during QA and potential future e2e test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="1535" height="1004" alt="Screenshot 2026-06-11 at 23 38 43" src="https://github.com/user-attachments/assets/880bbe78-6076-4d5a-ae5f-f71c3e7550ae" />
