### PR TITLE
fix(api-service): use link button for keyless welcome signup CTA fixes NV-8025

### DIFF
--- a/apps/api/src/app/keyless/keyless-signup.helpers.spec.ts
+++ b/apps/api/src/app/keyless/keyless-signup.helpers.spec.ts
@@ -56,15 +56,17 @@ describe('keyless-signup.helpers', () => {
     );
   });
 
-  it('buildKeylessWelcomeCard includes welcome text and a subtle signup link', () => {
+  it('buildKeylessWelcomeCard includes welcome text and a primary signup button', () => {
     const welcomeText = getWelcomeText(AgentPlatformEnum.SLACK);
     const card = buildKeylessWelcomeCard(welcomeText, 'https://example.com/claim');
+    const actions = card.children?.find((child) => child.type === 'actions');
 
     expect(card.children?.[0]).to.deep.equal({ type: 'text', content: welcomeText });
-    expect(card.children?.[2]).to.deep.equal({
-      type: 'link',
+    expect(actions?.children?.[0]).to.deep.equal({
+      type: 'link-button',
       label: 'Sign up free',
       url: 'https://example.com/claim',
+      style: 'primary',
     });
   });
 

--- a/apps/api/src/app/keyless/keyless-signup.helpers.ts
+++ b/apps/api/src/app/keyless/keyless-signup.helpers.ts
@@ -33,9 +33,15 @@ export function buildKeylessWelcomeCard(welcomeText: string, claimUrl: string): 
         content: 'This is a free demo — sign up anytime to keep this agent and your conversation.',
       },
       {
-        type: 'link',
-        label: 'Sign up free',
-        url: claimUrl,
+        type: 'actions',
+        children: [
+          {
+            type: 'link-button',
+            label: 'Sign up free',
+            url: claimUrl,
+            style: 'primary',
+          },
+        ],
       },
     ],
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the keyless mode welcome message to render the "Sign up free" CTA as a primary link button instead of a plain text link.

This matches the existing demo-cap signup card (`buildKeylessSignupCard`) and renders as a proper Slack button in Block Kit.

## Changes

- `buildKeylessWelcomeCard` now uses an `actions` block with a `link-button` element (`style: 'primary'`) instead of a `link` element
- Updated unit test to assert the new button structure

## Test plan

- [x] `pnpm test -- --grep "keyless-signup.helpers"` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f45e21c6-8342-4de6-9178-ebf4069110cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f45e21c6-8342-4de6-9178-ebf4069110cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The "Sign up free" call-to-action in the keyless welcome message was changed from a plain text link to a styled primary button. This improves visual hierarchy and consistency with the existing demo-cap signup card, rendering as a proper Slack button in Block Kit format.

## Affected areas

**api**: Updated `buildKeylessWelcomeCard` to use an `actions` block containing a `link-button` element (with `style: 'primary'`, label "Sign up free", and the claim URL) instead of a direct `link` element.

## Testing

Existing unit tests for `keyless-signup.helpers` were updated to verify the new button structure, confirming the `actions` block and `link-button` are rendered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the "Sign up free" CTA in `buildKeylessWelcomeCard` from a plain `link` element to a proper Slack Block Kit `actions` block containing a `link-button` with `style: 'primary'`. This brings the welcome card in line with the existing `buildKeylessSignupCard` pattern.

- **`keyless-signup.helpers.ts`**: Replaced the inline `link` element at index `[2]` with an `actions` block wrapping a `link-button`; structure now mirrors `buildKeylessSignupCard` exactly.
- **`keyless-signup.helpers.spec.ts`**: Updated the test description and assertion — now finds the `actions` block by `.type` rather than hard-coding an array index, which is more resilient to future child reordering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a small, focused change that aligns the welcome card's CTA with the already-shipped signup card pattern.

Both changed files are in sync: the helper produces an `actions`/`link-button` structure and the test correctly asserts it. The new structure is identical to `buildKeylessSignupCard`, which is already in production, so the rendering behavior is well-understood.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/keyless/keyless-signup.helpers.ts | Replaced the plain `link` element in `buildKeylessWelcomeCard` with an `actions` block containing a `link-button` (style: primary), making it consistent with `buildKeylessSignupCard`. |
| apps/api/src/app/keyless/keyless-signup.helpers.spec.ts | Test updated to find the `actions` block by type and assert the new `link-button` structure; test description also updated to match the new behavior. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Keyless as Keyless Handler
    participant Helper as keyless-signup.helpers
    participant Chat as Chat SDK (Block Kit)
    participant Slack as Slack API

    Keyless->>Helper: buildKeylessWelcomeCard(welcomeText, claimUrl)
    Helper-->>Keyless: "CardElement { type: 'card', children: [text, text, actions] }"
    Note over Helper,Keyless: actions.children[0] = { type: 'link-button', style: 'primary', ... }

    Keyless->>Chat: toReplyCard(card)
    Chat->>Slack: Render Block Kit Actions block with button element
    Slack-->>Chat: Displays primary "Sign up free" button
```

<sub>Reviews (1): Last reviewed commit: ["fix(api): use link button for keyless we..."](https://github.com/novuhq/novu/commit/65c9ee9093b6e7dc8b432ff698527c75d7695303) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37193493)</sub>

<!-- /greptile_comment -->