### PR TITLE
fix(dashboard): redirect to agents list on organization switch from agent details

### DIFF
--- a/apps/dashboard/src/context/environment/environment-provider.tsx
+++ b/apps/dashboard/src/context/environment/environment-provider.tsx
@@ -1,6 +1,6 @@
 import { type IEnvironment } from '@novu/shared';
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { matchPath, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '@/context/auth/hooks';
 import { EnvironmentContext } from '@/context/environment/environment-context';
 import { useFetchEnvironments } from '@/context/environment/hooks';
@@ -50,6 +50,11 @@ function selectEnvironment(
   return environment;
 }
 
+function isAgentDetailsPath(pathname: string) {
+  // Matches the agent details page and its sub-routes (tabs, integration detail).
+  return Boolean(matchPath({ path: ROUTES.AGENT_DETAILS, end: false }, pathname));
+}
+
 export function EnvironmentProvider({ children }: { children: React.ReactNode }) {
   const authResp = useAuth();
   const currentOrganization = authResp.currentOrganization;
@@ -64,6 +69,11 @@ export function EnvironmentProvider({ children }: { children: React.ReactNode })
       const selectedEnvironment = selectEnvironment(allEnvironments, environmentSlug, currentOrganization?._id);
       setCurrentEnvironment(selectedEnvironment);
       const newEnvironmentSlug = selectedEnvironment.slug;
+      // A slug that doesn't belong to any of the current organization's environments means the URL
+      // is left over from another organization (e.g. right after an org switch).
+      const isStaleEnvironmentSlug =
+        Boolean(environmentSlug) &&
+        !allEnvironments.some((env) => env.slug === environmentSlug || env._id === environmentSlug);
       const isNewEnvironmentDifferent =
         paramsEnvironmentSlug !== selectedEnvironment.slug && paramsEnvironmentSlug !== selectedEnvironment._id;
 
@@ -79,8 +89,14 @@ export function EnvironmentProvider({ children }: { children: React.ReactNode })
       if (pathname === ROUTES.ROOT || pathname === ROUTES.ENV || pathname === `${ROUTES.ENV}/`) {
         navigate(buildRoute(ROUTES.WORKFLOWS, { environmentSlug: newEnvironmentSlug ?? '' }));
       } else if (pathname.includes(ROUTES.ENV) && isNewEnvironmentDifferent) {
-        const newPath = pathname.replace(/\/env\/[^/]+(\/|$)/, `${ROUTES.ENV}/${newEnvironmentSlug}$1`);
-        navigate(`${newPath}${search}${hash}`);
+        if (isStaleEnvironmentSlug && isAgentDetailsPath(pathname)) {
+          // Agent detail pages can't survive an org switch — the agent doesn't exist in the new
+          // organization — so land on the agents list instead of an error page.
+          navigate(buildRoute(ROUTES.AGENTS, { environmentSlug: newEnvironmentSlug ?? '' }));
+        } else {
+          const newPath = pathname.replace(/\/env\/[^/]+(\/|$)/, `${ROUTES.ENV}/${newEnvironmentSlug}$1`);
+          navigate(`${newPath}${search}${hash}`);
+        }
       }
     },
     [navigate, pathname, search, hash, paramsEnvironmentSlug, currentOrganization?._id]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The EnvironmentProvider now detects when an organization switch leaves a stale environment slug in the URL (i.e., a slug from a different organization). When this occurs on an agent details page (`/env/:slug/agents/:id`), it redirects to the agents list of the newly selected organization instead of displaying a "This agent does not exist" error. For all other routes, the existing slug-rewrite behavior is preserved.

## Affected areas

**dashboard**: Updated EnvironmentProvider component to add detection logic for stale environment slugs and conditional routing. On agent details routes (overview, channels tabs, integration details), an organization switch redirects to the agents list; other routes rewrite the URL to use the correct environment slug while preserving query parameters and hash fragments.

## Key technical decisions

- Added an internal `isAgentDetailsPath` helper to detect agent details pages and their sub-routes, enabling route-specific handling without modifying route definitions.
- Implemented `isStaleEnvironmentSlug` check to distinguish between an organization switch (stale slug not found in current org) and an environment switch within the same organization (slug exists but differs).

## Testing

Manual verification confirmed the fix works correctly: organization switches from agent details pages now redirect to the agents list, regression testing verified that organization switches from the Workflows page keep you on Workflows, and environment switching within the same organization is unaffected. End-to-end testing was performed in a better-auth local setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

When switching organizations while on an agent details page (`/env/:environmentSlug/agents/:agentIdentifier/...`), the dashboard kept the agent-specific URL, only rewrote the environment slug, and then showed "This agent does not exist or was removed." — the user had to click Agents in the navbar to escape.

`EnvironmentProvider` now detects when the environment slug in the URL does not belong to any of the current organization's environments (i.e. the URL is left over from another organization). If that happens while on an agent details route (overview/channels tabs or integration detail), it navigates to the agents list of the newly selected environment instead of rewriting the slug in place. All other routes keep the existing slug-rewrite behavior, and environment switching within an organization is unaffected.

This covers both the Clerk cloud flow (in-app org switch, no reload) and the better-auth/self-hosted flow (full page reload on switch), since both funnel through the same environment-selection effect.

<!-- Linear: no Linear access available in this agent environment (no MCP server or API key), so a ticket could not be created. Please attach/create the ticket and add `fixes NV-XXX` to the title. -->

### Screenshots

Before — switching org from agent overview leaves you on a dead "Not found" page:

![Error after org switch before fix](https://cursor.com/artifacts/c/art-fa16e16c-376b-405b-966d-2a929a39e936)

After — switching org from agent overview lands on the agents list of the new organization:

<a href="https://cursor.com/agents/bc-06365f88-a2e2-4ee0-8512-b36d03bcf8d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forg_switch_redirects_to_agents_list.mp4"><img src="https://cursor.com/artifacts/c/art-b0414b67-5bd5-4c8a-ada8-8e9c80e4dfeb" alt="org_switch_redirects_to_agents_list.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Regression-tested that an org switch from the Workflows page still keeps you on Workflows (slug rewrite path unchanged), and that env switching within an org on agent details is untouched (valid slugs are never treated as stale).
- Verified end-to-end in the better-auth local setup: reproduced the bug on `next`, then confirmed the redirect with the fix applied.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06365f88-a2e2-4ee0-8512-b36d03bcf8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06365f88-a2e2-4ee0-8512-b36d03bcf8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

