### PR TITLE
fix(novu): restore in-terminal token entry for interactive connect fixes NV-8026

### DIFF
--- a/packages/novu/src/commands/connect/pipeline/channels/slack.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/slack.ts
@@ -123,15 +123,25 @@ async function runSlackQuickSetup(
   slackIntegration: IntegrationRecord,
   ui: ConnectUI,
   options: ConnectCommandOptions,
-  _flags: { retry: boolean }
+  flags: { retry: boolean }
 ): Promise<void> {
   const configToken = options.slackConfigToken?.trim();
 
   if (configToken) {
-    // Optional escape hatch for headless CI: the caller supplies the token directly.
     ui.runningSlackQuickSetup();
     await slackQuickSetup(client, slackIntegration._id, {
       configToken,
+      agentId: agent.id,
+    });
+
+    return;
+  }
+
+  if (ui.interactive) {
+    const token = await ui.promptForSlackConfigToken({ retry: flags.retry });
+    ui.runningSlackQuickSetup();
+    await slackQuickSetup(client, slackIntegration._id, {
+      configToken: token,
       agentId: agent.id,
     });
 

--- a/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
@@ -7,6 +7,7 @@ import {
   type TelegramSubscriberLinkResult,
 } from '../../api/agents';
 import type { ConnectApiClient } from '../../api/client';
+import { NovuApiError } from '../../api/client';
 import { createTelegramIntegration, type IntegrationRecord } from '../../api/integrations';
 import type { AgentSummary, ConnectCommandOptions } from '../../types';
 import { renderQR } from '../../ui/qr';
@@ -21,6 +22,7 @@ import { CHANNEL_POLL_INTERVAL_MS, CHANNEL_POLL_TIMEOUT_MS, pollUntil } from '..
 const TELEGRAM_PROVIDER_ID = 'telegram';
 const TELEGRAM_CHANNEL = 'chat';
 const BOTFATHER_URL = 'https://t.me/botfather';
+const MAX_TELEGRAM_TOKEN_ATTEMPTS = 5;
 
 export async function connectTelegramForAgent(
   client: ConnectApiClient,
@@ -142,7 +144,7 @@ async function promptAndSaveTelegramBotToken(
 ): Promise<TelegramSubscriberLinkResult | undefined> {
   let verificationError: string | undefined;
 
-  while (true) {
+  for (let attempt = 1; attempt <= MAX_TELEGRAM_TOKEN_ATTEMPTS; attempt++) {
     const token = await ui.promptForSecretInput({
       title: 'Telegram bot token',
       placeholder: '123456:ABC-…',
@@ -153,9 +155,25 @@ async function promptAndSaveTelegramBotToken(
     try {
       return await saveTelegramBotTokenViaMobileLink(client, agent, integration, subscriberId, token.trim());
     } catch (err) {
+      if (!isRepromptableTelegramTokenError(err)) {
+        throw err;
+      }
+
       verificationError = err instanceof Error ? err.message : String(err);
     }
   }
+
+  throw new Error(
+    `Telegram didn't accept the bot token after ${MAX_TELEGRAM_TOKEN_ATTEMPTS} attempts. ` +
+      'Double-check the token from @BotFather and re-run `npx novu connect`.'
+  );
+}
+
+function isRepromptableTelegramTokenError(err: unknown): boolean {
+  if (!(err instanceof NovuApiError)) return false;
+  if (err.status === 0) return false;
+
+  return err.status >= 400 && err.status < 500;
 }
 
 async function waitForTelegramSetupPageToken(

--- a/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
@@ -54,20 +54,15 @@ export async function connectTelegramForAgent(
   let prefetchedSubscriberLink: TelegramSubscriberLinkResult | undefined;
 
   if (botToken) {
-    // Optional escape hatch for headless CI: the caller supplies the token
-    // directly instead of routing the user through the secure setup page.
     ui.savingTelegramBotToken();
-    const mobileLink = await issueTelegramMobileLink(client, agent.identifier, integration._id, subscriberId);
     try {
-      const consumeResult = await consumeTelegramMobileLink(client, { token: mobileLink.token, botToken });
-
-      if (consumeResult.deepLinkUrl) {
-        prefetchedSubscriberLink = {
-          deepLinkUrl: consumeResult.deepLinkUrl,
-          botUsername: consumeResult.botUsername,
-          expiresAt: mobileLink.expiresAt,
-        };
-      }
+      prefetchedSubscriberLink = await saveTelegramBotTokenViaMobileLink(
+        client,
+        agent,
+        integration,
+        subscriberId,
+        botToken
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new Error(
@@ -79,45 +74,10 @@ export async function connectTelegramForAgent(
     const botfatherQr = await renderQR(BOTFATHER_URL);
     await ui.showTelegramIntro({ botfatherQr, botfatherUrl: BOTFATHER_URL });
 
-    const mobileLink = await issueTelegramMobileLink(client, agent.identifier, integration._id, subscriberId);
-    const mobileQr = await renderQR(mobileLink.url);
-    ui.showTelegramLinkToken({ mobileQr, mobileUrl: mobileLink.url });
-
-    let setupLinkFailure: 'expired' | 'invalid' | undefined;
-
-    const tokenSaved = await pollUntil(
-      async () => {
-        const status = await getTelegramMobileLinkStatus(client, mobileLink.token);
-        if (!status.valid && status.reason === 'used') return 'done';
-        if (!status.valid && status.reason === 'expired') {
-          setupLinkFailure = 'expired';
-
-          return 'failed';
-        }
-        if (!status.valid) {
-          setupLinkFailure = 'invalid';
-
-          return 'failed';
-        }
-
-        return 'pending';
-      },
-      { intervalMs: CHANNEL_POLL_INTERVAL_MS, timeoutMs: CHANNEL_POLL_TIMEOUT_MS }
-    );
-    if (!tokenSaved) {
-      if (setupLinkFailure === 'expired') {
-        throw new Error(
-          'The Telegram setup link expired before you could paste your bot token. Re-run `npx novu connect` to get a fresh link.'
-        );
-      }
-      if (setupLinkFailure === 'invalid') {
-        throw new Error('The Telegram setup link is no longer valid. Re-run `npx novu connect` to get a fresh link.');
-      }
-
-      throw new Error(
-        `The bot token wasn't saved within ${Math.round(CHANNEL_POLL_TIMEOUT_MS / 1000)} seconds. ` +
-          'Re-run `npx novu connect` to get a fresh setup link.'
-      );
+    if (ui.interactive && (await ui.pickTelegramTokenDelivery()) === 'terminal') {
+      prefetchedSubscriberLink = await promptAndSaveTelegramBotToken(client, agent, integration, subscriberId, ui);
+    } else {
+      await waitForTelegramSetupPageToken(client, agent, integration, subscriberId, ui);
     }
   }
 
@@ -150,4 +110,99 @@ export async function connectTelegramForAgent(
   });
 
   return { connected: true, integration };
+}
+
+async function saveTelegramBotTokenViaMobileLink(
+  client: ConnectApiClient,
+  agent: AgentSummary,
+  integration: IntegrationRecord,
+  subscriberId: string,
+  botToken: string
+): Promise<TelegramSubscriberLinkResult | undefined> {
+  const mobileLink = await issueTelegramMobileLink(client, agent.identifier, integration._id, subscriberId);
+  const consumeResult = await consumeTelegramMobileLink(client, { token: mobileLink.token, botToken });
+
+  if (consumeResult.deepLinkUrl) {
+    return {
+      deepLinkUrl: consumeResult.deepLinkUrl,
+      botUsername: consumeResult.botUsername,
+      expiresAt: mobileLink.expiresAt,
+    };
+  }
+
+  return undefined;
+}
+
+async function promptAndSaveTelegramBotToken(
+  client: ConnectApiClient,
+  agent: AgentSummary,
+  integration: IntegrationRecord,
+  subscriberId: string,
+  ui: ConnectUI
+): Promise<TelegramSubscriberLinkResult | undefined> {
+  let verificationError: string | undefined;
+
+  while (true) {
+    const token = await ui.promptForSecretInput({
+      title: 'Telegram bot token',
+      placeholder: '123456:ABC-…',
+      hint: 'Paste the token @BotFather sent you.',
+      verificationError,
+    });
+
+    try {
+      return await saveTelegramBotTokenViaMobileLink(client, agent, integration, subscriberId, token.trim());
+    } catch (err) {
+      verificationError = err instanceof Error ? err.message : String(err);
+    }
+  }
+}
+
+async function waitForTelegramSetupPageToken(
+  client: ConnectApiClient,
+  agent: AgentSummary,
+  integration: IntegrationRecord,
+  subscriberId: string,
+  ui: ConnectUI
+): Promise<void> {
+  const mobileLink = await issueTelegramMobileLink(client, agent.identifier, integration._id, subscriberId);
+  const mobileQr = await renderQR(mobileLink.url);
+  ui.showTelegramLinkToken({ mobileQr, mobileUrl: mobileLink.url });
+
+  let setupLinkFailure: 'expired' | 'invalid' | undefined;
+
+  const tokenSaved = await pollUntil(
+    async () => {
+      const status = await getTelegramMobileLinkStatus(client, mobileLink.token);
+      if (!status.valid && status.reason === 'used') return 'done';
+      if (!status.valid && status.reason === 'expired') {
+        setupLinkFailure = 'expired';
+
+        return 'failed';
+      }
+      if (!status.valid) {
+        setupLinkFailure = 'invalid';
+
+        return 'failed';
+      }
+
+      return 'pending';
+    },
+    { intervalMs: CHANNEL_POLL_INTERVAL_MS, timeoutMs: CHANNEL_POLL_TIMEOUT_MS }
+  );
+  if (!tokenSaved) {
+    if (setupLinkFailure === 'expired') {
+      throw new Error(
+        'The Telegram setup link expired before you could paste your bot token. Re-run `npx novu connect` to get a fresh link.'
+      );
+    }
+    if (setupLinkFailure === 'invalid') {
+      throw new Error('The Telegram setup link is no longer valid. Re-run `npx novu connect` to get a fresh link.');
+    }
+
+    throw new Error(
+      `The bot token wasn't saved within ${Math.round(CHANNEL_POLL_TIMEOUT_MS / 1000)} seconds. ` +
+        'Re-run `npx novu connect` to get a fresh setup link.'
+    );
+  }
 }

--- a/packages/novu/src/commands/connect/ui/index.tsx
+++ b/packages/novu/src/commands/connect/ui/index.tsx
@@ -6,7 +6,7 @@ import { ConnectChannelBackError } from '../errors';
 import type { AgentSummary, ConnectCommandOptions } from '../types';
 import { App } from './app';
 import { type ConnectStore, createConnectStore } from './store';
-import type { ConnectUI, GeneratedAgentPreviewResult, PickResult } from './ui';
+import type { ConnectUI, GeneratedAgentPreviewResult, PickResult, TelegramTokenDelivery } from './ui';
 
 export interface MountConnectUIParams {
   options: ConnectCommandOptions;
@@ -69,6 +69,7 @@ export function mountConnectUI(_params: MountConnectUIParams): MountConnectUIRes
 
 function createUiController(store: ConnectStore, shutdown: () => Promise<number>): ConnectUI {
   return {
+    interactive: true,
     showWelcome() {
       return new Promise<void>((resolve) => {
         store.phase.set({ kind: 'welcome', resolve });
@@ -204,6 +205,11 @@ function createUiController(store: ConnectStore, shutdown: () => Promise<number>
         store.phase.set({ kind: 'telegram-intro', botfatherQr, resolve });
       });
     },
+    pickTelegramTokenDelivery() {
+      return new Promise<TelegramTokenDelivery>((resolve) => {
+        store.phase.set({ kind: 'pick-telegram-token-delivery', resolve });
+      });
+    },
     showTelegramLinkToken({ mobileQr, mobileUrl }) {
       store.phase.set({ kind: 'telegram-link-token', mobileQr, mobileUrl });
     },
@@ -225,9 +231,7 @@ function createUiController(store: ConnectStore, shutdown: () => Promise<number>
         store.phase.set({ kind: 'paste-slack-token', retry, resolve, reject });
       });
     },
-    showSlackSetupLink({ setupUrl }) {
-      store.phase.set({ kind: 'slack-setup-link', setupUrl });
-    },
+    showSlackSetupLink(_opts) {},
     runningSlackQuickSetup() {
       store.phase.set({ kind: 'running-slack-quick-setup' });
     },

--- a/packages/novu/src/commands/connect/ui/logging-ui.ts
+++ b/packages/novu/src/commands/connect/ui/logging-ui.ts
@@ -43,6 +43,7 @@ export function createLoggingUI(): ConnectUI {
   };
 
   return {
+    interactive: false,
     showWelcome() {
       // Non-interactive: skip the welcome prompt; the run is unattended by
       // definition (--ci or piped stdin) so there's nobody to press Enter.
@@ -229,6 +230,9 @@ export function createLoggingUI(): ConnectUI {
       logTelegramBotfatherHandoffEvent({ botfatherUrl });
 
       return Promise.resolve();
+    },
+    pickTelegramTokenDelivery() {
+      return Promise.resolve('setup-page');
     },
     showTelegramLinkToken({ mobileUrl }) {
       stop();

--- a/packages/novu/src/commands/connect/ui/orb/orb-tint.ts
+++ b/packages/novu/src/commands/connect/ui/orb/orb-tint.ts
@@ -62,13 +62,13 @@ export function computeOrbTint(
       return hoveredChannel ? CHANNEL_TINTS[hoveredChannel] : DEFAULT_ORB_COLOR;
     case 'adding-slack':
     case 'paste-slack-token':
-    case 'slack-setup-link':
     case 'running-slack-quick-setup':
     case 'slack-oauth-ready':
     case 'waiting-slack':
       return CHANNEL_TINTS.slack;
     case 'adding-telegram':
     case 'telegram-intro':
+    case 'pick-telegram-token-delivery':
     case 'telegram-link-token':
     case 'telegram-test':
       return CHANNEL_TINTS.telegram;
@@ -106,13 +106,13 @@ export function computeOrbLabel(
       return hoveredChannel ? CHANNEL_LABELS[hoveredChannel] : undefined;
     case 'adding-slack':
     case 'paste-slack-token':
-    case 'slack-setup-link':
     case 'running-slack-quick-setup':
     case 'slack-oauth-ready':
     case 'waiting-slack':
       return CHANNEL_LABELS.slack;
     case 'adding-telegram':
     case 'telegram-intro':
+    case 'pick-telegram-token-delivery':
     case 'telegram-link-token':
     case 'telegram-test':
       return CHANNEL_LABELS.telegram;

--- a/packages/novu/src/commands/connect/ui/phase-content.tsx
+++ b/packages/novu/src/commands/connect/ui/phase-content.tsx
@@ -241,21 +241,6 @@ export function PhaseContent({
     case 'running-slack-quick-setup':
       return <Text color="cyan">Creating Slack app from manifest…</Text>;
 
-    case 'slack-setup-link':
-      return (
-        <Box flexDirection="column" gap={1}>
-          <Text bold color="cyan">
-            Paste your Slack App Configuration Token
-          </Text>
-          <Text dimColor>
-            Open the link below to paste your token on a secure page. We'll create the Slack app from a manifest — the
-            token never passes through this terminal.
-          </Text>
-          <CopyableLink url={phase.setupUrl} hint="Open this link:" />
-          <Text dimColor>Waiting for your Slack App Configuration Token…</Text>
-        </Box>
-      );
-
     case 'slack-oauth-ready':
       return (
         <SlackOAuthReadyContent
@@ -311,6 +296,21 @@ export function PhaseContent({
 
     case 'telegram-intro':
       return <TelegramIntroContent botfatherQr={phase.botfatherQr} onContinue={phase.resolve} />;
+
+    case 'pick-telegram-token-delivery': {
+      const options = [
+        { label: 'Scan QR / open setup page', value: 'setup-page' as const },
+        { label: 'Paste the bot token here', value: 'terminal' as const },
+      ];
+
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Text bold>How do you want to save your bot token?</Text>
+          <Text dimColor>Scan the QR on your phone, or paste the token directly in this terminal.</Text>
+          <Select options={options} onChange={(value) => phase.resolve(value as 'setup-page' | 'terminal')} />
+        </Box>
+      );
+    }
 
     case 'telegram-link-token':
       return (

--- a/packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts
+++ b/packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts
@@ -6,7 +6,6 @@ export function phaseHasCopyableUrl(phase: Phase): boolean {
     case 'auth':
       return Boolean(phase.dashboardUrl);
     case 'waiting-slack':
-    case 'slack-setup-link':
     case 'telegram-link-token':
     case 'telegram-test':
     case 'dashboard-channel-ready':

--- a/packages/novu/src/commands/connect/ui/store.ts
+++ b/packages/novu/src/commands/connect/ui/store.ts
@@ -60,10 +60,6 @@ export type Phase =
       resolve: (token: string) => void;
       reject: (reason: Error) => void;
     }
-  | {
-      kind: 'slack-setup-link';
-      setupUrl: string;
-    }
   | { kind: 'running-slack-quick-setup' }
   | {
       kind: 'slack-oauth-ready';
@@ -97,6 +93,10 @@ export type Phase =
       /** Pre-rendered ASCII QR for `t.me/botfather`. */
       botfatherQr: string;
       resolve: () => void;
+    }
+  | {
+      kind: 'pick-telegram-token-delivery';
+      resolve: (delivery: 'setup-page' | 'terminal') => void;
     }
   | {
       kind: 'telegram-link-token';

--- a/packages/novu/src/commands/connect/ui/ui.ts
+++ b/packages/novu/src/commands/connect/ui/ui.ts
@@ -7,7 +7,11 @@ export type GeneratedAgentPreviewResult = { action: 'confirm'; spec: GeneratedAg
 
 export type PickAgentIntegrationResult = { kind: 'existing'; integrationId: string } | { kind: 'new' };
 
+export type TelegramTokenDelivery = 'setup-page' | 'terminal';
+
 export interface ConnectUI {
+  /** True when running the Ink TUI; false for CI / non-TTY logging mode. */
+  readonly interactive: boolean;
   // Welcome screen
   /**
    * First screen the user sees. Renders a welcome message and waits for the
@@ -101,6 +105,8 @@ export interface ConnectUI {
    * Enter to advance.
    */
   showTelegramIntro(opts: { botfatherQr: string; botfatherUrl: string }): Promise<void>;
+  /** Interactive only: choose between the QR/setup page or pasting the token in the terminal. */
+  pickTelegramTokenDelivery(): Promise<TelegramTokenDelivery>;
   /**
    * Render the signed mobile-link QR. Fire-and-forget — the pipeline owns
    * the polling loop and transitions away from this phase when the bot token
@@ -127,9 +133,6 @@ export interface ConnectUI {
    * because the chosen Slack integration has no OAuth client credentials
    * configured yet. `retry` is true when this prompt is following an earlier
    * failed quick-setup (so the UI can hint at the cause).
-   *
-   * @deprecated Prefer {@link showSlackSetupLink} — the secure setup page keeps
-   * tokens out of the terminal and agent chat.
    */
   promptForSlackConfigToken(opts: { retry: boolean }): Promise<string>;
   /**


### PR DESCRIPTION
## Summary

- Interactive `novu connect` collects Slack App Configuration Tokens in the terminal again instead of routing through a secure setup page
- Telegram interactive flow adds a choice between QR/setup page and pasting the bot token in-terminal
- CI mode (`--ci` / non-TTY) is unchanged — secure setup links and `NOVU_CONNECT_*` handoff events are preserved for AI agent onboarding

## Why

NV-8008 applied secure setup pages to all connect runs. The interactive CLI is local with no third-party providers in the pipeline, so in-terminal token entry is appropriate there. Secure setup links remain the right path for headless CI runs where tokens must stay out of chat history.

## Architecture

```mermaid
flowchart TD
  start[runSlackQuickSetup / connectTelegram] --> flagCheck{Token flag provided?}
  flagCheck -->|yes| directSave[Save token via API]
  flagCheck -->|no| modeCheck{ui.interactive?}
  modeCheck -->|yes Slack| terminalSlack[promptForSlackConfigToken]
  modeCheck -->|yes Telegram| telegramChoice[pickTelegramTokenDelivery]
  modeCheck -->|no| setupLink[Issue setup link + poll]
  telegramChoice -->|setup-page| setupLink
  telegramChoice -->|terminal| terminalTelegram[promptForSecretInput]
  terminalSlack --> quickSetup[slackQuickSetup]
  terminalTelegram --> directSave
  setupLink --> poll[Poll until token saved]
```

## Test plan

- [x] `pnpm --filter novu build`
- [x] `pnpm vitest run src/commands/connect/ui/handoff-events.spec.ts src/commands/connect/pipeline/resolve-agent-runtime-integration.spec.ts`
- [ ] Interactive: `npx novu connect` → Slack path prompts for config token in terminal
- [ ] Interactive: `npx novu connect` → Telegram offers QR vs terminal paste choice
- [ ] CI: `npx novu connect --ci --channel slack` still prints `NOVU_CONNECT_SLACK_SETUP_URL`

## Linear

https://linear.app/novu/issue/NV-8026/restore-in-terminal-token-entry-for-interactive-novu-connect-cli

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Restores in-terminal token entry for interactive `novu connect` runs while preserving secure setup links for CI/non-TTY flows. Interactive runs now prompt for Slack config tokens directly in the terminal and let Telegram users choose between the existing QR/setup-page flow or pasting the BotFather token in-terminal. Non-interactive/CI behavior is unchanged. The UI now exposes an `interactive` flag and a new phase to capture Telegram token-delivery choice, and Telegram token validation gained bounded retries and failure handling.

## Affected areas

**js** — CLI connect pipeline and Ink/UI: updated the Connect command flow to branch on interactivity, reintroduced in-terminal Slack token entry, added `pick-telegram-token-delivery` phase and handlers for terminal vs setup-page Telegram flows, removed the unreachable `slack-setup-link` phase for interactive runs, and updated phase rendering and orb label/tint logic.

## Key technical decisions

- The ConnectUI exposes `interactive: boolean` to distinguish TTY (Ink) from non-TTY (logging/CI) flows.  
- Telegram token delivery is user-selected via a new phase and handled by two helpers: terminal-paste (with up-to-N retries and immediate abort on network/5xx errors) or setup-page polling.  
- Slack quick-setup remains link/poll-based for headless runs but uses an inline prompt for interactive runs to avoid routing through the secure setup page.

## Testing

Includes build and unit tests; interactive flows require manual verification (listed as TODO in the test plan). Automated CI behavior remains covered by existing non-interactive tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores in-terminal token collection for interactive `novu connect` runs while keeping secure setup-page links for CI/non-TTY mode. The `interactive` flag is threaded through the `ConnectUI` interface to let the pipeline branch cleanly between the two paths.

- **Slack**: `runSlackQuickSetup` now prompts for the App Configuration Token directly in the terminal when `ui.interactive` is true; non-interactive runs retain the setup-link + polling path unchanged.
- **Telegram**: A new `pick-telegram-token-delivery` phase offers the user a choice between QR/setup-page and pasting the bot token in-terminal; terminal entry uses a bounded 5-attempt retry loop (`promptAndSaveTelegramBotToken`) while the setup-page path is extracted into `waitForTelegramSetupPageToken`.
- **Phase cleanup**: The `slack-setup-link` phase is removed from the store, phase renderer, orb tint, and copyable-URL helpers; `pick-telegram-token-delivery` is added in its place for Telegram.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the CI / non-TTY path is unchanged and the new interactive branches are well-scoped.

All changed files are confined to the CLI connect pipeline and its UI layer. The interactive/non-interactive split is clearly gated on ui.interactive, existing CI behavior is preserved, and the previously unbounded Telegram retry loop is now capped at 5 attempts. The one open point (link-issuance errors surfacing as token errors) is a narrow UX rough edge rather than a data or correctness issue.

packages/novu/src/commands/connect/pipeline/channels/telegram.ts — the error classification in promptAndSaveTelegramBotToken could misattribute link-issuance failures as bad-token errors.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/channels/telegram.ts | Refactors Telegram flow to support interactive terminal token entry with a 5-attempt bounded retry loop and a setup-page fallback; clean extraction into helper functions. One concern: errors from issueTelegramMobileLink can be misattributed as bot-token validation errors and re-prompt the user. |
| packages/novu/src/commands/connect/pipeline/channels/slack.ts | Adds interactive branch to runSlackQuickSetup: prompts for token in-terminal when ui.interactive, otherwise falls back to secure setup-link polling. Logic is clean and consistent with CI mode. |
| packages/novu/src/commands/connect/ui/index.tsx | Adds interactive: true, pickTelegramTokenDelivery promise, and no-ops showSlackSetupLink. All safe — the no-op is unreachable in interactive mode due to the early-return guard in runSlackQuickSetup. |
| packages/novu/src/commands/connect/ui/store.ts | Removes slack-setup-link phase and adds pick-telegram-token-delivery phase with a typed resolve callback. Clean change. |
| packages/novu/src/commands/connect/ui/phase-content.tsx | Removes slack-setup-link UI case; adds pick-telegram-token-delivery with a Select component. Rendering logic is straightforward. |
| packages/novu/src/commands/connect/ui/ui.ts | Exports TelegramTokenDelivery type, adds interactive readonly flag, adds pickTelegramTokenDelivery to the interface, and removes the @deprecated annotation from promptForSlackConfigToken. |
| packages/novu/src/commands/connect/ui/orb/orb-tint.ts | Removes slack-setup-link from orb tint/label switch cases and adds pick-telegram-token-delivery under the Telegram tint. Mechanical and correct. |
| packages/novu/src/commands/connect/ui/phase-has-copyable-url.ts | Removes slack-setup-link from the copyable-URL phase set. Correct cleanup. |
| packages/novu/src/commands/connect/ui/logging-ui.ts | Adds interactive: false and pickTelegramTokenDelivery returning 'setup-page', correctly preserving CI-mode behavior. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[runSlackQuickSetup / connectTelegramForAgent] --> B{Token flag provided?}
  B -->|yes| C[Save token via API directly]
  B -->|no| D{ui.interactive?}
  D -->|yes - Slack| E[promptForSlackConfigToken]
  D -->|yes - Telegram| F[showTelegramIntro → pickTelegramTokenDelivery]
  D -->|no| G[Issue setup link + poll]
  E --> H[slackQuickSetup]
  F -->|terminal| I[promptAndSaveTelegramBotToken 5-attempt retry loop]
  F -->|setup-page| G
  I --> J[saveTelegramBotTokenViaMobileLink]
  G --> K[Poll until token saved]
  H --> L[Continue OAuth flow]
  J --> L
  K --> L
```

<sub>Reviews (2): Last reviewed commit: ["fix(novu): cap Telegram token retries an..."](https://github.com/novuhq/novu/commit/5519c654cccb0f424ebbe6ac6d759a30ffbd741d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37207607)</sub>

<!-- /greptile_comment -->