### PR TITLE
fix(novu): fall back to dashboard auth when keyless AI limit is hit fixes NV-8027

### DIFF
--- a/packages/novu/src/commands/connect/analytics/events.ts
+++ b/packages/novu/src/commands/connect/analytics/events.ts
@@ -5,6 +5,7 @@ export const CONNECT_EVENTS = {
   AUTH_STARTED: 'Connect Auth Started',
   AUTH_COMPLETED: 'Connect Auth Completed',
   AUTH_FAILED: 'Connect Auth Failed',
+  KEYLESS_LIMIT_AUTH_UPGRADE_STARTED: 'Connect Keyless Limit Auth Upgrade Started',
   AGENT_LISTED: 'Connect Agents Listed',
   AGENT_CREATED: 'Connect Agent Created',
   AGENT_REUSED: 'Connect Agent Reused',

--- a/packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts
+++ b/packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts
@@ -1,0 +1,44 @@
+import { type ConnectApiClient, createConnectApiClient } from '../api/client';
+import type { ConnectCommandOptions } from '../types';
+import type { ConnectUI } from '../ui/ui';
+import { type ResolvedConnectAuth, resolveConnectAuth } from './resolve-connect-auth';
+
+export interface ConnectSession {
+  auth: ResolvedConnectAuth;
+  client: ConnectApiClient;
+}
+
+export async function upgradeKeylessSessionToDashboardAuth(
+  session: ConnectSession,
+  options: ConnectCommandOptions,
+  ui: ConnectUI,
+  resolveOptions: {
+    onboardingSessionId?: string;
+    onAuthStarted?: () => void;
+    onAuthFailed?: (message: string) => void;
+  }
+): Promise<void> {
+  ui.authStatus('Daily keyless demo limit reached. Opening Novu dashboard sign-in to continue…');
+  ui.authStarted();
+
+  const auth = await resolveConnectAuth(
+    { ...options, login: true },
+    {
+      onStatus: (message) => ui.authStatus(message),
+      onDashboardUrl: (url) => ui.authDashboardUrl(url),
+      name: 'novu-connect',
+      authDashboardUrl: options.connectDashboardUrl,
+      onboardingSessionId: resolveOptions.onboardingSessionId,
+      onAuthStarted: resolveOptions.onAuthStarted,
+      onAuthFailed: resolveOptions.onAuthFailed,
+    }
+  );
+
+  ui.authCompleted(auth.environmentName ?? null);
+
+  session.auth = auth;
+  session.client = createConnectApiClient({
+    apiUrl: auth.apiUrl,
+    secretKey: auth.secretKey,
+  });
+}

--- a/packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts
+++ b/packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts
@@ -36,9 +36,11 @@ export async function upgradeKeylessSessionToDashboardAuth(
 
   ui.authCompleted(auth.environmentName ?? null);
 
-  session.auth = auth;
-  session.client = createConnectApiClient({
+  const nextClient = createConnectApiClient({
     apiUrl: auth.apiUrl,
     secretKey: auth.secretKey,
   });
+
+  session.auth = auth;
+  session.client = nextClient;
 }

--- a/packages/novu/src/commands/connect/keyless-limit-errors.spec.ts
+++ b/packages/novu/src/commands/connect/keyless-limit-errors.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CloudRegionEnum } from '../dev/enums';
 import { NovuApiError } from './api/client';
 import {
   isConnectInteractive,
@@ -12,18 +13,18 @@ describe('keyless-limit-errors', () => {
     apiUrl: 'https://api.novu.co',
     dashboardUrl: 'https://dashboard.novu.co',
     connectDashboardUrl: 'https://connect.novu.co',
-    region: 'us',
+    region: CloudRegionEnum.US,
   };
 
-  it('detects the keyless daily generate limit error', () => {
-    const err = new NovuApiError(
-      'Daily agent generation limit reached for this demo. Sign up for a free Novu account or try again tomorrow.',
-      429,
-      'POST https://api.novu.co/v1/agents/generate',
-      {}
-    );
+  const limitError = new NovuApiError(
+    'Daily agent generation limit reached for this demo. Sign up for a free Novu account or try again tomorrow.',
+    429,
+    'POST https://api.novu.co/v1/agents/generate',
+    {}
+  );
 
-    expect(isKeylessDailyGenerateLimitError(err)).toBe(true);
+  it('detects the keyless daily generate limit error', () => {
+    expect(isKeylessDailyGenerateLimitError(limitError)).toBe(true);
   });
 
   it('ignores unrelated 429 errors', () => {
@@ -32,22 +33,47 @@ describe('keyless-limit-errors', () => {
     expect(isKeylessDailyGenerateLimitError(err)).toBe(false);
   });
 
-  it('offers dashboard auth upgrade only for interactive keyless sessions', () => {
-    const err = new NovuApiError(
-      'Daily agent generation limit reached for this demo. Sign up for a free Novu account or try again tomorrow.',
-      429,
-      'POST https://api.novu.co/v1/agents/generate',
-      {}
-    );
+  describe('shouldUpgradeFromKeylessGenerateLimit', () => {
+    let stdinIsTTY: boolean | undefined;
+    let stdoutIsTTY: boolean | undefined;
+    let ciEnv: string | undefined;
 
-    expect(
-      shouldUpgradeFromKeylessGenerateLimit(err, { isKeyless: true } as never, {
-        ...baseOptions,
-        ci: true,
-      })
-    ).toBe(false);
+    beforeEach(() => {
+      stdinIsTTY = process.stdin.isTTY;
+      stdoutIsTTY = process.stdout.isTTY;
+      ciEnv = process.env.CI;
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+      delete process.env.CI;
+    });
 
-    expect(shouldUpgradeFromKeylessGenerateLimit(err, { isKeyless: false } as never, baseOptions)).toBe(false);
+    afterEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: stdinIsTTY });
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: stdoutIsTTY });
+
+      if (ciEnv === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = ciEnv;
+      }
+    });
+
+    it('returns true for interactive keyless sessions hitting the daily generate cap', () => {
+      expect(shouldUpgradeFromKeylessGenerateLimit(limitError, { isKeyless: true } as never, baseOptions)).toBe(true);
+    });
+
+    it('returns false in CI mode', () => {
+      expect(
+        shouldUpgradeFromKeylessGenerateLimit(limitError, { isKeyless: true } as never, {
+          ...baseOptions,
+          ci: true,
+        })
+      ).toBe(false);
+    });
+
+    it('returns false for authenticated clients', () => {
+      expect(shouldUpgradeFromKeylessGenerateLimit(limitError, { isKeyless: false } as never, baseOptions)).toBe(false);
+    });
   });
 
   describe('isConnectInteractive', () => {
@@ -78,6 +104,12 @@ describe('keyless-limit-errors', () => {
     it('treats TTY sessions as interactive when not in CI mode', () => {
       expect(isConnectInteractive(baseOptions)).toBe(true);
       expect(isConnectInteractive({ ...baseOptions, ci: true })).toBe(false);
+    });
+
+    it('treats any truthy CI env var as non-interactive', () => {
+      process.env.CI = '1';
+
+      expect(isConnectInteractive(baseOptions)).toBe(false);
     });
   });
 });

--- a/packages/novu/src/commands/connect/keyless-limit-errors.spec.ts
+++ b/packages/novu/src/commands/connect/keyless-limit-errors.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NovuApiError } from './api/client';
+import {
+  isConnectInteractive,
+  isKeylessDailyGenerateLimitError,
+  shouldUpgradeFromKeylessGenerateLimit,
+} from './keyless-limit-errors';
+import type { ConnectCommandOptions } from './types';
+
+describe('keyless-limit-errors', () => {
+  const baseOptions: ConnectCommandOptions = {
+    apiUrl: 'https://api.novu.co',
+    dashboardUrl: 'https://dashboard.novu.co',
+    connectDashboardUrl: 'https://connect.novu.co',
+    region: 'us',
+  };
+
+  it('detects the keyless daily generate limit error', () => {
+    const err = new NovuApiError(
+      'Daily agent generation limit reached for this demo. Sign up for a free Novu account or try again tomorrow.',
+      429,
+      'POST https://api.novu.co/v1/agents/generate',
+      {}
+    );
+
+    expect(isKeylessDailyGenerateLimitError(err)).toBe(true);
+  });
+
+  it('ignores unrelated 429 errors', () => {
+    const err = new NovuApiError('Too many requests', 429, 'POST https://api.novu.co/v1/agents/generate', {});
+
+    expect(isKeylessDailyGenerateLimitError(err)).toBe(false);
+  });
+
+  it('offers dashboard auth upgrade only for interactive keyless sessions', () => {
+    const err = new NovuApiError(
+      'Daily agent generation limit reached for this demo. Sign up for a free Novu account or try again tomorrow.',
+      429,
+      'POST https://api.novu.co/v1/agents/generate',
+      {}
+    );
+
+    expect(
+      shouldUpgradeFromKeylessGenerateLimit(err, { isKeyless: true } as never, {
+        ...baseOptions,
+        ci: true,
+      })
+    ).toBe(false);
+
+    expect(shouldUpgradeFromKeylessGenerateLimit(err, { isKeyless: false } as never, baseOptions)).toBe(false);
+  });
+
+  describe('isConnectInteractive', () => {
+    let stdinIsTTY: boolean | undefined;
+    let stdoutIsTTY: boolean | undefined;
+    let ciEnv: string | undefined;
+
+    beforeEach(() => {
+      stdinIsTTY = process.stdin.isTTY;
+      stdoutIsTTY = process.stdout.isTTY;
+      ciEnv = process.env.CI;
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+      delete process.env.CI;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: stdinIsTTY });
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: stdoutIsTTY });
+
+      if (ciEnv === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = ciEnv;
+      }
+    });
+
+    it('treats TTY sessions as interactive when not in CI mode', () => {
+      expect(isConnectInteractive(baseOptions)).toBe(true);
+      expect(isConnectInteractive({ ...baseOptions, ci: true })).toBe(false);
+    });
+  });
+});

--- a/packages/novu/src/commands/connect/keyless-limit-errors.ts
+++ b/packages/novu/src/commands/connect/keyless-limit-errors.ts
@@ -1,0 +1,49 @@
+import type { ConnectApiClient } from './api/client';
+import { NovuApiError } from './api/client';
+import type { ConnectCommandOptions } from './types';
+
+const KEYLESS_DAILY_GENERATE_LIMIT_SNIPPET = 'Daily agent generation limit reached';
+
+export function isConnectInteractive(options: ConnectCommandOptions): boolean {
+  if (options.ci) {
+    return false;
+  }
+
+  if (process.env.CI === 'true') {
+    return false;
+  }
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isKeylessDailyGenerateLimitError(err: unknown): boolean {
+  if (!(err instanceof NovuApiError)) {
+    return false;
+  }
+
+  if (err.status !== 429) {
+    return false;
+  }
+
+  return err.message.includes(KEYLESS_DAILY_GENERATE_LIMIT_SNIPPET);
+}
+
+export function shouldUpgradeFromKeylessGenerateLimit(
+  err: unknown,
+  client: ConnectApiClient,
+  options: ConnectCommandOptions
+): boolean {
+  if (!client.isKeyless) {
+    return false;
+  }
+
+  if (!isConnectInteractive(options)) {
+    return false;
+  }
+
+  return isKeylessDailyGenerateLimitError(err);
+}

--- a/packages/novu/src/commands/connect/keyless-limit-errors.ts
+++ b/packages/novu/src/commands/connect/keyless-limit-errors.ts
@@ -9,7 +9,7 @@ export function isConnectInteractive(options: ConnectCommandOptions): boolean {
     return false;
   }
 
-  if (process.env.CI === 'true') {
+  if (process.env.CI) {
     return false;
   }
 

--- a/packages/novu/src/commands/connect/pipeline/runner.ts
+++ b/packages/novu/src/commands/connect/pipeline/runner.ts
@@ -11,8 +11,10 @@ import { type ConnectApiClient, createConnectApiClient, NovuApiError } from '../
 import { deleteIntegration, type IntegrationRecord } from '../api/integrations';
 import { upsertSubscriber } from '../api/subscribers';
 import { type ResolvedConnectAuth, resolveConnectAuth } from '../auth/resolve-connect-auth';
+import { type ConnectSession, upgradeKeylessSessionToDashboardAuth } from '../auth/upgrade-keyless-session';
 import { buildConnectAgentDetailsUrl, channelDisplayName } from '../dashboard-urls';
 import { ConnectChannelBackError } from '../errors';
+import { shouldUpgradeFromKeylessGenerateLimit } from '../keyless-limit-errors';
 import type { AgentSummary, ChannelChoice, ConnectCommandOptions } from '../types';
 import type { ConnectUI } from '../ui/ui';
 import { connectEmailForAgent } from './channels/email';
@@ -62,12 +64,18 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
       input.onIdentityResolved?.(auth.user);
     }
 
-    const client = auth.isKeyless
-      ? createConnectApiClient({ apiUrl: auth.apiUrl, keylessApplicationIdentifier: auth.keylessApplicationIdentifier })
-      : createConnectApiClient({ apiUrl: auth.apiUrl, secretKey: auth.secretKey });
+    const session: ConnectSession = {
+      auth,
+      client: auth.isKeyless
+        ? createConnectApiClient({
+            apiUrl: auth.apiUrl,
+            keylessApplicationIdentifier: auth.keylessApplicationIdentifier,
+          })
+        : createConnectApiClient({ apiUrl: auth.apiUrl, secretKey: auth.secretKey }),
+    };
 
     ui.listingAgents();
-    const existingAgents = await listAgents(client);
+    const existingAgents = await listAgents(session.client);
     track(CONNECT_EVENTS.AGENT_LISTED, { count: existingAgents.length, ...sessionProps });
 
     let agent: AgentSummary;
@@ -80,12 +88,16 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
         flow = 'reused';
         track(CONNECT_EVENTS.AGENT_REUSED, { identifier: agent.identifier, ...sessionProps });
       } else {
-        agent = await createAgentFlow(client, ui, options, auth.environmentId, track, sessionProps);
+        agent = await createAgentFlow(session, ui, options, track, sessionProps, onboardingSessionId, {
+          onIdentityResolved: input.onIdentityResolved,
+        });
         flow = 'created';
         track(CONNECT_EVENTS.AGENT_CREATED, { identifier: agent.identifier, ...sessionProps });
       }
     } else {
-      agent = await createAgentFlow(client, ui, options, auth.environmentId, track, sessionProps);
+      agent = await createAgentFlow(session, ui, options, track, sessionProps, onboardingSessionId, {
+        onIdentityResolved: input.onIdentityResolved,
+      });
       flow = 'created';
       track(CONNECT_EVENTS.AGENT_CREATED, { identifier: agent.identifier, ...sessionProps });
     }
@@ -119,13 +131,13 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
             ui.slackSkipped();
             break;
           case 'slack': {
-            const subscriberId = await ensureSubscriberForUser(client, auth);
+            const subscriberId = await ensureSubscriberForUser(session.client, session.auth);
             const result = await connectSlackForAgent(
-              client,
+              session.client,
               agent,
               ui,
               options,
-              auth.environmentId,
+              session.auth.environmentId,
               subscriberId,
               track
             );
@@ -135,13 +147,13 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
             break;
           }
           case 'telegram': {
-            const subscriberId = await ensureSubscriberForUser(client, auth);
+            const subscriberId = await ensureSubscriberForUser(session.client, session.auth);
             const result = await connectTelegramForAgent(
-              client,
+              session.client,
               agent,
               ui,
               options,
-              auth.environmentId,
+              session.auth.environmentId,
               subscriberId,
               track
             );
@@ -151,9 +163,9 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
             break;
           }
           case 'email': {
-            await ensureSubscriberForUser(client, auth);
-            const sendFromEmail = auth.user?.email?.trim() || undefined;
-            const result = await connectEmailForAgent(client, agent, ui, track, {
+            await ensureSubscriberForUser(session.client, session.auth);
+            const sendFromEmail = session.auth.user?.email?.trim() || undefined;
+            const result = await connectEmailForAgent(session.client, agent, ui, track, {
               sendFromEmail,
               canGoBack: allowChannelPickerBack,
             });
@@ -166,7 +178,7 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
           case 'teams': {
             const agentDetailsUrl = buildConnectAgentDetailsUrl({
               connectDashboardUrl: options.connectDashboardUrl,
-              environmentSlug: auth.environmentSlug,
+              environmentSlug: session.auth.environmentSlug,
               agentIdentifier: agent.identifier,
               tab: 'integrations',
             });
@@ -199,7 +211,7 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
     if (channelConnected && connectedIntegration) {
       ui.sendingWelcome();
       try {
-        await sendAgentWelcomeMessage(client, agent.identifier, connectedIntegration.identifier);
+        await sendAgentWelcomeMessage(session.client, agent.identifier, connectedIntegration.identifier);
         track(CONNECT_EVENTS.WELCOME_SENT, { agent: agent.identifier, ...sessionProps });
       } catch (err) {
         ui.failure(`Could not send the welcome message: ${describeError(err)}`);
@@ -208,9 +220,9 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
 
     ui.success({
       agent,
-      dashboardUrl: auth.dashboardUrl.replace(/\/$/, ''),
+      dashboardUrl: session.auth.dashboardUrl.replace(/\/$/, ''),
       connectDashboardUrl: options.connectDashboardUrl.replace(/\/$/, ''),
-      environmentSlug: auth.environmentSlug ?? null,
+      environmentSlug: session.auth.environmentSlug ?? null,
       connectedChannel,
       dashboardRedirectChannel,
     });
@@ -238,12 +250,15 @@ export async function runConnectPipeline(input: ConnectPipelineInput): Promise<C
 }
 
 async function createAgentFlow(
-  client: ConnectApiClient,
+  session: ConnectSession,
   ui: ConnectUI,
   options: ConnectCommandOptions,
-  environmentId: string,
   track: (event: string, data?: Record<string, unknown>) => void,
-  sessionProps: Record<string, unknown>
+  sessionProps: Record<string, unknown>,
+  onboardingSessionId?: string,
+  callbacks?: {
+    onIdentityResolved?: (user: NonNullable<ResolvedConnectAuth['user']>) => void;
+  }
 ): Promise<AgentSummary> {
   const runtime =
     resolveRuntimeFromOptions(options) ??
@@ -258,15 +273,27 @@ async function createAgentFlow(
   }
 
   ui.loadingIntegrations();
-  const resolved = await resolveAgentRuntimeIntegration(client, ui, options, runtime, environmentId);
+  let resolved = await resolveAgentRuntimeIntegration(session.client, ui, options, runtime, session.auth.environmentId);
 
   const prompt = await ui.promptForDescription(options.prompt);
-  const generated = await generateAndPreviewAgent(client, ui, prompt.trim(), track, sessionProps);
+  const generated = await generateAndPreviewAgent(
+    session,
+    ui,
+    options,
+    prompt.trim(),
+    track,
+    sessionProps,
+    onboardingSessionId,
+    callbacks,
+    async () => {
+      resolved = await resolveAgentRuntimeIntegration(session.client, ui, options, runtime, session.auth.environmentId);
+    }
+  );
 
   ui.creatingAgent(generated.name);
 
   try {
-    const created = await createManagedAgent(client, {
+    const created = await createManagedAgent(session.client, {
       name: generated.name,
       identifier: generated.identifier,
       integrationId: resolved.integrationId,
@@ -281,7 +308,7 @@ async function createAgentFlow(
   } catch (err) {
     if (resolved.createdInThisFlow) {
       try {
-        await deleteIntegration(client, resolved.integrationId);
+        await deleteIntegration(session.client, resolved.integrationId);
       } catch {
         // Best-effort cleanup.
       }
@@ -291,12 +318,62 @@ async function createAgentFlow(
   }
 }
 
-async function generateAndPreviewAgent(
-  client: ConnectApiClient,
+async function withKeylessGenerateLimitFallback<T>(
+  session: ConnectSession,
+  options: ConnectCommandOptions,
   ui: ConnectUI,
+  onboardingSessionId: string | undefined,
+  track: (event: string, data?: Record<string, unknown>) => void,
+  sessionProps: Record<string, unknown>,
+  callbacks: { onIdentityResolved?: (user: NonNullable<ResolvedConnectAuth['user']>) => void } | undefined,
+  onUpgraded: () => Promise<void>,
+  run: () => Promise<T>
+): Promise<T> {
+  try {
+    return await run();
+  } catch (err) {
+    if (!shouldUpgradeFromKeylessGenerateLimit(err, session.client, options)) {
+      throw err;
+    }
+
+    track(CONNECT_EVENTS.KEYLESS_LIMIT_AUTH_UPGRADE_STARTED, sessionProps);
+
+    await upgradeKeylessSessionToDashboardAuth(session, options, ui, {
+      onboardingSessionId,
+      onAuthStarted: () => track(CONNECT_EVENTS.AUTH_STARTED, { ...sessionProps, source: 'keyless_limit_upgrade' }),
+      onAuthFailed: (message) =>
+        track(CONNECT_EVENTS.AUTH_FAILED, { ...sessionProps, source: 'keyless_limit_upgrade', message }),
+    });
+
+    track(CONNECT_EVENTS.AUTH_COMPLETED, {
+      source: 'keyless_limit_upgrade',
+      region: options.region,
+      keyless: false,
+      ...sessionProps,
+    });
+
+    if (session.auth.user?.id) {
+      callbacks?.onIdentityResolved?.(session.auth.user);
+    }
+
+    await onUpgraded();
+
+    return run();
+  }
+}
+
+async function generateAndPreviewAgent(
+  session: ConnectSession,
+  ui: ConnectUI,
+  options: ConnectCommandOptions,
   initialPrompt: string,
   track: (event: string, data?: Record<string, unknown>) => void,
-  sessionProps: Record<string, unknown>
+  sessionProps: Record<string, unknown>,
+  onboardingSessionId?: string,
+  callbacks?: {
+    onIdentityResolved?: (user: NonNullable<ResolvedConnectAuth['user']>) => void;
+  },
+  onSessionUpgraded?: () => Promise<void>
 ): Promise<Awaited<ReturnType<typeof generateAgent>>> {
   let prompt = initialPrompt;
 
@@ -306,7 +383,18 @@ async function generateAndPreviewAgent(
     }
 
     ui.generatingAgent();
-    const generated = await generateAgent(client, prompt.trim());
+
+    const generated = await withKeylessGenerateLimitFallback(
+      session,
+      options,
+      ui,
+      onboardingSessionId,
+      track,
+      sessionProps,
+      callbacks,
+      onSessionUpgraded ?? (async () => undefined),
+      () => generateAgent(session.client, prompt.trim())
+    );
     track(CONNECT_EVENTS.AGENT_PROMPT_GENERATED, {
       promptLength: prompt.trim().length,
       toolsCount: generated.tools.length,


### PR DESCRIPTION
### What changed? Why was the change needed?

Interactive `novu connect` now detects the keyless daily agent generation limit (429) and automatically opens the `/cli/auth` dashboard sign-in flow, switches to the authenticated API client, re-resolves the agent runtime integration, and retries generation instead of exiting.

Non-interactive runs (`--ci`, non-TTY) still fail fast with the existing error.

Linear: https://linear.app/novu/issue/NV-8027/connect-cli-fall-back-to-dashboard-auth-when-keyless-ai-generate-limit

```mermaid
flowchart TD
  A[POST /v1/agents/generate] --> B{429 keyless daily cap?}
  B -->|No| C[Continue connect flow]
  B -->|Yes, interactive| D[Open /cli/auth]
  D --> E[Authenticated API client]
  E --> F[Re-resolve runtime integration]
  F --> G[Retry generate]
  B -->|Yes, non-interactive| H[Exit with error]
```

### Screenshots

N/A — CLI behavior change only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Upgrade path is gated to interactive keyless sessions only (`shouldUpgradeFromKeylessGenerateLimit`).
- Session state (`auth` + `client`) is updated in place so later channel setup uses the signed-in environment.
- Added analytics event: `Connect Keyless Limit Auth Upgrade Started`.

</details>

## Test plan

- [x] `pnpm exec vitest run src/commands/connect/keyless-limit-errors.spec.ts`
- [ ] Run `npx novu connect` interactively in keyless mode after hitting the daily generate cap; confirm `/cli/auth` opens and generation retries after sign-in
- [ ] Confirm `--ci` mode still exits with 429 when the keyless cap is hit

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The `novu connect` CLI now detects the keyless daily agent-generation limit (HTTP 429) and, for interactive TTY sessions, automatically opens the dashboard sign-in flow, upgrades the session to an authenticated API client, re-resolves the agent runtime integration, and retries generation instead of exiting. Non-interactive runs (CI or non-TTY) keep failing fast. This prevents interactive users from being blocked by the keyless quota and records when an upgrade starts.

## Affected areas

**js**: Connect CLI behavior updated—agent generation flow now carries a ConnectSession (auth + client) through the pipeline; a fallback wrapper intercepts keyless-limit 429s, triggers an interactive dashboard auth upgrade, rebuilds the authenticated API client, mutates the session in-place, and retries generation; added analytics event "Connect Keyless Limit Auth Upgrade Started"; introduced helper checks for interactive environments and keyless-limit error detection.

## Key technical decisions

- The upgrade is gated to interactive sessions (TTY && not CI) to avoid surprising CI/non-interactive runs.  
- The authenticated API client is built before mutating session state to avoid partial mutations on client-creation failure.  
- Session state is mutated in-place (ConnectSession) so downstream steps use upgraded credentials without large refactors.  
- Fallback logic lives in a dedicated withKeylessGenerateLimitFallback wrapper to keep error handling separate from core generation logic.

## Testing

Added Vitest unit tests covering error detection, interactive/CI detection, and upgrade eligibility (keyless-limit-errors.spec.ts) plus tests and fixes for runner behavior; PR notes include manual verification steps for interactive and CI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a graceful fallback for interactive `novu connect` sessions when the keyless daily agent-generation limit (HTTP 429) is hit: instead of exiting, the CLI opens the dashboard sign-in flow, upgrades the in-place `ConnectSession`, re-resolves the runtime integration, and retries generation. Non-interactive / CI runs fail fast as before.

- Introduces `ConnectSession` interface and `upgradeKeylessSessionToDashboardAuth` to encapsulate in-place session mutation; `nextClient` is now constructed before any field is written, fixing the partial-mutation risk.
- Adds `withKeylessGenerateLimitFallback` wrapper in `runner.ts` that catches only the targeted keyless 429, gates on `isConnectInteractive`, and performs a single upgrade+retry without infinite-loop risk.
- Unit tests cover the happy path, CI-mode fast-fail, and authenticated-client no-op; the `CI` env-var guard correctly uses a truthy check to cover `CI=1`, `CI=yes`, etc.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the upgrade path is well-isolated and all three issues flagged in the prior review round have been addressed.

The session mutation ordering fix (build client before writing fields), the truthy CI-env check, and the missing positive test have all been correctly addressed. Remaining notes are minor: a keyless integration may be orphaned in the temporary demo environment when the upgrade path is taken, and one TTY=false branch in isConnectInteractive lacks a unit test — neither affects correctness of the authenticated flow.

runner.ts around the resolveAgentRuntimeIntegration/onUpgraded interaction; keyless-limit-errors.spec.ts for the non-TTY test gap.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/analytics/events.ts | Adds KEYLESS_LIMIT_AUTH_UPGRADE_STARTED analytics event constant; trivial one-liner addition. |
| packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts | New file implementing session upgrade logic; correctly builds nextClient before mutating the session object, avoiding the partial-mutation race addressed in a prior review. |
| packages/novu/src/commands/connect/keyless-limit-errors.ts | New helpers for detecting the keyless 429 and checking interactivity; CI guard correctly uses truthy check for all CI env var values. |
| packages/novu/src/commands/connect/keyless-limit-errors.spec.ts | Good coverage of happy path, CI mode, and authenticated-client no-op; missing a test for the non-TTY branch of isConnectInteractive. |
| packages/novu/src/commands/connect/pipeline/runner.ts | Refactored to use ConnectSession; withKeylessGenerateLimitFallback correctly wraps only the generate call; keyless integration resolved before upgrade may be orphaned when onUpgraded re-resolves under authenticated context. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[runConnectPipeline] --> B[resolveConnectAuth - keyless]
  B --> C[createConnectApiClient - keyless]
  C --> D{existingAgents?}
  D -->|yes| E[pick or create]
  D -->|no| F[createAgentFlow]
  E --> F
  F --> G[resolveAgentRuntimeIntegration - keyless]
  G --> H[ui.promptForDescription]
  H --> I[generateAndPreviewAgent loop]
  I --> J[withKeylessGenerateLimitFallback]
  J --> K[generateAgent - keyless client]
  K -->|success| L[user confirm/refine]
  L -->|confirm| M[createManagedAgent]
  L -->|refine| I
  K -->|429 keyless limit| N{isConnectInteractive?}
  N -->|no - CI/non-TTY| O[throw error - exit 1]
  N -->|yes| P[upgradeKeylessSessionToDashboardAuth]
  P --> Q[resolveConnectAuth - login:true]
  Q --> R[session.auth + session.client mutated]
  R --> S[onUpgraded - re-resolve integration]
  S --> T[retry generateAgent - auth client]
  T -->|success| L
  T -->|error| O
```

<sub>Reviews (2): Last reviewed commit: ["fix(novu): address PR review and fix con..."](https://github.com/novuhq/novu/commit/4e8fb65ffed3cfff70ae78721381ca88ed0d9b60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37242747)</sub>

<!-- /greptile_comment -->