### PR TITLE
fix(api-service): use timing-safe comparisons for secret validation fixes NV-8031

### DIFF
--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
@@ -3,6 +3,7 @@ import { createHash, PinoLogger } from '@novu/application-generic';
 import { EnvironmentRepository, McpConnectionRepository } from '@novu/dal';
 import { buildClaudePlatformVaultUrl, McpConnectionScopeEnum, McpConnectionStatusEnum } from '@novu/shared';
 
+import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
 import { CompleteManagedAgentSetup } from '../../../managed-runtime/setup/complete-managed-agent-setup.usecase';
 import { ManagedAgentSetupCompleteCommand } from '../../../managed-runtime/setup/managed-agent-setup-complete.command';
 import type { McpOAuthState } from '../../oauth/generate-mcp-oauth-url/mcp-oauth-state';
@@ -55,7 +56,9 @@ export class CompleteProviderManagedRedirect {
       throw new NotFoundException('Environment for redirect state not found or has no API keys.');
     }
 
-    const isValidSignature = environment.apiKeys.some(({ key }) => createHash(key, rawPayload) === signature);
+    const isValidSignature = environment.apiKeys.some(
+      ({ key }) => areHexDigestsEqual(createHash(key, rawPayload), signature)
+    );
     if (!isValidSignature) {
       throw new BadRequestException('Provider-managed redirect signature mismatch.');
     }

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts
@@ -3,7 +3,7 @@ import { createHash, PinoLogger } from '@novu/application-generic';
 import { EnvironmentRepository, McpConnectionRepository } from '@novu/dal';
 import { buildClaudePlatformVaultUrl, McpConnectionScopeEnum, McpConnectionStatusEnum } from '@novu/shared';
 
-import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../../../shared/helpers/timing-safe-equal';
 import { CompleteManagedAgentSetup } from '../../../managed-runtime/setup/complete-managed-agent-setup.usecase';
 import { ManagedAgentSetupCompleteCommand } from '../../../managed-runtime/setup/managed-agent-setup-complete.command';
 import type { McpOAuthState } from '../../oauth/generate-mcp-oauth-url/mcp-oauth-state';

--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
@@ -28,6 +28,7 @@ import {
   type McpTokenEndpointAuthMethod,
   resolvePersistedMcpTokenEndpointAuthMethod,
 } from '@novu/shared';
+import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
 import { CompleteManagedAgentSetup } from '../../../managed-runtime/setup/complete-managed-agent-setup.usecase';
 import { ManagedAgentSetupCompleteCommand } from '../../../managed-runtime/setup/managed-agent-setup-complete.command';
 import { trackAgentMcpOAuthCompleted, trackAgentMcpOAuthFailed } from '../../../shared/analytics/agent-analytics';
@@ -854,7 +855,7 @@ export class McpOAuthCallback {
     const apiKey = environment.apiKeys[0].key;
     const expected = createHash(apiKey, parts.payload);
 
-    if (parts.signature !== expected) {
+    if (!areHexDigestsEqual(expected, parts.signature)) {
       throw new BadRequestException('OAuth state signature mismatch.');
     }
 

--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
@@ -28,7 +28,7 @@ import {
   type McpTokenEndpointAuthMethod,
   resolvePersistedMcpTokenEndpointAuthMethod,
 } from '@novu/shared';
-import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../../../shared/helpers/timing-safe-equal';
 import { CompleteManagedAgentSetup } from '../../../managed-runtime/setup/complete-managed-agent-setup.usecase';
 import { ManagedAgentSetupCompleteCommand } from '../../../managed-runtime/setup/managed-agent-setup-complete.command';
 import { trackAgentMcpOAuthCompleted, trackAgentMcpOAuthFailed } from '../../../shared/analytics/agent-analytics';

--- a/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
@@ -7,6 +7,7 @@ import {
   AzureSetupStateData,
   GenerateAzureSetupOauthUrl,
 } from '../generate-azure-setup-oauth-url/generate-azure-setup-oauth-url.usecase';
+import { areHexDigestsEqual } from '../../../shared/helpers/is-valid-hmac';
 import { splitOAuthState } from '../generate-chat-oath-url/chat-oauth-state.util';
 import { AzureSetupOauthCallbackCommand } from './azure-setup-oauth-callback.command';
 
@@ -142,7 +143,7 @@ export class AzureSetupOauthCallback {
     try {
       const expectedSignature = createHash(signingKey, payload);
 
-      if (signature !== expectedSignature) {
+      if (!areHexDigestsEqual(expectedSignature, signature)) {
         throw new Error('Signature mismatch');
       }
 

--- a/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
@@ -7,7 +7,7 @@ import {
   AzureSetupStateData,
   GenerateAzureSetupOauthUrl,
 } from '../generate-azure-setup-oauth-url/generate-azure-setup-oauth-url.usecase';
-import { areHexDigestsEqual } from '../../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../../shared/helpers/timing-safe-equal';
 import { splitOAuthState } from '../generate-chat-oath-url/chat-oauth-state.util';
 import { AzureSetupOauthCallbackCommand } from './azure-setup-oauth-callback.command';
 

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { createHash } from '@novu/application-generic';
 import { EnvironmentRepository, ICredentialsEntity, IntegrationEntity, SubscriberRepository } from '@novu/dal';
 import { ChatProviderIdEnum, ContextPayload } from '@novu/shared';
-import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../../../shared/helpers/timing-safe-equal';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../chat-oauth.constants';
 import { encodeOAuthState, splitOAuthState } from '../chat-oauth-state.util';
 import { GenerateMsTeamsOauthUrlCommand } from './generate-msteams-oauth-url.command';

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { createHash } from '@novu/application-generic';
 import { EnvironmentRepository, ICredentialsEntity, IntegrationEntity, SubscriberRepository } from '@novu/dal';
 import { ChatProviderIdEnum, ContextPayload } from '@novu/shared';
+import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../chat-oauth.constants';
 import { encodeOAuthState, splitOAuthState } from '../chat-oauth-state.util';
 import { GenerateMsTeamsOauthUrlCommand } from './generate-msteams-oauth-url.command';
@@ -169,7 +170,7 @@ export class GenerateMsTeamsOauthUrl {
       const { payload, signature } = splitOAuthState(state);
 
       const expectedSignature = createHash(environmentApiKey, payload);
-      if (signature !== expectedSignature) {
+      if (!areHexDigestsEqual(expectedSignature, signature)) {
         throw new Error('Invalid state signature');
       }
 

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -20,7 +20,7 @@ import {
   ContextPayload,
   SLACK_AGENT_OAUTH_SCOPES,
 } from '@novu/shared';
-import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../../../shared/helpers/timing-safe-equal';
 import { validateConnectionMode } from '../../../../channel-connections/usecases/channel-connection.utils';
 import { ensureConnectDashboardSubscriber } from '../../../../channel-connections/usecases/ensure-connect-dashboard-subscriber';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../chat-oauth.constants';

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -20,6 +20,7 @@ import {
   ContextPayload,
   SLACK_AGENT_OAUTH_SCOPES,
 } from '@novu/shared';
+import { areHexDigestsEqual } from '../../../../shared/helpers/is-valid-hmac';
 import { validateConnectionMode } from '../../../../channel-connections/usecases/channel-connection.utils';
 import { ensureConnectDashboardSubscriber } from '../../../../channel-connections/usecases/ensure-connect-dashboard-subscriber';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../chat-oauth.constants';
@@ -211,7 +212,7 @@ export class GenerateSlackOauthUrl {
       const { payload, signature } = splitOAuthState(state);
 
       const expectedSignature = createHash(environmentApiKey, payload);
-      if (signature !== expectedSignature) {
+      if (!areHexDigestsEqual(expectedSignature, signature)) {
         throw new Error('Invalid state signature');
       }
 

--- a/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.usecase.ts
@@ -3,6 +3,7 @@ import { GetDecryptedIntegrations } from '@novu/application-generic';
 import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { ChatProviderIdEnum } from '@novu/shared';
 import { createHmac } from 'crypto';
+import { areHexDigestsEqual } from '../../../shared/helpers/is-valid-hmac';
 import { GenerateMsTeamsArmTemplateCommand } from './generate-msteams-arm-template.command';
 
 const ARM_TEMPLATE_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
@@ -74,7 +75,7 @@ export class GenerateMsTeamsArmTemplate {
     const payload = `${integrationId}:${expMs}`;
     const expected = createHmac('sha256', signingKey).update(payload).digest('hex');
 
-    if (sig !== expected) {
+    if (!areHexDigestsEqual(expected, sig)) {
       throw new UnauthorizedException('Invalid ARM template signature');
     }
   }

--- a/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.usecase.ts
@@ -3,7 +3,7 @@ import { GetDecryptedIntegrations } from '@novu/application-generic';
 import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { ChatProviderIdEnum } from '@novu/shared';
 import { createHmac } from 'crypto';
-import { areHexDigestsEqual } from '../../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../../shared/helpers/timing-safe-equal';
 import { GenerateMsTeamsArmTemplateCommand } from './generate-msteams-arm-template.command';
 
 const ARM_TEMPLATE_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes

--- a/apps/api/src/app/internal/guards/internal-callback.guard.ts
+++ b/apps/api/src/app/internal/guards/internal-callback.guard.ts
@@ -1,5 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import { areStringsEqual } from '../../shared/helpers/is-valid-hmac';
+import { areStringsEqual } from '../../shared/helpers/timing-safe-equal';
 
 @Injectable()
 export class InternalCallbackGuard implements CanActivate {

--- a/apps/api/src/app/internal/guards/internal-callback.guard.ts
+++ b/apps/api/src/app/internal/guards/internal-callback.guard.ts
@@ -1,4 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { getRequestHeaderValue } from '../../shared/helpers/get-request-header-value';
 import { areStringsEqual } from '../../shared/helpers/timing-safe-equal';
 
 @Injectable()
@@ -6,7 +7,7 @@ export class InternalCallbackGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
 
-    const authHeader = request.headers['authorization'];
+    const authHeader = getRequestHeaderValue(request.headers['authorization']);
     if (!authHeader) {
       throw new UnauthorizedException('Authorization header is missing');
     }

--- a/apps/api/src/app/internal/guards/internal-callback.guard.ts
+++ b/apps/api/src/app/internal/guards/internal-callback.guard.ts
@@ -1,4 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { areStringsEqual } from '../../shared/helpers/is-valid-hmac';
 
 @Injectable()
 export class InternalCallbackGuard implements CanActivate {
@@ -17,7 +18,7 @@ export class InternalCallbackGuard implements CanActivate {
       throw new UnauthorizedException('INTERNAL_CALLBACK_API_KEY is not configured');
     }
 
-    if (token !== expectedApiKey) {
+    if (!areStringsEqual(expectedApiKey, token)) {
       throw new UnauthorizedException('Invalid internal callback API key');
     }
 

--- a/apps/api/src/app/partner-integrations/usecases/process-vercel-webhook/process-vercel-webhook.usecase.ts
+++ b/apps/api/src/app/partner-integrations/usecases/process-vercel-webhook/process-vercel-webhook.usecase.ts
@@ -8,7 +8,7 @@ import {
   EnvironmentRepository,
   MemberRepository,
 } from '@novu/dal';
-import { areHexDigestsEqual } from '../../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../../shared/helpers/timing-safe-equal';
 import { Sync } from '../../../bridge/usecases/sync';
 import { ProcessVercelWebhookCommand } from './process-vercel-webhook.command';
 

--- a/apps/api/src/app/partner-integrations/usecases/process-vercel-webhook/process-vercel-webhook.usecase.ts
+++ b/apps/api/src/app/partner-integrations/usecases/process-vercel-webhook/process-vercel-webhook.usecase.ts
@@ -8,6 +8,7 @@ import {
   EnvironmentRepository,
   MemberRepository,
 } from '@novu/dal';
+import { areHexDigestsEqual } from '../../../shared/helpers/is-valid-hmac';
 import { Sync } from '../../../bridge/usecases/sync';
 import { ProcessVercelWebhookCommand } from './process-vercel-webhook.command';
 
@@ -138,7 +139,7 @@ export class ProcessVercelWebhook {
 
     const computedSignature = crypto.createHmac('sha1', secret).update(JSON.stringify(body)).digest('hex');
 
-    if (signature !== computedSignature) {
+    if (!areHexDigestsEqual(computedSignature, signature)) {
       throw new BadRequestException('Invalid signature');
     }
   }

--- a/apps/api/src/app/shared/helpers/get-request-header-value.ts
+++ b/apps/api/src/app/shared/helpers/get-request-header-value.ts
@@ -1,0 +1,7 @@
+export function getRequestHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}

--- a/apps/api/src/app/shared/helpers/is-valid-hmac.ts
+++ b/apps/api/src/app/shared/helpers/is-valid-hmac.ts
@@ -2,6 +2,17 @@ import { timingSafeEqual } from 'node:crypto';
 import { createContextHash, createHash, decryptApiKey } from '@novu/application-generic';
 import { ContextPayload } from '@novu/shared';
 
+export function areStringsEqual(expected: string, provided: string): boolean {
+  const expectedBuffer = Buffer.from(expected);
+  const providedBuffer = Buffer.from(provided);
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
 export function areHexDigestsEqual(expected: string, provided: string): boolean {
   if (expected.length !== provided.length) {
     return false;

--- a/apps/api/src/app/shared/helpers/is-valid-hmac.ts
+++ b/apps/api/src/app/shared/helpers/is-valid-hmac.ts
@@ -1,32 +1,6 @@
-import { timingSafeEqual } from 'node:crypto';
 import { createContextHash, createHash, decryptApiKey } from '@novu/application-generic';
 import { ContextPayload } from '@novu/shared';
-
-export function areStringsEqual(expected: string, provided: string): boolean {
-  const expectedBuffer = Buffer.from(expected);
-  const providedBuffer = Buffer.from(provided);
-
-  if (expectedBuffer.length !== providedBuffer.length) {
-    return false;
-  }
-
-  return timingSafeEqual(expectedBuffer, providedBuffer);
-}
-
-export function areHexDigestsEqual(expected: string, provided: string): boolean {
-  if (expected.length !== provided.length) {
-    return false;
-  }
-
-  const expectedBuffer = Buffer.from(expected, 'hex');
-  const providedBuffer = Buffer.from(provided, 'hex');
-
-  if (expectedBuffer.length !== providedBuffer.length) {
-    return false;
-  }
-
-  return timingSafeEqual(expectedBuffer, providedBuffer);
-}
+import { areHexDigestsEqual } from './timing-safe-equal';
 
 export function isHmacValid(secretKey: string, subscriberId: string, hmacHash: string | undefined) {
   if (!hmacHash) {

--- a/apps/api/src/app/shared/helpers/timing-safe-equal.ts
+++ b/apps/api/src/app/shared/helpers/timing-safe-equal.ts
@@ -14,7 +14,9 @@ export function areStringsEqual(
   const paddedExpected = Buffer.concat([expectedBuffer, Buffer.alloc(maxLen - expectedBuffer.length)]);
   const paddedProvided = Buffer.concat([providedBuffer, Buffer.alloc(maxLen - providedBuffer.length)]);
 
-  return expectedBuffer.length === providedBuffer.length && timingSafeEqual(paddedExpected, paddedProvided);
+  const timingResult = timingSafeEqual(paddedExpected, paddedProvided);
+
+  return timingResult && expectedBuffer.length === providedBuffer.length;
 }
 
 export function areHexDigestsEqual(

--- a/apps/api/src/app/shared/helpers/timing-safe-equal.ts
+++ b/apps/api/src/app/shared/helpers/timing-safe-equal.ts
@@ -1,0 +1,27 @@
+import { timingSafeEqual } from 'node:crypto';
+
+export function areStringsEqual(expected: string, provided: string): boolean {
+  const expectedBuffer = Buffer.from(expected);
+  const providedBuffer = Buffer.from(provided);
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
+export function areHexDigestsEqual(expected: string, provided: string): boolean {
+  if (expected.length !== provided.length) {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  const providedBuffer = Buffer.from(provided, 'hex');
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer);
+}

--- a/apps/api/src/app/shared/helpers/timing-safe-equal.ts
+++ b/apps/api/src/app/shared/helpers/timing-safe-equal.ts
@@ -1,17 +1,30 @@
 import { timingSafeEqual } from 'node:crypto';
 
-export function areStringsEqual(expected: string, provided: string): boolean {
-  const expectedBuffer = Buffer.from(expected);
-  const providedBuffer = Buffer.from(provided);
-
-  if (expectedBuffer.length !== providedBuffer.length) {
+export function areStringsEqual(
+  expected: string | null | undefined,
+  provided: string | null | undefined
+): boolean {
+  if (typeof expected !== 'string' || typeof provided !== 'string') {
     return false;
   }
 
-  return timingSafeEqual(expectedBuffer, providedBuffer);
+  const expectedBuffer = Buffer.from(expected);
+  const providedBuffer = Buffer.from(provided);
+  const maxLen = Math.max(expectedBuffer.length, providedBuffer.length);
+  const paddedExpected = Buffer.concat([expectedBuffer, Buffer.alloc(maxLen - expectedBuffer.length)]);
+  const paddedProvided = Buffer.concat([providedBuffer, Buffer.alloc(maxLen - providedBuffer.length)]);
+
+  return expectedBuffer.length === providedBuffer.length && timingSafeEqual(paddedExpected, paddedProvided);
 }
 
-export function areHexDigestsEqual(expected: string, provided: string): boolean {
+export function areHexDigestsEqual(
+  expected: string | null | undefined,
+  provided: string | null | undefined
+): boolean {
+  if (typeof expected !== 'string' || typeof provided !== 'string') {
+    return false;
+  }
+
   if (expected.length !== provided.length) {
     return false;
   }

--- a/apps/api/src/app/support/guards/plain-cards.guard.ts
+++ b/apps/api/src/app/support/guards/plain-cards.guard.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { Observable } from 'rxjs';
-import { areHexDigestsEqual } from '../../shared/helpers/is-valid-hmac';
+import { areHexDigestsEqual } from '../../shared/helpers/timing-safe-equal';
 
 @Injectable()
 export class PlainCardsGuard implements CanActivate {

--- a/apps/api/src/app/support/guards/plain-cards.guard.ts
+++ b/apps/api/src/app/support/guards/plain-cards.guard.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { areHexDigestsEqual } from '../../shared/helpers/timing-safe-equal';
+import { getRequestHeaderValue } from '../../shared/helpers/get-request-header-value';
 
 @Injectable()
 export class PlainCardsGuard implements CanActivate {
@@ -10,7 +11,7 @@ export class PlainCardsGuard implements CanActivate {
 
     const requestBody = JSON.stringify(request.body);
     const plainCardsHMACSecretKey = process.env.PLAIN_CARDS_HMAC_SECRET_KEY as string;
-    const incomingSignature = request.headers['plain-request-signature'];
+    const incomingSignature = getRequestHeaderValue(request.headers['plain-request-signature']);
     if (!incomingSignature) throw new UnauthorizedException('Plain request signature is missing');
     const expectedSignature = crypto.createHmac('sha-256', plainCardsHMACSecretKey).update(requestBody).digest('hex');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces direct string equality checks with constant-time comparison helpers when validating bearer tokens and HMAC signatures in the API service.

## Changes

- Added `timing-safe-equal.ts` shared helper with `areStringsEqual()` and `areHexDigestsEqual()`
- Kept `is-valid-hmac.ts` focused on HMAC validation (`isHmacValid`, `isContextHmacValid`)
- Updated `InternalCallbackGuard` to validate the internal callback bearer token with `areStringsEqual()`
- Updated OAuth state and webhook signature checks to use `areHexDigestsEqual()` in:
  - Azure setup OAuth callback
  - Slack OAuth state validation
  - MS Teams OAuth state validation
  - MS Teams ARM template signature verification
  - MCP OAuth callback state validation
  - Provider-managed redirect signature validation
  - Vercel webhook signature verification
- Normalized request header values before comparison to avoid array/string type confusion
- Helpers accept nullable inputs and `areStringsEqual` pads buffers before comparison

## Testing

- `@novu/api-service:build` passes locally
- No behavior change expected for valid or invalid credentials/signatures
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6e2ada-938d-49ee-989e-c27641fbe7fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6e2ada-938d-49ee-989e-c27641fbe7fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR hardens secret verification across the API service by replacing direct string/hex equality checks for bearer tokens and HMAC/OAuth signatures with shared constant-time comparison helpers. The new `timing-safe-equal` module centralizes comparisons using Node’s `crypto.timingSafeEqual` and ensures comparisons don’t short-circuit in a way that could leak length information. It also normalizes Express header values via a shared helper to safely handle `string[]` vs `string`, preserving existing validation behavior and error handling.

## Affected areas
**api**: Updated internal callback bearer token validation, Azure/Slack/MS Teams/MCP OAuth state validation, MS Teams ARM template signature verification, provider-managed redirect signature checks, and Vercel webhook HMAC verification to use timing-safe equality and normalized header access.  
**shared**: Added `timing-safe-equal.ts` (`areStringsEqual`, `areHexDigestsEqual`), refactored `is-valid-hmac.ts` to delegate to the shared helper, and added `getRequestHeaderValue.ts` for header normalization.

## Key technical decisions
- Centralized constant-time comparison logic in `shared/helpers/timing-safe-equal.ts` and reused it for both raw-string and hex-digest secret comparisons.  
- Ensured `areStringsEqual` always reaches `timingSafeEqual` (avoiding early-exit length-oracle behavior) and that hex-digest comparisons validate lengths before buffer comparison.  

## Testing
No new tests were added, as the change is a security-focused refactor intended to keep success/failure outcomes the same while improving timing resistance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens secret validation across the API service by replacing direct `===` comparisons with `timingSafeEqual`-backed helpers, eliminating timing oracles for bearer-token and HMAC signature checks.

- **New helpers (`timing-safe-equal.ts`, `get-request-header-value.ts`)**: `areStringsEqual` pads both buffers to the same length and calls `timingSafeEqual` unconditionally before the length equality check, correctly avoiding early-exit leakage. `areHexDigestsEqual` handles fixed-length hex digests. `getRequestHeaderValue` normalizes HTTP headers from `string | string[]` to a single `string`.
- **Call-site updates (8 files)**: All HMAC, OAuth state, and bearer-token comparisons now route through the new helpers; imports from the now-trimmed `is-valid-hmac.ts` are updated throughout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted hardening of secret comparisons with no behavioral change for valid or invalid credentials.

All comparison sites are updated consistently, no imports are left broken, and the core areStringsEqual implementation correctly calls timingSafeEqual unconditionally (result stored before the && length check) so length-differing inputs still exercise the constant-time path. The areHexDigestsEqual early-return on mismatched string lengths is acceptable for fixed-length HMAC digests where the algorithm and therefore the output length are known. No logic changes affect application behavior beyond replacing early-exit comparisons.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/helpers/timing-safe-equal.ts | New central module exporting areStringsEqual (bearer-token comparison with zero-padding and unconditional timingSafeEqual) and areHexDigestsEqual (HMAC digest comparison). Both helpers are correctly implemented. |
| apps/api/src/app/shared/helpers/get-request-header-value.ts | New helper normalizing header values from string | string[] | undefined to string | undefined; returns the first element when the value is an array. Downstream null checks handle the empty-array edge case. |
| apps/api/src/app/internal/guards/internal-callback.guard.ts | Replaces direct !== token comparison with areStringsEqual and normalizes the Authorization header through getRequestHeaderValue; guard logic is unchanged. |
| apps/api/src/app/shared/helpers/is-valid-hmac.ts | areHexDigestsEqual removed from this file and re-imported from timing-safe-equal; isHmacValid and isContextHmacValid are otherwise unchanged. No broken imports remain. |
| apps/api/src/app/support/guards/plain-cards.guard.ts | Import updated to timing-safe-equal and plain-request-signature header now normalized via getRequestHeaderValue; HMAC comparison logic unchanged. |
| apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase.ts | Signature validation in environment.apiKeys.some(...) switched from === to areHexDigestsEqual; null returns from createHash are handled by the helper's type guard. |
| apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts | OAuth state signature comparison updated to areHexDigestsEqual; no other logic changed. |
| apps/api/src/app/partner-integrations/usecases/process-vercel-webhook/process-vercel-webhook.usecase.ts | SHA-1 Vercel webhook HMAC comparison updated to areHexDigestsEqual; no other logic changed. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Header type?}
    B -->|array| C[getRequestHeaderValue: take index 0]
    B -->|string| D[getRequestHeaderValue: pass through]
    B -->|undefined| E[return undefined → 401]
    C --> F[Token / Signature string]
    D --> F

    F --> G{Comparison type?}
    G -->|Bearer token InternalCallbackGuard| H[areStringsEqual]
    G -->|HMAC hex digest HMAC / OAuth / Webhook guards| I[areHexDigestsEqual]

    H --> H1[Pad both buffers to maxLen]
    H1 --> H2[timingSafeEqual unconditionally]
    H2 --> H3[AND with length equality check]
    H3 --> J{Match?}

    I --> I1{String lengths equal?}
    I1 -->|No| K[return false]
    I1 -->|Yes| I2[Buffer.from hex]
    I2 --> I3{Buffer lengths equal?}
    I3 -->|No| K
    I3 -->|Yes| I4[timingSafeEqual]
    I4 --> J

    J -->|Yes| L[Request allowed]
    J -->|No| M[401 / 400 thrown]
```

<sub>Reviews (4): Last reviewed commit: ["fix(api-service): always run timingSafeE..."](https://github.com/novuhq/novu/commit/3e878964469c7daefaed3cee02e6cbc0137224ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37464932)</sub>

<!-- /greptile_comment -->