### PR TITLE
fix(dashboard): route agents empty state to onboarding setup fixes NV-8032

### DIFF
--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -52,7 +52,7 @@ import {
   clearPersistedAgentTemplateId,
   readActiveAgentTemplateId,
 } from '@/utils/agent-template-identity';
-import { AGENT_DETAILS_DEFAULT_TAB, buildRoute } from '@/utils/routes';
+import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 const PAGE_SIZE_OPTIONS = [10, 12, 20, 50];
@@ -86,6 +86,7 @@ export function AgentsList() {
   const [isAutoProvisioningFromTemplate, setIsAutoProvisioningFromTemplate] = useState(false);
   // Guards the deep-link template handling so it runs at most once per template id.
   const appliedTemplateIdRef = useRef<string | undefined>(undefined);
+  const pendingAfterLimitRef = useRef<'create-dialog' | 'onboarding'>('create-dialog');
 
   const [searchParams, setSearchParams] = useSearchParams();
   const { templates: agentTemplates } = useAgentTemplates();
@@ -247,6 +248,10 @@ export function AgentsList() {
     setBefore(undefined);
   }, []);
 
+  const goToAgentsSetup = useCallback(() => {
+    void navigate(ROUTES.AGENTS_SETUP);
+  }, [navigate]);
+
   const handleAddAgentClick = useCallback(() => {
     // Hard cap first — the API rejects creation outright at this point.
     if (isAtCreationLimit) {
@@ -256,6 +261,7 @@ export function AgentsList() {
     }
 
     if (isAtAgentLimit) {
+      pendingAfterLimitRef.current = 'create-dialog';
       setLimitDialogOpen(true);
 
       return;
@@ -263,6 +269,33 @@ export function AgentsList() {
 
     setCreateOpen(true);
   }, [isAtAgentLimit, isAtCreationLimit]);
+
+  const handleEmptyStateSetupClick = useCallback(() => {
+    if (isAtCreationLimit) {
+      setCreationLimitDialogOpen(true);
+
+      return;
+    }
+
+    if (isAtAgentLimit) {
+      pendingAfterLimitRef.current = 'onboarding';
+      setLimitDialogOpen(true);
+
+      return;
+    }
+
+    goToAgentsSetup();
+  }, [goToAgentsSetup, isAtAgentLimit, isAtCreationLimit]);
+
+  const handleContinuePastAgentLimit = useCallback(() => {
+    if (pendingAfterLimitRef.current === 'onboarding') {
+      goToAgentsSetup();
+
+      return;
+    }
+
+    setCreateOpen(true);
+  }, [goToAgentsSetup]);
 
   const handleCreateSubmit = useCallback(
     async (form: CreateAgentForm) => {
@@ -441,7 +474,7 @@ export function AgentsList() {
               variant="secondary"
               mode="gradient"
               trailingIcon={RiArrowRightSLine}
-              onClick={handleAddAgentClick}
+              onClick={handleEmptyStateSetupClick}
             >
               Setup an agent
             </PermissionButton>
@@ -557,7 +590,7 @@ export function AgentsList() {
             open={limitDialogOpen}
             onOpenChange={setLimitDialogOpen}
             planUsage={planUsage}
-            onContinueAnyway={() => setCreateOpen(true)}
+            onContinueAnyway={handleContinuePastAgentLimit}
           />
           <AgentCreationLimitDialog
             open={creationLimitDialogOpen}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores onboarding navigation for the agents list empty state CTA. Clicking **Setup an agent** now routes to `/onboarding/agents/setup` instead of opening the create-agent modal.

This behavior regressed when agent entitlements added limit-gated modal creation (`NV-7427`). The welcome/getting started page already navigates to the onboarding setup route.

## Changes

- Empty-state **Setup an agent** button navigates to `ROUTES.AGENTS_SETUP`
- Plan limit checks still apply before navigation
- Soft-limit **Create anyway** continues to onboarding when triggered from the empty state
- Toolbar **Add Agent** button still opens the create dialog for subsequent agents

## Test plan

- [ ] Open Agents page with no agents in dev environment
- [ ] Click **Setup an agent** → should navigate to `/onboarding/agents/setup`
- [ ] From welcome page, click **Add an agent** / **Setup agents** → should still navigate to onboarding setup
- [ ] With existing agents, **Add Agent** toolbar button still opens the create dialog
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22519e97-9539-4209-a8d9-73f3181285b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22519e97-9539-4209-a8d9-73f3181285b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The **Setup an agent** button in the agents list empty state now navigates to the onboarding setup route (`/onboarding/agents/setup`) instead of opening the create-agent modal. The fix maintains plan limit checks—when limits are hit, a dialog appears with a **Create anyway** action that completes the navigation. This restores the original behavior that regressed when agent entitlements introduced limit-gated modal creation.

## Affected areas

**dashboard**: The agents list component now uses separate click handlers for empty-state setup versus subsequent agent creation, with a pending-action ref to coordinate navigation after limit checks are acknowledged.

## Key technical decisions

- Uses a `pendingAfterLimitRef` to track whether the user should navigate to onboarding or open the create dialog after confirming they want to proceed past a limit.
- Separates empty-state behavior (`handleEmptyStateSetupClick`) from the toolbar "Add Agent" button behavior (`handleAddAgentClick`) to ensure the correct navigation path based on user context.

## Testing

Manual verification is required to confirm: empty-state navigation to the onboarding setup flow, that the welcome/getting-started page navigation still works correctly, and that the toolbar "Add Agent" button continues to open the create dialog for users with existing agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the onboarding navigation path for the agents list empty-state CTA, which had regressed when plan-limit gating was added. The "Setup an agent" button on the empty state now routes to `/onboarding/agents/setup` instead of opening the create-agent modal, while the toolbar "Add Agent" button retains its existing create-dialog behavior.

- A new `handleEmptyStateSetupClick` handler performs the same hard-cap and soft-limit checks as `handleAddAgentClick`, then navigates to `ROUTES.AGENTS_SETUP` instead of opening the create dialog.
- A `useRef` (`pendingAfterLimitRef`) tracks whether the soft-limit dialog was opened from the toolbar or the empty state, and `handleContinuePastAgentLimit` uses that value to dispatch the correct post-confirmation action.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the routing fix works correctly and the limit-gating logic is sound for both the toolbar and empty-state paths.

The empty-state handler and ref-based dispatcher are logically correct, and the change is well-scoped. The only rough edge is that AgentLimitUpgradeDialog always displays "Create anyway" even when the pending action is navigation to onboarding rather than agent creation — a label mismatch visible to users who hit their soft limit from the empty state.

apps/dashboard/src/components/agents/agents-list.tsx — specifically the interaction between handleEmptyStateSetupClick and the hardcoded continueLabel in AgentLimitUpgradeDialog.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agents-list.tsx | Adds empty-state-specific navigation handler and a ref-based dispatcher to route the limit-dialog "Continue anyway" action to either the create dialog or the onboarding setup page, depending on which button triggered the soft-limit warning. Logic is correct; the only concern is that the hardcoded "Create anyway" button label in AgentLimitUpgradeDialog mismatches the actual onboarding navigation that occurs when the dialog is opened from the empty state. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User on Agents Page] --> B{Has agents?}
    B -- Yes --> C[Toolbar: Add Agent button\nhandleAddAgentClick]
    B -- No / Empty State --> D[Empty State: Setup an agent button\nhandleEmptyStateSetupClick]

    C --> E{isAtCreationLimit?}
    D --> F{isAtCreationLimit?}

    E -- Yes --> G[Show AgentCreationLimitDialog\n hard block]
    E -- No --> H{isAtAgentLimit?}
    F -- Yes --> G
    F -- No --> I{isAtAgentLimit?}

    H -- Yes --> J[pendingAfterLimitRef = 'create-dialog'\nShow AgentLimitUpgradeDialog]
    H -- No --> K[Open CreateAgentDialog]

    I -- Yes --> L[pendingAfterLimitRef = 'onboarding'\nShow AgentLimitUpgradeDialog]
    I -- No --> M[Navigate to /onboarding/agents/setup]

    J --> N{User clicks 'Create anyway'}
    L --> N

    N --> O{pendingAfterLimitRef?}
    O -- create-dialog --> K
    O -- onboarding --> M
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Fagents-list.tsx%3A590-594%0A**Misleading%20%22Create%20anyway%22%20label%20when%20triggered%20from%20the%20empty%20state**%0A%0A%60AgentLimitUpgradeDialog%60%20hardcodes%20%60continueLabel%3D%22Create%20anyway%22%60%2C%20but%20when%20triggered%20via%20%60handleEmptyStateSetupClick%60%2C%20clicking%20that%20button%20navigates%20to%20the%20onboarding%20setup%20page%20%E2%80%94%20no%20agent%20is%20created.%20A%20user%20who%20reads%20%22Create%20anyway%22%20reasonably%20expects%20to%20be%20taken%20directly%20into%20agent%20creation%2C%20not%20routed%20to%20%60%2Fonboarding%2Fagents%2Fsetup%60.%20Consider%20threading%20a%20dynamic%20label%20through%20%60AgentLimitUpgradeDialog%60%20%28e.g.%20%60continueLabel%3D%22Continue%20to%20setup%22%60%29%20when%20the%20empty-state%20flow%20opens%20the%20dialog%2C%20so%20the%20affordance%20matches%20the%20action.%0A%0A&pr=11544&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/agents/agents-list.tsx:590-594
**Misleading "Create anyway" label when triggered from the empty state**

`AgentLimitUpgradeDialog` hardcodes `continueLabel="Create anyway"`, but when triggered via `handleEmptyStateSetupClick`, clicking that button navigates to the onboarding setup page — no agent is created. A user who reads "Create anyway" reasonably expects to be taken directly into agent creation, not routed to `/onboarding/agents/setup`. Consider threading a dynamic label through `AgentLimitUpgradeDialog` (e.g. `continueLabel="Continue to setup"`) when the empty-state flow opens the dialog, so the affordance matches the action.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): route agents empty state..."](https://github.com/novuhq/novu/commit/946c5f7cb542c895cd3e74b172a8567fe961cec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37466688)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->