### PR TITLE
fix(api-service): stabilize flaky digest merge e2e tests fixes NV-8033

### DIFF
--- a/apps/api/src/app/events/e2e/digest-events.e2e.ts
+++ b/apps/api/src/app/events/e2e/digest-events.e2e.ts
@@ -970,10 +970,16 @@ describe('Trigger event - Digest triggered events - /v1/events/trigger (POST) #n
     await session.waitForSubscriberQueueCompletion();
     await session.waitForStandardQueueCompletion();
 
-    const jobs = await jobRepository.find({
-      _environmentId: session.environment._id,
-      _templateId: template._id,
-      type: StepTypeEnum.DIGEST,
+    const jobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+      expectedCount: 10,
+      timeout: 15000,
     });
 
     expect(jobs && jobs.length).to.eql(10);
@@ -992,7 +998,7 @@ describe('Trigger event - Digest triggered events - /v1/events/trigger (POST) #n
           content: '',
           metadata: {
             unit: DigestUnitEnum.SECONDS,
-            amount: 1,
+            amount: 2,
             type: DigestTypeEnum.REGULAR,
           },
         },
@@ -1018,10 +1024,16 @@ describe('Trigger event - Digest triggered events - /v1/events/trigger (POST) #n
     await session.waitForSubscriberQueueCompletion();
     await session.waitForStandardQueueCompletion();
 
-    const jobs = await jobRepository.find({
-      _environmentId: session.environment._id,
-      _templateId: template._id,
-      type: StepTypeEnum.DIGEST,
+    const jobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+      expectedCount: 10,
+      timeout: 15000,
     });
 
     expect(jobs && jobs.length).to.eql(10);

--- a/apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts
+++ b/apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts
@@ -8,6 +8,28 @@ interface IPollForJobOptions {
   query: Partial<JobEntity> & EnforceEnvOrOrgIds;
   timeout?: number;
   pollInterval?: number;
+  expectedCount?: number;
+  until?: (jobs: JobEntity[]) => boolean;
+}
+
+function areJobsReady(jobs: JobEntity[], expectedCount?: number, until?: (jobs: JobEntity[]) => boolean): boolean {
+  if (jobs.length === 0) {
+    return false;
+  }
+
+  if (expectedCount !== undefined && jobs.length !== expectedCount) {
+    return false;
+  }
+
+  if (!jobs.every((job: JobEntity) => job.status !== JobStatusEnum.PENDING)) {
+    return false;
+  }
+
+  if (until && !until(jobs)) {
+    return false;
+  }
+
+  return true;
 }
 
 // Function overloads to make return type conditional based on findMultiple
@@ -25,14 +47,18 @@ export async function pollForJobStatusChange({
   timeout = 5000,
   pollInterval = 100,
   findMultiple = false,
+  expectedCount,
+  until,
 }: IPollForJobOptions & { findMultiple?: boolean }): Promise<JobEntity | JobEntity[] | null> {
   const startTime = Date.now();
+  let lastMultipleJobs: JobEntity[] = [];
 
   while (true) {
     if (findMultiple) {
       const jobs = await jobRepository.find(query);
+      lastMultipleJobs = jobs;
 
-      if (jobs.length > 0 && jobs.every((job: JobEntity) => job.status !== JobStatusEnum.PENDING)) {
+      if (areJobsReady(jobs, expectedCount, until)) {
         return jobs;
       }
     } else {
@@ -44,7 +70,7 @@ export async function pollForJobStatusChange({
     }
 
     if (Date.now() - startTime > timeout) {
-      return findMultiple ? ([] as JobEntity[]) : null;
+      return findMultiple ? lastMultipleJobs : null;
     }
 
     await sleep(pollInterval);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes intermittent failures in `should merge digest events when sequential calls` where the test expected 1 delayed digest job but observed 0.

## Root cause

The test waited for Redis queues to drain, then immediately queried Mongo for digest job statuses. Digest merge processing can still be in progress at that point, so jobs may exist but not yet be marked `DELAYED` / `MERGED`.

Additionally, the sequential test used a 1-second digest window while firing 10 sequential triggers. Under CI load, the window can expire before all events merge.

```mermaid
sequenceDiagram
    participant Test
    participant Redis
    participant Worker
    participant Mongo

    Test->>Redis: waitFor*QueueCompletion()
    Redis-->>Test: queues empty
    Test->>Mongo: find digest jobs (too early)
    Note over Worker,Mongo: merge still running
    Mongo-->>Test: 10 jobs, 0 DELAYED
    Worker->>Mongo: set 1 DELAYED + 9 MERGED
```

## Fix

- Poll Mongo until all 10 digest jobs exist and leave `PENDING` before asserting merge state (same pattern already used elsewhere in this file).
- Extend `pollForJobStatusChange` with `expectedCount`, optional `until`, and return last observed jobs on timeout for clearer failures.
- Align sequential digest window with concurrent merge test (`amount: 2` seconds).

## Test plan

- [ ] `digest-events.e2e.ts` merge tests pass in CI (`should merge digest events when sequential calls`, `should merge digest events accordingly when concurrent calls`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6adbf7c2-2571-4dab-8c41-0849011a6277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6adbf7c2-2571-4dab-8c41-0849011a6277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR fixes flaky digest merge e2e tests (issue NV-8033) by implementing robust polling logic that accounts for in-progress digest processing. The test was failing intermittently because it checked digest job statuses immediately after Redis queues drained, but the database had not yet updated the job states. The fix adds polling to wait for all jobs to exist and transition from `PENDING` state, extends the sequential digest window from 1 to 2 seconds to accommodate CI load, and enhances the polling utility to support expected count validation and optional predicates.

## Affected areas

- **api**: The digest event e2e tests (`digest-events.e2e.ts`) now use `pollForJobStatusChange` with an `expectedCount: 10` parameter instead of directly querying the job repository. The sequential merge test's digest window was extended from 1 to 2 seconds. The polling utility (`poll-for-job-status-change.util.ts`) was enhanced with an `areJobsReady` helper that validates jobs are ready based on non-empty results, non-`PENDING` states, optional expected count matching, and an optional `until` predicate. The utility now returns the last observed job array on timeout rather than an empty array, improving failure diagnostics.

## Key technical decisions

- The polling utility maintains the last retrieved jobs during polling and returns them on timeout, providing better visibility into the actual state when timeouts occur.
- The `expectedCount` parameter is optional, allowing backward compatibility with existing polling calls that don't require strict count validation.

## Testing

This is a test-only change; the e2e tests were updated to be more reliable under CI load, and the fixes are being validated through CI test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes two flaky digest-merge e2e tests by replacing immediate Mongo queries (after queue-drain waits) with a polling loop that waits until all 10 expected digest jobs exist and have left `PENDING` state, and bumps the sequential test's digest window from 1 s to 2 s.

- **`poll-for-job-status-change.util.ts`**: Adds `expectedCount` and `until` options; extracts an `areJobsReady` helper; changes the timeout return from an empty array to the last-observed job list for more informative test failures.
- **`digest-events.e2e.ts`**: Both merge tests now use `pollForJobStatusChange({ findMultiple: true, expectedCount: 10, timeout: 15000 })` instead of a bare `jobRepository.find`, closing the race between queue completion and Mongo write-through.

<h3>Confidence Score: 4/5</h3>

Safe to merge for test-only changes; the polling fix correctly closes the race condition, though the `findMultiple: true` overload advertises a return type wider than what the implementation actually produces.

The core polling fix is sound and directly addresses the described race condition. The `findMultiple: true` overload is declared as `Promise<JobEntity[] | null>` but the implementation never returns `null` for that branch, so callers (including the test's `jobs.filter(...)`) operate against a wider type than necessary — a compile error under strict null checks. The sequential test's 2-second digest window is an improvement over 1 second but still conceivably too short under heavy CI load.

`poll-for-job-status-change.util.ts` — the overload return type for `findMultiple: true` should be `Promise<JobEntity[]>` to match the implementation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts | Adds `expectedCount` and `until` options plus an `areJobsReady` helper; fixes timeout return to expose last-observed jobs. The `findMultiple: true` overload declares `Promise<JobEntity[] | null>` but the implementation never returns `null` for that branch, creating a type mismatch. |
| apps/api/src/app/events/e2e/digest-events.e2e.ts | Replaces direct `jobRepository.find` with `pollForJobStatusChange` (expectedCount=10, timeout=15s) in both merge tests, and bumps the sequential digest window from 1 s to 2 s to reduce CI timing failures. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts`, line 37-38 ([link](https://github.com/novuhq/novu/blob/0fce5553e82ac7c41911658dbc2bfbf5d8b4ef6f/apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts#L37-L38)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`findMultiple: true` overload declares `| null` but implementation never returns `null`**

   The implementation returns `lastMultipleJobs` (always a `JobEntity[]`) on timeout when `findMultiple` is true — it never reaches the `null` branch. Because the overload advertises `Promise<JobEntity[] | null>`, TypeScript types `jobs` as `JobEntity[] | null` at the call site, making `jobs.filter(...)` in the tests a strict-null-checks error. Changing the return type to `Promise<JobEntity[]>` would align with the actual runtime behaviour and remove the need for the `jobs &&` null-guard in the test assertions.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts
   Line: 37-38

   Comment:
   **`findMultiple: true` overload declares `| null` but implementation never returns `null`**

   The implementation returns `lastMultipleJobs` (always a `JobEntity[]`) on timeout when `findMultiple` is true — it never reaches the `null` branch. Because the overload advertises `Promise<JobEntity[] | null>`, TypeScript types `jobs` as `JobEntity[] | null` at the call site, making `jobs.filter(...)` in the tests a strict-null-checks error. Changing the return type to `Promise<JobEntity[]>` would align with the actual runtime behaviour and remove the need for the `jobs &&` null-guard in the test assertions.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fevents%2Fe2e%2Futils%2Fpoll-for-job-status-change.util.ts%0ALine%3A%2037-38%0A%0AComment%3A%0A**%60findMultiple%3A%20true%60%20overload%20declares%20%60%7C%20null%60%20but%20implementation%20never%20returns%20%60null%60**%0A%0AThe%20implementation%20returns%20%60lastMultipleJobs%60%20%28always%20a%20%60JobEntity%5B%5D%60%29%20on%20timeout%20when%20%60findMultiple%60%20is%20true%20%E2%80%94%20it%20never%20reaches%20the%20%60null%60%20branch.%20Because%20the%20overload%20advertises%20%60Promise%3CJobEntity%5B%5D%20%7C%20null%3E%60%2C%20TypeScript%20types%20%60jobs%60%20as%20%60JobEntity%5B%5D%20%7C%20null%60%20at%20the%20call%20site%2C%20making%20%60jobs.filter%28...%29%60%20in%20the%20tests%20a%20strict-null-checks%20error.%20Changing%20the%20return%20type%20to%20%60Promise%3CJobEntity%5B%5D%3E%60%20would%20align%20with%20the%20actual%20runtime%20behaviour%20and%20remove%20the%20need%20for%20the%20%60jobs%20%26%26%60%20null-guard%20in%20the%20test%20assertions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11545&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fevents%2Fe2e%2Futils%2Fpoll-for-job-status-change.util.ts%3A37-38%0A**%60findMultiple%3A%20true%60%20overload%20declares%20%60%7C%20null%60%20but%20implementation%20never%20returns%20%60null%60**%0A%0AThe%20implementation%20returns%20%60lastMultipleJobs%60%20%28always%20a%20%60JobEntity%5B%5D%60%29%20on%20timeout%20when%20%60findMultiple%60%20is%20true%20%E2%80%94%20it%20never%20reaches%20the%20%60null%60%20branch.%20Because%20the%20overload%20advertises%20%60Promise%3CJobEntity%5B%5D%20%7C%20null%3E%60%2C%20TypeScript%20types%20%60jobs%60%20as%20%60JobEntity%5B%5D%20%7C%20null%60%20at%20the%20call%20site%2C%20making%20%60jobs.filter%28...%29%60%20in%20the%20tests%20a%20strict-null-checks%20error.%20Changing%20the%20return%20type%20to%20%60Promise%3CJobEntity%5B%5D%3E%60%20would%20align%20with%20the%20actual%20runtime%20behaviour%20and%20remove%20the%20need%20for%20the%20%60jobs%20%26%26%60%20null-guard%20in%20the%20test%20assertions.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fevents%2Fe2e%2Fdigest-events.e2e.ts%3A1000-1001%0A**Sequential%20test%20still%20has%20a%20timing%20risk%20with%20a%202-second%20digest%20window**%0A%0AThe%20test%20fires%2010%20%60await%20triggerEvent%28...%29%60%20calls%20sequentially%2C%20each%20doing%20a%20round-trip%20HTTP%20request.%20Under%20CI%20load%2C%20those%2010%20calls%20can%20take%20longer%20than%202%20seconds%2C%20causing%20the%20digest%20window%20to%20expire%20before%20all%20events%20are%20submitted.%20In%20that%20scenario%20the%20system%20creates%20multiple%20DELAYED%20jobs%20%28one%20per%20%22batch%22%29%2C%20and%20%60pollForJobStatusChange%60%20would%20correctly%20exit%20%28all%2010%20jobs%20are%20non-PENDING%29%20but%20the%20assertion%20%60expect%28delayedJobs.length%29.to.eql%281%29%60%20would%20still%20fail.%20A%20substantially%20larger%20window%20%28e.g.%2C%2010%E2%80%9330%20s%29%20would%20make%20this%20test%20genuinely%20resilient%20to%20CI%20slowness%2C%20at%20the%20cost%20of%20a%20slower%20run%20when%20verifying%20that%20the%20delay%20fires%20correctly.%0A%0A&pr=11545&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts:37-38
**`findMultiple: true` overload declares `| null` but implementation never returns `null`**

The implementation returns `lastMultipleJobs` (always a `JobEntity[]`) on timeout when `findMultiple` is true — it never reaches the `null` branch. Because the overload advertises `Promise<JobEntity[] | null>`, TypeScript types `jobs` as `JobEntity[] | null` at the call site, making `jobs.filter(...)` in the tests a strict-null-checks error. Changing the return type to `Promise<JobEntity[]>` would align with the actual runtime behaviour and remove the need for the `jobs &&` null-guard in the test assertions.

### Issue 2 of 2
apps/api/src/app/events/e2e/digest-events.e2e.ts:1000-1001
**Sequential test still has a timing risk with a 2-second digest window**

The test fires 10 `await triggerEvent(...)` calls sequentially, each doing a round-trip HTTP request. Under CI load, those 10 calls can take longer than 2 seconds, causing the digest window to expire before all events are submitted. In that scenario the system creates multiple DELAYED jobs (one per "batch"), and `pollForJobStatusChange` would correctly exit (all 10 jobs are non-PENDING) but the assertion `expect(delayedJobs.length).to.eql(1)` would still fail. A substantially larger window (e.g., 10–30 s) would make this test genuinely resilient to CI slowness, at the cost of a slower run when verifying that the delay fires correctly.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): stabilize flaky digest merge e..."](https://github.com/novuhq/novu/commit/0fce5553e82ac7c41911658dbc2bfbf5d8b4ef6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37467309)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->