### PR TITLE
fix(dashboard): update onboarding loading label copy fixes NV-8034

### DIFF
--- a/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx
@@ -34,7 +34,7 @@ type AgentSuggestionPillsProps = {
   suggestions: AgentTemplate[];
   onSelect: (suggestion: AgentTemplate) => void;
   disabled?: boolean;
-  /** When true, render the "Personalizing suggestions" shimmer instead of the pills (loading / refreshing). */
+  /** When true, render the "Generating personal suggestions for you..." shimmer instead of the pills (loading / refreshing). */
   isLoading?: boolean;
   className?: string;
 };
@@ -64,7 +64,7 @@ export function AgentSuggestionPills({
             className={cn(ROW_HEIGHT_CLASS, 'flex min-w-0 items-center gap-1')}
           >
             <Broom fill="#525866" className="text-text-sub h-3 w-3 shrink-0 animate-pulse" />
-            <Shimmer className="text-label-xs">Personalizing suggestions</Shimmer>
+            <Shimmer className="text-label-xs">Generating personal suggestions for you...</Shimmer>
           </motion.div>
         ) : (
           <motion.div

--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -339,7 +339,7 @@ export const WorkflowsPage = () => {
                     <div className="flex flex-col gap-2">
                       <span className="flex items-center gap-1 text-label-sm text-text-strong">
                         <Broom fill="#525866" className="text-text-sub h-3 w-3 shrink-0 animate-pulse" />
-                        <Shimmer className="text-label-xs">Personalizing suggestions</Shimmer>
+                        <Shimmer className="text-label-xs">Generating personal suggestions for you...</Shimmer>
                       </span>
                       <span className="text-paragraph-xs text-text-soft">
                         Identifying common notification flows used by similar products. View{' '}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the agent onboarding loading state label from **"Personalizing suggestions"** to **"Generating personal suggestions for you..."** for clearer, more user-facing copy.

## Changes

- `agent-suggestion-pills.tsx` — loading shimmer in the connect-agent onboarding flow
- `workflows.tsx` — loading shimmer shown while onboarding suggestions are generating

## Testing

- Copy-only change; no logic affected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5e97ec2-03c0-4fe4-879b-ccb92a0646eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5e97ec2-03c0-4fe4-879b-ccb92a0646eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Updated loading state labels in the agent onboarding flow from "Personalizing suggestions" to "Generating personal suggestions for you..." to improve user-facing copy clarity and better communicate the action happening to users during the suggestion generation process.

## Affected areas

**dashboard**: Updated loading state copy in the agent suggestion pills component and workflows page to display improved messaging while suggestions are generating.

## Testing

No tests required for copy-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the onboarding loading-state copy in two places, changing "Personalizing suggestions" to "Generating personal suggestions for you..." for a more descriptive, user-facing message.

- `agent-suggestion-pills.tsx` — updates both the JSDoc comment and the shimmer label rendered during the connect-agent loading state.
- `workflows.tsx` — updates the matching shimmer label shown on the workflows page while onboarding suggestions are generating.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a copy update with no logic, state, or prop changes.

Both changed files only swap a string literal in a loading shimmer; the JSDoc in agent-suggestion-pills.tsx is also updated to match. No conditional logic, data flow, or component API is touched, and the new copy is consistent across both locations.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/onboarding/connect-agent/agent-suggestion-pills.tsx | Loading shimmer label updated from "Personalizing suggestions" to "Generating personal suggestions for you..." — both the JSDoc comment and rendered text are updated consistently. |
| apps/dashboard/src/pages/workflows.tsx | Same loading shimmer label update as in agent-suggestion-pills.tsx; only the rendered string changes, no logic affected. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant WorkflowsPage
    participant AgentSuggestionPills

    User->>WorkflowsPage: Opens onboarding flow
    WorkflowsPage->>WorkflowsPage: "isLoading = true"
    WorkflowsPage-->>User: Shimmer: "Generating personal suggestions for you..."
    WorkflowsPage->>AgentSuggestionPills: "passes isLoading=true"
    AgentSuggestionPills-->>User: Shimmer: "Generating personal suggestions for you..."
    WorkflowsPage->>WorkflowsPage: "Suggestions ready, isLoading = false"
    AgentSuggestionPills-->>User: Renders suggestion pills
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): update onboarding loadin..."](https://github.com/novuhq/novu/commit/896f0038afa0f558a18a4fd12b17aab608d0a17f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37470753)</sub>

<!-- /greptile_comment -->