### PR TITLE
fix(dashboard): tailor email onboarding for managed vs custom agents fixes NV-8035

### DIFF
--- a/apps/dashboard/src/components/agents/copyable-email-address.tsx
+++ b/apps/dashboard/src/components/agents/copyable-email-address.tsx
@@ -12,13 +12,15 @@ export function CopyableEmailAddress({ email, className, trailing }: CopyableEma
   return (
     <div
       className={cn(
-        'border-stroke-soft bg-bg-white flex items-start gap-2 rounded-lg border px-2.5 py-2 shadow-xs',
+        'border-stroke-soft bg-bg-white flex min-h-8 items-stretch overflow-hidden rounded-lg border shadow-xs',
         className
       )}
     >
-      <span className="text-text-sub text-paragraph-xs min-w-0 flex-1 break-all font-mono leading-5">{email}</span>
-      <div className="flex shrink-0 items-start gap-1">
-        <CopyButton size="2xs" valueToCopy={email} className="size-6 shrink-0 justify-center" />
+      <span className="text-text-sub text-paragraph-xs flex min-w-0 flex-1 items-center break-all px-2 py-1 font-mono leading-4">
+        {email}
+      </span>
+      <div className="border-stroke-soft flex shrink-0 items-center self-stretch border-l">
+        <CopyButton size="2xs" valueToCopy={email} className="size-8 shrink-0 justify-center rounded-none" />
         {trailing}
       </div>
     </div>

--- a/apps/dashboard/src/components/agents/copyable-email-address.tsx
+++ b/apps/dashboard/src/components/agents/copyable-email-address.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from 'react';
+import { CopyButton } from '@/components/primitives/copy-button';
+import { cn } from '@/utils/ui';
+
+type CopyableEmailAddressProps = {
+  email: string;
+  className?: string;
+  trailing?: ReactNode;
+};
+
+export function CopyableEmailAddress({ email, className, trailing }: CopyableEmailAddressProps) {
+  return (
+    <div
+      className={cn(
+        'border-stroke-soft bg-bg-white flex items-start gap-2 rounded-lg border px-2.5 py-2 shadow-xs',
+        className
+      )}
+    >
+      <span className="text-text-sub text-paragraph-xs min-w-0 flex-1 break-all font-mono leading-5">{email}</span>
+      <div className="flex shrink-0 items-start gap-1">
+        <CopyButton size="2xs" valueToCopy={email} className="size-6 shrink-0 justify-center" />
+        {trailing}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/agents/email-inbox-card.tsx
+++ b/apps/dashboard/src/components/agents/email-inbox-card.tsx
@@ -3,8 +3,8 @@ import { type ReactNode, useMemo, useRef, useState } from 'react';
 import { RiAddLine, RiCloseLine, RiInformation2Line } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
 import type { AgentIntegrationEmbedded, AgentResponse } from '@/api/agents';
+import { CopyableEmailAddress } from '@/components/agents/copyable-email-address';
 import { CompactButton } from '@/components/primitives/button-compact';
-import { CopyButton } from '@/components/primitives/copy-button';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
@@ -256,13 +256,24 @@ type InboxRowProps = {
  */
 function InboxRow({ address, badge, trailing }: InboxRowProps) {
   return (
-    <div className="bg-bg-weak/40 hover:bg-bg-weak flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors">
-      <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-mono leading-4">{address}</span>
-      {badge ? (
-        <span className="text-text-soft text-[10px] font-medium uppercase leading-3 tracking-wide">{badge}</span>
-      ) : null}
-      <CopyButton size="2xs" valueToCopy={address} className="size-6 shrink-0 justify-center" />
-      {trailing}
+    <div className="flex flex-col gap-1">
+      <CopyableEmailAddress
+        email={address}
+        trailing={
+          trailing ? (
+            <div className="flex items-center gap-1">
+              {badge ? (
+                <span className="text-text-soft text-[10px] font-medium uppercase leading-3 tracking-wide">{badge}</span>
+              ) : null}
+              {trailing}
+            </div>
+          ) : (
+            badge ? (
+              <span className="text-text-soft text-[10px] font-medium uppercase leading-3 tracking-wide">{badge}</span>
+            ) : undefined
+          )
+        }
+      />
     </div>
   );
 }
@@ -285,24 +296,23 @@ type SharedInboxRowProps = {
  * gives.
  */
 function SharedInboxRow({ address, disabled, toggleDisabled, toggleTooltip, onToggle }: SharedInboxRowProps) {
-  const rowContent = (
-    <div className="bg-bg-weak/40 hover:bg-bg-weak flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors">
-      <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-mono leading-4">{address}</span>
-      <CopyButton size="2xs" valueToCopy={address} className="size-6 shrink-0 justify-center" />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="inline-flex">
-            <Switch
-              aria-label={disabled ? 'Enable the shared inbox' : 'Disable the shared inbox'}
-              checked={!disabled}
-              onCheckedChange={onToggle}
-            />
-          </span>
-        </TooltipTrigger>
-        <TooltipContent className="max-w-xs">{toggleTooltip}</TooltipContent>
-      </Tooltip>
-    </div>
+  const switchControl = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">
+          <Switch
+            aria-label={disabled ? 'Enable the shared inbox' : 'Disable the shared inbox'}
+            checked={!disabled}
+            onCheckedChange={onToggle}
+            disabled={toggleDisabled}
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{toggleTooltip}</TooltipContent>
+    </Tooltip>
   );
+
+  const rowContent = <CopyableEmailAddress email={address} trailing={switchControl} />;
 
   if (!disabled) {
     return rowContent;

--- a/apps/dashboard/src/components/agents/email-inbox-card.tsx
+++ b/apps/dashboard/src/components/agents/email-inbox-card.tsx
@@ -254,28 +254,29 @@ type InboxRowProps = {
  * Minimal row: lighter visual weight than the previous bordered/shadowed
  * pill — relies on background tint + subtle stroke for separation.
  */
-function InboxRow({ address, badge, trailing }: InboxRowProps) {
+function buildInboxRowTrailing(badge?: string, trailing?: ReactNode) {
+  if (!trailing && !badge) {
+    return undefined;
+  }
+
+  const badgeNode = badge ? (
+    <span className="text-text-soft text-[10px] font-medium uppercase leading-3 tracking-wide">{badge}</span>
+  ) : null;
+
+  if (!trailing) {
+    return badgeNode ?? undefined;
+  }
+
   return (
-    <div className="flex flex-col gap-1">
-      <CopyableEmailAddress
-        email={address}
-        trailing={
-          trailing ? (
-            <div className="flex items-center gap-1">
-              {badge ? (
-                <span className="text-text-soft text-[10px] font-medium uppercase leading-3 tracking-wide">{badge}</span>
-              ) : null}
-              {trailing}
-            </div>
-          ) : (
-            badge ? (
-              <span className="text-text-soft text-[10px] font-medium uppercase leading-3 tracking-wide">{badge}</span>
-            ) : undefined
-          )
-        }
-      />
+    <div className="flex items-center gap-1">
+      {badgeNode}
+      {trailing}
     </div>
   );
+}
+
+function InboxRow({ address, badge, trailing }: InboxRowProps) {
+  return <CopyableEmailAddress email={address} trailing={buildInboxRowTrailing(badge, trailing)} />;
 }
 
 type SharedInboxRowProps = {

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -241,8 +241,8 @@ export function EmailSetupGuide({
         title="Test connection"
         description={
           isManagedAgent
-            ? 'Send an email to the inbound address below. We will detect when it arrives.'
-            : 'Send an email to the inbound address below and verify it reaches your agent handler.'
+            ? 'Send an email to your configured inbound address. We will detect when it arrives.'
+            : 'Send an email to your configured inbound address and verify it reaches your agent handler.'
         }
         extraContent={
           <div className="flex w-full flex-col gap-4">
@@ -260,7 +260,7 @@ export function EmailSetupGuide({
               connectedMessage="Your email integration is connected. This agent is ready to receive emails."
               listeningMessage={
                 isManagedAgent
-                  ? 'Waiting for your email — send a message to the inbound address above.'
+                  ? 'Waiting for your email — send a message to your configured inbound address.'
                   : 'Send a test email to verify the inbound pipeline reaches your agent.'
               }
             />

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -94,6 +94,7 @@ export function EmailSetupGuide({
   const sharedInboundAddress = integrationLink?.integration?.sharedInboundAddress;
   const sharedInboxDisabled = Boolean(integrationLink?.integration?.sharedInboxDisabled);
   const hasSharedInbox = Boolean(sharedInboundAddress) && !sharedInboxDisabled;
+  const isManagedAgent = agent.runtime === 'managed';
 
   const testEmailMutation = useMutation({
     mutationFn: async () => {
@@ -229,21 +230,27 @@ export function EmailSetupGuide({
         index={testStepIndex}
         status={deriveStepStatus(testStepIndex, firstIncompleteStep)}
         title="Test connection"
-        description="Send an email to the inbound address and verify it reaches your agent handler."
+        description={
+          isManagedAgent
+            ? 'Send an email to the inbound address above. We will detect when it arrives.'
+            : 'Send an email to the inbound address and verify it reaches your agent handler.'
+        }
         rightContent={
-          <SetupButton
-            leadingIcon={
-              testEmailMutation.isPending ? (
-                <RiLoader4Line className="size-3.5 animate-spin" />
-              ) : (
-                <RiMailSendLine className="size-3.5" />
-              )
-            }
-            disabled={firstIncompleteStep < testStepIndex || testEmailMutation.isPending}
-            onClick={() => testEmailMutation.mutate()}
-          >
-            {testEmailMutation.isPending ? 'Sending...' : 'Send test email'}
-          </SetupButton>
+          isManagedAgent ? undefined : (
+            <SetupButton
+              leadingIcon={
+                testEmailMutation.isPending ? (
+                  <RiLoader4Line className="size-3.5 animate-spin" />
+                ) : (
+                  <RiMailSendLine className="size-3.5" />
+                )
+              }
+              disabled={firstIncompleteStep < testStepIndex || testEmailMutation.isPending}
+              onClick={() => testEmailMutation.mutate()}
+            >
+              {testEmailMutation.isPending ? 'Sending...' : 'Send test email'}
+            </SetupButton>
+          )
         }
       />
     </>
@@ -258,7 +265,11 @@ export function EmailSetupGuide({
         onStepsCompleted?.();
       }}
       connectedMessage="Your email integration is connected. This agent is ready to receive emails."
-      listeningMessage="Send a test email to verify the inbound pipeline reaches your agent."
+      listeningMessage={
+        isManagedAgent
+          ? 'Waiting for your email — send a message to the inbound address above.'
+          : 'Send a test email to verify the inbound pipeline reaches your agent.'
+      }
     />
   );
 

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -10,6 +10,7 @@ import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
 import { InboundAddressConfig } from './inbound-address-config';
 import { OutboundProviderSelect } from './outbound-provider-select';
+import { SharedInboundAddressField } from './shared-inbound-address-field';
 import { IntegrationCredentialsSidebar, ListeningStatus, SetupButton, SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
 import { type ConfiguredAddress, useEmailSetupCredentials } from './use-email-setup-credentials';
@@ -143,6 +144,8 @@ export function EmailSetupGuide({
     testConnected,
   ]);
 
+  const showInboundAddressOnTestStep = isOnboarding && hasSharedInbox && sharedInboundAddress;
+
   const stepsColumn = (
     <>
       <SetupStep
@@ -213,16 +216,22 @@ export function EmailSetupGuide({
         status={deriveStepStatus(inboundStepIndex, firstIncompleteStep)}
         sectionLabel="SETUP RECEIVING EMAILS"
         title="Configure inbound address"
-        description="You can talk to your agent via this mail address. Override the address to send from another email. Reply-To always routes back to the agent so replies stay in the thread."
+        description={
+          showInboundAddressOnTestStep
+            ? 'Your agent receives email on a dedicated inbound address. Custom domains and providers can be configured later.'
+            : 'You can talk to your agent via this mail address. Override the address to send from another email. Reply-To always routes back to the agent so replies stay in the thread.'
+        }
         extraContent={
-          <InboundAddressConfig
-            sharedInboundAddress={hasSharedInbox ? sharedInboundAddress : undefined}
-            configuredAddresses={configuredAddresses}
-            domains={domains}
-            onAddAddress={addAddress}
-            onRemoveAddress={removeAddress}
-            hideCustomAddressForm={isOnboarding}
-          />
+          showInboundAddressOnTestStep ? undefined : (
+            <InboundAddressConfig
+              sharedInboundAddress={hasSharedInbox ? sharedInboundAddress : undefined}
+              configuredAddresses={configuredAddresses}
+              domains={domains}
+              onAddAddress={addAddress}
+              onRemoveAddress={removeAddress}
+              hideCustomAddressForm={isOnboarding}
+            />
+          )
         }
       />
 
@@ -232,8 +241,30 @@ export function EmailSetupGuide({
         title="Test connection"
         description={
           isManagedAgent
-            ? 'Send an email to the inbound address above. We will detect when it arrives.'
-            : 'Send an email to the inbound address and verify it reaches your agent handler.'
+            ? 'Send an email to the inbound address below. We will detect when it arrives.'
+            : 'Send an email to the inbound address below and verify it reaches your agent handler.'
+        }
+        extraContent={
+          <div className="flex w-full flex-col gap-4">
+            {showInboundAddressOnTestStep ? (
+              <SharedInboundAddressField sharedInboundAddress={sharedInboundAddress} />
+            ) : null}
+            <ListeningStatus
+              inline
+              agentIdentifier={agent.identifier}
+              watchedIntegrationId={integrationId}
+              onConnected={() => {
+                setTestConnected(true);
+                onStepsCompleted?.();
+              }}
+              connectedMessage="Your email integration is connected. This agent is ready to receive emails."
+              listeningMessage={
+                isManagedAgent
+                  ? 'Waiting for your email — send a message to the inbound address above.'
+                  : 'Send a test email to verify the inbound pipeline reaches your agent.'
+              }
+            />
+          </div>
         }
         rightContent={
           isManagedAgent ? undefined : (
@@ -254,23 +285,6 @@ export function EmailSetupGuide({
         }
       />
     </>
-  );
-
-  const listening = (
-    <ListeningStatus
-      agentIdentifier={agent.identifier}
-      watchedIntegrationId={integrationId}
-      onConnected={() => {
-        setTestConnected(true);
-        onStepsCompleted?.();
-      }}
-      connectedMessage="Your email integration is connected. This agent is ready to receive emails."
-      listeningMessage={
-        isManagedAgent
-          ? 'Waiting for your email — send a message to the inbound address above.'
-          : 'Send a test email to verify the inbound pipeline reaches your agent.'
-      }
-    />
   );
 
   const credentialsSidebar =
@@ -295,7 +309,6 @@ export function EmailSetupGuide({
           />
           {stepsColumn}
         </div>
-        {listening}
         {credentialsSidebar}
       </div>
     );
@@ -304,7 +317,6 @@ export function EmailSetupGuide({
   return (
     <>
       {stepsColumn}
-      {listening}
       {credentialsSidebar}
     </>
   );

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -214,7 +214,7 @@ export function EmailSetupGuide({
         sectionLabel="SETUP RECEIVING EMAILS"
         title="Configure inbound address"
         description="You can talk to your agent via this mail address. Override the address to send from another email. Reply-To always routes back to the agent so replies stay in the thread."
-        rightContent={
+        extraContent={
           <InboundAddressConfig
             sharedInboundAddress={hasSharedInbox ? sharedInboundAddress : undefined}
             configuredAddresses={configuredAddresses}

--- a/apps/dashboard/src/components/agents/inbound-address-config.tsx
+++ b/apps/dashboard/src/components/agents/inbound-address-config.tsx
@@ -40,7 +40,7 @@ export function InboundAddressConfig({
     : ROUTES.INTEGRATIONS;
 
   return (
-    <div className="flex flex-col gap-3 w-full">
+    <div className="flex w-full max-w-xl flex-col gap-3">
       <div className="flex flex-col gap-1.5">
         <div className="flex items-center gap-1">
           <span className="text-text-sub text-label-xs font-medium leading-4">Agent email address</span>

--- a/apps/dashboard/src/components/agents/inbound-address-config.tsx
+++ b/apps/dashboard/src/components/agents/inbound-address-config.tsx
@@ -1,8 +1,7 @@
-import { RiAtLine, RiCloseLine, RiInformation2Line } from 'react-icons/ri';
+import { RiCloseLine, RiInformation2Line } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
 import { type DomainResponse } from '@/api/domains';
-import { CopyButton } from '@/components/primitives/copy-button';
-import { Input } from '@/components/primitives/input';
+import { CopyableEmailAddress } from '@/components/agents/copyable-email-address';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { useEnvironment } from '@/context/environment/hooks';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -57,18 +56,7 @@ export function InboundAddressConfig({
           </Tooltip>
         </div>
 
-        {sharedInboundAddress && (
-          <Input
-            size="xs"
-            readOnly
-            aria-label="Agent email address"
-            value={sharedInboundAddress}
-            leadingIcon={RiAtLine}
-            inlineTrailingNode={
-              <CopyButton size="2xs" valueToCopy={sharedInboundAddress} className="size-6 shrink-0 justify-center" />
-            }
-          />
-        )}
+        {sharedInboundAddress ? <CopyableEmailAddress email={sharedInboundAddress} /> : null}
 
         {configuredAddresses.map((addr) => {
           const full = `${addr.address}@${addr.domain}`;

--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -204,12 +204,14 @@ export function ListeningStatus({
   onConnected,
   connectedMessage,
   listeningMessage,
+  inline = false,
 }: {
   agentIdentifier: string;
   watchedIntegrationId: string | undefined;
   onConnected?: () => void;
   connectedMessage: string;
   listeningMessage: string;
+  inline?: boolean;
 }) {
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
@@ -314,7 +316,7 @@ export function ListeningStatus({
           />,
           document.body
         )}
-      <div className="flex flex-col gap-2 py-4 pl-6">
+      <div className={cn('flex flex-col gap-2', !inline && 'py-4 pl-6')}>
         <div className="flex flex-col gap-3">
           {connectedAt ? (
             <div className="flex items-center gap-1">

--- a/apps/dashboard/src/components/agents/shared-inbound-address-field.tsx
+++ b/apps/dashboard/src/components/agents/shared-inbound-address-field.tsx
@@ -1,5 +1,5 @@
 import { RiInformation2Line } from 'react-icons/ri';
-import { CopyButton } from '@/components/primitives/copy-button';
+import { CopyableEmailAddress } from '@/components/agents/copyable-email-address';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 
 type SharedInboundAddressFieldProps = {
@@ -23,19 +23,7 @@ export function SharedInboundAddressField({ sharedInboundAddress }: SharedInboun
         </Tooltip>
       </div>
 
-      <div className="border-stroke-soft bg-bg-white flex h-8 items-center overflow-hidden rounded-lg border shadow-xs">
-        <span className="text-text-soft flex h-full items-center pl-2 pr-1 text-paragraph-xs font-mono leading-4">
-          @
-        </span>
-        <span className="text-text-sub text-paragraph-xs min-w-0 flex-1 truncate font-mono leading-4">
-          {sharedInboundAddress}
-        </span>
-        <CopyButton
-          size="2xs"
-          valueToCopy={sharedInboundAddress}
-          className="border-stroke-soft h-full w-8 shrink-0 justify-center border-l"
-        />
-      </div>
+      <CopyableEmailAddress email={sharedInboundAddress} />
 
       <p className="text-text-soft text-paragraph-xs flex items-start gap-1 leading-4">
         <RiInformation2Line className="mt-0.5 size-3.5 shrink-0" aria-hidden />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Managed agents**: Removed the "Send test email" button from the email setup "Test connection" step. These agents now only show the listening/waiting state while polling for an inbound message.
- **Custom code (self-hosted) agents**: Kept the "Send test email" action so users can trigger a test message from the dashboard.
- **Inbound address display**: Introduced a `CopyableEmailAddress` component that wraps long shared inbound addresses instead of truncating them in a single-line input. Applied across onboarding (`InboundAddressConfig`, `SharedInboundAddressField`) and the post-setup inbox card.

## Why

Managed agents receive inbound mail directly on Novu's shared inbox — users send from their own email client, so a dashboard "Send test email" action is unnecessary and confusing. Custom code agents still benefit from the one-click test send.

Long agent email addresses (e.g. `delivery-monitor-6avthl0m@dev.agentconnect.sh`) were cut off in the fixed-height input, making copy/paste error-prone.

## Test plan

- [ ] Create a **managed** agent and connect email — confirm step 5 shows listening state only (no "Send test email" button)
- [ ] Create a **custom code** agent and connect email — confirm "Send test email" button is still present
- [ ] Verify the full inbound address is visible and copyable in onboarding and agent details inbox settings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ff9bf34-6841-4c8e-80c3-b9953e6fc972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ff9bf34-6841-4c8e-80c3-b9953e6fc972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Email onboarding’s “Test connection” UI now adapts to the agent type. Managed agents no longer display a dashboard “Send test email” button; instead they stay in a listening/polling state because inbound mail arrives via Novu’s shared inbox. Self-hosted/custom code agents keep the one-click “Send test email” action. To prevent long inbox addresses from being truncated and copied incorrectly, a new `CopyableEmailAddress` component is used throughout onboarding and inbox rows. A shared-inbox toggle now correctly honors its disabled state during updates.

## Affected areas
**dashboard**: Updated the email setup wizard and inbox/onboarding row components to (1) gate the test-send vs listening UX by `agent.runtime`, (2) centralize inbound/shared address rendering via `CopyableEmailAddress`, and (3) fix shared-inbox `Switch` disabled behavior.

## Key technical decisions
- Gate UI behavior with `isManagedAgent` (`agent.runtime === 'managed'`) to remove the dashboard test-send flow for managed agents.
- Introduce `CopyableEmailAddress` with `break-all` word breaking so full addresses remain visible and reliably copyable.
- Reuse the `CopyableEmailAddress` “trailing” slot to compose row affordances while ensuring the shared-inbox `Switch` receives the correct `disabled` prop.

## Testing
Manual verification of onboarding/inbox UX across managed vs custom-code agents, including copy/paste of long shared/inbound addresses and non-interactivity of the shared-inbox toggle while it’s updating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tailors the email onboarding wizard for managed vs. custom-code agents and replaces truncated single-line email address inputs with a new `CopyableEmailAddress` component that word-wraps long addresses.

- Managed agents no longer see a "Send test email" button; the test step shows only the listening/polling state with the shared inbound address displayed above it. Custom-code agents retain the one-click send action.
- `CopyableEmailAddress` is adopted consistently across `InboundAddressConfig`, `SharedInboundAddressField`, and the post-setup inbox card rows, with a `trailing` slot composing badges and toggle controls.
- `SharedInboxRow` now correctly passes `disabled` to the `Switch` component, fixing an oversight where the toggle appeared interactive while an update was in flight.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing one compile-time type error in the test-step conditional render.

In email-setup-guide.tsx, sharedInboundAddress (typed string | undefined) is passed to SharedInboundAddressField.sharedInboundAddress: string inside a branch guarded by the derived variable showInboundAddressOnTestStep rather than by sharedInboundAddress itself. TypeScript control-flow analysis does not narrow the original variable through an indirect boolean, so this is a strict-null-checks violation that would fail the TypeScript compiler. All other changes are well-scoped UI refactors with no correctness concerns.

apps/dashboard/src/components/agents/email-setup-guide.tsx — lines 249–251 where sharedInboundAddress is passed without proper TypeScript narrowing.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/copyable-email-address.tsx | New component rendering a bordered email display with break-all wrapping and a copy button; clean and reusable. |
| apps/dashboard/src/components/agents/email-setup-guide.tsx | Adds isManagedAgent gating and moves ListeningStatus inline into the test step; a TypeScript narrowing issue exists when passing sharedInboundAddress to SharedInboundAddressField. |
| apps/dashboard/src/components/agents/email-inbox-card.tsx | Refactors InboxRow and SharedInboxRow to use CopyableEmailAddress; correctly adds the missing disabled prop to Switch in SharedInboxRow. |
| apps/dashboard/src/components/agents/inbound-address-config.tsx | Replaces Input+CopyButton with CopyableEmailAddress; uses correct direct null-check on sharedInboundAddress to satisfy TypeScript narrowing. |
| apps/dashboard/src/components/agents/setup-guide-primitives.tsx | Adds inline prop to ListeningStatus, conditionally removing the py-4 pl-6 padding; straightforward and correct. |
| apps/dashboard/src/components/agents/shared-inbound-address-field.tsx | Replaces custom address display with CopyableEmailAddress; correctly removes the spurious @ prefix that preceded a full email address. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EmailSetupGuide] --> B{agent.runtime === 'managed'?}
    B -- Yes --> C[isManagedAgent = true]
    B -- No --> D[isManagedAgent = false]

    C --> E{isOnboarding && hasSharedInbox?}
    D --> E

    E -- Yes --> F[showInboundAddressOnTestStep = sharedInboundAddress]
    E -- No --> G[showInboundAddressOnTestStep = false]

    F --> H[Inbound step: simplified description, no InboundAddressConfig]
    G --> I[Inbound step: full description + InboundAddressConfig]

    H --> J[Test step: SharedInboundAddressField + ListeningStatus inline]
    I --> K[Test step: ListeningStatus inline only]

    J --> L{isManagedAgent?}
    K --> L

    L -- Yes --> M[No 'Send test email' button, Listening-only UX]
    L -- No --> N[Show 'Send test email' button + ListeningStatus]

    M --> O[Polling detects connectedAt]
    N --> P[User clicks send, Polling detects connectedAt]

    O --> Q[onStepsCompleted callback]
    P --> Q
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/components/agents/email-setup-guide.tsx`, line 99-112 ([link](https://github.com/novuhq/novu/blob/44a30b2fa8e965a9c9e8588946b1775081dbfd6d/apps/dashboard/src/components/agents/email-setup-guide.tsx#L99-L112)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unused mutation instantiated for managed agents**

   `testEmailMutation` (including its `mutationFn`, success, and error handlers) is always constructed regardless of `isManagedAgent`. For managed agents the button is correctly hidden, so the mutation is dead weight each render. Consider hoisting it behind the `!isManagedAgent` guard, or extracting the non-managed test-step into a dedicated sub-component, so the mutation is only registered when it can actually be triggered.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/components/agents/email-setup-guide.tsx
   Line: 99-112

   Comment:
   **Unused mutation instantiated for managed agents**

   `testEmailMutation` (including its `mutationFn`, success, and error handlers) is always constructed regardless of `isManagedAgent`. For managed agents the button is correctly hidden, so the mutation is dead weight each render. Consider hoisting it behind the `!isManagedAgent` guard, or extracting the non-managed test-step into a dedicated sub-component, so the mutation is only registered when it can actually be triggered.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Femail-setup-guide.tsx%0ALine%3A%2099-112%0A%0AComment%3A%0A**Unused%20mutation%20instantiated%20for%20managed%20agents**%0A%0A%60testEmailMutation%60%20%28including%20its%20%60mutationFn%60%2C%20success%2C%20and%20error%20handlers%29%20is%20always%20constructed%20regardless%20of%20%60isManagedAgent%60.%20For%20managed%20agents%20the%20button%20is%20correctly%20hidden%2C%20so%20the%20mutation%20is%20dead%20weight%20each%20render.%20Consider%20hoisting%20it%20behind%20the%20%60!isManagedAgent%60%20guard%2C%20or%20extracting%20the%20non-managed%20test-step%20into%20a%20dedicated%20sub-component%2C%20so%20the%20mutation%20is%20only%20registered%20when%20it%20can%20actually%20be%20triggered.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11548&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Femail-setup-guide.tsx%3A249-251%0ATypeScript%20cannot%20narrow%20%60sharedInboundAddress%60%20to%20%60string%60%20here%20because%20the%20condition%20is%20on%20the%20derived%20variable%20%60showInboundAddressOnTestStep%60%2C%20not%20on%20%60sharedInboundAddress%60%20itself.%20With%20%60strictNullChecks%60%20enabled%2C%20passing%20%60string%20%7C%20undefined%60%20to%20a%20prop%20that%20expects%20%60string%60%20is%20a%20compile%20error.%20A%20direct%20check%20on%20%60sharedInboundAddress%60%20in%20the%20JSX%20condition%20fixes%20the%20narrowing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%7BshowInboundAddressOnTestStep%20%26%26%20sharedInboundAddress%20%3F%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CSharedInboundAddressField%20sharedInboundAddress%3D%7BsharedInboundAddress%7D%20%2F%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%20%3A%20null%7D%0A%60%60%60%0A%0A&pr=11548&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/agents/email-setup-guide.tsx:249-251
TypeScript cannot narrow `sharedInboundAddress` to `string` here because the condition is on the derived variable `showInboundAddressOnTestStep`, not on `sharedInboundAddress` itself. With `strictNullChecks` enabled, passing `string | undefined` to a prop that expects `string` is a compile error. A direct check on `sharedInboundAddress` in the JSX condition fixes the narrowing.

```suggestion
            {showInboundAddressOnTestStep && sharedInboundAddress ? (
              <SharedInboundAddressField sharedInboundAddress={sharedInboundAddress} />
            ) : null}
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(dashboard): address PR review feedba..."](https://github.com/novuhq/novu/commit/4bb4a1a8572cdca3ead30464aef08c9aca433318) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37470884)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->