### PR TITLE
fix(dashboard): update agent onboarding prompt placeholder fixes NV-8037

### DIFF
--- a/apps/dashboard/src/components/onboarding/connect-agent/prompt-input.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prompt-input.tsx
@@ -7,7 +7,7 @@ import { GenerationStatus, type GenerationStep } from './generation-status';
 const PROMPT_MAX_LENGTH = 2000;
 
 const DEFAULT_PLACEHOLDER =
-  'Review every new pull request for security issues, then post a concise risk summary as a PR comment';
+  'Describe your product or the agent you want to connect';
 
 type PromptInputProps = {
   value: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the empty-state placeholder on the agent onboarding prompt field from a specific use-case example to instructional copy that prompts users to describe their product or the agent they want to connect.

**Before:** "Review every new pull request for security issues, then post a concise risk summary as a PR comment"

**After:** "Describe your product or the agent you want to connect"

## Why

The previous placeholder read like a suggested use case, which could confuse users into thinking that was the expected input. The new copy makes it clear the field is for describing their own product or agent.

## Test plan

- [ ] Open agent onboarding step 2 ("What should your agent do?")
- [ ] Confirm the empty textarea shows the new placeholder text
- [ ] Confirm the "Try" suggestion chips still work as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa998b23-4733-4add-b541-b4a920bae939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa998b23-4733-4add-b541-b4a920bae939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the placeholder text in the agent onboarding prompt textarea from a specific PR-review use-case example to generic instructional copy ("Describe your product or the agent you want to connect"), improving UX clarity by signalling that users should enter their own context rather than a suggested workflow.

- **Only change**: the `DEFAULT_PLACEHOLDER` constant in `prompt-input.tsx` — no logic, state, or styling is affected.
- The new placeholder better aligns with the field's purpose and avoids anchoring users to a single example use case.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is limited to a single string constant with no effect on logic, state, or component behaviour.

The only modification is swapping one hardcoded placeholder string for another. No component logic, props, styling, or data flow is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/onboarding/connect-agent/prompt-input.tsx | Single-line change updating DEFAULT_PLACEHOLDER from a specific use-case example to instructional copy; no logic or structural changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PromptInput rendered] --> B{placeholder prop provided?}
    B -- Yes --> C[Use provided placeholder]
    B -- No --> D[Use DEFAULT_PLACEHOLDER]
    D --> E["'Describe your product or the agent you want to connect'"]
    C --> F[Textarea renders with placeholder]
    E --> F
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): update agent onboarding ..."](https://github.com/novuhq/novu/commit/7eac89ee8b4d18f1c3798e6a0141a702325283d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37480807)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The placeholder text in the agent onboarding prompt field (step 2: "What should your agent do?") was updated from a specific use-case example ("Review every new pull request for security issues, then post a concise risk summary as a PR comment") to clearer instructional copy ("Describe your product or the agent you want to connect"). This change removes misleading guidance that could be misinterpreted as the expected input format and provides users with clearer direction to describe their own product or agent instead.

## Affected areas

**dashboard** — Updated the `DEFAULT_PLACEHOLDER` constant in the `PromptInput` component used during agent onboarding to provide clearer guidance to users about what they should enter in the prompt field.

## Testing

Manual verification should confirm the new placeholder text displays correctly in the agent onboarding form (step 2) and that the existing "Try" suggestion pills continue to function as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->