### PR TITLE
fix(api-service,dashboard,shared): CLI auth slug, onboarding hang, and copy feedback fixes NV-8038

### DIFF
--- a/apps/api/src/app/cli-auth/usecases/approve-cli-device-session/approve-cli-device-session.usecase.ts
+++ b/apps/api/src/app/cli-auth/usecases/approve-cli-device-session/approve-cli-device-session.usecase.ts
@@ -1,20 +1,11 @@
 import { createHash } from 'node:crypto';
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { buildSlug } from '@novu/application-generic';
+import { buildSlug, shortenEnvironmentName } from '@novu/application-generic';
 import { EnvironmentRepository } from '@novu/dal';
-import { EnvironmentEnum, ShortIsPrefixEnum } from '@novu/shared';
+import { ShortIsPrefixEnum } from '@novu/shared';
 
 import { CliDeviceSessionNotFoundError, CliDeviceSessionService } from '../../services/cli-device-session.service';
 import { ApproveCliDeviceSessionCommand } from './approve-cli-device-session.command';
-
-function shortenEnvironmentName(name: string): string {
-  const mapToShortEnvName: Record<EnvironmentEnum, string> = {
-    [EnvironmentEnum.PRODUCTION]: 'prod',
-    [EnvironmentEnum.DEVELOPMENT]: 'dev',
-  };
-
-  return mapToShortEnvName[name] || name;
-}
 
 @Injectable()
 export class ApproveCliDeviceSession {

--- a/apps/api/src/app/cli-auth/usecases/approve-cli-device-session/approve-cli-device-session.usecase.ts
+++ b/apps/api/src/app/cli-auth/usecases/approve-cli-device-session/approve-cli-device-session.usecase.ts
@@ -1,9 +1,20 @@
 import { createHash } from 'node:crypto';
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { buildSlug } from '@novu/application-generic';
 import { EnvironmentRepository } from '@novu/dal';
+import { EnvironmentEnum, ShortIsPrefixEnum } from '@novu/shared';
 
 import { CliDeviceSessionNotFoundError, CliDeviceSessionService } from '../../services/cli-device-session.service';
 import { ApproveCliDeviceSessionCommand } from './approve-cli-device-session.command';
+
+function shortenEnvironmentName(name: string): string {
+  const mapToShortEnvName: Record<EnvironmentEnum, string> = {
+    [EnvironmentEnum.PRODUCTION]: 'prod',
+    [EnvironmentEnum.DEVELOPMENT]: 'dev',
+  };
+
+  return mapToShortEnvName[name] || name;
+}
 
 @Injectable()
 export class ApproveCliDeviceSession {
@@ -35,7 +46,11 @@ export class ApproveCliDeviceSession {
         approvedByUserId: command.userId,
         apiKey: command.apiKey,
         environmentId: environment._id,
-        environmentSlug: environment.identifier ?? null,
+        environmentSlug: buildSlug(
+          shortenEnvironmentName(environment.name),
+          ShortIsPrefixEnum.ENVIRONMENT,
+          environment._id
+        ),
         environmentName: environment.name ?? null,
         organizationId: environment._organizationId,
         user: {

--- a/apps/api/src/app/environments-v1/usecases/get-my-environments/get-my-environments.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/get-my-environments/get-my-environments.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException, Scope } from '@nestjs/common';
-import { buildSlug, decryptApiKey, PinoLogger } from '@novu/application-generic';
+import { buildSlug, decryptApiKey, PinoLogger, shortenEnvironmentName } from '@novu/application-generic';
 import { EnvironmentEntity, EnvironmentRepository } from '@novu/dal';
-import { EnvironmentEnum, ShortIsPrefixEnum } from '@novu/shared';
+import { ShortIsPrefixEnum } from '@novu/shared';
 import { EnvironmentResponseDto } from '../../dtos/environment-response.dto';
 import { GetMyEnvironmentsCommand } from './get-my-environments.command';
 
@@ -49,13 +49,4 @@ export class GetMyEnvironments {
       key: decryptApiKey(apiKey.key),
     }));
   }
-}
-
-function shortenEnvironmentName(name: string): string {
-  const mapToShotEnvName: Record<EnvironmentEnum, string> = {
-    [EnvironmentEnum.PRODUCTION]: 'prod',
-    [EnvironmentEnum.DEVELOPMENT]: 'dev',
-  };
-
-  return mapToShotEnvName[name] || name;
 }

--- a/apps/dashboard/src/components/agents/create-agent-fields/existing-agent-fields.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-fields/existing-agent-fields.tsx
@@ -74,7 +74,7 @@ export function ExistingAgentFields({
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-px">
           <label htmlFor={environmentIdInputId} className="text-text-strong text-label-xs font-medium">
-            Claude Environment ID
+            Claude Environment ID <span className="text-text-soft">(Optional)</span>
           </label>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -68,7 +68,7 @@ export function PrebuiltPromptBanner() {
                 : 'linear-gradient(180deg, rgba(255,255,255,0.16) 0%, rgba(255,255,255,0) 100%), linear-gradient(90deg, #0e121b 0%, #0e121b 100%)',
             }}
           >
-            <span className="px-1">{copied ? 'Copied!' : 'Copy prompt'}</span>
+            <span className="px-1">{copied ? 'Copied - paste in your project' : 'Copy prompt'}</span>
           </button>
         </div>
       </div>

--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -68,7 +68,7 @@ export function PrebuiltPromptBanner() {
                 : 'linear-gradient(180deg, rgba(255,255,255,0.16) 0%, rgba(255,255,255,0) 100%), linear-gradient(90deg, #0e121b 0%, #0e121b 100%)',
             }}
           >
-            <span className="px-1">{copied ? 'Copied - paste in your project' : 'Copy prompt'}</span>
+            <span className="whitespace-nowrap px-1">{copied ? 'Copied - paste in your project' : 'Copy prompt'}</span>
           </button>
         </div>
       </div>

--- a/libs/application-generic/src/utils/index.ts
+++ b/libs/application-generic/src/utils/index.ts
@@ -31,6 +31,7 @@ export * from './object';
 export * from './parse-payload-schema';
 export * from './parse-step-variables';
 export * from './sanitize-control-values';
+export * from './shorten-environment-name';
 export * from './slugify-or-random';
 export * from './ssrf-url-validation';
 export * from './step-resolver-control-state';

--- a/libs/application-generic/src/utils/shorten-environment-name.ts
+++ b/libs/application-generic/src/utils/shorten-environment-name.ts
@@ -1,8 +1,6 @@
 import { EnvironmentEnum } from '@novu/shared';
 
-export type ShortEnvironmentName = 'prod' | 'dev';
-
-export function shortenEnvironmentName(name: string): ShortEnvironmentName {
+export function shortenEnvironmentName(name: string): string {
   if (name === EnvironmentEnum.PRODUCTION) {
     return 'prod';
   }
@@ -11,5 +9,5 @@ export function shortenEnvironmentName(name: string): ShortEnvironmentName {
     return 'dev';
   }
 
-  throw new Error(`Unsupported environment name: ${name}`);
+  return name;
 }

--- a/libs/application-generic/src/utils/shorten-environment-name.ts
+++ b/libs/application-generic/src/utils/shorten-environment-name.ts
@@ -1,0 +1,15 @@
+import { EnvironmentEnum } from '@novu/shared';
+
+export type ShortEnvironmentName = 'prod' | 'dev';
+
+export function shortenEnvironmentName(name: string): ShortEnvironmentName {
+  if (name === EnvironmentEnum.PRODUCTION) {
+    return 'prod';
+  }
+
+  if (name === EnvironmentEnum.DEVELOPMENT) {
+    return 'dev';
+  }
+
+  throw new Error(`Unsupported environment name: ${name}`);
+}

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -181,7 +181,7 @@ Set the agent description in an environment variable first — do **not** paste 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --login \
   --channel <slack|email|telegram|whatsapp|teams|skip>
@@ -192,7 +192,7 @@ npx novu connect "$NOVU_AGENT_DESCRIPTION" \
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --channel <slack|email|telegram|skip>
 ```
@@ -204,7 +204,7 @@ Never pass `--channel whatsapp` or `--channel teams` in keyless mode — those r
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --login \
   --channel slack
@@ -230,7 +230,7 @@ Conditional flags:
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 export SLACK_CONFIG_TOKEN='<xoxe.xoxp-...>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --login \
   --channel slack \
@@ -393,7 +393,7 @@ Adapt the recap to what actually happened (drop the MCP clause when no integrati
 
 ## Command flag reference
 
-Run `novu connect --help` for the full contract. Keep help text in sync when changing connect flags.
+Run `novu@latest connect --help` for the full contract. Keep help text in sync when changing connect flags.
 
 | Flag | Purpose |
 |---|---|

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -29,7 +29,7 @@ These govern every step. When in doubt, follow these over any specific instructi
 - **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime, auth mode) unless the user raises it.
 - **Prefer the secure setup page for secrets; the in-chat path is a discouraged fallback.** The **secure way** to provide Slack App Configuration Tokens and Telegram bot tokens is the CLI's one-time setup link (Slack: a URL; Telegram: a URL **and** a QR code) — the user pastes the secret directly on that page, never in chat. Always offer this first and recommend it. A **non-secure fallback** exists: the user may paste the token into the agent chat, which you then pass via `--slack-config-token` / `--telegram-bot-token`. Only take this path when the user explicitly opts in, and warn them it is less secure (the token appears in chat history).
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
-- **One Connect shell, no log watchers.** Run the Step 3 connect command in a single Shell session. Read stdout from that session (or **Await** its shell id). Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path. **Never use timers** (`ScheduleWakeup`, `sleep`, or "check back in N minutes") to wait for handoffs — **Await** the Connect shell continuously until the next `NOVU_CONNECT_*` sentinel or `✓ Your agent is live` appears.
+- **One Connect shell, no log watchers.** Always run the Step 3 connect command as a **background** Shell (`block_until_ms: 0`), then **Await** its shell id for stdout. **Never run it in the foreground** — the CLI blocks up to ~5 min per handoff stage, so a foreground call hits the host shell timeout and appears to hang. Use a single Shell session only. Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path. **Never use timers** (`ScheduleWakeup`, `sleep`, or "check back in N minutes") to wait for handoffs — **Await** the Connect shell continuously until the next `NOVU_CONNECT_*` sentinel or `✓ Your agent is live` appears. The only exception: `--channel skip` without `--login` may run in the foreground.
 - **The CLI validates handoffs.** For dashboard OAuth (`--login`), `slack`/`email`/`telegram`, that Shell blocks and polls until the handoff completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion yourself.
 - **WhatsApp / MS Teams in keyless mode never reach the CLI.** If the user picks one and you are **not** using `--login`, do **not** run connect — redirect them to the Novu dashboard instead (Step 1). With **`--login`**, the CLI creates the agent and hands off a dashboard URL to finish channel setup.
 - **Report conclusion-first.** Lead with the CLI's result (live / failed), then the one action the user must take. Keep it terse.
@@ -61,8 +61,8 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 | **Demo runtime** | Default — shared Claude runtime. In keyless mode, limited to ~5 free replies. |
 | **Handoff** | The channel-specific user action (authorize link, send email, or dashboard URL) that finishes connecting the channel. |
 | **Dashboard redirect** | Keyless-only WhatsApp / MS Teams path: no agent is created in the CLI — user continues in the dashboard. |
-| **Connect shell** | The one Shell invocation that runs the Step 3 connect command. All connect output lives here — not in log files or separate watch commands. |
-| **CLI poll** | The Connect shell blocks up to ~5 min until OAuth, inbound email, or dashboard authorization completes. Success or timeout comes from its stdout only. |
+| **Connect shell** | The one background Shell invocation (`block_until_ms: 0`) that runs the Step 3 connect command. You **Await** its shell id for all stdout — not log files or separate watch commands. |
+| **CLI poll** | While the Connect shell runs in the background, the CLI process blocks up to ~5 min per handoff stage (OAuth, inbound email, dashboard authorization). You monitor progress by **Await**ing `NOVU_CONNECT_*` sentinels on that shell id. Success or timeout comes from its stdout only. |
 | **Claim** | Keyless only: user signs up via the in-channel link, migrating the temporary agent into their workspace. |
 
 ---
@@ -210,12 +210,16 @@ npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --channel slack
 ```
 
-**How to run the Connect shell** — pick one path; never combine with log redirection or a second watch command:
+**How to run the Connect shell** — never combine with log redirection or a second watch command:
 
-- **If using `--login`:** first **Await** `NOVU_CONNECT_AUTH_URL_FILE=`, **Read** that file for the auth URL, deliver the URL to the user, then **Await** channel handoff markers and success.
-- **If channel is `slack`, `email`, or `telegram`:** Shell with `block_until_ms: 0` (background). Use **Await** on that shell id (e.g. `NOVU_CONNECT_SLACK_SETUP_URL=`, `NOVU_CONNECT_INBOUND_ADDRESS=`, etc.). **Await** until `✓ Your agent is live` or `✗`. Do not use Monitor, `tail -f`, `grep`, Read on log files.
-- **If channel is `whatsapp` or `teams` (authenticated only):** background Shell; **Await** auth URL, then dashboard agent URL or success.
-- **If channel is `skip`:** foreground Shell is enough unless you need to capture `NOVU_CONNECT_AUTH_URL_FILE=` from a background run.
+Always start the Connect command as a **background** Shell (`block_until_ms: 0`), then **Await** its shell id for the markers below. This applies to every auth mode and channel. **Never run it in the foreground** — the CLI blocks up to ~5 min per handoff stage and a foreground call will hit the host shell timeout.
+
+Then follow the path that matches your flags:
+
+- **If using `--login`:** **Await** `NOVU_CONNECT_AUTH_URL_FILE=` on the background shell id, **Read** that file for the auth URL, deliver the URL to the user, then **Await** channel handoff markers and success on the same shell id.
+- **If channel is `slack`, `email`, or `telegram`:** **Await** on that shell id (e.g. `NOVU_CONNECT_SLACK_SETUP_URL=`, `NOVU_CONNECT_INBOUND_ADDRESS=`, etc.). **Await** until `✓ Your agent is live` or `✗`. Do not use Monitor, `tail -f`, `grep`, Read on log files.
+- **If channel is `whatsapp` or `teams` (authenticated only):** **Await** auth URL, then dashboard agent URL or success on the same shell id.
+- **If channel is `skip` without `--login`:** foreground Shell is allowed — the only exception to the background rule above.
 
 Conditional flags:
 


### PR DESCRIPTION
## Summary

- **CLI auth**: Store the canonical environment slug (`buildSlug`) when approving a CLI device session, instead of `environment.identifier`. This matches `GetMyEnvironments` and ensures `novu connect` receives slugs compatible with dashboard routing (e.g. `/env/{slug}/...`).
- **Onboarding agent hang**: Mandate running `novu connect` as a background shell (`block_until_ms: 0`) + `Await` in `agent-onboarding.md`. The CLI intentionally blocks up to ~5 min per handoff stage; running it in the foreground causes the host shell tool to timeout and appear hung.
- **Onboarding UX**: Update the prebuilt prompt banner copy button feedback from "Copied!" to "Copied - paste in your project" so users know the next step.
- **Dashboard**: Mark Claude Environment ID as optional in existing-agent fields.

```mermaid
sequenceDiagram
  participant Agent as OnboardingAgent
  participant Shell as HostShell
  participant CLI as novu_connect

  Agent->>Shell: Shell connect --ci (block_until_ms: 0)
  Shell-->>Agent: shell id (background)
  loop Each handoff stage
    CLI->>CLI: poll up to 5 min
    CLI-->>Agent: NOVU_CONNECT_* sentinel via Await
    Agent->>Agent: deliver handoff URL to user
  end
  CLI-->>Agent: "✓ Your agent is live."
```

## Test plan

- [ ] Approve a CLI device session from the dashboard and verify the CLI receives an `environmentSlug` in `dev_env_*` / `prod_env_*` format (not the legacy identifier).
- [ ] Confirm `novu connect` deep links and post-auth redirects resolve to the correct environment in the dashboard.
- [ ] Run the onboarding agent with the updated `agent-onboarding.md` and verify it backgrounds the Connect shell (`block_until_ms: 0`) and Awaits `NOVU_CONNECT_*` sentinels instead of running foreground and timing out.
- [ ] On agent onboarding, click **Copy prompt** and verify the button shows "Copied - paste in your project" for ~2s before reverting.
- [ ] Verify existing-agent fields show "Claude Environment ID (Optional)".

## Linear

https://linear.app/novu/issue/NV-8038/fix-cli-auth-environment-slug-and-improve-onboarding-copy-prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR resolves onboarding reliability and navigation issues by making CLI authentication produce a canonical `environmentSlug` in the `dev_env_*` / `prod_env_*` format the dashboard routing expects. It also updates the onboarding runbook and agent guidance so `novu connect` is started as a background shell and awaited via sentinel environment variables, preventing the host tooling from timing out and appearing hung. Finally, it improves onboarding UX (“Copied - paste in your project”) and marks Claude Environment ID as optional for existing agents, while ensuring `shortenEnvironmentName` remains backward-compatible with custom environment names.

## Affected areas
- **API**: CLI device session approval now computes `environmentSlug` using `buildSlug()` + `shortenEnvironmentName(...)`, including safe fallback behavior for non-standard environment names.
- **Dashboard**: Updated the prebuilt prompt banner copy feedback text and labeled Claude Environment ID as optional in existing-agent fields.
- **Shared (docs)**: Revised `agent-onboarding.md` to instruct running connect as a background shell and continuously awaiting sentinels; updated command examples to `npx novu@latest`.
- **Shared utils**: Added `shortenEnvironmentName` utility and re-exported it from the shared utils barrel.

## Key technical decisions
- Generate canonical `environmentSlug` during CLI auth (instead of passing through raw identifiers) to align with dashboard deep-link patterns.
- Prevent onboarding hangs by shifting connect execution to a background shell and awaiting sentinel variables rather than running connect in the foreground.
- Preserve backward compatibility by ensuring `shortenEnvironmentName` returns the original name for custom environment naming schemes.

## Testing
Manual verification covering the five planned checks: `environmentSlug` format, `novu connect` deep-link resolution, connect backgrounding/await behavior, copy-button feedback timing/text, and optional marking for Claude Environment ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CLI auth environment slug mismatch, prevents the onboarding `novu connect` shell from hanging by mandating background execution, updates copy-button feedback text, and marks Claude Environment ID as optional in the dashboard form. The shared `shortenEnvironmentName` utility correctly deduplicates the dev/prod mapping logic and falls back to the raw name for custom-named environments, so there is no regression for non-standard environments.

- **CLI auth slug fix**: `ApproveCliDeviceSession` now generates `environmentSlug` via `buildSlug(shortenEnvironmentName(name), ...)`, matching the format `GetMyEnvironments` already returned, so `novu connect` deep links and dashboard routes resolve correctly.
- **Onboarding hang fix**: `agent-onboarding.md` now explicitly requires the connect command to run as a background shell (`block_until_ms: 0`) with `Await` on the shell id, preventing the 5-minute CLI poll from hitting the host shell timeout.
- **UX / dashboard polish**: Copy-button feedback updated to "Copied - paste in your project" (with `whitespace-nowrap`), and Claude Environment ID labelled as optional.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three surface areas (API slug generation, dashboard UX, onboarding docs) receive narrow, well-contained fixes with no new error paths.

The slug fix aligns two code paths that were already supposed to agree; the shared utility safely falls back to the raw name for custom environments rather than throwing. Documentation and label changes carry no runtime risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/cli-auth/usecases/approve-cli-device-session/approve-cli-device-session.usecase.ts | Replaces environment.identifier with buildSlug(shortenEnvironmentName(name), ...) to align CLI auth slug format with GetMyEnvironments; logic is correct and error handling is unchanged. |
| libs/application-generic/src/utils/shorten-environment-name.ts | New shared utility that maps Development→dev and Production→prod, falling back to the raw name for any other value — safe for custom-named environments. |
| apps/api/src/app/environments-v1/usecases/get-my-environments/get-my-environments.usecase.ts | Removes the local shortenEnvironmentName helper and imports the new shared version; functionally identical (both fall back to raw name for non-standard environments). |
| apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx | Copy button feedback text updated to 'Copied - paste in your project' with whitespace-nowrap added to prevent layout overflow on the longer string. |
| apps/dashboard/src/components/agents/create-agent-fields/existing-agent-fields.tsx | Claude Environment ID label updated to include '(Optional)' indicator — straightforward label-only change. |
| packages/shared/docs/agent-onboarding.md | Runbook updated to mandate background shell (block_until_ms: 0) for connect command, pin npx to novu@latest, and refine CLI poll and Connect shell glossary definitions. |
| libs/application-generic/src/utils/index.ts | Adds re-export for the new shorten-environment-name utility. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Dashboard
  participant API as API (ApproveCliDeviceSession)
  participant Env as EnvironmentRepository
  participant Session as CliDeviceSessionService

  Dashboard->>API: "POST /cli-auth/approve {deviceCode, environmentId, apiKey}"
  API->>Env: findOne(_id, _organizationId)
  Env-->>API: "environment {name, _id, identifier}"
  API->>API: buildSlug(shortenEnvironmentName(name), ENV, _id)
  Note right of API: Previously: environment.identifier
  API->>Session: "approve({environmentSlug: dev_env_..., ...})"
  Session-->>API: ok
  API-->>Dashboard: "{ok: true}"
  Note over Dashboard,Session: CLI polls session and receives slug matching GetMyEnvironments format for correct routing
```

<sub>Reviews (3): Last reviewed commit: ["fix(api-service): preserve custom enviro..."](https://github.com/novuhq/novu/commit/610fb4ae0a5ed3de0e74e26b0b5e5b147d8c40df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37488133)</sub>

<!-- /greptile_comment -->