### PR TITLE
fix(dashboard): redirect connect claim to claimed agent fixes NV-8042

### DIFF
--- a/apps/dashboard/src/api/connect.ts
+++ b/apps/dashboard/src/api/connect.ts
@@ -6,9 +6,9 @@ export type ClaimKeylessConnectResponse = {
 };
 
 export async function claimKeylessConnect(token: string): Promise<ClaimKeylessConnectResponse> {
-  const response = await post<{ data: ClaimKeylessConnectResponse } | ClaimKeylessConnectResponse>('/connect/claim', {
+  const response = await post<{ data: ClaimKeylessConnectResponse }>('/connect/claim', {
     body: { token },
   });
 
-  return 'data' in response ? response.data : response;
+  return response.data;
 }

--- a/apps/dashboard/src/api/connect.ts
+++ b/apps/dashboard/src/api/connect.ts
@@ -6,7 +6,9 @@ export type ClaimKeylessConnectResponse = {
 };
 
 export async function claimKeylessConnect(token: string): Promise<ClaimKeylessConnectResponse> {
-  return post<ClaimKeylessConnectResponse>('/connect/claim', {
+  const response = await post<{ data: ClaimKeylessConnectResponse } | ClaimKeylessConnectResponse>('/connect/claim', {
     body: { token },
   });
+
+  return 'data' in response ? response.data : response;
 }

--- a/apps/dashboard/src/pages/connect-claim.tsx
+++ b/apps/dashboard/src/pages/connect-claim.tsx
@@ -4,7 +4,7 @@ import { EnvironmentTypeEnum } from '@novu/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { RiCheckLine, RiLoader4Line } from 'react-icons/ri';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
-import { claimKeylessConnect } from '@/api/connect';
+import { type ClaimKeylessConnectResponse, claimKeylessConnect } from '@/api/connect';
 import { AuthLayout } from '@/components/auth-layout';
 import { PageMeta } from '@/components/page-meta';
 import { Button } from '@/components/primitives/button';
@@ -21,7 +21,7 @@ import {
   readPendingConnectClaim,
   storePendingConnectClaim,
 } from '@/utils/connect-claim-pending';
-import { ROUTES } from '@/utils/routes';
+import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
 
 const CLAIM_FAILED_MESSAGE = 'Unable to claim this agent. Please try again or reopen the link from your chat.';
 const ENV_READY_TIMEOUT_MS = 60_000;
@@ -63,14 +63,14 @@ export const ConnectClaimPage = () => {
   );
 };
 
-function hasClaimableDevelopmentEnvironment(environments?: IEnvironment[]): boolean {
+function getClaimableDevelopmentEnvironment(environments?: IEnvironment[]): IEnvironment | undefined {
   if (!environments?.length) {
-    return false;
+    return undefined;
   }
 
-  return Boolean(
+  return (
     environments.find((env) => env.type === EnvironmentTypeEnum.DEV && !env._parentId) ??
-      environments.find((env) => !env._parentId)
+    environments.find((env) => !env._parentId)
   );
 }
 
@@ -87,7 +87,7 @@ function ConnectClaimContent({ token }: { token: string | null }) {
   });
 
   useEffect(() => {
-    if (hasClaimableDevelopmentEnvironment(environments)) {
+    if (getClaimableDevelopmentEnvironment(environments)) {
       setIsEnvironmentReady(true);
       setEnvironmentSetupError(null);
     }
@@ -110,6 +110,7 @@ function ConnectClaimContent({ token }: { token: string | null }) {
   }, [isEnvironmentReady, environmentSetupError]);
   const [isClaiming, setIsClaiming] = useState(false);
   const [didClaim, setDidClaim] = useState(false);
+  const [claimResult, setClaimResult] = useState<ClaimKeylessConnectResponse | null>(null);
   const [claimError, setClaimError] = useState<string | null>(null);
   const hasAttemptedRef = useRef(false);
 
@@ -124,8 +125,9 @@ function ConnectClaimContent({ token }: { token: string | null }) {
     setIsClaiming(true);
     setClaimError(null);
     try {
-      await claimKeylessConnect(token);
+      const result = await claimKeylessConnect(token);
       clearPendingConnectClaim();
+      setClaimResult(result);
       setDidClaim(true);
     } catch (error) {
       console.error('Connect claim failed', error);
@@ -141,6 +143,33 @@ function ConnectClaimContent({ token }: { token: string | null }) {
     setClaimError(null);
     void handleClaim();
   };
+
+  const handleVisitDashboard = useCallback(() => {
+    const devEnvironment =
+      environments?.find((env) => env._id === claimResult?.environmentId) ??
+      getClaimableDevelopmentEnvironment(environments);
+    const environmentSlug = devEnvironment?.slug;
+
+    if (!environmentSlug) {
+      navigate(ROUTES.ROOT);
+
+      return;
+    }
+
+    if (claimResult?.agentIdentifier) {
+      navigate(
+        buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+          environmentSlug,
+          agentIdentifier: encodeURIComponent(claimResult.agentIdentifier),
+          agentTab: AGENT_DETAILS_DEFAULT_TAB,
+        })
+      );
+
+      return;
+    }
+
+    navigate(buildRoute(ROUTES.AGENTS, { environmentSlug }));
+  }, [claimResult, environments, navigate]);
 
   const reason = tokenOk ? null : 'This page must be opened from the link in your chat.';
   const setupError = environmentSetupError;
@@ -202,7 +231,7 @@ function ConnectClaimContent({ token }: { token: string | null }) {
                 mode="ghost"
                 size="xs"
                 className="w-full"
-                onClick={() => navigate(ROUTES.ROOT)}
+                onClick={handleVisitDashboard}
               >
                 Visit Dashboard
               </Button>


### PR DESCRIPTION
## Summary

- Unwrap the `/connect/claim` API `{ data: ... }` response in `claimKeylessConnect` so `agentIdentifier` and `environmentId` are available to callers.
- Update the connect claim success flow so **Visit Dashboard** navigates to the claimed agent overview page instead of the agents list.

## Why

After a keyless connect claim, users expected to land on their newly claimed agent. The redirect fell back to `/env/:slug/agents` because the claim response was stored without unwrapping the API envelope, leaving `agentIdentifier` undefined.

```mermaid
sequenceDiagram
  participant UI as ConnectClaimPage
  participant API as claimKeylessConnect
  participant Server as POST /connect/claim

  UI->>API: claim(token)
  API->>Server: POST /connect/claim
  Server-->>API: { data: { environmentId, agentIdentifier } }
  API-->>UI: { environmentId, agentIdentifier }
  UI->>UI: Visit Dashboard → /env/:slug/agents/:agentIdentifier/overview
```

## Test plan

- [x] Complete a keyless connect claim flow
- [x] Click **Visit Dashboard** after claim succeeds
- [x] Confirm navigation lands on `/env/:environmentSlug/agents/:agentIdentifier/overview`
- [x] Dashboard TypeScript check passes (`pnpm --filter @novu/dashboard exec tsc --noEmit`)

## Linear

https://linear.app/novu/issue/NV-8042/connect-claim-visit-dashboard-redirects-to-agents-list-instead-of

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The keyless connect claim flow now correctly navigates users to the newly claimed agent’s overview page after a successful claim. Previously, the redirect logic landed on the generic agents list because the API response envelope wasn’t unwrapped, leaving `agentIdentifier` undefined for the page component. The claim page now stores the full claim result and uses it to compute the correct destination, with fallbacks when identifiers aren’t available.

## Affected areas
**api**: Updated the connect claim API client to unwrap the `{ data: ... }` response envelope so callers receive `environmentId` and `agentIdentifier`.
  
**dashboard**: Updated the connect-claim success/redirect logic to use the stored claim result, route to `/env/:environmentSlug/agents/:agentIdentifier/overview` when possible, and refactored the dev environment helper (`hasClaimableDevelopmentEnvironment` → `getClaimableDevelopmentEnvironment`) to return the environment object.

## Key technical decisions
- Typed the v1 API envelope in the claim API client and returned `response.data` to align with other dashboard dashboard API clients and ensure required identifiers propagate.
- Implemented a redirect callback that resolves the environment slug from `environmentId` (with fallback) and navigates to the claimed agent overview when `agentIdentifier` is present.

## Testing
Added/updated test validation that completes the keyless connect claim flow and verifies the **Visit Dashboard** button navigates to the claimed agent’s overview page; TypeScript compilation checks for the dashboard package also pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the post-claim redirect in the keyless connect flow by (1) unwrapping the `{ data: ... }` API envelope in `claimKeylessConnect` so `agentIdentifier` and `environmentId` are actually returned to callers, and (2) updating `ConnectClaimContent` to store the claim result and navigate to the agent overview page on "Visit Dashboard".

- `connect.ts`: Changed the `post` generic to `{ data: ClaimKeylessConnectResponse }` and returns `response.data`, consistent with other dashboard API clients.
- `connect-claim.tsx`: Renamed `hasClaimableDevelopmentEnvironment` → `getClaimableDevelopmentEnvironment` (returns `IEnvironment | undefined` instead of `boolean`), adds `claimResult` state, and introduces `handleVisitDashboard` which routes to `/env/:slug/agents/:agentIdentifier/overview` when the identifier is present, with a fallback to the agents list.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are minimal, targeted, and well-guarded with fallbacks.

The API envelope unwrap is a straightforward one-liner with correct typing, and the redirect logic has a clear fallback chain (`agentIdentifier → agents list → root`) that prevents any broken navigation state.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/api/connect.ts | Correctly wraps the post call with the `{ data: ClaimKeylessConnectResponse }` envelope type and returns `response.data`; simple, clean fix consistent with other API clients. |
| apps/dashboard/src/pages/connect-claim.tsx | Adds `claimResult` state, refactors the environment lookup helper, and implements `handleVisitDashboard` with proper agent-specific routing and a safe fallback chain. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as ConnectClaimPage
  participant API as claimKeylessConnect
  participant Server as POST /connect/claim

  UI->>API: claim(token)
  API->>Server: "POST /connect/claim { token }"
  Server-->>API: "{ data: { environmentId, agentIdentifier } }"
  Note over API: unwrap response.data
  API-->>UI: "{ environmentId, agentIdentifier }"
  UI->>UI: setClaimResult(result)
  UI->>UI: setDidClaim(true)
  UI->>UI: render "Visit Dashboard" button
  UI->>UI: handleVisitDashboard()
  alt agentIdentifier present
    UI->>UI: navigate /env/:slug/agents/:agentIdentifier/overview
  else agentIdentifier missing, environmentSlug present
    UI->>UI: navigate /env/:slug/agents
  else no environmentSlug
    UI->>UI: navigate /
  end
```

<sub>Reviews (2): Last reviewed commit: ["refactor(dashboard): simplify connect cl..."](https://github.com/novuhq/novu/commit/cabd6eaebfbf9ba144e1de167cd74890930c31a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37579755)</sub>

<!-- /greptile_comment -->