### PR TITLE
ci(root): notify Cursor automation on agent-onboarding doc changes fixes NV-8043

### DIFF
--- a/.github/workflows/agent-onboarding-webhook.yml
+++ b/.github/workflows/agent-onboarding-webhook.yml
@@ -1,0 +1,63 @@
+name: Notify Cursor Automation on Agent Onboarding Change
+
+on:
+  push:
+    paths:
+      - "packages/shared/docs/agent-onboarding.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  trigger-cursor-webhook:
+    name: Trigger Cursor automation webhook
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Send webhook to Cursor automation
+        env:
+          CURSOR_WEBHOOK_URL: ${{ secrets.CURSOR_WEBHOOK_URL }}
+          CURSOR_WEBHOOK_TOKEN: ${{ secrets.CURSOR_WEBHOOK_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          CHANGED_FILE: packages/shared/docs/agent-onboarding.md
+        run: |
+          if [ -z "$CURSOR_WEBHOOK_URL" ]; then
+            echo "::error::CURSOR_WEBHOOK_URL secret is not set"
+            exit 1
+          fi
+
+          if [ -z "$CURSOR_WEBHOOK_TOKEN" ]; then
+            echo "::error::CURSOR_WEBHOOK_TOKEN secret is not set"
+            exit 1
+          fi
+
+          payload=$(jq -n \
+            --arg event "agent-onboarding-changed" \
+            --arg repository "$REPOSITORY" \
+            --arg ref "$REF" \
+            --arg sha "$SHA" \
+            --arg actor "$ACTOR" \
+            --arg file "$CHANGED_FILE" \
+            '{event: $event, repository: $repository, ref: $ref, sha: $sha, actor: $actor, file: $file}')
+
+          http_code=$(curl --silent --show-error --location \
+            --retry 3 --retry-connrefused \
+            --output /dev/null --write-out "%{http_code}" \
+            --request POST "$CURSOR_WEBHOOK_URL" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: Bearer $CURSOR_WEBHOOK_TOKEN" \
+            --data "$payload")
+
+          echo "Webhook responded with HTTP $http_code"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::Cursor automation webhook failed with HTTP $http_code"
+            exit 1
+          fi

--- a/.github/workflows/agent-onboarding-webhook.yml
+++ b/.github/workflows/agent-onboarding-webhook.yml
@@ -22,21 +22,21 @@ jobs:
     steps:
       - name: Send webhook to Cursor automation
         env:
-          CURSOR_WEBHOOK_URL: ${{ secrets.CURSOR_WEBHOOK_URL }}
-          CURSOR_WEBHOOK_TOKEN: ${{ secrets.CURSOR_WEBHOOK_TOKEN }}
+          CURSOR_AGENT_ONBOARDING_WEBHOOK_URL: ${{ secrets.CURSOR_AGENT_ONBOARDING_WEBHOOK_URL }}
+          CURSOR_AGENT_ONBOARDING_WEBHOOK_TOKEN: ${{ secrets.CURSOR_AGENT_ONBOARDING_WEBHOOK_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           SHA: ${{ github.sha }}
           ACTOR: ${{ github.actor }}
           CHANGED_FILE: packages/shared/docs/agent-onboarding.md
         run: |
-          if [ -z "$CURSOR_WEBHOOK_URL" ]; then
-            echo "::error::CURSOR_WEBHOOK_URL secret is not set"
+          if [ -z "$CURSOR_AGENT_ONBOARDING_WEBHOOK_URL" ]; then
+            echo "::error::CURSOR_AGENT_ONBOARDING_WEBHOOK_URL secret is not set"
             exit 1
           fi
 
-          if [ -z "$CURSOR_WEBHOOK_TOKEN" ]; then
-            echo "::error::CURSOR_WEBHOOK_TOKEN secret is not set"
+          if [ -z "$CURSOR_AGENT_ONBOARDING_WEBHOOK_TOKEN" ]; then
+            echo "::error::CURSOR_AGENT_ONBOARDING_WEBHOOK_TOKEN secret is not set"
             exit 1
           fi
 
@@ -53,9 +53,9 @@ jobs:
             --max-time 30 \
             --retry 3 --retry-connrefused --retry-all-errors \
             --output /dev/null --write-out "%{http_code}" \
-            --request POST "$CURSOR_WEBHOOK_URL" \
+            --request POST "$CURSOR_AGENT_ONBOARDING_WEBHOOK_URL" \
             --header "Content-Type: application/json" \
-            --header "Authorization: Bearer $CURSOR_WEBHOOK_TOKEN" \
+            --header "Authorization: Bearer $CURSOR_AGENT_ONBOARDING_WEBHOOK_TOKEN" \
             --data "$payload")
 
           echo "Webhook responded with HTTP $http_code"

--- a/.github/workflows/agent-onboarding-webhook.yml
+++ b/.github/workflows/agent-onboarding-webhook.yml
@@ -2,6 +2,8 @@ name: Notify Cursor Automation on Agent Onboarding Change
 
 on:
   push:
+    branches:
+      - next
     paths:
       - "packages/shared/docs/agent-onboarding.md"
 

--- a/.github/workflows/agent-onboarding-webhook.yml
+++ b/.github/workflows/agent-onboarding-webhook.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   trigger-cursor-webhook:
@@ -50,7 +50,8 @@ jobs:
             '{event: $event, repository: $repository, ref: $ref, sha: $sha, actor: $actor, file: $file}')
 
           http_code=$(curl --silent --show-error --location \
-            --retry 3 --retry-connrefused \
+            --max-time 30 \
+            --retry 3 --retry-connrefused --retry-all-errors \
             --output /dev/null --write-out "%{http_code}" \
             --request POST "$CURSOR_WEBHOOK_URL" \
             --header "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/agent-onboarding-webhook.yml`, a GitHub Actions workflow that notifies Cursor automation whenever `packages/shared/docs/agent-onboarding.md` changes.
- Triggers on `push` only when that file is modified (via the `paths:` filter).
- POSTs a JSON payload (`event`, `repository`, `ref`, `sha`, `actor`, `file`) to the Cursor automation webhook, authenticated with an `Authorization: Bearer` header.

## Implementation notes

- Secrets (`CURSOR_WEBHOOK_URL`, `CURSOR_WEBHOOK_TOKEN`) flow through the step's `env:` and are referenced as shell vars — no `${{ github.* }}` interpolated into the `run:` body, satisfying the repo's `workflow-security-lint`.
- Payload is built with `jq -n` to avoid JSON injection/escaping issues.
- `curl` follows redirects (`--location`), retries transient failures (`--retry 3 --retry-connrefused`), and the job explicitly fails on any non-2xx response.
- Minimal `contents: read` permissions, a concurrency guard, and a 5-minute timeout.

## Ops / required follow-up

- Add repository secrets **`CURSOR_WEBHOOK_URL`** and **`CURSOR_WEBHOOK_TOKEN`**; the job fails fast if either is missing.

## Decisions for reviewers

- `on: push` is intentionally **not** scoped by branch, so it fires on any branch push that touches the file. Easy to scope to `next`/`main` with a `branches:` filter if preferred.

## Test plan

- [ ] Configure the two secrets in repo settings.
- [ ] Push a commit touching `packages/shared/docs/agent-onboarding.md` and confirm the workflow runs and the webhook is received.
- [ ] Push a commit that does not touch the file and confirm the workflow does not run.

fixes NV-8043

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a GitHub Actions workflow that listens for pushes to the `next` branch and only runs when `packages/shared/docs/agent-onboarding.md` changes. When triggered, it sends a POST request to a Cursor automation webhook with commit and change metadata, using secure secret handling, JSON payload construction, and hardened network settings to avoid missed or unreliable webhook deliveries.

## Affected areas

- **`.github`** — New workflow dispatches a Cursor webhook on `agent-onboarding.md` changes, with retries/timeouts and minimal `contents: read` permissions.
- **`shared`** — The `packages/shared/docs/agent-onboarding.md` documentation file becomes an integration trigger for external automation.

## Key technical decisions

- **Secure credential handling**: Uses `secrets.CURSOR_WEBHOOK_URL` / `secrets.CURSOR_WEBHOOK_TOKEN` via environment variables (not interpolated into the script body).
- **Injection-safe payload**: Builds the webhook JSON payload with `jq -n`.
- **Resilient delivery**: `curl` follows redirects, retries (`--retry 3 --retry-connrefused --retry-all-errors`), enforces `--max-time 30`, and fails on non-2xx responses.
- **Run control**: Uses a concurrency group keyed by workflow+ref with `cancel-in-progress: false` to ensure deliveries aren’t dropped by newer pushes.
- **Least privilege & safety**: Sets `permissions: contents: read` and a 5-minute job timeout.

## Testing

No automated tests were added; validate by pushing a commit to `next` that modifies the monitored doc and confirming the webhook POST succeeds (HTTP 2xx) via the Actions logs and/or webhook receiver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow (`.github/workflows/agent-onboarding-webhook.yml`) that fires on every push to the `next` branch touching `packages/shared/docs/agent-onboarding.md` and POSTs a structured JSON payload to a Cursor automation webhook.

- The workflow securely injects secrets via `env:` (never interpolated into the `run:` body), builds the payload with `jq -n` to prevent JSON injection, and validates both secrets before attempting the request.
- `curl` is configured with `--max-time 30`, `--retry 3 --retry-connrefused --retry-all-errors`, and strict non-2xx failure handling; the job uses `cancel-in-progress: false` so consecutive matching pushes each get their own delivery.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds a single, self-contained notification workflow with no impact on any existing CI path or application code.

The change is a single new workflow file. Secret handling, retry/timeout configuration, injection-safe payload construction, and failure detection are all implemented correctly. No application code is touched, and the workflow has no side effects on other jobs. All concerns raised in prior review rounds appear to be addressed in the final version.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/agent-onboarding-webhook.yml | New workflow that fires on pushes to `next` touching `agent-onboarding.md` and POSTs a JSON payload to Cursor automation; secrets, retry logic, timeout, injection safety, and concurrency are all handled correctly. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub (push event)
    participant WF as agent-onboarding-webhook workflow
    participant JQ as jq (payload builder)
    participant Curl as curl
    participant CW as Cursor Webhook

    Dev->>GH: git push (next branch)
    GH->>GH: Check paths filter (agent-onboarding.md)
    alt File changed
        GH->>WF: Trigger job: trigger-cursor-webhook
        WF->>WF: Validate CURSOR_AGENT_ONBOARDING_WEBHOOK_URL
        WF->>WF: Validate CURSOR_AGENT_ONBOARDING_WEBHOOK_TOKEN
        WF->>JQ: Build JSON payload (event, repo, ref, sha, actor, file)
        JQ-->>WF: Injection-safe JSON
        WF->>Curl: POST payload with Authorization: Bearer
        Curl->>CW: HTTP POST (max-time 30s, retry 3)
        CW-->>Curl: HTTP response
        alt HTTP 2xx
            Curl-->>WF: Success (http_code)
            WF-->>GH: Job success
        else HTTP non-2xx or network error (retry up to 3x)
            Curl->>CW: Retry POST
            CW-->>Curl: HTTP response
            Curl-->>WF: Final http_code
            WF-->>GH: Job failure (exit 1)
        end
    else File not changed
        GH->>GH: Skip workflow (paths filter)
    end
```

<sub>Reviews (3): Last reviewed commit: ["ci(workflows): update agent onboarding w..."](https://github.com/novuhq/novu/commit/73d804100a25448d2a1b2deb1b1133b234675630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37584416)</sub>

<!-- /greptile_comment -->