### PR TITLE
docs(root): add github-webhook-workflow Cursor skill fixes NV-8046

### DIFF
--- a/.cursor/skills/github-webhook-workflow/SKILL.md
+++ b/.cursor/skills/github-webhook-workflow/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: github-webhook-workflow
+description: Author path-gated GitHub Actions workflows that POST a webhook to an external service (e.g. Cursor automation) when specific files change, while passing Novu's workflow-security-lint. Use when creating a workflow that notifies an external endpoint on file/path changes, sends a webhook from CI, or triggers automation on push/PR for a given path.
+disable-model-invocation: true
+---
+
+# GitHub Webhook Workflow
+
+Author a `.github/workflows/*.yml` workflow that fires a webhook to an external service when specific files change. The result must pass `.github/workflows/scripts/check-workflow-security.py` (run by the `Workflow security lint` job on any `.github/workflows/**` change).
+
+## Hard requirements (security lint)
+
+These are **blocking** — the lint fails the PR otherwise:
+
+1. **No `${{ ... }}` interpolation inside `run:` blocks.** Route every `github.*`, `inputs.*`, and `secrets.*` value through the step's `env:` map and reference it as a shell variable (`"$VAR"`). This prevents script injection.
+2. **Pin every external action to a 40-char commit SHA**, with the human tag as a trailing comment: `owner/repo@<sha> # v4`. Local (`./`) and `docker://` refs are exempt.
+3. **No static AWS keys** (`secrets.AWS_ACCESS_KEY_ID` / `secrets.AWS_SECRET_ACCESS_KEY`) — use OIDC if AWS is needed.
+
+## Template
+
+```yaml
+name: Notify <Service> on <Thing> Change
+
+on:
+  push:
+    paths:
+      - "path/to/watched/file.ext"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  trigger-webhook:
+    name: Trigger <Service> webhook
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Send webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ] || [ -z "$WEBHOOK_TOKEN" ]; then
+            echo "::error::WEBHOOK_URL / WEBHOOK_TOKEN secret is not set"
+            exit 1
+          fi
+
+          payload=$(jq -n \
+            --arg event "thing-changed" \
+            --arg repository "$REPOSITORY" \
+            --arg ref "$REF" \
+            --arg sha "$SHA" \
+            --arg actor "$ACTOR" \
+            '{event: $event, repository: $repository, ref: $ref, sha: $sha, actor: $actor}')
+
+          http_code=$(curl --silent --show-error --location \
+            --retry 3 --retry-connrefused \
+            --output /dev/null --write-out "%{http_code}" \
+            --request POST "$WEBHOOK_URL" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: Bearer $WEBHOOK_TOKEN" \
+            --data "$payload")
+
+          echo "Webhook responded with HTTP $http_code"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::Webhook failed with HTTP $http_code"
+            exit 1
+          fi
+```
+
+## Key choices
+
+- **Payload via `jq -n`**, never string-interpolated JSON — avoids escaping/injection bugs. Each value is a `--arg` bound to an env var.
+- **Explicit non-2xx check** instead of relying on `curl --fail`. GitHub runs `run:` with `bash -eo pipefail`, so `--fail` + command-substitution would abort before any status line prints; the explicit `if` gives a clear error and meaningful logging.
+- **`--location`** follows redirects; **`--retry 3 --retry-connrefused`** hardens against transient failures.
+- **Auth**: default to `Authorization: Bearer $TOKEN`. If the endpoint expects HMAC signing instead (e.g. `X-Hub-Signature-256`), compute it with `openssl` over the payload.
+- **`paths:` works on `push` and `pull_request` only.** For "on merge", use `pull_request` with `types: [closed]` and gate on `github.event.pull_request.merged`.
+- **Branch scope**: bare `push` fires on every branch touching the path. Add `branches:` to limit to `main`/`next` if that's the intent — confirm with the user.
+
+## Verify before opening a PR
+
+```bash
+python3 .github/workflows/scripts/check-workflow-security.py
+```
+
+Exit 0 with no warnings/errors referencing your new file means it's clean (pre-existing warnings in other files are fine).
+
+## Ops follow-up
+
+Remind the user to add the required repository secrets (e.g. `WEBHOOK_URL`, `WEBHOOK_TOKEN`); the job fails fast if they're missing.


### PR DESCRIPTION
## What

Adds a Cursor skill at `.cursor/skills/github-webhook-workflow/SKILL.md` documenting how to author path-gated GitHub Actions workflows that POST a webhook to an external service while passing Novu's `Workflow security lint` (`check-workflow-security.py`).

## Why

This codifies the conventions discovered while implementing the agent-onboarding Cursor webhook workflow (`NV-8043`, merged in #11557), so future webhook workflows are authored correctly the first time instead of failing the security lint.

The skill covers:
- Blocking security-lint requirements: no `${{ }}` interpolation inside `run:`, SHA-pinned actions, no static AWS keys.
- A lint-passing template: env-hoisted values, `jq -n` payload construction, explicit non-2xx handling, retries/redirects.
- Trigger/branch-scoping guidance and a pre-PR verification step.

## Scope

Documentation-only. No runtime, product, or CI behavior changes — adds a single Markdown skill file.

## Test plan

- [x] `python3 .github/workflows/scripts/check-workflow-security.py` passes (no new warnings/errors)
- [x] No code or workflow files modified

Related: NV-8043 / #11557

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added a Cursor skill documentation file (`.cursor/skills/github-webhook-workflow/SKILL.md`) that provides conventions for authoring GitHub Actions workflows that POST webhooks to external services while passing Novu's security lint validation. This documentation addresses requirements discovered during the agent-onboarding webhook implementation, enabling future workflows to be authored correctly on the first attempt.

## Affected areas

**.cursor**: Added new skill documentation file with hard security requirements for webhook workflows (no `${{ }}` interpolation in `run:` blocks, SHA-pinned actions, no static AWS keys), a reference YAML template with payload construction via `jq`, HTTP status handling, and guidance on trigger scoping and branch conditions.

## Testing

No tests are required—the documentation-only change was verified to not impact the existing security lint script (`check-workflow-security.py`), which continues to pass with no new warnings or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Cursor skill at `.cursor/skills/github-webhook-workflow/SKILL.md` that documents how to author path-gated GitHub Actions workflows that POST a webhook to an external service while passing Novu's `check-workflow-security.py` lint. The skill covers security-lint hard requirements, a reusable YAML template, and key design rationale.

- The template correctly routes all `${{ }}` expressions through `env:` to satisfy the script-injection lint rule, uses `jq -n` for safe payload construction, and includes explicit non-2xx failure handling.
- `--location` in the curl command follows redirects, but HTTP 301/302 redirects on a POST silently change the method to GET and discard the body — if the endpoint redirects, the call can report success while delivering no payload.
- `--retry 3 --retry-connrefused` only covers connection-level failures; adding `--retry-all-errors` (available on `ubuntu-latest`) would also retry on HTTP 5xx transients as the \"hardens against transient failures\" note implies.

<h3>Confidence Score: 4/5</h3>

Documentation-only change with no runtime impact; the single file added is a Cursor skill template that is safe to merge but contains a curl redirect behaviour that could cause silent delivery failures in workflows generated from it.

The template's `--location` flag will silently drop the POST body and report success if the webhook endpoint returns a 301/302 redirect — a future workflow built from this skill could appear to succeed while no payload is delivered, which would be hard to diagnose. The retry flag gap is a smaller quality issue. No production code or CI behaviour is changed by this PR itself.

.cursor/skills/github-webhook-workflow/SKILL.md — specifically the curl command in the template block around lines 64-70.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .cursor/skills/github-webhook-workflow/SKILL.md | New Cursor skill documenting a lint-passing webhook workflow template; the template has a silent-failure risk with `--location` on 301/302 redirects (POST body dropped), and `--retry` covers only connection errors without `--retry-all-errors`. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant Lint as check-workflow-security.py
    participant WH as Webhook Endpoint

    Dev->>GH: push (matches paths:)
    GH->>Lint: Workflow security lint job
    Lint-->>GH: pass (no interpolation in run:, SHA-pinned actions)
    GH->>GH: Resolve env vars from secrets/context
    GH->>GH: jq -n build JSON payload
    GH->>WH: POST $WEBHOOK_URL (Authorization: Bearer)
    alt 2xx response
        WH-->>GH: 200 OK
        GH->>GH: echo success, exit 0
    else 301/302 redirect (risk)
        WH-->>GH: 301 Moved Permanently
        GH->>WH: GET $NEW_URL (body dropped)
        WH-->>GH: 200 OK (no payload received)
        GH->>GH: echo success, exit 0 - silent failure
    else non-2xx
        WH-->>GH: 4xx / 5xx
        GH->>GH: echo error, exit 1
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.cursor%2Fskills%2Fgithub-webhook-workflow%2FSKILL.md%3A64-70%0A**%60--location%60%20silently%20drops%20POST%20body%20on%20301%2F302%20redirects**%0A%0A%60curl%20--location%60%20follows%20redirects%2C%20but%20for%20HTTP%20301%2F302%20responses%20curl%20%28per%20RFC%202616%29%20changes%20the%20method%20from%20POST%20to%20GET%20and%20discards%20the%20request%20body.%20If%20the%20webhook%20endpoint%20ever%20issues%20a%20301%2F302%20%28e.g.%2C%20HTTP%E2%86%92HTTPS%2C%20trailing-slash%20normalisation%2C%20load-balancer%20quirk%29%2C%20the%20payload%20is%20silently%20dropped%20yet%20the%20final%20response%20may%20still%20be%20%60200%20OK%60%2C%20causing%20the%20script's%20non-2xx%20check%20to%20pass%20and%20the%20workflow%20to%20report%20success%20while%20no%20webhook%20was%20actually%20delivered.%20Either%20remove%20%60--location%60%20%28most%20webhook%20URLs%20don't%20redirect%29%20or%20replace%20it%20with%20%60--location%20--proto-redir%20-all%2Chttps%60%20to%20restrict%20redirects%20to%20HTTPS-only%2C%20and%20add%20a%20note%20in%20the%20skill%20about%20this%20trade-off.%0A%0A%23%23%23%20Issue%202%20of%202%0A.cursor%2Fskills%2Fgithub-webhook-workflow%2FSKILL.md%3A64-65%0A%60--retry%203%20--retry-connrefused%60%20only%20retries%20on%20connection-level%20failures%20%28refused%20connections%2C%20timeouts%2C%20DNS%29%3B%20it%20does%20**not**%20retry%20on%20HTTP%205xx%20responses.%20The%20%22Key%20choices%22%20bullet%20calls%20this%20out%20as%20hardening%20against%20%22transient%20failures%22%2C%20which%20is%20accurate%20for%20network%20errors%2C%20but%20readers%20may%20expect%20it%20to%20also%20retry%20on%20server%20errors.%20Adding%20%60--retry-all-errors%60%20%28curl%20%E2%89%A5%207.71%2C%20available%20on%20%60ubuntu-latest%60%29%20covers%20HTTP%205xx%20transients%20too.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20http_code%3D%24%28curl%20--silent%20--show-error%20--location%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20--retry%203%20--retry-connrefused%20--retry-all-errors%20%5C%0A%60%60%60%0A%0A&pr=11561&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.cursor/skills/github-webhook-workflow/SKILL.md:64-70
**`--location` silently drops POST body on 301/302 redirects**

`curl --location` follows redirects, but for HTTP 301/302 responses curl (per RFC 2616) changes the method from POST to GET and discards the request body. If the webhook endpoint ever issues a 301/302 (e.g., HTTP→HTTPS, trailing-slash normalisation, load-balancer quirk), the payload is silently dropped yet the final response may still be `200 OK`, causing the script's non-2xx check to pass and the workflow to report success while no webhook was actually delivered. Either remove `--location` (most webhook URLs don't redirect) or replace it with `--location --proto-redir -all,https` to restrict redirects to HTTPS-only, and add a note in the skill about this trade-off.

### Issue 2 of 2
.cursor/skills/github-webhook-workflow/SKILL.md:64-65
`--retry 3 --retry-connrefused` only retries on connection-level failures (refused connections, timeouts, DNS); it does **not** retry on HTTP 5xx responses. The "Key choices" bullet calls this out as hardening against "transient failures", which is accurate for network errors, but readers may expect it to also retry on server errors. Adding `--retry-all-errors` (curl ≥ 7.71, available on `ubuntu-latest`) covers HTTP 5xx transients too.

```suggestion
          http_code=$(curl --silent --show-error --location \
            --retry 3 --retry-connrefused --retry-all-errors \
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(root): add github-webhook-workflow ..."](https://github.com/novuhq/novu/commit/b78ef775be4a97d477b8093c0fc1e0ea7acf6945) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37596796)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->