### PR TITLE
fix(shared): add REDIS_SKIP_VERSION_CHECK to bypass BullMQ version check for Redis proxies fixes NV-8044

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -29,6 +29,8 @@ REDIS_HOST=redis
 DOCKER_REDIS_SERVICE_PORT=6379
 REDIS_PASSWORD=
 REDIS_CACHE_SERVICE_HOST=
+# Set to true when connecting through a proxy that does not support the Redis INFO command
+REDIS_SKIP_VERSION_CHECK=false
 
 # AWS
 S3_LOCAL_STACK=$HOST_NAME:4566

--- a/docker/community/.env.example
+++ b/docker/community/.env.example
@@ -35,6 +35,8 @@ REDIS_HOST=redis
 
 REDIS_PASSWORD=
 REDIS_CACHE_SERVICE_HOST=
+# Set to true when connecting through a proxy that does not support the Redis INFO command
+REDIS_SKIP_VERSION_CHECK=false
 
 # AWS
 S3_LOCAL_STACK=${HOST_NAME}:4566

--- a/libs/application-generic/src/services/in-memory-provider/providers/azure-cache-for-redis-cluster-provider.ts
+++ b/libs/application-generic/src/services/in-memory-provider/providers/azure-cache-for-redis-cluster-provider.ts
@@ -91,16 +91,21 @@ export const getAzureCacheForRedisClusterProviderConfig = (): IAzureCacheForRedi
 export const getAzureCacheForRedisCluster = (enableAutoPipelining?: boolean): Cluster | undefined => {
   const { instances, password, tls, username } = getAzureCacheForRedisClusterProviderConfig();
 
+  const skipVersionCheck = process.env.REDIS_SKIP_VERSION_CHECK === 'true';
+
+  const redisOptions = {
+    tls,
+    connectTimeout: 10000,
+    ...(password && { password }),
+    ...(username && { username }),
+    skipVersionCheck,
+  };
+
   const options: ClusterOptions = {
     dnsLookup: (address, callback) => callback(null, address),
     enableAutoPipelining: enableAutoPipelining ?? false,
     enableOfflineQueue: false,
-    redisOptions: {
-      tls,
-      connectTimeout: 10000,
-      ...(password && { password }),
-      ...(username && { username }),
-    },
+    redisOptions,
     scaleReads: 'slave',
     /*
      *  Disabled in Prod as affects performance

--- a/libs/application-generic/src/services/in-memory-provider/providers/elasticache-cluster-provider.ts
+++ b/libs/application-generic/src/services/in-memory-provider/providers/elasticache-cluster-provider.ts
@@ -86,16 +86,21 @@ export const getElasticacheClusterProviderConfig = (): IElasticacheClusterProvid
 export const getElasticacheCluster = (enableAutoPipelining?: boolean): Cluster | undefined => {
   const { instances, password, tls } = getElasticacheClusterProviderConfig();
 
+  const skipVersionCheck = process.env.REDIS_SKIP_VERSION_CHECK === 'true';
+
+  const redisOptions = {
+    tls,
+    ...(password && { password }),
+    connectTimeout: 10000,
+    skipVersionCheck,
+  };
+
   const options: ClusterOptions = {
     dnsLookup: (address, callback) => callback(null, address),
     enableAutoPipelining: enableAutoPipelining ?? false,
     enableOfflineQueue: false,
     enableReadyCheck: true,
-    redisOptions: {
-      tls,
-      ...(password && { password }),
-      connectTimeout: 10000,
-    },
+    redisOptions,
     scaleReads: 'slave',
     /*
      *  Disabled in Prod as affects performance

--- a/libs/application-generic/src/services/in-memory-provider/providers/memory-db-cluster-provider.ts
+++ b/libs/application-generic/src/services/in-memory-provider/providers/memory-db-cluster-provider.ts
@@ -91,10 +91,13 @@ export const getMemoryDbClusterProviderConfig = (): IMemoryDbClusterProviderConf
 export const getMemoryDbCluster = (enableAutoPipelining?: boolean): Cluster | undefined => {
   const { instances, password, username, tls, connectTimeout } = getMemoryDbClusterProviderConfig();
 
+  const skipVersionCheck = process.env.REDIS_SKIP_VERSION_CHECK === 'true';
+
   const redisOptions: any = {
     maxRetriesPerRequest: null,
     tls,
     connectTimeout,
+    skipVersionCheck,
   };
 
   if (username && password) {

--- a/libs/application-generic/src/services/in-memory-provider/providers/redis-cluster-provider.ts
+++ b/libs/application-generic/src/services/in-memory-provider/providers/redis-cluster-provider.ts
@@ -86,15 +86,20 @@ export const getRedisClusterProviderConfig = (): IRedisClusterProviderConfig => 
 export const getRedisCluster = (enableAutoPipelining?: boolean): Cluster | undefined => {
   const { instances, password, tls } = getRedisClusterProviderConfig();
 
+  const skipVersionCheck = process.env.REDIS_SKIP_VERSION_CHECK === 'true';
+
+  const redisOptions = {
+    ...(tls && { tls }),
+    ...(password && { password }),
+    skipVersionCheck,
+  };
+
   const options: ClusterOptions = {
     dnsLookup: (address, callback) => callback(null, address),
     enableAutoPipelining: enableAutoPipelining ?? false,
     enableOfflineQueue: false,
     enableReadyCheck: true,
-    redisOptions: {
-      ...(tls && { tls }),
-      ...(password && { password }),
-    },
+    redisOptions,
     scaleReads: 'slave',
     /*
      *  Disabled in Prod as affects performance

--- a/libs/application-generic/src/services/in-memory-provider/providers/redis-master-slave-provider.ts
+++ b/libs/application-generic/src/services/in-memory-provider/providers/redis-master-slave-provider.ts
@@ -116,15 +116,20 @@ export const getRedisMasterSlaveProviderConfig = (): IRedisMasterSlaveProviderCo
 export const getRedisMasterSlaveCluster = (enableAutoPipelining?: boolean): Cluster | undefined => {
   const { instances, password, tls } = getRedisMasterSlaveProviderConfig();
 
+  const skipVersionCheck = process.env.REDIS_SKIP_VERSION_CHECK === 'true';
+
+  const redisOptions = {
+    tls,
+    ...(password && { password }),
+    connectTimeout: 10000,
+    skipVersionCheck,
+  };
+
   const options: ClusterOptions = {
     enableAutoPipelining: enableAutoPipelining ?? false,
     enableOfflineQueue: false,
     enableReadyCheck: true,
-    redisOptions: {
-      tls,
-      ...(password && { password }),
-      connectTimeout: 10000,
-    },
+    redisOptions,
     // Scale reads to slave nodes for better performance
     scaleReads: 'slave',
     /*

--- a/libs/application-generic/src/services/in-memory-provider/providers/redis-provider.ts
+++ b/libs/application-generic/src/services/in-memory-provider/providers/redis-provider.ts
@@ -88,9 +88,12 @@ export const getRedisProviderConfig = (): IRedisProviderConfig => {
 export const getRedisInstance = (): Redis | undefined => {
   const { port, host, ...configOptions } = getRedisProviderConfig();
 
+  const skipVersionCheck = process.env.REDIS_SKIP_VERSION_CHECK === 'true';
+
   const options = {
     ...configOptions,
     maxRetriesPerRequest: null,
+    skipVersionCheck,
     /*
      *  Disabled in Prod as affects performance
      */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

When `REDIS_HOST`/`REDIS_PORT` point at a Redis proxy (e.g. Predixy in front of Sentinel), BullMQ 3.x runs `Redis INFO` on startup and expects `redis_version`. Proxies often omit that field, causing semver to throw "Invalid version" and api/worker fail to start.

This adds support for a `REDIS_SKIP_VERSION_CHECK=true` environment variable which passes `skipVersionCheck: true` to the BullMQ Redis connection options, bypassing the version check that fails with Redis proxies.

**Changes:**
- Added `REDIS_SKIP_VERSION_CHECK` env var support (default: `false`) to all Redis provider files in `libs/application-generic`
- Single-node Redis provider (`redis-provider.ts`)
- Redis Cluster provider (`redis-cluster-provider.ts`)
- MemoryDB Cluster provider (`memory-db-cluster-provider.ts`)
- ElastiCache Cluster provider (`elasticache-cluster-provider.ts`)
- Azure Cache for Redis provider (`azure-cache-for-redis-cluster-provider.ts`)
- Redis Master-Slave provider (`redis-master-slave-provider.ts`)

**Who's affected:**
- Self-hosted setups using Redis proxies without `redis_version` in INFO response
- Not affected: Direct Redis, most managed Redis, Novu Cloud (MemoryDB)

**How it works:**

BullMQ 3.10.4 already has `skipVersionCheck` support in its `RedisConnection` class:
```js
if (this.opts && this.opts.skipVersionCheck !== true && !this.closing) {
    this.version = await this.getRedisVersion();
    // ...throws if version is invalid
}
```

When Novu passes an existing ioredis client to BullMQ, BullMQ reads options from `client.options`. By including `skipVersionCheck` in the ioredis constructor options, BullMQ finds and respects it.

Fixes https://github.com/novuhq/novu/issues/11558

### Screenshots

N/A - infrastructure change with no visual impact.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- `skipVersionCheck` is an existing but undocumented option in BullMQ 3.10.4 (confirmed in source at `dist/cjs/classes/redis-connection.js:137`)
- The default value is `false`, so existing behavior is completely unchanged
- For cluster providers, `redisOptions` was extracted to a separate variable to avoid TypeScript excess property checking (since `skipVersionCheck` is not in ioredis's type definitions but BullMQ reads it from there)

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1781527435797439?thread_ts=1781527435.797439&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-3726e816-5f6c-5406-9aa2-6f24b251c8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3726e816-5f6c-5406-9aa2-6f24b251c8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What changed:**
Added support for the `REDIS_SKIP_VERSION_CHECK` environment variable to bypass BullMQ 3.x Redis INFO/`redis_version` semver validation when the field is missing. This prevents startup failures and restart loops in self-hosted environments where Redis proxies (e.g., Predixy) omit `redis_version` from their INFO responses. When set to `true`, the Redis/cluster connection options now include `skipVersionCheck: true`; default behavior remains unchanged.

**Affected areas:**
- `application-generic`: Updated six Redis provider implementations to read `process.env.REDIS_SKIP_VERSION_CHECK` and pass `skipVersionCheck` into BullMQ’s Redis connection options.
- `docker`: Added `REDIS_SKIP_VERSION_CHECK` documentation to `docker/.env.example` and `docker/community/.env.example`.

**Key technical decisions:**
- For cluster providers, extracted `redisOptions` into a standalone object to satisfy TypeScript excess property checking, since `skipVersionCheck` is not part of ioredis’s official types but is consumed by BullMQ.

**Testing:**
No automated tests were added; this is a configuration-level workaround intended for manual verification against Redis proxies that omit `redis_version`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `REDIS_SKIP_VERSION_CHECK` environment variable (default `false`) that passes `skipVersionCheck: true` to ioredis options, allowing BullMQ 3.x to bypass its Redis version check when connecting through proxies (e.g. Predixy in front of Sentinel) that omit `redis_version` from their `INFO` response. Both `.env.example` files are updated to document the new variable.

- `redis-provider.ts` receives the fix that actually matters for BullMQ: `skipVersionCheck` is placed in the top-level `RedisOptions` that BullMQ reads from `client.options` — this correctly addresses the startup crash.
- The five cluster providers add `skipVersionCheck` inside `redisOptions` (per-node options), which is a level too deep for BullMQ to read from `client.options` on a `Cluster` instance; the flag is silently inert in those paths, but harmless since Novu's BullMQ queues use the single-node provider.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive, defaults to false (no behavior change for existing deployments), and correctly fixes the described single-node proxy startup crash.

The fix in redis-provider.ts is technically correct and addresses the root cause. The cluster-provider changes add skipVersionCheck at the wrong nesting level for BullMQ to read, but this is inconsequential because Novu's BullMQ queues use the single-node provider, not cluster connections. No data paths are affected, and existing behaviour is fully preserved when the env var is unset.

No files require special attention; the cluster providers have a minor placement gap but it has no practical impact on any current code path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/in-memory-provider/providers/redis-provider.ts | Reads REDIS_SKIP_VERSION_CHECK and adds skipVersionCheck to single-node Redis options — this is the correct and effective fix for the described BullMQ proxy issue. |
| libs/application-generic/src/services/in-memory-provider/providers/redis-cluster-provider.ts | Adds skipVersionCheck to per-node redisOptions; this placement is at the wrong level (should be top-level ClusterOptions) for BullMQ to read it from client.options on a Cluster instance. |
| libs/application-generic/src/services/in-memory-provider/providers/memory-db-cluster-provider.ts | Adds skipVersionCheck to existing redisOptions: any block; same depth issue as other cluster providers relative to BullMQ's client.options check, though harmless for MemoryDB (Novu Cloud) use. |
| libs/application-generic/src/services/in-memory-provider/providers/elasticache-cluster-provider.ts | Extracts redisOptions to a standalone variable and adds skipVersionCheck; same depth concern as redis-cluster-provider. |
| libs/application-generic/src/services/in-memory-provider/providers/azure-cache-for-redis-cluster-provider.ts | Extracts redisOptions to a standalone variable and adds skipVersionCheck; same depth concern as other cluster providers. |
| libs/application-generic/src/services/in-memory-provider/providers/redis-master-slave-provider.ts | Extracts redisOptions and adds skipVersionCheck; same depth concern, but master-slave is closer to the single-node proxy use case than pure cluster providers. |
| docker/.env.example | Adds REDIS_SKIP_VERSION_CHECK=false with a descriptive comment alongside existing REDIS_* vars. |
| docker/community/.env.example | Adds REDIS_SKIP_VERSION_CHECK=false with the same comment as docker/.env.example. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    ENV["REDIS_SKIP_VERSION_CHECK=true"]

    ENV --> SP["redis-provider.ts\ngetRedisInstance()"]
    ENV --> CP["redis-cluster-provider.ts\ngetRedisCluster()"]
    ENV --> MS["redis-master-slave-provider.ts\ngetRedisMasterSlaveCluster()"]
    ENV --> MDB["memory-db-cluster-provider.ts\ngetMemoryDbCluster()"]
    ENV --> EC["elasticache-cluster-provider.ts\ngetElasticacheCluster()"]
    ENV --> AZ["azure-cache-for-redis-cluster-provider.ts\ngetAzureCacheForRedisCluster()"]

    SP -->|"options.skipVersionCheck\n✅ top-level RedisOptions"| BULLMQ["BullMQ RedisConnection\nclient.options.skipVersionCheck"]
    BULLMQ -->|"skipVersionCheck === true"| SKIP["Version check skipped\n✅ Proxy works"]
    BULLMQ -->|"skipVersionCheck !== true"| CHECK["getRedisVersion()\n❌ Throws on proxy"]

    CP -->|"redisOptions.skipVersionCheck\n⚠️ nested, BullMQ won't read"| CLUSTER["Redis.Cluster\nclient.options = ClusterOptions"]
    MS -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
    MDB -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
    EC -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
    AZ -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    ENV["REDIS_SKIP_VERSION_CHECK=true"]

    ENV --> SP["redis-provider.ts\ngetRedisInstance()"]
    ENV --> CP["redis-cluster-provider.ts\ngetRedisCluster()"]
    ENV --> MS["redis-master-slave-provider.ts\ngetRedisMasterSlaveCluster()"]
    ENV --> MDB["memory-db-cluster-provider.ts\ngetMemoryDbCluster()"]
    ENV --> EC["elasticache-cluster-provider.ts\ngetElasticacheCluster()"]
    ENV --> AZ["azure-cache-for-redis-cluster-provider.ts\ngetAzureCacheForRedisCluster()"]

    SP -->|"options.skipVersionCheck\n✅ top-level RedisOptions"| BULLMQ["BullMQ RedisConnection\nclient.options.skipVersionCheck"]
    BULLMQ -->|"skipVersionCheck === true"| SKIP["Version check skipped\n✅ Proxy works"]
    BULLMQ -->|"skipVersionCheck !== true"| CHECK["getRedisVersion()\n❌ Throws on proxy"]

    CP -->|"redisOptions.skipVersionCheck\n⚠️ nested, BullMQ won't read"| CLUSTER["Redis.Cluster\nclient.options = ClusterOptions"]
    MS -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
    MDB -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
    EC -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
    AZ -->|"redisOptions.skipVersionCheck\n⚠️ nested"| CLUSTER
```

</a>

<sub>Reviews (2): Last reviewed commit: ["feat: add REDIS\_SKIP\_VERSION\_CHECK to .e..."](https://github.com/novuhq/novu/commit/de396f708acdf356c2d92401ba55b6f1b55a8c10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37618539)</sub>

<!-- /greptile_comment -->