### PR TITLE
feat(novu): default connect to dashboard OAuth, add --keyless flag fixes NV-8048

### DIFF
--- a/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx
@@ -7,7 +7,7 @@ import { TelemetryEvent } from '@/utils/telemetry';
  * spin up from the "What should your agent do?" step, so copying it (or opening it in Cursor)
  * gets them to a working agent description without typing anything.
  */
-const PREBUILT_AGENT_PROMPT = `I'm signed in to the Novu dashboard, so use the --login flag. Add an agent to my app following instructions from this markdown file: https://novu.co/agents.md`;
+const PREBUILT_AGENT_PROMPT = `I'm signed in to the Novu dashboard, so use dashboard login (not keyless mode). Add an agent to my app following instructions from this markdown file: https://novu.co/agents.md`;
 
 function safeCursorEncode(text: string): string {
   return encodeURIComponent(text).replace(/[!'()*~]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);

--- a/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
+++ b/packages/novu/src/commands/connect/auth/resolve-connect-auth.ts
@@ -17,57 +17,56 @@ export async function resolveConnectAuth(
   const cliFlagSecret = options.secretKey?.trim();
   const envSecret = process.env.NOVU_SECRET_KEY?.trim();
   const isInteractive = Boolean(process.stdin.isTTY && process.stdout.isTTY) && process.env.CI !== 'true';
-  const wantsLogin = Boolean(options.login);
-  const wantsAuthenticated = Boolean(cliFlagSecret || (envSecret && !isInteractive) || wantsLogin);
+  const wantsKeyless = Boolean(options.keyless);
 
-  if (wantsLogin) {
-    if (cliFlagSecret) {
-      throw new Error(
-        'Cannot use --login together with --secret-key. Omit --secret-key to authenticate via the dashboard.'
-      );
-    }
-
-    resolveOptions.onStatus?.('Authorizing via the Novu Dashboard…');
-
-    const auth = await browserDeviceAuth({
-      apiUrl: options.apiUrl,
-      dashboardUrl: resolveOptions.authDashboardUrl ?? options.connectDashboardUrl,
-      region: options.region,
-      onStatus: resolveOptions.onStatus,
-      onDashboardUrl: resolveOptions.onDashboardUrl,
-      name: resolveOptions.name ?? 'novu-connect',
-      onboardingSessionId: resolveOptions.onboardingSessionId,
-      onAuthStarted: resolveOptions.onAuthStarted,
-      onAuthFailed: resolveOptions.onAuthFailed,
-    });
-
-    return { ...auth, isKeyless: false };
+  if (cliFlagSecret && wantsKeyless) {
+    throw new Error(
+      'Cannot use --keyless together with --secret-key. Omit --secret-key for keyless mode, or omit --keyless to authenticate with your account.'
+    );
   }
 
-  if (wantsAuthenticated) {
+  if (cliFlagSecret || (envSecret && !isInteractive && !wantsKeyless)) {
     const auth = await resolveAuth(toWizardAuthOptions(options), resolveOptions);
 
     return { ...auth, isKeyless: false };
   }
 
-  resolveOptions.onStatus?.('Setting up a temporary keyless workspace…');
+  if (wantsKeyless) {
+    resolveOptions.onStatus?.('Setting up a temporary keyless workspace…');
 
-  const session = await bootstrapKeylessSession(options.apiUrl);
+    const session = await bootstrapKeylessSession(options.apiUrl);
 
-  return {
-    secretKey: '',
-    environmentId: '',
-    environmentSlug: null,
-    environmentName: 'Keyless',
-    organizationId: null,
-    user: null,
+    return {
+      secretKey: '',
+      environmentId: '',
+      environmentSlug: null,
+      environmentName: 'Keyless',
+      organizationId: null,
+      user: null,
+      apiUrl: options.apiUrl,
+      dashboardUrl: options.dashboardUrl,
+      region: options.region,
+      source: 'keyless',
+      isKeyless: true,
+      keylessApplicationIdentifier: session.applicationIdentifier,
+    };
+  }
+
+  resolveOptions.onStatus?.('Authorizing via the Novu Dashboard…');
+
+  const auth = await browserDeviceAuth({
     apiUrl: options.apiUrl,
-    dashboardUrl: options.dashboardUrl,
+    dashboardUrl: resolveOptions.authDashboardUrl ?? options.connectDashboardUrl,
     region: options.region,
-    source: 'keyless',
-    isKeyless: true,
-    keylessApplicationIdentifier: session.applicationIdentifier,
-  };
+    onStatus: resolveOptions.onStatus,
+    onDashboardUrl: resolveOptions.onDashboardUrl,
+    name: resolveOptions.name ?? 'novu-connect',
+    onboardingSessionId: resolveOptions.onboardingSessionId,
+    onAuthStarted: resolveOptions.onAuthStarted,
+    onAuthFailed: resolveOptions.onAuthFailed,
+  });
+
+  return { ...auth, isKeyless: false };
 }
 
 function toWizardAuthOptions(options: ConnectCommandOptions): WizardCommandOptions {

--- a/packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts
+++ b/packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts
@@ -22,7 +22,7 @@ export async function upgradeKeylessSessionToDashboardAuth(
   ui.authStarted();
 
   const auth = await resolveConnectAuth(
-    { ...options, login: true },
+    { ...options, keyless: false },
     {
       onStatus: (message) => ui.authStatus(message),
       onDashboardUrl: (url) => ui.authDashboardUrl(url),

--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -1,19 +1,32 @@
 export const CONNECT_HELP_TEXT = `
 Examples (non-interactive / agent / CI):
 
-  Keyless Slack (default — no Novu account required):
+  Dashboard OAuth Slack (default — Novu account via browser):
     npx novu connect "A support assistant for Acme's customers that answers billing questions." \\
       --ci \\
+      --channel slack
+
+  Dashboard OAuth Email:
+    npx novu connect "An onboarding assistant for Acme's new members." \\
+      --ci \\
+      --channel email
+
+  Keyless Slack (no Novu account — pass --keyless):
+    npx novu connect "A support assistant for Acme's customers that answers billing questions." \\
+      --ci \\
+      --keyless \\
       --channel slack
 
   Keyless Email:
     npx novu connect "An onboarding assistant for Acme's new members." \\
       --ci \\
+      --keyless \\
       --channel email
 
   Keyless Telegram:
     npx novu connect "A concierge for Acme's shoppers that helps with orders." \\
       --ci \\
+      --keyless \\
       --channel telegram
 
   Agent only (no channel):
@@ -27,27 +40,21 @@ Examples (non-interactive / agent / CI):
       --region eu \\
       --channel email
 
-  Existing Novu account (instead of keyless):
+  Existing Novu account (secret key instead of dashboard OAuth):
     npx novu connect "A support assistant for Acme's customers." \\
       --ci \\
       --secret-key "$NOVU_SECRET_KEY" \\
-      --channel slack
-
-  Dashboard user (OAuth via browser — no secret key):
-    npx novu connect "A support assistant for Acme's customers." \\
-      --ci \\
-      --login \\
       --channel slack
 
 Non-interactive (agent / CI) contract:
 
   Required for --ci mode:
     - Pass the agent description as the positional <prompt> argument or --prompt.
-    - Pass --channel <slack|email|telegram|skip> (or whatsapp/teams with --login).
+    - Pass --channel <slack|email|telegram|skip> (or whatsapp/teams without --keyless).
 
   Authentication (pick one):
-    - Keyless (default): omit --secret-key and --login (temporary agent; user claims via in-channel sign-up link)
-    - Dashboard OAuth: pass --login (opens /cli/auth; user approves in the browser; agent is created in their Development environment)
+    - Dashboard OAuth (default): omit --secret-key and --keyless (opens /cli/auth; user approves in the browser; agent is created in their Development environment)
+    - Keyless: pass --keyless (temporary agent; user claims via in-channel sign-up link)
     - Existing account: pass --secret-key (or set NOVU_SECRET_KEY in non-interactive shells)
 
   Channel-specific flags:
@@ -61,21 +68,21 @@ Non-interactive (agent / CI) contract:
     - --telegram-bot-token "123456:ABC-…"   → skip the setup page; pass token directly
 
   Defaults (do not pass unless needed):
-    - Keyless mode: omit --secret-key and --login (creates a temporary agent; user claims via in-channel sign-up link)
+    - Dashboard OAuth: omit --secret-key and --keyless (creates the agent in the user's Development environment)
     - Demo runtime: omit --runtime (shared Claude runtime in keyless mode; authenticated environments need a demo integration)
     - US region: omit --region (use --region eu for EU Novu Cloud)
 
-  Not supported headlessly without --login:
-    - whatsapp and teams → pass --login to create the agent, then finish channel setup in the dashboard
+  Not supported headlessly with --keyless:
+    - whatsapp and teams → omit --keyless to authenticate via the dashboard, then finish channel setup in the dashboard
 
   Not supported headlessly in keyless mode:
-    - whatsapp and teams → use the Novu dashboard instead; do not pass --channel whatsapp or --channel teams without --login
+    - whatsapp and teams → use the Novu dashboard instead; do not pass --channel whatsapp or --channel teams with --keyless
 
   One run = one new agent + one channel. Re-running creates another agent.
 
 Machine-readable stdout (plain text, no ANSI — watch these in --ci mode):
 
-  Authentication (--login):
+  Authentication (dashboard OAuth — default):
     NOVU_CONNECT_AUTH_URL_FILE=<absolute path to one-line auth URL file>
 
   Slack:

--- a/packages/novu/src/commands/connect/types.ts
+++ b/packages/novu/src/commands/connect/types.ts
@@ -49,8 +49,8 @@ export interface ConnectCommandOptions {
   telegramBotToken?: string;
   /** Force the non-interactive logging UI (no Ink TUI). Used in CI / piped-stdin shells. */
   ci?: boolean;
-  /** Authenticate via the Novu dashboard (device auth) instead of keyless mode. */
-  login?: boolean;
+  /** Use a temporary keyless workspace instead of dashboard OAuth (the default). */
+  keyless?: boolean;
 }
 
 export interface AgentSummary {

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -140,7 +140,7 @@ program
 program
   .command('connect')
   .description(
-    `Create a managed agent and connect it to a channel (keyless by default; use --ci for non-interactive agent/CI runs)`
+    `Create a managed agent and connect it to a channel (dashboard OAuth by default; use --ci for non-interactive agent/CI runs)`
   )
   .usage('[prompt] [--ci] [--channel <name>] [options]')
   .argument(
@@ -149,11 +149,11 @@ program
   )
   .option(
     '-s, --secret-key <secret-key>',
-    'Use an existing Novu account instead of keyless mode (omit for keyless — the default)'
+    'Use an existing Novu account via secret key instead of dashboard OAuth (the default)'
   )
   .option(
-    '--login',
-    'Authenticate via the Novu dashboard instead of keyless mode (opens /cli/auth for approval)',
+    '--keyless',
+    'Use a temporary keyless workspace instead of dashboard OAuth (creates a demo agent the user can claim later)',
     false
   )
   .option('-a, --api-url <url>', 'Override the Novu API URL (default follows --region)')
@@ -169,7 +169,7 @@ program
   )
   .option(
     '--runtime <runtime>',
-    `Agent runtime for new agents (${AGENT_RUNTIME_CHOICES.join(' | ')}). Defaults to demo — omit in --ci keyless runs`
+    `Agent runtime for new agents (${AGENT_RUNTIME_CHOICES.join(' | ')}). Defaults to demo — omit in --ci authenticated runs`
   )
   .option(
     '--agent-integration-id <id>',
@@ -181,7 +181,7 @@ program
   .option('--aws-claude-workspace-id <id>', 'AWS Claude workspace ID for --runtime claude-aws')
   .option(
     '--channel <name>',
-    `Channel to connect (required in --ci mode). One of: ${CHANNEL_CHOICES.join(', ')}. whatsapp/teams require --login in --ci mode`
+    `Channel to connect (required in --ci mode). One of: ${CHANNEL_CHOICES.join(', ')}. whatsapp/teams require dashboard OAuth (omit --keyless)`
   )
   .option('--skip-slack', 'Create the agent and exit; do not connect any channel (equivalent to --channel skip)', false)
   .option(
@@ -222,22 +222,22 @@ program
 
       if (!channel) {
         console.error(
-          'Non-interactive mode requires --channel <slack|email|telegram|skip> (or <whatsapp|teams> with --login).\n(run `novu connect --help` for the non-interactive contract and examples)'
+          'Non-interactive mode requires --channel <slack|email|telegram|skip> (or <whatsapp|teams> without --keyless).\n(run `novu connect --help` for the non-interactive contract and examples)'
         );
         process.exit(1);
       }
 
-      if (options.channel && isDashboardOnlyChannel(options.channel as ChannelChoice) && !options.login) {
+      if (options.channel && isDashboardOnlyChannel(options.channel as ChannelChoice) && options.keyless) {
         console.error(
-          'Non-interactive mode does not support --channel whatsapp or --channel teams without --login. Pass --login to authenticate via the dashboard, or use the Novu dashboard instead.\n(run `novu connect --help` for the non-interactive contract and examples)'
+          'Non-interactive mode does not support --channel whatsapp or --channel teams with --keyless. Omit --keyless to authenticate via the dashboard, or use the Novu dashboard instead.\n(run `novu connect --help` for the non-interactive contract and examples)'
         );
         process.exit(1);
       }
     }
 
-    if (options.login && options.secretKey) {
+    if (options.keyless && options.secretKey) {
       console.error(
-        'Cannot use --login together with --secret-key. Omit --secret-key to authenticate via the dashboard.'
+        'Cannot use --keyless together with --secret-key. Omit --secret-key for keyless mode, or omit --keyless to authenticate with your account.'
       );
       process.exit(1);
     }

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -12,12 +12,14 @@ Your job, end to end: collect a couple of inputs, infer the agent's purpose from
 
 | Mode | When to use | CLI flag |
 |---|---|---|
-| **Keyless** (default) | User is trying Novu from their codebase with no explicit dashboard signal | Omit `--login` and `--secret-key` — temporary agent; user claims via in-channel sign-up link |
-| **Authenticated** | User came from the Novu dashboard, is already signed in, mentions an existing account, or asks to log in | **`--login`** — dashboard OAuth; agent is created in their Development environment |
+| **Keyless** (default) | User is trying Novu from their codebase with no explicit dashboard signal | **`--keyless`** — temporary agent; user claims via in-channel sign-up link |
+| **Dashboard OAuth** | User came from the Novu dashboard, is already signed in, mentions an existing account, or asks to log in | Omit `--keyless` and `--secret-key` — dashboard OAuth (the CLI default); agent is created in their Development environment |
 
-**Default to keyless** — omit `--login` and `--secret-key` unless one of the authenticated triggers below applies. Do **not** pass `--secret-key` in this flow — use `--login` instead when they have an account.
+**Default to keyless** — always pass **`--keyless`** unless one of the dashboard-signal triggers below applies. Do **not** pass `--secret-key` in this flow — use dashboard OAuth (omit `--keyless`) instead when they have an account.
 
-**Dashboard prompt rule (mandatory):** If the user's prompt contains the sentence **"I'm signed in to the Novu dashboard"** (or otherwise states they came from the Novu dashboard), you **MUST** pass `--login`. Never run keyless in that case.
+> The CLI's own default (no flag) is dashboard OAuth. This guided flow deliberately overrides that by passing `--keyless` for anonymous users; you only omit `--keyless` when a dashboard signal applies.
+
+**Dashboard prompt rule (mandatory):** If the user's prompt contains the sentence **"I'm signed in to the Novu dashboard"** (or otherwise states they came from the Novu dashboard), you **MUST** use dashboard OAuth — omit `--keyless`. Never pass `--keyless` in that case.
 
 ---
 
@@ -29,9 +31,9 @@ These govern every step. When in doubt, follow these over any specific instructi
 - **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime, auth mode) unless the user raises it.
 - **Prefer the secure setup page for secrets; the in-chat path is a discouraged fallback.** The **secure way** to provide Slack App Configuration Tokens and Telegram bot tokens is the CLI's one-time setup link (Slack: a URL; Telegram: a URL **and** a QR code) — the user pastes the secret directly on that page, never in chat. Always offer this first and recommend it. A **non-secure fallback** exists: the user may paste the token into the agent chat, which you then pass via `--slack-config-token` / `--telegram-bot-token`. Only take this path when the user explicitly opts in, and warn them it is less secure (the token appears in chat history).
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
-- **One Connect shell, no log watchers.** Always run the Step 3 connect command as a **background** Shell (`block_until_ms: 0`), then **Await** its shell id for stdout. **Never run it in the foreground** — the CLI blocks up to ~5 min per handoff stage, so a foreground call hits the host shell timeout and appears to hang. Use a single Shell session only. Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path. **Never use timers** (`ScheduleWakeup`, `sleep`, or "check back in N minutes") to wait for handoffs — **Await** the Connect shell continuously until the next `NOVU_CONNECT_*` sentinel or `✓ Your agent is live` appears. The only exception: `--channel skip` without `--login` may run in the foreground.
-- **The CLI validates handoffs.** For dashboard OAuth (`--login`), `slack`/`email`/`telegram`, that Shell blocks and polls until the handoff completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion yourself.
-- **WhatsApp / MS Teams in keyless mode never reach the CLI.** If the user picks one and you are **not** using `--login`, do **not** run connect — redirect them to the Novu dashboard instead (Step 1). With **`--login`**, the CLI creates the agent and hands off a dashboard URL to finish channel setup.
+- **One Connect shell, no log watchers.** Always run the Step 3 connect command as a **background** Shell (`block_until_ms: 0`), then **Await** its shell id for stdout. **Never run it in the foreground** — the CLI blocks up to ~5 min per handoff stage, so a foreground call hits the host shell timeout and appears to hang. Use a single Shell session only. Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path. **Never use timers** (`ScheduleWakeup`, `sleep`, or "check back in N minutes") to wait for handoffs — **Await** the Connect shell continuously until the next `NOVU_CONNECT_*` sentinel or `✓ Your agent is live` appears. The only exception: `--channel skip` in keyless mode may run in the foreground.
+- **The CLI validates handoffs.** For dashboard OAuth, `slack`/`email`/`telegram`, that Shell blocks and polls until the handoff completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion yourself.
+- **WhatsApp / MS Teams in keyless mode never reach the CLI.** If the user picks one and you are using **`--keyless`** (the default), do **not** run connect — redirect them to the Novu dashboard instead (Step 1). With **dashboard OAuth** (omit `--keyless`), the CLI creates the agent and hands off a dashboard URL to finish channel setup.
 - **Report conclusion-first.** Lead with the CLI's result (live / failed), then the one action the user must take. Keep it terse.
 - **Use the option picker for decisions.** When the user must choose between fixed options, call the structured question tool — never ask decision questions as plain chat text. See [User decisions (option picker)](#user-decisions-option-picker).
 
@@ -56,8 +58,8 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 | Term | Meaning |
 |---|---|
-| **Dashboard OAuth** | The `--login` auth path. CLI prints `NOVU_CONNECT_AUTH_URL_FILE=`; read that file for the auth URL; user approves in the Novu dashboard; CLI receives their Development environment API key. |
-| **Keyless mode** | No `--login`, no `--secret-key`. Creates a temporary agent with no Novu account. |
+| **Keyless mode** | The default for this flow — pass `--keyless` (no `--secret-key`). Creates a temporary agent with no Novu account. |
+| **Dashboard OAuth** | The dashboard-signal auth path — omit `--keyless`. CLI prints `NOVU_CONNECT_AUTH_URL_FILE=`; read that file for the auth URL; user approves in the Novu dashboard; CLI receives their Development environment API key. |
 | **Demo runtime** | Default — shared Claude runtime. In keyless mode, limited to ~5 free replies. |
 | **Handoff** | The channel-specific user action (authorize link, send email, or dashboard URL) that finishes connecting the channel. |
 | **Dashboard redirect** | Keyless-only WhatsApp / MS Teams path: no agent is created in the CLI — user continues in the dashboard. |
@@ -69,10 +71,10 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 ## Flow overview
 
-1. **Channel** — ask which channel. Keyless + WhatsApp / MS Teams → dashboard redirect only (Steps 2–5 skipped). Authenticated (`--login`) supports all channels.
+1. **Channel** — ask which channel. Keyless + WhatsApp / MS Teams → dashboard redirect only (Steps 2–5 skipped). Dashboard OAuth supports all channels.
 2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user.
-3. **Run** — connect command from Step 3 (`--ci`, plus `--login` only when authenticated), streamed.
-4. **Handoff** — dashboard OAuth first when using `--login` (`NOVU_CONNECT_AUTH_URL_FILE=`), then channel-specific next steps. For Slack/Telegram, present the inline secure-page-vs-paste-in-chat token choice only when the token is actually needed. Let the CLI poll.
+3. **Run** — connect command from Step 3 (`--ci`, plus `--keyless` for the default keyless mode), streamed.
+4. **Handoff** — dashboard OAuth first when omitting `--keyless` (`NOVU_CONNECT_AUTH_URL_FILE=`), then channel-specific next steps. For Slack/Telegram, present the inline secure-page-vs-paste-in-chat token choice only when the token is actually needed. Let the CLI poll.
 5. **Report** — relay the CLI's success or error, give a 1–2 sentence recap of what onboarding set up, and point the user to the next step. Keyless: explain demo limit → claim link. Authenticated: report agent identifier + dashboard URL.
 
 ---
@@ -88,11 +90,11 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 | `slack` | Slack | **Recommended (secure):** open the setup link the CLI prints and paste a Slack App Configuration Token there, then click an OAuth link to approve the install. **Non-secure fallback:** paste the token in chat instead and you pass it via `--slack-config-token`. |
 | `email` | Email | Nothing up front. The CLI prints an inbound email address; the user sends one email to it. |
 | `telegram` | Telegram | Create a bot via @BotFather. **Recommended (secure):** open the setup link/QR the CLI prints and paste the token there. **Non-secure fallback:** paste the token in chat instead and you pass it via `--telegram-bot-token`. Then tap **Start** on the bot in Telegram. |
-| `dashboard` | WhatsApp / MS Teams | **Keyless:** sign in to the Novu dashboard and continue there (no CLI run). **Authenticated (`--login`):** CLI creates the agent, then opens the dashboard to finish channel setup. |
+| `dashboard` | WhatsApp / MS Teams | **Keyless (`--keyless`, default):** sign in to the Novu dashboard and continue there (no CLI run). **Dashboard OAuth (omit `--keyless`):** CLI creates the agent, then opens the dashboard to finish channel setup. |
 
-**If they pick `dashboard` and you are using keyless (no `--login`):** stop — do **not** run connect and do **not** generate an agent. Give the user the dashboard URL — **<https://dashboard.novu.co>** (or <https://eu.dashboard.novu.co> if they asked for the EU region) — and tell them to **sign in (or sign up) and continue the onboarding from the dashboard**. Steps 2–5 do not apply.
+**If they pick `dashboard` and you are using keyless (`--keyless`, the default):** stop — do **not** run connect and do **not** generate an agent. Give the user the dashboard URL — **<https://dashboard.novu.co>** (or <https://eu.dashboard.novu.co> if they asked for the EU region) — and tell them to **sign in (or sign up) and continue the onboarding from the dashboard**. Steps 2–5 do not apply.
 
-**If they pick `dashboard` and you are using `--login`:** ask WhatsApp or MS Teams if unclear; use `--channel whatsapp` or `--channel teams` in Step 3.
+**If they pick `dashboard` and you are using dashboard OAuth (omit `--keyless`):** ask WhatsApp or MS Teams if unclear; use `--channel whatsapp` or `--channel teams` in Step 3.
 
 **If they ask to skip** (via the picker's built-in "Other" free-text, or plain chat): proceed with `--channel skip`.
 
@@ -100,7 +102,7 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 - **slack / telegram** → collect **nothing** up front. Default Step 3 to the **secure path** (omit token flags). Token-delivery choice is **inline in Step 4**.
 - **email / skip** → no extra input up front.
-- **dashboard (WhatsApp / MS Teams)** → keyless: flow ends with dashboard redirect; authenticated: `--channel whatsapp` or `--channel teams`.
+- **dashboard (WhatsApp / MS Teams)** → keyless (default): flow ends with dashboard redirect; dashboard OAuth: `--channel whatsapp` or `--channel teams`.
 
 **Runtime:** always use the **demo runtime** — do not ask for an Anthropic API key and do not pass `--runtime` or `--anthropic-api-key`.
 
@@ -170,43 +172,43 @@ If they pick **edit**, ask for their revised text in chat (not the picker), upda
 
 ## Step 3 — Run connect (non-interactive)
 
-**Goal:** authenticate (when using `--login`), create the agent, and start the channel connection in one Connect shell.
+**Goal:** create the agent (keyless by default) and start the channel connection in one Connect shell.
 
 Substitute the channel the user picked. Run the command **exactly as written** — no `>`, `tee`, or log file.
 
 Set the agent description in an environment variable first — do **not** paste user-provided prose directly into a double-quoted shell argument (command substitution would execute inside `"…"`).
 
-**Authenticated (user has Novu account — include `--login`):**
+**Keyless (default — pass `--keyless`):**
 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
 npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
-  --login \
-  --channel <slack|email|telegram|whatsapp|teams|skip>
-```
-
-**Keyless (no account — omit `--login` and `--secret-key`):**
-
-```bash
-export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
-
-npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
-  --ci \
+  --keyless \
   --channel <slack|email|telegram|skip>
 ```
 
-Never pass `--channel whatsapp` or `--channel teams` in keyless mode — those require `--login`.
-
-**Canonical example (authenticated, slack):**
+**Dashboard OAuth (dashboard signal — omit `--keyless`):**
 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
 npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
-  --login \
+  --channel <slack|email|telegram|whatsapp|teams|skip>
+```
+
+Never pass `--channel whatsapp` or `--channel teams` with `--keyless` — those require dashboard OAuth (omit `--keyless`).
+
+**Canonical example (keyless, slack):**
+
+```bash
+export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
+
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
+  --ci \
+  --keyless \
   --channel slack
 ```
 
@@ -216,19 +218,19 @@ Always start the Connect command as a **background** Shell (`block_until_ms: 0`)
 
 Then follow the path that matches your flags:
 
-- **If using `--login`:** **Await** `NOVU_CONNECT_AUTH_URL_FILE=` on the background shell id, **Read** that file for the auth URL, deliver the URL to the user, then **Await** channel handoff markers and success on the same shell id.
+- **If using dashboard OAuth (omitting `--keyless`):** **Await** `NOVU_CONNECT_AUTH_URL_FILE=` on the background shell id, **Read** that file for the auth URL, deliver the URL to the user, then **Await** channel handoff markers and success on the same shell id.
 - **If channel is `slack`, `email`, or `telegram`:** **Await** on that shell id (e.g. `NOVU_CONNECT_SLACK_SETUP_URL=`, `NOVU_CONNECT_INBOUND_ADDRESS=`, etc.). **Await** until `✓ Your agent is live` or `✗`. Do not use Monitor, `tail -f`, `grep`, Read on log files.
-- **If channel is `whatsapp` or `teams` (authenticated only):** **Await** auth URL, then dashboard agent URL or success on the same shell id.
-- **If channel is `skip` without `--login`:** foreground Shell is allowed — the only exception to the background rule above.
+- **If channel is `whatsapp` or `teams` (dashboard OAuth only):** **Await** auth URL, then dashboard agent URL or success on the same shell id.
+- **If channel is `skip` in keyless mode:** foreground Shell is allowed — the only exception to the background rule above.
 
 Conditional flags:
 
-- **`--login`:** required when the dashboard prompt rule applies, or the user has a Novu account / asks to log in. Ignores `NOVU_SECRET_KEY`. Cannot combine with `--secret-key`.
+- **`--keyless`:** the default for this flow — pass it for anonymous users. Omit it only when a dashboard signal applies (dashboard OAuth). Cannot combine with `--secret-key`.
 - **Prefer secure setup links** over `--slack-config-token` / `--telegram-bot-token` on the first run.
 - **Runtime:** do not pass `--runtime` or `--anthropic-api-key` — demo runtime is always used.
 - **Region:** pass `--region eu` only when the user explicitly asks; otherwise default is **US** Novu Cloud.
 
-**Example — Step 4 Slack re-run (`in_chat` path, authenticated):**
+**Example — Step 4 Slack re-run (`in_chat` path, keyless default):**
 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
@@ -236,10 +238,12 @@ export SLACK_CONFIG_TOKEN='<xoxe.xoxp-...>'
 
 npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
-  --login \
+  --keyless \
   --channel slack \
   --slack-config-token "$SLACK_CONFIG_TOKEN"
 ```
+
+(Drop `--keyless` on the re-run if the original run used dashboard OAuth.)
 
 **Safe retry — Slack only:** silently re-run once on `Failed to create Slack app: …` before reporting.
 
@@ -251,9 +255,9 @@ npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
 
 **Always paste the literal URL — never a placeholder.** Every handoff link must be the full resolved value from the matching `NOVU_CONNECT_*` line. **Await** the pattern before sending any handoff message.
 
-### Dashboard OAuth (when using `--login`)
+### Dashboard OAuth (when omitting `--keyless`)
 
-Every `--login` run prints:
+Every dashboard OAuth run prints:
 
 ```text
 NOVU_CONNECT_AUTH_URL_FILE=<absolute path>
@@ -391,7 +395,7 @@ Adapt the recap to what actually happened (drop the MCP clause when no integrati
 | `Slack OAuth was not completed within … seconds` | Re-run the same command. |
 | `We didn't see your email at … within …s` | Re-run after they send the email. |
 | Telegram token / `/start` timeouts | Re-run the same command. |
-| `Keyless environment creation is currently disabled` | Wrong API/region, or use `--login` / `--secret-key` for an existing account. |
+| `Keyless environment creation is currently disabled` | Wrong API/region, or omit `--keyless` and use dashboard OAuth / `--secret-key` for an existing account. |
 
 ---
 
@@ -403,21 +407,21 @@ Run `novu@latest connect --help` for the full contract. Keep help text in sync w
 |---|---|
 | `connect "<description>"` | Positional agent description (required in `--ci`). |
 | `--ci` | Non-interactive mode (required). |
-| `--login` | Dashboard OAuth — use when the user has a Novu account or the dashboard prompt rule applies. |
+| `--keyless` | Temporary demo agent with no Novu account — **the default for this guided flow.** |
 | `--region <us\|eu>` | Target Novu Cloud region (default: `us`). |
-| `--channel <slack\|email\|telegram\|whatsapp\|teams\|skip>` | Channel to connect. `whatsapp`/`teams` require `--login`. |
+| `--channel <slack\|email\|telegram\|whatsapp\|teams\|skip>` | Channel to connect. `whatsapp`/`teams` require dashboard OAuth (omit `--keyless`). |
 | `--slack-config-token` / `--telegram-bot-token` | Non-secure CI escape hatches when user opts in. |
-| *(omit both)* | Keyless mode — temporary agent, no account. Do not pass `--secret-key` in this guided flow. |
+| *(omit `--keyless`)* | Dashboard OAuth — the CLI's own default; use only when a dashboard signal applies. Agent created in the user's Development environment. Do not pass `--secret-key` in this guided flow. |
 
 ---
 
 ## Limitations to keep in mind
 
 - **One run = one new agent + one channel.** Re-running creates another agent.
-- **Channel support is uneven headlessly:** `slack` and `telegram` need two user actions after auth; `email` one; `whatsapp`/`teams` need `--login` and finish in the dashboard.
+- **Channel support is uneven headlessly:** `slack` and `telegram` need two user actions after auth; `email` one; `whatsapp`/`teams` need dashboard OAuth and finish in the dashboard.
 - **Prefer secure setup pages for Slack/Telegram tokens.**
 - **Keyless data is temporary** until claimed via the in-channel sign-up link.
-- **`--login` ignores `NOVU_SECRET_KEY`** — dashboard OAuth always wins when the flag is set.
+- **Keyless is the default for this flow** — always pass `--keyless` unless a dashboard signal applies (then omit it for dashboard OAuth).
 
 ---
 
@@ -428,7 +432,7 @@ Run `novu@latest connect --help` for the full contract. Keep help text in sync w
 You are done when:
 
 1. The user picked a channel and confirmed the agent description.
-2. Dashboard OAuth completed (when using `--login`), or keyless bootstrap succeeded.
+2. Keyless bootstrap succeeded (default, with `--keyless`), or dashboard OAuth completed (when omitting `--keyless`).
 3. You delivered channel handoffs (or noted `skip` / whatsapp-teams dashboard URL).
 4. Connect shell printed `✓ Your agent is live.` (exit `0`); CLI poll validated handoffs where applicable.
 5. You reported agent identifier + next step (claim link for keyless, dashboard URL for authenticated), gave a brief recap of what onboarding set up, and explained how the user can keep going.


### PR DESCRIPTION
## What

Flips the `novu connect` CLI default from **keyless** to **dashboard OAuth (login)**, and makes keyless an explicit opt-in via a new `--keyless` flag.

- Removed `--login`; added `--keyless`.
- Auth resolution order in `resolve-connect-auth.ts`: `--secret-key` → `--keyless` → dashboard OAuth (default).
- Updated `connect` command flags, `--ci` validation messages, and `--help` text.
- `packages/shared/docs/agent-onboarding.md` (the guided `agents.md` prompt): still defaults to **keyless** (`--keyless`) for anonymous users, using dashboard OAuth only when a dashboard signal is present.
- Dashboard `prebuilt-prompt-banner` prompt now explicitly flags the login flow ("use dashboard login, not keyless mode").

## Why

We want the bare `novu connect` (and dashboard-originated flows) to authenticate the user against their account by default, while keeping a frictionless keyless path for anonymous "try it from my codebase" users who run the public `agents.md` prompt as-is.

## Auth resolution

```mermaid
flowchart TD
    A[novu connect] --> B{--secret-key set?}
    B -- yes --> C[Secret-key auth]
    B -- no --> D{--keyless set?}
    D -- yes --> E[Keyless workspace]
    D -- no --> F{NOVU_SECRET_KEY in non-interactive shell?}
    F -- yes --> C
    F -- no --> G[Dashboard OAuth - default]
```

## Behavior by entry point

| Entry point | Result |
|---|---|
| `novu connect` (no flag) | Dashboard OAuth (login) |
| `novu connect --keyless` | Keyless temporary agent |
| Generic `agents.md` prompt as-is | Keyless (doc passes `--keyless`) |
| Dashboard prebuilt-prompt banner | Dashboard OAuth (login) |

## Scope / risk

- CLI + docs only. No API/Worker/DAL/Mongo changes; no multi-tenant data paths touched.
- Backwards-incompatible flag change: `--login` is removed. Acceptable for this unreleased connect flow.

## Test plan

- [x] `packages/novu` typecheck passes (after building `@novu/shared`)
- [x] No remaining `--login` / `options.login` references
- [ ] `novu connect --help` renders the updated contract
- [ ] `novu connect "<desc>" --ci --channel slack` → dashboard OAuth handoff
- [ ] `novu connect "<desc>" --ci --keyless --channel slack` → keyless bootstrap
- [ ] `--keyless --secret-key` errors out

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The default authentication method for `novu connect` switched from keyless to dashboard OAuth login. The `--login` flag was removed and replaced with an explicit `--keyless` flag to opt into keyless temporary agent mode. Authentication resolution now follows: `--secret-key` → `--keyless` → dashboard OAuth (default). All related CLI help text, validation, and documentation were updated accordingly.

## Affected areas

**dashboard**: Updated the prebuilt-prompt-banner component to instruct dashboard OAuth login instead of keyless mode for clipboard copying and deep-link generation.

**js**: Modified authentication resolution in `resolve-connect-auth.ts` to treat keyless as an explicit opt-in mode; updated `ConnectCommandOptions` to include the new `keyless` flag; refreshed help text, validation messages, and CLI option descriptions to reflect the new authentication flow; modified `upgrade-keyless-session.ts` to use the updated auth resolution path.

**shared**: Updated agent-onboarding documentation to default to keyless for anonymous users while using dashboard OAuth only when dashboard signals are present; clarified command examples and error messaging.

## Key technical decisions

- **Breaking change**: Removal of `--login` flag is acceptable since the `connect` flow is still unreleased.
- **Validation constraint**: `--keyless` and `--secret-key` cannot be used together; an explicit error is raised if both are provided.
- **Authentication precedence**: Secret-key authentication takes priority, keyless is an explicit opt-in, and dashboard OAuth serves as the default fallback.

## Testing

Test plan covers typecheck validation, help text rendering, CI workflow authentication paths with both dashboard OAuth and keyless modes, and flag conflict validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR flips `novu connect` from keyless-by-default to dashboard OAuth-by-default, adding an explicit `--keyless` opt-in flag and removing the old `--login` flag. The guided `agents.md` flow deliberately preserves keyless as its own default by always passing `--keyless`, keeping anonymous onboarding frictionless while directing dashboard-originated flows through OAuth.

- `resolve-connect-auth.ts` reorders the auth chain to: `--secret-key` → `--keyless` → dashboard OAuth (new default); `upgrade-keyless-session.ts` is updated to clear `keyless` rather than set `login`.
- All seven changed files — CLI flags, type definitions, help text, the dashboard banner prompt, and the agent-onboarding doc — are updated consistently to reflect the new flag name and reversed defaults.

<h3>Confidence Score: 4/5</h3>

CLI and docs only — safe to merge with minor robustness improvements worth considering before or after.

The auth inversion is consistent across all seven files and the logic in resolve-connect-auth.ts is correct for all documented entry points. Two small gaps exist: upgrade-keyless-session.ts achieves dashboard OAuth by relying on default fallthrough rather than an explicit intent signal, and passing --keyless alongside a NOVU_SECRET_KEY environment variable in CI silently ignores the key without any warning — a new scenario this PR makes reachable.

resolve-connect-auth.ts and upgrade-keyless-session.ts warrant a second look for the env-var silent-ignore and the implicit fallthrough behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/auth/resolve-connect-auth.ts | Core auth resolution logic inverted: secret-key → keyless → dashboard OAuth (default). Logic is sound; minor gap where NOVU_SECRET_KEY env var is silently ignored when --keyless is passed. |
| packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts | Switched from explicit login:true to keyless:false — functional in all current call-paths, but relies on fallthrough default rather than explicit dashboard-OAuth trigger. |
| packages/novu/src/index.ts | Cleanly replaces --login with --keyless flag; validation logic for whatsapp/teams inverted from !login to keyless, which is correct; error messages updated consistently. |
| packages/novu/src/commands/connect/types.ts | Straightforward field rename from login? to keyless? with updated JSDoc. |
| packages/novu/src/commands/connect/help-text.ts | Help text updated to reflect new defaults and --keyless flag; examples and contract section are consistent. |
| apps/dashboard/src/components/onboarding/connect-agent/prebuilt-prompt-banner.tsx | Prompt updated from explicit --login flag reference to natural-language dashboard signal; still contains the trigger phrase matched by the mandatory dashboard prompt rule in agents.md. |
| packages/shared/docs/agent-onboarding.md | Updated throughout to reflect inverted defaults; keyless now requires explicit --keyless in the guided flow; added a callout box clarifying the intentional divergence between CLI default and guided-flow default. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[novu connect] --> B{--secret-key set?}
    B -- yes --> C{--keyless set?}
    C -- yes --> ERR[❌ Error: cannot combine]
    C -- no --> SK[Secret-key auth\nresolveAuth]
    B -- no --> D{NOVU_SECRET_KEY in\nnon-interactive shell?}
    D -- yes --> E{--keyless set?}
    E -- yes --> KL[Keyless workspace\nbootstrapKeylessSession]
    E -- no --> SK
    D -- no --> F{--keyless set?}
    F -- yes --> KL
    F -- no --> OA[Dashboard OAuth\nbrowserDeviceAuth\n← new default]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fauth%2Fupgrade-keyless-session.ts%3A24-25%0A**Implicit%20dashboard-OAuth%20trigger%20via%20fallthrough**%0A%0AThe%20old%20call%20was%20%60%7B%20...options%2C%20login%3A%20true%20%7D%60%2C%20which%20explicitly%20entered%20the%20%60if%20%28wantsLogin%29%60%20branch%20and%20always%20reached%20%60browserDeviceAuth%60%20%E2%80%94%20even%20if%20%60cliFlagSecret%60%20was%20present%20%28it%20would%20throw%20a%20visible%20conflict%20error%29.%20The%20new%20%60%7B%20...options%2C%20keyless%3A%20false%20%7D%60%20reaches%20%60browserDeviceAuth%60%20only%20by%20falling%20through%20all%20earlier%20guards.%20If%20%60cliFlagSecret%60%20is%20present%20in%20%60options%60%20%28e.g.%2C%20a%20future%20caller%20passes%20%60--secret-key%60%20to%20the%20upstream%20command%20for%20some%20reason%29%2C%20the%20function%20silently%20uses%20secret-key%20auth%20instead%20of%20dashboard%20OAuth%20with%20no%20error%20surfaced.%20Adding%20an%20explicit%20override%20such%20as%20%60%7B%20...options%2C%20keyless%3A%20false%2C%20secretKey%3A%20undefined%20%7D%60%20or%20a%20dedicated%20%60forceDashboardOAuth%60%20parameter%20to%20%60resolveConnectAuth%60%20would%20make%20the%20intent%20unambiguous.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fauth%2Fresolve-connect-auth.ts%3A22-32%0A**%60NOVU_SECRET_KEY%60%20silently%20ignored%20when%20%60--keyless%60%20is%20passed%20in%20CI**%0A%0AThere%20is%20a%20hard%20error%20for%20the%20%60--keyless%60%20%2B%20%60--secret-key%60%20flag%20combination%2C%20but%20there%20is%20no%20warning%20when%20%60--keyless%60%20is%20combined%20with%20%60NOVU_SECRET_KEY%60%20in%20a%20non-interactive%20shell.%20The%20guard%20on%20line%2028%20%E2%80%94%20%60envSecret%20%26%26%20!isInteractive%20%26%26%20!wantsKeyless%60%20%E2%80%94%20evaluates%20to%20%60false%60%20when%20%60wantsKeyless%60%20is%20%60true%60%2C%20so%20the%20env%20secret%20is%20dropped%20and%20keyless%20mode%20proceeds%20without%20any%20notice%20to%20the%20user.%20In%20a%20CI%20pipeline%20where%20%60NOVU_SECRET_KEY%60%20is%20already%20in%20the%20environment%20and%20a%20developer%20adds%20%60--keyless%60%20intending%20to%20test%20the%20anonymous%20path%2C%20the%20account%20credentials%20are%20silently%20unused%20%E2%80%94%20potentially%20surprising%20and%20hard%20to%20debug.%20A%20short%20warning%20%28or%20the%20same%20kind%20of%20error%20thrown%20for%20the%20flag%20combo%29%20would%20surface%20the%20conflict%20explicitly.%0A%0A&pr=11566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/novu/src/commands/connect/auth/upgrade-keyless-session.ts:24-25
**Implicit dashboard-OAuth trigger via fallthrough**

The old call was `{ ...options, login: true }`, which explicitly entered the `if (wantsLogin)` branch and always reached `browserDeviceAuth` — even if `cliFlagSecret` was present (it would throw a visible conflict error). The new `{ ...options, keyless: false }` reaches `browserDeviceAuth` only by falling through all earlier guards. If `cliFlagSecret` is present in `options` (e.g., a future caller passes `--secret-key` to the upstream command for some reason), the function silently uses secret-key auth instead of dashboard OAuth with no error surfaced. Adding an explicit override such as `{ ...options, keyless: false, secretKey: undefined }` or a dedicated `forceDashboardOAuth` parameter to `resolveConnectAuth` would make the intent unambiguous.

### Issue 2 of 2
packages/novu/src/commands/connect/auth/resolve-connect-auth.ts:22-32
**`NOVU_SECRET_KEY` silently ignored when `--keyless` is passed in CI**

There is a hard error for the `--keyless` + `--secret-key` flag combination, but there is no warning when `--keyless` is combined with `NOVU_SECRET_KEY` in a non-interactive shell. The guard on line 28 — `envSecret && !isInteractive && !wantsKeyless` — evaluates to `false` when `wantsKeyless` is `true`, so the env secret is dropped and keyless mode proceeds without any notice to the user. In a CI pipeline where `NOVU_SECRET_KEY` is already in the environment and a developer adds `--keyless` intending to test the anonymous path, the account credentials are silently unused — potentially surprising and hard to debug. A short warning (or the same kind of error thrown for the flag combo) would surface the conflict explicitly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(novu): default connect to dashboard..."](https://github.com/novuhq/novu/commit/7849c25fcc77484e8c9456635860f0b06636e728) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37632889)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->