### PR TITLE
fix(api-service): show hourglass only for queued inbound turns fixes NV-7742

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -74,7 +74,7 @@
     "@novu/notifications": "workspace:*",
     "@novu/shared": "workspace:*",
     "@novu/stateless": "workspace:*",
-    "@novu/thalamus": "0.1.0-alpha.13",
+    "@novu/thalamus": "0.1.0-alpha.14",
     "@novu/testing": "workspace:*",
     "@sendgrid/mail": "^8.1.6",
     "@slack/types": "2.20.1",

--- a/apps/api/src/app/agents/conversation-runtime/ack/inbound-ack.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ack/inbound-ack.service.ts
@@ -6,7 +6,7 @@ import { type AgentPlatformEnum, PLATFORMS_WITH_TYPING_INDICATOR } from '../../s
 import { OutboundGateway } from '../egress/outbound.gateway';
 
 export const INBOUND_ACK_EMOJI = {
-  /** Persistent processing signal for managed turns (active and queued). */
+  /** Persistent signal while a managed turn waits in the dispatch queue. */
   queued: 'hourglass',
   /** Receipt signal for non-typing platforms (first message only). */
   receipt: 'eyes',
@@ -94,7 +94,7 @@ export class InboundAckService {
     );
   }
 
-  /** Managed turn: persistent `hourglass` on the user message (all platforms). */
+  /** Managed turn queued behind an active turn: `hourglass` on the user message (all platforms). */
   async showQueuedSignal(params: QueuedSignalParams): Promise<void> {
     const { agentId, config, platformThreadId, platformMessageId } = params;
 

--- a/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
@@ -72,7 +72,6 @@ export class ManagedRuntime implements AgentRuntime {
           ...ackParams,
           isFirstMessage,
         });
-        await this.inboundAck.showQueuedSignal(ackParams);
       } else if (status === 'queued') {
         await this.inboundAck.showQueuedSignal(ackParams);
       }

--- a/enterprise/workers/thalamus-observer/package.json
+++ b/enterprise/workers/thalamus-observer/package.json
@@ -13,7 +13,7 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "@novu/thalamus": "0.1.0-alpha.13",
+    "@novu/thalamus": "0.1.0-alpha.14",
     "agents": "^0.12.4",
     "eventsource-parser": "^3.0.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,8 +429,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/testing
       '@novu/thalamus':
-        specifier: 0.1.0-alpha.13
-        version: 0.1.0-alpha.13(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))
+        specifier: 0.1.0-alpha.14
+        version: 0.1.0-alpha.14(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))
       '@sendgrid/mail':
         specifier: ^8.1.6
         version: 8.1.6
@@ -9015,8 +9015,8 @@ packages:
     resolution: {integrity: sha512-5E8EKp30Ee06FQRpax204nyZOb1uv0kW72VfZXkU/4hG4CcqDsJbfrNnUjB6xIPSvIwAAlwv76MdIAsOflkLXg==}
     engines: {node: '>=18.0.0'}
 
-  '@novu/thalamus@0.1.0-alpha.13':
-    resolution: {integrity: sha512-QCG87tWICP2y2URte0TvyP3HqkHzolSGVqbgITJ+xPXmQijoa9ymv6zJ6LaSGODoGWOqH4P479juc/0k+MGaFA==}
+  '@novu/thalamus@0.1.0-alpha.14':
+    resolution: {integrity: sha512-XWDnpUybkhuvoHoash6Nj1MW45EWH5kbduLaIRERj5bECzsSZ2Az97zt2SXKlCvFtGbzU0SHmbuE9XHvgOZGAg==}
     peerDependencies:
       '@anthropic-ai/aws-sdk': '>=0.86.0'
       '@anthropic-ai/sdk': '>=0.86.0'
@@ -35400,7 +35400,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@novu/thalamus@0.1.0-alpha.13(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))':
+  '@novu/thalamus@0.1.0-alpha.14(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))':
     optionalDependencies:
       '@anthropic-ai/sdk': 0.95.1(zod@3.25.20)
       '@aws-crypto/sha256-js': 5.2.0


### PR DESCRIPTION
## Summary
- Show the hourglass reaction only when a managed inbound turn is **queued** behind an active turn — not on the first/active message (typing indicator only).
- Bump `@novu/thalamus` to `0.1.0-alpha.14`, which defers agent overrides until dispatch so follow-up messages enqueue correctly while a session is running.

## Flow

```mermaid
sequenceDiagram
    participant User
    participant Novu
    participant Thalamus
    participant Observer

    User->>Novu: Message 1
    Novu->>Thalamus: send (active)
    Thalamus->>Observer: enqueue → active
    Novu->>User: typing (no hourglass)

    User->>Novu: Message 2 (while busy)
    Novu->>Thalamus: send (existing session)
    Thalamus->>Observer: enqueue → queued
    Novu->>User: hourglass on message 2
```

## Related
- Thalamus: https://github.com/novuhq/thalamus/pull/14

## Test plan
- [ ] Send one message → typing indicator only, no hourglass
- [ ] Send a second message while the agent is still processing → hourglass on the queued message
- [ ] Confirm no `Cannot update agent while session is running` errors when spamming messages

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR fixes incorrect hourglass reaction display on inbound messages by ensuring the hourglass appears only when a message is queued, not when it's active (which displays a typing indicator instead). The fix changes the acknowledgement behavior in the managed runtime's dispatch logic and bumps the `@novu/thalamus` dependency to version `0.1.0-alpha.14`, which defers agent overrides until dispatch time, preventing "Cannot update agent while session is running" errors during rapid message sends.

## Affected areas

**api**: Updated the managed runtime dispatch logic to call `showWorkingSignal` instead of `showQueuedSignal` for active inbound messages, computing whether the current message is the first in the conversation. Also bumped `@novu/thalamus` from `0.1.0-alpha.13` to `0.1.0-alpha.14` and updated comments describing the hourglass/queued signal semantics.

**worker** (enterprise): Updated `@novu/thalamus` dependency from `0.1.0-alpha.13` to `0.1.0-alpha.14` in the thalamus-observer worker.

## Key technical decisions

- The `@novu/thalamus` version bump (`0.1.0-alpha.14`) defers agent overrides until dispatch time, allowing follow-up messages to enqueue correctly while a session is actively running—this is critical to preventing runtime errors during rapid message sends.

## Testing

No new test files are included in this PR. The fix relies on the existing test coverage and manual verification of the three expected scenarios: single message sends (typing indicator only), multiple messages during agent processing (hourglass on queued messages), and rapid message sends without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates managed-agent inbound acknowledgements so active inbound turns show only the working/typing signal.
- Keeps the hourglass reaction for managed inbound turns that are queued behind an active turn.
- Bumps `@novu/thalamus` to `0.1.0-alpha.14` in the API and observer worker packages.

<h3>Confidence Score: 5/5</h3>

The change is focused and matches the intended managed inbound-turn acknowledgement behavior.

No code issues were identified in the reviewed changes, and the dependency bump aligns with the described enqueue behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Base behavior was confirmed: active turns called both showWorkingSignal and showQueuedSignal, causing an hourglass on every active message.
- Post-change behavior was confirmed: active turns now call only showWorkingSignal, with the hourglass reserved for queued turns.
- Active-status path verification showed that when status is active, only showWorkingSignal is invoked and showQueuedSignal is used only for the queued branch.
- Work was blocked by a dependency installation issue: Node.js v20.9.0 is present while the required version is 22 or newer, preventing exercising @novu/thalamus changes.

<a href="https://app.greptile.com/trex/runs/11244970/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): show hourglass only fo..."](https://github.com/novuhq/novu/commit/96571fd41e971353e023d0ed0bdc626aaa4a8de6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37842448)</sub>

<!-- /greptile_comment -->