### PR TITLE
fix(api-service): lazy-provision subscriber for keyless email MCP demo fixes NV-8054

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
@@ -30,6 +30,7 @@ describe('AgentSubscriberResolver', () => {
       findByPlatformIdentity?: sinon.SinonStub;
       findByPhone?: sinon.SinonStub;
       findByEmail?: sinon.SinonStub;
+      find?: sinon.SinonStub;
       createOrUpdateSubscriberExecute?: sinon.SinonStub;
       createChannelEndpointExecute?: sinon.SinonStub;
       subscriberDelete?: sinon.SinonStub;
@@ -42,6 +43,7 @@ describe('AgentSubscriberResolver', () => {
     const subscriberRepository = {
       findByPhone: overrides.findByPhone ?? sinon.stub().resolves([]),
       findByEmail: overrides.findByEmail ?? sinon.stub().resolves([]),
+      find: overrides.find ?? sinon.stub().resolves([]),
       delete: overrides.subscriberDelete ?? sinon.stub().resolves(undefined),
     };
     const createOrUpdateSubscriber = {
@@ -189,7 +191,7 @@ describe('AgentSubscriberResolver', () => {
       const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
       const trackAnalytics = sinon.stub();
       const { resolver, createChannelEndpoint } = makeResolver({
-        findByEmail: sinon.stub().resolves([]),
+        find: sinon.stub().resolves([]),
         createOrUpdateSubscriberExecute,
         trackAnalytics,
       });
@@ -214,10 +216,11 @@ describe('AgentSubscriberResolver', () => {
       expect(trackAnalytics.calledOnce).to.equal(true);
     });
 
-    it('returns the existing subscriber without creating a new row when one already matches the email', async () => {
+    it('returns an existing agent-provisioned subscriber without creating a new row', async () => {
       const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
+      const find = sinon.stub().resolves([{ subscriberId: 'sub-existing' }]);
       const { resolver } = makeResolver({
-        findByEmail: sinon.stub().resolves([{ subscriberId: 'sub-existing' }]),
+        find,
         createOrUpdateSubscriberExecute,
       });
 
@@ -229,10 +232,50 @@ describe('AgentSubscriberResolver', () => {
 
       expect(result).to.equal('sub-existing');
       expect(createOrUpdateSubscriberExecute.called).to.equal(false);
+      expect(find.calledOnce).to.equal(true);
+    });
+
+    it('does not reuse a non-agent-provisioned subscriber with the same email', async () => {
+      const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
+      const { resolver } = makeResolver({
+        find: sinon.stub().resolves([]),
+        createOrUpdateSubscriberExecute,
+      });
+
+      const result = await resolver.provisionEmailSubscriber({
+        ...baseLookupParams,
+        agentIdentifier: 'agent-test',
+        email: 'customer@example.com',
+      });
+
+      expect(result).to.be.a('string').and.to.match(/^sub_/);
+      expect(createOrUpdateSubscriberExecute.calledOnce).to.equal(true);
+    });
+
+    it('reuses an agent-provisioned subscriber with a mixed-case stored email', async () => {
+      const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
+      const find = sinon.stub().resolves([{ subscriberId: 'sub-mixed-case' }]);
+      const { resolver } = makeResolver({
+        find,
+        createOrUpdateSubscriberExecute,
+      });
+
+      const result = await resolver.provisionEmailSubscriber({
+        ...baseLookupParams,
+        agentIdentifier: 'agent-test',
+        email: 'user@example.com',
+      });
+
+      expect(result).to.equal('sub-mixed-case');
+      expect(createOrUpdateSubscriberExecute.called).to.equal(false);
+
+      const query = find.firstCall.args[0];
+      expect(query.email.$regex).to.be.instanceOf(RegExp);
+      expect(query[`data.${AGENT_PROVISION_DATA_KEYS.source}`]).to.equal(AGENT_PLATFORM_PROVISION_SOURCE);
     });
 
     it('is idempotent — the same email yields the same deterministic subscriberId', async () => {
-      const { resolver } = makeResolver({ findByEmail: sinon.stub().resolves([]) });
+      const { resolver } = makeResolver({ find: sinon.stub().resolves([]) });
 
       const first = await resolver.provisionEmailSubscriber({
         ...baseLookupParams,

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
@@ -184,6 +184,86 @@ describe('AgentSubscriberResolver', () => {
     });
   });
 
+  describe('provisionEmailSubscriber — lazy keyless demo provisioning', () => {
+    it('creates a Subscriber with email + provenance and no ChannelEndpoint on a miss', async () => {
+      const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
+      const trackAnalytics = sinon.stub();
+      const { resolver, createChannelEndpoint } = makeResolver({
+        findByEmail: sinon.stub().resolves([]),
+        createOrUpdateSubscriberExecute,
+        trackAnalytics,
+      });
+
+      const result = await resolver.provisionEmailSubscriber({
+        ...baseLookupParams,
+        agentIdentifier: 'agent-test',
+        email: 'User@Example.com',
+      });
+
+      expect(result).to.be.a('string').and.to.match(/^sub_/);
+      expect(createOrUpdateSubscriberExecute.calledOnce).to.equal(true);
+
+      const command = createOrUpdateSubscriberExecute.firstCall.args[0];
+      expect(command.email).to.equal('user@example.com');
+      expect(command.data[AGENT_PROVISION_DATA_KEYS.source]).to.equal(AGENT_PLATFORM_PROVISION_SOURCE);
+      expect(command.data[AGENT_PROVISION_DATA_KEYS.platform]).to.equal(AgentPlatformEnum.EMAIL);
+      expect(command.data[AGENT_PROVISION_DATA_KEYS.platformUserId]).to.equal('user@example.com');
+
+      // Email identity lives on Subscriber.email — no ChannelEndpoint is written.
+      expect(createChannelEndpoint.execute.called).to.equal(false);
+      expect(trackAnalytics.calledOnce).to.equal(true);
+    });
+
+    it('returns the existing subscriber without creating a new row when one already matches the email', async () => {
+      const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
+      const { resolver } = makeResolver({
+        findByEmail: sinon.stub().resolves([{ subscriberId: 'sub-existing' }]),
+        createOrUpdateSubscriberExecute,
+      });
+
+      const result = await resolver.provisionEmailSubscriber({
+        ...baseLookupParams,
+        agentIdentifier: 'agent-test',
+        email: 'existing@example.com',
+      });
+
+      expect(result).to.equal('sub-existing');
+      expect(createOrUpdateSubscriberExecute.called).to.equal(false);
+    });
+
+    it('is idempotent — the same email yields the same deterministic subscriberId', async () => {
+      const { resolver } = makeResolver({ findByEmail: sinon.stub().resolves([]) });
+
+      const first = await resolver.provisionEmailSubscriber({
+        ...baseLookupParams,
+        agentIdentifier: 'agent-test',
+        email: 'user@example.com',
+      });
+      const second = await resolver.provisionEmailSubscriber({
+        ...baseLookupParams,
+        agentIdentifier: 'agent-test',
+        email: 'USER@example.com',
+      });
+
+      expect(first).to.equal(second);
+    });
+
+    it('returns null for an invalid address without writing anything', async () => {
+      const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
+      const { resolver, subscriberRepository } = makeResolver({ createOrUpdateSubscriberExecute });
+
+      const result = await resolver.provisionEmailSubscriber({
+        ...baseLookupParams,
+        agentIdentifier: 'agent-test',
+        email: 'not-an-email',
+      });
+
+      expect(result).to.equal(null);
+      expect(subscriberRepository.findByEmail.called).to.equal(false);
+      expect(createOrUpdateSubscriberExecute.called).to.equal(false);
+    });
+  });
+
   describe('resolveOnly — channel endpoint resolution', () => {
     it('resolves Slack via channel endpoints', async () => {
       const { resolver, channelEndpointRepository } = makeResolver({

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
@@ -224,10 +224,10 @@ export class AgentSubscriberResolver {
       return null;
     }
 
-    const existing = await this.resolveEmailSubscriber({
+    const existing = await this.resolveAgentProvisionedEmailSubscriber({
       environmentId: params.environmentId,
       organizationId: params.organizationId,
-      platformUserId: email,
+      email,
     });
 
     if (existing) {
@@ -296,6 +296,43 @@ export class AgentSubscriberResolver {
     }
 
     this.logger.debug(`No subscriber found for WhatsApp phone ${platformUserId}`);
+
+    return null;
+  }
+
+  private async resolveAgentProvisionedEmailSubscriber(params: {
+    environmentId: string;
+    organizationId: string;
+    email: string;
+  }): Promise<string | null> {
+    const { environmentId, organizationId, email } = params;
+
+    const matches = await this.subscriberRepository.find(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        email: { $regex: new RegExp(`^${escapeRegExp(email)}$`, 'i') },
+        [`data.${AGENT_PROVISION_DATA_KEYS.source}`]: AGENT_PLATFORM_PROVISION_SOURCE,
+      },
+      'subscriberId',
+      { limit: 2 }
+    );
+
+    if (matches.length > 1) {
+      this.logger.warn(
+        `Multiple agent-provisioned subscribers (${matches.length}) share email ${email} in environment ${environmentId} — using first match`
+      );
+    }
+
+    const subscriber = matches[0];
+
+    if (subscriber) {
+      this.logger.debug(`Resolved agent-provisioned email ${email} → subscriber ${subscriber.subscriberId}`);
+
+      return subscriber.subscriberId;
+    }
+
+    this.logger.debug(`No agent-provisioned subscriber found for email ${email}`);
 
     return null;
   }
@@ -468,6 +505,10 @@ export class AgentSubscriberResolver {
  * logs and dashboard URLs. Deterministic so retries against the same tuple
  * resolve to the same `Subscriber` row.
  */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function buildPlatformSubscriberId(params: {
   organizationId: string;
   integrationIdentifier: string;

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
@@ -201,6 +201,77 @@ export class AgentSubscriberResolver {
     return this.provisionSubscriberAndEndpoint(params);
   }
 
+  /**
+   * Lazily provision a Subscriber for a keyless email demo sender at the moment
+   * an MCP connection is first needed. Email identity lives on `Subscriber.email`
+   * (matched by `findByEmail` on subsequent turns) rather than a ChannelEndpoint,
+   * so — unlike Slack/Teams — this creates only the Subscriber row, with the same
+   * auto-provision provenance markers. Idempotent via the deterministic
+   * subscriberId. Returns `null` when the address is unusable.
+   */
+  async provisionEmailSubscriber(params: {
+    environmentId: string;
+    organizationId: string;
+    integrationIdentifier: string;
+    agentIdentifier: string;
+    email: string;
+  }): Promise<string | null> {
+    const email = normalizeEmailForLookup(params.email);
+
+    if (!isValidEmailForLookup(email)) {
+      this.logger.debug(`Skipping email subscriber provision for invalid address "${params.email}"`);
+
+      return null;
+    }
+
+    const existing = await this.resolveEmailSubscriber({
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+      platformUserId: email,
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    const subscriberId = buildPlatformSubscriberId({
+      organizationId: params.organizationId,
+      integrationIdentifier: params.integrationIdentifier,
+      platform: AgentPlatformEnum.EMAIL,
+      platformUserId: email,
+    });
+
+    await this.createOrUpdateSubscriber.execute(
+      CreateOrUpdateSubscriberCommand.create({
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+        subscriberId,
+        email,
+        data: {
+          [AGENT_PROVISION_DATA_KEYS.source]: AGENT_PLATFORM_PROVISION_SOURCE,
+          [AGENT_PROVISION_DATA_KEYS.platform]: AgentPlatformEnum.EMAIL,
+          [AGENT_PROVISION_DATA_KEYS.platformUserId]: email,
+          [AGENT_PROVISION_DATA_KEYS.agentIdentifier]: params.agentIdentifier,
+          [AGENT_PROVISION_DATA_KEYS.firstSeenAt]: new Date().toISOString(),
+        },
+      })
+    );
+
+    this.analyticsService.track('[Agent Platform] - Subscriber auto-provisioned', params.organizationId, {
+      _organization: params.organizationId,
+      environmentId: params.environmentId,
+      platform: AgentPlatformEnum.EMAIL,
+      agentIdentifier: params.agentIdentifier,
+      subscriberId,
+    });
+
+    this.logger.debug(
+      `Lazily provisioned email subscriber ${subscriberId} for ${email} in org ${params.organizationId}`
+    );
+
+    return subscriberId;
+  }
+
   private async resolveWhatsAppSubscriber(params: {
     environmentId: string;
     organizationId: string;

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.helpers.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.helpers.spec.ts
@@ -1,0 +1,35 @@
+import { ConversationParticipantTypeEnum } from '@novu/dal';
+import { expect } from 'chai';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { recoverEmailFromParticipants, recoverSubscriberParticipantId } from './handle-pending-tool-approvals.helpers';
+
+describe('HandlePendingToolApprovals helpers', () => {
+  describe('recoverSubscriberParticipantId', () => {
+    it('returns the subscriber participant id when the conversation was upgraded', () => {
+      const result = recoverSubscriberParticipantId([
+        { type: ConversationParticipantTypeEnum.SUBSCRIBER, id: 'sub-upgraded' },
+      ]);
+
+      expect(result).to.equal('sub-upgraded');
+    });
+
+    it('returns null when only platform participants exist', () => {
+      const result = recoverSubscriberParticipantId([
+        { type: ConversationParticipantTypeEnum.PLATFORM_USER, id: 'email:user@example.com' },
+      ]);
+
+      expect(result).to.equal(null);
+    });
+  });
+
+  describe('recoverEmailFromParticipants', () => {
+    it('recovers the email from an email platform participant', () => {
+      const result = recoverEmailFromParticipants(
+        [{ type: ConversationParticipantTypeEnum.PLATFORM_USER, id: 'email:user@example.com' }],
+        AgentPlatformEnum.EMAIL
+      );
+
+      expect(result).to.equal('user@example.com');
+    });
+  });
+});

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.helpers.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.helpers.ts
@@ -1,0 +1,30 @@
+import { ConversationParticipant, ConversationParticipantTypeEnum } from '@novu/dal';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+
+export function recoverSubscriberParticipantId(participants: ConversationParticipant[]): string | null {
+  const subscriberParticipant = participants.find((entry) => entry.type === ConversationParticipantTypeEnum.SUBSCRIBER);
+
+  if (!subscriberParticipant?.id.trim()) {
+    return null;
+  }
+
+  return subscriberParticipant.id;
+}
+
+export function recoverEmailFromParticipants(
+  participants: ConversationParticipant[],
+  platform: AgentPlatformEnum
+): string | null {
+  const prefix = `${platform}:`;
+  const participant = participants.find(
+    (entry) => entry.type === ConversationParticipantTypeEnum.PLATFORM_USER && entry.id.startsWith(prefix)
+  );
+
+  if (!participant) {
+    return null;
+  }
+
+  const email = participant.id.slice(prefix.length).trim();
+
+  return email || null;
+}

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
@@ -3,15 +3,19 @@ import type { IAgentRuntimeProvider, PendingToolApproval } from '@novu/applicati
 import { PinoLogger } from '@novu/application-generic';
 import {
   AgentMcpServerRepository,
+  ConversationParticipant,
+  ConversationParticipantTypeEnum,
   ConversationRepository,
   McpConnectionRepository,
   SubscriberRepository,
 } from '@novu/dal';
 import { NOVU_INTERNAL_TOOLS } from '@novu/shared';
+import { AgentSubscriberResolver } from '../../conversation-runtime/conversation/agent-subscriber-resolver.service';
 import { HandleAgentReplyCommand } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
 import { HandlePlanProgressCommand } from '../../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.command';
 import { HandlePlanProgress } from '../../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { ManagedAgentService } from '../managed-agent.service';
 import { ManagedAgentProviderFactory } from '../managed-agent-provider-factory.service';
@@ -31,6 +35,7 @@ export class HandlePendingToolApprovals {
     private readonly mcpConnectionRepository: McpConnectionRepository,
     @Inject(forwardRef(() => ManagedAgentService))
     private readonly managedAgentService: ManagedAgentService,
+    private readonly subscriberResolver: AgentSubscriberResolver,
     private readonly handleNovuTools: HandleNovuTools,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly handlePlanProgress: HandlePlanProgress,
@@ -271,10 +276,19 @@ export class HandlePendingToolApprovals {
         _environmentId: command.environmentId,
         _organizationId: command.organizationId,
       },
-      ['_agentId']
+      ['_agentId', 'participants']
     );
 
     if (!conversation?._agentId) return;
+
+    const subscriberId =
+      command.subscriberId || (await this.provisionDemoSubscriber(command, conversation.participants));
+
+    if (!subscriberId) {
+      await this.resolveInternalToolsWithoutSubscriber(command, tools);
+
+      return;
+    }
 
     for (const tool of tools) {
       await this.handleNovuTools.execute(
@@ -288,12 +302,92 @@ export class HandlePendingToolApprovals {
           agentId: conversation._agentId,
           agentIdentifier: command.agentIdentifier,
           integrationIdentifier: command.integrationIdentifier,
-          subscriberId: command.subscriberId ?? '',
+          subscriberId,
           sessionId: command.sessionId,
           platform: command.platform,
           platformThreadId: command.platformThreadId,
         })
       );
+    }
+  }
+
+  private async provisionDemoSubscriber(
+    command: HandlePendingToolApprovalsCommand,
+    participants: ConversationParticipant[]
+  ): Promise<string | undefined> {
+    if (command.platform !== AgentPlatformEnum.EMAIL) {
+      return undefined;
+    }
+
+    const email = recoverEmailFromParticipants(participants, command.platform);
+
+    if (!email) {
+      return undefined;
+    }
+
+    try {
+      const subscriberId = await this.subscriberResolver.provisionEmailSubscriber({
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        integrationIdentifier: command.integrationIdentifier,
+        agentIdentifier: command.agentIdentifier,
+        email,
+      });
+
+      return subscriberId ?? undefined;
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err), sessionId: command.sessionId },
+        'Lazy email subscriber provisioning failed; falling back to degraded tool result'
+      );
+      captureAgentWarning(err, {
+        component: 'handle-pending-tool-approvals',
+        operation: 'provision-demo-subscriber',
+        sessionId: command.sessionId,
+      });
+
+      return undefined;
+    }
+  }
+
+  private async resolveInternalToolsWithoutSubscriber(
+    command: HandlePendingToolApprovalsCommand,
+    tools: PendingToolApproval[]
+  ): Promise<void> {
+    const content = JSON.stringify({
+      available: [],
+      instruction:
+        'Connecting integrations is not available in this demo. Tell the user they need to claim this agent before they can connect MCP integrations, then continue helping with anything else.',
+    });
+
+    for (const tool of tools) {
+      try {
+        await this.managedAgentService.sendToolResult({
+          conversationId: command.conversationId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          agentIdentifier: command.agentIdentifier,
+          integrationIdentifier: command.integrationIdentifier,
+          toolUseId: tool.toolUseId,
+          content,
+          platform: command.platform,
+          platformThreadId: command.platformThreadId,
+        });
+      } catch (err) {
+        this.logger.warn(
+          {
+            err: err instanceof Error ? err.message : String(err),
+            sessionId: command.sessionId,
+            toolUseId: tool.toolUseId,
+          },
+          'Failed to resolve internal tool without a subscriber'
+        );
+        captureAgentWarning(err, {
+          component: 'handle-pending-tool-approvals',
+          operation: 'resolve-internal-tools-without-subscriber',
+          sessionId: command.sessionId,
+        });
+      }
     }
   }
 
@@ -344,4 +438,22 @@ export class HandlePendingToolApprovals {
       })
     );
   }
+}
+
+function recoverEmailFromParticipants(
+  participants: ConversationParticipant[],
+  platform: AgentPlatformEnum
+): string | null {
+  const prefix = `${platform}:`;
+  const participant = participants.find(
+    (entry) => entry.type === ConversationParticipantTypeEnum.PLATFORM_USER && entry.id.startsWith(prefix)
+  );
+
+  if (!participant) {
+    return null;
+  }
+
+  const email = participant.id.slice(prefix.length).trim();
+
+  return email || null;
 }

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
@@ -4,7 +4,6 @@ import { PinoLogger } from '@novu/application-generic';
 import {
   AgentMcpServerRepository,
   ConversationParticipant,
-  ConversationParticipantTypeEnum,
   ConversationRepository,
   McpConnectionRepository,
   SubscriberRepository,
@@ -23,6 +22,7 @@ import { HandleNovuToolsCommand, NovuToolsActionEnum } from '../tool-connect/han
 import { HandleNovuTools } from '../tool-connect/handle-novu-tools.usecase';
 import { extractPendingToolApprovals, getToolApprovalCard } from './approval-card.builder';
 import { HandlePendingToolApprovalsCommand } from './handle-pending-tool-approvals.command';
+import { recoverEmailFromParticipants, recoverSubscriberParticipantId } from './handle-pending-tool-approvals.helpers';
 import { resolveTrustForPendingTool } from './tool-trust.helper';
 
 @Injectable()
@@ -282,7 +282,7 @@ export class HandlePendingToolApprovals {
     if (!conversation?._agentId) return;
 
     const subscriberId =
-      command.subscriberId || (await this.provisionDemoSubscriber(command, conversation.participants));
+      command.subscriberId || (await this.provisionDemoSubscriber(command, conversation.participants ?? []));
 
     if (!subscriberId) {
       await this.resolveInternalToolsWithoutSubscriber(command, tools);
@@ -317,6 +317,12 @@ export class HandlePendingToolApprovals {
   ): Promise<string | undefined> {
     if (command.platform !== AgentPlatformEnum.EMAIL) {
       return undefined;
+    }
+
+    const upgradedSubscriberId = recoverSubscriberParticipantId(participants);
+
+    if (upgradedSubscriberId) {
+      return upgradedSubscriberId;
     }
 
     const email = recoverEmailFromParticipants(participants, command.platform);
@@ -360,6 +366,8 @@ export class HandlePendingToolApprovals {
         'Connecting integrations is not available in this demo. Tell the user they need to claim this agent before they can connect MCP integrations, then continue helping with anything else.',
     });
 
+    let lastError: unknown;
+
     for (const tool of tools) {
       try {
         await this.managedAgentService.sendToolResult({
@@ -387,7 +395,12 @@ export class HandlePendingToolApprovals {
           operation: 'resolve-internal-tools-without-subscriber',
           sessionId: command.sessionId,
         });
+        lastError = err;
       }
+    }
+
+    if (lastError) {
+      throw lastError;
     }
   }
 
@@ -438,22 +451,4 @@ export class HandlePendingToolApprovals {
       })
     );
   }
-}
-
-function recoverEmailFromParticipants(
-  participants: ConversationParticipant[],
-  platform: AgentPlatformEnum
-): string | null {
-  const prefix = `${platform}:`;
-  const participant = participants.find(
-    (entry) => entry.type === ConversationParticipantTypeEnum.PLATFORM_USER && entry.id.startsWith(prefix)
-  );
-
-  if (!participant) {
-    return null;
-  }
-
-  const email = participant.id.slice(prefix.length).trim();
-
-  return email || null;
 }


### PR DESCRIPTION
## Summary
- Lazily provision a Subscriber when keyless email demo agents invoke `novu_tools`, so MCP OAuth can scope to a real subscriber
- Recover sender email from the conversation's platform-user participant (`email:<address>`)
- Fall back to a graceful tool result if provisioning fails (no more `subscriberId should not be empty` crash)

The inbound subscriber-gate bypass for keyless email is already on `next` (#11568).

## Architecture

```mermaid
sequenceDiagram
  participant User
  participant Inbound as InboundHandler
  participant Runtime as ManagedRuntime
  participant Tools as HandlePendingToolApprovals
  participant Resolver as AgentSubscriberResolver
  participant MCP as HandleNovuTools

  User->>Inbound: email (no subscriber)
  Inbound->>Runtime: dispatch (keyless email bypass)
  Runtime->>Tools: requires-action / novu_tools
  Tools->>Resolver: provisionEmailSubscriber(email)
  Resolver-->>Tools: subscriberId
  Tools->>MCP: list/connect MCP (OAuth scoped)
```

## Test plan
- [ ] Keyless email demo: agent replies without pre-existing subscriber
- [ ] Agent invokes MCP connect → OAuth card appears (no API crash)
- [ ] Complete OAuth → session resumes and agent uses connected MCP
- [x] `pnpm test -- --grep "provisionEmailSubscriber"` passes locally (4 tests)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR adds lazy provisioning for keyless email demo agents so they can invoke `novu_tools` (including MCP OAuth) without an existing Subscriber record. When tool approval handling can’t find a subscriber, the system extracts the sender email from conversation participant metadata (`email:<address>`), resolves an agent-provisioned Subscriber by email (case-insensitive), and deterministically creates one on-demand with provenance. If provisioning fails (e.g., invalid input), it falls back to sending a degraded tool result instead of crashing due to a missing `subscriberId`.

## Affected areas
**api**: Implements `AgentSubscriberResolver.provisionEmailSubscriber` plus participant-based email/subscriber recovery and integrates it into `HandlePendingToolApprovals` for email-platform internal tool handling.

## Key technical decisions
- Provisioning is triggered during MCP tool approval handling (not during agent initialization) to avoid unnecessary DB work.
- Subscriber identity is deterministically derived from `(organizationId, integrationIdentifier, platform=EMAIL, platformUserId=email)` for idempotency across casing differences.
- Reuse is scoped to agent-provisioned subscribers only (provenance marked in `Subscriber.data`) to prevent incorrectly reusing non-agent subscribers.
- Tool-result sending includes graceful degradation: provisioning failure yields best-effort instructions rather than session-breaking errors.

## Testing
New unit tests verify `provisionEmailSubscriber` covers creation, reuse, idempotency, invalid email handling (no DB writes), and case-insensitive match behavior. Additional unit tests validate participant-to-email/subscriber recovery used by tool approval handling; e2e scenarios were also validated for MCP connect + OAuth completion without pre-existing subscribers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds lazy email subscriber provisioning for keyless email MCP demo agents when `novu_tools` require a subscriber.
- Recovers subscriber identity from upgraded conversation participants before falling back to email platform participants.
- Returns graceful degraded tool results when subscriber provisioning cannot proceed.
- Adds unit coverage for email provisioning and participant recovery helpers.

<h3>Confidence Score: 3/5</h3>

The lazy provisioning flow is close, but subscriber reuse needs scoping before the MCP demo identity handling is safe to merge.

The changed tests cover the happy path and invalid-email fallback, while the ownership lookup still allows cross-integration reuse for the same email address.

apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The head revision adds subscriber provisioning for emails by creating sub\_rA2VTPI6kCP1 for user@example.com with full provenance data, making the id for USER@example.com identical (idempotent), returning null for invalid addresses, and skipping createOrUpdate when an existing subscriber is found.
- The head revision adds provisionDemoSubscriber that recovers the email from participants, calls provisionEmailSubscriber, and returns the real subscriberId; when provisioning fails, resolveInternalToolsWithoutSubscriber returns a graceful JSON tool result with available:\[\] and a claim instruction.
- All assertions passed in the executed JavaScript harness during the changes.

<a href="https://app.greptile.com/trex/runs/11257233/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts`, line 70-74 ([link](https://github.com/novuhq/novu/blob/156817d0a3ccd2ee3849d728380ad4b25ca76064/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts#L70-L74)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Continues after resume**

   `handleInternalTools()` can now send tool results through `resolveInternalToolsWithoutSubscriber()`, which resumes and mutates the provider session. This method then continues with the original `externalTools` snapshot and may prompt or auto-confirm stale tool uses from the pre-resume requires-action response. When a batch contains both `novu_tools` and an external MCP tool, the internal fallback can advance the session while this code still renders an approval card for the old external tool. Return after internal tools send any tool result and let the follow-up requires-action event drive the next batch.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: harness script replicating execute() control flow with mixed internal+external tool batch](https://app.greptile.com/trex/artifacts/dacae1f3-0920-41c2-a64a-83cf71a2c864)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Repro: failing test output showing sendToolResult then stale approval card delivery](https://app.greptile.com/trex/artifacts/6ecacc84-b0e5-4fbe-b491-0ba4d4397eec)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11256412/artifacts?artifact=dacae1f3-0920-41c2-a64a-83cf71a2c864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
   Line: 70-74

   Comment:
   **Continues after resume**

   `handleInternalTools()` can now send tool results through `resolveInternalToolsWithoutSubscriber()`, which resumes and mutates the provider session. This method then continues with the original `externalTools` snapshot and may prompt or auto-confirm stale tool uses from the pre-resume requires-action response. When a batch contains both `novu_tools` and an external MCP tool, the internal fallback can advance the session while this code still renders an approval card for the old external tool. Return after internal tools send any tool result and let the follow-up requires-action event drive the next batch.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fmanaged-runtime%2Ftool-approval%2Fhandle-pending-tool-approvals.usecase.ts%0ALine%3A%2070-74%0A%0AComment%3A%0A**Continues%20after%20resume**%0A%0A%60handleInternalTools%28%29%60%20can%20now%20send%20tool%20results%20through%20%60resolveInternalToolsWithoutSubscriber%28%29%60%2C%20which%20resumes%20and%20mutates%20the%20provider%20session.%20This%20method%20then%20continues%20with%20the%20original%20%60externalTools%60%20snapshot%20and%20may%20prompt%20or%20auto-confirm%20stale%20tool%20uses%20from%20the%20pre-resume%20requires-action%20response.%20When%20a%20batch%20contains%20both%20%60novu_tools%60%20and%20an%20external%20MCP%20tool%2C%20the%20internal%20fallback%20can%20advance%20the%20session%20while%20this%20code%20still%20renders%20an%20approval%20card%20for%20the%20old%20external%20tool.%20Return%20after%20internal%20tools%20send%20any%20tool%20result%20and%20let%20the%20follow-up%20requires-action%20event%20drive%20the%20next%20batch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11581&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Fconversation%2Fagent-subscriber-resolver.service.ts%3A310-316%0A**Scope%20email%20subscriber%20reuse**%0A%0AThis%20lookup%20can%20reuse%20an%20agent-provisioned%20subscriber%20from%20a%20different%20agent%20or%20integration.%20New%20email%20subscriber%20IDs%20are%20derived%20from%20%60integrationIdentifier%60%2C%20and%20the%20row%20is%20stamped%20with%20%60agentIdentifier%60%2C%20but%20this%20query%20only%20filters%20by%20environment%2C%20organization%2C%20email%2C%20and%20source.%20When%20%60user%40example.com%60%20was%20first%20provisioned%20for%20integration%20A%20and%20later%20uses%20a%20keyless%20email%20demo%20for%20integration%20B%2C%20this%20returns%20A's%20subscriber%20before%20B's%20deterministic%20subscriber%20ID%20is%20computed.%20The%20%60novu_tools%60%20flow%20then%20lists%20or%20creates%20subscriber-scoped%20MCP%20connections%20for%20the%20wrong%20demo%20identity.%20Include%20the%20same%20ownership%20tuple%20in%20the%20lookup%2C%20or%20look%20up%20the%20deterministic%20subscriber%20for%20the%20current%20tuple%20before%20reusing%20a%20provenance%20row.%0A%0A&pr=11581&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts:310-316
**Scope email subscriber reuse**

This lookup can reuse an agent-provisioned subscriber from a different agent or integration. New email subscriber IDs are derived from `integrationIdentifier`, and the row is stamped with `agentIdentifier`, but this query only filters by environment, organization, email, and source. When `user@example.com` was first provisioned for integration A and later uses a keyless email demo for integration B, this returns A's subscriber before B's deterministic subscriber ID is computed. The `novu_tools` flow then lists or creates subscriber-scoped MCP connections for the wrong demo identity. Include the same ownership tuple in the lookup, or look up the deterministic subscriber for the current tuple before reusing a provenance row.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): harden keyless email M..."](https://github.com/novuhq/novu/commit/f367dc38388374e1f8319a8f1217758ae4c3a0bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37867618)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->