### PR TITLE
feat(api, dashboard, dal, shared): implement active conversation logic for billing fixes NV-8055 

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -12,6 +12,7 @@ import {
   ChannelConnectionRepository,
   ChannelEndpointRepository,
   CommunityOrganizationRepository,
+  ConversationActivationRepository,
   ConversationActivityRepository,
   ConversationRepository,
   IntegrationRepository,
@@ -37,6 +38,7 @@ import { AgentActionTokenService } from './conversation-runtime/action-token/age
 import { AgentAttachmentStorage } from './conversation-runtime/conversation/agent-attachment-storage.service';
 import { AgentConversationService } from './conversation-runtime/conversation/agent-conversation.service';
 import { AgentSubscriberResolver } from './conversation-runtime/conversation/agent-subscriber-resolver.service';
+import { ConversationActivationService } from './conversation-runtime/conversation/conversation-activation.service';
 import { FileMaterializer } from './conversation-runtime/egress/file-materializer.service';
 import { OutboundGateway } from './conversation-runtime/egress/outbound.gateway';
 import { AgentInboundController } from './conversation-runtime/ingress/agent-inbound.controller';
@@ -97,6 +99,7 @@ import { USE_CASES } from './usecases';
     ChannelEndpointRepository,
     CommunityOrganizationRepository,
     ConversationRepository,
+    ConversationActivationRepository,
     ConversationActivityRepository,
     IntegrationRepository,
     McpConnectionRepository,
@@ -106,6 +109,7 @@ import { USE_CASES } from './usecases';
     AgentConfigResolver,
     AgentSubscriberResolver,
     AgentConversationService,
+    ConversationActivationService,
     InboundAckService,
     AgentEmailActionTokenService,
     AgentActionTokenService,

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -57,6 +57,8 @@ export interface CreateOrGetConversationParams {
   participantType: ConversationParticipantTypeEnum;
   platformUserId: string;
   firstMessageText: string;
+  /** Whether the thread is a direct message — persisted for active-conversation window selection. */
+  isDirectMessage?: boolean;
 }
 
 export interface PersistInboundMessageParams {
@@ -175,6 +177,7 @@ export class AgentConversationService {
       status: ConversationStatusEnum.ACTIVE,
       title: getConversationTitle(params.firstMessageText),
       metadata: {},
+      isDirectMessage: params.isDirectMessage,
       _environmentId: environmentId,
       _organizationId: organizationId,
       lastActivityAt: new Date().toISOString(),

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -402,6 +402,14 @@ export class AgentConversationService {
         params.conversationId,
         ConversationStatusEnum.RESOLVED
       ),
+      // Mark for billing so the next agent engagement is counted as a reopen
+      // activation (a closed thread ends the active conversation episode).
+      this.conversationRepository.markBillingResolved(
+        params.environmentId,
+        params.organizationId,
+        params.conversationId,
+        new Date().toISOString()
+      ),
       this.conversationRepository.clearExternalSessionId(params.environmentId, params.conversationId),
       this.activityRepository.createSignalActivity({
         identifier: `act_${shortId(12)}`,

--- a/apps/api/src/app/agents/conversation-runtime/conversation/billing-activation-rules.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/billing-activation-rules.spec.ts
@@ -1,0 +1,90 @@
+import {
+  type ActivationRuleParams,
+  buildActivationOrConditions,
+  classifyActivationReason,
+  ConversationActivationReasonEnum,
+  type ConversationBillingState,
+} from '@novu/dal';
+import { expect } from 'chai';
+
+/**
+ * Locks the single source of truth: `classifyActivationReason` (the in-memory
+ * gate predicate) must agree with `buildActivationOrConditions` (the atomic
+ * Mongo write-claim). If the two ever diverge, counting silently breaks in prod
+ * with no type error — this test fails by construction instead.
+ */
+describe('billing-activation-rules #novu-v2', () => {
+  const PERIOD = '2026-06';
+  const THRESHOLD = '2026-06-15T00:00:00.000Z'; // engagements before this are window-expired
+  const params: ActivationRuleParams = { periodKey: PERIOD, windowThresholdIso: THRESHOLD };
+
+  // Minimal faithful simulation of the MongoDB operators the rules emit,
+  // applied to an in-memory billing object (mirrors Mongo's missing-field semantics).
+  function evalFragment(fragment: Record<string, unknown>, billing: ConversationBillingState | undefined): boolean {
+    const [path, condition] = Object.entries(fragment)[0] as [string, Record<string, unknown>];
+    const field = path.replace('billing.', '') as keyof ConversationBillingState;
+    const value = billing?.[field];
+
+    if ('$exists' in condition) {
+      return condition.$exists ? value !== undefined : value === undefined;
+    }
+    if ('$ne' in condition) {
+      // Mongo: a missing field also satisfies $ne.
+      return value !== condition.$ne;
+    }
+    if ('$lt' in condition) {
+      return value !== undefined && (value as string) < (condition.$lt as string);
+    }
+
+    throw new Error(`Unsupported operator in fragment: ${JSON.stringify(condition)}`);
+  }
+
+  function orMatches(billing: ConversationBillingState | undefined): boolean {
+    return buildActivationOrConditions(params).some((fragment) => evalFragment(fragment, billing));
+  }
+
+  const cases: Array<{ name: string; billing: ConversationBillingState | undefined }> = [
+    { name: 'no billing (brand new)', billing: undefined },
+    { name: 'empty billing', billing: {} },
+    { name: 'counted this period, recent engagement', billing: { lastCountedPeriodKey: PERIOD, lastEngagementAt: '2026-06-20T00:00:00.000Z' } },
+    { name: 'counted this period, stale engagement', billing: { lastCountedPeriodKey: PERIOD, lastEngagementAt: '2026-06-01T00:00:00.000Z' } },
+    { name: 'counted a previous period', billing: { lastCountedPeriodKey: '2026-05', lastEngagementAt: '2026-06-20T00:00:00.000Z' } },
+    { name: 'resolved since last count', billing: { lastCountedPeriodKey: PERIOD, lastEngagementAt: '2026-06-20T00:00:00.000Z', resolvedAt: '2026-06-21T00:00:00.000Z' } },
+    { name: 'counted, no engagement timestamp', billing: { lastCountedPeriodKey: PERIOD } },
+  ];
+
+  it('classify and the Mongo $or agree on whether to count, across the state matrix', () => {
+    for (const { name, billing } of cases) {
+      const classified = classifyActivationReason(billing, params) !== null;
+      const matched = orMatches(billing);
+
+      expect(classified, `mismatch for "${name}" (classify=${classified}, $or=${matched})`).to.equal(matched);
+    }
+  });
+
+  it('returns the highest-priority reason (NEW > REOPEN > NEW_CYCLE > WINDOW_EXPIRED)', () => {
+    expect(classifyActivationReason(undefined, params)).to.equal(ConversationActivationReasonEnum.NEW);
+
+    // resolved wins over an otherwise-quiet, same-period conversation
+    expect(
+      classifyActivationReason(
+        { lastCountedPeriodKey: PERIOD, lastEngagementAt: '2026-06-20T00:00:00.000Z', resolvedAt: '2026-06-21T00:00:00.000Z' },
+        params
+      )
+    ).to.equal(ConversationActivationReasonEnum.REOPEN);
+
+    expect(
+      classifyActivationReason({ lastCountedPeriodKey: '2026-05', lastEngagementAt: '2026-06-20T00:00:00.000Z' }, params)
+    ).to.equal(ConversationActivationReasonEnum.NEW_CYCLE);
+
+    expect(
+      classifyActivationReason({ lastCountedPeriodKey: PERIOD, lastEngagementAt: '2026-06-01T00:00:00.000Z' }, params)
+    ).to.equal(ConversationActivationReasonEnum.WINDOW_EXPIRED);
+  });
+
+  it('does not count an active conversation inside its window and period', () => {
+    expect(
+      classifyActivationReason({ lastCountedPeriodKey: PERIOD, lastEngagementAt: '2026-06-20T00:00:00.000Z' }, params)
+    ).to.equal(null);
+  });
+});

--- a/apps/api/src/app/agents/conversation-runtime/conversation/billing-activation-rules.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/billing-activation-rules.spec.ts
@@ -33,7 +33,7 @@ describe('billing-activation-rules #novu-v2', () => {
       return value !== condition.$ne;
     }
     if ('$lt' in condition) {
-      return value !== undefined && (value as string) < (condition.$lt as string);
+      return typeof value === 'string' && value < (condition.$lt as string);
     }
 
     throw new Error(`Unsupported operator in fragment: ${JSON.stringify(condition)}`);

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
@@ -79,9 +79,17 @@ interface EngagementContext {
 }
 
 interface LimitCheckContext {
-  conversation: ConversationEntity;
+  /**
+   * The conversation being engaged, or `undefined` for a brand-new thread that
+   * hasn't been persisted yet — the gate evaluates it as a NEW activation so the
+   * caller can block before creating an orphaned conversation.
+   */
+  conversation?: ConversationEntity;
   platform: AgentPlatformEnum;
   organizationId: string;
+  /** Used for analytics when there is no conversation yet; otherwise taken from the conversation. */
+  environmentId?: string;
+  agentId?: string;
   isDirectMessage?: boolean;
   now?: Date;
 }
@@ -305,7 +313,7 @@ export class ConversationActivationService {
    * Delegates the decision to the shared `classifyActivationReason` rules.
    */
   classifyActivation(
-    conversation: ConversationEntity,
+    conversation: ConversationEntity | undefined,
     platform: AgentPlatformEnum,
     periodKey: string,
     options: { isDirectMessage?: boolean; now?: Date } = {}
@@ -315,7 +323,8 @@ export class ConversationActivationService {
     const windowMs = this.resolveWindowMs(platform, this.deriveThreadKind(isDirectMessage));
     const windowThresholdIso = new Date(now.getTime() - windowMs).toISOString();
 
-    return classifyActivationReason(conversation.billing, { periodKey, windowThresholdIso });
+    // No conversation yet → no billing state → the shared rules classify it as NEW.
+    return classifyActivationReason(conversation?.billing, { periodKey, windowThresholdIso });
   }
 
   /**
@@ -481,9 +490,9 @@ export class ConversationActivationService {
         try {
           trackAgentActiveConversationLimitReached(this.analyticsService, {
             organizationId: context.organizationId,
-            environmentId: context.conversation._environmentId,
-            agentId: context.conversation._agentId,
-            conversationId: context.conversation._id,
+            environmentId: context.conversation?._environmentId ?? context.environmentId ?? '',
+            agentId: context.conversation?._agentId ?? context.agentId ?? '',
+            conversationId: context.conversation?._id ?? '',
             platform: context.platform,
             apiServiceLevel,
             limit,
@@ -562,8 +571,8 @@ export class ConversationActivationService {
     );
   }
 
-  /** Live hint takes precedence; otherwise the value persisted on the conversation. */
-  private resolveIsDirectMessage(conversation: ConversationEntity, hint?: boolean): boolean | undefined {
-    return hint ?? conversation.isDirectMessage;
+  /** Live hint takes precedence; otherwise the value persisted on the conversation (if any). */
+  private resolveIsDirectMessage(conversation: ConversationEntity | undefined, hint?: boolean): boolean | undefined {
+    return hint ?? conversation?.isDirectMessage;
   }
 }

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
@@ -40,7 +40,7 @@ export const ACTIVATION_WINDOW_MS = {
 } as const;
 
 export interface BillingPeriod {
-  /** Month-anchored key (YYYY-MM, UTC) derived from `periodStart` — the identity activations are counted against. */
+  /** Period identity activations are counted against: `stripe:<ISO start>` for billed orgs, `YYYY-MM` (UTC) otherwise. */
   periodKey: string;
   /** Inclusive UTC start of the period (Stripe period start for billed orgs, month start otherwise). */
   periodStart: Date;
@@ -192,8 +192,7 @@ export class ConversationActivationService {
     }
 
     // Cold start with no cached period (rare) — fall back to calendar without
-    // caching, so the next engagement retries Stripe. The month-anchored key
-    // keeps this consistent with a same-month Stripe period.
+    // caching, so the next engagement retries Stripe and adopts the real period.
     return calendar;
   }
 
@@ -223,7 +222,11 @@ export class ConversationActivationService {
       const periodStart = new Date(subscription.currentPeriodStart);
       const periodEnd = new Date(subscription.currentPeriodEnd);
 
-      return { periodKey: this.monthKey(periodStart), periodStart, periodEnd };
+      // Key on the Stripe period start so two periods starting in the same UTC month
+      // (plan change, trial conversion, cycle reset, short custom cycle) never collide
+      // and overcount. Transient-failure protection comes from the sticky cache fallback
+      // in `resolveBillingPeriod`, not from month-anchoring this key.
+      return { periodKey: `stripe:${periodStart.toISOString()}`, periodStart, periodEnd };
     } catch (err) {
       this.logger.warn(
         { err: err instanceof Error ? err.message : String(err), organizationId },

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { AgentEntitlementsService, PinoLogger, throwPlanLimitExceeded } from '@novu/application-generic';
+import { AgentEntitlementsService, AnalyticsService, PinoLogger, throwPlanLimitExceeded } from '@novu/application-generic';
 import {
   CommunityOrganizationRepository,
   ConversationActivationReasonEnum,
@@ -10,6 +10,10 @@ import {
   ConversationThreadKindEnum,
 } from '@novu/dal';
 import { ApiServiceLevelEnum, UNLIMITED_VALUE } from '@novu/shared';
+import {
+  trackAgentActiveConversationCounted,
+  trackAgentActiveConversationLimitReached,
+} from '../../shared/analytics/agent-analytics';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -19,6 +23,7 @@ const DAY_MS = 24 * HOUR_MS;
  * How long a resolved billing period is served from memory. Periods change at
  * most monthly, so a short TTL keeps the inbound hot path off the EE billing
  * use case (itself Redis-cached for 24h) while staying fresh near boundaries.
+ * TODO: Move to Redis Cache when we have enough traffic on this service
  */
 const PERIOD_CACHE_TTL_MS = 60_000;
 const PERIOD_CACHE_MAX_ENTRIES = 10_000;
@@ -82,6 +87,7 @@ export class ConversationActivationService {
     private readonly organizationRepository: CommunityOrganizationRepository,
     private readonly agentEntitlements: AgentEntitlementsService,
     private readonly moduleRef: ModuleRef,
+    private readonly analyticsService: AnalyticsService,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -166,9 +172,7 @@ export class ConversationActivationService {
         return null;
       }
 
-      const subscription = await getSubscription.execute(
-        billing.GetSubscriptionCommand.create({ organizationId })
-      );
+      const subscription = await getSubscription.execute(billing.GetSubscriptionCommand.create({ organizationId }));
       if (!subscription?.currentPeriodStart || !subscription?.currentPeriodEnd) {
         return null;
       }
@@ -205,7 +209,11 @@ export class ConversationActivationService {
     this.periodCache.set(organizationId, { value, expiresAt: now.getTime() + PERIOD_CACHE_TTL_MS });
   }
 
-  deriveThreadKind(platform: string, platformThreadId: string, isDirectMessageHint?: boolean): ConversationThreadKindEnum {
+  deriveThreadKind(
+    platform: string,
+    platformThreadId: string,
+    isDirectMessageHint?: boolean
+  ): ConversationThreadKindEnum {
     if (isDirectMessageHint !== undefined) {
       return isDirectMessageHint ? ConversationThreadKindEnum.DIRECT : ConversationThreadKindEnum.GROUP;
     }
@@ -333,7 +341,71 @@ export class ConversationActivationService {
       periodKey,
     });
 
+    await this.emitCountedAnalytics(context, threadKind, reason, periodKey);
+
     return true;
+  }
+
+  /**
+   * Fire-and-forget analytics for a counted activation. Always emits the
+   * "counted" event; additionally emits "limit reached" (blocked=false) for
+   * finite tiers once usage is at/over the included limit, so paid overage is
+   * measured per extra conversation. Fully isolated — analytics must never
+   * affect counting.
+   */
+  private async emitCountedAnalytics(
+    context: EngagementContext,
+    threadKind: ConversationThreadKindEnum,
+    reason: ConversationActivationReasonEnum,
+    periodKey: string
+  ): Promise<void> {
+    try {
+      const apiServiceLevel = await this.getApiServiceLevel(context.organizationId);
+
+      trackAgentActiveConversationCounted(this.analyticsService, {
+        organizationId: context.organizationId,
+        environmentId: context.environmentId,
+        agentId: context.agentId,
+        conversationId: context.conversation._id,
+        platform: context.platform,
+        threadKind,
+        reason,
+        periodKey,
+        apiServiceLevel,
+      });
+
+      const limit = await this.agentEntitlements.getActiveConversationsLimit(context.organizationId, apiServiceLevel);
+      if (limit >= UNLIMITED_VALUE) {
+        return;
+      }
+
+      const currentCount = await this.activationRepository.countForOrganizationPeriod(context.organizationId, periodKey);
+      if (currentCount >= limit) {
+        trackAgentActiveConversationLimitReached(this.analyticsService, {
+          organizationId: context.organizationId,
+          environmentId: context.environmentId,
+          agentId: context.agentId,
+          conversationId: context.conversation._id,
+          platform: context.platform,
+          apiServiceLevel,
+          limit,
+          currentCount,
+          overage: Math.max(0, currentCount - limit),
+          blocked: false,
+        });
+      }
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err), organizationId: context.organizationId },
+        'Failed to emit active-conversation analytics'
+      );
+    }
+  }
+
+  private async getApiServiceLevel(organizationId: string): Promise<ApiServiceLevelEnum> {
+    const organization = await this.organizationRepository.findById(organizationId, '_id apiServiceLevel');
+
+    return organization?.apiServiceLevel ?? ApiServiceLevelEnum.FREE;
   }
 
   /**
@@ -384,8 +456,29 @@ export class ConversationActivationService {
         periodKey,
         limit + 1
       );
+      const willBlock = current >= limit;
 
-      return current >= limit;
+      if (willBlock) {
+        // Isolated so an analytics failure can never flip the block decision.
+        try {
+          trackAgentActiveConversationLimitReached(this.analyticsService, {
+            organizationId: context.organizationId,
+            environmentId: context.conversation._environmentId,
+            agentId: context.conversation._agentId,
+            conversationId: context.conversation._id,
+            platform: context.platform,
+            apiServiceLevel,
+            limit,
+            currentCount: current,
+            overage: Math.max(0, current - limit),
+            blocked: true,
+          });
+        } catch {
+          // Swallow — never let analytics affect gating.
+        }
+      }
+
+      return willBlock;
     } catch (err) {
       this.logger.warn(
         { err: err instanceof Error ? err.message : String(err), organizationId: context.organizationId },

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { AgentEntitlementsService, AnalyticsService, PinoLogger, throwPlanLimitExceeded } from '@novu/application-generic';
 import {
+  classifyActivationReason,
   CommunityOrganizationRepository,
   ConversationActivationReasonEnum,
   ConversationActivationRepository,
@@ -39,11 +40,11 @@ export const ACTIVATION_WINDOW_MS = {
 } as const;
 
 export interface BillingPeriod {
-  /** YYYY-MM (UTC) — the key activations are counted against. */
+  /** Month-anchored key (YYYY-MM, UTC) derived from `periodStart` — the identity activations are counted against. */
   periodKey: string;
-  /** Inclusive UTC start of the period. */
+  /** Inclusive UTC start of the period (Stripe period start for billed orgs, month start otherwise). */
   periodStart: Date;
-  /** Exclusive UTC end of the period (start of next month). */
+  /** Exclusive UTC end of the period. */
   periodEnd: Date;
 }
 
@@ -55,13 +56,32 @@ export interface ConversationActivationUsage {
   periodEnd: Date;
 }
 
+/** Outcome of the Free-tier gate; carries the resolved limit so callers don't re-fetch it. */
+interface FreeTierBlockDecision {
+  blocked: boolean;
+  limit?: number;
+  apiServiceLevel?: ApiServiceLevelEnum;
+}
+
 interface EngagementContext {
   conversation: ConversationEntity;
-  platform: string;
+  platform: AgentPlatformEnum;
   organizationId: string;
   environmentId: string;
   agentId: string;
-  /** Authoritative DM flag from the live thread when available (inbound path). */
+  /**
+   * DM flag for window classification: the live `thread.isDM` (inbound) or the
+   * persisted `conversation.isDirectMessage` (outbound). When absent the window
+   * defaults to DIRECT (undercount-safe).
+   */
+  isDirectMessage?: boolean;
+  now?: Date;
+}
+
+interface LimitCheckContext {
+  conversation: ConversationEntity;
+  platform: AgentPlatformEnum;
+  organizationId: string;
   isDirectMessage?: boolean;
   now?: Date;
 }
@@ -73,9 +93,10 @@ interface EngagementContext {
  * and again whenever a new billing period begins. Closing a thread ends the
  * activation; reopening it starts a new one.
  *
- * Counting is per organization (summed across environments) and anchored to the
- * UTC calendar month. Nothing is reported to Stripe — this is a usage meter and
- * a Free-tier short-circuit only.
+ * Counting is per organization (summed across environments), anchored to the
+ * org's Stripe billing period (calendar month for self-hosted/unbilled orgs).
+ * Nothing is reported to Stripe — this is a usage meter and a Free-tier
+ * short-circuit only.
  */
 @Injectable()
 export class ConversationActivationService {
@@ -101,14 +122,20 @@ export class ConversationActivationService {
     return process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
   }
 
-  /** UTC calendar-month period — the anchor for community, self-hosted, and unbilled orgs. */
+  /** Month-anchored period key (YYYY-MM, UTC). Stable across a Stripe cycle and a calendar fallback in the same month. */
+  private monthKey(date: Date): string {
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+  }
+
+  /** UTC calendar-month period — the anchor for self-hosted and unbilled orgs. */
   resolveCalendarPeriod(now: Date = new Date()): BillingPeriod {
     const year = now.getUTCFullYear();
     const month = now.getUTCMonth();
+    const periodStart = new Date(Date.UTC(year, month, 1));
 
     return {
-      periodKey: `${year}-${String(month + 1).padStart(2, '0')}`,
-      periodStart: new Date(Date.UTC(year, month, 1)),
+      periodKey: this.monthKey(periodStart),
+      periodStart,
       periodEnd: new Date(Date.UTC(year, month + 1, 1)),
     };
   }
@@ -116,11 +143,12 @@ export class ConversationActivationService {
   /**
    * Resolves the billing period an active conversation is counted against.
    *
-   *   - Cloud + EE billing + the org already has a Stripe customer → the Stripe
-   *     metered subscription's `current_period_start/end` (aligns counting to the
-   *     invoice cycle).
-   *   - Self-hosted, community builds, unbilled/free orgs (no Stripe customer),
-   *     or any resolution failure → UTC calendar month.
+   *   - Cloud + EE billing + the org has a Stripe customer → the Stripe metered
+   *     subscription's `current_period_start/end`.
+   *   - Self-hosted / community / unbilled orgs → UTC calendar month.
+   *   - Transient Stripe failure for a billed org → the last known period
+   *     (sticky) rather than the calendar key, so a hiccup never manufactures a
+   *     spurious new cycle and double-counts the meter.
    *
    * Free/unbilled orgs deliberately never trigger the EE `GetSubscription` path:
    * it would create a Stripe customer as a side effect. Resolved periods are
@@ -148,16 +176,31 @@ export class ConversationActivationService {
     }
 
     const stripePeriod = await this.fetchStripeBillingPeriod(organizationId);
-    const value = stripePeriod ?? calendar;
-    this.setPeriodCache(organizationId, value, now);
+    if (stripePeriod) {
+      this.setPeriodCache(organizationId, stripePeriod, now);
 
-    return value;
+      return stripePeriod;
+    }
+
+    // Billed org but the Stripe lookup failed transiently. Reuse the last known
+    // period (sticky) instead of flipping to a calendar key — flipping would be
+    // a different periodKey and would be read as a new billing cycle.
+    if (cached) {
+      this.setPeriodCache(organizationId, cached.value, now);
+
+      return cached.value;
+    }
+
+    // Cold start with no cached period (rare) — fall back to calendar without
+    // caching, so the next engagement retries Stripe. The month-anchored key
+    // keeps this consistent with a same-month Stripe period.
+    return calendar;
   }
 
   /**
    * Reads the current Stripe billing period via the optional EE billing use
-   * case. Returns `null` (caller falls back to calendar month) when the billing
-   * module is absent, the subscription has no period, or anything fails.
+   * case. Returns `null` (caller falls back per the sticky rules) when the
+   * billing module is absent, the subscription has no period, or anything fails.
    * Isolated so it can be stubbed in tests with dummy period data.
    */
   protected async fetchStripeBillingPeriod(organizationId: string): Promise<BillingPeriod | null> {
@@ -180,11 +223,11 @@ export class ConversationActivationService {
       const periodStart = new Date(subscription.currentPeriodStart);
       const periodEnd = new Date(subscription.currentPeriodEnd);
 
-      return { periodKey: `stripe:${periodStart.toISOString()}`, periodStart, periodEnd };
+      return { periodKey: this.monthKey(periodStart), periodStart, periodEnd };
     } catch (err) {
       this.logger.warn(
         { err: err instanceof Error ? err.message : String(err), organizationId },
-        'Failed to resolve Stripe billing period; falling back to calendar month'
+        'Failed to resolve Stripe billing period; falling back per sticky rules'
       );
 
       return null;
@@ -209,26 +252,21 @@ export class ConversationActivationService {
     this.periodCache.set(organizationId, { value, expiresAt: now.getTime() + PERIOD_CACHE_TTL_MS });
   }
 
-  deriveThreadKind(
-    platform: string,
-    platformThreadId: string,
-    isDirectMessageHint?: boolean
-  ): ConversationThreadKindEnum {
-    if (isDirectMessageHint !== undefined) {
-      return isDirectMessageHint ? ConversationThreadKindEnum.DIRECT : ConversationThreadKindEnum.GROUP;
+  /**
+   * Classifies a thread as DM or group for window selection. Prefers the
+   * authoritative `isDirectMessage` (live thread inbound, or persisted on the
+   * conversation). When absent (legacy conversation on the outbound path),
+   * defaults to DIRECT — the wider 30d window is undercount-safe.
+   */
+  deriveThreadKind(isDirectMessage?: boolean): ConversationThreadKindEnum {
+    if (isDirectMessage === undefined) {
+      return ConversationThreadKindEnum.DIRECT;
     }
 
-    // No live thread hint (outbound path): infer for Slack/Teams from the thread
-    // id. Slack DM channel ids start with `D` (e.g. `slack:D08…`). Other
-    // platforms are 1:1 and treated as direct (their window is DM-independent).
-    if (platform === AgentPlatformEnum.SLACK || platform === AgentPlatformEnum.TEAMS) {
-      return /:D[^:]/i.test(platformThreadId) ? ConversationThreadKindEnum.DIRECT : ConversationThreadKindEnum.GROUP;
-    }
-
-    return ConversationThreadKindEnum.DIRECT;
+    return isDirectMessage ? ConversationThreadKindEnum.DIRECT : ConversationThreadKindEnum.GROUP;
   }
 
-  resolveWindowMs(platform: string, threadKind: ConversationThreadKindEnum): number {
+  resolveWindowMs(platform: AgentPlatformEnum, threadKind: ConversationThreadKindEnum): number {
     switch (platform) {
       case AgentPlatformEnum.WHATSAPP:
       case AgentPlatformEnum.TELEGRAM:
@@ -241,8 +279,19 @@ export class ConversationActivationService {
       case AgentPlatformEnum.EMAIL:
         return ACTIVATION_WINDOW_MS.MONTH_30;
       default:
-        return ACTIVATION_WINDOW_MS.MONTH_30;
+        return this.unhandledPlatformWindow(platform);
     }
+  }
+
+  /**
+   * Compile-time exhaustiveness guard: adding an `AgentPlatformEnum` member
+   * without a window mapping fails the build here. Defensive at runtime
+   * (returns the safe 30d default) in case a non-enum value is ever cast in.
+   */
+  private unhandledPlatformWindow(platform: never): number {
+    this.logger.warn({ platform }, 'Unhandled agent platform for activation window; defaulting to 30 days');
+
+    return ACTIVATION_WINDOW_MS.MONTH_30;
   }
 
   /**
@@ -250,37 +299,20 @@ export class ConversationActivationService {
    * start a new activation (and which reason), evaluated against the supplied
    * billing period. Returns `null` when it would fall inside the current
    * activation. Used by the Free-tier gate before dispatch — never mutates.
+   * Delegates the decision to the shared `classifyActivationReason` rules.
    */
   classifyActivation(
     conversation: ConversationEntity,
-    platform: string,
+    platform: AgentPlatformEnum,
     periodKey: string,
     options: { isDirectMessage?: boolean; now?: Date } = {}
   ): ConversationActivationReasonEnum | null {
     const now = options.now ?? new Date();
-    const threadKind = this.deriveThreadKind(platform, this.primaryThreadId(conversation), options.isDirectMessage);
-    const windowMs = this.resolveWindowMs(platform, threadKind);
-    const windowThreshold = new Date(now.getTime() - windowMs);
+    const isDirectMessage = this.resolveIsDirectMessage(conversation, options.isDirectMessage);
+    const windowMs = this.resolveWindowMs(platform, this.deriveThreadKind(isDirectMessage));
+    const windowThresholdIso = new Date(now.getTime() - windowMs).toISOString();
 
-    const billing = conversation.billing;
-
-    if (!billing?.lastCountedPeriodKey) {
-      return ConversationActivationReasonEnum.NEW;
-    }
-
-    if (billing.resolvedAt) {
-      return ConversationActivationReasonEnum.REOPEN;
-    }
-
-    if (billing.lastCountedPeriodKey !== periodKey) {
-      return ConversationActivationReasonEnum.NEW_CYCLE;
-    }
-
-    if (billing.lastEngagementAt && new Date(billing.lastEngagementAt) < windowThreshold) {
-      return ConversationActivationReasonEnum.WINDOW_EXPIRED;
-    }
-
-    return null;
+    return classifyActivationReason(conversation.billing, { periodKey, windowThresholdIso });
   }
 
   /**
@@ -293,19 +325,13 @@ export class ConversationActivationService {
   async registerEngagement(context: EngagementContext): Promise<boolean> {
     const now = context.now ?? new Date();
     const { periodKey } = await this.resolveBillingPeriod(context.organizationId, now);
-    const threadKind = this.deriveThreadKind(
-      context.platform,
-      this.primaryThreadId(context.conversation),
-      context.isDirectMessage
-    );
+    const isDirectMessage = this.resolveIsDirectMessage(context.conversation, context.isDirectMessage);
+    const threadKind = this.deriveThreadKind(isDirectMessage);
     const windowMs = this.resolveWindowMs(context.platform, threadKind);
     const nowIso = now.toISOString();
     const windowThresholdIso = new Date(now.getTime() - windowMs).toISOString();
 
-    const reason = this.classifyActivation(context.conversation, context.platform, periodKey, {
-      isDirectMessage: context.isDirectMessage,
-      now,
-    });
+    const reason = classifyActivationReason(context.conversation.billing, { periodKey, windowThresholdIso });
 
     if (!reason) {
       await this.slideWindow(context, nowIso);
@@ -360,7 +386,7 @@ export class ConversationActivationService {
     periodKey: string
   ): Promise<void> {
     try {
-      const apiServiceLevel = await this.getApiServiceLevel(context.organizationId);
+      const apiServiceLevel = await this.agentEntitlements.getApiServiceLevel(context.organizationId);
 
       trackAgentActiveConversationCounted(this.analyticsService, {
         organizationId: context.organizationId,
@@ -402,27 +428,16 @@ export class ConversationActivationService {
     }
   }
 
-  private async getApiServiceLevel(organizationId: string): Promise<ApiServiceLevelEnum> {
-    const organization = await this.organizationRepository.findById(organizationId, '_id apiServiceLevel');
-
-    return organization?.apiServiceLevel ?? ApiServiceLevelEnum.FREE;
-  }
-
   /**
    * Whether a Free-tier organization (not on trial) must be blocked from
    * starting a *new* activation because it has reached its included limit.
    * Existing activations within their window/period keep working — only new
    * conversations are short-circuited. Paid tiers and trials are never blocked
    * (counting only). Fails open on any error so a transient failure never
-   * silently disables a customer's agent.
+   * silently disables a customer's agent. Returns the resolved limit/level so
+   * callers (e.g. the outbound 402) don't re-fetch them.
    */
-  async shouldBlockFreeTier(context: {
-    conversation: ConversationEntity;
-    platform: string;
-    organizationId: string;
-    isDirectMessage?: boolean;
-    now?: Date;
-  }): Promise<boolean> {
+  async shouldBlockFreeTier(context: LimitCheckContext): Promise<FreeTierBlockDecision> {
     try {
       const organization = await this.organizationRepository.findById(
         context.organizationId,
@@ -432,7 +447,7 @@ export class ConversationActivationService {
       const apiServiceLevel = organization?.apiServiceLevel ?? ApiServiceLevelEnum.FREE;
       const isBlockableFreeTier = apiServiceLevel === ApiServiceLevelEnum.FREE && !organization?.isTrial;
       if (!isBlockableFreeTier) {
-        return false;
+        return { blocked: false, apiServiceLevel };
       }
 
       const now = context.now ?? new Date();
@@ -443,12 +458,12 @@ export class ConversationActivationService {
         now,
       });
       if (!reason) {
-        return false;
+        return { blocked: false, apiServiceLevel };
       }
 
       const limit = await this.agentEntitlements.getActiveConversationsLimit(context.organizationId, apiServiceLevel);
       if (limit >= UNLIMITED_VALUE) {
-        return false;
+        return { blocked: false, limit, apiServiceLevel };
       }
 
       const current = await this.activationRepository.countForOrganizationPeriod(
@@ -478,14 +493,14 @@ export class ConversationActivationService {
         }
       }
 
-      return willBlock;
+      return { blocked: willBlock, limit, apiServiceLevel };
     } catch (err) {
       this.logger.warn(
         { err: err instanceof Error ? err.message : String(err), organizationId: context.organizationId },
         'Failed to evaluate active-conversation limit; failing open (not blocking)'
       );
 
-      return false;
+      return { blocked: false };
     }
   }
 
@@ -493,21 +508,15 @@ export class ConversationActivationService {
    * Hard-stops an agent-initiated (outbound) message that would start a new
    * active conversation for a Free-tier organization at its limit, throwing the
    * shared 402 plan-limit error. Existing conversations and paid tiers pass
-   * through untouched.
+   * through untouched. Reuses the limit resolved by the gate.
    */
-  async assertOutboundWithinLimit(context: {
-    conversation: ConversationEntity;
-    platform: string;
-    organizationId: string;
-    isDirectMessage?: boolean;
-    now?: Date;
-  }): Promise<void> {
-    const blocked = await this.shouldBlockFreeTier(context);
-    if (!blocked) {
+  async assertOutboundWithinLimit(context: LimitCheckContext): Promise<void> {
+    const decision = await this.shouldBlockFreeTier(context);
+    if (!decision.blocked) {
       return;
     }
 
-    const limit = await this.agentEntitlements.getActiveConversationsLimit(context.organizationId);
+    const limit = decision.limit ?? (await this.agentEntitlements.getActiveConversationsLimit(context.organizationId));
 
     throwPlanLimitExceeded({
       resource: 'active conversations',
@@ -550,7 +559,8 @@ export class ConversationActivationService {
     );
   }
 
-  private primaryThreadId(conversation: ConversationEntity): string {
-    return conversation.channels?.[0]?.platformThreadId ?? '';
+  /** Live hint takes precedence; otherwise the value persisted on the conversation. */
+  private resolveIsDirectMessage(conversation: ConversationEntity, hint?: boolean): boolean | undefined {
+    return hint ?? conversation.isDirectMessage;
   }
 }

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
@@ -1,0 +1,463 @@
+import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { AgentEntitlementsService, PinoLogger, throwPlanLimitExceeded } from '@novu/application-generic';
+import {
+  CommunityOrganizationRepository,
+  ConversationActivationReasonEnum,
+  ConversationActivationRepository,
+  ConversationEntity,
+  ConversationRepository,
+  ConversationThreadKindEnum,
+} from '@novu/dal';
+import { ApiServiceLevelEnum, UNLIMITED_VALUE } from '@novu/shared';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * How long a resolved billing period is served from memory. Periods change at
+ * most monthly, so a short TTL keeps the inbound hot path off the EE billing
+ * use case (itself Redis-cached for 24h) while staying fresh near boundaries.
+ */
+const PERIOD_CACHE_TTL_MS = 60_000;
+const PERIOD_CACHE_MAX_ENTRIES = 10_000;
+
+/** Rolling inactivity windows per channel kind (see plan counting model). */
+export const ACTIVATION_WINDOW_MS = {
+  /** WhatsApp / Telegram — a fresh reply after 24h of silence is a new conversation. */
+  DAY: DAY_MS,
+  /** Slack / Teams group threads — every new 7-day stretch of activity counts again. */
+  WEEK: 7 * DAY_MS,
+  /** Slack / Teams DMs and email threads. */
+  MONTH_30: 30 * DAY_MS,
+} as const;
+
+export interface BillingPeriod {
+  /** YYYY-MM (UTC) — the key activations are counted against. */
+  periodKey: string;
+  /** Inclusive UTC start of the period. */
+  periodStart: Date;
+  /** Exclusive UTC end of the period (start of next month). */
+  periodEnd: Date;
+}
+
+export interface ConversationActivationUsage {
+  current: number;
+  /** `null` when the tier is unlimited. */
+  included: number | null;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+interface EngagementContext {
+  conversation: ConversationEntity;
+  platform: string;
+  organizationId: string;
+  environmentId: string;
+  agentId: string;
+  /** Authoritative DM flag from the live thread when available (inbound path). */
+  isDirectMessage?: boolean;
+  now?: Date;
+}
+
+/**
+ * Owns the "active conversation / month" counting model. An active conversation
+ * is counted once per activation episode: the first agent engagement on a
+ * (re)opened thread, again once a channel's rolling inactivity window lapses,
+ * and again whenever a new billing period begins. Closing a thread ends the
+ * activation; reopening it starts a new one.
+ *
+ * Counting is per organization (summed across environments) and anchored to the
+ * UTC calendar month. Nothing is reported to Stripe — this is a usage meter and
+ * a Free-tier short-circuit only.
+ */
+@Injectable()
+export class ConversationActivationService {
+  private readonly periodCache = new Map<string, { value: BillingPeriod; expiresAt: number }>();
+
+  constructor(
+    private readonly conversationRepository: ConversationRepository,
+    private readonly activationRepository: ConversationActivationRepository,
+    private readonly organizationRepository: CommunityOrganizationRepository,
+    private readonly agentEntitlements: AgentEntitlementsService,
+    private readonly moduleRef: ModuleRef,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  private get isSelfHosted(): boolean {
+    return process.env.IS_SELF_HOSTED === 'true';
+  }
+
+  private get isEnterpriseBillingEnabled(): boolean {
+    return process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+  }
+
+  /** UTC calendar-month period — the anchor for community, self-hosted, and unbilled orgs. */
+  resolveCalendarPeriod(now: Date = new Date()): BillingPeriod {
+    const year = now.getUTCFullYear();
+    const month = now.getUTCMonth();
+
+    return {
+      periodKey: `${year}-${String(month + 1).padStart(2, '0')}`,
+      periodStart: new Date(Date.UTC(year, month, 1)),
+      periodEnd: new Date(Date.UTC(year, month + 1, 1)),
+    };
+  }
+
+  /**
+   * Resolves the billing period an active conversation is counted against.
+   *
+   *   - Cloud + EE billing + the org already has a Stripe customer → the Stripe
+   *     metered subscription's `current_period_start/end` (aligns counting to the
+   *     invoice cycle).
+   *   - Self-hosted, community builds, unbilled/free orgs (no Stripe customer),
+   *     or any resolution failure → UTC calendar month.
+   *
+   * Free/unbilled orgs deliberately never trigger the EE `GetSubscription` path:
+   * it would create a Stripe customer as a side effect. Resolved periods are
+   * cached briefly per organization.
+   */
+  async resolveBillingPeriod(organizationId: string, now: Date = new Date()): Promise<BillingPeriod> {
+    const calendar = this.resolveCalendarPeriod(now);
+
+    if (this.isSelfHosted || !this.isEnterpriseBillingEnabled) {
+      return calendar;
+    }
+
+    const cached = this.periodCache.get(organizationId);
+    if (cached && cached.expiresAt > now.getTime() && now < cached.value.periodEnd) {
+      return cached.value;
+    }
+
+    // Only orgs that already have a Stripe customer are billed; resolving the
+    // subscription for the rest would create a customer as a side effect.
+    const organization = await this.organizationRepository.findById(organizationId, '_id stripeCustomerId');
+    if (!organization?.stripeCustomerId) {
+      this.setPeriodCache(organizationId, calendar, now);
+
+      return calendar;
+    }
+
+    const stripePeriod = await this.fetchStripeBillingPeriod(organizationId);
+    const value = stripePeriod ?? calendar;
+    this.setPeriodCache(organizationId, value, now);
+
+    return value;
+  }
+
+  /**
+   * Reads the current Stripe billing period via the optional EE billing use
+   * case. Returns `null` (caller falls back to calendar month) when the billing
+   * module is absent, the subscription has no period, or anything fails.
+   * Isolated so it can be stubbed in tests with dummy period data.
+   */
+  protected async fetchStripeBillingPeriod(organizationId: string): Promise<BillingPeriod | null> {
+    try {
+      const billing = this.loadEeBilling();
+      if (!billing?.GetSubscription || !billing?.GetSubscriptionCommand) {
+        return null;
+      }
+
+      const getSubscription = this.moduleRef.get(billing.GetSubscription, { strict: false });
+      if (!getSubscription) {
+        return null;
+      }
+
+      const subscription = await getSubscription.execute(
+        billing.GetSubscriptionCommand.create({ organizationId })
+      );
+      if (!subscription?.currentPeriodStart || !subscription?.currentPeriodEnd) {
+        return null;
+      }
+
+      const periodStart = new Date(subscription.currentPeriodStart);
+      const periodEnd = new Date(subscription.currentPeriodEnd);
+
+      return { periodKey: `stripe:${periodStart.toISOString()}`, periodStart, periodEnd };
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err), organizationId },
+        'Failed to resolve Stripe billing period; falling back to calendar month'
+      );
+
+      return null;
+    }
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: optional EE module surface is untyped in OSS builds
+  private loadEeBilling(): any {
+    try {
+      // biome-ignore lint/style/noCommonJs: dynamic require keeps @novu/ee-billing optional for OSS builds
+      return require('@novu/ee-billing');
+    } catch {
+      return null;
+    }
+  }
+
+  private setPeriodCache(organizationId: string, value: BillingPeriod, now: Date): void {
+    if (this.periodCache.size >= PERIOD_CACHE_MAX_ENTRIES) {
+      this.periodCache.clear();
+    }
+
+    this.periodCache.set(organizationId, { value, expiresAt: now.getTime() + PERIOD_CACHE_TTL_MS });
+  }
+
+  deriveThreadKind(platform: string, platformThreadId: string, isDirectMessageHint?: boolean): ConversationThreadKindEnum {
+    if (isDirectMessageHint !== undefined) {
+      return isDirectMessageHint ? ConversationThreadKindEnum.DIRECT : ConversationThreadKindEnum.GROUP;
+    }
+
+    // No live thread hint (outbound path): infer for Slack/Teams from the thread
+    // id. Slack DM channel ids start with `D` (e.g. `slack:D08…`). Other
+    // platforms are 1:1 and treated as direct (their window is DM-independent).
+    if (platform === AgentPlatformEnum.SLACK || platform === AgentPlatformEnum.TEAMS) {
+      return /:D[^:]/i.test(platformThreadId) ? ConversationThreadKindEnum.DIRECT : ConversationThreadKindEnum.GROUP;
+    }
+
+    return ConversationThreadKindEnum.DIRECT;
+  }
+
+  resolveWindowMs(platform: string, threadKind: ConversationThreadKindEnum): number {
+    switch (platform) {
+      case AgentPlatformEnum.WHATSAPP:
+      case AgentPlatformEnum.TELEGRAM:
+        return ACTIVATION_WINDOW_MS.DAY;
+      case AgentPlatformEnum.SLACK:
+      case AgentPlatformEnum.TEAMS:
+        return threadKind === ConversationThreadKindEnum.DIRECT
+          ? ACTIVATION_WINDOW_MS.MONTH_30
+          : ACTIVATION_WINDOW_MS.WEEK;
+      case AgentPlatformEnum.EMAIL:
+        return ACTIVATION_WINDOW_MS.MONTH_30;
+      default:
+        return ACTIVATION_WINDOW_MS.MONTH_30;
+    }
+  }
+
+  /**
+   * Read-only: whether an agent engagement on this conversation right now would
+   * start a new activation (and which reason), evaluated against the supplied
+   * billing period. Returns `null` when it would fall inside the current
+   * activation. Used by the Free-tier gate before dispatch — never mutates.
+   */
+  classifyActivation(
+    conversation: ConversationEntity,
+    platform: string,
+    periodKey: string,
+    options: { isDirectMessage?: boolean; now?: Date } = {}
+  ): ConversationActivationReasonEnum | null {
+    const now = options.now ?? new Date();
+    const threadKind = this.deriveThreadKind(platform, this.primaryThreadId(conversation), options.isDirectMessage);
+    const windowMs = this.resolveWindowMs(platform, threadKind);
+    const windowThreshold = new Date(now.getTime() - windowMs);
+
+    const billing = conversation.billing;
+
+    if (!billing?.lastCountedPeriodKey) {
+      return ConversationActivationReasonEnum.NEW;
+    }
+
+    if (billing.resolvedAt) {
+      return ConversationActivationReasonEnum.REOPEN;
+    }
+
+    if (billing.lastCountedPeriodKey !== periodKey) {
+      return ConversationActivationReasonEnum.NEW_CYCLE;
+    }
+
+    if (billing.lastEngagementAt && new Date(billing.lastEngagementAt) < windowThreshold) {
+      return ConversationActivationReasonEnum.WINDOW_EXPIRED;
+    }
+
+    return null;
+  }
+
+  /**
+   * Records an agent engagement on a conversation, counting a new active
+   * conversation when warranted. Idempotent within an activation: engagements
+   * inside the current window/period only slide the rolling window. Safe under
+   * concurrency — only the caller that wins the atomic claim writes a count.
+   * Returns whether a new activation was counted.
+   */
+  async registerEngagement(context: EngagementContext): Promise<boolean> {
+    const now = context.now ?? new Date();
+    const { periodKey } = await this.resolveBillingPeriod(context.organizationId, now);
+    const threadKind = this.deriveThreadKind(
+      context.platform,
+      this.primaryThreadId(context.conversation),
+      context.isDirectMessage
+    );
+    const windowMs = this.resolveWindowMs(context.platform, threadKind);
+    const nowIso = now.toISOString();
+    const windowThresholdIso = new Date(now.getTime() - windowMs).toISOString();
+
+    const reason = this.classifyActivation(context.conversation, context.platform, periodKey, {
+      isDirectMessage: context.isDirectMessage,
+      now,
+    });
+
+    if (!reason) {
+      await this.slideWindow(context, nowIso);
+
+      return false;
+    }
+
+    const claimed = await this.conversationRepository.startActivationIfNeeded({
+      environmentId: context.environmentId,
+      organizationId: context.organizationId,
+      conversationId: context.conversation._id,
+      periodKey,
+      windowThresholdIso,
+      nowIso,
+    });
+
+    if (!claimed) {
+      // Lost the race (another concurrent engagement counted first) — still
+      // slide the window so the rolling clock reflects this engagement.
+      await this.slideWindow(context, nowIso);
+
+      return false;
+    }
+
+    await this.activationRepository.recordActivation({
+      environmentId: context.environmentId,
+      organizationId: context.organizationId,
+      conversationId: context.conversation._id,
+      agentId: context.agentId,
+      platform: context.platform,
+      threadKind,
+      reason,
+      periodKey,
+    });
+
+    return true;
+  }
+
+  /**
+   * Whether a Free-tier organization (not on trial) must be blocked from
+   * starting a *new* activation because it has reached its included limit.
+   * Existing activations within their window/period keep working — only new
+   * conversations are short-circuited. Paid tiers and trials are never blocked
+   * (counting only). Fails open on any error so a transient failure never
+   * silently disables a customer's agent.
+   */
+  async shouldBlockFreeTier(context: {
+    conversation: ConversationEntity;
+    platform: string;
+    organizationId: string;
+    isDirectMessage?: boolean;
+    now?: Date;
+  }): Promise<boolean> {
+    try {
+      const organization = await this.organizationRepository.findById(
+        context.organizationId,
+        '_id apiServiceLevel isTrial'
+      );
+
+      const apiServiceLevel = organization?.apiServiceLevel ?? ApiServiceLevelEnum.FREE;
+      const isBlockableFreeTier = apiServiceLevel === ApiServiceLevelEnum.FREE && !organization?.isTrial;
+      if (!isBlockableFreeTier) {
+        return false;
+      }
+
+      const now = context.now ?? new Date();
+      const { periodKey } = await this.resolveBillingPeriod(context.organizationId, now);
+
+      const reason = this.classifyActivation(context.conversation, context.platform, periodKey, {
+        isDirectMessage: context.isDirectMessage,
+        now,
+      });
+      if (!reason) {
+        return false;
+      }
+
+      const limit = await this.agentEntitlements.getActiveConversationsLimit(context.organizationId, apiServiceLevel);
+      if (limit >= UNLIMITED_VALUE) {
+        return false;
+      }
+
+      const current = await this.activationRepository.countForOrganizationPeriod(
+        context.organizationId,
+        periodKey,
+        limit + 1
+      );
+
+      return current >= limit;
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err), organizationId: context.organizationId },
+        'Failed to evaluate active-conversation limit; failing open (not blocking)'
+      );
+
+      return false;
+    }
+  }
+
+  /**
+   * Hard-stops an agent-initiated (outbound) message that would start a new
+   * active conversation for a Free-tier organization at its limit, throwing the
+   * shared 402 plan-limit error. Existing conversations and paid tiers pass
+   * through untouched.
+   */
+  async assertOutboundWithinLimit(context: {
+    conversation: ConversationEntity;
+    platform: string;
+    organizationId: string;
+    isDirectMessage?: boolean;
+    now?: Date;
+  }): Promise<void> {
+    const blocked = await this.shouldBlockFreeTier(context);
+    if (!blocked) {
+      return;
+    }
+
+    const limit = await this.agentEntitlements.getActiveConversationsLimit(context.organizationId);
+
+    throwPlanLimitExceeded({
+      resource: 'active conversations',
+      limitSource: 'plan',
+      limit,
+      currentCount: limit,
+      planMessage:
+        `You have reached the number of active conversations included in your plan (${limit}). ` +
+        'Upgrade your plan to start new conversations.',
+    });
+  }
+
+  async getUsage(organizationId: string): Promise<ConversationActivationUsage> {
+    const { periodKey, periodStart, periodEnd } = await this.resolveBillingPeriod(organizationId);
+    const [limit, current] = await Promise.all([
+      this.agentEntitlements.getActiveConversationsLimit(organizationId),
+      this.activationRepository.countForOrganizationPeriod(organizationId, periodKey),
+    ]);
+
+    return {
+      current,
+      included: limit >= UNLIMITED_VALUE ? null : limit,
+      periodStart,
+      periodEnd,
+    };
+  }
+
+  private async slideWindow(context: EngagementContext, nowIso: string): Promise<void> {
+    // Only meaningful once the conversation has been counted at least once;
+    // before that there is no window to slide and the next engagement counts.
+    if (!context.conversation.billing?.lastCountedPeriodKey) {
+      return;
+    }
+
+    await this.conversationRepository.bumpLastEngagement(
+      context.environmentId,
+      context.organizationId,
+      context.conversation._id,
+      nowIso
+    );
+  }
+
+  private primaryThreadId(conversation: ConversationEntity): string {
+    return conversation.channels?.[0]?.platformThreadId ?? '';
+  }
+}

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -147,6 +147,10 @@ describe('AgentInboundHandler', () => {
     };
     const planLimitGate = {
       maybeBlock: sinon.stub().resolves(false),
+      maybeBlockConversation: sinon.stub().resolves(false),
+    };
+    const conversationActivation = {
+      registerEngagement: sinon.stub().resolves(false),
     };
     const handler = new AgentInboundHandler(
       logger as any,
@@ -165,7 +169,8 @@ describe('AgentInboundHandler', () => {
       connectClaimTokenService as any,
       keylessAbuseGuard as any,
       planLimitGate as any,
-      inboundAck as any
+      inboundAck as any,
+      conversationActivation as any
     );
 
     return {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -32,6 +32,7 @@ import { type AutoProvisionPlatform, isAutoProvisionPlatform } from '../../share
 import { InboundAckService } from '../ack/inbound-ack.service';
 import { AgentAttachmentStorage, type StoredAttachment } from '../conversation/agent-attachment-storage.service';
 import { AgentConversationService, getInboundActivityPreview } from '../conversation/agent-conversation.service';
+import { ConversationActivationService } from '../conversation/conversation-activation.service';
 import {
   AgentSubscriberResolver,
   BotAuthorSkippedError,
@@ -245,7 +246,8 @@ export class AgentInboundHandler implements OnModuleInit {
     private readonly connectClaimTokenService: ConnectClaimTokenService,
     private readonly keylessAbuseGuard: KeylessAbuseGuardService,
     private readonly planLimitGate: PlanLimitGateService,
-    private readonly inboundAck: InboundAckService
+    private readonly inboundAck: InboundAckService,
+    private readonly conversationActivation: ConversationActivationService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -345,6 +347,13 @@ export class AgentInboundHandler implements OnModuleInit {
       }
     }
 
+    // Free-tier active-conversations short-circuit: block engagements that would
+    // start a *new* active conversation once the included limit is reached.
+    // Existing (already-counted) conversations keep working.
+    if (await this.planLimitGate.maybeBlockConversation(agentId, config, thread, conversation)) {
+      return;
+    }
+
     const storedAttachments = await this.storeInboundAttachments(config, conversation, message);
     const isFirstMessage = !this.conversationService.getPrimaryChannel(conversation).firstPlatformMessageId;
 
@@ -394,6 +403,39 @@ export class AgentInboundHandler implements OnModuleInit {
     };
 
     await runtime.dispatch(turn);
+
+    await this.registerConversationEngagement(agentId, config, conversation, thread.isDM);
+  }
+
+  /**
+   * Counts the active conversation once the agent has actually engaged
+   * (dispatch succeeded). Idempotent per activation — repeated engagements
+   * inside the same window/period only slide the rolling window. Fail-soft:
+   * billing accounting must never crash the inbound webhook.
+   */
+  private async registerConversationEngagement(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    conversation: ConversationEntity,
+    isDirectMessage: boolean
+  ): Promise<void> {
+    try {
+      await this.conversationActivation.registerEngagement({
+        conversation,
+        platform: config.platform,
+        organizationId: config.organizationId,
+        environmentId: config.environmentId,
+        agentId,
+        isDirectMessage,
+      });
+    } catch (err) {
+      this.logger.warn(err, `[agent:${agentId}] Failed to register active-conversation engagement`);
+      captureAgentWarning(err, {
+        component: 'agent-inbound-handler',
+        operation: 'register-conversation-engagement',
+        agentId,
+      });
+    }
   }
 
   /** Telegram `/start <code>` is control input; when present it is always consumed here. */

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -325,7 +325,14 @@ export class AgentInboundHandler implements OnModuleInit {
     }
 
     const platformThreadId = getInboundPlatformThreadId(config.platform, thread, message);
-    const conversation = await this.openConversation(agentId, config, message, subscriberId, platformThreadId);
+    const conversation = await this.openConversation(
+      agentId,
+      config,
+      message,
+      subscriberId,
+      platformThreadId,
+      thread.isDM
+    );
 
     if (config.isKeyless) {
       const aiEnabled = await this.keylessAbuseGuard.isKeylessAgentAiEnabled(config.organizationId);
@@ -462,7 +469,8 @@ export class AgentInboundHandler implements OnModuleInit {
     config: ResolvedAgentConfig,
     message: Message,
     subscriberId: string | null,
-    platformThreadId: string
+    platformThreadId: string,
+    isDirectMessage: boolean
   ): Promise<ConversationEntity> {
     const participantId = subscriberId ?? `${config.platform}:${message.author.userId}`;
     const participantType = subscriberId
@@ -480,6 +488,7 @@ export class AgentInboundHandler implements OnModuleInit {
       participantType,
       platformUserId: message.author.userId,
       firstMessageText: resolveInboundFirstMessageText(config.platform, message),
+      isDirectMessage,
     });
   }
 
@@ -896,6 +905,7 @@ export class AgentInboundHandler implements OnModuleInit {
       participantType,
       platformUserId: userId,
       firstMessageText: `[action:${action.id}]`,
+      isDirectMessage: thread.isDM,
     });
 
     trackAgentInboundAction(this.analyticsService, {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -325,6 +325,30 @@ export class AgentInboundHandler implements OnModuleInit {
     }
 
     const platformThreadId = getInboundPlatformThreadId(config.platform, thread, message);
+
+    // Resolve whether this thread already has a conversation *before* creating
+    // one. The free-tier active-conversations gate must run before persistence
+    // so a blocked brand-new thread never leaves an orphaned Conversation and
+    // participants. Existing threads pass their entity so reopen / new-cycle
+    // activations are still gated (and they carry no orphan risk).
+    const existingConversation = await this.conversationService.findByPlatformThread(
+      config.environmentId,
+      config.organizationId,
+      agentId,
+      config.integrationId,
+      platformThreadId
+    );
+
+    // Free-tier active-conversations short-circuit: block engagements that would
+    // start a *new* active conversation once the included limit is reached.
+    // Existing (already-counted) conversations keep working.
+    if (await this.planLimitGate.maybeBlockConversation(agentId, config, thread, existingConversation ?? undefined)) {
+      return;
+    }
+
+    // Persist only after the gate. For an existing thread this reconciles
+    // participants and reopens a RESOLVED conversation; for a brand-new one it
+    // creates the Conversation that the gate just cleared.
     const conversation = await this.openConversation(
       agentId,
       config,
@@ -352,13 +376,6 @@ export class AgentInboundHandler implements OnModuleInit {
 
         return;
       }
-    }
-
-    // Free-tier active-conversations short-circuit: block engagements that would
-    // start a *new* active conversation once the included limit is reached.
-    // Existing (already-counted) conversations keep working.
-    if (await this.planLimitGate.maybeBlockConversation(agentId, config, thread, conversation)) {
-      return;
     }
 
     const storedAttachments = await this.storeInboundAttachments(config, conversation, message);

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -149,14 +149,14 @@ export class PlanLimitGateService {
       return false;
     }
 
-    const shouldBlock = await this.conversationActivation.shouldBlockFreeTier({
+    const { blocked } = await this.conversationActivation.shouldBlockFreeTier({
       conversation,
       platform: config.platform,
       organizationId: config.organizationId,
       isDirectMessage: thread.isDM,
     });
 
-    if (!shouldBlock) {
+    if (!blocked) {
       return false;
     }
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -138,12 +138,16 @@ export class PlanLimitGateService {
    * conversations are never blocked — only new ones — so an organization at its
    * limit keeps serving its current threads. Posts the upgrade card before
    * returning. Keyless/demo orgs are governed by their own caps and skipped.
+   *
+   * `conversation` is omitted for a brand-new thread (not yet persisted); the
+   * caller invokes this before creating it so a block can't orphan a
+   * Conversation/participants. A brand-new thread is always a NEW activation.
    */
   async maybeBlockConversation(
     agentId: string,
     config: ResolvedAgentConfig,
     thread: Thread,
-    conversation: ConversationEntity
+    conversation?: ConversationEntity
   ): Promise<boolean> {
     if (config.isKeyless) {
       return false;
@@ -153,6 +157,8 @@ export class PlanLimitGateService {
       conversation,
       platform: config.platform,
       organizationId: config.organizationId,
+      environmentId: config.environmentId,
+      agentId,
       isDirectMessage: thread.isDM,
     });
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { AgentEntitlementsService, PinoLogger } from '@novu/application-generic';
+import { ConversationEntity } from '@novu/dal';
 import type { AgentAction } from '@novu/framework';
 import type { CardElement, Thread } from 'chat';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { buildAttributedNovuUrl } from '../../shared/util/novu-attribution-url';
+import { ConversationActivationService } from '../conversation/conversation-activation.service';
 import { OutboundGateway } from '../egress/outbound.gateway';
 
 const NOVU_AGENTS_UPGRADE_URL = 'https://go.novu.co/agents-upgrade';
@@ -16,14 +18,16 @@ export function isLinkButtonActionId(id: string | undefined): boolean {
   return typeof id === 'string' && id.startsWith('link-');
 }
 
-/** Which plan entitlement caused an over-limit agent/channel to be soft-blocked at runtime. */
-type PlanLimitBlockReason = 'agents' | 'channels';
+/** Which plan entitlement caused an over-limit agent/channel/conversation to be soft-blocked at runtime. */
+type PlanLimitBlockReason = 'agents' | 'channels' | 'conversations';
 
 const PLAN_LIMIT_BLOCK_MESSAGES: Record<PlanLimitBlockReason, string> = {
   agents:
     "This agent isn't active on your current Novu plan — you've reached the number of agents included in your plan. Please upgrade your plan to activate it.",
   channels:
     "This channel isn't active on your current Novu plan — you've reached the number of active channels included in your plan. Please upgrade your plan to activate it.",
+  conversations:
+    "You've reached the number of active conversations included in your current Novu plan. Upgrade your plan to start new conversations — your existing conversations keep working.",
 };
 
 function buildUpgradeRequiredCard(
@@ -81,7 +85,8 @@ export class PlanLimitGateService {
   constructor(
     private readonly logger: PinoLogger,
     private readonly agentEntitlements: AgentEntitlementsService,
-    private readonly outboundGateway: OutboundGateway
+    private readonly outboundGateway: OutboundGateway,
+    private readonly conversationActivation: ConversationActivationService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -122,6 +127,40 @@ export class PlanLimitGateService {
     if (!isLinkButtonActionId(action?.id)) {
       await this.postUpgradeRequiredReply(agentId, config, thread, reason);
     }
+
+    return true;
+  }
+
+  /**
+   * Returns `true` when inbound processing must stop because a Free-tier
+   * organization has reached its included active-conversations limit and this
+   * engagement would start a *new* activation. Existing (already-counted)
+   * conversations are never blocked — only new ones — so an organization at its
+   * limit keeps serving its current threads. Posts the upgrade card before
+   * returning. Keyless/demo orgs are governed by their own caps and skipped.
+   */
+  async maybeBlockConversation(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    thread: Thread,
+    conversation: ConversationEntity
+  ): Promise<boolean> {
+    if (config.isKeyless) {
+      return false;
+    }
+
+    const shouldBlock = await this.conversationActivation.shouldBlockFreeTier({
+      conversation,
+      platform: config.platform,
+      organizationId: config.organizationId,
+      isDirectMessage: thread.isDM,
+    });
+
+    if (!shouldBlock) {
+      return false;
+    }
+
+    await this.postUpgradeRequiredReply(agentId, config, thread, 'conversations');
 
     return true;
   }

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -19,6 +19,7 @@ import { AgentEventEnum } from '../../../shared/enums/agent-event.enum';
 import { InboundAckService } from '../../ack/inbound-ack.service';
 import type { MetadataOp } from '../../conversation/agent-conversation.service';
 import { AgentConversationService } from '../../conversation/agent-conversation.service';
+import { ConversationActivationService } from '../../conversation/conversation-activation.service';
 import { OutboundGateway } from '../../egress/outbound.gateway';
 import { BridgeExecutorService } from '../../runtime/bridge-executor.service';
 import { buildAgentPlatformContext, buildEmailPlatformContext } from '../../runtime/build-platform-context.util';
@@ -36,7 +37,8 @@ export class HandleAgentReply {
     private readonly parseEventRequest: ParseEventRequest,
     private readonly analyticsService: AnalyticsService,
     private readonly outboundGateway: OutboundGateway,
-    private readonly inboundAck: InboundAckService
+    private readonly inboundAck: InboundAckService,
+    private readonly conversationActivation: ConversationActivationService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -88,7 +90,19 @@ export class HandleAgentReply {
 
     let replyInfo: SentMessageInfo | undefined;
     if (command.reply) {
+      // Free-tier short-circuit: an agent-initiated reply that would start a new
+      // active conversation is rejected once the included limit is reached
+      // (covers proactive/outbound-only threads). Replies inside an already-counted
+      // conversation pass through.
+      await this.conversationActivation.assertOutboundWithinLimit({
+        conversation,
+        platform: channel.platform,
+        organizationId: command.organizationId,
+      });
+
       replyInfo = await this.deliverMessage(command, conversation, channel, command.reply, agentName);
+
+      await this.registerConversationEngagement(command, conversation, channel);
 
       if (!config!.isManaged) {
         void this.inboundAck.onBridgeReplyDelivered({
@@ -173,6 +187,33 @@ export class HandleAgentReply {
     }
 
     return agent.name;
+  }
+
+  /**
+   * Counts the active conversation for an agent-initiated reply. Idempotent per
+   * activation (a reply following a counted inbound dispatch only slides the
+   * rolling window). Fail-soft — billing accounting must never fail a delivered
+   * reply.
+   */
+  private async registerConversationEngagement(
+    command: HandleAgentReplyCommand,
+    conversation: ConversationEntity,
+    channel: ConversationChannel
+  ): Promise<void> {
+    try {
+      await this.conversationActivation.registerEngagement({
+        conversation,
+        platform: channel.platform,
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        agentId: conversation._agentId,
+      });
+    } catch (err) {
+      this.logger.warn(
+        err,
+        `[agent:${command.agentIdentifier}] Failed to register active-conversation engagement for reply`
+      );
+    }
   }
 
   private async deliverMessage(

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -16,6 +16,7 @@ import { trackAgentReplyProcessed } from '../../../shared/analytics/agent-analyt
 import type { EditPayloadDto, ReplyContentDto } from '../../../shared/dtos/agent-reply-payload.dto';
 import { isValidMetadataSignalKey } from '../../../shared/dtos/agent-reply-payload.dto';
 import { AgentEventEnum } from '../../../shared/enums/agent-event.enum';
+import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
 import { InboundAckService } from '../../ack/inbound-ack.service';
 import type { MetadataOp } from '../../conversation/agent-conversation.service';
 import { AgentConversationService } from '../../conversation/agent-conversation.service';
@@ -96,7 +97,7 @@ export class HandleAgentReply {
       // conversation pass through.
       await this.conversationActivation.assertOutboundWithinLimit({
         conversation,
-        platform: channel.platform,
+        platform: channel.platform as AgentPlatformEnum,
         organizationId: command.organizationId,
       });
 
@@ -203,7 +204,7 @@ export class HandleAgentReply {
     try {
       await this.conversationActivation.registerEngagement({
         conversation,
-        platform: channel.platform,
+        platform: channel.platform as AgentPlatformEnum,
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         agentId: conversation._agentId,

--- a/apps/api/src/app/agents/e2e/active-conversations.e2e.ts
+++ b/apps/api/src/app/agents/e2e/active-conversations.e2e.ts
@@ -267,6 +267,8 @@ describe('Active Conversations metering - inbound flow #novu-v2', () => {
       expect(await countActivations(), 'blocked conversation must not be counted').to.equal(1);
       expect(bridgeCalls.length, 'blocked conversation must not dispatch').to.equal(1);
       expect(cardSpy.called, 'an upgrade card should be posted').to.equal(true);
+      // Gate runs before persistence — a blocked brand-new thread leaves no orphan.
+      expect(await findConversation(threadB), 'blocked new conversation must not be persisted').to.equal(null);
 
       // The already-counted conversation keeps working.
       await invokeSlack(threadA, 'follow up');

--- a/apps/api/src/app/agents/e2e/active-conversations.e2e.ts
+++ b/apps/api/src/app/agents/e2e/active-conversations.e2e.ts
@@ -1,0 +1,343 @@
+import { AgentEntitlementsService } from '@novu/application-generic';
+import {
+  CommunityOrganizationRepository,
+  ConversationActivationRepository,
+  ConversationStatusEnum,
+} from '@novu/dal';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { testServer } from '@novu/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { AgentConfigResolver } from '../channels/agent-config-resolver.service';
+import { ConversationActivationService } from '../conversation-runtime/conversation/conversation-activation.service';
+import { OutboundGateway } from '../conversation-runtime/egress/outbound.gateway';
+import { ChatInstanceRegistry } from '../conversation-runtime/ingress/chat-instance.registry';
+import { AgentInboundHandler } from '../conversation-runtime/ingress/inbound-turn.handler';
+import { AgentExecutionParams, BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
+import { RuntimeResolver } from '../conversation-runtime/runtime/runtime-resolver.service';
+import { AgentEventEnum } from '../shared/enums/agent-event.enum';
+import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
+import { AgentTestContext, conversationRepository, setupAgentTestContext } from './helpers/agent-test-setup';
+
+function mockSentMessage() {
+  return {
+    addReaction: async () => {},
+    removeReaction: async () => {},
+    edit: async () => mockSentMessage(),
+    delete: async () => {},
+  };
+}
+
+function mockThread(id: string, opts: { channelId?: string; isDM?: boolean } = {}) {
+  const channelId = opts.channelId ?? 'C_TEST';
+
+  return {
+    id,
+    channelId,
+    isDM: opts.isDM ?? false,
+    startTyping: async () => {},
+    subscribe: async () => {},
+    post: async () => mockSentMessage(),
+    toJSON: () => ({ id, channelId }),
+    createSentMessageFromMessage: () => mockSentMessage(),
+  };
+}
+
+function mockMessage(opts: { id?: string; userId: string; text: string }) {
+  return {
+    id: opts.id ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    text: opts.text,
+    author: { userId: opts.userId, fullName: 'Test User', userName: 'testuser', isBot: false },
+    metadata: { dateSent: new Date() },
+  };
+}
+
+async function clearChatSdkInstances(): Promise<void> {
+  const registry = testServer.getService(ChatInstanceRegistry);
+  await registry.onModuleDestroy();
+}
+
+describe('Active Conversations metering - inbound flow #novu-v2', () => {
+  const organizationRepository = new CommunityOrganizationRepository();
+  const activationRepository = new ConversationActivationRepository();
+
+  let ctx: AgentTestContext;
+  let inboundHandler: AgentInboundHandler;
+  let configResolver: AgentConfigResolver;
+  let activationService: ConversationActivationService;
+  let bridgeCalls: AgentExecutionParams[];
+
+  beforeEach(async () => {
+    ctx = await setupAgentTestContext();
+    inboundHandler = testServer.getService(AgentInboundHandler);
+    configResolver = testServer.getService(AgentConfigResolver);
+    activationService = testServer.getService(ConversationActivationService);
+
+    bridgeCalls = [];
+    const bridgeExecutor = testServer.getService(BridgeExecutorService);
+    sinon.stub(bridgeExecutor, 'execute').callsFake(async (params: AgentExecutionParams) => {
+      bridgeCalls.push(params);
+    });
+  });
+
+  afterEach(async () => {
+    await clearChatSdkInstances();
+    sinon.restore();
+  });
+
+  // Count is period-agnostic (every test uses a fresh org), so it works whether
+  // the resolved period is calendar month or a Stripe billing cycle.
+  async function countActivations(): Promise<number> {
+    return activationRepository.count({ _organizationId: ctx.session.organization._id });
+  }
+
+  async function setServiceLevel(apiServiceLevel: ApiServiceLevelEnum, isTrial = false): Promise<void> {
+    await organizationRepository.update(
+      { _id: ctx.session.organization._id },
+      { $set: { apiServiceLevel, isTrial } }
+    );
+  }
+
+  async function invokeSlack(threadId: string, text: string, opts: { isDM?: boolean; userId?: string } = {}) {
+    const config = await configResolver.resolve(ctx.agentId, ctx.integrationIdentifier);
+    const thread = mockThread(threadId, { isDM: opts.isDM, channelId: opts.isDM ? 'D_TEST' : 'C_TEST' });
+    const message = mockMessage({ userId: opts.userId ?? 'U_ACTIVE', text });
+    await inboundHandler.handle(ctx.agentId, config, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+  }
+
+  async function invokeWhatsApp(phone: string, text: string) {
+    const baseConfig = await configResolver.resolve(ctx.agentId, ctx.integrationIdentifier);
+    const config = { ...baseConfig, platform: AgentPlatformEnum.WHATSAPP };
+    const threadId = `whatsapp:${phone}`;
+    const thread = mockThread(threadId, { channelId: threadId, isDM: true });
+    const message = mockMessage({ userId: phone, text });
+    await inboundHandler.handle(ctx.agentId, config, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+    return threadId;
+  }
+
+  async function findConversation(threadId: string) {
+    return conversationRepository.findByPlatformThread(
+      ctx.session.environment._id,
+      ctx.session.organization._id,
+      ctx.agentId,
+      ctx.integrationId,
+      threadId
+    );
+  }
+
+  describe('Counting model', () => {
+    it('counts a single conversation once across many messages', async () => {
+      const threadId = `T_MANY_${Date.now()}`;
+
+      await invokeSlack(threadId, 'one');
+      await invokeSlack(threadId, 'two');
+      await invokeSlack(threadId, 'three');
+
+      expect(await countActivations()).to.equal(1);
+    });
+
+    it('counts a separate conversation per distinct thread', async () => {
+      await invokeSlack(`T_A_${Date.now()}`, 'hi A');
+      await invokeSlack(`T_B_${Date.now()}`, 'hi B');
+
+      expect(await countActivations()).to.equal(2);
+    });
+
+    it('counts a reopen after resolve as a new active conversation (same cycle)', async () => {
+      const threadId = `T_REOPEN_${Date.now()}`;
+
+      await invokeSlack(threadId, 'initial');
+      expect(await countActivations()).to.equal(1);
+
+      const conversation = await findConversation(threadId);
+      // Mimic resolveConversation's billing + status effects.
+      await conversationRepository.updateStatus(
+        ctx.session.environment._id,
+        ctx.session.organization._id,
+        conversation!._id,
+        ConversationStatusEnum.RESOLVED
+      );
+      await conversationRepository.markBillingResolved(
+        ctx.session.environment._id,
+        ctx.session.organization._id,
+        conversation!._id,
+        new Date().toISOString()
+      );
+
+      await invokeSlack(threadId, 'reopening');
+
+      const reopened = await findConversation(threadId);
+      expect(reopened!.status).to.equal(ConversationStatusEnum.ACTIVE);
+      expect(reopened!._id).to.equal(conversation!._id);
+      expect(await countActivations()).to.equal(2);
+    });
+
+    it('counts again after the rolling inactivity window lapses (WhatsApp 24h)', async () => {
+      const threadId = await invokeWhatsApp('15551230000', 'day one');
+      expect(await countActivations()).to.equal(1);
+
+      const conversation = await findConversation(threadId);
+      // Rewind the last engagement past the 24h WhatsApp window.
+      const stale = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+      await conversationRepository.update(
+        { _id: conversation!._id, _environmentId: ctx.session.environment._id, _organizationId: ctx.session.organization._id },
+        { $set: { 'billing.lastEngagementAt': stale } }
+      );
+
+      await invokeWhatsApp('15551230000', 'next day');
+
+      expect(await countActivations()).to.equal(2);
+    });
+
+    it('does not recount within the rolling window', async () => {
+      const threadId = await invokeWhatsApp('15551231111', 'first');
+      const conversation = await findConversation(threadId);
+      // Only 2h elapsed — inside the 24h WhatsApp window.
+      const recent = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      await conversationRepository.update(
+        { _id: conversation!._id, _environmentId: ctx.session.environment._id, _organizationId: ctx.session.organization._id },
+        { $set: { 'billing.lastEngagementAt': recent } }
+      );
+
+      await invokeWhatsApp('15551231111', 'a bit later');
+
+      expect(await countActivations()).to.equal(1);
+    });
+
+    it('counts again in a new billing period for a continuing conversation', async () => {
+      const threadId = `T_CYCLE_${Date.now()}`;
+
+      await invokeSlack(threadId, 'this month');
+      expect(await countActivations()).to.equal(1);
+
+      const conversation = await findConversation(threadId);
+      // Pretend it was last counted in a previous period.
+      await conversationRepository.update(
+        { _id: conversation!._id, _environmentId: ctx.session.environment._id, _organizationId: ctx.session.organization._id },
+        { $set: { 'billing.lastCountedPeriodKey': '2000-01' } }
+      );
+
+      await invokeSlack(threadId, 'new cycle');
+
+      expect(await countActivations()).to.equal(2);
+    });
+
+    it('does not count when dispatch fails (no agent engagement)', async () => {
+      const runtimeResolver = testServer.getService(RuntimeResolver);
+      sinon.stub(runtimeResolver, 'resolve').returns({
+        dispatch: async () => {
+          throw new Error('dispatch failed');
+        },
+      } as any);
+
+      const threadId = `T_FAIL_${Date.now()}`;
+      let threw = false;
+      try {
+        await invokeSlack(threadId, 'will fail');
+      } catch {
+        threw = true;
+      }
+
+      expect(threw).to.equal(true);
+      expect(await countActivations()).to.equal(0);
+    });
+  });
+
+  describe('Free-tier short-circuit', () => {
+    beforeEach(() => {
+      sinon.stub(testServer.getService(AgentEntitlementsService), 'getActiveConversationsLimit').resolves(1);
+    });
+
+    it('blocks a new conversation once the included limit is reached, but keeps existing ones working', async () => {
+      await setServiceLevel(ApiServiceLevelEnum.FREE);
+
+      const cardSpy = sinon
+        .stub(testServer.getService(OutboundGateway), 'replyOnThreadWithCard')
+        .resolves(undefined as any);
+
+      const threadA = `T_FREE_A_${Date.now()}`;
+      await invokeSlack(threadA, 'first conversation');
+      expect(await countActivations()).to.equal(1);
+      expect(bridgeCalls.length).to.equal(1);
+
+      // New conversation would start a second activation — blocked at the limit.
+      const threadB = `T_FREE_B_${Date.now()}`;
+      await invokeSlack(threadB, 'second conversation');
+      expect(await countActivations(), 'blocked conversation must not be counted').to.equal(1);
+      expect(bridgeCalls.length, 'blocked conversation must not dispatch').to.equal(1);
+      expect(cardSpy.called, 'an upgrade card should be posted').to.equal(true);
+
+      // The already-counted conversation keeps working.
+      await invokeSlack(threadA, 'follow up');
+      expect(bridgeCalls.length, 'existing conversation should still dispatch').to.equal(2);
+      expect(await countActivations()).to.equal(1);
+    });
+
+    it('does not block paid tiers even when over the limit', async () => {
+      await setServiceLevel(ApiServiceLevelEnum.PRO);
+
+      await invokeSlack(`T_PRO_A_${Date.now()}`, 'a');
+      await invokeSlack(`T_PRO_B_${Date.now()}`, 'b');
+
+      expect(bridgeCalls.length).to.equal(2);
+      expect(await countActivations()).to.equal(2);
+    });
+
+    it('does not block trial organizations', async () => {
+      await setServiceLevel(ApiServiceLevelEnum.FREE, true);
+
+      await invokeSlack(`T_TRIAL_A_${Date.now()}`, 'a');
+      await invokeSlack(`T_TRIAL_B_${Date.now()}`, 'b');
+
+      expect(bridgeCalls.length).to.equal(2);
+      expect(await countActivations()).to.equal(2);
+    });
+  });
+
+  describe('Usage endpoint', () => {
+    it('returns the current count and included limit for the period', async () => {
+      await setServiceLevel(ApiServiceLevelEnum.PRO);
+
+      await invokeSlack(`T_USAGE_${Date.now()}`, 'count me');
+
+      const res = await ctx.session.testAgent.get('/v1/agents/usage/conversations');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.data.current).to.equal(1);
+      expect(res.body.data.included).to.equal(1000);
+      expect(res.body.data.periodStart).to.be.a('string');
+      expect(res.body.data.periodEnd).to.be.a('string');
+    });
+  });
+
+  describe('Stripe billing period', () => {
+    const DAY = 24 * 60 * 60 * 1000;
+
+    it('anchors counting and usage to the Stripe billing period for a billed org', async () => {
+      await setServiceLevel(ApiServiceLevelEnum.PRO);
+      // A billed org has a Stripe customer, which enables the Stripe-period path.
+      await organizationRepository.update(
+        { _id: ctx.session.organization._id },
+        { $set: { stripeCustomerId: 'cus_dummy_e2e' } }
+      );
+
+      const periodStart = new Date(Date.now() - 10 * DAY);
+      const periodEnd = new Date(Date.now() + 20 * DAY);
+      const periodKey = `stripe:${periodStart.toISOString()}`;
+      // Dummy Stripe period (no live Stripe call in tests).
+      sinon.stub(activationService as any, 'fetchStripeBillingPeriod').resolves({ periodKey, periodStart, periodEnd });
+
+      await invokeSlack(`T_STRIPE_${Date.now()}`, 'billed');
+
+      // Activation was recorded against the Stripe period key, not the calendar month.
+      expect(await activationRepository.countForOrganizationPeriod(ctx.session.organization._id, periodKey)).to.equal(1);
+
+      const res = await ctx.session.testAgent.get('/v1/agents/usage/conversations');
+      expect(res.status).to.equal(200);
+      expect(res.body.data.current).to.equal(1);
+      expect(res.body.data.periodStart).to.equal(periodStart.toISOString());
+      expect(res.body.data.periodEnd).to.equal(periodEnd.toISOString());
+    });
+  });
+});

--- a/apps/api/src/app/agents/management/agents.controller.ts
+++ b/apps/api/src/app/agents/management/agents.controller.ts
@@ -31,12 +31,14 @@ import { UserSession } from '../../shared/framework/user.decorator';
 import { AgentRuntimeExceptionFilter } from '../shared/agent-runtime-exception.filter';
 import {
   AgentResponseDto,
+  ConversationUsageResponseDto,
   CreateAgentRequestDto,
   ListAgentsQueryDto,
   ListAgentsResponseDto,
   UpdateAgentBridgeRequestDto,
   UpdateAgentRequestDto,
 } from '../shared/dtos';
+import { ConversationActivationService } from '../conversation-runtime/conversation/conversation-activation.service';
 import { type AgentEmojiEntry, ListAgentEmoji } from '../shared/emoji/list-agent-emoji/list-agent-emoji.usecase';
 import { CreateAgentCommand } from './usecases/create-agent/create-agent.command';
 import { CreateAgent } from './usecases/create-agent/create-agent.usecase';
@@ -62,8 +64,29 @@ export class AgentsController {
     private readonly getAgentUsecase: GetAgent,
     private readonly updateAgentUsecase: UpdateAgent,
     private readonly deleteAgentUsecase: DeleteAgent,
-    private readonly listAgentEmojiUsecase: ListAgentEmoji
+    private readonly listAgentEmojiUsecase: ListAgentEmoji,
+    private readonly conversationActivation: ConversationActivationService
   ) {}
+
+  @Get('/usage/conversations')
+  @ApiResponse(ConversationUsageResponseDto)
+  @ApiOperation({
+    summary: 'Get active-conversations usage',
+    description:
+      'Returns the number of active conversations counted for the organization in the current billing period, ' +
+      'the amount included in the plan (`null` when unlimited), and the period bounds.',
+  })
+  @RequirePermissions(PermissionsEnum.AGENT_READ)
+  async getConversationUsage(@UserSession() user: UserSessionData): Promise<ConversationUsageResponseDto> {
+    const usage = await this.conversationActivation.getUsage(user.organizationId);
+
+    return {
+      current: usage.current,
+      included: usage.included,
+      periodStart: usage.periodStart.toISOString(),
+      periodEnd: usage.periodEnd.toISOString(),
+    };
+  }
 
   @Get('/emoji')
   @ApiOperation({

--- a/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
+++ b/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
@@ -339,6 +339,74 @@ export function trackAgentMcpOAuthFailed(
   });
 }
 
+/**
+ * Fired each time an active conversation is counted (one activation episode):
+ * a new/reopened thread, a rolling-window lapse, or a new billing cycle. Gives
+ * per-tier / per-channel conversation volume for pricing analysis. Org-scoped.
+ */
+export function trackAgentActiveConversationCounted(
+  analytics: AnalyticsService,
+  params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    conversationId: string;
+    platform: string;
+    threadKind: string;
+    reason: string;
+    periodKey: string;
+    apiServiceLevel: string;
+  }
+): void {
+  analytics.track(`Agent Active Conversation Counted - ${AGENT_SEGMENT_CATEGORY}`, params.organizationId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+    platform: params.platform,
+    threadKind: params.threadKind,
+    reason: params.reason,
+    periodKey: params.periodKey,
+    apiServiceLevel: params.apiServiceLevel,
+  });
+}
+
+/**
+ * Fired when an organization reaches/exceeds its included active-conversations
+ * limit. Fires on every finite tier (not just Free): for Free `blocked` is true
+ * (the engagement was short-circuited); for paid tiers `blocked` is false and
+ * `overage` measures the extra conversations beyond the included amount — the
+ * signal for deciding overage pricing. Org-scoped.
+ */
+export function trackAgentActiveConversationLimitReached(
+  analytics: AnalyticsService,
+  params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    conversationId: string;
+    platform: string;
+    apiServiceLevel: string;
+    limit: number;
+    currentCount: number;
+    overage: number;
+    blocked: boolean;
+  }
+): void {
+  analytics.track(`Agent Active Conversation Limit Reached - ${AGENT_SEGMENT_CATEGORY}`, params.organizationId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+    platform: params.platform,
+    apiServiceLevel: params.apiServiceLevel,
+    limit: params.limit,
+    currentCount: params.currentCount,
+    overage: params.overage,
+    blocked: params.blocked,
+  });
+}
+
 /** Fired once per agent–integration when the first inbound webhook is successfully resolved (sets connectedAt). */
 export function trackAgentIntegrationFirstWebhook(
   analytics: AnalyticsService,

--- a/apps/api/src/app/agents/shared/dtos/conversation-usage-response.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/conversation-usage-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Active-conversations usage for the current billing period, summed across the
+ * organization's environments. `included` is the plan limit (`null` for
+ * unlimited tiers). Counting is informational — nothing is reported to Stripe.
+ */
+export class ConversationUsageResponseDto {
+  @ApiProperty({ description: 'Active conversations counted for the organization in the current billing period.' })
+  current: number;
+
+  @ApiProperty({
+    description: 'Active conversations included in the organization plan. `null` when the tier is unlimited.',
+    type: Number,
+    nullable: true,
+  })
+  included: number | null;
+
+  @ApiProperty({ description: 'Inclusive UTC start of the current billing period (ISO 8601).' })
+  periodStart: string;
+
+  @ApiProperty({ description: 'Exclusive UTC end of the current billing period (ISO 8601).' })
+  periodEnd: string;
+}

--- a/apps/api/src/app/agents/shared/dtos/index.ts
+++ b/apps/api/src/app/agents/shared/dtos/index.ts
@@ -5,6 +5,7 @@ export * from './agent-integration-response.dto';
 export * from './agent-integration-summary.dto';
 export * from './agent-response.dto';
 export * from './agent-runtime-config.dto';
+export * from './conversation-usage-response.dto';
 export * from './create-agent-request.dto';
 export * from './generate-managed-agent.dto';
 export * from './list-agent-integrations-query.dto';

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -242,6 +242,23 @@ export async function getAgentDemoQuota(
   return 'data' in response ? response.data : response;
 }
 
+export type ConversationUsage = {
+  current: number;
+  /** `null` when the tier is unlimited. */
+  included: number | null;
+  periodStart: string;
+  periodEnd: string;
+};
+
+export async function getConversationUsage(environment: IEnvironment, signal?: AbortSignal): Promise<ConversationUsage> {
+  const response = await get<{ data: ConversationUsage } | ConversationUsage>('/agents/usage/conversations', {
+    environment,
+    signal,
+  });
+
+  return 'data' in response ? response.data : response;
+}
+
 export async function migrateAgentRuntime(
   environment: IEnvironment,
   agentIdentifier: string,

--- a/apps/dashboard/src/components/billing/active-plan-banner.tsx
+++ b/apps/dashboard/src/components/billing/active-plan-banner.tsx
@@ -9,15 +9,15 @@ import {
 } from '@novu/shared';
 import { Check, Minus } from 'lucide-react';
 import { useEffect } from 'react';
-import { RiCalendarEventLine, RiRouteFill, RiTeamLine } from 'react-icons/ri';
+import { RiCalendarEventLine, RiChat3Line, RiTeamLine } from 'react-icons/ri';
 import { Badge } from '@/components/primitives/badge';
 import { LinkButton } from '@/components/primitives/button-link';
 import { Card } from '@/components/primitives/card';
 import { Progress } from '@/components/primitives/progress';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
+import { useFetchConversationUsage } from '../../hooks/use-fetch-conversation-usage';
 import { useFetchSubscription } from '../../hooks/use-fetch-subscription';
-import { useFetchWorkflows } from '../../hooks/use-fetch-workflows';
 import { getPlanFeatures, type PlanFeature } from './features-config';
 import { PlanActionButton } from './plan-action-button';
 
@@ -26,14 +26,14 @@ interface ActivePlanBannerProps {
 }
 
 interface UsageMetric {
-  type: 'events' | 'workflows' | 'teammates';
+  type: 'events' | 'conversations' | 'teammates';
   icon: React.ComponentType<{ className?: string }>;
   label: string;
 }
 
 const USAGE_METRICS: UsageMetric[] = [
   { type: 'events', icon: RiCalendarEventLine, label: 'Workflow Runs' },
-  { type: 'workflows', icon: RiRouteFill, label: 'Workflows' },
+  { type: 'conversations', icon: RiChat3Line, label: 'Conversations' },
   { type: 'teammates', icon: RiTeamLine, label: 'Teammates' },
 ];
 
@@ -61,6 +61,35 @@ function getEventsTooltipContent(
     : 'Pay as you grow. No hard limit.';
 
   return `Includes ${formatLimit(usageData.included)} workflow runs — ${limitMessage}`;
+}
+
+function getConversationsTooltipContent(
+  usageData: { included: number },
+  subscription: ReturnType<typeof useFetchSubscription>['subscription']
+): string {
+  const currentPlan = subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE;
+  const isFreePlan = currentPlan === ApiServiceLevelEnum.FREE;
+
+  const limitMessage = isFreePlan
+    ? "New conversations won't be allowed after the free limit is reached — existing conversations keep working."
+    : 'Counted for usage. No hard limit.';
+
+  return `Includes ${formatLimit(usageData.included)} active conversations / month — ${limitMessage}`;
+}
+
+function getUsageTooltipContent(
+  type: UsageMetric['type'],
+  usageData: { included: number },
+  subscription: ReturnType<typeof useFetchSubscription>['subscription']
+): string | null {
+  switch (type) {
+    case 'events':
+      return getEventsTooltipContent(usageData, subscription);
+    case 'conversations':
+      return getConversationsTooltipContent(usageData, subscription);
+    default:
+      return null;
+  }
 }
 
 function formatDateRange(
@@ -91,7 +120,7 @@ function getPlanBadgeText(subscription: ReturnType<typeof useFetchSubscription>[
 function getUsageData(
   type: UsageMetric['type'],
   subscription: ReturnType<typeof useFetchSubscription>['subscription'],
-  workflowsData: ReturnType<typeof useFetchWorkflows>['data'],
+  conversationUsage: ReturnType<typeof useFetchConversationUsage>['conversationUsage'],
   organization: ReturnType<typeof useOrganization>['organization']
 ) {
   const currentPlan = subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE;
@@ -105,11 +134,13 @@ function getUsageData(
           getFeatureForTierAsNumber(FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED, currentPlan, false),
         label: 'included',
       };
-    case 'workflows':
+    case 'conversations':
       return {
-        current: workflowsData?.totalCount ?? 0,
-        included: getFeatureForTierAsNumber(FeatureNameEnum.PLATFORM_MAX_WORKFLOWS, currentPlan, false),
-        label: 'workflows',
+        current: conversationUsage?.current ?? 0,
+        included:
+          conversationUsage?.included ??
+          getFeatureForTierAsNumber(FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS, currentPlan, false),
+        label: 'included',
       };
     case 'teammates':
       return {
@@ -147,13 +178,14 @@ function CardHeader({ title, children, rightContent, titleInline = false }: Card
 interface UsageMetricRowProps {
   metric: UsageMetric;
   subscription: ReturnType<typeof useFetchSubscription>['subscription'];
-  workflowsData: ReturnType<typeof useFetchWorkflows>['data'];
+  conversationUsage: ReturnType<typeof useFetchConversationUsage>['conversationUsage'];
   organization: ReturnType<typeof useOrganization>['organization'];
 }
 
-function UsageMetricRow({ metric, subscription, workflowsData, organization }: UsageMetricRowProps) {
-  const usageData = getUsageData(metric.type, subscription, workflowsData, organization);
+function UsageMetricRow({ metric, subscription, conversationUsage, organization }: UsageMetricRowProps) {
+  const usageData = getUsageData(metric.type, subscription, conversationUsage, organization);
   const Icon = metric.icon;
+  const tooltipContent = getUsageTooltipContent(metric.type, usageData, subscription);
 
   if (!subscription) {
     return (
@@ -181,13 +213,13 @@ function UsageMetricRow({ metric, subscription, workflowsData, organization }: U
           <span className="text-text-sub">{usageData.current.toLocaleString()}</span> /{' '}
           <span className="text-text-soft">
             {formatLimit(usageData.included)}{' '}
-            {metric.type === 'events' ? (
+            {tooltipContent ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="border-b border-dotted border-text-soft/40 cursor-help">{usageData.label}</span>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{getEventsTooltipContent(usageData, subscription)}</p>
+                  <p>{tooltipContent}</p>
                 </TooltipContent>
               </Tooltip>
             ) : (
@@ -260,12 +292,12 @@ function ActionButton({ selectedBillingInterval, subscription }: ActionButtonPro
 function UsageCard({
   subscription,
   daysLeft,
-  workflowsData,
+  conversationUsage,
   organization,
 }: {
   subscription: ReturnType<typeof useFetchSubscription>['subscription'];
   daysLeft: number;
-  workflowsData: ReturnType<typeof useFetchWorkflows>['data'];
+  conversationUsage: ReturnType<typeof useFetchConversationUsage>['conversationUsage'];
   organization: ReturnType<typeof useOrganization>['organization'];
 }) {
   return (
@@ -288,7 +320,7 @@ function UsageCard({
               key={metric.type}
               metric={metric}
               subscription={subscription}
-              workflowsData={workflowsData}
+              conversationUsage={conversationUsage}
               organization={organization}
             />
           ))}
@@ -335,7 +367,7 @@ function PlanCard({
 export function ActivePlanBanner({ selectedBillingInterval }: ActivePlanBannerProps) {
   const { subscription, daysLeft } = useFetchSubscription();
   const { organization } = useOrganization();
-  const { data: workflowsData } = useFetchWorkflows({ limit: 1 });
+  const { conversationUsage } = useFetchConversationUsage();
 
   useEffect(() => {
     (async () => {
@@ -350,7 +382,7 @@ export function ActivePlanBanner({ selectedBillingInterval }: ActivePlanBannerPr
         <UsageCard
           subscription={subscription}
           daysLeft={daysLeft}
-          workflowsData={workflowsData}
+          conversationUsage={conversationUsage}
           organization={organization}
         />
         <PlanCard selectedBillingInterval={selectedBillingInterval} subscription={subscription} />

--- a/apps/dashboard/src/components/billing/active-plan-banner.tsx
+++ b/apps/dashboard/src/components/billing/active-plan-banner.tsx
@@ -137,9 +137,13 @@ function getUsageData(
     case 'conversations':
       return {
         current: conversationUsage?.current ?? 0,
+        // `null` is the API's explicit "unlimited" contract — keep it unlimited (∞) rather than
+        // coalescing to the local tier table. Only `undefined` (not loaded yet) uses the fallback.
         included:
-          conversationUsage?.included ??
-          getFeatureForTierAsNumber(FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS, currentPlan, false),
+          conversationUsage?.included === null
+            ? UNLIMITED_VALUE
+            : (conversationUsage?.included ??
+              getFeatureForTierAsNumber(FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS, currentPlan, false)),
         label: 'included',
       };
     case 'teammates':

--- a/apps/dashboard/src/components/billing/features-config.ts
+++ b/apps/dashboard/src/components/billing/features-config.ts
@@ -39,8 +39,11 @@ export const FEATURE_SECTIONS: FeatureSectionConfig[] = [
   {
     title: 'Agents',
     features: [
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
+      FeatureNameEnum.AGENT_COST_PER_ADDITIONAL_CONVERSATION,
       FeatureNameEnum.AGENT_MAX_AGENTS,
       FeatureNameEnum.AGENT_MAX_ACTIVE_CHANNELS,
+      FeatureNameEnum.PLATFORM_REMOVE_NOVU_BRANDING_BOOLEAN,
       FeatureNameEnum.AGENT_MAX_CUSTOM_EMAIL_DOMAINS,
     ],
   },
@@ -66,8 +69,6 @@ export const FEATURE_SECTIONS: FeatureSectionConfig[] = [
     features: [
       FeatureNameEnum.ACCOUNT_MAX_TEAM_MEMBERS,
       FeatureNameEnum.ACCOUNT_ROLE_BASED_ACCESS_CONTROL_BOOLEAN,
-      FeatureNameEnum.COMPLIANCE_GDPR_BOOLEAN,
-      FeatureNameEnum.COMPLIANCE_HIPAA_BAA_BOOLEAN,
       FeatureNameEnum.ACCOUNT_CUSTOM_SAML_SSO_OIDC_BOOLEAN,
     ],
   },
@@ -78,24 +79,36 @@ export const FEATURE_SECTIONS: FeatureSectionConfig[] = [
   {
     title: 'Legal & Vendor management',
     features: [
+      FeatureNameEnum.COMPLIANCE_GDPR_BOOLEAN,
       FeatureNameEnum.PAYMENT_METHOD,
       FeatureNameEnum.COMPLIANCE_CUSTOM_SECURITY_REVIEWS,
+      FeatureNameEnum.COMPLIANCE_HIPAA_BAA_BOOLEAN,
       FeatureNameEnum.PLATFORM_TERMS_OF_SERVICE,
       FeatureNameEnum.COMPLIANCE_DATA_PROCESSING_AGREEMENTS,
     ],
   },
 ];
 
-const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfig[]; excluded: FeatureConfig[] }> = {
+const PLAN_FEATURES_CONFIG: Record<
+  ApiServiceLevelEnum,
+  { highlights: FeatureConfig[]; included: FeatureConfig[]; excluded: FeatureConfig[] }
+> = {
   [ApiServiceLevelEnum.FREE]: {
+    highlights: [
+      FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED,
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
+      FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
+    ],
     included: [
       FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED,
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
       FeatureNameEnum.PLATFORM_MAX_WORKFLOWS,
       FeatureNameEnum.PLATFORM_SUBSCRIBERS,
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
     ],
     excluded: [
       '30,000 workflow runs & more',
+      'More active conversations',
       'Unlimited workflows',
       FeatureNameEnum.CUSTOM_ENVIRONMENTS_BOOLEAN,
       'Dedicated support',
@@ -103,14 +116,21 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
     ],
   },
   [ApiServiceLevelEnum.PRO]: {
+    highlights: [
+      FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED,
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
+      FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
+    ],
     included: [
       FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED,
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
       FeatureNameEnum.PLATFORM_MAX_WORKFLOWS,
       FeatureNameEnum.PLATFORM_REMOVE_NOVU_BRANDING_BOOLEAN,
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
     ],
     excluded: [
       '250,000 workflow runs & more',
+      'More active conversations',
       'Unlimited workflows',
       FeatureNameEnum.CUSTOM_ENVIRONMENTS_BOOLEAN,
       FeatureNameEnum.WEBHOOKS,
@@ -118,8 +138,14 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
     ],
   },
   [ApiServiceLevelEnum.BUSINESS]: {
+    highlights: [
+      FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED,
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
+      FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
+    ],
     included: [
       FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED,
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
       FeatureNameEnum.PLATFORM_MAX_WORKFLOWS,
       FeatureNameEnum.ACCOUNT_MAX_TEAM_MEMBERS,
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
@@ -133,8 +159,10 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
     ],
   },
   [ApiServiceLevelEnum.ENTERPRISE]: {
+    highlights: ['Custom workflow runs', FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS, 'SAML SSO'],
     included: [
       'Volume discounts',
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
       FeatureNameEnum.PLATFORM_MAX_WORKFLOWS,
       FeatureNameEnum.ACCOUNT_MAX_TEAM_MEMBERS,
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
@@ -142,8 +170,10 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
     excluded: ['Being told "you need to upgrade"'],
   },
   [ApiServiceLevelEnum.UNLIMITED]: {
+    highlights: ['Custom workflow runs', FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS, 'SAML SSO'],
     included: [
       'Custom workflow runs',
+      FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS,
       FeatureNameEnum.PLATFORM_MAX_WORKFLOWS,
       FeatureNameEnum.ACCOUNT_MAX_TEAM_MEMBERS,
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
@@ -185,9 +215,9 @@ export function getPlanFeatures(plan: ApiServiceLevelEnum): { included: PlanFeat
   return { included, excluded };
 }
 
-// Get just the included features for plan highlights (for plan cards)
+// Get just the highlight features for plan cards (compact 3-line summary)
 export function getPlanHighlightFeatures(plan: ApiServiceLevelEnum): string[] {
   const config = PLAN_FEATURES_CONFIG[plan];
 
-  return config.included.map((feature: FeatureConfig) => getFeatureDisplayText(feature, plan));
+  return config.highlights.map((feature: FeatureConfig) => getFeatureDisplayText(feature, plan));
 }

--- a/apps/dashboard/src/components/billing/features.tsx
+++ b/apps/dashboard/src/components/billing/features.tsx
@@ -34,6 +34,21 @@ function getFeatureDisplay(featureName: FeatureNameEnum, plan: ApiServiceLevelEn
 function FeatureItem({ featureName, plan }: { featureName: FeatureNameEnum; plan: ApiServiceLevelEnum }) {
   const { content, disabled } = getFeatureDisplay(featureName, plan);
 
+  // Conversation overage is shown for transparency but not charged yet — concrete
+  // prices (Pro/Business) render struck-through with a "Free for now" note. Free
+  // ("No additional conversations") and Enterprise ("Custom …") fall through to
+  // normal rendering.
+  const isOverage = featureName === FeatureNameEnum.AGENT_COST_PER_ADDITIONAL_CONVERSATION;
+  if (isOverage && typeof content === 'string' && content.startsWith('$')) {
+    return (
+      <div className="flex items-center gap-2 text-label-xs text-text-sub">
+        <Check className="h-3 w-3" />
+        <span className="text-text-soft line-through">{content}</span>
+        <span className="text-text-sub">Free for now</span>
+      </div>
+    );
+  }
+
   return (
     <div className={`flex items-center gap-2 text-label-xs ${disabled ? 'text-text-disabled' : 'text-text-sub'}`}>
       {typeof content === 'string' ? (

--- a/apps/dashboard/src/components/billing/features.tsx
+++ b/apps/dashboard/src/components/billing/features.tsx
@@ -34,21 +34,6 @@ function getFeatureDisplay(featureName: FeatureNameEnum, plan: ApiServiceLevelEn
 function FeatureItem({ featureName, plan }: { featureName: FeatureNameEnum; plan: ApiServiceLevelEnum }) {
   const { content, disabled } = getFeatureDisplay(featureName, plan);
 
-  // Conversation overage is shown for transparency but not charged yet — concrete
-  // prices (Pro/Business) render struck-through with a "Free for now" note. Free
-  // ("No additional conversations") and Enterprise ("Custom …") fall through to
-  // normal rendering.
-  const isOverage = featureName === FeatureNameEnum.AGENT_COST_PER_ADDITIONAL_CONVERSATION;
-  if (isOverage && typeof content === 'string' && content.startsWith('$')) {
-    return (
-      <div className="flex items-center gap-2 text-label-xs text-text-sub">
-        <Check className="h-3 w-3" />
-        <span className="text-text-soft line-through">{content}</span>
-        <span className="text-text-sub">Free for now</span>
-      </div>
-    );
-  }
-
   return (
     <div className={`flex items-center gap-2 text-label-xs ${disabled ? 'text-text-disabled' : 'text-text-sub'}`}>
       {typeof content === 'string' ? (

--- a/apps/dashboard/src/components/side-navigation/usage-card.tsx
+++ b/apps/dashboard/src/components/side-navigation/usage-card.tsx
@@ -43,9 +43,11 @@ export function UsageCard({ subscription }: UsageCardProps) {
   // Only show conversations when the tier has a finite included limit
   // (unlimited tiers don't need the nudge).
   if (conversationUsage && conversationUsage.included !== null) {
+    // Keep the raw current value so over-limit usage (e.g. 1,200 / 1,000) is
+    // visible; the progress bar is clamped separately in `getUsagePercentage`.
     metrics.push({
       label: 'Conversations',
-      current: Math.min(conversationUsage.current, conversationUsage.included),
+      current: conversationUsage.current,
       max: conversationUsage.included,
     });
   }

--- a/apps/dashboard/src/components/side-navigation/usage-card.tsx
+++ b/apps/dashboard/src/components/side-navigation/usage-card.tsx
@@ -2,6 +2,7 @@ import { GetSubscriptionDto } from '@novu/shared';
 import { format } from 'date-fns';
 import { RiCalendarEventLine, RiErrorWarningLine } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
+import { useFetchConversationUsage } from '@/hooks/use-fetch-conversation-usage';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -13,12 +14,19 @@ type UsageStatus = {
   isComplete: boolean;
 };
 
+type UsageMetric = {
+  label: string;
+  current: number;
+  max: number;
+};
+
 export type UsageCardProps = {
   subscription: GetSubscriptionDto | undefined;
 };
 
 export function UsageCard({ subscription }: UsageCardProps) {
   const track = useTelemetry();
+  const { conversationUsage } = useFetchConversationUsage();
 
   if (!subscription) {
     return null;
@@ -27,6 +35,20 @@ export function UsageCard({ subscription }: UsageCardProps) {
   const currentEvents = subscription.events?.current ?? 0;
   const maxEvents = subscription.events?.included ?? 10000;
   const resetDate = subscription.currentPeriodEnd ?? null;
+
+  const metrics: UsageMetric[] = [
+    { label: 'Workflow Runs', current: Math.min(currentEvents, maxEvents), max: maxEvents },
+  ];
+
+  // Only show conversations when the tier has a finite included limit
+  // (unlimited tiers don't need the nudge).
+  if (conversationUsage && conversationUsage.included !== null) {
+    metrics.push({
+      label: 'Conversations',
+      current: Math.min(conversationUsage.current, conversationUsage.included),
+      max: conversationUsage.included,
+    });
+  }
 
   const handleUsageCardClick = () => {
     track(TelemetryEvent.USAGE_CARD_CLICKED, {
@@ -40,14 +62,10 @@ export function UsageCard({ subscription }: UsageCardProps) {
   return (
     <Link
       to={ROUTES.SETTINGS_BILLING}
-      className="bg-bg-white group relative mb-2 flex h-[58px] cursor-pointer flex-col rounded-lg"
+      className="bg-bg-white group relative mb-2 flex min-h-[58px] cursor-pointer flex-col rounded-lg"
       onClick={handleUsageCardClick}
     >
-      <CardContent
-        currentEvents={currentEvents > maxEvents ? maxEvents : currentEvents}
-        maxEvents={maxEvents}
-        resetDate={resetDate}
-      />
+      <CardContent metrics={metrics} resetDate={resetDate} />
     </Link>
   );
 }
@@ -67,59 +85,70 @@ const getUsageStatus = (current: number, limit: number): UsageStatus => {
   };
 };
 
+function UsageMetricRow({ label, current, max }: UsageMetric) {
+  const percentage = getUsagePercentage(current, max);
+  const { progressVariant, isComplete } = getUsageStatus(current, max);
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center">
+        {isComplete ? (
+          <span className="text-error-base text-label-xs flex items-center gap-1">
+            <RiErrorWarningLine className="size-3.5" />
+            {label} limit reached
+          </span>
+        ) : (
+          <span className="text-label-xs">{label}</span>
+        )}
+        <span className="text-foreground-600 text-label-xs ml-auto text-[12px]">
+          {formatNumber(current)} / <span className="text-text-soft">{formatNumber(max)}</span>
+        </span>
+      </div>
+      <Progress value={percentage} max={100} variant={progressVariant} className="h-1 rounded-lg" />
+    </div>
+  );
+}
+
 type CardContentProps = {
-  currentEvents: number;
-  maxEvents: number;
+  metrics: UsageMetric[];
   resetDate: string | null;
 };
 
-function CardContent({ currentEvents, maxEvents, resetDate }: CardContentProps) {
-  const percentage = getUsagePercentage(currentEvents, maxEvents);
-  const { progressVariant, isComplete } = getUsageStatus(currentEvents, maxEvents);
+function CardContent({ metrics, resetDate }: CardContentProps) {
+  const anyComplete = metrics.some((metric) => getUsageStatus(metric.current, metric.max).isComplete);
   const formattedResetDate = resetDate ? format(new Date(resetDate), 'MMM d yyyy') : '';
 
   return (
     <div className="relative flex flex-col overflow-hidden p-2">
-      <div className="flex items-center">
-        {!isComplete ? (
-          <>
-            <span className="text-label-xs">Workflow Runs</span>
-          </>
-        ) : (
-          <>
-            <span className="text-error-base text-label-xs flex items-center gap-1">
-              <RiErrorWarningLine className="size-3.5" />
-              Usage limit reached
-            </span>
-          </>
+      <div
+        className={
+          anyComplete
+            ? 'space-y-2'
+            : 'space-y-2 transition-all duration-200 ease-out group-hover:translate-y-[-8px] group-hover:opacity-0'
+        }
+      >
+        {metrics.map((metric) => (
+          <UsageMetricRow key={metric.label} {...metric} />
+        ))}
+        {formattedResetDate && (
+          <span className="text-text-soft text-label-xs flex items-center gap-1 leading-[16px]">
+            <RiCalendarEventLine className="size-3.5" />
+            Usage resets on {formattedResetDate}
+          </span>
         )}
-        <span className="text-foreground-600 text-label-xs ml-auto text-[12px]">
-          {formatNumber(currentEvents)} / <span className="text-text-soft">{formatNumber(maxEvents)}</span>
-        </span>
       </div>
 
-      {!isComplete ? (
-        <>
-          <div className="mt-1 space-y-1 transition-all duration-200 ease-out group-hover:translate-y-[-8px] group-hover:opacity-0">
-            <Progress value={percentage} max={100} variant={progressVariant} className="h-1 rounded-lg" />
-            <span className="text-text-soft text-label-xs flex items-center gap-1 leading-[16px]">
-              <RiCalendarEventLine className="size-3.5" />
-              Usage resets on {formattedResetDate}
-            </span>
-          </div>
-          <div className="absolute bottom-2 left-2 right-2 translate-y-[10px] opacity-0 transition-all duration-300 ease-out group-hover:translate-y-0 group-hover:opacity-100">
-            <Button className="h-[24px] w-full" variant="secondary" mode="lighter" size="2xs">
-              Upgrade now
-            </Button>
-          </div>
-        </>
-      ) : (
-        <div className="mt-1">
-          <Button className="h-[24px] w-full" variant="secondary" mode="lighter" size="2xs">
-            Upgrade now
-          </Button>
-        </div>
-      )}
+      <div
+        className={
+          anyComplete
+            ? 'mt-2'
+            : 'absolute bottom-2 left-2 right-2 translate-y-[10px] opacity-0 transition-all duration-300 ease-out group-hover:translate-y-0 group-hover:opacity-100'
+        }
+      >
+        <Button className="h-[24px] w-full" variant="secondary" mode="lighter" size="2xs">
+          Upgrade now
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/hooks/use-fetch-conversation-usage.ts
+++ b/apps/dashboard/src/hooks/use-fetch-conversation-usage.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { type ConversationUsage, getConversationUsage } from '@/api/agents';
+import { useAuth } from '@/context/auth/hooks';
+import { useEnvironment } from '@/context/environment/hooks';
+import { QueryKeys } from '@/utils/query-keys';
+
+export const useFetchConversationUsage = () => {
+  const { currentOrganization } = useAuth();
+  const { currentEnvironment } = useEnvironment();
+
+  const { data: conversationUsage, isLoading } = useQuery<ConversationUsage>({
+    queryKey: [QueryKeys.fetchConversationUsage, currentOrganization?._id, currentEnvironment?._id],
+    queryFn: ({ signal }) => getConversationUsage(currentEnvironment!, signal),
+    enabled: !!currentOrganization && !!currentEnvironment,
+    meta: {
+      showError: false,
+    },
+  });
+
+  return {
+    conversationUsage,
+    isLoading,
+  };
+};

--- a/apps/dashboard/src/hooks/use-fetch-conversation-usage.ts
+++ b/apps/dashboard/src/hooks/use-fetch-conversation-usage.ts
@@ -9,7 +9,8 @@ export const useFetchConversationUsage = () => {
   const { currentEnvironment } = useEnvironment();
 
   const { data: conversationUsage, isLoading } = useQuery<ConversationUsage>({
-    queryKey: [QueryKeys.fetchConversationUsage, currentOrganization?._id, currentEnvironment?._id],
+    // Org-scoped data (counts org-wide) — environment is not part of the identity.
+    queryKey: [QueryKeys.fetchConversationUsage, currentOrganization?._id],
     queryFn: ({ signal }) => getConversationUsage(currentEnvironment!, signal),
     enabled: !!currentOrganization && !!currentEnvironment,
     meta: {

--- a/apps/dashboard/src/utils/query-keys.ts
+++ b/apps/dashboard/src/utils/query-keys.ts
@@ -11,6 +11,7 @@ export const QueryKeys = Object.freeze({
   fetchActivity: 'fetchActivity',
   fetchActivities: 'fetchActivities',
   fetchWorkflowRunsCount: 'fetchWorkflowRunsCount',
+  fetchConversationUsage: 'fetchConversationUsage',
   fetchSubscribers: 'fetchSubscribers',
   fetchSubscriber: 'fetchSubscriber',
   fetchSubscriberPreferences: 'fetchSubscriberPreferences',

--- a/libs/application-generic/src/services/agent-entitlements.service.ts
+++ b/libs/application-generic/src/services/agent-entitlements.service.ts
@@ -422,7 +422,7 @@ export class AgentEntitlementsService {
     this.runtimeLimitCache.set(cacheKey, { value, expiresAt: Date.now() + RUNTIME_LIMIT_CACHE_TTL_MS });
   }
 
-  private async getApiServiceLevel(organizationId: string): Promise<ApiServiceLevelEnum> {
+  async getApiServiceLevel(organizationId: string): Promise<ApiServiceLevelEnum> {
     const organization = await this.organizationRepository.findById(organizationId, '_id apiServiceLevel');
 
     return organization?.apiServiceLevel || ApiServiceLevelEnum.FREE;

--- a/libs/application-generic/src/services/agent-entitlements.service.ts
+++ b/libs/application-generic/src/services/agent-entitlements.service.ts
@@ -225,6 +225,26 @@ export class AgentEntitlementsService {
   }
 
   /**
+   * Resolves the organization's active-conversations / month limit straight from
+   * the plan tier table — no platform/system cap and no per-org LaunchDarkly
+   * override. A value `>= UNLIMITED_VALUE` means unlimited (Enterprise/Unlimited
+   * tiers): paid customers are never capped, only Free is short-circuited.
+   * Counting still runs self-hosted, but the limit is never binding there.
+   */
+  async getActiveConversationsLimit(
+    organizationId: string,
+    knownApiServiceLevel?: ApiServiceLevelEnum
+  ): Promise<number> {
+    if (this.isSelfHosted) {
+      return UNLIMITED_VALUE;
+    }
+
+    const apiServiceLevel = knownApiServiceLevel ?? (await this.getApiServiceLevel(organizationId));
+
+    return getFeatureForTierAsNumber(FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS, apiServiceLevel);
+  }
+
+  /**
    * Snapshot of the environment's agent usage against the organization's plan
    * limit, including which agents are within limit when the environment is over
    * it. Limits resolve at the organization level; usage counts per environment

--- a/libs/dal/src/index.ts
+++ b/libs/dal/src/index.ts
@@ -11,6 +11,7 @@ export * from './repositories/channel-endpoint';
 export * from './repositories/context';
 export * from './repositories/control-values';
 export * from './repositories/conversation';
+export * from './repositories/conversation-activation';
 export * from './repositories/conversation-activity';
 export * from './repositories/domain';
 export * from './repositories/domain-route';

--- a/libs/dal/src/repositories/conversation-activation/conversation-activation.entity.ts
+++ b/libs/dal/src/repositories/conversation-activation/conversation-activation.entity.ts
@@ -1,0 +1,56 @@
+import { ChangePropsValueType } from '../../types/helpers';
+import { EnvironmentId } from '../environment';
+import { OrganizationId } from '../organization';
+
+/** Why an engagement was counted as a new active conversation. */
+export enum ConversationActivationReasonEnum {
+  /** First agent engagement on a brand-new conversation. */
+  NEW = 'new',
+  /** Agent engaged after the conversation had been resolved. */
+  REOPEN = 'reopen',
+  /** Agent engaged after the rolling inactivity window had lapsed. */
+  WINDOW_EXPIRED = 'window_expired',
+  /** Agent engaged on a continuing conversation in a new billing period. */
+  NEW_CYCLE = 'new_cycle',
+}
+
+/** Whether the thread the activation occurred on is a direct message or a group. */
+export enum ConversationThreadKindEnum {
+  DIRECT = 'direct',
+  GROUP = 'group',
+}
+
+/**
+ * Append-only audit record of a counted active-conversation activation. One row
+ * is written each time `ConversationActivationService` counts a conversation as
+ * active. The per-organization, per-period count of these rows is the usage
+ * number surfaced to billing and the dashboard.
+ */
+export class ConversationActivationEntity {
+  _id: string;
+
+  _conversationId: string;
+
+  _agentId: string;
+
+  /** Platform slug the activation occurred on (slack | whatsapp | telegram | email | teams). */
+  platform: string;
+
+  threadKind: ConversationThreadKindEnum;
+
+  reason: ConversationActivationReasonEnum;
+
+  /** Billing period key (YYYY-MM, UTC) this activation is counted against. */
+  periodKey: string;
+
+  _environmentId: EnvironmentId;
+
+  _organizationId: OrganizationId;
+
+  createdAt: string;
+}
+
+export type ConversationActivationDBModel = ChangePropsValueType<
+  ConversationActivationEntity,
+  '_conversationId' | '_agentId' | '_environmentId' | '_organizationId'
+>;

--- a/libs/dal/src/repositories/conversation-activation/conversation-activation.repository.ts
+++ b/libs/dal/src/repositories/conversation-activation/conversation-activation.repository.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { EnforceEnvOrOrgIds } from '../../types';
+import { BaseRepositoryV2 } from '../base-repository-v2';
+import {
+  ConversationActivationDBModel,
+  ConversationActivationEntity,
+  ConversationActivationReasonEnum,
+  ConversationThreadKindEnum,
+} from './conversation-activation.entity';
+import { ConversationActivation } from './conversation-activation.schema';
+
+@Injectable()
+export class ConversationActivationRepository extends BaseRepositoryV2<
+  ConversationActivationDBModel,
+  ConversationActivationEntity,
+  EnforceEnvOrOrgIds
+> {
+  constructor() {
+    super(ConversationActivation, ConversationActivationEntity);
+  }
+
+  async recordActivation(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    agentId: string;
+    platform: string;
+    threadKind: ConversationThreadKindEnum;
+    reason: ConversationActivationReasonEnum;
+    periodKey: string;
+  }): Promise<void> {
+    await this.create({
+      _conversationId: params.conversationId,
+      _agentId: params.agentId,
+      platform: params.platform,
+      threadKind: params.threadKind,
+      reason: params.reason,
+      periodKey: params.periodKey,
+      _environmentId: params.environmentId,
+      _organizationId: params.organizationId,
+    });
+  }
+
+  /**
+   * Counts active conversations for an organization in a billing period.
+   * Pass `limit` (e.g. `planLimit + 1`) so the count short-circuits instead of
+   * scanning the entire period when only "at/over limit" matters.
+   */
+  async countForOrganizationPeriod(organizationId: string, periodKey: string, limit?: number): Promise<number> {
+    return this.count({ _organizationId: organizationId, periodKey }, limit);
+  }
+}

--- a/libs/dal/src/repositories/conversation-activation/conversation-activation.schema.ts
+++ b/libs/dal/src/repositories/conversation-activation/conversation-activation.schema.ts
@@ -1,0 +1,60 @@
+import mongoose, { Schema } from 'mongoose';
+import { schemaOptions } from '../schema-default.options';
+import {
+  ConversationActivationDBModel,
+  ConversationActivationReasonEnum,
+  ConversationThreadKindEnum,
+} from './conversation-activation.entity';
+
+const conversationActivationSchema = new Schema<ConversationActivationDBModel>(
+  {
+    _conversationId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Conversation',
+      required: true,
+    },
+    _agentId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+    },
+    platform: {
+      type: Schema.Types.String,
+      required: true,
+    },
+    threadKind: {
+      type: Schema.Types.String,
+      enum: Object.values(ConversationThreadKindEnum),
+      required: true,
+    },
+    reason: {
+      type: Schema.Types.String,
+      enum: Object.values(ConversationActivationReasonEnum),
+      required: true,
+    },
+    periodKey: {
+      type: Schema.Types.String,
+      required: true,
+    },
+    _environmentId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Environment',
+      required: true,
+    },
+    _organizationId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
+  },
+  schemaOptions
+);
+
+// Primary read pattern: count activations for an organization in a billing period.
+conversationActivationSchema.index({ _organizationId: 1, periodKey: 1 });
+// Per-environment usage breakdowns and conversation-scoped lookups.
+conversationActivationSchema.index({ _environmentId: 1, periodKey: 1 });
+conversationActivationSchema.index({ _conversationId: 1, createdAt: 1 });
+
+export const ConversationActivation =
+  (mongoose.models.ConversationActivation as mongoose.Model<ConversationActivationDBModel>) ||
+  mongoose.model<ConversationActivationDBModel>('ConversationActivation', conversationActivationSchema);

--- a/libs/dal/src/repositories/conversation-activation/index.ts
+++ b/libs/dal/src/repositories/conversation-activation/index.ts
@@ -1,0 +1,3 @@
+export * from './conversation-activation.entity';
+export * from './conversation-activation.repository';
+export * from './conversation-activation.schema';

--- a/libs/dal/src/repositories/conversation/billing-activation-rules.ts
+++ b/libs/dal/src/repositories/conversation/billing-activation-rules.ts
@@ -1,0 +1,84 @@
+import { ConversationActivationReasonEnum } from '../conversation-activation/conversation-activation.entity';
+import { ConversationBillingState } from './conversation.entity';
+
+/**
+ * Inputs the activation rules are evaluated against. `windowThresholdIso` is the
+ * ISO timestamp before which the last engagement counts as "window expired"
+ * (i.e. `now - rollingWindow`), computed by the caller from the channel's window.
+ */
+export interface ActivationRuleParams {
+  /** The billing period key the conversation would be counted against now. */
+  periodKey: string;
+  /** ISO timestamp; an engagement older than this has lapsed its rolling window. */
+  windowThresholdIso: string;
+}
+
+/**
+ * Single source of truth for "does this engagement start a new active
+ * conversation?". Each rule colocates its two encodings — the MongoDB fragment
+ * used by the atomic write-claim (`startActivationIfNeeded`) and the in-memory
+ * predicate used by the read-only gate (`classifyActivation`) — so the two
+ * paths cannot silently diverge. Order encodes reason priority
+ * (NEW > REOPEN > NEW_CYCLE > WINDOW_EXPIRED); for the count decision only
+ * "any rule matches" matters, the order just picks the audit reason.
+ *
+ * Keep `toMongo` and `matches` semantically equivalent — `billing-activation-rules.spec.ts`
+ * locks this with a state matrix.
+ */
+interface ActivationRule {
+  reason: ConversationActivationReasonEnum;
+  toMongo(params: ActivationRuleParams): Record<string, unknown>;
+  matches(billing: ConversationBillingState | undefined, params: ActivationRuleParams): boolean;
+}
+
+export const ACTIVATION_RULES: ActivationRule[] = [
+  {
+    // Never counted before (brand-new conversation, or post-resolve with billing cleared).
+    reason: ConversationActivationReasonEnum.NEW,
+    toMongo: () => ({ 'billing.lastCountedPeriodKey': { $exists: false } }),
+    matches: (billing) => !billing?.lastCountedPeriodKey,
+  },
+  {
+    // Resolved since it was last counted — the next engagement is a reopen.
+    reason: ConversationActivationReasonEnum.REOPEN,
+    toMongo: () => ({ 'billing.resolvedAt': { $exists: true } }),
+    matches: (billing) => Boolean(billing?.resolvedAt),
+  },
+  {
+    // Continuing conversation, but a new billing period has begun.
+    reason: ConversationActivationReasonEnum.NEW_CYCLE,
+    toMongo: (params) => ({ 'billing.lastCountedPeriodKey': { $ne: params.periodKey } }),
+    matches: (billing, params) =>
+      Boolean(billing?.lastCountedPeriodKey) && billing?.lastCountedPeriodKey !== params.periodKey,
+  },
+  {
+    // Continuing conversation, same period, but the rolling window has lapsed.
+    reason: ConversationActivationReasonEnum.WINDOW_EXPIRED,
+    toMongo: (params) => ({ 'billing.lastEngagementAt': { $lt: params.windowThresholdIso } }),
+    matches: (billing, params) =>
+      billing?.lastEngagementAt !== undefined && billing.lastEngagementAt < params.windowThresholdIso,
+  },
+];
+
+/**
+ * Builds the `$or` clause for the atomic activation claim. The conditions are
+ * order-independent for matching — any match means a new activation should be
+ * counted.
+ */
+export function buildActivationOrConditions(params: ActivationRuleParams): Record<string, unknown>[] {
+  return ACTIVATION_RULES.map((rule) => rule.toMongo(params));
+}
+
+/**
+ * Read-only classification mirroring `buildActivationOrConditions`. Returns the
+ * highest-priority reason the engagement would start a new activation under, or
+ * `null` if it falls inside the current activation.
+ */
+export function classifyActivationReason(
+  billing: ConversationBillingState | undefined,
+  params: ActivationRuleParams
+): ConversationActivationReasonEnum | null {
+  const rule = ACTIVATION_RULES.find((candidate) => candidate.matches(billing, params));
+
+  return rule ? rule.reason : null;
+}

--- a/libs/dal/src/repositories/conversation/conversation.entity.ts
+++ b/libs/dal/src/repositories/conversation/conversation.entity.ts
@@ -125,6 +125,13 @@ export class ConversationEntity {
   /** Active-conversations billing/metering state — see `ConversationBillingState`. */
   billing?: ConversationBillingState;
 
+  /**
+   * Whether the primary channel thread is a direct message (vs a group/channel),
+   * captured from the platform at creation. Drives the rolling-window selection
+   * for active-conversation counting on paths without a live thread (outbound).
+   */
+  isDirectMessage?: boolean;
+
   _environmentId: EnvironmentId;
 
   _organizationId: OrganizationId;

--- a/libs/dal/src/repositories/conversation/conversation.entity.ts
+++ b/libs/dal/src/repositories/conversation/conversation.entity.ts
@@ -45,6 +45,28 @@ export interface PendingManagedAgentSetup {
   setupMessageId?: string;
 }
 
+/**
+ * Active-conversations billing state. An "active conversation" is counted once
+ * per activation episode: the first time an agent engages on a (re)opened
+ * thread, again after a rolling inactivity window lapses, and again whenever a
+ * new billing period begins. These fields let `ConversationActivationService`
+ * decide idempotently whether an engagement starts a new activation without
+ * scanning the activity log.
+ */
+export interface ConversationBillingState {
+  /** Period key (YYYY-MM, UTC) the conversation was last counted in. */
+  lastCountedPeriodKey?: string;
+  /** ISO timestamp of the most recent counted agent engagement — anchors the rolling window. */
+  lastEngagementAt?: string;
+  /** ISO timestamp the current activation episode began. */
+  activationStartedAt?: string;
+  /**
+   * ISO timestamp set when the conversation is resolved. While present, the next
+   * agent engagement is counted as a reopen activation. Cleared when counted.
+   */
+  resolvedAt?: string;
+}
+
 export class ConversationEntity {
   _id: string;
 
@@ -99,6 +121,9 @@ export class ConversationEntity {
   pendingManagedAgentSetup?: PendingManagedAgentSetup;
 
   tokenUsage?: ConversationTokenUsage;
+
+  /** Active-conversations billing/metering state — see `ConversationBillingState`. */
+  billing?: ConversationBillingState;
 
   _environmentId: EnvironmentId;
 

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -4,6 +4,7 @@ import { type ClientSession, FilterQuery, Types } from 'mongoose';
 import { EnforceEnvOrOrgIds } from '../../types';
 import { SortOrder } from '../../types/sort-order';
 import { BaseRepositoryV2 } from '../base-repository-v2';
+import { buildActivationOrConditions } from './billing-activation-rules';
 import {
   ConversationDBModel,
   ConversationEntity,
@@ -325,12 +326,11 @@ export class ConversationRepository extends BaseRepositoryV2<
         _id: params.conversationId,
         _environmentId: params.environmentId,
         _organizationId: params.organizationId,
-        $or: [
-          { 'billing.lastCountedPeriodKey': { $exists: false } },
-          { 'billing.resolvedAt': { $exists: true } },
-          { 'billing.lastCountedPeriodKey': { $ne: params.periodKey } },
-          { 'billing.lastEngagementAt': { $lt: params.windowThresholdIso } },
-        ],
+        // Single source of truth shared with `classifyActivationReason` — see billing-activation-rules.ts.
+        $or: buildActivationOrConditions({
+          periodKey: params.periodKey,
+          windowThresholdIso: params.windowThresholdIso,
+        }) as FilterQuery<ConversationDBModel>[],
       },
       {
         $set: {

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -298,6 +298,87 @@ export class ConversationRepository extends BaseRepositoryV2<
     );
   }
 
+  /**
+   * Atomically claims a new active-conversation activation for this billing
+   * period. Returns `true` only for the single caller that wins the race —
+   * MongoDB serializes `findOneAndUpdate`, so a concurrent engagement that
+   * arrives after the winner stamps the billing state re-evaluates the `$or`
+   * against the updated document and matches nothing.
+   *
+   * An engagement starts a new activation when any of the following hold:
+   *   - the conversation has never been counted (`lastCountedPeriodKey` absent);
+   *   - it was resolved since it was last counted (`resolvedAt` present) — reopen;
+   *   - it was last counted in a different billing period — new cycle;
+   *   - the rolling inactivity window has lapsed since the last engagement.
+   */
+  async startActivationIfNeeded(params: {
+    environmentId: string;
+    organizationId: string;
+    conversationId: string;
+    periodKey: string;
+    /** ISO timestamp; engagements older than this are window-expired. */
+    windowThresholdIso: string;
+    nowIso: string;
+  }): Promise<boolean> {
+    const updated = await this.findOneAndUpdate(
+      {
+        _id: params.conversationId,
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+        $or: [
+          { 'billing.lastCountedPeriodKey': { $exists: false } },
+          { 'billing.resolvedAt': { $exists: true } },
+          { 'billing.lastCountedPeriodKey': { $ne: params.periodKey } },
+          { 'billing.lastEngagementAt': { $lt: params.windowThresholdIso } },
+        ],
+      },
+      {
+        $set: {
+          'billing.lastCountedPeriodKey': params.periodKey,
+          'billing.lastEngagementAt': params.nowIso,
+          'billing.activationStartedAt': params.nowIso,
+        },
+        $unset: { 'billing.resolvedAt': '' },
+      }
+    );
+
+    return updated !== null;
+  }
+
+  /**
+   * Slides the rolling inactivity window forward without counting a new
+   * activation. Called for every engagement that did not start a new
+   * activation so a continuous thread keeps its window fresh.
+   */
+  async bumpLastEngagement(
+    environmentId: string,
+    organizationId: string,
+    conversationId: string,
+    nowIso: string
+  ): Promise<void> {
+    await this.update(
+      { _id: conversationId, _environmentId: environmentId, _organizationId: organizationId },
+      { $set: { 'billing.lastEngagementAt': nowIso } }
+    );
+  }
+
+  /**
+   * Marks the conversation resolved for billing so the next agent engagement is
+   * counted as a reopen activation. Paired with the status flip in
+   * `resolveConversation`.
+   */
+  async markBillingResolved(
+    environmentId: string,
+    organizationId: string,
+    conversationId: string,
+    nowIso: string
+  ): Promise<void> {
+    await this.update(
+      { _id: conversationId, _environmentId: environmentId, _organizationId: organizationId },
+      { $set: { 'billing.resolvedAt': nowIso } }
+    );
+  }
+
   async incrementTokenUsage(
     environmentId: string,
     organizationId: string,

--- a/libs/dal/src/repositories/conversation/conversation.schema.ts
+++ b/libs/dal/src/repositories/conversation/conversation.schema.ts
@@ -108,6 +108,17 @@ const conversationSchema = new Schema<ConversationDBModel>(
         { _id: false }
       ),
     },
+    billing: {
+      type: new Schema(
+        {
+          lastCountedPeriodKey: { type: Schema.Types.String },
+          lastEngagementAt: { type: Schema.Types.String },
+          activationStartedAt: { type: Schema.Types.String },
+          resolvedAt: { type: Schema.Types.String },
+        },
+        { _id: false }
+      ),
+    },
     lastActivityAt: {
       type: Schema.Types.String,
     },

--- a/libs/dal/src/repositories/conversation/conversation.schema.ts
+++ b/libs/dal/src/repositories/conversation/conversation.schema.ts
@@ -119,6 +119,9 @@ const conversationSchema = new Schema<ConversationDBModel>(
         { _id: false }
       ),
     },
+    isDirectMessage: {
+      type: Schema.Types.Boolean,
+    },
     lastActivityAt: {
       type: Schema.Types.String,
     },

--- a/libs/dal/src/repositories/conversation/index.ts
+++ b/libs/dal/src/repositories/conversation/index.ts
@@ -1,3 +1,4 @@
+export * from './billing-activation-rules';
 export * from './conversation.entity';
 export * from './conversation.repository';
 export * from './conversation.schema';

--- a/packages/shared/src/consts/feature-tiers-constants.ts
+++ b/packages/shared/src/consts/feature-tiers-constants.ts
@@ -75,6 +75,7 @@ export enum FeatureNameEnum {
   AGENT_MAX_AGENTS = 'agentMaxAgents',
   AGENT_MAX_ACTIVE_CHANNELS = 'agentMaxActiveChannels',
   AGENT_MAX_CUSTOM_EMAIL_DOMAINS = 'agentMaxCustomEmailDomains',
+  AGENT_MAX_ACTIVE_CONVERSATIONS = 'agentMaxActiveConversations',
 }
 
 /**
@@ -534,6 +535,13 @@ const novuServiceTiers: Record<FeatureNameEnum, Record<ApiServiceLevelEnum, Feat
     [ApiServiceLevelEnum.BUSINESS]: { label: 'Unlimited custom email domains', value: UNLIMITED_VALUE },
     [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Unlimited custom email domains', value: UNLIMITED_VALUE },
     [ApiServiceLevelEnum.UNLIMITED]: { label: 'Unlimited custom email domains', value: UNLIMITED_VALUE },
+  },
+  [FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS]: {
+    [ApiServiceLevelEnum.FREE]: { label: '100 active conversations / month', value: 5 },
+    [ApiServiceLevelEnum.PRO]: { label: '1,000 active conversations / month', value: 1000 },
+    [ApiServiceLevelEnum.BUSINESS]: { label: '5,000 active conversations / month', value: 5000 },
+    [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Unlimited active conversations', value: UNLIMITED_VALUE },
+    [ApiServiceLevelEnum.UNLIMITED]: { label: 'Unlimited active conversations', value: UNLIMITED_VALUE },
   },
 };
 

--- a/packages/shared/src/consts/feature-tiers-constants.ts
+++ b/packages/shared/src/consts/feature-tiers-constants.ts
@@ -544,7 +544,7 @@ const novuServiceTiers: Record<FeatureNameEnum, Record<ApiServiceLevelEnum, Feat
     [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Custom active conversations', value: UNLIMITED_VALUE },
     [ApiServiceLevelEnum.UNLIMITED]: { label: 'Custom active conversations', value: UNLIMITED_VALUE },
   },
-  // TODO: Product is in beta phase, Backend is not yet implemented. 
+  // TODO: Product is in beta phase, Backend is not yet implemented for overage pricing.
   [FeatureNameEnum.AGENT_COST_PER_ADDITIONAL_CONVERSATION]: {
     [ApiServiceLevelEnum.FREE]: { label: 'No additional conversations', value: null },
     [ApiServiceLevelEnum.PRO]: { label: '$0.03 per extra conversation', value: 0.03 },

--- a/packages/shared/src/consts/feature-tiers-constants.ts
+++ b/packages/shared/src/consts/feature-tiers-constants.ts
@@ -76,6 +76,7 @@ export enum FeatureNameEnum {
   AGENT_MAX_ACTIVE_CHANNELS = 'agentMaxActiveChannels',
   AGENT_MAX_CUSTOM_EMAIL_DOMAINS = 'agentMaxCustomEmailDomains',
   AGENT_MAX_ACTIVE_CONVERSATIONS = 'agentMaxActiveConversations',
+  AGENT_COST_PER_ADDITIONAL_CONVERSATION = 'agentCostPerAdditionalConversation',
 }
 
 /**
@@ -475,14 +476,14 @@ const novuServiceTiers: Record<FeatureNameEnum, Record<ApiServiceLevelEnum, Feat
     [ApiServiceLevelEnum.UNLIMITED]: 1,
   },
   [FeatureNameEnum.COMPLIANCE_HIPAA_BAA_BOOLEAN]: {
-    [ApiServiceLevelEnum.FREE]: { label: 'HIPAA compliance', value: false },
-    [ApiServiceLevelEnum.PRO]: { label: 'HIPAA compliance', value: false },
-    [ApiServiceLevelEnum.BUSINESS]: { label: 'HIPAA compliance', value: false },
+    [ApiServiceLevelEnum.FREE]: { label: 'No HIPAA compliance', value: false },
+    [ApiServiceLevelEnum.PRO]: { label: 'No HIPAA compliance', value: false },
+    [ApiServiceLevelEnum.BUSINESS]: { label: 'No HIPAA compliance', value: false },
     [ApiServiceLevelEnum.ENTERPRISE]: { label: 'HIPAA compliance', value: true },
     [ApiServiceLevelEnum.UNLIMITED]: { label: 'HIPAA compliance', value: true },
   },
   [FeatureNameEnum.COMPLIANCE_CUSTOM_SECURITY_REVIEWS]: {
-    [ApiServiceLevelEnum.FREE]: { label: 'Security reviews: SOC 2 and ISO 27001 upon request', value: true },
+    [ApiServiceLevelEnum.FREE]: { label: 'No security reviews', value: false },
     [ApiServiceLevelEnum.PRO]: { label: 'Security reviews: SOC 2 and ISO 27001 upon request', value: true },
     [ApiServiceLevelEnum.BUSINESS]: { label: 'Security reviews: SOC 2 and ISO 27001 upon request', value: true },
     [ApiServiceLevelEnum.ENTERPRISE]: {
@@ -532,16 +533,24 @@ const novuServiceTiers: Record<FeatureNameEnum, Record<ApiServiceLevelEnum, Feat
   [FeatureNameEnum.AGENT_MAX_CUSTOM_EMAIL_DOMAINS]: {
     [ApiServiceLevelEnum.FREE]: { label: 'No custom email domains', value: 0 },
     [ApiServiceLevelEnum.PRO]: { label: 'No custom email domains', value: 0 },
-    [ApiServiceLevelEnum.BUSINESS]: { label: 'Unlimited custom email domains', value: UNLIMITED_VALUE },
+    [ApiServiceLevelEnum.BUSINESS]: { label: 'Custom email domains', value: UNLIMITED_VALUE },
     [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Unlimited custom email domains', value: UNLIMITED_VALUE },
     [ApiServiceLevelEnum.UNLIMITED]: { label: 'Unlimited custom email domains', value: UNLIMITED_VALUE },
   },
   [FeatureNameEnum.AGENT_MAX_ACTIVE_CONVERSATIONS]: {
-    [ApiServiceLevelEnum.FREE]: { label: '100 active conversations / month', value: 5 },
-    [ApiServiceLevelEnum.PRO]: { label: '1,000 active conversations / month', value: 1000 },
-    [ApiServiceLevelEnum.BUSINESS]: { label: '5,000 active conversations / month', value: 5000 },
-    [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Unlimited active conversations', value: UNLIMITED_VALUE },
-    [ApiServiceLevelEnum.UNLIMITED]: { label: 'Unlimited active conversations', value: UNLIMITED_VALUE },
+    [ApiServiceLevelEnum.FREE]: { label: '100 active conversations included', value: 100 },
+    [ApiServiceLevelEnum.PRO]: { label: '1,000 active conversations included', value: 1000 },
+    [ApiServiceLevelEnum.BUSINESS]: { label: '5,000 active conversations included', value: 5000 },
+    [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Custom active conversations', value: UNLIMITED_VALUE },
+    [ApiServiceLevelEnum.UNLIMITED]: { label: 'Custom active conversations', value: UNLIMITED_VALUE },
+  },
+  // TODO: Product is in beta phase, Backend is not yet implemented. 
+  [FeatureNameEnum.AGENT_COST_PER_ADDITIONAL_CONVERSATION]: {
+    [ApiServiceLevelEnum.FREE]: { label: 'No additional conversations', value: null },
+    [ApiServiceLevelEnum.PRO]: { label: '$0.03 per extra conversation', value: 0.03 },
+    [ApiServiceLevelEnum.BUSINESS]: { label: '$0.02 per extra conversation', value: 0.02 },
+    [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Custom pricing for additional conversations', value: 0.015 },
+    [ApiServiceLevelEnum.UNLIMITED]: { label: 'Custom pricing for additional conversations', value: 0.015 },
   },
 };
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR adds active conversation metering and free-tier billing enforcement so agent-based conversations are counted per billing period and blocked from creation when an organization exceeds its included free limit. It introduces a conversation activation/audit trail to track when conversations become billable (with DM vs group handling), resolves billing when conversations end, and exposes a new usage endpoint for the dashboard. Dashboard billing UI is updated to show true conversation usage and over-limit visibility, backed by consistent plan-tier constants and correct Stripe period anchoring.

## Affected areas
**api**: Implements `ConversationActivationService`, integrates free-tier gating into inbound and outbound flows (`maybeBlockConversation`, outbound 402-style limit error), records engagement/activations, marks billing resolved on conversation resolution, and adds `GET /agents/usage/conversations`.
**dashboard**: Updates usage UI (side-navigation usage card/banner) to display conversation usage vs plan limits without clamping, and adds hooks/client logic to fetch the new usage endpoint.
**dal**: Adds a new append-only `ConversationActivation` audit model/repository plus conversation billing state fields (`billing` and `isDirectMessage`) and billing activation rule logic used for counting.
**shared**: Adds plan-tier constants for active-conversation limits and per-additional-conversation overage pricing, ensuring consistent enforcement and UI.

## Key technical decisions
- Conversation creation blocking happens **before persisting** new conversations to avoid orphaned records.
- Billing period keys use **Stripe period start timestamps** (not only month/year) to prevent miscounting across multiple periods in the same month.
- Activation counting uses ordered rule priority with a shared `classifyActivationReason`, and DM vs group determines rolling inactivity windows.

## Testing
Added/updated unit tests for activation-rule equivalence (Mongo filter vs in-memory predicate) and comprehensive e2e coverage for inbound metering, free-tier blocking behavior, usage endpoint output, and Stripe period anchoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds active-conversation metering for agent conversations, including activation classification, billing-period handling, and audit persistence.
- Enforces free-tier conversation limits through inbound and outbound agent engagement paths.
- Exposes conversation usage data for the dashboard and updates billing UI components to show conversation usage.
- Extends DAL schemas, shared feature constants, analytics, and tests for conversation-based billing behavior.

<h3>Confidence Score: 3/5</h3>

The billing implementation is close, but two conversation-creation paths bypass the new metering and limit checks.

The main metering design and tests cover the common message/reply paths, but action-only inbound threads and proactive welcome messages can still create billable conversations without updating usage.

apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts and apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I added a focused Mocha test that exercises AgentInboundHandler.handleAction with a non-link action and spies on maybeBlockConversation, createOrGetConversation, dispatch, and registerEngagement.
- Running the gate test was blocked due to Node.js and pnpm version constraints in the environment.
- I added a focused Mocha test for the SendAgentWelcomeMessage use case, spying on direct-message sending, conversation creation, outbound limit checks, engagement registration, and simulated usage counts.
- Running the welcome-use-case test was blocked by Node runtime and pnpm version issues, so test execution could not start.
- I collected and inspected the captured command-output artifacts from attempted runs to understand environment state and command results.
- I observed a 404 Not Found for /v1/agents/usage/conversations before changes and a 200 OK with current data after changes, informing expected API behavior.
- I saved intermedate artifacts for persistence and activation rules checks to inspect data states before and after transitions.
- I attempted runtime setup with pnpm install --frozen-lockfile but it failed due to a SyntaxError about node:util.styleText, so real UI rendering couldn't be produced.
- Because dependencies were missing, I switched to executable Node inspection scripts to read and report actual checked-out DAL/rule files from base/head worktrees.
- I documented that I could not produce real before/after UI screenshots without fabricating UI components given the environment constraints.

<a href="https://app.greptile.com/trex/runs/11369988/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts`, line 914-974 ([link](https://github.com/novuhq/novu/blob/421edf4262dfd1e16a9d9b7481994be81b16ca76/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts#L914-L974)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Gate action engagements**

   This action path creates or reopens a conversation and dispatches non-link actions without running the active-conversation gate or recording the engagement. A free organization at its conversation limit can still start an action-only thread, and successful action handlers that reply or resolve are never written to `ConversationActivation`, so usage and billing undercount. Mirror the message path here: check `maybeBlockConversation` before `createOrGetConversation`, then call `registerEngagement` after successful non-link dispatch.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
   Line: 914-974

   Comment:
   **Gate action engagements**

   This action path creates or reopens a conversation and dispatches non-link actions without running the active-conversation gate or recording the engagement. A free organization at its conversation limit can still start an action-only thread, and successful action handlers that reply or resolve are never written to `ConversationActivation`, so usage and billing undercount. Mirror the message path here: check `maybeBlockConversation` before `createOrGetConversation`, then call `registerEngagement` after successful non-link dispatch.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Fingress%2Finbound-turn.handler.ts%0ALine%3A%20914-974%0A%0AComment%3A%0A**Gate%20action%20engagements**%0A%0AThis%20action%20path%20creates%20or%20reopens%20a%20conversation%20and%20dispatches%20non-link%20actions%20without%20running%20the%20active-conversation%20gate%20or%20recording%20the%20engagement.%20A%20free%20organization%20at%20its%20conversation%20limit%20can%20still%20start%20an%20action-only%20thread%2C%20and%20successful%20action%20handlers%20that%20reply%20or%20resolve%20are%20never%20written%20to%20%60ConversationActivation%60%2C%20so%20usage%20and%20billing%20undercount.%20Mirror%20the%20message%20path%20here%3A%20check%20%60maybeBlockConversation%60%20before%20%60createOrGetConversation%60%2C%20then%20call%20%60registerEngagement%60%20after%20successful%20non-link%20dispatch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11582&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Fingress%2Finbound-turn.handler.ts%3A914-974%0A**Gate%20action%20engagements**%0A%0AThis%20action%20path%20creates%20or%20reopens%20a%20conversation%20and%20dispatches%20non-link%20actions%20without%20running%20the%20active-conversation%20gate%20or%20recording%20the%20engagement.%20A%20free%20organization%20at%20its%20conversation%20limit%20can%20still%20start%20an%20action-only%20thread%2C%20and%20successful%20action%20handlers%20that%20reply%20or%20resolve%20are%20never%20written%20to%20%60ConversationActivation%60%2C%20so%20usage%20and%20billing%20undercount.%20Mirror%20the%20message%20path%20here%3A%20check%20%60maybeBlockConversation%60%20before%20%60createOrGetConversation%60%2C%20then%20call%20%60registerEngagement%60%20after%20successful%20non-link%20dispatch.%0A%0A&pr=11582&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts:914-974
**Gate action engagements**

This action path creates or reopens a conversation and dispatches non-link actions without running the active-conversation gate or recording the engagement. A free organization at its conversation limit can still start an action-only thread, and successful action handlers that reply or resolve are never written to `ConversationActivation`, so usage and billing undercount. Mirror the message path here: check `maybeBlockConversation` before `createOrGetConversation`, then call `registerEngagement` after successful non-link dispatch.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(api): enhance conversation hand..."](https://github.com/novuhq/novu/commit/421edf4262dfd1e16a9d9b7481994be81b16ca76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37870058)</sub>

<!-- /greptile_comment -->