### PR TITLE
fix(api-service): improve WhatsApp agent watermark and MCP connect links fixes NV-8057

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -63,6 +63,7 @@ import { AgentRuntimeController } from './management/agent-runtime.controller';
 import { AgentsController } from './management/agents.controller';
 import { McpNovuAppCredentialsService } from './mcp/connections/get-mcp-novu-app-credentials/get-mcp-novu-app-credentials.service';
 import { McpConnectionVaultService } from './mcp/connections/mcp-connection-vault.service';
+import { McpConnectRedirectService } from './mcp/connections/mcp-connect-redirect.service';
 import { AgentsMcpOAuthController } from './mcp/oauth/agents-mcp-oauth.controller';
 import { McpOAuthDiscoveryService } from './mcp/oauth/mcp-oauth-discovery.service';
 import { AgentMcpDefinitionService } from './mcp/runtime/agent-mcp-definition.service';
@@ -120,6 +121,7 @@ import { USE_CASES } from './usecases';
     ManagedAgentEventHandler,
     ManagedAgentService,
     McpConnectionVaultService,
+    McpConnectRedirectService,
     AgentMcpDefinitionService,
     AgentMcpSessionService,
     NovuEmailCleanupService,

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -7,7 +7,10 @@ import { AgentConfigResolver, ResolvedAgentConfig } from '../../channels/agent-c
 import type { ReplyContentDto } from '../../shared/dtos/agent-reply-payload.dto';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { esmImport } from '../../shared/util/esm-import';
-import { buildAttributedNovuUrl } from '../../shared/util/novu-attribution-url';
+import {
+  buildPoweredByWatermark,
+  contentHasPoweredByWatermark,
+} from '../../shared/util/novu-powered-by-watermark';
 import { type AgentActionTokenBinding, AgentActionTokenService } from '../action-token/agent-action-token.service';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { ChatInstanceRegistry } from '../ingress/chat-instance.registry';
@@ -24,14 +27,6 @@ import {
 } from './slack-native-delivery';
 
 export type { SlackNativeDelivery } from './slack-native-delivery';
-
-/** Free-plan branding appended as the last line of outbound agent messages. */
-const NOVU_AGENT_POWERED_URL = 'https://go.novu.co/agent-powered';
-
-/** "Powered by Novu" watermark with per-message campaign attribution. */
-function buildPoweredByWatermark(agentIdentifier: string, platform: string): string {
-  return `[Powered by Novu](${buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform)})`;
-}
 
 /** The subset of the resolved config that drives outbound watermarking. */
 type OutboundBrandingContext = Pick<ResolvedAgentConfig, 'removeNovuBranding' | 'agentIdentifier' | 'platform'>;
@@ -526,7 +521,7 @@ export class OutboundGateway {
    * untouched.
    */
   private applyOutboundBranding(content: ChatSdkReplyContent, branding: OutboundBrandingContext): ChatSdkReplyContent {
-    if (content.card || !content.markdown || content.markdown.includes(NOVU_AGENT_POWERED_URL)) {
+    if (content.card || !content.markdown || contentHasPoweredByWatermark(content.markdown)) {
       return content;
     }
 

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.spec.ts
@@ -9,33 +9,11 @@ describe('buildConnectCardDelivery', () => {
     const connectRedirect = {
       issue: sinon.stub().resolves('https://api.example.com/v1/agents/mcp/r/short-token'),
     };
+    const authorizeUrl = 'https://app.attio.com/oidc/authorize?state=very-long';
 
-    const delivery = await buildConnectCardDelivery(
+    await buildConnectCardDelivery(
       {
         platform: AgentPlatformEnum.WHATSAPP,
-        mcpId: 'attio',
-        mcpName: 'Attio',
-        authorizeUrl: 'https://app.attio.com/oidc/authorize?state=very-long',
-      },
-      { connectRedirect }
-    );
-
-    expect(connectRedirect.issue.calledOnceWithExactly('https://app.attio.com/oidc/authorize?state=very-long')).to.equal(
-      true
-    );
-    expect((delivery.content.card as { children: Array<{ children: Array<{ url?: string }> }> }).children[1].children[0]
-      .url).to.equal('https://api.example.com/v1/agents/mcp/r/short-token');
-  });
-
-  it('keeps the authorize URL unchanged on Slack', async () => {
-    const connectRedirect = {
-      issue: sinon.stub(),
-    };
-    const authorizeUrl = 'https://provider.example/oauth/authorize?state=abc';
-
-    const delivery = await buildConnectCardDelivery(
-      {
-        platform: AgentPlatformEnum.SLACK,
         mcpId: 'attio',
         mcpName: 'Attio',
         authorizeUrl,
@@ -43,9 +21,25 @@ describe('buildConnectCardDelivery', () => {
       { connectRedirect }
     );
 
+    expect(connectRedirect.issue.calledOnceWithExactly(authorizeUrl)).to.equal(true);
+  });
+
+  it('keeps the authorize URL unchanged on Slack', async () => {
+    const connectRedirect = {
+      issue: sinon.stub(),
+    };
+
+    const delivery = await buildConnectCardDelivery(
+      {
+        platform: AgentPlatformEnum.SLACK,
+        mcpId: 'attio',
+        mcpName: 'Attio',
+        authorizeUrl: 'https://provider.example/oauth/authorize?state=abc',
+      },
+      { connectRedirect }
+    );
+
     expect(connectRedirect.issue.called).to.equal(false);
-    expect((delivery.content.card as { children: Array<{ children: Array<{ url?: string }> }> }).children[1].children[0]
-      .url).to.equal(authorizeUrl);
     expect(delivery.slackNative).to.not.equal(undefined);
   });
 });

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.spec.ts
@@ -5,13 +5,21 @@ import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { buildConnectCardDelivery } from './connect-card.builder';
 
 describe('buildConnectCardDelivery', () => {
+  function getConnectButtonUrl(delivery: Awaited<ReturnType<typeof buildConnectCardDelivery>>): string | undefined {
+    const card = delivery.content.card;
+    const actions = card?.children?.find((child) => child.type === 'actions');
+
+    return actions?.children?.find((action) => action.type === 'link-button')?.url;
+  }
+
   it('shortens the authorize URL on WhatsApp before building the card', async () => {
+    const shortUrl = 'https://api.example.com/v1/agents/mcp/r/short-token';
     const connectRedirect = {
-      issue: sinon.stub().resolves('https://api.example.com/v1/agents/mcp/r/short-token'),
+      issue: sinon.stub().resolves(shortUrl),
     };
     const authorizeUrl = 'https://app.attio.com/oidc/authorize?state=very-long';
 
-    await buildConnectCardDelivery(
+    const delivery = await buildConnectCardDelivery(
       {
         platform: AgentPlatformEnum.WHATSAPP,
         mcpId: 'attio',
@@ -22,6 +30,7 @@ describe('buildConnectCardDelivery', () => {
     );
 
     expect(connectRedirect.issue.calledOnceWithExactly(authorizeUrl)).to.equal(true);
+    expect(getConnectButtonUrl(delivery)).to.equal(shortUrl);
   });
 
   it('keeps the authorize URL unchanged on Slack', async () => {

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { buildConnectCardDelivery } from './connect-card.builder';
+
+describe('buildConnectCardDelivery', () => {
+  it('shortens the authorize URL on WhatsApp before building the card', async () => {
+    const connectRedirect = {
+      issue: sinon.stub().resolves('https://api.example.com/v1/agents/mcp/r/short-token'),
+    };
+
+    const delivery = await buildConnectCardDelivery(
+      {
+        platform: AgentPlatformEnum.WHATSAPP,
+        mcpId: 'attio',
+        mcpName: 'Attio',
+        authorizeUrl: 'https://app.attio.com/oidc/authorize?state=very-long',
+      },
+      { connectRedirect }
+    );
+
+    expect(connectRedirect.issue.calledOnceWithExactly('https://app.attio.com/oidc/authorize?state=very-long')).to.equal(
+      true
+    );
+    expect((delivery.content.card as { children: Array<{ children: Array<{ url?: string }> }> }).children[1].children[0]
+      .url).to.equal('https://api.example.com/v1/agents/mcp/r/short-token');
+  });
+
+  it('keeps the authorize URL unchanged on Slack', async () => {
+    const connectRedirect = {
+      issue: sinon.stub(),
+    };
+    const authorizeUrl = 'https://provider.example/oauth/authorize?state=abc';
+
+    const delivery = await buildConnectCardDelivery(
+      {
+        platform: AgentPlatformEnum.SLACK,
+        mcpId: 'attio',
+        mcpName: 'Attio',
+        authorizeUrl,
+      },
+      { connectRedirect }
+    );
+
+    expect(connectRedirect.issue.called).to.equal(false);
+    expect((delivery.content.card as { children: Array<{ children: Array<{ url?: string }> }> }).children[1].children[0]
+      .url).to.equal(authorizeUrl);
+    expect(delivery.slackNative).to.not.equal(undefined);
+  });
+});

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.ts
@@ -3,7 +3,7 @@ import type { Block } from '@slack/types';
 
 import type { SlackNativeDelivery } from '../../conversation-runtime/egress/slack-native-delivery';
 import type { ReplyContentDto } from '../../shared/dtos/agent-reply-payload.dto';
-import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { AgentPlatformEnum, requiresShortConnectUrl } from '../../shared/enums/agent-platform.enum';
 
 type SlackCardBlock = Block & {
   type: 'card';
@@ -24,6 +24,18 @@ const SLACK_CARD_BODY_MAX = 200;
 export type ConnectCardDelivery = {
   content: ReplyContentDto;
   slackNative?: SlackNativeDelivery;
+};
+
+type ConnectRedirectIssuer = {
+  issue(authorizeUrl: string): Promise<string>;
+};
+
+export type BuildConnectCardParams = {
+  platform: AgentPlatformEnum;
+  mcpId: string;
+  mcpName: string;
+  authorizeUrl: string;
+  authorizeUrlWithAutoApprove?: string;
 };
 
 function resolveDashboardBaseUrl(): string {
@@ -102,13 +114,7 @@ function buildConnectCardSlackBlocks(params: {
   };
 }
 
-export function buildConnectCard(params: {
-  platform: AgentPlatformEnum;
-  mcpId: string;
-  mcpName: string;
-  authorizeUrl: string;
-  authorizeUrlWithAutoApprove?: string;
-}): ConnectCardDelivery {
+export function buildConnectCard(params: BuildConnectCardParams): ConnectCardDelivery {
   const content: ReplyContentDto = {
     card: {
       type: 'card',
@@ -141,4 +147,19 @@ export function buildConnectCard(params: {
   }
 
   return { content };
+}
+
+export async function buildConnectCardDelivery(
+  params: BuildConnectCardParams,
+  deps: { connectRedirect: ConnectRedirectIssuer }
+): Promise<ConnectCardDelivery> {
+  let authorizeUrl = params.authorizeUrl;
+  if (requiresShortConnectUrl(params.platform)) {
+    authorizeUrl = await deps.connectRedirect.issue(authorizeUrl);
+  }
+
+  return buildConnectCard({
+    ...params,
+    authorizeUrl,
+  });
 }

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/connect-card.builder.ts
@@ -30,7 +30,7 @@ type ConnectRedirectIssuer = {
   issue(authorizeUrl: string): Promise<string>;
 };
 
-export type BuildConnectCardParams = {
+type BuildConnectCardParams = {
   platform: AgentPlatformEnum;
   mcpId: string;
   mcpName: string;
@@ -153,13 +153,10 @@ export async function buildConnectCardDelivery(
   params: BuildConnectCardParams,
   deps: { connectRedirect: ConnectRedirectIssuer }
 ): Promise<ConnectCardDelivery> {
-  let authorizeUrl = params.authorizeUrl;
-  if (requiresShortConnectUrl(params.platform)) {
-    authorizeUrl = await deps.connectRedirect.issue(authorizeUrl);
-  }
-
   return buildConnectCard({
     ...params,
-    authorizeUrl,
+    authorizeUrl: requiresShortConnectUrl(params.platform)
+      ? await deps.connectRedirect.issue(params.authorizeUrl)
+      : params.authorizeUrl,
   });
 }

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.ts
@@ -7,9 +7,8 @@ import { HandleAgentReply } from '../../conversation-runtime/reply/handle-agent-
 import { GenerateMcpOAuthUrlCommand } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.command';
 import { GenerateMcpOAuthUrl } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
 import { McpConnectRedirectService } from '../../mcp/connections/mcp-connect-redirect.service';
-import { requiresShortConnectUrl } from '../../shared/enums/agent-platform.enum';
 import { ManagedAgentService } from '../managed-agent.service';
-import { buildConnectCard } from './connect-card.builder';
+import { buildConnectCardDelivery } from './connect-card.builder';
 import { HandleNovuToolsCommand, NovuToolsActionEnum } from './handle-novu-tools.command';
 import { listOAuthMcps } from './list-oauth-mcps.helper';
 
@@ -114,18 +113,16 @@ export class HandleNovuTools {
     const mcp = MCP_SERVERS.find((s) => s.id === command.mcpId);
     const mcpName = mcp?.name ?? command.mcpId;
 
-    let authorizeUrl = oauthUrls.authorizeUrl;
-    if (requiresShortConnectUrl(command.platform)) {
-      authorizeUrl = await this.mcpConnectRedirect.issue(authorizeUrl);
-    }
-
-    const delivery = buildConnectCard({
-      platform: command.platform,
-      mcpId: command.mcpId,
-      mcpName,
-      authorizeUrl,
-      authorizeUrlWithAutoApprove: oauthUrls.authorizeUrlWithAutoApprove,
-    });
+    const delivery = await buildConnectCardDelivery(
+      {
+        platform: command.platform,
+        mcpId: command.mcpId,
+        mcpName,
+        authorizeUrl: oauthUrls.authorizeUrl,
+        authorizeUrlWithAutoApprove: oauthUrls.authorizeUrlWithAutoApprove,
+      },
+      { connectRedirect: this.mcpConnectRedirect }
+    );
 
     const sent = await this.handleAgentReply.execute(
       HandleAgentReplyCommand.create({

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.ts
@@ -6,6 +6,8 @@ import { HandleAgentReplyCommand } from '../../conversation-runtime/reply/handle
 import { HandleAgentReply } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
 import { GenerateMcpOAuthUrlCommand } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.command';
 import { GenerateMcpOAuthUrl } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
+import { McpConnectRedirectService } from '../../mcp/connections/mcp-connect-redirect.service';
+import { requiresShortConnectUrl } from '../../shared/enums/agent-platform.enum';
 import { ManagedAgentService } from '../managed-agent.service';
 import { buildConnectCard } from './connect-card.builder';
 import { HandleNovuToolsCommand, NovuToolsActionEnum } from './handle-novu-tools.command';
@@ -18,6 +20,7 @@ export class HandleNovuTools {
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
     private readonly mcpConnectionRepository: McpConnectionRepository,
     private readonly generateMcpOAuthUrl: GenerateMcpOAuthUrl,
+    private readonly mcpConnectRedirect: McpConnectRedirectService,
     private readonly handleAgentReply: HandleAgentReply,
     @Inject(forwardRef(() => ManagedAgentService))
     private readonly managedAgentService: ManagedAgentService,
@@ -111,11 +114,16 @@ export class HandleNovuTools {
     const mcp = MCP_SERVERS.find((s) => s.id === command.mcpId);
     const mcpName = mcp?.name ?? command.mcpId;
 
+    let authorizeUrl = oauthUrls.authorizeUrl;
+    if (requiresShortConnectUrl(command.platform)) {
+      authorizeUrl = await this.mcpConnectRedirect.issue(authorizeUrl);
+    }
+
     const delivery = buildConnectCard({
       platform: command.platform,
       mcpId: command.mcpId,
       mcpName,
-      authorizeUrl: oauthUrls.authorizeUrl,
+      authorizeUrl,
       authorizeUrlWithAutoApprove: oauthUrls.authorizeUrlWithAutoApprove,
     });
 

--- a/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/provider-managed-redirect-state.ts
+++ b/apps/api/src/app/agents/mcp/connections/ensure-provider-managed-vault/provider-managed-redirect-state.ts
@@ -1,6 +1,8 @@
 import { BadRequestException } from '@nestjs/common';
 import { createHash, encodeOAuthState, splitOAuthState } from '@novu/application-generic';
 
+import { buildAgentApiRootUrl } from '../../../shared/util/agent-api-root-url';
+
 /**
  * Public path mounted under `AgentsMcpOAuthController`. Receives the click on
  * the in-channel "Connect from provider" link, marks the connection row as
@@ -99,12 +101,5 @@ export function decodeProviderManagedRedirectState(state: string): {
 }
 
 export function buildProviderManagedRedirectUrl(signedState: string): string {
-  const rootUrl = process.env.AGENT_API_HOSTNAME?.trim() || process.env.API_ROOT_URL?.trim();
-  if (!rootUrl) {
-    throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL environment variable is required');
-  }
-
-  const baseUrl = rootUrl.replace(/\/$/, '');
-
-  return `${baseUrl}${PROVIDER_MANAGED_REDIRECT_PATH}?state=${encodeURIComponent(signedState)}`;
+  return `${buildAgentApiRootUrl()}${PROVIDER_MANAGED_REDIRECT_PATH}?state=${encodeURIComponent(signedState)}`;
 }

--- a/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.spec.ts
+++ b/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  buildMcpConnectRedirectUrl,
+  MCP_CONNECT_REDIRECT_PATH,
+  MCP_CONNECT_REDIRECT_TTL_SECONDS,
+  McpConnectRedirectService,
+} from './mcp-connect-redirect.service';
+
+describe('McpConnectRedirectService', () => {
+  const originalApiRootUrl = process.env.API_ROOT_URL;
+
+  afterEach(() => {
+    if (originalApiRootUrl === undefined) {
+      delete process.env.API_ROOT_URL;
+    } else {
+      process.env.API_ROOT_URL = originalApiRootUrl;
+    }
+  });
+
+  function makeService() {
+    const cacheStore = new Map<string, string>();
+    const cacheService = {
+      cacheEnabled: () => true,
+      set: sinon.stub().callsFake(async (key: string, value: string, options?: { ttl?: number }) => {
+        cacheStore.set(key, value);
+
+        expect(options?.ttl).to.equal(MCP_CONNECT_REDIRECT_TTL_SECONDS);
+
+        return 'OK';
+      }),
+      get: sinon.stub().callsFake(async (key: string) => cacheStore.get(key) ?? null),
+    };
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+      info: sinon.stub(),
+    };
+
+    const service = new McpConnectRedirectService(cacheService as any, logger as any);
+
+    return { service, cacheService, cacheStore };
+  }
+
+  it('issues a short redirect URL and stores the authorize URL in Redis', async () => {
+    process.env.API_ROOT_URL = 'https://api.example.com';
+    const { service, cacheStore } = makeService();
+    const authorizeUrl = 'https://app.attio.com/oidc/authorize?client_id=abc&state=very-long';
+
+    const redirectUrl = await service.issue(authorizeUrl);
+
+    expect(redirectUrl).to.match(
+      new RegExp(`^https://api\\.example\\.com${MCP_CONNECT_REDIRECT_PATH.replace(/\//g, '\\/')}/[A-Za-z0-9_-]+$`)
+    );
+
+    const token = redirectUrl.split('/').pop()!;
+    expect(cacheStore.get(`mcp-connect-redirect:${token}`)).to.equal(authorizeUrl);
+  });
+
+  it('resolves a stored token to the authorize URL', async () => {
+    process.env.API_ROOT_URL = 'https://api.example.com';
+    const { service } = makeService();
+    const authorizeUrl = 'https://provider.example/oauth/authorize?state=xyz';
+
+    const redirectUrl = await service.issue(authorizeUrl);
+    const token = redirectUrl.split('/').pop()!;
+    const resolved = await service.resolve(token);
+
+    expect(resolved).to.equal(authorizeUrl);
+  });
+
+  it('returns null for unknown tokens', async () => {
+    const { service } = makeService();
+
+    const resolved = await service.resolve('missing-token');
+
+    expect(resolved).to.equal(null);
+  });
+
+  it('falls back to the full authorize URL when cache is disabled', async () => {
+    const cacheService = {
+      cacheEnabled: () => false,
+      set: sinon.stub(),
+      get: sinon.stub(),
+    };
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    const service = new McpConnectRedirectService(cacheService as any, logger as any);
+    const authorizeUrl = 'https://provider.example/oauth/authorize?state=xyz';
+
+    const redirectUrl = await service.issue(authorizeUrl);
+
+    expect(redirectUrl).to.equal(authorizeUrl);
+    expect(cacheService.set.called).to.equal(false);
+  });
+
+  it('buildMcpConnectRedirectUrl encodes the token in the public path', () => {
+    process.env.API_ROOT_URL = 'https://api.example.com/';
+
+    expect(buildMcpConnectRedirectUrl('abc123')).to.equal(
+      `https://api.example.com${MCP_CONNECT_REDIRECT_PATH}/abc123`
+    );
+  });
+});

--- a/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.spec.ts
+++ b/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.spec.ts
@@ -80,6 +80,25 @@ describe('McpConnectRedirectService', () => {
     expect(resolved).to.equal(null);
   });
 
+  it('falls back to the full authorize URL when cache write fails', async () => {
+    const cacheService = {
+      cacheEnabled: () => true,
+      set: sinon.stub().rejects(new Error('redis unavailable')),
+      get: sinon.stub(),
+    };
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    const service = new McpConnectRedirectService(cacheService as any, logger as any);
+    const authorizeUrl = 'https://provider.example/oauth/authorize?state=xyz';
+
+    const redirectUrl = await service.issue(authorizeUrl);
+
+    expect(redirectUrl).to.equal(authorizeUrl);
+    expect(logger.warn.calledOnce).to.equal(true);
+  });
+
   it('falls back to the full authorize URL when cache is disabled', async () => {
     const cacheService = {
       cacheEnabled: () => false,

--- a/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
+++ b/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
@@ -32,9 +32,15 @@ export class McpConnectRedirectService {
 
     const token = randomBytes(16).toString('base64url');
 
-    await this.cacheService.set(this.cacheKey(token), authorizeUrl, {
-      ttl: MCP_CONNECT_REDIRECT_TTL_SECONDS,
-    });
+    try {
+      await this.cacheService.set(this.cacheKey(token), authorizeUrl, {
+        ttl: MCP_CONNECT_REDIRECT_TTL_SECONDS,
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to store MCP connect redirect token: ${(err as Error).message}`);
+
+      return authorizeUrl;
+    }
 
     return buildMcpConnectRedirectUrl(token);
   }

--- a/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
+++ b/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
@@ -23,10 +23,6 @@ export class McpConnectRedirectService {
     this.logger.setContext(this.constructor.name);
   }
 
-  /**
-   * Store a long OAuth authorize URL under a short opaque token and return the
-   * public redirect URL. Falls back to the original URL when Redis is unavailable.
-   */
   async issue(authorizeUrl: string): Promise<string> {
     if (!this.cacheService.cacheEnabled()) {
       this.logger.warn('Cache unavailable — returning full MCP authorize URL for connect redirect');

--- a/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
+++ b/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
@@ -1,0 +1,72 @@
+import { randomBytes } from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import { CacheService, PinoLogger } from '@novu/application-generic';
+
+export const MCP_CONNECT_REDIRECT_PATH = '/v1/agents/mcp/r';
+
+export const MCP_CONNECT_REDIRECT_TTL_SECONDS = 24 * 60 * 60;
+
+const CACHE_KEY_PREFIX = 'mcp-connect-redirect:';
+
+export function buildAgentApiRootUrl(): string {
+  const rootUrl = process.env.AGENT_API_HOSTNAME?.trim() || process.env.API_ROOT_URL?.trim();
+  if (!rootUrl) {
+    throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL environment variable is required');
+  }
+
+  return rootUrl.replace(/\/$/, '');
+}
+
+export function buildMcpConnectRedirectUrl(token: string): string {
+  return `${buildAgentApiRootUrl()}${MCP_CONNECT_REDIRECT_PATH}/${token}`;
+}
+
+@Injectable()
+export class McpConnectRedirectService {
+  constructor(
+    private readonly cacheService: CacheService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  /**
+   * Store a long OAuth authorize URL under a short opaque token and return the
+   * public redirect URL. Falls back to the original URL when Redis is unavailable.
+   */
+  async issue(authorizeUrl: string): Promise<string> {
+    if (!this.cacheService.cacheEnabled()) {
+      this.logger.warn('Cache unavailable — returning full MCP authorize URL for connect redirect');
+
+      return authorizeUrl;
+    }
+
+    const token = randomBytes(16).toString('base64url');
+
+    await this.cacheService.set(this.cacheKey(token), authorizeUrl, {
+      ttl: MCP_CONNECT_REDIRECT_TTL_SECONDS,
+    });
+
+    return buildMcpConnectRedirectUrl(token);
+  }
+
+  async resolve(token: string): Promise<string | null> {
+    if (!token || !this.cacheService.cacheEnabled()) {
+      return null;
+    }
+
+    try {
+      const url = await this.cacheService.get(this.cacheKey(token));
+
+      return url || null;
+    } catch (err) {
+      this.logger.warn(`Failed to resolve MCP connect redirect token: ${(err as Error).message}`);
+
+      return null;
+    }
+  }
+
+  private cacheKey(token: string): string {
+    return `${CACHE_KEY_PREFIX}${token}`;
+  }
+}

--- a/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
+++ b/apps/api/src/app/agents/mcp/connections/mcp-connect-redirect.service.ts
@@ -2,20 +2,13 @@ import { randomBytes } from 'node:crypto';
 import { Injectable } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 
+import { buildAgentApiRootUrl } from '../../shared/util/agent-api-root-url';
+
 export const MCP_CONNECT_REDIRECT_PATH = '/v1/agents/mcp/r';
 
 export const MCP_CONNECT_REDIRECT_TTL_SECONDS = 24 * 60 * 60;
 
 const CACHE_KEY_PREFIX = 'mcp-connect-redirect:';
-
-export function buildAgentApiRootUrl(): string {
-  const rootUrl = process.env.AGENT_API_HOSTNAME?.trim() || process.env.API_ROOT_URL?.trim();
-  if (!rootUrl) {
-    throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL environment variable is required');
-  }
-
-  return rootUrl.replace(/\/$/, '');
-}
 
 export function buildMcpConnectRedirectUrl(token: string): string {
   return `${buildAgentApiRootUrl()}${MCP_CONNECT_REDIRECT_PATH}/${token}`;

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.spec.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.spec.ts
@@ -1,0 +1,60 @@
+import { HttpStatus } from '@nestjs/common';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { AgentsMcpOAuthController } from './agents-mcp-oauth.controller';
+
+describe('AgentsMcpOAuthController connect redirect', () => {
+  function makeController() {
+    const mcpOAuthCallbackUsecase = {};
+    const completeProviderManagedRedirect = {};
+    const mcpConnectRedirect = {
+      resolve: sinon.stub(),
+    };
+    const controller = new AgentsMcpOAuthController(
+      mcpOAuthCallbackUsecase as any,
+      completeProviderManagedRedirect as any,
+      mcpConnectRedirect as any
+    );
+
+    return { controller, mcpConnectRedirect };
+  }
+
+  it('302-redirects to the stored authorize URL', async () => {
+    const { controller, mcpConnectRedirect } = makeController();
+    mcpConnectRedirect.resolve.resolves('https://provider.example/oauth/authorize?state=abc');
+
+    const res = {
+      redirect: sinon.stub(),
+      status: sinon.stub().returnsThis(),
+      setHeader: sinon.stub().returnsThis(),
+      send: sinon.stub(),
+    };
+
+    await controller.getConnectRedirect(res as any, 'short-token');
+
+    expect(mcpConnectRedirect.resolve.calledOnceWithExactly('short-token')).to.equal(true);
+    expect(res.redirect.calledOnceWithExactly(HttpStatus.FOUND, 'https://provider.example/oauth/authorize?state=abc'))
+      .to.equal(true);
+    expect(res.send.called).to.equal(false);
+  });
+
+  it('renders an expired link page when the token is missing', async () => {
+    const { controller, mcpConnectRedirect } = makeController();
+    mcpConnectRedirect.resolve.resolves(null);
+
+    const res = {
+      redirect: sinon.stub(),
+      status: sinon.stub().returnsThis(),
+      setHeader: sinon.stub().returnsThis(),
+      send: sinon.stub(),
+    };
+
+    await controller.getConnectRedirect(res as any, 'expired-token');
+
+    expect(res.redirect.called).to.equal(false);
+    expect(res.status.calledOnceWithExactly(HttpStatus.OK)).to.equal(true);
+    expect(res.send.calledOnce).to.equal(true);
+    expect(String(res.send.firstCall.args[0])).to.include('This link has expired');
+  });
+});

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -146,8 +146,6 @@ export class AgentsMcpOAuthController {
 
   /**
    * Resolve a short MCP connect redirect token to the full OAuth authorize URL.
-   * Used by WhatsApp (and future text-only adapters) where long authorize URLs
-   * cannot be rendered as native link buttons.
    */
   @Get('/r/:token')
   @ApiOperation({

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -4,12 +4,13 @@ import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { Response } from 'express';
 
 import { ThrottlerCategory } from '../../../rate-limiting/guards';
-import { CONNECTION_RESULT_CSP, renderConnectionResultPage } from '../../../shared/html/connection-result-page';
+import { renderConnectionResultPage } from '../../../shared/html/connection-result-page';
 import { CompleteProviderManagedRedirect } from '../connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase';
 import { McpConnectRedirectService } from '../connections/mcp-connect-redirect.service';
 import { PROVIDER_MANAGED_REDIRECT_PATH } from '../connections/ensure-provider-managed-vault/provider-managed-redirect-state';
 import { McpOAuthCallbackCommand } from './mcp-oauth-callback/mcp-oauth-callback.command';
 import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecase';
+import { renderExpiredMcpSetupLinkPage, sendMcpOAuthResultPage } from './mcp-oauth-result-page.util';
 
 /**
  * Public-facing controller for the Novu-managed MCP OAuth callback.
@@ -77,9 +78,7 @@ export class AgentsMcpOAuthController {
           message: 'Something went wrong while connecting your MCP server. Please go back and try again.',
         });
 
-    res.setHeader('Content-Type', 'text/html');
-    res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
-    res.send(page);
+    sendMcpOAuthResultPage(res, page);
   }
 
   /**
@@ -120,26 +119,28 @@ export class AgentsMcpOAuthController {
         'Something went wrong while opening the provider connection. Send a new message to your agent and try again.';
 
       if (isExpired) {
-        title = 'Link expired';
-        heading = 'This link has expired';
-        message =
-          'This setup link is no longer valid. Send a new message to your agent to get a fresh Connect from provider link.';
+        sendMcpOAuthResultPage(
+          res,
+          renderExpiredMcpSetupLinkPage(
+            'This setup link is no longer valid. Send a new message to your agent to get a fresh Connect from provider link.'
+          )
+        );
+
+        return;
       } else if (isNotFound) {
         message =
           'The connection or environment for this link no longer exists. Send a new message to your agent to restart setup.';
       }
 
-      const page = renderConnectionResultPage({
-        status: 'error',
-        title,
-        heading,
-        message,
-      });
-
-      res.status(HttpStatus.OK);
-      res.setHeader('Content-Type', 'text/html');
-      res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
-      res.send(page);
+      sendMcpOAuthResultPage(
+        res,
+        renderConnectionResultPage({
+          status: 'error',
+          title,
+          heading,
+          message,
+        })
+      );
     }
   }
 
@@ -163,17 +164,6 @@ export class AgentsMcpOAuthController {
       return;
     }
 
-    const page = renderConnectionResultPage({
-      status: 'error',
-      title: 'Link expired',
-      heading: 'This link has expired',
-      message:
-        'This setup link is no longer valid. Send a new message to your agent to get a fresh Connect link.',
-    });
-
-    res.status(HttpStatus.OK);
-    res.setHeader('Content-Type', 'text/html');
-    res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
-    res.send(page);
+    sendMcpOAuthResultPage(res, renderExpiredMcpSetupLinkPage());
   }
 }

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Get, HttpStatus, NotFoundException, Query, Res } from '@nestjs/common';
+import { BadRequestException, Controller, Get, HttpStatus, NotFoundException, Param, Query, Res } from '@nestjs/common';
 import { ApiExcludeController, ApiOperation } from '@nestjs/swagger';
 import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { Response } from 'express';
@@ -6,6 +6,7 @@ import { Response } from 'express';
 import { ThrottlerCategory } from '../../../rate-limiting/guards';
 import { CONNECTION_RESULT_CSP, renderConnectionResultPage } from '../../../shared/html/connection-result-page';
 import { CompleteProviderManagedRedirect } from '../connections/ensure-provider-managed-vault/complete-provider-managed-redirect.usecase';
+import { McpConnectRedirectService } from '../connections/mcp-connect-redirect.service';
 import { PROVIDER_MANAGED_REDIRECT_PATH } from '../connections/ensure-provider-managed-vault/provider-managed-redirect-state';
 import { McpOAuthCallbackCommand } from './mcp-oauth-callback/mcp-oauth-callback.command';
 import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecase';
@@ -27,7 +28,8 @@ import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecas
 export class AgentsMcpOAuthController {
   constructor(
     private readonly mcpOAuthCallbackUsecase: McpOAuthCallback,
-    private readonly completeProviderManagedRedirect: CompleteProviderManagedRedirect
+    private readonly completeProviderManagedRedirect: CompleteProviderManagedRedirect,
+    private readonly mcpConnectRedirect: McpConnectRedirectService
   ) {}
 
   @Get('/oauth/callback')
@@ -139,5 +141,39 @@ export class AgentsMcpOAuthController {
       res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
       res.send(page);
     }
+  }
+
+  /**
+   * Resolve a short MCP connect redirect token to the full OAuth authorize URL.
+   * Used by WhatsApp (and future text-only adapters) where long authorize URLs
+   * cannot be rendered as native link buttons.
+   */
+  @Get('/r/:token')
+  @ApiOperation({
+    summary: 'MCP connect short redirect',
+    description:
+      '302-redirects a short-lived opaque token to the full OAuth authorize URL stored when the in-chat Connect card was issued.',
+  })
+  async getConnectRedirect(@Res() res: Response, @Param('token') token: string): Promise<void> {
+    const authorizeUrl = await this.mcpConnectRedirect.resolve(token);
+
+    if (authorizeUrl) {
+      res.redirect(HttpStatus.FOUND, authorizeUrl);
+
+      return;
+    }
+
+    const page = renderConnectionResultPage({
+      status: 'error',
+      title: 'Link expired',
+      heading: 'This link has expired',
+      message:
+        'This setup link is no longer valid. Send a new message to your agent to get a fresh Connect link.',
+    });
+
+    res.status(HttpStatus.OK);
+    res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
+    res.send(page);
   }
 }

--- a/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.spec.ts
+++ b/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.spec.ts
@@ -4,45 +4,15 @@ import { buildMcpOAuthRedirectUri } from './mcp-oauth-state';
 
 describe('buildMcpOAuthRedirectUri', () => {
   const originalApiRootUrl = process.env.API_ROOT_URL;
-  const originalAgentApiHostname = process.env.AGENT_API_HOSTNAME;
 
   afterEach(() => {
     process.env.API_ROOT_URL = originalApiRootUrl;
-    process.env.AGENT_API_HOSTNAME = originalAgentApiHostname;
+    delete process.env.AGENT_API_HOSTNAME;
   });
 
-  it('uses API_ROOT_URL when AGENT_API_HOSTNAME is not set', () => {
+  it('appends the OAuth callback path to the agent API root URL', () => {
     process.env.API_ROOT_URL = 'https://api.example.com';
-    delete process.env.AGENT_API_HOSTNAME;
 
     expect(buildMcpOAuthRedirectUri()).to.equal(`https://api.example.com${MCP_OAUTH_CALLBACK_PATH}`);
-  });
-
-  it('prefers AGENT_API_HOSTNAME over API_ROOT_URL when both are set (tunnel takes precedence)', () => {
-    process.env.API_ROOT_URL = 'https://api.example.com';
-    process.env.AGENT_API_HOSTNAME = 'https://tunnel.ngrok.app';
-
-    expect(buildMcpOAuthRedirectUri()).to.equal(`https://tunnel.ngrok.app${MCP_OAUTH_CALLBACK_PATH}`);
-  });
-
-  it('falls back to API_ROOT_URL when AGENT_API_HOSTNAME is empty/whitespace', () => {
-    process.env.API_ROOT_URL = 'https://api.example.com';
-    process.env.AGENT_API_HOSTNAME = '   ';
-
-    expect(buildMcpOAuthRedirectUri()).to.equal(`https://api.example.com${MCP_OAUTH_CALLBACK_PATH}`);
-  });
-
-  it('strips a single trailing slash from the resolved root URL', () => {
-    process.env.API_ROOT_URL = 'https://api.example.com/';
-    delete process.env.AGENT_API_HOSTNAME;
-
-    expect(buildMcpOAuthRedirectUri()).to.equal(`https://api.example.com${MCP_OAUTH_CALLBACK_PATH}`);
-  });
-
-  it('throws when neither env var is set', () => {
-    delete process.env.API_ROOT_URL;
-    delete process.env.AGENT_API_HOSTNAME;
-
-    expect(() => buildMcpOAuthRedirectUri()).to.throw(/AGENT_API_HOSTNAME or API_ROOT_URL/i);
   });
 });

--- a/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.spec.ts
+++ b/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.spec.ts
@@ -4,10 +4,11 @@ import { buildMcpOAuthRedirectUri } from './mcp-oauth-state';
 
 describe('buildMcpOAuthRedirectUri', () => {
   const originalApiRootUrl = process.env.API_ROOT_URL;
+  const originalAgentApiHostname = process.env.AGENT_API_HOSTNAME;
 
   afterEach(() => {
     process.env.API_ROOT_URL = originalApiRootUrl;
-    delete process.env.AGENT_API_HOSTNAME;
+    process.env.AGENT_API_HOSTNAME = originalAgentApiHostname;
   });
 
   it('appends the OAuth callback path to the agent API root URL', () => {

--- a/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.ts
+++ b/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.ts
@@ -1,5 +1,6 @@
 import { McpConnectionScopeEnum } from '@novu/shared';
 
+import { buildAgentApiRootUrl } from '../../../shared/util/agent-api-root-url';
 import { MCP_OAUTH_CALLBACK_PATH } from './mcp-oauth.constants';
 
 /**
@@ -39,18 +40,5 @@ export interface McpOAuthState {
 }
 
 export function buildMcpOAuthRedirectUri(): string {
-  // Upstream MCP providers must reach the callback over the public internet,
-  // so `api.novu.localhost` and other LAN-only hostnames are unreachable.
-  // `AGENT_API_HOSTNAME` (e.g. an ngrok URL) takes precedence over the
-  // standard `API_ROOT_URL` so a tunnelled API can be addressed without
-  // rewriting the regular root URL. Matches the convention used by the
-  // Slack / Telegram / WhatsApp webhook configurators.
-  const rootUrl = process.env.AGENT_API_HOSTNAME?.trim() || process.env.API_ROOT_URL?.trim();
-  if (!rootUrl) {
-    throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL environment variable is required');
-  }
-
-  const baseUrl = rootUrl.replace(/\/$/, '');
-
-  return `${baseUrl}${MCP_OAUTH_CALLBACK_PATH}`;
+  return `${buildAgentApiRootUrl()}${MCP_OAUTH_CALLBACK_PATH}`;
 }

--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-result-page.util.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-result-page.util.ts
@@ -1,0 +1,22 @@
+import { HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+
+import { CONNECTION_RESULT_CSP, renderConnectionResultPage } from '../../../shared/html/connection-result-page';
+
+export function renderExpiredMcpSetupLinkPage(
+  message = 'This setup link is no longer valid. Send a new message to your agent to get a fresh Connect link.'
+): string {
+  return renderConnectionResultPage({
+    status: 'error',
+    title: 'Link expired',
+    heading: 'This link has expired',
+    message,
+  });
+}
+
+export function sendMcpOAuthResultPage(res: Response, page: string, status = HttpStatus.OK): void {
+  res.status(status);
+  res.setHeader('Content-Type', 'text/html');
+  res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
+  res.send(page);
+}

--- a/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
@@ -13,16 +13,35 @@ export const PLATFORMS_WITH_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
   AgentPlatformEnum.TELEGRAM,
 ]);
 
-/** Platforms where `[label](url)` markdown links do not render (e.g. WhatsApp). */
-export const PLATFORMS_WITHOUT_MARKDOWN_LINKS = new Set<AgentPlatformEnum>([AgentPlatformEnum.WHATSAPP]);
+export type PlatformEgressCapabilities = {
+  markdownLinks: boolean;
+  nativeUrlButtons: boolean;
+};
 
-/** Platforms where card link-buttons fall back to visible URL text (e.g. WhatsApp). */
-export const PLATFORMS_WITHOUT_NATIVE_URL_BUTTONS = new Set<AgentPlatformEnum>([AgentPlatformEnum.WHATSAPP]);
+const DEFAULT_EGRESS_CAPABILITIES: PlatformEgressCapabilities = {
+  markdownLinks: true,
+  nativeUrlButtons: true,
+};
+
+export const PLATFORM_EGRESS_CAPABILITIES: Record<AgentPlatformEnum, PlatformEgressCapabilities> = {
+  [AgentPlatformEnum.SLACK]: DEFAULT_EGRESS_CAPABILITIES,
+  [AgentPlatformEnum.TEAMS]: DEFAULT_EGRESS_CAPABILITIES,
+  [AgentPlatformEnum.TELEGRAM]: DEFAULT_EGRESS_CAPABILITIES,
+  [AgentPlatformEnum.EMAIL]: DEFAULT_EGRESS_CAPABILITIES,
+  [AgentPlatformEnum.WHATSAPP]: {
+    markdownLinks: false,
+    nativeUrlButtons: false,
+  },
+};
+
+function resolvePlatformEgressCapabilities(platform: string): PlatformEgressCapabilities {
+  return PLATFORM_EGRESS_CAPABILITIES[platform as AgentPlatformEnum] ?? DEFAULT_EGRESS_CAPABILITIES;
+}
 
 export function supportsMarkdownLinks(platform: string): boolean {
-  return !PLATFORMS_WITHOUT_MARKDOWN_LINKS.has(platform as AgentPlatformEnum);
+  return resolvePlatformEgressCapabilities(platform).markdownLinks;
 }
 
 export function requiresShortConnectUrl(platform: string): boolean {
-  return PLATFORMS_WITHOUT_NATIVE_URL_BUTTONS.has(platform as AgentPlatformEnum);
+  return !resolvePlatformEgressCapabilities(platform).nativeUrlButtons;
 }

--- a/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
@@ -13,7 +13,7 @@ export const PLATFORMS_WITH_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
   AgentPlatformEnum.TELEGRAM,
 ]);
 
-export type PlatformEgressCapabilities = {
+type PlatformEgressCapabilities = {
   markdownLinks: boolean;
   nativeUrlButtons: boolean;
 };
@@ -23,7 +23,7 @@ const DEFAULT_EGRESS_CAPABILITIES: PlatformEgressCapabilities = {
   nativeUrlButtons: true,
 };
 
-export const PLATFORM_EGRESS_CAPABILITIES: Record<AgentPlatformEnum, PlatformEgressCapabilities> = {
+const PLATFORM_EGRESS_CAPABILITIES: Record<AgentPlatformEnum, PlatformEgressCapabilities> = {
   [AgentPlatformEnum.SLACK]: DEFAULT_EGRESS_CAPABILITIES,
   [AgentPlatformEnum.TEAMS]: DEFAULT_EGRESS_CAPABILITIES,
   [AgentPlatformEnum.TELEGRAM]: DEFAULT_EGRESS_CAPABILITIES,

--- a/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
@@ -12,3 +12,17 @@ export const PLATFORMS_WITH_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
   AgentPlatformEnum.TEAMS,
   AgentPlatformEnum.TELEGRAM,
 ]);
+
+/** Platforms where `[label](url)` markdown links do not render (e.g. WhatsApp). */
+export const PLATFORMS_WITHOUT_MARKDOWN_LINKS = new Set<AgentPlatformEnum>([AgentPlatformEnum.WHATSAPP]);
+
+/** Platforms where card link-buttons fall back to visible URL text (e.g. WhatsApp). */
+export const PLATFORMS_WITHOUT_NATIVE_URL_BUTTONS = new Set<AgentPlatformEnum>([AgentPlatformEnum.WHATSAPP]);
+
+export function supportsMarkdownLinks(platform: string): boolean {
+  return !PLATFORMS_WITHOUT_MARKDOWN_LINKS.has(platform as AgentPlatformEnum);
+}
+
+export function requiresShortConnectUrl(platform: string): boolean {
+  return PLATFORMS_WITHOUT_NATIVE_URL_BUTTONS.has(platform as AgentPlatformEnum);
+}

--- a/apps/api/src/app/agents/shared/util/agent-api-root-url.spec.ts
+++ b/apps/api/src/app/agents/shared/util/agent-api-root-url.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+
+import { buildAgentApiRootUrl } from './agent-api-root-url';
+
+describe('buildAgentApiRootUrl', () => {
+  const originalApiRootUrl = process.env.API_ROOT_URL;
+  const originalAgentApiHostname = process.env.AGENT_API_HOSTNAME;
+
+  afterEach(() => {
+    process.env.API_ROOT_URL = originalApiRootUrl;
+    process.env.AGENT_API_HOSTNAME = originalAgentApiHostname;
+  });
+
+  it('uses API_ROOT_URL when AGENT_API_HOSTNAME is not set', () => {
+    process.env.API_ROOT_URL = 'https://api.example.com';
+    delete process.env.AGENT_API_HOSTNAME;
+
+    expect(buildAgentApiRootUrl()).to.equal('https://api.example.com');
+  });
+
+  it('prefers AGENT_API_HOSTNAME over API_ROOT_URL when both are set', () => {
+    process.env.API_ROOT_URL = 'https://api.example.com';
+    process.env.AGENT_API_HOSTNAME = 'https://tunnel.ngrok.app';
+
+    expect(buildAgentApiRootUrl()).to.equal('https://tunnel.ngrok.app');
+  });
+
+  it('falls back to API_ROOT_URL when AGENT_API_HOSTNAME is empty/whitespace', () => {
+    process.env.API_ROOT_URL = 'https://api.example.com';
+    process.env.AGENT_API_HOSTNAME = '   ';
+
+    expect(buildAgentApiRootUrl()).to.equal('https://api.example.com');
+  });
+
+  it('strips a single trailing slash from the resolved root URL', () => {
+    process.env.API_ROOT_URL = 'https://api.example.com/';
+    delete process.env.AGENT_API_HOSTNAME;
+
+    expect(buildAgentApiRootUrl()).to.equal('https://api.example.com');
+  });
+
+  it('throws when neither env var is set', () => {
+    delete process.env.API_ROOT_URL;
+    delete process.env.AGENT_API_HOSTNAME;
+
+    expect(() => buildAgentApiRootUrl()).to.throw(/AGENT_API_HOSTNAME or API_ROOT_URL/i);
+  });
+});

--- a/apps/api/src/app/agents/shared/util/agent-api-root-url.spec.ts
+++ b/apps/api/src/app/agents/shared/util/agent-api-root-url.spec.ts
@@ -39,6 +39,13 @@ describe('buildAgentApiRootUrl', () => {
     expect(buildAgentApiRootUrl()).to.equal('https://api.example.com');
   });
 
+  it('strips multiple trailing slashes from the resolved root URL', () => {
+    process.env.API_ROOT_URL = 'https://api.example.com///';
+    delete process.env.AGENT_API_HOSTNAME;
+
+    expect(buildAgentApiRootUrl()).to.equal('https://api.example.com');
+  });
+
   it('throws when neither env var is set', () => {
     delete process.env.API_ROOT_URL;
     delete process.env.AGENT_API_HOSTNAME;

--- a/apps/api/src/app/agents/shared/util/agent-api-root-url.ts
+++ b/apps/api/src/app/agents/shared/util/agent-api-root-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Public agent API root used for OAuth callbacks, MCP redirects, and webhooks.
+ * `AGENT_API_HOSTNAME` (e.g. ngrok) takes precedence over `API_ROOT_URL`.
+ */
+export function buildAgentApiRootUrl(): string {
+  const rootUrl = process.env.AGENT_API_HOSTNAME?.trim() || process.env.API_ROOT_URL?.trim();
+  if (!rootUrl) {
+    throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL environment variable is required');
+  }
+
+  return rootUrl.replace(/\/$/, '');
+}

--- a/apps/api/src/app/agents/shared/util/agent-api-root-url.ts
+++ b/apps/api/src/app/agents/shared/util/agent-api-root-url.ts
@@ -1,7 +1,3 @@
-/**
- * Public agent API root used for OAuth callbacks, MCP redirects, and webhooks.
- * `AGENT_API_HOSTNAME` (e.g. ngrok) takes precedence over `API_ROOT_URL`.
- */
 export function buildAgentApiRootUrl(): string {
   const rootUrl = process.env.AGENT_API_HOSTNAME?.trim() || process.env.API_ROOT_URL?.trim();
   if (!rootUrl) {

--- a/apps/api/src/app/agents/shared/util/agent-api-root-url.ts
+++ b/apps/api/src/app/agents/shared/util/agent-api-root-url.ts
@@ -4,5 +4,5 @@ export function buildAgentApiRootUrl(): string {
     throw new Error('AGENT_API_HOSTNAME or API_ROOT_URL environment variable is required');
   }
 
-  return rootUrl.replace(/\/$/, '');
+  return rootUrl.replace(/\/+$/, '');
 }

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import { AgentPlatformEnum } from '../enums/agent-platform.enum';
+import {
+  buildPoweredByWatermark,
+  contentHasPoweredByWatermark,
+  NOVU_AGENT_POWERED_URL,
+  NOVU_AGENT_POWERED_WATERMARK_TEXT,
+} from './novu-powered-by-watermark';
+
+describe('novu-powered-by-watermark', () => {
+  it('returns link-less text on WhatsApp', () => {
+    expect(buildPoweredByWatermark('my-agent', AgentPlatformEnum.WHATSAPP)).to.equal(
+      NOVU_AGENT_POWERED_WATERMARK_TEXT
+    );
+  });
+
+  it('returns attributed markdown link on Slack', () => {
+    const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.SLACK);
+
+    expect(watermark).to.include('[Powered by Novu](');
+    expect(watermark).to.include(NOVU_AGENT_POWERED_URL);
+    expect(watermark).to.include('utm_source=my-agent');
+    expect(watermark).to.include('utm_channel=slack');
+  });
+
+  it('detects attributed watermark in markdown', () => {
+    const markdown = `Hello\n\n[Powered by Novu](${NOVU_AGENT_POWERED_URL}?utm_campaign=agent-powered)`;
+
+    expect(contentHasPoweredByWatermark(markdown)).to.equal(true);
+  });
+
+  it('detects link-less watermark in markdown', () => {
+    const markdown = `Hello\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`;
+
+    expect(contentHasPoweredByWatermark(markdown)).to.equal(true);
+  });
+
+  it('does not treat unrelated body text as watermarked', () => {
+    expect(contentHasPoweredByWatermark('Hello there')).to.equal(false);
+  });
+});

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
@@ -10,9 +10,10 @@ import {
 
 describe('novu-powered-by-watermark', () => {
   it('returns link-less text on WhatsApp', () => {
-    expect(buildPoweredByWatermark('my-agent', AgentPlatformEnum.WHATSAPP)).to.equal(
-      NOVU_AGENT_POWERED_WATERMARK_TEXT
-    );
+    const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.WHATSAPP);
+
+    expect(watermark.startsWith(NOVU_AGENT_POWERED_WATERMARK_TEXT)).to.equal(true);
+    expect(watermark.length).to.be.greaterThan(NOVU_AGENT_POWERED_WATERMARK_TEXT.length);
   });
 
   it('returns attributed markdown link on Slack', () => {
@@ -31,9 +32,14 @@ describe('novu-powered-by-watermark', () => {
   });
 
   it('detects link-less watermark in markdown', () => {
-    const markdown = `Hello\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`;
+    const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.WHATSAPP);
+    const markdown = `Hello\n\n${watermark}`;
 
     expect(contentHasPoweredByWatermark(markdown)).to.equal(true);
+  });
+
+  it('does not treat plain Powered by Novu text as watermarked', () => {
+    expect(contentHasPoweredByWatermark(`Hello\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`)).to.equal(false);
   });
 
   it('does not treat unrelated body text as watermarked', () => {

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
@@ -38,5 +38,7 @@ describe('novu-powered-by-watermark', () => {
 
   it('does not treat unrelated body text as watermarked', () => {
     expect(contentHasPoweredByWatermark('Hello there')).to.equal(false);
+    expect(contentHasPoweredByWatermark('Powered by Novu is a great product')).to.equal(false);
+    expect(contentHasPoweredByWatermark('Hello\n\nPowered by Novu is great')).to.equal(false);
   });
 });

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -18,5 +18,10 @@ export function contentHasPoweredByWatermark(markdown: string): boolean {
     return true;
   }
 
-  return markdown.includes(`\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`);
+  const trimmed = markdown.trimEnd();
+  if (trimmed === NOVU_AGENT_POWERED_WATERMARK_TEXT) {
+    return true;
+  }
+
+  return trimmed.endsWith(`\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`);
 }

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -5,22 +5,25 @@ export const NOVU_AGENT_POWERED_URL = 'https://go.novu.co/agent-powered';
 
 export const NOVU_AGENT_POWERED_WATERMARK_TEXT = 'Powered by Novu';
 
+const NOVU_POWERED_WATERMARK_MARKER = '\u200B';
+
+const ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `[${NOVU_AGENT_POWERED_WATERMARK_TEXT}](${NOVU_AGENT_POWERED_URL}`;
+
 export function buildPoweredByWatermark(agentIdentifier: string, platform: string): string {
   if (!supportsMarkdownLinks(platform)) {
-    return NOVU_AGENT_POWERED_WATERMARK_TEXT;
+    return `${NOVU_AGENT_POWERED_WATERMARK_TEXT}${NOVU_POWERED_WATERMARK_MARKER}`;
   }
 
   return `[Powered by Novu](${buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform)})`;
 }
 
 export function contentHasPoweredByWatermark(markdown: string): boolean {
-  if (markdown.includes(NOVU_AGENT_POWERED_URL)) {
+  if (markdown.includes(ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX)) {
     return true;
   }
 
+  const linklessWatermark = `${NOVU_AGENT_POWERED_WATERMARK_TEXT}${NOVU_POWERED_WATERMARK_MARKER}`;
   const trimmed = markdown.trimEnd();
 
-  return (
-    trimmed === NOVU_AGENT_POWERED_WATERMARK_TEXT || trimmed.endsWith(`\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`)
-  );
+  return trimmed === linklessWatermark || trimmed.endsWith(`\n\n${linklessWatermark}`);
 }

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -1,0 +1,22 @@
+import { supportsMarkdownLinks } from '../enums/agent-platform.enum';
+import { buildAttributedNovuUrl } from './novu-attribution-url';
+
+export const NOVU_AGENT_POWERED_URL = 'https://go.novu.co/agent-powered';
+
+export const NOVU_AGENT_POWERED_WATERMARK_TEXT = 'Powered by Novu';
+
+export function buildPoweredByWatermark(agentIdentifier: string, platform: string): string {
+  if (!supportsMarkdownLinks(platform)) {
+    return NOVU_AGENT_POWERED_WATERMARK_TEXT;
+  }
+
+  return `[Powered by Novu](${buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform)})`;
+}
+
+export function contentHasPoweredByWatermark(markdown: string): boolean {
+  if (markdown.includes(NOVU_AGENT_POWERED_URL)) {
+    return true;
+  }
+
+  return markdown.includes(`\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`);
+}

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -19,9 +19,8 @@ export function contentHasPoweredByWatermark(markdown: string): boolean {
   }
 
   const trimmed = markdown.trimEnd();
-  if (trimmed === NOVU_AGENT_POWERED_WATERMARK_TEXT) {
-    return true;
-  }
 
-  return trimmed.endsWith(`\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`);
+  return (
+    trimmed === NOVU_AGENT_POWERED_WATERMARK_TEXT || trimmed.endsWith(`\n\n${NOVU_AGENT_POWERED_WATERMARK_TEXT}`)
+  );
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
WhatsApp agent messages were showing markdown link syntax and long OAuth URLs as broken/truncated text instead of tappable links. This PR fixes rendering and link behavior by making the “Powered by Novu” watermark platform-aware (plain text on WhatsApp, markdown-attributed link on platforms that support it) and by replacing MCP connect OAuth links with short redirect-token URLs backed by Redis (24-hour TTL) that resolve to the full provider authorize URL. It also centralizes platform capability/URL-building logic to reduce duplication.  

## Affected areas
**api**: Introduced Redis-backed `McpConnectRedirectService`, added the `GET /agents/mcp/r/:token` redirect endpoint, updated MCP OAuth controller flow and connect-card delivery to use platform-aware redirect/link building, and centralized MCP OAuth result-page rendering.  
**shared**: Added shared platform capability helpers (markdown link support / short-URL requirement), standardized agent API root URL construction, and implemented platform-aware Novu watermark/link detection utilities.

## Key technical decisions
- Short-lived redirect tokens are issued and resolved via `/v1/agents/mcp/r/:token`, stored in Redis for 24 hours, with safe fallback to full authorize URLs when caching is disabled or fails.  
- Platform capability rules (markdown link support and native URL button availability) drive both watermark rendering and whether OAuth URLs are shortened.

## Testing
Added unit tests for token issuance/resolution + cache-failure/disabled fallback, API root URL resolution, watermark rendering/detection, connect-card delivery platform handling, and MCP OAuth redirect behavior. Also includes manual verification of WhatsApp message rendering and redirect flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

WhatsApp does not render markdown links or native URL buttons from the Chat SDK adapter, so agent replies showed raw `[Powered by Novu](url)` text and MCP connect cards dumped multi-KB OAuth URLs as broken, truncated text.

This PR fixes that Novu-side by:
- Rendering a link-less `Powered by Novu` watermark on platforms without markdown link support (WhatsApp today)
- Issuing short-lived `/v1/agents/mcp/r/:token` redirect URLs for connect cards on platforms without native URL buttons
- Centralizing platform egress capabilities, connect-card delivery, and agent API root URL resolution

```mermaid
sequenceDiagram
  participant User as WhatsAppUser
  participant Agent as HandleNovuTools
  participant Redis
  participant API as AgentsMcpOAuthController
  participant Provider as OAuthProvider

  Agent->>Redis: store authorizeUrl under short token
  Agent->>User: Connect card with short api.novu.co/r/token URL
  User->>API: GET /v1/agents/mcp/r/:token
  API->>Redis: resolve token
  API->>Provider: 302 redirect to full authorizeUrl
```

Linear: https://linear.app/novu/issue/NV-8057/fix-whatsapp-agent-watermark-and-mcp-connect-link-rendering

### Screenshots

N/A — backend delivery changes only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None

### Special notes for your reviewer

- Slack/Telegram behavior is unchanged (attributed watermark link + native connect buttons)
- Short redirect tokens are Redis-backed with 24h TTL; cache-disabled environments fall back to the full authorize URL
- Upstream Chat SDK WhatsApp adapter changes (CTA URL buttons, markdown link rendering) remain out of scope

</details>

## Test plan

- [x] `pnpm test -- --grep "buildAgentApiRootUrl|novu-powered-by-watermark|McpConnectRedirectService|AgentsMcpOAuthController connect redirect|buildConnectCardDelivery|buildMcpOAuthRedirectUri"`
- [ ] Send a WhatsApp agent reply on a free plan org and confirm watermark shows as plain `Powered by Novu` (no markdown/URL artifacts)
- [ ] Trigger MCP connect on WhatsApp and confirm the card shows a short `/v1/agents/mcp/r/...` link that redirects to the provider OAuth screen
- [ ] Confirm Slack/Telegram connect cards and attributed watermark links still work as before

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds platform-aware `Powered by Novu` watermark rendering so WhatsApp receives plain text while platforms with markdown support keep linked attribution.
- Adds Redis-backed short MCP connect redirect URLs and a public `/v1/agents/mcp/r/:token` resolver for platforms that cannot render native URL buttons.
- Centralizes agent platform capabilities, connect-card delivery behavior, OAuth result page helpers, and agent API root URL resolution.

<h3>Confidence Score: 4/5</h3>

The change appears merge-safe, with focused backend updates and matching tests for the new redirect, URL-building, watermark, and connect-card behavior.

The implementation is scoped to platform-specific rendering and MCP redirect handling, and the described tests cover the main fallback and redirect paths. Remaining risk is mostly around production integration details such as Redis availability and real platform rendering behavior.

No specific files require follow-up based on the reviewed changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a cross-platform watermark rendering test and confirmed that after the update WhatsApp shows plain text watermark while Slack and Telegram retain the markdown watermark.
- Reviewed and described the code changes affecting watermark behavior and OAuth URL building, noting that WhatsApp now uses markdownLinks=false and requiresShortConnectUrl=true, while Slack/Teams/Telegram/Email/unknown use markdownLinks=true and requiresShortConnectUrl=false; buildAgentApiRootUrl now prefers AGENT\_API\_HOSTNAME, trims whitespace, strips ///, and buildMcpOAuthRedirectUri now returns the exact OAuth callback URL.

<a href="https://app.greptile.com/trex/runs/11285377/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): address PR review for WhatsApp..."](https://github.com/novuhq/novu/commit/3fa92ae643a8abf3514031a65c254af7a6619a2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37909261)</sub>

<!-- /greptile_comment -->