### PR TITLE
feat(dashboard): enhance usage card with upgrade button and reset date label

### DIFF
--- a/apps/dashboard/src/components/side-navigation/usage-card.tsx
+++ b/apps/dashboard/src/components/side-navigation/usage-card.tsx
@@ -116,40 +116,60 @@ type CardContentProps = {
   resetDate: string | null;
 };
 
+function UpgradeButton() {
+  return (
+    <Button className="h-[24px] w-full" variant="secondary" mode="lighter" size="2xs">
+      Upgrade now
+    </Button>
+  );
+}
+
+function ResetDateLabel({ formattedResetDate }: { formattedResetDate: string }) {
+  return (
+    <span className="text-text-soft text-label-xs flex items-center gap-1 leading-[16px]">
+      <RiCalendarEventLine className="size-3.5" />
+      Usage resets on {formattedResetDate}
+    </span>
+  );
+}
+
 function CardContent({ metrics, resetDate }: CardContentProps) {
   const anyComplete = metrics.some((metric) => getUsageStatus(metric.current, metric.max).isComplete);
   const formattedResetDate = resetDate ? format(new Date(resetDate), 'MMM d yyyy') : '';
 
+  if (anyComplete) {
+    return (
+      <div className="flex flex-col p-2">
+        <div className="space-y-2">
+          {metrics.map((metric) => (
+            <UsageMetricRow key={metric.label} {...metric} />
+          ))}
+          {formattedResetDate && <ResetDateLabel formattedResetDate={formattedResetDate} />}
+        </div>
+        <div className="mt-2">
+          <UpgradeButton />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative flex flex-col overflow-hidden p-2">
-      <div
-        className={
-          anyComplete
-            ? 'space-y-2'
-            : 'space-y-2 transition-all duration-200 ease-out group-hover:translate-y-[-8px] group-hover:opacity-0'
-        }
-      >
+      <div className="space-y-2 transition-transform duration-200 ease-out group-hover:-translate-y-1">
         {metrics.map((metric) => (
           <UsageMetricRow key={metric.label} {...metric} />
         ))}
-        {formattedResetDate && (
-          <span className="text-text-soft text-label-xs flex items-center gap-1 leading-[16px]">
-            <RiCalendarEventLine className="size-3.5" />
-            Usage resets on {formattedResetDate}
-          </span>
-        )}
       </div>
 
-      <div
-        className={
-          anyComplete
-            ? 'mt-2'
-            : 'absolute bottom-2 left-2 right-2 translate-y-[10px] opacity-0 transition-all duration-300 ease-out group-hover:translate-y-0 group-hover:opacity-100'
-        }
-      >
-        <Button className="h-[24px] w-full" variant="secondary" mode="lighter" size="2xs">
-          Upgrade now
-        </Button>
+      <div className="relative mt-2 h-6">
+        {formattedResetDate && (
+          <div className="absolute inset-0 flex items-center transition-all duration-200 ease-out group-hover:-translate-y-1 group-hover:opacity-0">
+            <ResetDateLabel formattedResetDate={formattedResetDate} />
+          </div>
+        )}
+        <div className="absolute inset-0 flex items-center translate-y-1 opacity-0 transition-all duration-200 ease-out group-hover:translate-y-0 group-hover:opacity-100">
+          <UpgradeButton />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The usage card component was refactored to improve the UI layout strategy. Two new subcomponents—`UpgradeButton` and `ResetDateLabel`—were extracted for better code organization. The `CardContent` component now implements different layouts based on usage status: when any usage metric reaches its limit, the reset date and upgrade button are displayed in a static stacked layout; when limits aren't reached, they're positioned absolutely with opacity transitions triggered on hover.

## Affected areas

**dashboard**: Updated the usage card component to display upgrade and reset information with enhanced interactivity through conditional layout rendering and hover-driven transitions.

## Testing

No tests were added; the changes are purely UI refactoring with no functional behavior changes to the underlying usage tracking or billing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates the dashboard side-navigation usage card with a reusable upgrade button.
- Adds a reset-date label with a calendar icon.
- Changes the hover state so the reset date swaps with the upgrade CTA, while keeping the CTA visible when usage is complete.

<h3>Confidence Score: 3/5</h3>

The change is localized to a dashboard navigation card, but the nullable reset date case can affect layout spacing in the sidebar.

The review focuses on the only changed UI component and the issue is tied to a concrete nullable data path. Runtime capture was attempted but did not complete with a valid rendered artifact, so confidence remains moderate rather than higher.

apps/dashboard/src/components/side-navigation/usage-card.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I created a focused Vite harness that renders the UsageCard component with events at 4500 of 10000 and currentPeriodEnd set to null.
- The dashboard Vite server could be started with the focused harness.
- Playwright capture attempts were disrupted by environment and tooling issues and did not produce a valid rendered UI capture.
- A direct server-start test showed the harness server could bind to localhost:4201, but the run timed out as it is a long-running dev server rather than a UI issue.
- No reliable before/after rendered UI evidence was captured, so no contract mismatch finding was filed.

<a href="https://app.greptile.com/trex/runs/11377935/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fside-navigation%2Fusage-card.tsx%3A164-173%0A**Avoid%20empty%20footer%20space**%0A%0AWhen%20%60resetDate%60%20is%20%60null%60%2C%20this%20branch%20still%20renders%20the%20in-flow%20%60mt-2%20h-6%60%20footer.%20The%20reset%20label%20is%20skipped%2C%20and%20the%20only%20remaining%20child%20is%20the%20absolutely%20positioned%20upgrade%20button%20with%20%60opacity-0%60%20until%20hover.%20Since%20%60currentPeriodEnd%60%20is%20nullable%20in%20the%20subscription%20DTO%2C%20these%20cards%20can%20show%20a%20blank%2024px%20footer%20in%20the%20resting%20state%20and%20push%20the%20bottom%20navigation%20down.%20The%20previous%20non-complete%20layout%20kept%20the%20hidden%20upgrade%20button%20out%20of%20normal%20flow%2C%20so%20a%20missing%20reset%20date%20did%20not%20reserve%20this%20empty%20space.%0A%0A&pr=11592&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/side-navigation/usage-card.tsx:164-173
**Avoid empty footer space**

When `resetDate` is `null`, this branch still renders the in-flow `mt-2 h-6` footer. The reset label is skipped, and the only remaining child is the absolutely positioned upgrade button with `opacity-0` until hover. Since `currentPeriodEnd` is nullable in the subscription DTO, these cards can show a blank 24px footer in the resting state and push the bottom navigation down. The previous non-complete layout kept the hidden upgrade button out of normal flow, so a missing reset date did not reserve this empty space.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): enhance usage card with..."](https://github.com/novuhq/novu/commit/d73c4829531720c87e1e235a8ad907ea8b2e1ce6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38106866)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->