### PR TITLE
feat(root): sort selected items to top in agent creation multi-select fixes NV-8076

### DIFF
--- a/packages/novu/src/commands/connect/ui/preview-generated-content.tsx
+++ b/packages/novu/src/commands/connect/ui/preview-generated-content.tsx
@@ -4,7 +4,7 @@ import { Box, Text, useInput, useStdout } from 'ink';
 // biome-ignore lint/correctness/noUnusedImports: classic-JSX linter falls back here because tsconfig.json excludes ui/.
 import React from 'react';
 import type { GeneratedAgentSpec } from '../api/agents';
-import { wrapPreviewLines } from './agent-spec-labels';
+import { type CatalogSelectOption, wrapPreviewLines } from './agent-spec-labels';
 import {
   applyPreviewMultiEdit,
   applyPreviewTextEdit,
@@ -320,6 +320,22 @@ function PreviewTextEditor({
   );
 }
 
+function sortSelectedFirst(options: CatalogSelectOption[], selectedValues: string[]): CatalogSelectOption[] {
+  const selectedSet = new Set(selectedValues);
+  const selected: CatalogSelectOption[] = [];
+  const unselected: CatalogSelectOption[] = [];
+
+  for (const option of options) {
+    if (selectedSet.has(option.value)) {
+      selected.push(option);
+    } else {
+      unselected.push(option);
+    }
+  }
+
+  return [...selected, ...unselected];
+}
+
 function PreviewMultiEditor({
   fieldId,
   draft,
@@ -336,8 +352,8 @@ function PreviewMultiEditor({
   validationError: string | null;
 }): React.ReactElement {
   const title = getPreviewFieldLabel(fieldId);
-  const options = readPreviewMultiOptions(fieldId);
   const defaultValue = readPreviewMultiDefaultValue(fieldId, draft);
+  const options = sortSelectedFirst(readPreviewMultiOptions(fieldId), defaultValue);
   const limitHint = (() => {
     if (fieldId === 'mcpServers') return `Select up to ${MAX_GENERATED_MCP_SERVERS}.`;
     if (fieldId === 'skills') return `Select up to ${MAX_GENERATED_SKILLS}.`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

In the `novu connect` CLI agent creation flow, when editing multi-select fields (MCP servers, tools, skills), the selected items were displayed in catalog order mixed with unselected items. This made it difficult to find and deselect already-chosen items, especially as the list grows.

This change adds a `sortSelectedFirst` utility that partitions options into selected and unselected groups, placing selected items at the top of the list. This applies to all multi-select editors in the preview screen (MCPs, tools, and skills).

Resolves feedback from @victor_yakubu: selected MCPs should be immediately visible at the top of the edit list for easy removal.

### Screenshots

N/A — This is a terminal UI (Ink/CLI) change. Selected items now appear first in the multi-select list when editing MCP, tools, or skills fields during agent creation.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- `sortSelectedFirst` preserves the relative catalog order within each group (selected and unselected). It is applied generically to all `PreviewMultiEditor` instances (tools, mcpServers, skills) since the same UX improvement benefits all of them.
- **On the "selection goes stale during the edit session" review note (Greptile/CodeRabbit):** the ordering is intentionally computed once from the draft value when the editor opens, not on every space-toggle. The feature goal is that *already-selected* items are visible at the top when re-opening the editor so they're easy to remove. Re-sorting live as the user toggles would shift rows under the cursor mid-navigation — a worse, more jarring UX that most multi-select pickers deliberately avoid. The toggled state is still committed correctly on submit; only the visual top-grouping is fixed at open time, which matches the requested behavior.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8076](https://linear.app/novu/issue/NV-8076/sort-selected-mcps-to-the-top-in-agent-creation-flow)

<div><a href="https://cursor.com/agents/bc-f81120bc-fe45-464f-b9ea-d5be83b3cb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f81120bc-fe45-464f-b9ea-d5be83b3cb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `novu connect` CLI agent creation flow now displays selected items first in multi-select fields. A new `sortSelectedFirst` utility function reorders multi-select options so that items matching the current selection appear at the top of the list, with unselected items below. This applies to MCP servers, tools, and skills fields in the preview screen, making selected items immediately visible and easier to deselect as the list grows.

## Affected areas

**novu**: Updated the CLI connect command's preview generation UI to sort multi-select options with selected items appearing first, improving discoverability of already-chosen items during agent configuration.

## Testing

No new tests are mentioned in the summary. Given that this is a localized UI utility change affecting option ordering in existing components, manual verification through the agent creation flow would validate the sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds selected-first ordering for agent creation preview multi-select editors.
- Applies the behavior to MCP servers, tools, and skills.
- Preserves relative catalog order within the selected and unselected groups.

<h3>Confidence Score: 3/5</h3>

The change is narrowly scoped to CLI multi-select ordering, but the editor ordering can become stale during an active selection session.

The reviewed file is small and the main behavior is straightforward, with one interaction-state issue identified around sorting from the initial draft value rather than live selection state.

packages/novu/src/commands/connect/ui/preview-generated-content.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Created a repository-backed Ink/Vitest harness to exercise the PreviewGeneratedContent component and simulate selecting options in the MCP editor.
- Resolved environment blockers by upgrading Node to a 22.x version and reinstalling dependencies with pnpm.
- Attempt to run the harness was blocked because vitest was not available, so no runtime proof of the selection-order behavior was captured.
- Observed the selection-order behavior when selectedFirst is toggled: selected items appear first in their original relative order, followed by unselected items in their original relative order for tools, MCP servers, and skills.

<a href="https://app.greptile.com/trex/runs/11513433/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnovu%2Fsrc%2Fcommands%2Fconnect%2Fui%2Fpreview-generated-content.tsx%3A356%0A**Selection%20order%20goes%20stale**%0A%0A%60options%60%20is%20sorted%20from%20%60defaultValue%60%2C%20but%20%60defaultValue%60%20only%20reflects%20the%20draft%20value%20when%20the%20editor%20opens.%20If%20a%20user%20scrolls%20to%20an%20unselected%20MCP%2C%20tool%2C%20or%20skill%20and%20toggles%20it%20with%20space%2C%20the%20selected%20value%20is%20stored%20inside%20%60MultiSelect%60%20until%20submit%2C%20so%20the%20option%20stays%20in%20its%20old%20catalog%20position%20instead%20of%20moving%20into%20the%20selected-at-top%20group.%20That%20means%20the%20new%20behavior%20only%20works%20for%20items%20selected%20before%20opening%20the%20editor%2C%20not%20for%20selections%20made%20during%20the%20edit%20session.%0A%0A&pr=11601&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/novu/src/commands/connect/ui/preview-generated-content.tsx:356
**Selection order goes stale**

`options` is sorted from `defaultValue`, but `defaultValue` only reflects the draft value when the editor opens. If a user scrolls to an unselected MCP, tool, or skill and toggles it with space, the selected value is stored inside `MultiSelect` until submit, so the option stays in its old catalog position instead of moving into the selected-at-top group. That means the new behavior only works for items selected before opening the editor, not for selections made during the edit session.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(root): sort selected items to top i..."](https://github.com/novuhq/novu/commit/ef7c94d7c50005fa2e8bb27ede84208ac3ac2e00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38383596)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->