### PR TITLE
refactor(api-service): unify agent conversation history fetching across runtimes fixes NV-8080

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -16,6 +16,9 @@ import type { TriggerRecipientsPayload } from '@novu/shared';
 export const INBOUND_ATTACHMENT_ONLY_PREVIEW = '[Attachment]';
 export const DEFAULT_CONVERSATION_TITLE = 'Untitled conversation';
 
+/** Default number of recent activities loaded as conversation history for every runtime. */
+export const AGENT_HISTORY_LIMIT = 50;
+
 export function getConversationTitle(firstMessageText: string): string {
   const trimmed = firstMessageText.trim();
 
@@ -256,8 +259,21 @@ export class AgentConversationService {
     return activity;
   }
 
-  async getHistory(environmentId: string, conversationId: string, limit = 20): Promise<ConversationActivityEntity[]> {
+  async getHistory(
+    environmentId: string,
+    conversationId: string,
+    limit = AGENT_HISTORY_LIMIT
+  ): Promise<ConversationActivityEntity[]> {
     return this.activityRepository.findByConversation(environmentId, conversationId, limit);
+  }
+
+  /** Resolves the stored activity a reaction targets, matched by platform-native message id. */
+  async findSourceActivity(
+    environmentId: string,
+    conversationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.activityRepository.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
   }
 
   async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -61,7 +61,12 @@ describe('AgentInboundHandler', () => {
       setFirstPlatformMessageId: sinon.stub().resolves(undefined),
       findByPlatformThread: sinon.stub().resolves(conversation),
       getHistory: sinon.stub().resolves(overrides.history ?? []),
-      findSourceActivity: sinon.stub().resolves((overrides.history ?? [])[0] ?? null),
+      findSourceActivity: sinon
+        .stub()
+        .callsFake(
+          async (_environmentId: string, _conversationId: string, platformMessageId: string) =>
+            (overrides.history ?? []).find((activity: any) => activity?.platformMessageId === platformMessageId) ?? null
+        ),
       countAgentMessages: sinon.stub().resolves(0),
     };
     const bridgeExecutor = {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -61,6 +61,7 @@ describe('AgentInboundHandler', () => {
       setFirstPlatformMessageId: sinon.stub().resolves(undefined),
       findByPlatformThread: sinon.stub().resolves(conversation),
       getHistory: sinon.stub().resolves(overrides.history ?? []),
+      findSourceActivity: sinon.stub().resolves((overrides.history ?? [])[0] ?? null),
       countAgentMessages: sinon.stub().resolves(0),
     };
     const bridgeExecutor = {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -32,12 +32,12 @@ import { type AutoProvisionPlatform, isAutoProvisionPlatform } from '../../share
 import { InboundAckService } from '../ack/inbound-ack.service';
 import { AgentAttachmentStorage, type StoredAttachment } from '../conversation/agent-attachment-storage.service';
 import { AgentConversationService, getInboundActivityPreview } from '../conversation/agent-conversation.service';
-import { ConversationActivationService } from '../conversation/conversation-activation.service';
 import {
   AgentSubscriberResolver,
   BotAuthorSkippedError,
   ConnectOrgSubscriberCapExceededError,
 } from '../conversation/agent-subscriber-resolver.service';
+import { ConversationActivationService } from '../conversation/conversation-activation.service';
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { BridgeReaction } from '../runtime/bridge-executor.service';
 import type { ConversationTurn } from '../runtime/conversation-turn';
@@ -196,15 +196,7 @@ function mapStoredAttachmentsFromRichContent(richContent?: Record<string, unknow
   });
 }
 
-function findSourceMessageStoredAttachments(
-  history: ConversationActivityEntity[],
-  messageIds: string[]
-): StoredAttachment[] | undefined {
-  const messageIdSet = new Set(messageIds);
-  const sourceActivity = history.find(
-    (activity) => activity.platformMessageId && messageIdSet.has(activity.platformMessageId)
-  );
-
+function extractStoredAttachments(sourceActivity: ConversationActivityEntity | null): StoredAttachment[] | undefined {
   if (!sourceActivity) {
     return undefined;
   }
@@ -389,11 +381,10 @@ export class AgentInboundHandler implements OnModuleInit {
       isFirstMessage,
     });
 
-    const [subscriber, history, agent] = await Promise.all([
+    const [subscriber, agent] = await Promise.all([
       subscriberId
         ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
         : Promise.resolve(null),
-      this.conversationService.getHistory(config.environmentId, conversation._id),
       this.agentRepository.findOne({ _id: agentId, _environmentId: config.environmentId }, [
         '_id',
         'runtime',
@@ -418,7 +409,6 @@ export class AgentInboundHandler implements OnModuleInit {
       config,
       conversation,
       subscriber,
-      history,
       message,
       event,
       thread,
@@ -843,15 +833,14 @@ export class AgentInboundHandler implements OnModuleInit {
       ? await this.resolveSubscriberId(agentId, config, platformUserId, 'resolve-subscriber-reaction')
       : null;
 
-    const [subscriber, history] = await Promise.all([
+    const [subscriber, sourceActivity] = await Promise.all([
       subscriberId
         ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
         : Promise.resolve(null),
-      this.conversationService.getHistory(config.environmentId, conversation._id),
+      this.conversationService.findSourceActivity(config.environmentId, conversation._id, event.messageId),
     ]);
 
-    const sourceMessageIds = [event.messageId, event.message?.id].filter((id): id is string => Boolean(id));
-    let sourceMessageStoredAttachments = findSourceMessageStoredAttachments(history, sourceMessageIds);
+    let sourceMessageStoredAttachments = extractStoredAttachments(sourceActivity);
 
     if (!sourceMessageStoredAttachments && event.message?.attachments?.length) {
       sourceMessageStoredAttachments = await this.attachmentStorage.storeInbound(event.message.attachments, {
@@ -880,7 +869,6 @@ export class AgentInboundHandler implements OnModuleInit {
       config,
       conversation,
       subscriber,
-      history,
       message: null,
       event: AgentEventEnum.ON_REACTION,
       thread: event.thread ?? ({ id: threadId, channelId: '', isDM: false } as Thread),
@@ -944,11 +932,10 @@ export class AgentInboundHandler implements OnModuleInit {
 
     // Everything else (incl. mcp-approval:* for managed) routes through the runtime,
     // which owns its own action semantics.
-    const [subscriber, history, agent] = await Promise.all([
+    const [subscriber, agent] = await Promise.all([
       subscriberId
         ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
         : Promise.resolve(null),
-      this.conversationService.getHistory(config.environmentId, conversation._id),
       this.agentRepository.findOne({ _id: agentId, _environmentId: config.environmentId }, [
         '_id',
         'runtime',
@@ -963,7 +950,6 @@ export class AgentInboundHandler implements OnModuleInit {
       config,
       conversation,
       subscriber,
-      history,
       message: null,
       event: AgentEventEnum.ON_ACTION,
       thread,

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -487,19 +487,15 @@ export class HandleAgentReply {
     const subscriberParticipant = conversation.participants.find(
       (p) => p.type === ConversationParticipantTypeEnum.SUBSCRIBER
     );
-    const [subscriber, history] = await Promise.all([
-      subscriberParticipant
-        ? this.subscriberRepository.findBySubscriberId(command.environmentId, subscriberParticipant.id)
-        : Promise.resolve(null),
-      this.conversationService.getHistory(command.environmentId, conversation._id),
-    ]);
+    const subscriber = subscriberParticipant
+      ? await this.subscriberRepository.findBySubscriberId(command.environmentId, subscriberParticipant.id)
+      : null;
 
     await this.bridgeExecutor.execute({
       event: AgentEventEnum.ON_RESOLVE,
       config,
       conversation,
       subscriber,
-      history,
       message: null,
       platformContext: buildAgentPlatformContext({
         platformThreadId: channel.platformThreadId,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
@@ -45,7 +45,7 @@ describe('BridgeExecutorService', () => {
       const attachmentStorage = {
         signRead: sinon.stub().rejects(new Error('storage unavailable')),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       const result = await (service as any).mapRichContentForBridge(
         {
@@ -71,7 +71,7 @@ describe('BridgeExecutorService', () => {
       const attachmentStorage = {
         signRead: sinon.stub().resolves('https://signed/read'),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       const result = await (service as any).mapRichContentForBridge(
         {
@@ -98,7 +98,7 @@ describe('BridgeExecutorService', () => {
       const attachmentStorage = {
         signRead: sinon.stub().resolves('https://signed/read'),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       const result = await (service as any).mapRichContentForBridge(
         {
@@ -126,7 +126,7 @@ describe('BridgeExecutorService', () => {
           return 'https://signed/read';
         }),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       await (service as any).mapRichContentForBridge(
         {
@@ -156,7 +156,7 @@ describe('BridgeExecutorService', () => {
           return 'https://signed/read';
         }),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       await (service as any).mapHistory([
         makeActivity({
@@ -190,7 +190,7 @@ describe('BridgeExecutorService', () => {
       const attachmentStorage = {
         signRead: sinon.stub().resolves('https://fresh-signed/read'),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       const result = await (service as any).mapMessage(
         makeMessage(),
@@ -230,7 +230,7 @@ describe('BridgeExecutorService', () => {
       const attachmentStorage = {
         signRead: sinon.stub().rejects(new Error('sign failed')),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       const result = await (service as any).mapMessage(
         makeMessage(),
@@ -266,7 +266,7 @@ describe('BridgeExecutorService', () => {
           return 'https://fresh-signed/read';
         }),
       };
-      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any, {} as any);
 
       const result = await (service as any).mapMessage(
         makeMessage(),

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
@@ -26,6 +26,7 @@ import type { Message } from 'chat';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { AgentAttachmentStorage, type StoredAttachment } from '../conversation/agent-attachment-storage.service';
+import { AgentConversationService } from '../conversation/agent-conversation.service';
 
 const MAX_RETRIES = 2;
 
@@ -85,7 +86,6 @@ export interface AgentExecutionParams {
   config: ResolvedAgentConfig;
   conversation: ConversationEntity;
   subscriber: SubscriberEntity | null;
-  history: ConversationActivityEntity[];
   message: Message | null;
   platformContext: AgentPlatformContext;
   action?: AgentAction;
@@ -107,7 +107,8 @@ export class BridgeExecutorService {
   constructor(
     private readonly getDecryptedSecretKey: GetDecryptedSecretKey,
     private readonly logger: PinoLogger,
-    private readonly attachmentStorage: AgentAttachmentStorage
+    private readonly attachmentStorage: AgentAttachmentStorage,
+    private readonly conversationService: AgentConversationService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -260,8 +261,10 @@ export class BridgeExecutorService {
   }
 
   private async buildPayload(params: AgentExecutionParams): Promise<AgentBridgeRequest> {
-    const { event, config, conversation, subscriber, history, message, platformContext, action, reaction } = params;
+    const { event, config, conversation, subscriber, message, platformContext, action, reaction } = params;
     const agentIdentifier = config.agentIdentifier;
+
+    const history = await this.conversationService.getHistory(config.environmentId, conversation._id);
 
     const replyUrl = `${resolveAgentReplyApiOrigin()}/v1/agents/${agentIdentifier}/reply`;
 

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
@@ -264,7 +264,7 @@ export class BridgeExecutorService {
     const { event, config, conversation, subscriber, message, platformContext, action, reaction } = params;
     const agentIdentifier = config.agentIdentifier;
 
-    const history = await this.conversationService.getHistory(config.environmentId, conversation._id);
+    const history = await this.loadHistory(config.environmentId, conversation._id, agentIdentifier);
 
     const replyUrl = `${resolveAgentReplyApiOrigin()}/v1/agents/${agentIdentifier}/reply`;
 
@@ -305,6 +305,26 @@ export class BridgeExecutorService {
       action: action ?? null,
       reaction: reaction ? await this.mapReaction(reaction, config, conversation) : null,
     };
+  }
+
+  /** Fail-soft: a history read error must not drop the bridge delivery — send the event with empty history. */
+  private async loadHistory(
+    environmentId: string,
+    conversationId: string,
+    agentIdentifier: string
+  ): Promise<ConversationActivityEntity[]> {
+    try {
+      return await this.conversationService.getHistory(environmentId, conversationId);
+    } catch (err) {
+      this.logger.warn(err, `[agent:${agentIdentifier}] Failed to load conversation history; continuing without it`);
+      captureAgentWarning(err, {
+        component: 'bridge-executor',
+        operation: 'load-history',
+        agentIdentifier,
+      });
+
+      return [];
+    }
   }
 
   private async mapMessage(

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
@@ -69,7 +69,6 @@ export class BridgeRuntime implements AgentRuntime {
       config: turn.config,
       conversation: turn.conversation,
       subscriber: turn.subscriber,
-      history: turn.history,
       message: turn.message,
       platformContext: buildAgentPlatformContext({
         platformThreadId: turn.platformThreadId,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/conversation-turn.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/conversation-turn.ts
@@ -1,4 +1,4 @@
-import type { AgentEntity, ConversationActivityEntity, ConversationEntity, SubscriberEntity } from '@novu/dal';
+import type { AgentEntity, ConversationEntity, SubscriberEntity } from '@novu/dal';
 import type { AgentAction } from '@novu/framework';
 import type { Message, Thread } from 'chat';
 import type { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
@@ -12,7 +12,6 @@ export interface ConversationTurn {
   config: ResolvedAgentConfig;
   conversation: ConversationEntity;
   subscriber: SubscriberEntity | null;
-  history: ConversationActivityEntity[];
   message: Message | null;
   event: AgentEventEnum;
   thread: Thread;

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -382,7 +382,6 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       expect(call.subscriber!.firstName).to.equal('Bridge');
       expect(call.subscriber!.email).to.equal('bridge@test.com');
 
-      expect(call.history).to.be.an('array');
       expect(call.message).to.exist;
       expect(call.message!.text).to.equal('Bridge test');
 

--- a/apps/api/src/app/agents/managed-runtime/managed-agent.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent.service.ts
@@ -16,6 +16,7 @@ import { createWebhookHandler, type WebhookHandler } from '@novu/thalamus/webhoo
 import type { Request, Response } from 'express';
 import type { ResolvedAgentConfig } from '../channels/agent-config-resolver.service';
 import { InboundAckService } from '../conversation-runtime/ack/inbound-ack.service';
+import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
 import { AgentMcpSessionService } from '../mcp/runtime/agent-mcp-session.service';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
 import { AgentRuntimeDefinitionService } from './agent-runtime-definition.service';
@@ -64,6 +65,7 @@ export class ManagedAgentService implements OnModuleInit {
     private readonly eventHandler: ManagedAgentEventHandler,
     private readonly conversationRepository: ConversationRepository,
     private readonly conversationActivityRepository: ConversationActivityRepository,
+    private readonly conversationService: AgentConversationService,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly agentMcpSessionService: AgentMcpSessionService,
     private readonly demoQuota: DemoClaudeQuotaPolicy,
@@ -401,10 +403,9 @@ export class ManagedAgentService implements OnModuleInit {
   }
 
   private async buildMessagesWithHistory(context: ManagedAgentContext): Promise<Message[]> {
-    const history = await this.conversationActivityRepository.findByConversation(
+    const history = await this.conversationService.getHistory(
       context.config.environmentId,
-      String(context.conversation._id),
-      50
+      String(context.conversation._id)
     );
 
     const messages: Message[] = history

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -45,6 +45,22 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     });
   }
 
+  /** Resolves the activity for a specific platform-native message id (e.g. the message a reaction targets). */
+  async findByPlatformMessageId(
+    environmentId: string,
+    conversationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.findOne(
+      {
+        _environmentId: environmentId,
+        _conversationId: conversationId,
+        platformMessageId,
+      },
+      '*'
+    );
+  }
+
   async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
     return this.count({
       _environmentId: environmentId,


### PR DESCRIPTION
## Summary

Conversation history was fetched in two places with divergent semantics:

- **Ingress** (`inbound-turn.handler`) eagerly fetched history (limit 20) onto every `ConversationTurn`, but only the **bridge** runtime ever read it.
- **Managed** ignored `turn.history` and re-fetched its own (limit 50, signals filtered) inside `ManagedAgentService`.

So managed turns paid for a wasted ingress read (and a double read on the first turn), and the 20-vs-50 window had drifted by accident.

This unifies on **one canonical fetch, mapped per runtime**:

- Removed `history` from `ConversationTurn` and dropped the eager ingress fetch for message/action turns.
- Both runtimes read through the single `AgentConversationService.getHistory` source, unified to one window (`AGENT_HISTORY_LIMIT = 50`):
  - **Bridge** fetches + maps to `AgentHistoryEntry[]` inside `bridge-executor` (`history` removed from `AgentExecutionParams`; `handle-agent-reply` no longer passes it).
  - **Managed** fetches + maps to `Message[]` (signals filtered) only when there is no session.
- Each runtime owns its own mapping/shape.

### Reaction cleanup

The reaction path only needed history to resolve the reacted-to message's stored attachments. Replaced the "fetch 50 rows + `.find()`" scan with a targeted `ConversationActivityRepository.findByPlatformMessageId` lookup keyed on `event.messageId` — removing the reaction-path double fetch and the redundant two-id array.

## Flow

```mermaid
flowchart TD
    I[Ingress: inbound-turn.handler] -->|no history fetch for message/action| R{RuntimeResolver}
    I -->|reaction: findByPlatformMessageId for attachments| R
    R -->|bridge| B[BridgeExecutor.buildPayload]
    R -->|managed| M[ManagedAgentService.dispatch]
    B -->|getHistory 50| S[(AgentConversationService.getHistory)]
    M -->|getHistory 50 when sessionless| S
    B --> BH[map to AgentHistoryEntry array]
    M --> MH[map to Message array, signals filtered]
```

## Test plan

- [x] `inbound-turn.handler.spec` passes (incl. reaction attachment tests)
- [x] `bridge-executor.service.spec` passes
- [x] Lints clean; `@novu/dal` rebuilt for the new repository method
- [ ] CI green

Fixes NV-8080

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR unifies conversation history fetching across agent runtimes in the API service to remove redundant database reads and inconsistent history windows. Ingress no longer eagerly loads history for every turn, and the canonical `AgentConversationService.getHistory` becomes the shared source with a unified 50-message limit. The `history` field is removed from `ConversationTurn` and `AgentExecutionParams`, and both bridge and managed runtimes fetch and map history independently. Reaction handling is optimized by resolving the reacted-to “source” activity via `findByPlatformMessageId` instead of scanning full history, with bridge history loads made fail-soft on transient DAL errors.

## Affected areas
**api**: Removes `history` from turn/execution payload types, drops ingress eager history fetching, updates bridge/managed runtimes to fetch and transform history via `AgentConversationService`, and refactors reaction attachment resolution to a targeted source-activity lookup.  
**dal**: Adds `ConversationActivityRepository.findByPlatformMessageId` to support keyed reaction-source resolution.

## Key technical decisions
- History window is standardized to 50 messages via `AGENT_HISTORY_LIMIT` using a single `getHistory` entrypoint.
- Runtime-specific mapping remains inside each runtime to preserve filtering/shape requirements (e.g., managed signal filtering).
- Reaction resolution switches from full history scans to a single platform-message-id lookup to avoid the reaction-path double fetch.

## Testing
Updated unit tests for `inbound-turn.handler` and `bridge-executor` to match the new call signatures and reaction lookup behavior, and adjusted the Slack bridge-call E2E assertion to remove the now-absent `history` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Centralizes agent conversation history fetching through `AgentConversationService.getHistory` with a shared 50-entry window.
- Removes eager history loading from inbound turns and lets bridge and managed runtimes fetch and map history in their own runtime-specific shapes.
- Replaces reaction-path history scans with a targeted source-activity lookup by platform message id.

<h3>Confidence Score: 4/5</h3>

The refactor is mostly contained to agent conversation history and reaction handling, but the reaction attachment lookup path needs attention before merging.

The change has focused tests around the main history-fetching behavior, and the remaining concern is isolated to alternate source id handling in reactions.

apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Created a focused Mocha repro test that models event.messageId as a non-source reaction id and event.message.id as the stored source platform id.
- Attempted to run the focused test, but the environment blocked execution due to Node.js version constraints and pnpm resolution requiring Node v22.13 while only Node v20.9.0 is available.
- Tried to invoke pnpm via npx as an alternative, but the environment still resolved pnpm 11.0.9 and failed before Mocha could run due to missing Node.js built-ins.
- Ran the verification step, but local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/11534550/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Fingress%2Finbound-turn.handler.ts%3A836-843%0A**Preserve%20alternate%20source%20id**%0A%0AThe%20old%20reaction%20path%20looked%20up%20stored%20source-message%20attachments%20by%20both%20%60event.messageId%60%20and%20%60event.message%3F.id%60.%20This%20new%20targeted%20lookup%20only%20checks%20%60event.messageId%60%2C%20while%20the%20fallback%20storage%20path%20below%20still%20treats%20%60event.message.id%60%20as%20the%20stored%20platform%20message%20id.%20When%20an%20adapter%20sends%20a%20reaction%20whose%20target%20id%20is%20in%20%60event.message.id%60%2C%20this%20lookup%20returns%20%60null%60%2C%20so%20existing%20stored%20attachments%20are%20either%20uploaded%20again%20or%20omitted%20when%20the%20source%20message%20is%20not%20hydrated.%0A%0A&pr=11603&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts:836-843
**Preserve alternate source id**

The old reaction path looked up stored source-message attachments by both `event.messageId` and `event.message?.id`. This new targeted lookup only checks `event.messageId`, while the fallback storage path below still treats `event.message.id` as the stored platform message id. When an adapter sends a reaction whose target id is in `event.message.id`, this lookup returns `null`, so existing stored attachments are either uploaded again or omitted when the source message is not hydrated.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api-service): fail-soft bridge ..."](https://github.com/novuhq/novu/commit/86eab63db8882a6552fe3798fc63d7890e994ad9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38414200)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->