### PR TITLE
feat(api-service): stream agent replies per message via onMessage fixes NV-7420

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -74,7 +74,7 @@
     "@novu/notifications": "workspace:*",
     "@novu/shared": "workspace:*",
     "@novu/stateless": "workspace:*",
-    "@novu/thalamus": "0.1.0-alpha.14",
+    "@novu/thalamus": "0.1.0-alpha.15",
     "@novu/testing": "workspace:*",
     "@sendgrid/mail": "^8.1.6",
     "@slack/types": "2.20.1",

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -137,6 +137,26 @@ export class ManagedAgentEventHandler {
         }
       },
 
+      onMessage: async (event: { text: string }) => {
+        try {
+          if (metadata.suppressReply === 'true') {
+            return;
+          }
+          const markdown = event.text?.trim();
+          if (!markdown) {
+            return;
+          }
+          await this.handleAgentReply.execute(HandleAgentReplyCommand.create({ ...baseFields, reply: { markdown } }));
+        } catch (err) {
+          this.logger.error(err, `onMessage failed: session=${sessionId}`);
+          captureAgentException(err, {
+            component: 'managed-agent-event-handler',
+            operation: 'on-message',
+            sessionId,
+          });
+        }
+      },
+
       onFinish: async (event: { response: ThalamusResponse }) => {
         try {
           if (event.response.finishReason === 'requires-action') {
@@ -159,13 +179,6 @@ export class ManagedAgentEventHandler {
             await this.inboundAck.onManagedTurnComplete(metadata);
 
             return;
-          }
-
-          const replyMarkdown = event.response.content?.trim();
-          if (replyMarkdown) {
-            await this.handleAgentReply.execute(
-              HandleAgentReplyCommand.create({ ...baseFields, reply: { markdown: replyMarkdown } })
-            );
           }
 
           await this.inboundAck.onManagedTurnComplete(metadata);

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -181,6 +181,17 @@ export class ManagedAgentEventHandler {
             return;
           }
 
+          // Rollout compat shim: a pre-messages[] observer still sends `response.content`
+          // and no `message` parts, so reply from it. The current observer never emits
+          // `content`, so this never fires (and never double-sends) once both are deployed.
+          // Remove after the observer is upgraded everywhere.
+          const legacyContent = (event.response as { content?: string }).content?.trim();
+          if (legacyContent) {
+            await this.handleAgentReply.execute(
+              HandleAgentReplyCommand.create({ ...baseFields, reply: { markdown: legacyContent } })
+            );
+          }
+
           await this.inboundAck.onManagedTurnComplete(metadata);
 
           await this.demoQuota.recordUsage(

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -181,10 +181,9 @@ export class ManagedAgentEventHandler {
             return;
           }
 
-          // Rollout compat shim: a pre-messages[] observer still sends `response.content`
-          // and no `message` parts, so reply from it. The current observer never emits
-          // `content`, so this never fires (and never double-sends) once both are deployed.
-          // Remove after the observer is upgraded everywhere.
+          // TODO: remove after the observer is fully rolled out.
+          // Old observers still send `response.content`; new ones reply via `onMessage`
+          // and never set `content`, so this only runs against an old observer.
           const legacyContent = (event.response as { content?: string }).content?.trim();
           if (legacyContent) {
             await this.handleAgentReply.execute(

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -154,6 +154,9 @@ export class ManagedAgentEventHandler {
             operation: 'on-message',
             sessionId,
           });
+          // Re-throw so the webhook returns 5xx and the observer retries delivery,
+          // otherwise a failed reply is acked as complete and silently lost.
+          throw err;
         }
       },
 

--- a/enterprise/workers/thalamus-observer/package.json
+++ b/enterprise/workers/thalamus-observer/package.json
@@ -13,7 +13,7 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "@novu/thalamus": "0.1.0-alpha.14",
+    "@novu/thalamus": "0.1.0-alpha.15",
     "agents": "^0.12.4",
     "eventsource-parser": "^3.0.8"
   },

--- a/enterprise/workers/thalamus-observer/src/parsers.ts
+++ b/enterprise/workers/thalamus-observer/src/parsers.ts
@@ -12,15 +12,11 @@ export class EdgeAccumulator {
   conversationId: string | undefined;
   mcpServerByToolUseId = new Map<string, string>();
   stepIndex = 0;
-
-  set content(_: string) {}
-  get content() {
-    return '';
-  }
+  messages: string[] = [];
 
   toResponse(sessionId?: string): ThalamusResponse {
     return {
-      content: '',
+      messages: this.messages,
       sessionId: sessionId ?? this.conversationId ?? this.sessionId,
       finishReason: this.finishReason,
       usage: this.usage,

--- a/enterprise/workers/thalamus-observer/src/session-observer.ts
+++ b/enterprise/workers/thalamus-observer/src/session-observer.ts
@@ -241,10 +241,10 @@ export class SessionObserver extends Agent<Env, State> {
     sequence: number,
     acc: import('./parsers').EdgeAccumulator
   ): number {
-    const content = this.reconstructContent(sessionId);
+    const messages = this.reconstructMessages(sessionId);
     const finish: StreamPart = {
       type: 'finish',
-      response: { ...acc.toResponse(sessionId), content },
+      response: { ...acc.toResponse(sessionId), messages },
     };
     this.persistEvent(sessionId, sequence, finish);
     this.triggerDelivery(params);
@@ -378,18 +378,18 @@ export class SessionObserver extends Agent<Env, State> {
     return (row?.max_seq ?? 0) + 1;
   }
 
-  private reconstructContent(sessionId: string): string {
+  private reconstructMessages(sessionId: string): string[] {
     const cursor = this.ctx.storage.sql.exec<{ text: string }>(
-      "SELECT json_extract(event_json, '$.text') as text FROM events WHERE session_id = ? AND json_extract(event_json, '$.type') = 'text-delta' ORDER BY sequence",
+      "SELECT json_extract(event_json, '$.text') as text FROM events WHERE session_id = ? AND json_extract(event_json, '$.type') = 'message' ORDER BY sequence",
       sessionId
     );
 
-    let content = '';
+    const messages: string[] = [];
     for (const row of cursor) {
-      content += row.text;
+      if (row.text) messages.push(row.text);
     }
 
-    return content;
+    return messages;
   }
 
   private getPendingEvents(sessionId: string): EventRow[] {

--- a/enterprise/workers/thalamus-observer/src/session-observer.ts
+++ b/enterprise/workers/thalamus-observer/src/session-observer.ts
@@ -241,6 +241,8 @@ export class SessionObserver extends Agent<Env, State> {
     sequence: number,
     acc: import('./parsers').EdgeAccumulator
   ): number {
+    // Override acc.messages with the DB-reconstructed list: it includes messages
+    // from before a fiber recovery, where the in-memory accumulator is recreated empty.
     const messages = this.reconstructMessages(sessionId);
     const finish: StreamPart = {
       type: 'finish',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,8 +430,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/testing
       '@novu/thalamus':
-        specifier: 0.1.0-alpha.14
-        version: 0.1.0-alpha.14(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))
+        specifier: 0.1.0-alpha.15
+        version: 0.1.0-alpha.15(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))
       '@sendgrid/mail':
         specifier: ^8.1.6
         version: 8.1.6
@@ -9057,8 +9057,8 @@ packages:
     resolution: {integrity: sha512-5E8EKp30Ee06FQRpax204nyZOb1uv0kW72VfZXkU/4hG4CcqDsJbfrNnUjB6xIPSvIwAAlwv76MdIAsOflkLXg==}
     engines: {node: '>=18.0.0'}
 
-  '@novu/thalamus@0.1.0-alpha.14':
-    resolution: {integrity: sha512-XWDnpUybkhuvoHoash6Nj1MW45EWH5kbduLaIRERj5bECzsSZ2Az97zt2SXKlCvFtGbzU0SHmbuE9XHvgOZGAg==}
+  '@novu/thalamus@0.1.0-alpha.15':
+    resolution: {integrity: sha512-RSKaskbTOiNnLQGmqRAsevoHDkD8j5uSitqwsEN9ysM/L6Lm/Cihmr2RK5wy2eTBPvACf86iM6EBDWysGmBD6Q==}
     peerDependencies:
       '@anthropic-ai/aws-sdk': '>=0.86.0'
       '@anthropic-ai/sdk': '>=0.86.0'
@@ -35470,7 +35470,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@novu/thalamus@0.1.0-alpha.14(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))':
+  '@novu/thalamus@0.1.0-alpha.15(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))':
     optionalDependencies:
       '@anthropic-ai/sdk': 0.95.1(zod@3.25.20)
       '@aws-crypto/sha256-js': 5.2.0


### PR DESCRIPTION
## Summary

Adopts the `@novu/thalamus` `messages[]` release (`0.1.0-alpha.15`), which replaces `Response.content` with `Response.messages: string[]` and makes a **complete message** the atomic stream part. The managed agent now emits each assistant message (including pre-tool preambles) as its own reply **as it completes**, instead of gluing or losing intermediate Anthropic messages into a single `onFinish` reply.

### Changes
- **deps**: bump `@novu/thalamus` `0.1.0-alpha.14` → `0.1.0-alpha.15` in `apps/api` and `enterprise/workers/thalamus-observer`.
- **thalamus-observer** (`parsers.ts`, `session-observer.ts`): `EdgeAccumulator` accumulates `messages[]` (drops the `content` stub); the synthetic `finish` webhook reconstructs an ordered `string[]` from persisted `message` rows (previously keyed on `text-delta`, which Anthropic no longer emits).
- **api managed-agent** (`managed-agent-event-handler.service.ts`): adds an `onMessage` handler that sends each completed assistant message as a reply (respecting `suppressReply`). `onFinish` no longer reads `response.content`; it still handles tool approvals, inbound ack, demo quota, and plan-progress completion.

### Why the split is correct
The `message` stream part only carries `{ type: "message"; text: string }` — no `finishReason`/`usage`/`actionsRequired`. Those live only on the `finish` `Response`, so turn-level concerns (approvals, ack, usage, "complete") stay in `onFinish`, while per-message reply emission moves to `onMessage`. Notably, in the `requires-action` case, preamble messages are now delivered (previously dropped) — this is the intended fix.

```mermaid
sequenceDiagram
    participant Provider as Anthropic/OpenAI
    participant Observer as thalamus-observer
    participant API as managed-agent handler
    participant Chat

    Provider->>Observer: message part (complete text)
    Observer->>API: webhook: message
    API->>Chat: reply (onMessage)
    Provider->>Observer: message part (another)
    Observer->>API: webhook: message
    API->>Chat: reply (onMessage)
    Provider->>Observer: stream end
    Observer->>API: webhook: finish (messages[], usage, finishReason)
    API->>API: approvals / ack / quota / plan-progress (onFinish)
```

## Test plan
- [x] `enterprise/workers/thalamus-observer`: `pnpm typecheck` passes
- [x] `@novu/api-service`: `pnpm build` (TSC) passes, `lint` clean on edited files
- [ ] Manual: managed-agent turn with multiple assistant messages delivers each as a separate reply, in order
- [ ] Manual: turn ending in `requires-action` delivers preamble message(s) + approval card

## Notes
- `enterprise/workers/thalamus-observer` is not a pnpm workspace member; verify it with `cd enterprise/workers/thalamus-observer && pnpm typecheck` (not `--filter`).
- `0.1.0-alpha.15` was published recently; the repo runs `minimumReleaseAgeStrict: false` so install resolves it. If a stricter env rejects it on release age, wait out the window rather than excluding the package.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR upgrades `@novu/thalamus` to `0.1.0-alpha.15` to support per-message streaming of managed agent replies. Instead of aggregating interim output into a single final payload, the observer accumulates `messages: string[]` and the API emits each completed assistant message as its own reply while preserving turn-level handling (tool approvals, acknowledgements, usage, and completion) on finish. This fixes NV-7420 where pre-tool preamble messages could be dropped when multiple assistant messages were produced.

## Affected areas
- **api**: Added an `onMessage` handler to deliver each completed assistant message in order (with `suppressReply` support) and updated `onFinish` to avoid relying on the deprecated `response.content`, using it only as a rollout-compatibility shim.
- **enterprise/workers/thalamus-observer** (enterprise): Updated stream parsing/accumulation to collect `messages[]` and changed “finish” webhook reconstruction to rebuild message arrays from persisted `message` events ordered by `sequence`.

## Key technical decisions
- Stream contract change: per-message parts now carry only `{ type: "message"; text: string }`, while finish remains the place for turn-level metadata.
- Finish reconstruction moved away from `text-delta` because it’s no longer reliably emitted by Anthropic; it now reconstructs from stored `message` rows.

## Testing
Typecheck/build verification completed. Manual verification pending for ordered multi-message delivery and `requires-action` flows where preamble messages must reach the approval card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adopts `@novu/thalamus` `0.1.0-alpha.15`, which switches the `Response` contract from `content: string` to `messages: string[]`, making each completed assistant message the atomic delivery unit. The managed-agent event handler and thalamus-observer accumulator are updated accordingly.

- **`managed-agent-event-handler.service.ts`**: A new `onMessage` handler now sends each completed assistant message as a separate `handleAgentReply` call (respecting `suppressReply`); errors re-throw so the observer retries rather than silently losing messages. `onFinish` retains turn-level operations (approvals, ACK, quota, plan progress) and includes a backward-compat shim for old observers that still send `response.content`.
- **`parsers.ts` / `session-observer.ts`**: `EdgeAccumulator` drops the no-op `content` accessor in favour of a `messages: string[]` array; `emitFinishWebhook` reconstructs the ordered `messages` list from persisted `message`-typed DB rows (instead of concatenating `text-delta` rows), which correctly covers fiber-recovery scenarios where the in-memory accumulator starts empty.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, both delivery paths (new `onMessage` and legacy `content` shim) are mutually exclusive in practice, and error handling is correct throughout.

The `onMessage` handler correctly re-throws on failure so the observer retries delivery rather than silently acking a lost turn. `reconstructMessages` in the observer safely queries the DB instead of relying on the in-memory accumulator, handling fiber recovery correctly. The legacy `response.content` shim in `onFinish` is properly type-cast and gated so it only fires for old observers. `handlePendingToolApprovals` was verified to use only `response.actionsRequired`, not `response.messages`, ruling out any double-reply on `requires-action` turns.

No files require special attention. The TODO comment in `managed-agent-event-handler.service.ts` (remove legacy `content` shim after observer rollout) is the only remaining housekeeping item.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts | Adds `onMessage` handler for per-message delivery with correct error re-throw; backward-compat shim for `response.content` is well-guarded with a TODO. No issues found. |
| enterprise/workers/thalamus-observer/src/session-observer.ts | Replaces `reconstructContent` with `reconstructMessages`, querying `type='message'` rows instead of `text-delta`. DB-reconstruction overrides `acc.messages` to handle fiber-recovery gaps correctly. No issues found. |
| enterprise/workers/thalamus-observer/src/parsers.ts | Drops the no-op `content` getter/setter and adds `messages: string[]`; `toResponse()` now returns `messages` correctly aligned with the new `ThalamusResponse` schema. |
| apps/api/package.json | Version bump of `@novu/thalamus` from `0.1.0-alpha.14` to `0.1.0-alpha.15`. |
| enterprise/workers/thalamus-observer/package.json | Version bump of `@novu/thalamus` from `0.1.0-alpha.14` to `0.1.0-alpha.15`. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Anthropic
    participant Observer as thalamus-observer (EdgeAccumulator)
    participant DB as SQLite Events DB
    participant API as managed-agent handler
    participant Chat

    Anthropic->>Observer: SSE: message part (text)
    Observer->>DB: "persistEvent(type=message, text)"
    Observer->>API: "webhook: {type: message, text}"
    API->>Chat: onMessage → handleAgentReply(text)

    Anthropic->>Observer: SSE: message part (another text)
    Observer->>DB: "persistEvent(type=message, text)"
    Observer->>API: "webhook: {type: message, text}"
    API->>Chat: onMessage → handleAgentReply(text)

    Anthropic->>Observer: "SSE stream end (done=true)"
    Observer->>DB: reconstructMessages() → [msg1, msg2]
    Observer->>DB: "persistEvent(type=finish, messages=[msg1,msg2], finishReason, usage)"
    Observer->>API: "webhook: {type: finish, response}"
    API->>API: onFinish → approvals / ACK / quota / plan-progress

    note over Observer,DB: Fiber recovery: reconstructMessages queries DB,<br/>not in-memory acc.messages (which resets on recovery)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Anthropic
    participant Observer as thalamus-observer (EdgeAccumulator)
    participant DB as SQLite Events DB
    participant API as managed-agent handler
    participant Chat

    Anthropic->>Observer: SSE: message part (text)
    Observer->>DB: "persistEvent(type=message, text)"
    Observer->>API: "webhook: {type: message, text}"
    API->>Chat: onMessage → handleAgentReply(text)

    Anthropic->>Observer: SSE: message part (another text)
    Observer->>DB: "persistEvent(type=message, text)"
    Observer->>API: "webhook: {type: message, text}"
    API->>Chat: onMessage → handleAgentReply(text)

    Anthropic->>Observer: "SSE stream end (done=true)"
    Observer->>DB: reconstructMessages() → [msg1, msg2]
    Observer->>DB: "persistEvent(type=finish, messages=[msg1,msg2], finishReason, usage)"
    Observer->>API: "webhook: {type: finish, response}"
    API->>API: onFinish → approvals / ACK / quota / plan-progress

    note over Observer,DB: Fiber recovery: reconstructMessages queries DB,<br/>not in-memory acc.messages (which resets on recovery)
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(api-service): re-throw onMessage fai..."](https://github.com/novuhq/novu/commit/449094d4c9543153d8eb8f268ecb60a54bfcc103) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38646872)</sub>

<!-- /greptile_comment -->