### PR TITLE
fix(js): ensure notification instances in cache after cross-tab sync fixes NV-8092

### DIFF
--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -81,6 +81,61 @@ describe('NotificationsCache', () => {
     jest.clearAllMocks();
   });
 
+  it('should normalize plain notification objects when storing in cache', () => {
+    const args = { tags: ['tag1'], limit: 10, offset: 0 };
+    const plainNotification = {
+      id: '1',
+      transactionId: 'tx-1',
+      body: 'test1',
+      isRead: false,
+      isArchived: false,
+      isSeen: false,
+      isSnoozed: false,
+      to: { id: '1', subscriberId: '1' },
+      createdAt: new Date().toISOString(),
+      channelType: ChannelType.IN_APP,
+      workflow: {
+        id: 'test-workflow-1',
+        critical: true,
+        identifier: 'test-workflow-1',
+        name: 'Test Workflow 1',
+        tags: ['tag1'],
+        severity: SeverityLevelEnum.NONE,
+      },
+      severity: SeverityLevelEnum.NONE,
+    };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [plainNotification],
+    };
+
+    notificationsCache.set(args, data as unknown as ListNotificationsResponse);
+    const result = notificationsCache.getAll(args);
+
+    expect(result?.notifications[0]).toBeInstanceOf(Notification);
+    expect(typeof result?.notifications[0].read).toBe('function');
+  });
+
+  it('should normalize plain notification objects when updating cache', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const plainNotification = {
+      ...notification1,
+      isRead: true,
+      readAt: new Date().toISOString(),
+    };
+    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent()({ data: plainNotification });
+
+    const result = notificationsCache.getAll(args);
+
+    expect(result?.notifications[0]).toBeInstanceOf(Notification);
+    expect(typeof result?.notifications[0].read).toBe('function');
+    expect(result?.notifications[0].isRead).toBe(true);
+  });
+
   it('should set and get notifications from the cache', () => {
     const args = { tags: ['tag1'], limit: 10, offset: 0 };
     const data = {

--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -16,7 +16,7 @@ import type {
   UnsnoozeArgs,
 } from '../notifications';
 import type { InboxNotification, NotificationFilter, TagsFilter } from '../types';
-import { createNotification } from '../ui/internal/createNotification';
+import { ensureNotificationInstance } from '../notifications/helpers';
 import { areDataEqual, areTagsEqual, isSameFilter } from '../utils/notification-utils';
 import { InMemoryCache } from './in-memory-cache';
 import type { Cache } from './types';
@@ -146,7 +146,19 @@ export class NotificationsCache {
     this.#cache = new InMemoryCache();
   }
 
-  private updateNotification = (key: string, data: Notification): boolean => {
+  #toNotificationInstance = (notification: Notification | InboxNotification): Notification => {
+    return ensureNotificationInstance({
+      notification,
+      emitter: this.#emitter,
+      inboxService: this.#inboxService,
+    });
+  };
+
+  #normalizeNotifications = (notifications: Array<Notification | InboxNotification>): Notification[] => {
+    return notifications.map((notification) => this.#toNotificationInstance(notification));
+  };
+
+  private updateNotification = (key: string, data: Notification | InboxNotification): boolean => {
     const notificationsResponse = this.#cache.get(key);
     if (!notificationsResponse) {
       return false;
@@ -158,7 +170,7 @@ export class NotificationsCache {
     }
 
     const updatedNotifications = [...notificationsResponse.notifications];
-    updatedNotifications[index] = data;
+    updatedNotifications[index] = this.#toNotificationInstance(data);
 
     this.#cache.set(key, { ...notificationsResponse, notifications: updatedNotifications });
 
@@ -284,7 +296,10 @@ export class NotificationsCache {
   }
 
   set(args: ListNotificationsArgs, data: ListNotificationsResponse): void {
-    this.#cache.set(getCacheKey(args), data);
+    this.#cache.set(getCacheKey(args), {
+      ...data,
+      notifications: this.#normalizeNotifications(data.notifications),
+    });
   }
 
   unshift(args: ListNotificationsArgs, notification: InboxNotification): void {
@@ -295,11 +310,7 @@ export class NotificationsCache {
       notifications: [],
     };
 
-    const notificationInstance = createNotification({
-      notification: { ...notification },
-      emitter: this.#emitter,
-      inboxService: this.#inboxService,
-    });
+    const notificationInstance = this.#toNotificationInstance({ ...notification });
 
     this.update(args, {
       ...cachedData,

--- a/packages/js/src/notifications/helpers.ts
+++ b/packages/js/src/notifications/helpers.ts
@@ -1,9 +1,29 @@
 import type { InboxService } from '../api';
 import type { NotificationsCache } from '../cache';
 import type { NovuEventEmitter } from '../event-emitter';
-import { Action, ActionTypeEnum, NotificationFilter, Result } from '../types';
+import { Action, ActionTypeEnum, InboxNotification, NotificationFilter, Result } from '../types';
 import { NovuError } from '../utils/errors';
 import { Notification } from './notification';
+
+export function ensureNotificationInstance({
+  notification,
+  emitter,
+  inboxService,
+}: {
+  notification: Notification | InboxNotification;
+  emitter: NovuEventEmitter;
+  inboxService: InboxService;
+}): Notification {
+  if (notification instanceof Notification) {
+    return notification;
+  }
+
+  if (typeof (notification as Notification).read === 'function') {
+    return notification as Notification;
+  }
+
+  return new Notification(notification, emitter, inboxService);
+}
 import type {
   ArchivedArgs,
   CompleteArgs,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes an intermittent failure when marking notifications as read with two active inbox tabs open.

**Root cause:** WebSocket events (e.g. `notifications.notification_received`) are broadcast between tabs via `BroadcastChannel`. The structured-clone algorithm strips class methods, so notifications received in non-primary tabs become plain objects. When those objects were stored in `NotificationsCache`, clicking a notification in the UI called `props.notification.read()` and threw `TypeError: props.notification.read is not a function`.

**Fix:** Normalize all notifications to `Notification` class instances when writing to the cache (`set`, `updateNotification`, `unshift`). Added `ensureNotificationInstance` helper that re-hydrates plain objects into proper instances.

## Changes

- `packages/js/src/notifications/helpers.ts` — add `ensureNotificationInstance` helper
- `packages/js/src/cache/notifications-cache.ts` — normalize notifications on cache writes
- `packages/js/src/cache/notifications-cache.test.ts` — tests for plain-object normalization

## Test plan

- [x] Unit tests: `pnpm --filter @novu/js test` (64 passed)
- [x] New tests verify plain objects stored via `set` and `updateNotification` are re-hydrated with a working `read()` method
- [ ] Manual: open inbox in two tabs, send notification, mark as read in both tabs — no console error

```mermaid
sequenceDiagram
    participant TabA
    participant WS as WebSocket (primary tab)
    participant BC as BroadcastChannel
    participant TabB
    participant Cache as NotificationsCache

    TabA->>WS: notification_received
    WS->>TabA: Notification instance (has read())
    TabA->>BC: postMessage(notification)
    BC->>TabB: plain object (no read())
    TabB->>Cache: update(plain object)
    Note over Cache: ensureNotificationInstance()
    Cache->>TabB: Notification instance (has read())
```
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8092](https://linear.app/novu/issue/NV-8092/marking-notifications-as-read-fails-with-two-active-inbox-tabs)

<div><a href="https://cursor.com/agents/bc-ff3e1e00-c217-494c-a1a8-7bfe61bb238c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff3e1e00-c217-494c-a1a8-7bfe61bb238c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR fixes an intermittent failure when marking notifications as read with multiple inbox tabs open. WebSocket events broadcast between tabs via BroadcastChannel strip class methods, converting `Notification` instances to plain objects. The fix adds a normalization helper that re-hydrates plain objects back into full `Notification` class instances when writing to cache, ensuring methods like `read()` remain available to the UI.

## Affected areas

**js** — Added `ensureNotificationInstance` helper to normalize notifications to proper class instances. Updated NotificationsCache to apply this normalization across all write operations (`set`, `updateNotification`, `unshift`), ensuring cached notifications always expose their full method interfaces.

## Key technical decisions

- Normalization is applied at the cache layer (write paths) rather than at event reception, maintaining separation of concerns while guaranteeing consistency.
- The helper checks if a notification is already a `Notification` instance and falls back to constructing one from raw data if needed.

## Testing

Unit tests added to verify that plain notification objects are correctly normalized to `Notification` instances with working `read()` methods when written to and retrieved from cache. Test coverage includes both direct `set()` operations and event-driven updates via `handleNotificationEvent()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds `ensureNotificationInstance` to rehydrate plain notification objects into `Notification` instances.
- Normalizes notification cache writes in `set`, `updateNotification`, and `unshift` so cross-tab synced notifications keep instance methods.
- Adds cache tests covering plain-object normalization for set/update flows.

<h3>Confidence Score: 4/5</h3>

The cache normalization fix is narrowly scoped, but the helper still allows partial plain objects to bypass full rehydration.

Focused tests cover the intended plain-object set/update behavior, and a runtime check confirmed the remaining duck-type bypass can still expose cached values without the full Notification method surface.

packages/js/src/notifications/helpers.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the duck-type bypass by running a focused ts-node harness in packages/js that stores a plain object with a read function through NotificationsCache.set and retrieves it with getAll, then observed that the retrieved value is the same plain object reference and not a Notification instance, and that archive is not a function.
- Validated that after the PR, cache entries for set, updateEvent, and unshift are all Notification instances with proper prototype and instanceof checks, and that read results show data with a passing exit code.

<a href="https://app.greptile.com/trex/runs/11767649/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fjs%2Fsrc%2Fnotifications%2Fhelpers.ts%3A21-25%0A**Remove%20duck-type%20bypass**%0A%0AThis%20branch%20lets%20any%20non-%60Notification%60%20object%20with%20a%20%60read%60%20function%20skip%20rehydration%20and%20enter%20%60NotificationsCache%60%20as-is.%20The%20cache%20then%20exposes%20it%20as%20a%20%60Notification%60%2C%20but%20callers%20can%20still%20hit%20missing%20methods%20such%20as%20%60archive%60%2C%20%60unread%60%2C%20%60snooze%60%2C%20or%20action%20methods%2C%20producing%20the%20same%20kind%20of%20runtime%20%60TypeError%60%20this%20change%20is%20meant%20to%20prevent.%20A%20real%20%60Notification%60%20is%20already%20covered%20by%20the%20%60instanceof%60%20branch%2C%20so%20all%20other%20objects%20should%20be%20wrapped%20with%20the%20current%20emitter%20and%20inbox%20service.%0A%0A&pr=11617&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/js/src/notifications/helpers.ts:21-25
**Remove duck-type bypass**

This branch lets any non-`Notification` object with a `read` function skip rehydration and enter `NotificationsCache` as-is. The cache then exposes it as a `Notification`, but callers can still hit missing methods such as `archive`, `unread`, `snooze`, or action methods, producing the same kind of runtime `TypeError` this change is meant to prevent. A real `Notification` is already covered by the `instanceof` branch, so all other objects should be wrapped with the current emitter and inbox service.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js): ensure notification instances i..."](https://github.com/novuhq/novu/commit/05e098192fc60e4150bb6e2c7c7dfb8f239e50bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38875615)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->