### PR TITLE
feat(nextjs): add headless Telegram connect demo to playground fixes NV-8095

### DIFF
--- a/playground/nextjs/.env.example
+++ b/playground/nextjs/.env.example
@@ -41,6 +41,16 @@ NOVU_MSTEAMS_INTEGRATION_IDENTIFIER=
 # Workflow ID to trigger when clicking "Send Test Message" on the connect-msteams playground page
 NEXT_PUBLIC_NOVU_MSTEAMS_TEST_WORKFLOW_ID=
 
+# Telegram headless Connect demo (/connect-telegram)
+# Where the useTelegramSubscriberLink hook sends its requests:
+#   /api/novu-proxy    -> live proxy that injects NOVU_SECRET_KEY (default)
+#   /api/telegram-demo -> offline simulator, no bot/agent/secret required
+NEXT_PUBLIC_NOVU_TELEGRAM_API_URL=/api/novu-proxy
+# Agent identifier (the agent's `identifier`, not its _id) with a linked Telegram integration
+NEXT_PUBLIC_NOVU_TELEGRAM_AGENT_IDENTIFIER=
+# Telegram integration _id linked to the agent above
+NEXT_PUBLIC_NOVU_TELEGRAM_INTEGRATION_ID=
+
 # SMTP settings for scripts/send-email.mjs
 # Defaults work with a local Mailpit instance:
 #   docker run -d -p 1025:1025 -p 8025:8025 axllent/mailpit

--- a/playground/nextjs/src/components/SideNav.tsx
+++ b/playground/nextjs/src/components/SideNav.tsx
@@ -18,6 +18,7 @@ const LINKS: LinkType[] = [
   { href: '/preferences', label: 'Preferences', category: 'Components' },
   { href: '/connect-chat', label: 'Connect Chat (Slack)', category: 'Components' },
   { href: '/connect-msteams', label: 'Connect MS Teams', category: 'Components' },
+  { href: '/connect-telegram', label: 'Connect Telegram (headless)', category: 'Components' },
   { href: '/subscription', label: 'Subscription', category: 'Components' },
   { href: '/subscription-components', label: 'Subscription Components', category: 'Components' },
   { href: '/subscription-hooks', label: 'Subscription Hooks', category: 'Components' },

--- a/playground/nextjs/src/pages/api/novu-proxy/[...path].ts
+++ b/playground/nextjs/src/pages/api/novu-proxy/[...path].ts
@@ -1,0 +1,69 @@
+/**
+ * Catch-all proxy: forwards `/api/novu-proxy/<path>` to the Novu API and injects
+ * the server-side `Authorization: ApiKey <NOVU_SECRET_KEY>` header.
+ *
+ * WHY THIS EXISTS
+ * The Telegram subscriber-link endpoint requires `AGENT_WRITE` permission, so it
+ * must be called with a secret key — which must never reach the browser. The
+ * `useTelegramSubscriberLink` hook is pointed at this proxy (`apiUrl: '/api/novu-proxy'`)
+ * so the headless logic runs in the browser while the secret stays server-side.
+ *
+ * Required ENV vars:
+ *   NOVU_SECRET_KEY     Novu API secret (sk_...) — injected as `ApiKey` auth
+ *   NOVU_API_BASE_URL   Optional Novu API base URL (falls back to NEXT_PUBLIC_NOVU_BACKEND_URL, then https://api.novu.co)
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const BASE_URL = (
+  process.env.NOVU_API_BASE_URL ??
+  process.env.NEXT_PUBLIC_NOVU_BACKEND_URL ??
+  'https://api.novu.co'
+).replace(/\/$/, '');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const secretKey = process.env.NOVU_SECRET_KEY?.trim();
+
+  if (!secretKey) {
+    res.status(500).json({ message: 'NOVU_SECRET_KEY is not configured on the server.' });
+
+    return;
+  }
+
+  const segments = req.query.path;
+  const pathParts = Array.isArray(segments) ? segments : [segments].filter(Boolean);
+  const upstreamPath = (pathParts as string[]).map(encodeURIComponent).join('/');
+
+  const queryIndex = req.url?.indexOf('?') ?? -1;
+  const search = queryIndex >= 0 ? req.url!.slice(queryIndex) : '';
+  const upstreamUrl = `${BASE_URL}/${upstreamPath}${search}`;
+
+  const headers: Record<string, string> = {
+    Authorization: `ApiKey ${secretKey}`,
+  };
+
+  let body: string | undefined;
+  if (req.method !== 'GET' && req.method !== 'HEAD' && req.body) {
+    body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+    headers['Content-Type'] = 'application/json';
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, { method: req.method, headers, body });
+  } catch (error) {
+    res.status(502).json({
+      message: `Failed to reach Novu API at ${BASE_URL}: ${error instanceof Error ? error.message : String(error)}`,
+    });
+
+    return;
+  }
+
+  const text = await upstream.text();
+  const contentType = upstream.headers.get('content-type');
+  if (contentType) {
+    res.setHeader('content-type', contentType);
+  }
+
+  res.status(upstream.status).send(text);
+}

--- a/playground/nextjs/src/pages/api/telegram-demo/[...path].ts
+++ b/playground/nextjs/src/pages/api/telegram-demo/[...path].ts
@@ -1,0 +1,59 @@
+/**
+ * Offline simulator for the Telegram subscriber-link flow.
+ *
+ * Lets you exercise the `useTelegramSubscriberLink` headless logic end-to-end
+ * WITHOUT a real Telegram bot, agent, or secret key. Point the page at it with:
+ *
+ *   NEXT_PUBLIC_NOVU_TELEGRAM_API_URL=/api/telegram-demo
+ *
+ * It mimics the two endpoints the hook calls:
+ *   POST .../telegram/subscriber-link  -> issues a fake deep link + expiry
+ *   GET  .../integrations              -> reports `connectedAt` after CONNECT_DELAY_MS
+ *
+ * The "connection" auto-confirms a few seconds after the link is issued so you
+ * can watch the status transition pending -> connected.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const CONNECT_DELAY_MS = 6_000;
+const EXPIRY_MS = 5 * 60_000;
+const BOT_USERNAME = 'novu_playground_bot';
+
+// Module-level state — fine for a single-user local playground.
+let issuedAt: number | null = null;
+
+function randomCode(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const url = req.url ?? '';
+
+  if (req.method === 'POST' && url.includes('/telegram/subscriber-link')) {
+    issuedAt = Date.now();
+    const code = randomCode();
+
+    res.status(200).json({
+      data: {
+        deepLinkUrl: `https://t.me/${BOT_USERNAME}?start=${code}`,
+        botUsername: BOT_USERNAME,
+        expiresAt: new Date(Date.now() + EXPIRY_MS).toISOString(),
+      },
+    });
+
+    return;
+  }
+
+  if (req.method === 'GET' && url.includes('/integrations')) {
+    const connected = issuedAt !== null && Date.now() - issuedAt >= CONNECT_DELAY_MS;
+
+    res.status(200).json({
+      data: [{ connectedAt: connected ? new Date().toISOString() : null }],
+    });
+
+    return;
+  }
+
+  res.status(404).json({ message: `telegram-demo: unhandled ${req.method} ${url}` });
+}

--- a/playground/nextjs/src/pages/connect-telegram/index.tsx
+++ b/playground/nextjs/src/pages/connect-telegram/index.tsx
@@ -1,0 +1,163 @@
+import { useTelegramSubscriberLink } from '@novu/nextjs/hooks';
+import { CheckCircle2, ExternalLink, Loader2, RefreshCw, TimerReset, XCircle } from 'lucide-react';
+import Title from '@/components/Title';
+import { novuConfig } from '@/utils/config';
+
+// Point the headless hook at a backend that injects the secret key:
+//   - `/api/novu-proxy`    -> forwards to the real Novu API (production-style, secure)
+//   - `/api/telegram-demo` -> offline simulator (no bot/agent/secret required)
+const TELEGRAM_API_URL = process.env.NEXT_PUBLIC_NOVU_TELEGRAM_API_URL ?? '/api/novu-proxy';
+const AGENT_IDENTIFIER = process.env.NEXT_PUBLIC_NOVU_TELEGRAM_AGENT_IDENTIFIER ?? '';
+const INTEGRATION_ID = process.env.NEXT_PUBLIC_NOVU_TELEGRAM_INTEGRATION_ID ?? '';
+
+const IS_DEMO = TELEGRAM_API_URL.includes('telegram-demo');
+
+const STATUS_META = {
+  pending: { label: 'Waiting for connection…', className: 'text-amber-600', Icon: Loader2, spin: true },
+  connected: { label: 'Connected', className: 'text-green-600', Icon: CheckCircle2, spin: false },
+  expired: { label: 'Link expired — re-issuing…', className: 'text-muted-foreground', Icon: TimerReset, spin: false },
+} as const;
+
+function TelegramConnector({
+  apiUrl,
+  agentIdentifier,
+  integrationId,
+  subscriberId,
+}: {
+  apiUrl: string;
+  agentIdentifier: string;
+  integrationId: string;
+  subscriberId: string;
+}) {
+  const { deepLinkUrl, botUsername, status, error, refresh } = useTelegramSubscriberLink({
+    apiUrl,
+    agentIdentifier,
+    integrationId,
+    subscriberId,
+    pollIntervalMs: 2000,
+  });
+
+  const meta = STATUS_META[status];
+
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border p-5">
+      <div className={`flex items-center gap-2 text-sm font-medium ${meta.className}`}>
+        <meta.Icon className={`h-4 w-4 ${meta.spin ? 'animate-spin' : ''}`} aria-hidden="true" />
+        <span>{meta.label}</span>
+      </div>
+
+      {status === 'connected' ? (
+        <p className="text-sm text-muted-foreground">
+          Subscriber <code>{subscriberId}</code> is now linked to Telegram. Notifications routed through this
+          integration will reach their chat.
+        </p>
+      ) : (
+        <>
+          <p className="text-xs text-muted-foreground">
+            Tap the button (or scan the QR with your phone) to open Telegram and press <strong>Start</strong>. The hook
+            polls until the connection is confirmed and auto-reissues the link when the 10-minute code expires.
+          </p>
+
+          {deepLinkUrl ? (
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+              {/* QR is a nicety for opening on a phone; hidden gracefully if the generator is unreachable. */}
+              <img
+                src={`https://api.qrserver.com/v1/create-qr-code/?size=160x160&data=${encodeURIComponent(deepLinkUrl)}`}
+                alt="Telegram deep link QR code"
+                width={160}
+                height={160}
+                className="rounded-md border"
+                onError={(e) => {
+                  e.currentTarget.style.display = 'none';
+                }}
+              />
+              <div className="flex flex-col gap-2">
+                <a
+                  href={deepLinkUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex w-fit items-center gap-2 rounded-md bg-[#229ED9] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+                >
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  Open @{botUsername} in Telegram
+                </a>
+                <code className="max-w-md break-all text-xs text-muted-foreground">{deepLinkUrl}</code>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Issuing deep link…</p>
+          )}
+        </>
+      )}
+
+      {error && (
+        <p className="flex items-start gap-2 text-xs text-destructive">
+          <XCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span className="break-all">{error.message}</span>
+        </p>
+      )}
+
+      <button
+        onClick={() => void refresh()}
+        className="inline-flex w-fit items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+      >
+        <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        Re-issue link
+      </button>
+    </div>
+  );
+}
+
+export default function ConnectTelegramPage() {
+  const subscriberId = novuConfig.subscriberId || 'playground-subscriber';
+  const ready = IS_DEMO || (AGENT_IDENTIFIER && INTEGRATION_ID);
+
+  return (
+    <>
+      <Title title="Connect Telegram (headless)" />
+      <div className="flex max-w-xl flex-col gap-6 p-4">
+        <section className="flex flex-col gap-2">
+          <h4 className="text-sm font-semibold">
+            <code>useTelegramSubscriberLink</code> — subscriber-link deep link
+          </h4>
+          <p className="text-xs text-muted-foreground">
+            Headless Telegram linking from <code>@novu/react</code> (re-exported by <code>@novu/nextjs/hooks</code>). The
+            hook issues a <code>t.me/&lt;bot&gt;?start=&lt;code&gt;</code> deep link, polls for the subscriber&apos;s{' '}
+            <strong>Start</strong> tap, and re-issues automatically on code expiry. Calls are routed through{' '}
+            <code>{TELEGRAM_API_URL}</code> so the secret key never reaches the browser.
+          </p>
+          <div className="flex flex-col gap-1 rounded-md bg-muted/40 p-3 text-xs text-muted-foreground">
+            <span>
+              Mode: <code>{IS_DEMO ? 'demo simulator' : 'live proxy'}</code>
+            </span>
+            <span>
+              Agent: <code>{AGENT_IDENTIFIER || (IS_DEMO ? 'demo-agent' : '— set NEXT_PUBLIC_NOVU_TELEGRAM_AGENT_IDENTIFIER')}</code>
+            </span>
+            <span>
+              Integration: <code>{INTEGRATION_ID || (IS_DEMO ? 'demo-integration' : '— set NEXT_PUBLIC_NOVU_TELEGRAM_INTEGRATION_ID')}</code>
+            </span>
+            <span>
+              Subscriber: <code>{subscriberId}</code>
+            </span>
+          </div>
+        </section>
+
+        {ready ? (
+          <TelegramConnector
+            apiUrl={TELEGRAM_API_URL}
+            agentIdentifier={AGENT_IDENTIFIER || 'demo-agent'}
+            integrationId={INTEGRATION_ID || 'demo-integration'}
+            subscriberId={subscriberId}
+          />
+        ) : (
+          <div className="rounded-lg border border-dashed p-5 text-sm text-muted-foreground">
+            Set <code>NEXT_PUBLIC_NOVU_TELEGRAM_AGENT_IDENTIFIER</code> and{' '}
+            <code>NEXT_PUBLIC_NOVU_TELEGRAM_INTEGRATION_ID</code> (plus <code>NOVU_SECRET_KEY</code> on the server) to use
+            the live proxy — or set <code>NEXT_PUBLIC_NOVU_TELEGRAM_API_URL=/api/telegram-demo</code> to try the offline
+            simulator with no bot required.
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a lean playground page that exercises the new headless Telegram subscriber-link logic shipped on this feature branch (`useTelegramSubscriberLink` from `@novu/react`, re-exported via `@novu/nextjs/hooks`).

- **`/connect-telegram`** — lean UI built on `useTelegramSubscriberLink`. Issues a `t.me/<bot>?start=<code>` deep link, renders it as a button + QR + raw URL, polls until the subscriber taps **Start**, surfaces `pending`/`connected`/`expired` status, exposes a **Re-issue link** action, and shows errors.
- **`/api/novu-proxy/[...path]`** — secure catch-all that injects `Authorization: ApiKey <NOVU_SECRET_KEY>` server-side and forwards to the Novu API. The subscriber-link endpoint needs `AGENT_WRITE`, so the secret must never reach the browser — the hook is pointed at this proxy (`apiUrl: '/api/novu-proxy'`).
- **`/api/telegram-demo/[...path]`** — offline simulator of the two endpoints the hook calls, so the full flow can be exercised without a real bot/agent/secret. Auto-confirms the connection a few seconds after issuing.
- Nav link + `.env.example` documentation.

## How it works

```mermaid
sequenceDiagram
    participant UI as /connect-telegram
    participant Hook as useTelegramSubscriberLink
    participant Proxy as /api/novu-proxy (secret injected)
    participant API as Novu API
    UI->>Hook: mount
    Hook->>Proxy: POST .../telegram/subscriber-link
    Proxy->>API: + ApiKey
    API-->>Hook: { deepLinkUrl, botUsername, expiresAt }
    UI-->>UI: render deep link / QR (pending)
    loop poll
      Hook->>Proxy: GET .../integrations
      Proxy->>API: + ApiKey
      API-->>Hook: connectedAt?
    end
    Hook-->>UI: status = connected
```

## Testing

Verified end-to-end against the offline simulator (`NEXT_PUBLIC_NOVU_TELEGRAM_API_URL=/api/telegram-demo`) on the running playground dev server: the page issues a deep link (status `pending`), auto-transitions to `connected` once polling detects the link, and **Re-issue link** generates a fresh deep link and returns to `pending`.

<a href="https://cursor.com/agents/bc-ff8b5b9f-0a94-45b6-bff1-36294188eec6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftelegram_headless_connect_flow.mp4"><img src="https://cursor.com/artifacts/c/art-1b3cca2a-56e1-42a9-9f33-4681711ee8be" alt="telegram_headless_connect_flow.mp4" /></a>

![Waiting for connection state with deep link and QR](https://cursor.com/artifacts/c/art-1da425cf-4480-4f7c-b2ce-cb758a1e779c)
![Connected state](https://cursor.com/artifacts/c/art-bbaeca84-7e02-4cc8-afea-156fe9155210)

## Notes

- Playground-only; no production/shared package changes.
- Linear MCP was unauthenticated in this environment, so a dedicated ticket could not be created — associating with `NV-8095`, the ticket for the Telegram subscriber-link SDK this demo validates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff8b5b9f-0a94-45b6-bff1-36294188eec6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff8b5b9f-0a94-45b6-bff1-36294188eec6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a headless Telegram subscriber-link demo to the Next.js playground, exercising the new `useTelegramSubscriberLink` hook from `@novu/react`. It introduces a secure server-side proxy, an offline simulator, a demo page with QR+deep-link UI, and supporting nav/env-var docs.

- **`/api/novu-proxy`** injects `NOVU_SECRET_KEY` server-side so the secret never reaches the browser, but currently forwards *any* Novu API path without restriction — a path allowlist would limit the blast radius if the playground is deployed to a shared environment.
- **`/api/telegram-demo`** uses module-level state (`issuedAt`) which works locally but will silently break in serverless/preview deployments where each invocation may get a fresh container.
- **`/connect-telegram`** renders a QR code via the third-party `api.qrserver.com` service, passing the full deep-link URL (including the one-time subscriber code) as a query parameter.

<h3>Confidence Score: 3/5</h3>

The playground proxy grants callers unrestricted authenticated access to the Novu API; the scope needs to be narrowed before this is deployed anywhere beyond a purely local dev setup.

The novu-proxy handler injects an AGENT_WRITE-capable secret into every request it forwards, but nothing prevents a browser from requesting paths outside the two endpoints the hook actually uses. If this playground is pushed to a preview or shared environment, any visitor can perform admin-level operations against the connected Novu account.

playground/nextjs/src/pages/api/novu-proxy/[...path].ts needs a path allowlist. playground/nextjs/src/pages/connect-telegram/index.tsx should consider a client-side QR library instead of api.qrserver.com.

<details open><summary><h3>Security Review</h3></summary>

- **Unrestricted authenticated proxy** (`/api/novu-proxy`): The proxy forwards any path to the Novu API with the `AGENT_WRITE` secret key. A client can call destructive endpoints (e.g. `DELETE /subscribers`) in addition to the two paths the hook actually needs.
- **Subscriber link code leaked to third party** (`/connect-telegram`): The one-time Telegram deep-link URL is sent to `api.qrserver.com` as a plain query parameter on every link issuance, exposing the short-lived bearer-equivalent code to an external service.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| playground/nextjs/src/pages/api/novu-proxy/[...path].ts | New catch-all proxy that injects NOVU_SECRET_KEY for every forwarded request with no path allowlist — any Novu API endpoint is reachable from the browser. |
| playground/nextjs/src/pages/api/telegram-demo/[...path].ts | Offline simulator using module-level state; correctly scoped to local dev but will break silently in serverless preview deployments. |
| playground/nextjs/src/pages/connect-telegram/index.tsx | Well-structured headless demo page; subscriber link code is leaked to a third-party QR service on every issuance. |
| playground/nextjs/src/components/SideNav.tsx | Adds a nav link for the new Connect Telegram page; no issues. |
| playground/nextjs/.env.example | Documents the three new Telegram env vars with clear comments; no issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as /connect-telegram (Browser)
    participant Hook as useTelegramSubscriberLink
    participant Proxy as /api/novu-proxy (server)
    participant Demo as /api/telegram-demo (server)
    participant API as Novu API

    Browser->>Hook: mount (apiUrl, agentIdentifier, integrationId)
    alt Live mode (NOVU_SECRET_KEY set)
        Hook->>Proxy: POST /v1/telegram/subscriber-link
        Proxy->>API: + Authorization: ApiKey sk_...
        API-->>Proxy: "{ deepLinkUrl, botUsername, expiresAt }"
        Proxy-->>Hook: response
    else Demo mode
        Hook->>Demo: POST .../telegram/subscriber-link
        Demo-->>Hook: fake deepLinkUrl + expiresAt (issuedAt set)
    end
    Hook-->>Browser: "status=pending, deepLinkUrl"
    Browser-->>Browser: render QR (api.qrserver.com) + button

    loop Poll every 2s
        alt Live mode
            Hook->>Proxy: GET /v1/integrations
            Proxy->>API: + Authorization: ApiKey sk_...
            API-->>Hook: "[{ connectedAt }]"
        else Demo mode
            Hook->>Demo: GET .../integrations
            Demo-->>Hook: connectedAt (after 6s delay)
        end
        Hook-->>Browser: "status=connected (when connectedAt present)"
    end

    Browser->>Hook: refresh() (Re-issue link)
    Hook-->>Browser: "status=pending, new deepLinkUrl"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as /connect-telegram (Browser)
    participant Hook as useTelegramSubscriberLink
    participant Proxy as /api/novu-proxy (server)
    participant Demo as /api/telegram-demo (server)
    participant API as Novu API

    Browser->>Hook: mount (apiUrl, agentIdentifier, integrationId)
    alt Live mode (NOVU_SECRET_KEY set)
        Hook->>Proxy: POST /v1/telegram/subscriber-link
        Proxy->>API: + Authorization: ApiKey sk_...
        API-->>Proxy: "{ deepLinkUrl, botUsername, expiresAt }"
        Proxy-->>Hook: response
    else Demo mode
        Hook->>Demo: POST .../telegram/subscriber-link
        Demo-->>Hook: fake deepLinkUrl + expiresAt (issuedAt set)
    end
    Hook-->>Browser: "status=pending, deepLinkUrl"
    Browser-->>Browser: render QR (api.qrserver.com) + button

    loop Poll every 2s
        alt Live mode
            Hook->>Proxy: GET /v1/integrations
            Proxy->>API: + Authorization: ApiKey sk_...
            API-->>Hook: "[{ connectedAt }]"
        else Demo mode
            Hook->>Demo: GET .../integrations
            Demo-->>Hook: connectedAt (after 6s delay)
        end
        Hook-->>Browser: "status=connected (when connectedAt present)"
    end

    Browser->>Hook: refresh() (Re-issue link)
    Hook-->>Browser: "status=pending, new deepLinkUrl"
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aplayground%2Fnextjs%2Fsrc%2Fpages%2Fapi%2Fnovu-proxy%2F%5B...path%5D.ts%3A24-35%0A**Unrestricted%20authenticated%20proxy%20%E2%80%94%20any%20Novu%20API%20path%20accessible**%0A%0AThe%20proxy%20forwards%20any%20path%20to%20the%20Novu%20API%20with%20the%20%60AGENT_WRITE%60-capable%20secret%20key.%20A%20browser%20client%20can%20call%20%60DELETE%20%2Fsubscribers%60%2C%20%60DELETE%20%2Fworkflows%60%2C%20or%20any%20other%20destructive%20endpoint%20just%20by%20changing%20the%20URL.%20The%20hook%20only%20needs%20two%20paths%20%28%60POST%20...%2Ftelegram%2Fsubscriber-link%60%20and%20%60GET%20...%2Fintegrations%60%29%2C%20so%20unrestricted%20forwarding%20is%20much%20broader%20than%20necessary.%20If%20this%20playground%20is%20deployed%20to%20a%20shared%20or%20preview%20environment%2C%20anyone%20with%20the%20URL%20can%20perform%20admin-level%20operations%20on%20your%20Novu%20account.%20Adding%20an%20allowlist%20check%20%28e.g.%20%60pathParts%5B0%5D%60%20must%20be%20%60v1%60%20and%20only%20the%20two%20expected%20sub-paths%20are%20permitted%29%20would%20close%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%204%0Aplayground%2Fnextjs%2Fsrc%2Fpages%2Fconnect-telegram%2Findex.tsx%3A64-65%0A**Subscriber%20link%20code%20sent%20to%20third-party%20QR%20service**%0A%0AThe%20full%20%60deepLinkUrl%60%20%E2%80%94%20including%20the%20one-time%20subscriber%20link%20code%20%E2%80%94%20is%20passed%20to%20%60api.qrserver.com%60%20as%20a%20plain%20query-string%20parameter.%20Even%20though%20the%20code%20is%20short-lived%2C%20this%20sends%20a%20bearer-equivalent%20token%20to%20a%20third%20party%20on%20every%20link%20issuance%20and%20re-issue.%20Consider%20generating%20the%20QR%20code%20client-side%20%28e.g.%20%60qrcode.react%60%29%20so%20the%20code%20never%20leaves%20the%20browser.%0A%0A%23%23%23%20Issue%203%20of%204%0Aplayground%2Fnextjs%2Fsrc%2Fpages%2Fapi%2Ftelegram-demo%2F%5B...path%5D.ts%3A23-24%0A**Module-level%20state%20won't%20survive%20serverless%20cold%20starts**%0A%0A%60issuedAt%60%20is%20a%20module-level%20variable.%20In%20serverless%20deployments%20%28Vercel%2C%20AWS%20Lambda%2C%20etc.%29%20each%20function%20invocation%20may%20run%20in%20a%20fresh%20container%2C%20so%20a%20POST%20that%20sets%20%60issuedAt%60%20in%20one%20container%20is%20invisible%20to%20the%20next%20GET.%20The%20comment%20acknowledges%20%22single-user%20local%20playground%2C%22%20but%20if%20the%20playground%20is%20deployed%20to%20a%20preview%20URL%20the%20demo%20will%20appear%20permanently%20stuck%20in%20%60pending%60.%20Returning%20a%20real%20timestamp%20in%20the%20POST%20response%20and%20carrying%20it%20in%20a%20cookie%20or%20query%20param%20would%20make%20the%20demo%20self-contained%20per%20request.%0A%0A%23%23%23%20Issue%204%20of%204%0Aplayground%2Fnextjs%2Fsrc%2Fpages%2Fconnect-telegram%2Findex.tsx%3A58%0AThe%20inline%20description%20says%20%2210-minute%20code%20expires%22%20but%20the%20demo%20simulator%20sets%20%60EXPIRY_MS%20%3D%205%20*%2060_000%60%20%285%20minutes%29.%20Even%20though%20this%20comment%20refers%20to%20the%20real%20API's%20expiry%2C%20it%20will%20confuse%20developers%20whose%20first%20experience%20with%20the%20page%20is%20through%20the%20demo%20simulator%20which%20auto-expires%20at%205%20min.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20polls%20until%20the%20connection%20is%20confirmed%20and%20auto-reissues%20the%20link%20when%20the%20code%20expires.%0A%60%60%60%0A%0A&pr=11620&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
playground/nextjs/src/pages/api/novu-proxy/[...path].ts:24-35
**Unrestricted authenticated proxy — any Novu API path accessible**

The proxy forwards any path to the Novu API with the `AGENT_WRITE`-capable secret key. A browser client can call `DELETE /subscribers`, `DELETE /workflows`, or any other destructive endpoint just by changing the URL. The hook only needs two paths (`POST .../telegram/subscriber-link` and `GET .../integrations`), so unrestricted forwarding is much broader than necessary. If this playground is deployed to a shared or preview environment, anyone with the URL can perform admin-level operations on your Novu account. Adding an allowlist check (e.g. `pathParts[0]` must be `v1` and only the two expected sub-paths are permitted) would close this gap.

### Issue 2 of 4
playground/nextjs/src/pages/connect-telegram/index.tsx:64-65
**Subscriber link code sent to third-party QR service**

The full `deepLinkUrl` — including the one-time subscriber link code — is passed to `api.qrserver.com` as a plain query-string parameter. Even though the code is short-lived, this sends a bearer-equivalent token to a third party on every link issuance and re-issue. Consider generating the QR code client-side (e.g. `qrcode.react`) so the code never leaves the browser.

### Issue 3 of 4
playground/nextjs/src/pages/api/telegram-demo/[...path].ts:23-24
**Module-level state won't survive serverless cold starts**

`issuedAt` is a module-level variable. In serverless deployments (Vercel, AWS Lambda, etc.) each function invocation may run in a fresh container, so a POST that sets `issuedAt` in one container is invisible to the next GET. The comment acknowledges "single-user local playground," but if the playground is deployed to a preview URL the demo will appear permanently stuck in `pending`. Returning a real timestamp in the POST response and carrying it in a cookie or query param would make the demo self-contained per request.

### Issue 4 of 4
playground/nextjs/src/pages/connect-telegram/index.tsx:58
The inline description says "10-minute code expires" but the demo simulator sets `EXPIRY_MS = 5 * 60_000` (5 minutes). Even though this comment refers to the real API's expiry, it will confuse developers whose first experience with the page is through the demo simulator which auto-expires at 5 min.

```suggestion
            polls until the connection is confirmed and auto-reissues the link when the code expires.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(playground): add headless Telegram ..."](https://github.com/novuhq/novu/commit/a692714ee211bf8847e6062d72377e686d61a342) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38909668)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->