### PR TITLE
feat(api-service,dashboard): redact secrets from channel-connection responses and add subscriber Channels tab fixes NV-8096

### DIFF
--- a/apps/api/src/app/channel-connections/dtos/dto.mapper.ts
+++ b/apps/api/src/app/channel-connections/dtos/dto.mapper.ts
@@ -1,19 +1,20 @@
-import { decryptChannelConnectionAuth } from '@novu/application-generic';
 import { ChannelConnectionEntity } from '@novu/dal';
+import { ConnectionMode } from '@novu/shared';
 import { GetChannelConnectionResponseDto } from './get-channel-connection-response.dto';
 
 /**
  * Maps a stored `ChannelConnectionEntity` into the public-facing response DTO.
  *
- * `auth` is encrypted at rest (see `encryptChannelConnectionAuth` on the write path),
- * so we decrypt here to preserve the existing API contract — callers still receive the
- * plaintext access token they wrote. The decrypt helper is idempotent, so legacy
- * unencrypted records pass through unchanged.
+ * Secrets (`accessToken`, `refreshToken`, `signingSecret`, `clientSecret`) are
+ * NEVER included in the response. The `auth` field is kept for SDK backward
+ * compatibility but always returns an empty/redacted value. Use `connected` to
+ * determine if credentials are present.
  */
 export function mapChannelConnectionEntityToDto(
   channelConnection: ChannelConnectionEntity
 ): GetChannelConnectionResponseDto {
-  const decryptedAuth = decryptChannelConnectionAuth(channelConnection.auth);
+  const connectionMode: ConnectionMode = channelConnection.subscriberId ? 'subscriber' : 'shared';
+  const connected = Boolean(channelConnection.auth?.accessToken);
 
   return {
     identifier: channelConnection.identifier,
@@ -23,9 +24,9 @@ export function mapChannelConnectionEntityToDto(
     subscriberId: channelConnection.subscriberId || null,
     contextKeys: channelConnection.contextKeys || [],
     workspace: channelConnection.workspace,
-    auth: {
-      accessToken: decryptedAuth?.accessToken ?? '',
-    },
+    auth: { accessToken: '' },
+    connected,
+    connectionMode,
     createdAt: channelConnection.createdAt,
     updatedAt: channelConnection.updatedAt,
   };

--- a/apps/api/src/app/channel-connections/dtos/get-channel-connection-response.dto.ts
+++ b/apps/api/src/app/channel-connections/dtos/get-channel-connection-response.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ChannelTypeEnum, ProvidersIdEnum, ProvidersIdEnumConst } from '@novu/shared';
+import { ChannelTypeEnum, ConnectionMode, ProvidersIdEnum, ProvidersIdEnumConst } from '@novu/shared';
 import { AuthDto, WorkspaceDto } from './shared.dto';
 
 export class GetChannelConnectionResponseDto {
   @ApiProperty({
-    description: 'The unique identifier of the channel endpoint.',
+    description: 'The unique identifier of the channel connection.',
     type: String,
   })
   identifier: string;
@@ -48,17 +48,36 @@ export class GetChannelConnectionResponseDto {
   @ApiProperty({ type: WorkspaceDto })
   workspace: WorkspaceDto;
 
-  @ApiProperty({ type: AuthDto })
+  @ApiProperty({
+    description: 'Deprecated — always returns an empty/redacted value. Use the `connected` field instead.',
+    type: AuthDto,
+    deprecated: true,
+  })
   auth: AuthDto;
 
   @ApiProperty({
-    description: 'The timestamp indicating when the channel endpoint was created, in ISO 8601 format.',
+    description: 'Whether the connection has valid authentication credentials configured.',
+    type: Boolean,
+    example: true,
+  })
+  connected: boolean;
+
+  @ApiProperty({
+    description: 'The connection mode: "subscriber" (personal OAuth) or "shared" (workspace/tenant).',
+    type: String,
+    enum: ['subscriber', 'shared'],
+    example: 'shared',
+  })
+  connectionMode: ConnectionMode;
+
+  @ApiProperty({
+    description: 'The timestamp indicating when the channel connection was created, in ISO 8601 format.',
     type: String,
   })
   createdAt: string;
 
   @ApiProperty({
-    description: 'The timestamp indicating when the channel endpoint was last updated, in ISO 8601 format.',
+    description: 'The timestamp indicating when the channel connection was last updated, in ISO 8601 format.',
     type: String,
   })
   updatedAt: string;

--- a/apps/api/src/app/channel-connections/e2e/channel-connection-auth-security.e2e.ts
+++ b/apps/api/src/app/channel-connections/e2e/channel-connection-auth-security.e2e.ts
@@ -61,50 +61,85 @@ describe('Channel Connection auth — at-rest encryption #novu-v2', () => {
     expect(stored?.auth?.accessToken?.startsWith(NOVU_ENCRYPTION_PREFIX)).to.equal(true);
   });
 
-  it('decrypts on read so callers receive the plaintext token they wrote', async () => {
+  it('never exposes secrets in retrieve response', async () => {
     const integration = await createSlackIntegration(session);
-    const cleartextToken = `xoxb-round-trip-${Date.now()}`;
+    const cleartextToken = `xoxb-secret-check-${Date.now()}`;
 
     const { result: created } = await novuClient.channelConnections.create({
       integrationIdentifier: integration.identifier,
-      context: { tenant: 'at-rest-round-trip' },
-      workspace: { id: 'T_round_trip' },
+      context: { tenant: 'secret-check' },
+      workspace: { id: 'T_secret_check' },
       auth: { accessToken: cleartextToken },
     });
 
-    const { result } = await novuClient.channelConnections.retrieve(created.identifier);
-    expect(result.auth.accessToken).to.equal(cleartextToken);
+    const { body } = await session.testAgent
+      .get(`/v1/channel-connections/${created.identifier}`)
+      .set('authorization', `ApiKey ${session.apiKey}`);
+
+    const response = body.data;
+    const responseJson = JSON.stringify(response);
+
+    expect(responseJson).to.not.include(cleartextToken);
+    expect(responseJson).to.not.include('refreshToken');
+    expect(responseJson).to.not.include('signingSecret');
+    expect(responseJson).to.not.include('clientSecret');
+
+    expect(response.auth.accessToken).to.equal('');
+    expect(response.connected).to.equal(true);
+    expect(response.connectionMode).to.be.oneOf(['subscriber', 'shared']);
   });
 
-  it('legacy unencrypted records continue to round-trip (idempotent decrypt)', async () => {
+  it('never exposes secrets in list response', async () => {
     const integration = await createSlackIntegration(session);
+    const cleartextToken = `xoxb-list-secret-${Date.now()}`;
 
-    // Simulate a record written before the encryption layer existed: bypass the
-    // create usecase and write a plaintext token directly via the repository.
-    const legacyToken = 'xoxb-legacy-unprefixed-token';
-    const legacyIdentifier = `legacy_${Date.now()}`;
+    await novuClient.channelConnections.create({
+      integrationIdentifier: integration.identifier,
+      context: { tenant: 'list-secret-check' },
+      workspace: { id: 'T_list_secret' },
+      auth: { accessToken: cleartextToken },
+    });
+
+    const { body } = await session.testAgent
+      .get('/v1/channel-connections')
+      .set('authorization', `ApiKey ${session.apiKey}`);
+
+    const responseJson = JSON.stringify(body);
+
+    expect(responseJson).to.not.include(cleartextToken);
+    expect(responseJson).to.not.include('refreshToken');
+    expect(responseJson).to.not.include('signingSecret');
+    expect(responseJson).to.not.include('clientSecret');
+
+    for (const conn of body.data) {
+      expect(conn.auth.accessToken).to.equal('');
+      expect(conn.connected).to.be.a('boolean');
+      expect(conn.connectionMode).to.be.oneOf(['subscriber', 'shared']);
+    }
+  });
+
+  it('shows connected=false when no auth token is present', async () => {
+    const integration = await createSlackIntegration(session);
+    const identifier = `no_auth_${Date.now()}`;
+
     await channelConnectionRepository.create({
-      identifier: legacyIdentifier,
+      identifier,
       _environmentId: session.environment._id,
       _organizationId: session.organization._id,
       integrationIdentifier: integration.identifier,
       providerId: integration.providerId,
       channel: integration.channel,
       contextKeys: [],
-      workspace: { id: 'T_legacy' },
-      auth: { accessToken: legacyToken },
+      workspace: { id: 'T_no_auth' },
+      auth: { accessToken: '' },
     });
 
-    // Read path passes legacy unprefixed value through unchanged.
-    const { result } = await novuClient.channelConnections.retrieve(legacyIdentifier);
-    expect(result.auth.accessToken).to.equal(legacyToken);
+    const { body } = await session.testAgent
+      .get(`/v1/channel-connections/${identifier}`)
+      .set('authorization', `ApiKey ${session.apiKey}`);
 
-    // And the legacy stored value is left untouched (no forced migration).
-    const stored = await channelConnectionRepository.findOne({
-      _environmentId: session.environment._id,
-      _organizationId: session.organization._id,
-      identifier: legacyIdentifier,
-    });
-    expect(stored?.auth?.accessToken).to.equal(legacyToken);
+    const response = body.data;
+    expect(response.connected).to.equal(false);
+    expect(response.connectionMode).to.equal('shared');
   });
 });

--- a/apps/api/src/app/channel-connections/e2e/create-channel-connection.e2e.ts
+++ b/apps/api/src/app/channel-connections/e2e/create-channel-connection.e2e.ts
@@ -32,15 +32,23 @@ describe('Create Channel Connection - /channel-connections (POST) #novu-v2', () 
       },
     };
 
-    const { result } = await novuClient.channelConnections.create(createDto);
+    const { result: created } = await novuClient.channelConnections.create(createDto);
 
-    expect(result.identifier).to.be.a('string');
-    expect(result.integrationIdentifier).to.equal(integration.identifier);
-    expect(result.subscriberId).to.equal(subscriber.subscriberId);
-    expect(result.workspace.id).to.equal('T123456');
-    expect(result.workspace.name).to.equal('Test Workspace');
-    expect(result.auth.accessToken).to.equal('xoxb-test-token');
-    expect(result.contextKeys).to.be.an('array').that.is.empty;
+    const { body } = await session.testAgent
+      .get(`/v1/channel-connections/${created.identifier}`)
+      .set('authorization', `ApiKey ${session.apiKey}`);
+
+    const response = body.data;
+
+    expect(response.identifier).to.be.a('string');
+    expect(response.integrationIdentifier).to.equal(integration.identifier);
+    expect(response.subscriberId).to.equal(subscriber.subscriberId);
+    expect(response.workspace.id).to.equal('T123456');
+    expect(response.workspace.name).to.equal('Test Workspace');
+    expect(response.auth.accessToken).to.equal('');
+    expect(response.connected).to.equal(true);
+    expect(response.connectionMode).to.equal('subscriber');
+    expect(response.contextKeys).to.be.an('array').that.is.empty;
   });
 
   it('should create channel connection with context', async () => {

--- a/apps/api/src/app/channel-connections/e2e/get-channel-connection.e2e.ts
+++ b/apps/api/src/app/channel-connections/e2e/get-channel-connection.e2e.ts
@@ -35,13 +35,19 @@ describe('Get Channel Connection - /channel-connections/:identifier (GET) #novu-
     const { result: created } = await novuClient.channelConnections.create(createDto);
     const identifier = created.identifier;
 
-    const { result } = await novuClient.channelConnections.retrieve(identifier);
+    const { body } = await session.testAgent
+      .get(`/v1/channel-connections/${identifier}`)
+      .set('authorization', `ApiKey ${session.apiKey}`);
 
-    expect(result.identifier).to.equal(identifier);
-    expect(result.integrationIdentifier).to.equal(integration.identifier);
-    expect(result.subscriberId).to.equal(subscriber.subscriberId);
-    expect(result.workspace.id).to.equal('T123456');
-    expect(result.auth.accessToken).to.equal('xoxb-test-token');
+    const response = body.data;
+
+    expect(response.identifier).to.equal(identifier);
+    expect(response.integrationIdentifier).to.equal(integration.identifier);
+    expect(response.subscriberId).to.equal(subscriber.subscriberId);
+    expect(response.workspace.id).to.equal('T123456');
+    expect(response.auth.accessToken).to.equal('');
+    expect(response.connected).to.equal(true);
+    expect(response.connectionMode).to.equal('subscriber');
   });
 
   it('should return 404 when connection does not exist', async () => {

--- a/apps/api/src/app/channel-connections/e2e/update-channel-connection.e2e.ts
+++ b/apps/api/src/app/channel-connections/e2e/update-channel-connection.e2e.ts
@@ -38,12 +38,19 @@ describe('Update Channel Connection - /channel-connections/:identifier (PATCH) #
       },
     };
 
-    const { result } = await novuClient.channelConnections.update(updateDto, identifier);
+    await novuClient.channelConnections.update(updateDto, identifier);
 
-    expect(result.identifier).to.equal(identifier);
-    expect(result.workspace.id).to.equal('T789012');
-    expect(result.workspace.name).to.equal('Updated Workspace');
-    expect(result.auth.accessToken).to.equal('xoxb-updated-token');
+    const { body } = await session.testAgent
+      .get(`/v1/channel-connections/${identifier}`)
+      .set('authorization', `ApiKey ${session.apiKey}`);
+
+    const response = body.data;
+
+    expect(response.identifier).to.equal(identifier);
+    expect(response.workspace.id).to.equal('T789012');
+    expect(response.workspace.name).to.equal('Updated Workspace');
+    expect(response.auth.accessToken).to.equal('');
+    expect(response.connected).to.equal(true);
   });
 
   it('should return 404 when connection does not exist', async () => {

--- a/apps/dashboard/src/api/channel-connections.ts
+++ b/apps/dashboard/src/api/channel-connections.ts
@@ -1,0 +1,66 @@
+import { ChannelTypeEnum, ConnectionMode, IEnvironment, ProvidersIdEnum } from '@novu/shared';
+import { get } from './api.client';
+
+export type ChannelConnectionDto = {
+  identifier: string;
+  channel: ChannelTypeEnum | null;
+  providerId: ProvidersIdEnum | null;
+  integrationIdentifier: string | null;
+  subscriberId: string | null;
+  contextKeys: string[];
+  workspace: { id: string; name?: string };
+  connected: boolean;
+  connectionMode: ConnectionMode;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ListChannelConnectionsResponse = {
+  data: ChannelConnectionDto[];
+  next: string | null;
+  previous: string | null;
+  totalCount: number;
+};
+
+export type ListChannelConnectionsParams = {
+  subscriberId?: string;
+  integrationIdentifier?: string;
+  channel?: ChannelTypeEnum;
+  providerId?: ProvidersIdEnum;
+  contextKeys?: string[];
+  limit?: number;
+  after?: string;
+};
+
+export async function listChannelConnections(
+  params: ListChannelConnectionsParams,
+  environment: IEnvironment
+): Promise<ListChannelConnectionsResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (params.subscriberId) searchParams.set('subscriberId', params.subscriberId);
+  if (params.integrationIdentifier) searchParams.set('integrationIdentifier', params.integrationIdentifier);
+  if (params.channel) searchParams.set('channel', params.channel);
+  if (params.providerId) searchParams.set('providerId', params.providerId);
+  if (params.limit) searchParams.set('limit', String(params.limit));
+  if (params.after) searchParams.set('after', params.after);
+  if (params.contextKeys?.length) {
+    for (const key of params.contextKeys) {
+      searchParams.append('contextKeys', key);
+    }
+  }
+
+  const query = searchParams.toString();
+  const url = `/channel-connections${query ? `?${query}` : ''}`;
+
+  return get<ListChannelConnectionsResponse>(url, { environment });
+}
+
+export async function getChannelConnection(
+  identifier: string,
+  environment: IEnvironment
+): Promise<ChannelConnectionDto> {
+  const { data } = await get<{ data: ChannelConnectionDto }>(`/channel-connections/${identifier}`, { environment });
+
+  return data;
+}

--- a/apps/dashboard/src/api/channel-endpoints.ts
+++ b/apps/dashboard/src/api/channel-endpoints.ts
@@ -1,0 +1,59 @@
+import { ChannelEndpointType, ChannelTypeEnum, IEnvironment, ProvidersIdEnum } from '@novu/shared';
+import { get } from './api.client';
+
+export type ChannelEndpointDto = {
+  identifier: string;
+  channel: ChannelTypeEnum | null;
+  providerId: ProvidersIdEnum | null;
+  integrationIdentifier: string | null;
+  connectionIdentifier: string | null;
+  subscriberId: string | null;
+  contextKeys: string[];
+  type: ChannelEndpointType;
+  endpoint: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ListChannelEndpointsResponse = {
+  data: ChannelEndpointDto[];
+  next: string | null;
+  previous: string | null;
+  totalCount: number;
+};
+
+export type ListChannelEndpointsParams = {
+  subscriberId?: string;
+  connectionIdentifier?: string;
+  integrationIdentifier?: string;
+  channel?: ChannelTypeEnum;
+  providerId?: ProvidersIdEnum;
+  contextKeys?: string[];
+  limit?: number;
+  after?: string;
+};
+
+export async function listChannelEndpoints(
+  params: ListChannelEndpointsParams,
+  environment: IEnvironment
+): Promise<ListChannelEndpointsResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (params.subscriberId) searchParams.set('subscriberId', params.subscriberId);
+  if (params.connectionIdentifier) searchParams.set('connectionIdentifier', params.connectionIdentifier);
+  if (params.integrationIdentifier) searchParams.set('integrationIdentifier', params.integrationIdentifier);
+  if (params.channel) searchParams.set('channel', params.channel);
+  if (params.providerId) searchParams.set('providerId', params.providerId);
+  if (params.limit) searchParams.set('limit', String(params.limit));
+  if (params.after) searchParams.set('after', params.after);
+  if (params.contextKeys?.length) {
+    for (const key of params.contextKeys) {
+      searchParams.append('contextKeys', key);
+    }
+  }
+
+  const query = searchParams.toString();
+  const url = `/channel-endpoints${query ? `?${query}` : ''}`;
+
+  return get<ListChannelEndpointsResponse>(url, { environment });
+}

--- a/apps/dashboard/src/components/subscribers/subscriber-channels.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-channels.tsx
@@ -1,0 +1,110 @@
+import { motion } from 'motion/react';
+import { RiLink, RiLinkUnlink } from 'react-icons/ri';
+import { ProviderIcon } from '@/components/integrations/components/provider-icon';
+import { Badge } from '@/components/primitives/badge';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { SidebarContent } from '@/components/side-navigation/sidebar';
+import { useSubscriberChannelGraph } from '@/hooks/use-subscriber-channel-graph';
+import { getConnectionModeLabel, getEndpointDisplayLabel, getEndpointPrimaryValue } from '@/utils/channel-delivery';
+import { itemVariants, listVariants } from '@/utils/animation';
+
+type SubscriberChannelsProps = {
+  subscriberId: string;
+};
+
+export function SubscriberChannels({ subscriberId }: SubscriberChannelsProps) {
+  const { channelGraph, isPending } = useSubscriberChannelGraph(subscriberId);
+
+  if (isPending) {
+    return <SubscriberChannelsSkeleton />;
+  }
+
+  if (channelGraph.length === 0) {
+    return (
+      <SidebarContent>
+        <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+          <RiLinkUnlink className="text-foreground-400 size-8" />
+          <p className="text-foreground-600 text-sm">No channel connections or endpoints configured for this subscriber.</p>
+        </div>
+      </SidebarContent>
+    );
+  }
+
+  return (
+    <SidebarContent>
+      <motion.div variants={listVariants} initial="hidden" animate="visible" className="flex flex-col gap-4 py-3">
+        {channelGraph.map((group) => (
+          <motion.div key={group.integrationIdentifier} variants={itemVariants} className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 px-3">
+              {group.connection?.providerId && (
+                <ProviderIcon
+                  providerId={group.connection.providerId}
+                  providerDisplayName={group.connection.providerId}
+                  className="size-5"
+                />
+              )}
+              <span className="text-foreground-950 text-sm font-medium">{group.integrationIdentifier}</span>
+              {group.connection && (
+                <Badge variant="light" color={group.connection.connected ? 'green' : 'orange'} className="ml-auto">
+                  {group.connection.connected ? 'Connected' : 'Disconnected'}
+                </Badge>
+              )}
+            </div>
+
+            {group.connection && (
+              <div className="bg-bg-weak mx-3 flex flex-col gap-1 rounded-lg p-3">
+                <div className="flex items-center gap-2">
+                  <RiLink className="text-foreground-400 size-4" />
+                  <span className="text-foreground-600 text-xs">
+                    {group.connection.workspace?.name ?? group.connection.workspace?.id}
+                  </span>
+                  <Badge variant="stroke" color="gray" className="ml-auto">
+                    {getConnectionModeLabel(group.connection.connectionMode)}
+                  </Badge>
+                </div>
+              </div>
+            )}
+
+            {group.endpoints.length > 0 && (
+              <div className="mx-3 flex flex-col gap-1">
+                {group.endpoints.map((ep) => (
+                  <div
+                    key={ep.identifier}
+                    className="border-border flex items-center gap-2 rounded-md border px-3 py-2"
+                  >
+                    <span className="text-foreground-600 text-xs font-medium">
+                      {getEndpointDisplayLabel(ep.type)}
+                    </span>
+                    <span className="text-foreground-950 ml-auto text-xs font-mono">
+                      {getEndpointPrimaryValue(ep.type, ep.endpoint)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </motion.div>
+        ))}
+      </motion.div>
+    </SidebarContent>
+  );
+}
+
+function SubscriberChannelsSkeleton() {
+  return (
+    <SidebarContent>
+      <div className="flex flex-col gap-4 py-3">
+        {[1, 2].map((i) => (
+          <div key={i} className="flex flex-col gap-2 px-3">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-5 rounded" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="ml-auto h-5 w-20 rounded-full" />
+            </div>
+            <Skeleton className="h-10 w-full rounded-lg" />
+            <Skeleton className="h-8 w-full rounded-md" />
+          </div>
+        ))}
+      </div>
+    </SidebarContent>
+  );
+}

--- a/apps/dashboard/src/components/subscribers/subscriber-channels.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-channels.tsx
@@ -5,8 +5,8 @@ import { Badge } from '@/components/primitives/badge';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { SidebarContent } from '@/components/side-navigation/sidebar';
 import { useSubscriberChannelGraph } from '@/hooks/use-subscriber-channel-graph';
-import { getConnectionModeLabel, getEndpointDisplayLabel, getEndpointPrimaryValue } from '@/utils/channel-delivery';
 import { itemVariants, listVariants } from '@/utils/animation';
+import { getConnectionModeLabel, getEndpointDisplayLabel, getEndpointPrimaryValue } from '@/utils/channel-delivery';
 
 type SubscriberChannelsProps = {
   subscriberId: string;
@@ -24,7 +24,9 @@ export function SubscriberChannels({ subscriberId }: SubscriberChannelsProps) {
       <SidebarContent>
         <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
           <RiLinkUnlink className="text-foreground-400 size-8" />
-          <p className="text-foreground-600 text-sm">No channel connections or endpoints configured for this subscriber.</p>
+          <p className="text-foreground-600 text-sm">
+            No channel connections or endpoints configured for this subscriber.
+          </p>
         </div>
       </SidebarContent>
     );
@@ -72,9 +74,7 @@ export function SubscriberChannels({ subscriberId }: SubscriberChannelsProps) {
                     key={ep.identifier}
                     className="border-border flex items-center gap-2 rounded-md border px-3 py-2"
                   >
-                    <span className="text-foreground-600 text-xs font-medium">
-                      {getEndpointDisplayLabel(ep.type)}
-                    </span>
+                    <span className="text-foreground-600 text-xs font-medium">{getEndpointDisplayLabel(ep.type)}</span>
                     <span className="text-foreground-950 ml-auto text-xs font-mono">
                       {getEndpointPrimaryValue(ep.type, ep.endpoint)}
                     </span>

--- a/apps/dashboard/src/components/subscribers/subscriber-tabs.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-tabs.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitive
 import { Preferences } from '@/components/subscribers/preferences/preferences';
 import { PreferencesSkeleton } from '@/components/subscribers/preferences/preferences-skeleton';
 import { SubscriberActivity } from '@/components/subscribers/subscriber-activity';
+import { SubscriberChannels } from '@/components/subscribers/subscriber-channels';
 import { SubscriberOverviewForm } from '@/components/subscribers/subscriber-overview-form';
 import { SubscriberOverviewSkeleton } from '@/components/subscribers/subscriber-overview-skeleton';
 import { SubscriberSubscriptions } from '@/components/subscribers/subscriptions/subscriber-subscriptions';
@@ -109,6 +110,10 @@ export function SubscriberTabs(props: SubscriberTabsProps) {
           <span>Activity Feed</span>
           {tab === 'activity-feed' && <ActiveTabIndicator />}
         </TabsTrigger>
+        <TabsTrigger value="channels" className={tabTriggerClasses} variant="regular" size="lg">
+          <span>Channels</span>
+          {tab === 'channels' && <ActiveTabIndicator />}
+        </TabsTrigger>
       </TabsList>
       <TabsContent value="overview" className="h-full w-full overflow-y-auto">
         <SubscriberOverview
@@ -126,6 +131,9 @@ export function SubscriberTabs(props: SubscriberTabsProps) {
       </TabsContent>
       <TabsContent value="activity-feed" className="h-full w-full overflow-y-auto">
         <SubscriberActivity subscriberId={subscriberId} />
+      </TabsContent>
+      <TabsContent value="channels" className="h-full w-full overflow-y-auto">
+        <SubscriberChannels subscriberId={subscriberId} />
       </TabsContent>
       <Separator />
     </Tabs>

--- a/apps/dashboard/src/hooks/use-subscriber-channel-graph.ts
+++ b/apps/dashboard/src/hooks/use-subscriber-channel-graph.ts
@@ -1,0 +1,75 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEnvironment } from '../context/environment/hooks';
+import { QueryKeys } from '../utils/query-keys';
+import { ChannelConnectionDto, listChannelConnections } from '@/api/channel-connections';
+import { ChannelEndpointDto, listChannelEndpoints } from '@/api/channel-endpoints';
+
+export type ChannelGraphGroup = {
+  integrationIdentifier: string;
+  connection: ChannelConnectionDto | null;
+  endpoints: ChannelEndpointDto[];
+};
+
+function buildChannelGraph(
+  connections: ChannelConnectionDto[],
+  endpoints: ChannelEndpointDto[]
+): ChannelGraphGroup[] {
+  const groupMap = new Map<string, ChannelGraphGroup>();
+
+  for (const conn of connections) {
+    if (conn.integrationIdentifier) {
+      groupMap.set(conn.integrationIdentifier, {
+        integrationIdentifier: conn.integrationIdentifier,
+        connection: conn,
+        endpoints: [],
+      });
+    }
+  }
+
+  for (const ep of endpoints) {
+    const key = ep.integrationIdentifier ?? ep.connectionIdentifier ?? ep.identifier;
+    const existing = groupMap.get(key);
+    if (existing) {
+      existing.endpoints.push(ep);
+    } else {
+      groupMap.set(key, {
+        integrationIdentifier: key,
+        connection: null,
+        endpoints: [ep],
+      });
+    }
+  }
+
+  return Array.from(groupMap.values());
+}
+
+export function useSubscriberChannelGraph(subscriberId: string) {
+  const { currentEnvironment } = useEnvironment();
+
+  const connectionsQuery = useQuery({
+    queryKey: [QueryKeys.fetchChannelConnections, currentEnvironment?._id, { subscriberId }],
+    queryFn: () => listChannelConnections({ subscriberId, limit: 100 }, currentEnvironment!),
+    enabled: !!currentEnvironment?._id && !!subscriberId,
+  });
+
+  const endpointsQuery = useQuery({
+    queryKey: [QueryKeys.fetchChannelEndpoints, currentEnvironment?._id, { subscriberId }],
+    queryFn: () => listChannelEndpoints({ subscriberId, limit: 100 }, currentEnvironment!),
+    enabled: !!currentEnvironment?._id && !!subscriberId,
+  });
+
+  const isPending = connectionsQuery.isPending || endpointsQuery.isPending;
+  const isError = connectionsQuery.isError || endpointsQuery.isError;
+
+  const channelGraph = !isPending && !isError
+    ? buildChannelGraph(connectionsQuery.data?.data ?? [], endpointsQuery.data?.data ?? [])
+    : [];
+
+  return {
+    channelGraph,
+    isPending,
+    isError,
+    connections: connectionsQuery.data?.data ?? [],
+    endpoints: endpointsQuery.data?.data ?? [],
+  };
+}

--- a/apps/dashboard/src/hooks/use-subscriber-channel-graph.ts
+++ b/apps/dashboard/src/hooks/use-subscriber-channel-graph.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEnvironment } from '../context/environment/hooks';
-import { QueryKeys } from '../utils/query-keys';
 import { ChannelConnectionDto, listChannelConnections } from '@/api/channel-connections';
 import { ChannelEndpointDto, listChannelEndpoints } from '@/api/channel-endpoints';
+import { useEnvironment } from '../context/environment/hooks';
+import { QueryKeys } from '../utils/query-keys';
 
 export type ChannelGraphGroup = {
   integrationIdentifier: string;
@@ -10,10 +10,7 @@ export type ChannelGraphGroup = {
   endpoints: ChannelEndpointDto[];
 };
 
-function buildChannelGraph(
-  connections: ChannelConnectionDto[],
-  endpoints: ChannelEndpointDto[]
-): ChannelGraphGroup[] {
+function buildChannelGraph(connections: ChannelConnectionDto[], endpoints: ChannelEndpointDto[]): ChannelGraphGroup[] {
   const groupMap = new Map<string, ChannelGraphGroup>();
 
   for (const conn of connections) {
@@ -61,9 +58,8 @@ export function useSubscriberChannelGraph(subscriberId: string) {
   const isPending = connectionsQuery.isPending || endpointsQuery.isPending;
   const isError = connectionsQuery.isError || endpointsQuery.isError;
 
-  const channelGraph = !isPending && !isError
-    ? buildChannelGraph(connectionsQuery.data?.data ?? [], endpointsQuery.data?.data ?? [])
-    : [];
+  const channelGraph =
+    !isPending && !isError ? buildChannelGraph(connectionsQuery.data?.data ?? [], endpointsQuery.data?.data ?? []) : [];
 
   return {
     channelGraph,

--- a/apps/dashboard/src/utils/channel-delivery.ts
+++ b/apps/dashboard/src/utils/channel-delivery.ts
@@ -1,0 +1,69 @@
+import { ChannelEndpointType, ENDPOINT_TYPES } from '@novu/shared';
+
+type EndpointDisplayConfig = {
+  label: string;
+  primaryField: string;
+  formatValue: (endpoint: Record<string, string>) => string;
+};
+
+const ENDPOINT_DISPLAY_MAP: Record<ChannelEndpointType, EndpointDisplayConfig> = {
+  [ENDPOINT_TYPES.SLACK_CHANNEL]: {
+    label: 'Slack channel',
+    primaryField: 'channelId',
+    formatValue: (ep) => `#${ep.channelId}`,
+  },
+  [ENDPOINT_TYPES.SLACK_USER]: {
+    label: 'Slack DM',
+    primaryField: 'userId',
+    formatValue: (ep) => `@${ep.userId}`,
+  },
+  [ENDPOINT_TYPES.MS_TEAMS_CHANNEL]: {
+    label: 'Teams channel',
+    primaryField: 'channelId',
+    formatValue: (ep) => ep.channelId,
+  },
+  [ENDPOINT_TYPES.MS_TEAMS_USER]: {
+    label: 'Teams DM',
+    primaryField: 'userId',
+    formatValue: (ep) => `@${ep.userId}`,
+  },
+  [ENDPOINT_TYPES.TELEGRAM_CHAT]: {
+    label: 'Telegram chat',
+    primaryField: 'chatId',
+    formatValue: (ep) => ep.chatId,
+  },
+  [ENDPOINT_TYPES.PHONE]: {
+    label: 'Phone',
+    primaryField: 'phoneNumber',
+    formatValue: (ep) => ep.phoneNumber,
+  },
+  [ENDPOINT_TYPES.WEBHOOK]: {
+    label: 'Webhook',
+    primaryField: 'url',
+    formatValue: (ep) => {
+      const url = ep.url;
+      if (url.length > 40) {
+        return `${url.slice(0, 37)}...`;
+      }
+
+      return url;
+    },
+  },
+};
+
+export function getEndpointDisplayLabel(type: ChannelEndpointType): string {
+  return ENDPOINT_DISPLAY_MAP[type]?.label ?? type;
+}
+
+export function getEndpointPrimaryValue(type: ChannelEndpointType, endpoint: Record<string, string>): string {
+  const config = ENDPOINT_DISPLAY_MAP[type];
+  if (!config) {
+    return JSON.stringify(endpoint);
+  }
+
+  return config.formatValue(endpoint);
+}
+
+export function getConnectionModeLabel(mode: 'subscriber' | 'shared'): string {
+  return mode === 'subscriber' ? 'Personal' : 'Shared';
+}

--- a/apps/dashboard/src/utils/query-keys.ts
+++ b/apps/dashboard/src/utils/query-keys.ts
@@ -45,4 +45,6 @@ export const QueryKeys = Object.freeze({
   fetchDomain: 'fetchDomain',
   fetchDomainRoutes: 'fetchDomainRoutes',
   fetchDomainConnectStatus: 'fetchDomainConnectStatus',
+  fetchChannelConnections: 'fetchChannelConnections',
+  fetchChannelEndpoints: 'fetchChannelEndpoints',
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR implements Phase 1 of NV-8096: secret redaction (blocking) + read-only subscriber Channels tab.

**Problem**: The `GetChannelConnectionResponseDto` was returning decrypted `accessToken` in plaintext, creating a secret leak surface. Operators also had no way to see channel connections/endpoints in the Dashboard.

**Solution**:

1. **Secret redaction** (highest priority): The DTO mapper no longer decrypts or returns secrets. The `auth` field is kept for SDK backward compatibility but always returns `{ accessToken: '' }` (redacted). New `connected` (boolean) and `connectionMode` ('subscriber' | 'shared') fields replace the information previously inferred from the token.

2. **Automated security tests**: New e2e tests verify that no channel-connection response (retrieve or list) ever contains a real `accessToken`, `refreshToken`, `signingSecret`, or `clientSecret`.

3. **Dashboard Channels tab**: A new "Channels" tab on the subscriber profile shows connections and endpoints grouped by integration, with connection status and mode displayed in product language.

#### Architecture

```mermaid
flowchart LR
    A[ChannelConnectionEntity] -->|mapChannelConnectionEntityToDto| B[Response DTO]
    B -->|auth.accessToken = empty| C[Never exposes secrets]
    B -->|connected: boolean| D[Dashboard reads status]
    B -->|connectionMode| D
    E[Dashboard API Layer] -->|TanStack Query| F[useSubscriberChannelGraph]
    F --> G[SubscriberChannels component]
```

#### Key changes

| File | Change |
|------|--------|
| `apps/api/.../dtos/dto.mapper.ts` | Remove `decryptChannelConnectionAuth`, return redacted auth + new fields |
| `apps/api/.../dtos/get-channel-connection-response.dto.ts` | Add `connected`, `connectionMode`; deprecate `auth` |
| `apps/api/.../e2e/channel-connection-auth-security.e2e.ts` | Rewrite: verify no secrets in retrieve/list, test connected=false |
| `apps/dashboard/src/api/channel-connections.ts` | New API client for channel connections |
| `apps/dashboard/src/api/channel-endpoints.ts` | New API client for channel endpoints |
| `apps/dashboard/src/hooks/use-subscriber-channel-graph.ts` | Composite hook: fetch endpoints + connections → grouped graph |
| `apps/dashboard/src/utils/channel-delivery.ts` | Endpoint type → label/value helpers |
| `apps/dashboard/src/components/subscribers/subscriber-channels.tsx` | Channels tab component |
| `apps/dashboard/src/components/subscribers/subscriber-tabs.tsx` | Add Channels tab trigger |

### Screenshots

![Channels tab showing empty state in subscriber profile](https://cursor.com/artifacts/c/art-5eef679a-cd43-47ba-a7a5-fa2225aed91b)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- The `auth` field is kept in the response DTO for backward compatibility with the published `@novu/api` SDK (v3.15.0) which has a Zod schema requiring it. Once the SDK is regenerated, `auth` can be fully removed.
- ChannelEndpoint responses were audited and confirmed safe — the entity has no `auth` field, only targeting data.
- All 22 channel-connection e2e tests + 19 channel-endpoint e2e tests pass.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8096](https://linear.app/novu/issue/NV-8096/surface-channelconnection-and-channelendpoint-data-transparently-in)

<div><a href="https://cursor.com/agents/bc-8491d966-51a8-421e-b2f1-13183146051d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8491d966-51a8-421e-b2f1-13183146051d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

A critical security vulnerability was fixed where `GetChannelConnectionResponseDto` exposed decrypted secrets (`accessToken`, `refreshToken`, `signingSecret`, `clientSecret`) in plaintext API responses. The DTO mapper no longer decrypts secrets; instead, it returns an empty `auth` field for backward compatibility with SDK v3.15.0, while adding `connected` (boolean) and `connectionMode` ('subscriber' | 'shared') fields to convey connection status without exposing sensitive data.

## Affected areas

**api**: Channel-connection DTO mapper modified to redact secrets instead of decrypting them. Response DTO updated with new `connected` and `connectionMode` fields. E2e tests rewritten to verify that retrieve and list operations never expose plaintext secrets—all assertions now check for empty `auth.accessToken` and appropriate status fields.

**dashboard**: New API clients (`channel-connections.ts`, `channel-endpoints.ts`) added to query channel data. New `SubscriberChannels` component displays channel connections and endpoints grouped by integration with status and mode badges. New hook `useSubscriberChannelGraph` fetches and combines data from both endpoints via TanStack Query. New utilities (`channel-delivery.ts`) format endpoint types and connection modes for display. Query keys (`query-keys.ts`) updated to include new data-fetching identifiers.

## Key technical decisions

- `auth` field is retained (empty) for backward compatibility with published SDK v3.15.0; full removal is planned once the SDK is regenerated.
- New `connected` and `connectionMode` fields replace information previously inferred from token contents, eliminating the need to decrypt or expose secrets.
- Dashboard composite hook uses parallel TanStack Query queries (connections and endpoints) to build a grouped channel graph only when both queries succeed.

## Testing

E2e tests across channel-connection and channel-endpoint operations (41 tests total) verify that secrets are never exposed in retrieve or list responses, with explicit assertions that `auth.accessToken` is empty and `connected`/`connectionMode` fields are present and correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a secret-leak vulnerability where `GetChannelConnectionResponseDto` was returning decrypted `accessToken` values in plaintext. It also adds a new "Channels" tab to the subscriber profile in the Dashboard.

- **API (security fix):** The DTO mapper drops all secret decryption and returns `auth: { accessToken: '' }` for SDK backward compatibility, while introducing `connected: boolean` and `connectionMode: 'subscriber' | 'shared'` as the canonical status fields. E2e tests are rewritten to assert that no secret values appear in retrieve or list responses.
- **Dashboard (new feature):** New `SubscriberChannels` component, `useSubscriberChannelGraph` hook, and supporting API clients display channel connections and endpoints grouped by integration. Three issues need attention: the component renders an empty-state message instead of an error state when queries fail; the endpoint grouping fallback in `buildChannelGraph` uses `connectionIdentifier` as a key into a map keyed by `integrationIdentifier`, so endpoints without `integrationIdentifier` are always orphaned; and the WEBHOOK formatter in `channel-delivery.ts` will throw if `ep.url` is absent.

<h3>Confidence Score: 3/5</h3>

The API-side secret redaction is solid and well-tested. The Dashboard feature has three bugs that would show incorrect or misleading UI to operators in real scenarios.

The mapper change and security e2e tests are correct and address the core vulnerability cleanly. The dashboard hook's buildChannelGraph will silently misplace any endpoint whose integrationIdentifier is null, producing orphaned groups with no connection context. The component renders the 'no channels' empty state whenever either query errors, hiding failures from operators. The webhook formatter crashes on an absent url field, breaking the Channels tab render entirely for affected subscribers.

use-subscriber-channel-graph.ts (grouping logic), subscriber-channels.tsx (missing error state), and channel-delivery.ts (null-guard on endpoint fields)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/channel-connections/dtos/dto.mapper.ts | Removes secret decryption from the read path; computes `connected` from encrypted field presence and `connectionMode` from `subscriberId`; returns `auth: { accessToken: '' }` for SDK compat. |
| apps/api/src/app/channel-connections/dtos/get-channel-connection-response.dto.ts | Adds `connected: boolean` and `connectionMode: ConnectionMode` fields; marks `auth` as deprecated with correct OpenAPI decorator. |
| apps/api/src/app/channel-connections/e2e/channel-connection-auth-security.e2e.ts | Rewrites security e2e tests to assert secrets are never present in retrieve or list responses, and verifies `connected=false` for empty-token records. |
| apps/dashboard/src/hooks/use-subscriber-channel-graph.ts | Composite TanStack Query hook; has a grouping bug where endpoints with null `integrationIdentifier` use `connectionIdentifier` as the map key, which never matches existing connection entries, producing orphaned groups. |
| apps/dashboard/src/components/subscribers/subscriber-channels.tsx | New Channels tab component; does not consume `isError` from the hook, so API failures are silently displayed as the empty-state 'No channel connections' message. |
| apps/dashboard/src/utils/channel-delivery.ts | Endpoint type → display helpers; the WEBHOOK formatter accesses `ep.url` without a null guard — crashes if the field is absent from the endpoint record. |
| apps/dashboard/src/api/channel-connections.ts | New API client for channel connections; correctly omits `auth` from the DTO type and builds query strings including multi-value `contextKeys`. |
| apps/dashboard/src/api/channel-endpoints.ts | New API client for channel endpoints; mirrors the connections client structure and handles `contextKeys` array serialization correctly. |
| apps/dashboard/src/components/subscribers/subscriber-tabs.tsx | Adds the Channels tab trigger and content slot to the subscriber sidebar; minimal change, follows the existing tab pattern. |
| apps/dashboard/src/utils/query-keys.ts | Adds `fetchChannelConnections` and `fetchChannelEndpoints` query key constants. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant DB as MongoDB (encrypted)
    participant Mapper as dto.mapper.ts
    participant API as API Response
    participant Hook as useSubscriberChannelGraph
    participant UI as SubscriberChannels

    DB->>Mapper: "ChannelConnectionEntity (auth.accessToken = encrypted)"
    Mapper->>Mapper: "connected = Boolean(auth?.accessToken)"
    Mapper->>Mapper: "connectionMode = subscriberId ? subscriber : shared"
    Mapper->>API: "{ auth: {accessToken:''}, connected, connectionMode }"

    UI->>Hook: subscriberId
    Hook->>API: "GET /channel-connections?subscriberId=..."
    Hook->>API: "GET /channel-endpoints?subscriberId=..."
    API-->>Hook: connections[] + endpoints[]
    Hook->>Hook: buildChannelGraph(connections, endpoints)
    Hook-->>UI: channelGraph[], isPending, isError
    Note over UI: isError not consumed — shown as empty state on failure
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant DB as MongoDB (encrypted)
    participant Mapper as dto.mapper.ts
    participant API as API Response
    participant Hook as useSubscriberChannelGraph
    participant UI as SubscriberChannels

    DB->>Mapper: "ChannelConnectionEntity (auth.accessToken = encrypted)"
    Mapper->>Mapper: "connected = Boolean(auth?.accessToken)"
    Mapper->>Mapper: "connectionMode = subscriberId ? subscriber : shared"
    Mapper->>API: "{ auth: {accessToken:''}, connected, connectionMode }"

    UI->>Hook: subscriberId
    Hook->>API: "GET /channel-connections?subscriberId=..."
    Hook->>API: "GET /channel-endpoints?subscriberId=..."
    API-->>Hook: connections[] + endpoints[]
    Hook->>Hook: buildChannelGraph(connections, endpoints)
    Hook-->>UI: channelGraph[], isPending, isError
    Note over UI: isError not consumed — shown as empty state on failure
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fsubscribers%2Fsubscriber-channels.tsx%3A16-33%0A**Error%20state%20silently%20shown%20as%20empty%20state**%0A%0A%60isError%60%20is%20returned%20by%20the%20hook%20but%20not%20consumed%20here.%20When%20either%20query%20fails%20%28network%20error%2C%205xx%2C%20auth%20error%29%2C%20%60channelGraph%60%20is%20%60%5B%5D%60%20and%20%60isPending%60%20is%20%60false%60%2C%20so%20the%20component%20renders%20%22No%20channel%20connections%20or%20endpoints%20configured%20for%20this%20subscriber.%22%20A%20real%20failure%20is%20indistinguishable%20from%20a%20subscriber%20with%20no%20channels%2C%20which%20will%20confuse%20operators%20debugging%20connection%20issues.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fdashboard%2Fsrc%2Fhooks%2Fuse-subscriber-channel-graph.ts%3A26-37%0A**Endpoint%20grouping%20fallback%20key%20is%20the%20wrong%20identifier%20type**%0A%0AWhen%20%60ep.integrationIdentifier%60%20is%20%60null%60%2C%20the%20code%20falls%20back%20to%20%60ep.connectionIdentifier%60%20as%20the%20%60groupMap%60%20lookup%20key.%20However%2C%20%60groupMap%60%20is%20keyed%20by%20%60integrationIdentifier%60%20values%20from%20connections%20%28%60conn.integrationIdentifier%60%29.%20A%20connection's%20identifier%20%28the%20%60connectionIdentifier%60%20field%20on%20the%20endpoint%29%20is%20a%20different%20value%20and%20will%20never%20match%20a%20key%20in%20that%20map.%20Any%20endpoint%20that%20lacks%20%60integrationIdentifier%60%20but%20carries%20%60connectionIdentifier%60%20will%20be%20placed%20into%20a%20new%20orphaned%20group%20with%20%60connection%3A%20null%60%2C%20even%20when%20its%20parent%20connection%20is%20already%20in%20the%20map.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fdashboard%2Fsrc%2Futils%2Fchannel-delivery.ts%3A40-51%0AIf%20the%20%60url%60%20field%20is%20absent%20from%20the%20endpoint%20record%20%28the%20type%20is%20%60Record%3Cstring%2C%20string%3E%60%20with%20no%20guaranteed%20keys%29%2C%20%60ep.url%60%20is%20%60undefined%60%20and%20%60url.length%60%20throws%20a%20%60TypeError%60%2C%20crashing%20the%20Channels%20tab%20render.%20The%20same%20risk%20applies%20to%20%60ep.channelId%60%2C%20%60ep.userId%60%2C%20%60ep.chatId%60%2C%20and%20%60ep.phoneNumber%60%20in%20the%20other%20formatters.%0A%0A%60%60%60suggestion%0A%20%20%5BENDPOINT_TYPES.WEBHOOK%5D%3A%20%7B%0A%20%20%20%20label%3A%20'Webhook'%2C%0A%20%20%20%20primaryField%3A%20'url'%2C%0A%20%20%20%20formatValue%3A%20%28ep%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20const%20url%20%3D%20ep.url%20%3F%3F%20''%3B%0A%20%20%20%20%20%20if%20%28url.length%20%3E%2040%29%20%7B%0A%20%20%20%20%20%20%20%20return%20%60%24%7Burl.slice%280%2C%2037%29%7D...%60%3B%0A%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20return%20url%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fdashboard%2Fsrc%2Fhooks%2Fuse-subscriber-channel-graph.ts%3A48-55%0A**Hardcoded%20%60limit%3A%20100%60%20silently%20truncates%20data**%0A%0ABoth%20queries%20use%20a%20fixed%20%60limit%3A%20100%60%20with%20no%20follow-up%20pagination.%20A%20subscriber%20with%20more%20than%20100%20connections%20or%20endpoints%20will%20show%20an%20incomplete%20channel%20graph%20with%20no%20indication%20that%20data%20is%20missing.%20Consider%20either%20increasing%20the%20limit%20to%20a%20safer%20ceiling%2C%20adding%20a%20%60hasMore%60%20indicator%2C%20or%20paginating.%0A%0A&pr=11621&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
apps/dashboard/src/components/subscribers/subscriber-channels.tsx:16-33
**Error state silently shown as empty state**

`isError` is returned by the hook but not consumed here. When either query fails (network error, 5xx, auth error), `channelGraph` is `[]` and `isPending` is `false`, so the component renders "No channel connections or endpoints configured for this subscriber." A real failure is indistinguishable from a subscriber with no channels, which will confuse operators debugging connection issues.

### Issue 2 of 4
apps/dashboard/src/hooks/use-subscriber-channel-graph.ts:26-37
**Endpoint grouping fallback key is the wrong identifier type**

When `ep.integrationIdentifier` is `null`, the code falls back to `ep.connectionIdentifier` as the `groupMap` lookup key. However, `groupMap` is keyed by `integrationIdentifier` values from connections (`conn.integrationIdentifier`). A connection's identifier (the `connectionIdentifier` field on the endpoint) is a different value and will never match a key in that map. Any endpoint that lacks `integrationIdentifier` but carries `connectionIdentifier` will be placed into a new orphaned group with `connection: null`, even when its parent connection is already in the map.

### Issue 3 of 4
apps/dashboard/src/utils/channel-delivery.ts:40-51
If the `url` field is absent from the endpoint record (the type is `Record<string, string>` with no guaranteed keys), `ep.url` is `undefined` and `url.length` throws a `TypeError`, crashing the Channels tab render. The same risk applies to `ep.channelId`, `ep.userId`, `ep.chatId`, and `ep.phoneNumber` in the other formatters.

```suggestion
  [ENDPOINT_TYPES.WEBHOOK]: {
    label: 'Webhook',
    primaryField: 'url',
    formatValue: (ep) => {
      const url = ep.url ?? '';
      if (url.length > 40) {
        return `${url.slice(0, 37)}...`;
      }

      return url;
    },
  },
```

### Issue 4 of 4
apps/dashboard/src/hooks/use-subscriber-channel-graph.ts:48-55
**Hardcoded `limit: 100` silently truncates data**

Both queries use a fixed `limit: 100` with no follow-up pagination. A subscriber with more than 100 connections or endpoints will show an incomplete channel graph with no indication that data is missing. Consider either increasing the limit to a safer ceiling, adding a `hasMore` indicator, or paginating.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(dashboard): fix import ordering an..."](https://github.com/novuhq/novu/commit/0f1c6cb968442f86755c266bee9569ae9d0560ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38920794)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->