### PR TITLE
ci(agent-evals): fail workflow when ANTHROPIC_API_KEY is missing fixes NV-8059

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -17,6 +17,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
+      - name: Require Anthropic API key
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not set. Add it in GitHub → Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a fail-fast check to the **Agent evals** workflow so CI fails with a clear error when `ANTHROPIC_API_KEY` is not configured, instead of silently skipping all 8 scenarios and reporting green.

## Why

On PR #11589, the workflow ran but every eval was skipped because the secret was missing. Vitest treats skipped tests as non-failures, so the job looked successful while doing no work. The empty env var in logs was easy to miss.

## Change

Before setup/install, the workflow now checks `${{ secrets.ANTHROPIC_API_KEY }}` and exits with a GitHub Actions annotation:

```
::error::ANTHROPIC_API_KEY secret is not set. Add it in GitHub → Settings → Secrets and variables → Actions.
```

This matches the pattern used in `agent-onboarding-webhook.yml`.

## Test plan

- [ ] With secret unset: **Require Anthropic API key** step fails immediately with the error message
- [ ] With secret set: step passes and evals run as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf31192b-d24f-4029-9f06-591fc7165230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf31192b-d24f-4029-9f06-591fc7165230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds a fail-fast `ANTHROPIC_API_KEY` check to the Agent evals GitHub Actions workflow.
- Emits a GitHub Actions error annotation and exits when the secret is missing.
- Keeps the existing eval setup and execution path unchanged when the secret is present.

<h3>Confidence Score: 4/5</h3>

The workflow change is small, but it can block valid external pull requests that trigger the eval workflow without access to repository secrets.

The changed file is limited to one GitHub Actions workflow, and the main risk is isolated to pull request event handling for forked contributions.

.github/workflows/agent-evals.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the fork PR failure when ANTHROPIC\_API\_KEY is missing by running the shell harness that mirrors the workflow's secret-check step; the run exits with code 1 and shows an error annotation, while providing the key makes the run exit with code 0.
- The logs show before/after secret scenarios: the base workflow without the key lacks the Require Anthropic API key step and reaches Setup with exit code 0, while adding the key triggers the step and, with a non-empty key, the head workflow exits cleanly with exit code 0 and no error annotation.

<a href="https://app.greptile.com/trex/runs/11830220/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fagent-evals.yml%3A20-27%0A**Fork%20PRs%20always%20fail**%0A%0AThis%20workflow%20runs%20on%20%60pull_request%60%2C%20but%20GitHub%20does%20not%20pass%20repository%20secrets%20other%20than%20%60GITHUB_TOKEN%60%20to%20runs%20triggered%20from%20forked%20repositories.%20For%20an%20external%20PR%20that%20touches%20the%20eval%20paths%2C%20%60%24%7B%7B%20secrets.ANTHROPIC_API_KEY%20%7D%7D%60%20is%20empty%20even%20when%20the%20secret%20is%20configured%20in%20the%20base%20repo%2C%20so%20this%20step%20fails%20before%20setup%20and%20blocks%20those%20PRs.%20Consider%20limiting%20the%20fail-fast%20check%20to%20trusted%20same-repo%20PRs%2C%20or%20explicitly%20skipping%2Finternalizing%20evals%20for%20forked%20PRs.%0A%0A&pr=11623&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/agent-evals.yml:20-27
**Fork PRs always fail**

This workflow runs on `pull_request`, but GitHub does not pass repository secrets other than `GITHUB_TOKEN` to runs triggered from forked repositories. For an external PR that touches the eval paths, `${{ secrets.ANTHROPIC_API_KEY }}` is empty even when the secret is configured in the base repo, so this step fails before setup and blocks those PRs. Consider limiting the fail-fast check to trusted same-repo PRs, or explicitly skipping/internalizing evals for forked PRs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(agent-evals): fail workflow when ANTH..."](https://github.com/novuhq/novu/commit/92f4605ad13f53c3cc28483d3970c23d76bcbc2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38981962)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->