### PR TITLE
fix(step-resolver-worker): increase request body limit to 20MB for email attachments

### DIFF
--- a/enterprise/workers/step-resolver/README.md
+++ b/enterprise/workers/step-resolver/README.md
@@ -37,7 +37,7 @@ Route validation (strict):
 - `stepResolverHash`: format `sr-xxxxx-xxxxx` (e.g., `sr-abc12-def34`)
 - `stepId`: one URL path segment (`[^/]+`)
 - `Content-Type`: must be `application/json`
-- Body size: max `1MB`
+- Body size: max `20MB`
 
 Auth headers:
 

--- a/enterprise/workers/step-resolver/README.md
+++ b/enterprise/workers/step-resolver/README.md
@@ -37,7 +37,7 @@ Route validation (strict):
 - `stepResolverHash`: format `sr-xxxxx-xxxxx` (e.g., `sr-abc12-def34`)
 - `stepId`: one URL path segment (`[^/]+`)
 - `Content-Type`: must be `application/json`
-- Body size: max `20MB`
+- Body size: max `26MB` (supports ~20MB raw attachments after base64 and JSON envelope overhead)
 
 Auth headers:
 

--- a/enterprise/workers/step-resolver/src/index.ts
+++ b/enterprise/workers/step-resolver/src/index.ts
@@ -7,7 +7,7 @@ const RESOLVE_ROUTE_REGEX =
   /^\/resolve\/(?<organizationId>[a-f0-9]{24})\/(?<stepResolverWorkerHash>sr-[^/]+)\/(?<workflowId>[^/]+)\/(?<stepId>[^/]+)$/;
 const REQUEST_ID_HEADER = 'x-request-id';
 const JSON_CONTENT_TYPE = 'application/json';
-const MAX_REQUEST_BODY_BYTES = 1024 * 1024; // 1MB
+const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024; // 20MB — matches team-plan email attachment payload limit
 
 function jsonResponse(body: unknown, status: number, requestId: string, headers?: Record<string, string>): Response {
   return new Response(JSON.stringify(body), {

--- a/enterprise/workers/step-resolver/src/index.ts
+++ b/enterprise/workers/step-resolver/src/index.ts
@@ -7,7 +7,7 @@ const RESOLVE_ROUTE_REGEX =
   /^\/resolve\/(?<organizationId>[a-f0-9]{24})\/(?<stepResolverWorkerHash>sr-[^/]+)\/(?<workflowId>[^/]+)\/(?<stepId>[^/]+)$/;
 const REQUEST_ID_HEADER = 'x-request-id';
 const JSON_CONTENT_TYPE = 'application/json';
-const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024; // 20MB — matches team-plan email attachment payload limit
+const MAX_REQUEST_BODY_BYTES = 26 * 1024 * 1024; // 26MB — room for ~20MB attachments after base64 + JSON envelope (matches api-service body limit)
 
 function jsonResponse(body: unknown, status: number, requestId: string, headers?: Record<string, string>): Response {
   return new Response(JSON.stringify(body), {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `STEP_RESOLVER_PAYLOAD_TOO_LARGE` errors when using code-step email with attachments larger than ~250–500KB.

## Root cause

The step resolver **dispatch worker** (`enterprise/workers/step-resolver/src/index.ts`) enforced a hardcoded **1MB** request body limit (`MAX_REQUEST_BODY_BYTES = 1024 * 1024`). When Novu resolves a code-step email, it POSTs the full execution context (controls, state, subscriber, payload) to `step-resolver.novu.co`. Email attachments embedded as base64 in that JSON payload add ~33% overhead, so a ~500KB PDF can exceed 1MB once combined with the rest of the event.

The error surfaced as HTTP 413 from the dispatch worker and was mapped to `STEP_RESOLVER_PAYLOAD_TOO_LARGE` in `ExecuteStepResolverRequest`.

## Fix

Increase `MAX_REQUEST_BODY_BYTES` from **1MB → 26MB** to:

1. Unblock the reported customer failures (500KB+ attachments).
2. Support ~20MB raw attachments after base64 encoding and JSON envelope overhead.
3. Align with the api-service extended body limit (`26mb` in `apps/api/src/bootstrap.ts`).

## Deployment note

This change requires redeploying the step resolver dispatch worker to staging and production (US + EU):

```bash
pnpm --filter @novu/step-resolver-worker deploy:staging
pnpm --filter @novu/step-resolver-worker deploy:production
pnpm --filter @novu/step-resolver-worker deploy:production-eu
```

## Enterprise submodule

This touches `enterprise/workers/step-resolver/`. A matching PR in `novuhq/packages-enterprise` may be required per submodule sync policy.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1781925816925809?thread_ts=1781925816.925809&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-dd63658a-2a73-5496-8347-14064d628b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd63658a-2a73-5496-8347-14064d628b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Updated the step resolver dispatch worker’s maximum allowed JSON request body size from **1MB to 26MB**. This prevents `STEP_RESOLVER_PAYLOAD_TOO_LARGE` (HTTP 413) failures when resolving code-step emails that include attachments, where base64 encoding (~33% overhead) can push otherwise-valid payloads over the previous **1MB** cap. The new limit is sized to support roughly **~20MB raw attachments** after base64 and JSON envelope overhead.

## Affected areas

**enterprise/workers/step-resolver (enterprise/EE)** — Increased `MAX_REQUEST_BODY_BYTES` to 26MB and updated request validation documentation to reflect the higher limit; overflow behavior and error structure remain the same (HTTP 413).

## Key technical decisions

- Set the cap to **26MB** (not 20MB) to account for base64 encoding expansion and additional JSON envelope fields, ensuring intended attachment sizes don’t get rejected.

## Testing

No new automated tests were added; this is a runtime limit change. Verification should be done via redeploying the worker to staging and production (US + EU) and manually confirming that large code-step email attachments no longer trigger `STEP_RESOLVER_PAYLOAD_TOO_LARGE`:

```bash
pnpm --filter `@novu/step-resolver-worker` deploy:staging
pnpm --filter `@novu/step-resolver-worker` deploy:production
pnpm --filter `@novu/step-resolver-worker` deploy:production-eu
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Raises the step resolver dispatch worker request body cap for larger email attachment payloads.
- Updates the step resolver README to document the new request size limit.
- Leaves the existing request validation and 413 handling flow in place.

<h3>Confidence Score: 4/5</h3>

The change is small and targeted, but large valid payload handling still needs attention because the handler creates avoidable full-body copies before forwarding.

The modified worker limit and README are straightforward, and the remaining concern is localized to the request processing path for near-limit attachment payloads.

enterprise/workers/step-resolver/src/index.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Sent a 1,258,291-byte JSON payload against the base commit 641c9d577... and received HTTP 413, confirming the request exceeded the maximum body size of 1048576 bytes.
- Re-tested the same 1,258,291-byte payload against the head commit 3edc4a118... and received HTTP 500, indicating the request passed the size gate but the server configuration produced an error.
- Sent a 27,264,000-byte JSON payload and got HTTP 413, confirming the new 26 MiB cap is enforced.

<a href="https://app.greptile.com/trex/runs/11838699/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `enterprise/workers/step-resolver/src/index.ts`, line 151-152 ([link](https://github.com/novuhq/novu/blob/908dda191e2a6e5079777bbdbfe072b63fdbf088/enterprise/workers/step-resolver/src/index.ts#L151-L152)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Large bodies overbuffer**

   With the limit raised to 20MB, a max-sized attachment request is now accepted and then copied into `bodyBytes`, decoded into `bodyString`, parsed into `bodyJson`, and forwarded to a generated worker that does another full `request.text()` and `JSON.parse()`. A realistic near-20MB base64 JSON payload can consume several multiples of the request size before the step handler runs, which can hit Cloudflare Worker memory or CPU limits and return worker failures instead of resolving the attachment. Consider avoiding the unused full `JSON.parse` in this dispatch worker, streaming the forwarded body where possible after HMAC validation, or using a lower cap with enough runtime headroom.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: enterprise/workers/step-resolver/src/index.ts
   Line: 151-152

   Comment:
   **Large bodies overbuffer**

   With the limit raised to 20MB, a max-sized attachment request is now accepted and then copied into `bodyBytes`, decoded into `bodyString`, parsed into `bodyJson`, and forwarded to a generated worker that does another full `request.text()` and `JSON.parse()`. A realistic near-20MB base64 JSON payload can consume several multiples of the request size before the step handler runs, which can hit Cloudflare Worker memory or CPU limits and return worker failures instead of resolving the attachment. Consider avoiding the unused full `JSON.parse` in this dispatch worker, streaming the forwarded body where possible after HMAC validation, or using a lower cap with enough runtime headroom.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20enterprise%2Fworkers%2Fstep-resolver%2Fsrc%2Findex.ts%0ALine%3A%20151-152%0A%0AComment%3A%0A**Large%20bodies%20overbuffer**%0A%0AWith%20the%20limit%20raised%20to%2020MB%2C%20a%20max-sized%20attachment%20request%20is%20now%20accepted%20and%20then%20copied%20into%20%60bodyBytes%60%2C%20decoded%20into%20%60bodyString%60%2C%20parsed%20into%20%60bodyJson%60%2C%20and%20forwarded%20to%20a%20generated%20worker%20that%20does%20another%20full%20%60request.text%28%29%60%20and%20%60JSON.parse%28%29%60.%20A%20realistic%20near-20MB%20base64%20JSON%20payload%20can%20consume%20several%20multiples%20of%20the%20request%20size%20before%20the%20step%20handler%20runs%2C%20which%20can%20hit%20Cloudflare%20Worker%20memory%20or%20CPU%20limits%20and%20return%20worker%20failures%20instead%20of%20resolving%20the%20attachment.%20Consider%20avoiding%20the%20unused%20full%20%60JSON.parse%60%20in%20this%20dispatch%20worker%2C%20streaming%20the%20forwarded%20body%20where%20possible%20after%20HMAC%20validation%2C%20or%20using%20a%20lower%20cap%20with%20enough%20runtime%20headroom.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11625&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `enterprise/workers/step-resolver/src/index.ts`, line 190 ([link](https://github.com/novuhq/novu/blob/3edc4a118cde4b1b8bfe85d1a502206ebd89279f/enterprise/workers/step-resolver/src/index.ts#L190)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Avoid parsing large bodies**

   With the new 26 MiB limit, requests near the cap are materialized as `bodyBytes`, decoded into `bodyString`, and then parsed into `bodyJson`, but `bodyJson` is never used before forwarding the original bytes. For attachment payloads dominated by base64 strings, this creates multiple large copies inside the Worker and can fail before dispatching the request this change is meant to unblock. Removing the unused parse, or otherwise avoiding an extra full-payload materialization, keeps large valid requests from turning into worker failures.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: enterprise/workers/step-resolver/src/index.ts
   Line: 190

   Comment:
   **Avoid parsing large bodies**

   With the new 26 MiB limit, requests near the cap are materialized as `bodyBytes`, decoded into `bodyString`, and then parsed into `bodyJson`, but `bodyJson` is never used before forwarding the original bytes. For attachment payloads dominated by base64 strings, this creates multiple large copies inside the Worker and can fail before dispatching the request this change is meant to unblock. Removing the unused parse, or otherwise avoiding an extra full-payload materialization, keeps large valid requests from turning into worker failures.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20enterprise%2Fworkers%2Fstep-resolver%2Fsrc%2Findex.ts%0ALine%3A%20190%0A%0AComment%3A%0A**Avoid%20parsing%20large%20bodies**%0A%0AWith%20the%20new%2026%20MiB%20limit%2C%20requests%20near%20the%20cap%20are%20materialized%20as%20%60bodyBytes%60%2C%20decoded%20into%20%60bodyString%60%2C%20and%20then%20parsed%20into%20%60bodyJson%60%2C%20but%20%60bodyJson%60%20is%20never%20used%20before%20forwarding%20the%20original%20bytes.%20For%20attachment%20payloads%20dominated%20by%20base64%20strings%2C%20this%20creates%20multiple%20large%20copies%20inside%20the%20Worker%20and%20can%20fail%20before%20dispatching%20the%20request%20this%20change%20is%20meant%20to%20unblock.%20Removing%20the%20unused%20parse%2C%20or%20otherwise%20avoiding%20an%20extra%20full-payload%20materialization%2C%20keeps%20large%20valid%20requests%20from%20turning%20into%20worker%20failures.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11625&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aenterprise%2Fworkers%2Fstep-resolver%2Fsrc%2Findex.ts%3A190%0A**Avoid%20parsing%20large%20bodies**%0A%0AWith%20the%20new%2026%20MiB%20limit%2C%20requests%20near%20the%20cap%20are%20materialized%20as%20%60bodyBytes%60%2C%20decoded%20into%20%60bodyString%60%2C%20and%20then%20parsed%20into%20%60bodyJson%60%2C%20but%20%60bodyJson%60%20is%20never%20used%20before%20forwarding%20the%20original%20bytes.%20For%20attachment%20payloads%20dominated%20by%20base64%20strings%2C%20this%20creates%20multiple%20large%20copies%20inside%20the%20Worker%20and%20can%20fail%20before%20dispatching%20the%20request%20this%20change%20is%20meant%20to%20unblock.%20Removing%20the%20unused%20parse%2C%20or%20otherwise%20avoiding%20an%20extra%20full-payload%20materialization%2C%20keeps%20large%20valid%20requests%20from%20turning%20into%20worker%20failures.%0A%0A&pr=11625&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
enterprise/workers/step-resolver/src/index.ts:190
**Avoid parsing large bodies**

With the new 26 MiB limit, requests near the cap are materialized as `bodyBytes`, decoded into `bodyString`, and then parsed into `bodyJson`, but `bodyJson` is never used before forwarding the original bytes. For attachment payloads dominated by base64 strings, this creates multiple large copies inside the Worker and can fail before dispatching the request this change is meant to unblock. Removing the unused parse, or otherwise avoiding an extra full-payload materialization, keeps large valid requests from turning into worker failures.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(step-resolver-worker): raise body li..."](https://github.com/novuhq/novu/commit/3edc4a118cde4b1b8bfe85d1a502206ebd89279f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38993768)</sub>

<!-- /greptile_comment -->