### PR TITLE
fix(api, dashboard, dal): count active channels by channel type, not integration fixes NV-8103

### DIFF
--- a/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/channels/agent-config-resolver.service.ts
@@ -63,6 +63,12 @@ export interface ResolvedAgentConfig {
   integrationIdentifier: string;
   integrationId: string;
   /**
+   * Provider id of the resolved integration (e.g. `slack`, `msteams`). Identifies
+   * the channel type for active-channel plan-limit enforcement, where multiple
+   * integrations of the same provider count as a single channel.
+   */
+  providerId: string;
+  /**
    * Whether the organization removed Novu branding (Pro and above). Drives the
    * "Powered by Novu" watermark applied by the outbound gateway on every
    * delivery path.
@@ -288,6 +294,7 @@ export class AgentConfigResolver {
       agentName: agent.name,
       integrationIdentifier,
       integrationId: integration._id,
+      providerId: integration.providerId,
       removeNovuBranding: await this.resolveRemoveNovuBranding(organizationId),
       acknowledgeOnReceived: agent.behavior?.acknowledgeOnReceived !== false,
       reactionOnResolved: await resolveReaction(

--- a/apps/api/src/app/agents/channels/integrations/list-agent-integrations/list-agent-integrations.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/list-agent-integrations/list-agent-integrations.usecase.ts
@@ -136,8 +136,7 @@ export class ListAgentIntegrations {
       }
 
       const exceedsPlanLimit = isChannelOverPlanLimit(channelUsage, {
-        integrationId: link._integrationId,
-        connected: Boolean(link.connectedAt),
+        providerId: integration.providerId,
       });
 
       acc.push({

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -110,7 +110,7 @@ export class PlanLimitGateService {
       config.organizationId,
       config.environmentId,
       agentId,
-      config.integrationId
+      config.providerId
     );
 
     let reason: PlanLimitBlockReason | null = null;

--- a/apps/api/src/app/agents/shared/dtos/agent-integration-response.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-integration-response.dto.ts
@@ -78,9 +78,11 @@ export class AgentIntegrationResponseDto {
 
   @ApiPropertyOptional({
     description:
-      'Cloud only. `true` when this channel falls outside the organization plan active-channel limit ' +
-      '(by connection order). Over-limit channels keep their configuration but the agent will not respond ' +
-      'on them until the plan is upgraded or older channels are disconnected.',
+      'Cloud only. `true` when this channel type (provider) falls outside the organization plan active-channel ' +
+      'limit (by connection order). Active channels are counted per channel type, so multiple integrations of the ' +
+      'same provider (e.g. several Slack workspaces) count as a single active channel. Over-limit channels keep ' +
+      'their configuration but the agent will not respond on them until the plan is upgraded or older channel ' +
+      'types are disconnected.',
   })
   exceedsPlanLimit?: boolean;
 }

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -1,8 +1,3 @@
-import { ChannelTypeEnum, type IIntegration, providers as novuProviders, PermissionsEnum } from '@novu/shared';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { RiAddLine, RiArrowRightSLine, RiErrorWarningFill } from 'react-icons/ri';
-import { useLocation, useNavigate } from 'react-router-dom';
 import {
   type AgentIntegrationLink,
   type AgentResponse,
@@ -24,6 +19,11 @@ import { useTelemetry } from '@/hooks/use-telemetry';
 import { buildRoute } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
+import { ChannelTypeEnum, type IIntegration, providers as novuProviders, PermissionsEnum } from '@novu/shared';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { RiAddLine, RiArrowRightSLine, RiErrorWarningFill } from 'react-icons/ri';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { ResolveAgentIntegrationGuide } from './agent-integration-guides/resolve-agent-integration-guide';
 import { ChannelsPlanLimitBanner } from './agents-plan-limit-banner';
 import { getExceedsPlanTooltipCopy } from './exceeds-plan-indicator';
@@ -311,10 +311,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
   };
 
   const handleChannelLimitDialogOpenChange = (open: boolean) => {
-    if (!open) {
-      pendingChannelLinkRef.current = null;
-    }
-
     setChannelLimitDialogOpen(open);
   };
 

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -1,6 +1,6 @@
 import { ChannelTypeEnum, type IIntegration, providers as novuProviders, PermissionsEnum } from '@novu/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { RiAddLine, RiArrowRightSLine, RiErrorWarningFill } from 'react-icons/ri';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -270,21 +270,52 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
 
   const [providerDropdownOpen, setProviderDropdownOpen] = useState(false);
   const [channelLimitDialogOpen, setChannelLimitDialogOpen] = useState(false);
-  const [channelLimitAcknowledged, setChannelLimitAcknowledged] = useState(false);
+  // Deferred link to run if the user accepts the channel-limit warning ("Add anyway").
+  const pendingChannelLinkRef = useRef<(() => void) | null>(null);
 
-  const handleProviderDropdownOpenChange = (next: boolean) => {
-    if (next && isAtChannelLimit && !channelLimitAcknowledged) {
-      setChannelLimitDialogOpen(true);
+  // Providers that already occupy a within-limit active-channel slot. Adding
+  // another integration of one of these (e.g. a second Slack workspace) does not
+  // consume a new slot, so it must not trigger the channel-limit warning.
+  const connectedWithinLimitProviderIds = useMemo(
+    () =>
+      new Set(
+        (linkedRows ?? [])
+          .filter((row) => Boolean(row.connectedAt) && !row.exceedsPlanLimit)
+          .map((row) => row.integration.providerId)
+      ),
+    [linkedRows]
+  );
 
-      return;
+  // Confirm only when adding the selected provider would actually exceed the
+  // plan: the environment is at its active-channel limit and the provider is a
+  // new channel type (not one that already holds a within-limit slot).
+  const confirmChannelLimitBeforeLink = (providerId: string) => {
+    if (!isAtChannelLimit) {
+      return false;
     }
 
-    setProviderDropdownOpen(next);
+    return !connectedWithinLimitProviderIds.has(providerId);
+  };
+
+  const handleChannelLimitConfirmRequired = (proceed: () => void) => {
+    pendingChannelLinkRef.current = proceed;
+    setProviderDropdownOpen(false);
+    setChannelLimitDialogOpen(true);
   };
 
   const handleChannelLimitContinue = () => {
-    setChannelLimitAcknowledged(true);
-    setProviderDropdownOpen(true);
+    const proceed = pendingChannelLinkRef.current;
+    pendingChannelLinkRef.current = null;
+    setChannelLimitDialogOpen(false);
+    proceed?.();
+  };
+
+  const handleChannelLimitDialogOpenChange = (open: boolean) => {
+    if (!open) {
+      pendingChannelLinkRef.current = null;
+    }
+
+    setChannelLimitDialogOpen(open);
   };
 
   useEffect(() => {
@@ -554,8 +585,10 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                     linkedIntegrationIds={linkedIntegrationIdSet}
                     excludeLinked
                     open={providerDropdownOpen}
-                    onOpenChange={handleProviderDropdownOpenChange}
+                    onOpenChange={setProviderDropdownOpen}
                     onSelect={handleProviderDropdownSelect}
+                    confirmBeforeLink={confirmChannelLimitBeforeLink}
+                    onConfirmRequired={handleChannelLimitConfirmRequired}
                     renderTrigger={({ isBusy }) => (
                       <button
                         type="button"
@@ -589,7 +622,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
       {planUsage && (
         <ChannelLimitUpgradeDialog
           open={channelLimitDialogOpen}
-          onOpenChange={setChannelLimitDialogOpen}
+          onOpenChange={handleChannelLimitDialogOpenChange}
           planUsage={planUsage}
           onContinueAnyway={handleChannelLimitContinue}
         />

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -270,7 +270,12 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
 
   const [providerDropdownOpen, setProviderDropdownOpen] = useState(false);
   const [channelLimitDialogOpen, setChannelLimitDialogOpen] = useState(false);
-  // Deferred link to run if the user accepts the channel-limit warning ("Add anyway").
+  // Deferred link to run when the user accepts the channel-limit warning ("Add
+  // anyway"). Intentionally not cleared on dialog dismissal: the dialog fires
+  // onOpenChange(false) before onContinueAnyway, so clearing on close would
+  // race-null this ref before handleChannelLimitContinue can read it. It's
+  // always re-set in handleChannelLimitConfirmRequired before the dialog
+  // reopens, so a dismissed dialog never leaves a stale link that could fire.
   const pendingChannelLinkRef = useRef<(() => void) | null>(null);
 
   // Providers that already occupy a within-limit active-channel slot. Adding
@@ -308,10 +313,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
     pendingChannelLinkRef.current = null;
     setChannelLimitDialogOpen(false);
     proceed?.();
-  };
-
-  const handleChannelLimitDialogOpenChange = (open: boolean) => {
-    setChannelLimitDialogOpen(open);
   };
 
   useEffect(() => {
@@ -618,7 +619,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
       {planUsage && (
         <ChannelLimitUpgradeDialog
           open={channelLimitDialogOpen}
-          onOpenChange={handleChannelLimitDialogOpenChange}
+          onOpenChange={setChannelLimitDialogOpen}
           planUsage={planUsage}
           onContinueAnyway={handleChannelLimitContinue}
         />

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -68,6 +68,28 @@ type DropdownItem = {
   integration?: IIntegration;
 };
 
+/**
+ * Confirmation gating is a paired contract: either both `confirmBeforeLink`
+ * and `onConfirmRequired` are provided, or neither. This guarantees that
+ * whenever `confirmBeforeLink` defers a selection, `onConfirmRequired` exists
+ * to run the deferred link — preventing a silent no-op.
+ */
+type ConfirmBeforeLinkProps =
+  | {
+      /**
+       * Guard run after a provider is selected but before it is linked.
+       * Return `true` to defer the link and require confirmation — the dropdown
+       * then calls `onConfirmRequired` with a `proceed` callback instead of linking.
+       */
+      confirmBeforeLink: (providerId: string) => boolean;
+      /** Invoked when `confirmBeforeLink` defers a selection. Call `proceed` to run the deferred link. */
+      onConfirmRequired: (proceed: () => void) => void;
+    }
+  | {
+      confirmBeforeLink?: undefined;
+      onConfirmRequired?: undefined;
+    };
+
 type ProviderDropdownProps = {
   /** When set, trigger and list highlight match this integration. */
   selectedIntegrationId: string | undefined;
@@ -86,15 +108,7 @@ type ProviderDropdownProps = {
   /** Controlled open state — pass together with `onOpenChange` to gate opening (e.g. behind a plan-limit dialog). */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  /**
-   * Optional guard run after a provider is selected but before it is linked.
-   * Return `true` to defer the link and require confirmation — the dropdown
-   * then calls `onConfirmRequired` with a `proceed` callback instead of linking.
-   */
-  confirmBeforeLink?: (providerId: string) => boolean;
-  /** Invoked when `confirmBeforeLink` defers a selection. Call `proceed` to run the deferred link. */
-  onConfirmRequired?: (proceed: () => void) => void;
-};
+} & ConfirmBeforeLinkProps;
 
 function buildDropdownItems(
   conversationalProviders: readonly ConversationalProvider[],

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -86,6 +86,14 @@ type ProviderDropdownProps = {
   /** Controlled open state — pass together with `onOpenChange` to gate opening (e.g. behind a plan-limit dialog). */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Optional guard run after a provider is selected but before it is linked.
+   * Return `true` to defer the link and require confirmation — the dropdown
+   * then calls `onConfirmRequired` with a `proceed` callback instead of linking.
+   */
+  confirmBeforeLink?: (providerId: string, integration?: IIntegration) => boolean;
+  /** Invoked when `confirmBeforeLink` defers a selection. Call `proceed` to run the deferred link. */
+  onConfirmRequired?: (proceed: () => void) => void;
 };
 
 function buildDropdownItems(
@@ -151,6 +159,8 @@ export function ProviderDropdown({
   renderTrigger,
   open: controlledOpen,
   onOpenChange,
+  confirmBeforeLink,
+  onConfirmRequired,
 }: ProviderDropdownProps) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const open = controlledOpen ?? uncontrolledOpen;
@@ -248,15 +258,7 @@ export function ProviderDropdown({
     if (!next) setExpandedProviderId(null);
   }
 
-  async function handleSelect(item: DropdownItem, index: number) {
-    if (item.comingSoon || isBusy) {
-      return;
-    }
-
-    if (item.requiresBusinessTier && !isAgentEmailAvailable) {
-      return;
-    }
-
+  async function performLink(item: DropdownItem, index: number) {
     const itemKey = getInstanceItemKey(item, index);
     const channel = PROVIDER_ID_TO_CHANNEL_MAP[item.providerId];
     const newIntegrationName = channel === ChannelTypeEnum.CHAT ? (agentName ?? agentIdentifier) : item.displayName;
@@ -270,6 +272,28 @@ export function ProviderDropdown({
       },
       itemKey
     );
+  }
+
+  async function handleSelect(item: DropdownItem, index: number) {
+    if (item.comingSoon || isBusy) {
+      return;
+    }
+
+    if (item.requiresBusinessTier && !isAgentEmailAvailable) {
+      return;
+    }
+
+    // Defer to the caller's plan-limit confirmation when the chosen provider
+    // would exceed the limit. The link runs only if the user confirms.
+    if (confirmBeforeLink?.(item.providerId, item.integration)) {
+      onConfirmRequired?.(() => {
+        void performLink(item, index);
+      });
+
+      return;
+    }
+
+    await performLink(item, index);
   }
 
   const defaultTrigger = (

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -91,7 +91,7 @@ type ProviderDropdownProps = {
    * Return `true` to defer the link and require confirmation — the dropdown
    * then calls `onConfirmRequired` with a `proceed` callback instead of linking.
    */
-  confirmBeforeLink?: (providerId: string, integration?: IIntegration) => boolean;
+  confirmBeforeLink?: (providerId: string) => boolean;
   /** Invoked when `confirmBeforeLink` defers a selection. Call `proceed` to run the deferred link. */
   onConfirmRequired?: (proceed: () => void) => void;
 };
@@ -285,7 +285,7 @@ export function ProviderDropdown({
 
     // Defer to the caller's plan-limit confirmation when the chosen provider
     // would exceed the limit. The link runs only if the user confirms.
-    if (confirmBeforeLink?.(item.providerId, item.integration)) {
+    if (confirmBeforeLink?.(item.providerId)) {
       onConfirmRequired?.(() => {
         void performLink(item, index);
       });

--- a/libs/application-generic/src/services/agent-entitlements.service.spec.ts
+++ b/libs/application-generic/src/services/agent-entitlements.service.spec.ts
@@ -22,7 +22,7 @@ interface Stubs {
   countTotalInEnvironment: sinon.SinonStub;
   countOlderAgentsInEnvironment: sinon.SinonStub;
   findOldestAgentIds: sinon.SinonStub;
-  listConnectedIntegrationIdsForEnvironment: sinon.SinonStub;
+  listConnectedChannelTypesForEnvironment: sinon.SinonStub;
 }
 
 function buildService(apiServiceLevel: ApiServiceLevelEnum): { service: AgentEntitlementsService; stubs: Stubs } {
@@ -32,7 +32,7 @@ function buildService(apiServiceLevel: ApiServiceLevelEnum): { service: AgentEnt
   const countTotalInEnvironment = sinon.stub().resolves(0);
   const countOlderAgentsInEnvironment = sinon.stub().resolves(0);
   const findOldestAgentIds = sinon.stub().resolves([]);
-  const listConnectedIntegrationIdsForEnvironment = sinon.stub().resolves([]);
+  const listConnectedChannelTypesForEnvironment = sinon.stub().resolves([]);
 
   const featureFlagsService = { getFlag } as unknown as FeatureFlagsService;
   const organizationRepository = { findById } as unknown as CommunityOrganizationRepository;
@@ -43,7 +43,7 @@ function buildService(apiServiceLevel: ApiServiceLevelEnum): { service: AgentEnt
     findOldestAgentIds,
   } as unknown as AgentRepository;
   const agentIntegrationRepository = {
-    listConnectedIntegrationIdsForEnvironment,
+    listConnectedChannelTypesForEnvironment,
   } as unknown as AgentIntegrationRepository;
   const logger = { setContext: sinon.stub(), warn: sinon.stub() } as unknown as PinoLogger;
 
@@ -64,7 +64,7 @@ function buildService(apiServiceLevel: ApiServiceLevelEnum): { service: AgentEnt
       countTotalInEnvironment,
       countOlderAgentsInEnvironment,
       findOldestAgentIds,
-      listConnectedIntegrationIdsForEnvironment,
+      listConnectedChannelTypesForEnvironment,
     },
   };
 }
@@ -285,9 +285,9 @@ describe('AgentEntitlementsService', () => {
       process.env.IS_SELF_HOSTED = 'false';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
       stubs.countOlderAgentsInEnvironment.resolves(0);
-      stubs.listConnectedIntegrationIdsForEnvironment.resolves(['int-1']);
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack']);
 
-      const checks = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'int-1');
+      const checks = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'slack');
 
       expect(checks).to.deep.equal({ agentWithinLimit: true, channelWithinLimit: true });
       expect(stubs.findById.callCount).to.equal(1);
@@ -297,7 +297,7 @@ describe('AgentEntitlementsService', () => {
       process.env.IS_SELF_HOSTED = 'true';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
 
-      const checks = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'int-1');
+      const checks = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'slack');
 
       expect(checks).to.deep.equal({ agentWithinLimit: true, channelWithinLimit: true });
       expect(stubs.findById.called).to.equal(false);
@@ -308,7 +308,7 @@ describe('AgentEntitlementsService', () => {
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
       stubs.findById.rejects(new Error('boom'));
 
-      const checks = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'int-1');
+      const checks = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'slack');
 
       expect(checks).to.deep.equal({ agentWithinLimit: true, channelWithinLimit: true });
     });
@@ -316,14 +316,14 @@ describe('AgentEntitlementsService', () => {
     it('serves repeated checks from the short-TTL cache without new lookups', async () => {
       process.env.IS_SELF_HOSTED = 'false';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
-      stubs.listConnectedIntegrationIdsForEnvironment.resolves(['int-1']);
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack']);
 
-      const first = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'int-1');
-      const second = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'int-1');
+      const first = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'slack');
+      const second = await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'slack');
 
       expect(second).to.deep.equal(first);
       expect(stubs.findById.callCount).to.equal(1);
-      expect(stubs.listConnectedIntegrationIdsForEnvironment.callCount).to.equal(1);
+      expect(stubs.listConnectedChannelTypesForEnvironment.callCount).to.equal(1);
     });
 
     it('does not cache fail-open results', async () => {
@@ -331,8 +331,8 @@ describe('AgentEntitlementsService', () => {
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
       stubs.findById.onFirstCall().rejects(new Error('boom'));
 
-      await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'int-1');
-      await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'int-1');
+      await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'slack');
+      await service.checkRuntimeLimits(ORGANIZATION_ID, ENVIRONMENT_ID, 'agent-1', 'slack');
 
       expect(stubs.findById.callCount).to.equal(2);
     });
@@ -342,33 +342,48 @@ describe('AgentEntitlementsService', () => {
     it('reports headroom for unconnected channels while under the limit', async () => {
       process.env.IS_SELF_HOSTED = 'false';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
-      stubs.listConnectedIntegrationIdsForEnvironment.resolves(['int-1']);
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack']);
 
       const usage = await service.getChannelPlanUsage(ORGANIZATION_ID, ENVIRONMENT_ID);
 
-      expect(usage.withinLimitIntegrationIds).to.equal(null);
+      expect(usage.used).to.equal(1);
+      expect(usage.connectedProviderIds).to.deep.equal(['slack']);
+      expect(usage.blocksUnconnectedChannels).to.equal(false);
+    });
+
+    it('counts multiple integrations of the same provider as a single channel', async () => {
+      process.env.IS_SELF_HOSTED = 'false';
+      const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
+      // The repository already dedupes by provider, so two Slack workspaces
+      // surface as a single `slack` channel type here.
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack']);
+
+      const usage = await service.getChannelPlanUsage(ORGANIZATION_ID, ENVIRONMENT_ID);
+
+      expect(usage.used).to.equal(1);
       expect(usage.blocksUnconnectedChannels).to.equal(false);
     });
 
     it('blocks unconnected channels once the environment is at its limit', async () => {
       process.env.IS_SELF_HOSTED = 'false';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
-      stubs.listConnectedIntegrationIdsForEnvironment.resolves(['int-1', 'int-2']);
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack', 'msteams']);
 
       const usage = await service.getChannelPlanUsage(ORGANIZATION_ID, ENVIRONMENT_ID);
 
-      expect(usage.withinLimitIntegrationIds).to.equal(null);
+      expect(usage.used).to.equal(2);
       expect(usage.blocksUnconnectedChannels).to.equal(true);
     });
 
-    it('lists within-limit integrations when over the limit', async () => {
+    it('reports the over-limit channel types when over the limit', async () => {
       process.env.IS_SELF_HOSTED = 'false';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
-      stubs.listConnectedIntegrationIdsForEnvironment.resolves(['int-1', 'int-2', 'int-3']);
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack', 'msteams', 'telegram']);
 
       const usage = await service.getChannelPlanUsage(ORGANIZATION_ID, ENVIRONMENT_ID);
 
-      expect(usage.withinLimitIntegrationIds).to.deep.equal(['int-1', 'int-2']);
+      expect(usage.used).to.equal(3);
+      expect(usage.connectedProviderIds).to.deep.equal(['slack', 'msteams', 'telegram']);
       expect(usage.blocksUnconnectedChannels).to.equal(true);
     });
   });
@@ -396,42 +411,69 @@ describe('AgentEntitlementsService', () => {
       expect(isAgentOverPlanLimit(usage, { _id: 'agent-3', active: true })).to.equal(false);
     });
 
-    it('flags connected channels outside the within-limit list and unconnected channels without headroom', () => {
+    it('flags channel types ranked beyond the limit and brand-new channel types without headroom', () => {
       const usage = {
         used: 3,
         limit: 2,
-        withinLimitIntegrationIds: ['int-1', 'int-2'],
+        connectedProviderIds: ['slack', 'msteams', 'telegram'],
         blocksUnconnectedChannels: true,
       };
 
-      expect(isChannelOverPlanLimit(usage, { integrationId: 'int-3', connected: true })).to.equal(true);
-      expect(isChannelOverPlanLimit(usage, { integrationId: 'int-1', connected: true })).to.equal(false);
-      expect(isChannelOverPlanLimit(usage, { integrationId: 'int-new', connected: false })).to.equal(true);
+      // Third connected channel type is over the limit.
+      expect(isChannelOverPlanLimit(usage, { providerId: 'telegram' })).to.equal(true);
+      // Channel types within the first `limit` are fine.
+      expect(isChannelOverPlanLimit(usage, { providerId: 'slack' })).to.equal(false);
+      expect(isChannelOverPlanLimit(usage, { providerId: 'msteams' })).to.equal(false);
+      // A brand-new provider has no slot once the environment is at/over its limit.
+      expect(isChannelOverPlanLimit(usage, { providerId: 'whatsapp-business' })).to.equal(true);
+    });
+
+    it('never flags additional integrations of an already within-limit provider', () => {
+      // Two Slack workspaces collapse to a single `slack` channel type, so the
+      // org sits at 1/2 used and Slack is comfortably within the limit.
+      const usage = {
+        used: 1,
+        limit: 2,
+        connectedProviderIds: ['slack'],
+        blocksUnconnectedChannels: false,
+      };
+
+      expect(isChannelOverPlanLimit(usage, { providerId: 'slack' })).to.equal(false);
     });
   });
 
   describe('isChannelWithinLimit', () => {
-    it('allows channels connected within the limit by connection order', async () => {
+    it('allows channel types connected within the limit by connection order', async () => {
       process.env.IS_SELF_HOSTED = 'false';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
-      stubs.listConnectedIntegrationIdsForEnvironment.resolves(['int-1', 'int-2']);
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack', 'msteams']);
 
-      const withinLimit = await service.isChannelWithinLimit(ORGANIZATION_ID, ENVIRONMENT_ID, 'int-2');
+      const withinLimit = await service.isChannelWithinLimit(ORGANIZATION_ID, ENVIRONMENT_ID, 'msteams');
 
       expect(withinLimit).to.equal(true);
-      expect(stubs.listConnectedIntegrationIdsForEnvironment.calledWith(ORGANIZATION_ID, ENVIRONMENT_ID)).to.equal(
-        true
-      );
+      expect(stubs.listConnectedChannelTypesForEnvironment.calledWith(ORGANIZATION_ID, ENVIRONMENT_ID)).to.equal(true);
     });
 
-    it('blocks channels connected beyond the limit by connection order', async () => {
+    it('blocks channel types connected beyond the limit by connection order', async () => {
       process.env.IS_SELF_HOSTED = 'false';
       const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
-      stubs.listConnectedIntegrationIdsForEnvironment.resolves(['int-1', 'int-2', 'int-3']);
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack', 'msteams', 'telegram']);
 
-      const withinLimit = await service.isChannelWithinLimit(ORGANIZATION_ID, ENVIRONMENT_ID, 'int-3');
+      const withinLimit = await service.isChannelWithinLimit(ORGANIZATION_ID, ENVIRONMENT_ID, 'telegram');
 
       expect(withinLimit).to.equal(false);
+    });
+
+    it('allows another integration of an already within-limit provider even at the limit', async () => {
+      process.env.IS_SELF_HOSTED = 'false';
+      const { service, stubs } = buildService(ApiServiceLevelEnum.FREE);
+      // Slack and Teams fill both Free-tier slots; a second Slack workspace
+      // resolves to the already-connected `slack` channel type and is allowed.
+      stubs.listConnectedChannelTypesForEnvironment.resolves(['slack', 'msteams']);
+
+      const withinLimit = await service.isChannelWithinLimit(ORGANIZATION_ID, ENVIRONMENT_ID, 'slack');
+
+      expect(withinLimit).to.equal(true);
     });
   });
 });

--- a/libs/application-generic/src/services/agent-entitlements.service.ts
+++ b/libs/application-generic/src/services/agent-entitlements.service.ts
@@ -104,6 +104,30 @@ export function isAgentOverPlanLimit(usage: AgentPlanUsage, agent: { _id: string
 }
 
 /**
+ * Single source of truth for the active-channel rank rule, shared by the
+ * over-limit derivation (`isChannelOverPlanLimit`) and the runtime check
+ * (`isChannelWithinLimit`) so the two can never drift. Counting is per channel
+ * type (provider): a channel type is within the limit when the plan is
+ * unlimited; when it is already connected at a rank below the limit; or when it
+ * is not yet connected but there is remaining headroom. Several integrations of
+ * the same provider (e.g. multiple Slack workspaces) collapse to a single
+ * ranked entry and therefore share one slot.
+ */
+function isProviderWithinChannelLimit(connectedProviderIds: string[], providerId: string, limit: number): boolean {
+  if (limit >= UNLIMITED_VALUE) {
+    return true;
+  }
+
+  const rank = connectedProviderIds.indexOf(providerId);
+
+  if (rank === -1) {
+    return connectedProviderIds.length < limit;
+  }
+
+  return rank < limit;
+}
+
+/**
  * Whether a channel is over the organization's active-channel plan limit (and
  * therefore soft-blocked at runtime). Counting is per channel type (provider):
  * once any integration of a provider has connected, that provider occupies a
@@ -113,17 +137,7 @@ export function isAgentOverPlanLimit(usage: AgentPlanUsage, agent: { _id: string
  * at/over its limit.
  */
 export function isChannelOverPlanLimit(usage: ChannelPlanUsage, channel: { providerId: string }): boolean {
-  const rank = usage.connectedProviderIds.indexOf(channel.providerId);
-
-  if (rank === -1) {
-    return usage.blocksUnconnectedChannels;
-  }
-
-  if (usage.limit >= UNLIMITED_VALUE) {
-    return false;
-  }
-
-  return rank >= usage.limit;
+  return !isProviderWithinChannelLimit(usage.connectedProviderIds, channel.providerId, usage.limit);
 }
 
 /**
@@ -401,6 +415,7 @@ export class AgentEntitlementsService {
     knownApiServiceLevel?: ApiServiceLevelEnum
   ): Promise<boolean> {
     const limit = await this.getActiveChannelLimit(organizationId, knownApiServiceLevel);
+    // Skip the DB read on unlimited plans — every channel type is within limit.
     if (limit >= UNLIMITED_VALUE) {
       return true;
     }
@@ -409,14 +424,8 @@ export class AgentEntitlementsService {
       organizationId,
       environmentId
     );
-    const rank = connectedProviderIds.indexOf(providerId);
 
-    if (rank === -1) {
-      // Channel type not yet recorded as connected — allow only if there is remaining headroom.
-      return connectedProviderIds.length < limit;
-    }
-
-    return rank < limit;
+    return isProviderWithinChannelLimit(connectedProviderIds, providerId, limit);
   }
 
   private setRuntimeLimitCacheEntry(cacheKey: string, value: RuntimeLimitChecks): void {

--- a/libs/application-generic/src/services/agent-entitlements.service.ts
+++ b/libs/application-generic/src/services/agent-entitlements.service.ts
@@ -68,19 +68,23 @@ export interface RuntimeLimitChecks {
 }
 
 export interface ChannelPlanUsage {
-  /** Number of connected channels (distinct integrations) in the environment. */
+  /**
+   * Number of connected channels (distinct channel types / providers) in the
+   * environment. Several integrations of the same provider (e.g. multiple Slack
+   * workspaces) count as a single active channel.
+   */
   used: number;
   limit: number;
   /**
-   * Ids of the connected integrations that fall within the plan limit
-   * (connection order). `null` when the environment is not over its limit (or
-   * the limit is unlimited), meaning every connected channel is within limit.
+   * Provider ids of the connected channel types, ordered by connection order
+   * (oldest first). A channel type is within the plan limit when its index in
+   * this list is below `limit`.
    */
-  withinLimitIntegrationIds: string[] | null;
+  connectedProviderIds: string[];
   /**
-   * Whether a channel that has not connected yet would be soft-blocked at
-   * runtime. Mirrors the `isChannelWithinLimit` rule: at/over the limit an
-   * unconnected channel has no reserved slot. Exposed here so consumers never
+   * Whether a channel type that has not connected yet would be soft-blocked at
+   * runtime. Mirrors the `isChannelWithinLimit` rule: at/over the limit a brand
+   * new channel type has no reserved slot. Exposed here so consumers never
    * re-derive runtime semantics.
    */
   blocksUnconnectedChannels: boolean;
@@ -101,18 +105,25 @@ export function isAgentOverPlanLimit(usage: AgentPlanUsage, agent: { _id: string
 
 /**
  * Whether a channel is over the organization's active-channel plan limit (and
- * therefore soft-blocked at runtime). Unconnected channels have no reserved
- * slot and are blocked whenever the environment is at/over its limit.
+ * therefore soft-blocked at runtime). Counting is per channel type (provider):
+ * once any integration of a provider has connected, that provider occupies a
+ * single slot, so additional integrations of an already within-limit provider
+ * (e.g. a second Slack workspace) are never over-limit. A provider that has not
+ * connected yet has no reserved slot and is blocked whenever the environment is
+ * at/over its limit.
  */
-export function isChannelOverPlanLimit(
-  usage: ChannelPlanUsage,
-  channel: { integrationId: string; connected: boolean }
-): boolean {
-  if (!channel.connected) {
+export function isChannelOverPlanLimit(usage: ChannelPlanUsage, channel: { providerId: string }): boolean {
+  const rank = usage.connectedProviderIds.indexOf(channel.providerId);
+
+  if (rank === -1) {
     return usage.blocksUnconnectedChannels;
   }
 
-  return usage.withinLimitIntegrationIds !== null && !usage.withinLimitIntegrationIds.includes(channel.integrationId);
+  if (usage.limit >= UNLIMITED_VALUE) {
+    return false;
+  }
+
+  return rank >= usage.limit;
 }
 
 /**
@@ -279,27 +290,21 @@ export class AgentEntitlementsService {
    * channels that are soft-blocked at runtime.
    */
   async getChannelPlanUsage(organizationId: string, environmentId: string): Promise<ChannelPlanUsage> {
-    const [limit, connectedIntegrationIds] = await Promise.all([
+    const [limit, connectedProviderIds] = await Promise.all([
       this.getActiveChannelLimit(organizationId),
-      this.agentIntegrationRepository.listConnectedIntegrationIdsForEnvironment(organizationId, environmentId),
+      this.agentIntegrationRepository.listConnectedChannelTypesForEnvironment(organizationId, environmentId),
     ]);
-    const used = connectedIntegrationIds.length;
+    const used = connectedProviderIds.length;
 
     if (limit >= UNLIMITED_VALUE) {
-      return { used, limit, withinLimitIntegrationIds: null, blocksUnconnectedChannels: false };
-    }
-
-    const blocksUnconnectedChannels = used >= limit;
-
-    if (used <= limit) {
-      return { used, limit, withinLimitIntegrationIds: null, blocksUnconnectedChannels };
+      return { used, limit, connectedProviderIds, blocksUnconnectedChannels: false };
     }
 
     return {
       used,
       limit,
-      withinLimitIntegrationIds: connectedIntegrationIds.slice(0, limit),
-      blocksUnconnectedChannels,
+      connectedProviderIds,
+      blocksUnconnectedChannels: used >= limit,
     };
   }
 
@@ -347,13 +352,13 @@ export class AgentEntitlementsService {
     organizationId: string,
     environmentId: string,
     agentId: string,
-    integrationId: string
+    providerId: string
   ): Promise<RuntimeLimitChecks> {
     if (this.isSelfHosted) {
       return { agentWithinLimit: true, channelWithinLimit: true };
     }
 
-    const cacheKey = `${organizationId}:${environmentId}:${agentId}:${integrationId}`;
+    const cacheKey = `${organizationId}:${environmentId}:${agentId}:${providerId}`;
     const cached = this.runtimeLimitCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
       return cached.value;
@@ -363,7 +368,7 @@ export class AgentEntitlementsService {
       const apiServiceLevel = await this.getApiServiceLevel(organizationId);
       const [agentWithinLimit, channelWithinLimit] = await Promise.all([
         this.isAgentWithinLimit(organizationId, environmentId, agentId, apiServiceLevel),
-        this.isChannelWithinLimit(organizationId, environmentId, integrationId, apiServiceLevel),
+        this.isChannelWithinLimit(organizationId, environmentId, providerId, apiServiceLevel),
       ]);
       const value = { agentWithinLimit, channelWithinLimit };
 
@@ -372,7 +377,7 @@ export class AgentEntitlementsService {
       return value;
     } catch (err) {
       this.logger.warn(
-        { err: err instanceof Error ? err.message : String(err), organizationId, agentId, integrationId },
+        { err: err instanceof Error ? err.message : String(err), organizationId, agentId, providerId },
         'Failed to evaluate runtime plan limits; failing open (all within limit)'
       );
 
@@ -382,14 +387,17 @@ export class AgentEntitlementsService {
   }
 
   /**
-   * Whether the given channel integration is within the organization's active
-   * channel limit, by connection order within its environment. Channels
-   * connected beyond the limit are soft-blocked at runtime.
+   * Whether the given channel type (provider) is within the organization's
+   * active channel limit, by connection order within its environment. Channel
+   * types connected beyond the limit are soft-blocked at runtime. Several
+   * integrations of the same provider (e.g. multiple Slack workspaces) share a
+   * single slot, so a second Slack integration is never blocked while Slack is
+   * within the limit.
    */
   async isChannelWithinLimit(
     organizationId: string,
     environmentId: string,
-    integrationId: string,
+    providerId: string,
     knownApiServiceLevel?: ApiServiceLevelEnum
   ): Promise<boolean> {
     const limit = await this.getActiveChannelLimit(organizationId, knownApiServiceLevel);
@@ -397,15 +405,15 @@ export class AgentEntitlementsService {
       return true;
     }
 
-    const connectedIntegrationIds = await this.agentIntegrationRepository.listConnectedIntegrationIdsForEnvironment(
+    const connectedProviderIds = await this.agentIntegrationRepository.listConnectedChannelTypesForEnvironment(
       organizationId,
       environmentId
     );
-    const rank = connectedIntegrationIds.indexOf(integrationId);
+    const rank = connectedProviderIds.indexOf(providerId);
 
     if (rank === -1) {
-      // Not yet recorded as connected — allow only if there is remaining headroom.
-      return connectedIntegrationIds.length < limit;
+      // Channel type not yet recorded as connected — allow only if there is remaining headroom.
+      return connectedProviderIds.length < limit;
     }
 
     return rank < limit;

--- a/libs/dal/src/repositories/agent-integration/agent-integration.repository.ts
+++ b/libs/dal/src/repositories/agent-integration/agent-integration.repository.ts
@@ -18,14 +18,16 @@ export class AgentIntegrationRepository extends BaseRepositoryV2<
   }
 
   /**
-   * Distinct integration ids (channels) that are connected in the environment,
-   * ordered by the earliest time each channel became connected (stable, ascending).
+   * Distinct connected channel types (provider ids) in the environment, ordered
+   * by the earliest time each channel type became connected (stable, ascending).
    *
-   * A "channel" is a distinct `_integrationId` — the same integration linked to
-   * multiple agents counts once. Used for active-channel plan-limit enforcement,
-   * where the first N channels (by connection order) are within the plan limit.
-   * Counting is per environment so a channel promoted (synced) to production
-   * does not consume a second plan slot for the same logical channel.
+   * A "channel" is a distinct provider (e.g. Slack, Microsoft Teams) — NOT a
+   * distinct integration. An organization may connect several Slack workspaces
+   * (multiple Slack integrations); they all share the same provider and count
+   * as a single active channel. Used for active-channel plan-limit enforcement,
+   * where the first N channel types (by connection order) are within the plan
+   * limit. Counting is per environment so a channel promoted (synced) to
+   * production does not consume a second plan slot for the same logical channel.
    *
    * Links whose integration was (soft-)deleted from the integration store are
    * excluded — a removed channel must not consume a plan slot, and stale links
@@ -33,7 +35,7 @@ export class AgentIntegrationRepository extends BaseRepositoryV2<
    * Tombstoned (disconnected) links are excluded explicitly: the schema-level
    * exclusion hook does not apply to aggregation pipelines.
    */
-  async listConnectedIntegrationIdsForEnvironment(organizationId: string, environmentId: string): Promise<string[]> {
+  async listConnectedChannelTypesForEnvironment(organizationId: string, environmentId: string): Promise<string[]> {
     const result = await this.aggregate([
       {
         $match: {
@@ -51,14 +53,15 @@ export class AgentIntegrationRepository extends BaseRepositoryV2<
           as: 'integration',
         },
       },
+      { $unwind: '$integration' },
       {
         $match: {
-          integration: { $elemMatch: { deleted: { $ne: true } } },
+          'integration.deleted': { $ne: true },
         },
       },
       {
         $group: {
-          _id: '$_integrationId',
+          _id: '$integration.providerId',
           firstConnectedAt: { $min: '$connectedAt' },
         },
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Agents "Active Channels" billing / plan-limit enforcement was counting **distinct integrations** rather than **distinct channels**. An organization can connect multiple integrations of the same provider (for example, several Slack workspaces) — these are all the *Slack channel* and should count once. Slack and Teams are two channels; two Slack workspaces are still one channel.

This change counts distinct **channel types (providerId)** instead of integrations, so multiple Slack integrations collapse to a single active Slack channel.

**Backend / counting**
- `libs/dal` — `AgentIntegrationRepository`: `listConnectedIntegrationIdsForEnvironment` → `listConnectedChannelTypesForEnvironment`, grouping connected (non-deleted, non-tombstoned) links by `integration.providerId`, ordered by first connection.
- `libs/application-generic` — `AgentEntitlementsService`: `ChannelPlanUsage` now exposes `connectedProviderIds`; `getChannelPlanUsage`, `isChannelWithinLimit`, and `checkRuntimeLimits` rank by channel type. The runtime check and `checkRuntimeLimits` take a `providerId`.
- `isChannelOverPlanLimit(usage, { providerId })` — predicate is provider-keyed; a second integration of an already within-limit provider is never over-limit.
- `apps/api` — `ResolvedAgentConfig` carries `providerId`; `PlanLimitGateService` keys the runtime channel check on `config.providerId`; `list-agent-integrations` passes the integration `providerId`.
- Updated the `agent-entitlements` unit spec and the `exceedsPlanLimit` OpenAPI doc for channel-type semantics.

**Dashboard UX**
- The active-channel limit dialog previously fired when the **Add provider** dropdown opened, regardless of which provider was chosen. It now fires **after a provider is selected**, and only when that provider is a **new channel type** that would exceed the limit. Adding another integration of an already within-limit provider (e.g. a second Slack workspace) links directly with no warning. `ProviderDropdown` gained an optional `confirmBeforeLink` / `onConfirmRequired` guard that defers the link until the user accepts the warning ("Add anyway").

Behavior preserved: the first N channel **types** respond; a new type beyond the limit gets the upgrade CTA; to free a slot you must disconnect every integration of a channel type (the type holds the slot while any of its integrations stays connected). Self-hosted/community editions are unaffected (active-channel limits short-circuit to unlimited there).

<!-- Linear: no Linear integration is available in this environment, so a ticket could not be created automatically. Please link/add the appropriate NV-XXX ticket. -->

### Screenshots

N/A — counting logic plus a change to *when* an existing dialog fires. `planUsage.used/limit` and `exceedsPlanLimit` keep their contract.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

Backend verified end-to-end against the running Mongo (two Slack + one Teams ⇒ two channel types) and the compiled service (a second Slack workspace is allowed even at the Free limit; a brand-new third type is blocked; `isChannelOverPlanLimit` correct).

Testing limitations in the cloud agent VM:
- The repo's `jest` install is broken (mixed `@jest/core@27` + `jest-environment-node@30`, no `transformIgnorePatterns` for ESM deps like `@launchdarkly/js-sdk-common`), so `agent-entitlements.service.spec.ts` could not run; logic was validated via the compiled build + a real-Mongo script.
- The dashboard limit dialog could not be exercised here: the local API runs with `IS_SELF_HOSTED=true` (limit unbinds), the seeded org is Enterprise (unlimited channels), and there are no agents/integrations seeded — so the at-limit Free-tier state can't be reached without flipping env, restarting the API, and seeding connected channels. The dashboard change is type-checked (`tsc --noEmit` clean).

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75c3bb84-5995-48d6-9fa7-90067fe72203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75c3bb84-5995-48d6-9fa7-90067fe72203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Agent active-channel plan-limit enforcement was fixed to count distinct channel *types/providers* (by `integration.providerId`) instead of distinct integrations. This prevents multiple integrations of the same provider (e.g., two Slack workspaces) from incorrectly consuming multiple channel slots and triggering upgrade blocks/warnings. Backend entitlement logic, runtime gating, and the integration-list computation were updated to be provider-keyed, and the dashboard confirmation dialog now appears only when selecting a new provider type that would exceed the limit.

## Affected areas
- **api**: `ResolvedAgentConfig` now carries `providerId`; runtime plan-limit gating and `list-agent-integrations` compute `exceedsPlanLimit` using provider-keyed semantics.
- **application-generic**: `AgentEntitlementsService` now derives plan usage from connected provider types (`connectedProviderIds`) and enforces limits by `providerId`.
- **dal**: `AgentIntegrationRepository` now lists connected channel types per environment via `listConnectedChannelTypesForEnvironment`, grouping by `integration.providerId` and ranking by first connection.
- **dashboard**: Channel-limit confirmation moved to provider selection time; confirmation behavior bypasses the dialog when adding another integration of an already within-limit provider.
- **documentation**: Swagger/OpenAPI `exceedsPlanLimit` descriptions were updated to reflect provider/type semantics.

## Key technical decisions
- Provider-keyed plan usage/enforcement allows multiple integrations for the same provider without increasing counted usage.
- Provider ranking is based on earliest connection time, determining which provider types consume available headroom.
- Provider selection confirmation is guarded by a stricter paired props contract to avoid deferred “no-op” behavior.

## Testing
Updated `agent-entitlements` unit tests to validate provider-type ranking, duplicate-provider behavior, and over-limit detection. Swagger/OpenAPI docs were updated, and end-to-end logic was validated against running Mongo. No dependency changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes active-channel plan-limit enforcement for Agents by counting distinct **channel types** (provider IDs) instead of distinct integrations, so multiple Slack workspaces correctly collapse to a single "Slack" slot. Backend logic, runtime gating, DAL aggregation, and the dashboard confirmation dialog are all updated consistently.

- **DAL**: `listConnectedChannelTypesForEnvironment` groups by `integration.providerId` via `$unwind` + `$group`, replacing the previous per-integration count.
- **Service**: `ChannelPlanUsage` now carries `connectedProviderIds[]`; a shared `isProviderWithinChannelLimit` predicate unifies the over-limit derivation and runtime check so they can't drift.
- **Dashboard**: The upgrade dialog now fires at provider-selection time (not dropdown-open time) and is guarded by `confirmChannelLimitBeforeLink`; however, the within-limit provider set is derived from the current agent's integrations rather than the environment-wide list, which can produce a false-positive dialog in multi-agent environments.

<h3>Confidence Score: 4/5</h3>

Backend and runtime gating changes are correct and well-tested; the dashboard confirmation guard has a scope mismatch that can show a spurious upgrade warning in multi-agent environments.

The core fix — counting distinct provider IDs rather than distinct integrations — is sound throughout the DAL, service layer, and runtime gate. The one gap is in the dashboard: `connectedWithinLimitProviderIds` is built from the current agent's `linkedRows` rather than the environment-wide `connectedProviderIds`. When another agent already holds a within-limit slot for a given provider, the current agent's tab doesn't see it, and the upgrade dialog fires unnecessarily. The backend never actually blocks the link, so no data is corrupted — but the spurious upgrade CTA is directly opposed to the stated goal of the PR (avoiding false limit warnings for second integrations of an established provider).

apps/dashboard/src/components/agents/agent-integrations-tab.tsx — the `connectedWithinLimitProviderIds` derivation needs to use environment-wide provider data rather than the current agent's integration list.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agent-integrations-tab.tsx | Replaces the dropdown-open gate with a provider-selection-time gate using `pendingChannelLinkRef`; `connectedWithinLimitProviderIds` is derived from agent-scoped `linkedRows` rather than environment-wide data, causing a false-positive upgrade dialog when another agent already holds a within-limit slot for the same provider. |
| apps/dashboard/src/components/agents/provider-dropdown.tsx | Adds paired `confirmBeforeLink`/`onConfirmRequired` props with a discriminated union type to enforce the contract; splits `handleSelect` into guard + `performLink` helper; ref management and deferred-link flow are correctly handled. |
| libs/application-generic/src/services/agent-entitlements.service.ts | Refactored `ChannelPlanUsage` to expose `connectedProviderIds[]` instead of `withinLimitIntegrationIds`; extracted `isProviderWithinChannelLimit` as a shared rank predicate; all limit checks are now provider-keyed and correctly allow additional integrations of an already within-limit provider. |
| libs/application-generic/src/services/agent-entitlements.service.spec.ts | Tests updated to use provider IDs ('slack', 'msteams', 'telegram') instead of integration IDs, with new cases for duplicate-provider collapsing and second-integration-of-within-limit-provider; coverage looks comprehensive for the new semantics. |
| libs/dal/src/repositories/agent-integration/agent-integration.repository.ts | Renamed `listConnectedIntegrationIdsForEnvironment` to `listConnectedChannelTypesForEnvironment`; groups by `integration.providerId` (via `$unwind` + `$group`) instead of `_integrationId`, correctly collapsing multiple integrations of the same provider into a single counted slot. |
| apps/api/src/app/agents/channels/integrations/list-agent-integrations/list-agent-integrations.usecase.ts | Updated `isChannelOverPlanLimit` call to use `integration.providerId` instead of `link._integrationId`; the `planUsage` response still only exposes `used` and `limit`, omitting `connectedProviderIds` which the dashboard needs for the environment-wide check. |
| apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts | Passes `config.providerId` instead of `config.integrationId` to `checkRuntimeLimits`, correctly keying the runtime soft-block and its cache on channel type rather than individual integration. |
| apps/api/src/app/agents/channels/agent-config-resolver.service.ts | Adds `providerId` to `ResolvedAgentConfig` interface and populates it from the resolved integration; straightforward plumbing change, no issues. |
| apps/api/src/app/agents/shared/dtos/agent-integration-response.dto.ts | OpenAPI description for `exceedsPlanLimit` updated to reflect channel-type (provider) semantics; no functional change. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Dashboard
    participant API as ListAgentIntegrations
    participant SVC as AgentEntitlementsService
    participant DAL as AgentIntegrationRepository

    UI->>API: GET /agents/:id/integrations
    API->>SVC: getChannelPlanUsage(orgId, envId)
    SVC->>DAL: listConnectedChannelTypesForEnvironment(orgId, envId)
    DAL-->>SVC: ['slack', 'msteams'] (grouped by providerId)
    SVC-->>API: "{ used:2, limit:2, connectedProviderIds, blocksUnconnected:true }"
    API->>API: "isChannelOverPlanLimit(usage, { providerId })"
    API-->>UI: "{ data, planUsage: { used:2, limit:2 } }"

    Note over UI: connectedWithinLimitProviderIds derived from THIS agent's linkedRows only

    UI->>UI: user selects provider
    UI->>UI: confirmChannelLimitBeforeLink(providerId)
    alt providerId in connectedWithinLimitProviderIds
        UI->>UI: proceed directly (no dialog)
    else providerId NOT in set (may be false-positive)
        UI->>UI: open upgrade dialog
        UI->>UI: user clicks Add anyway
        UI->>API: POST link integration
    end

    Note over UI,API: Runtime path
    API->>SVC: checkRuntimeLimits(orgId, envId, agentId, providerId)
    SVC->>DAL: listConnectedChannelTypesForEnvironment
    DAL-->>SVC: connected provider IDs
    SVC-->>API: "{ agentWithinLimit, channelWithinLimit }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Dashboard
    participant API as ListAgentIntegrations
    participant SVC as AgentEntitlementsService
    participant DAL as AgentIntegrationRepository

    UI->>API: GET /agents/:id/integrations
    API->>SVC: getChannelPlanUsage(orgId, envId)
    SVC->>DAL: listConnectedChannelTypesForEnvironment(orgId, envId)
    DAL-->>SVC: ['slack', 'msteams'] (grouped by providerId)
    SVC-->>API: "{ used:2, limit:2, connectedProviderIds, blocksUnconnected:true }"
    API->>API: "isChannelOverPlanLimit(usage, { providerId })"
    API-->>UI: "{ data, planUsage: { used:2, limit:2 } }"

    Note over UI: connectedWithinLimitProviderIds derived from THIS agent's linkedRows only

    UI->>UI: user selects provider
    UI->>UI: confirmChannelLimitBeforeLink(providerId)
    alt providerId in connectedWithinLimitProviderIds
        UI->>UI: proceed directly (no dialog)
    else providerId NOT in set (may be false-positive)
        UI->>UI: open upgrade dialog
        UI->>UI: user clicks Add anyway
        UI->>API: POST link integration
    end

    Note over UI,API: Runtime path
    API->>SVC: checkRuntimeLimits(orgId, envId, agentId, providerId)
    SVC->>DAL: listConnectedChannelTypesForEnvironment
    DAL-->>SVC: connected provider IDs
    SVC-->>API: "{ agentWithinLimit, channelWithinLimit }"
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Fagent-integrations-tab.tsx%3A284-302%0A**False-positive%20upgrade%20dialog%20in%20multi-agent%20environments**%0A%0A%60connectedWithinLimitProviderIds%60%20is%20built%20from%20%60linkedRows%60%2C%20which%20only%20contains%20integrations%20linked%20to%20the%20*current%20agent*.%20In%20a%20multi-agent%20environment%20where%20Agent%20A%20has%20Slack%20connected%20%28within%20the%20plan%20limit%29%20and%20Agent%20B%20has%20no%20Slack%20integration%2C%20%60connectedWithinLimitProviderIds%60%20for%20Agent%20B's%20tab%20will%20not%20include%20%60'slack'%60.%20When%20Agent%20B's%20environment%20is%20at%20the%20channel%20limit%20and%20a%20user%20selects%20Slack%2C%20%60confirmChannelLimitBeforeLink%28'slack'%29%60%20incorrectly%20returns%20%60true%60%20and%20shows%20the%20upgrade%20CTA%20%E2%80%94%20even%20though%20Slack%20is%20already%20an%20established%2C%20within-limit%20channel%20type%20for%20the%20environment%20and%20the%20backend%20would%20allow%20the%20link.%0A%0AThe%20environment-wide%20truth%20lives%20in%20%60channelUsage.connectedProviderIds%60%20%28already%20computed%20by%20%60getChannelPlanUsage%60%29%2C%20but%20only%20%60used%60%20and%20%60limit%60%20are%20exposed%20in%20the%20%60planUsage%60%20API%20response.%20Exposing%20%60connectedProviderIds%60%20in%20that%20response%20%28and%20using%20it%20here%20instead%20of%20deriving%20from%20%60linkedRows%60%29%20would%20fix%20the%20false-positive.%0A%0A&pr=11627&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/agents/agent-integrations-tab.tsx:284-302
**False-positive upgrade dialog in multi-agent environments**

`connectedWithinLimitProviderIds` is built from `linkedRows`, which only contains integrations linked to the *current agent*. In a multi-agent environment where Agent A has Slack connected (within the plan limit) and Agent B has no Slack integration, `connectedWithinLimitProviderIds` for Agent B's tab will not include `'slack'`. When Agent B's environment is at the channel limit and a user selects Slack, `confirmChannelLimitBeforeLink('slack')` incorrectly returns `true` and shows the upgrade CTA — even though Slack is already an established, within-limit channel type for the environment and the backend would allow the link.

The environment-wide truth lives in `channelUsage.connectedProviderIds` (already computed by `getChannelPlanUsage`), but only `used` and `limit` are exposed in the `planUsage` API response. Exposing `connectedProviderIds` in that response (and using it here instead of deriving from `linkedRows`) would fix the false-positive.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["refactor(dashboard): enhance provider dr..."](https://github.com/novuhq/novu/commit/64e855d6c42fcf2e67adb3592f8e4db808d3822b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39031995)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->