### PR TITLE
feat(root): add @novu/eve unified Eve↔Novu channel package fixes NV-8112

### DIFF
--- a/docs/superpowers/specs/2026-06-19-novu-eve-integration-design.md
+++ b/docs/superpowers/specs/2026-06-19-novu-eve-integration-design.md
@@ -1,0 +1,312 @@
+# Novu × Eve Integration — Design Spec
+
+**Date:** 2026-06-19
+**Status:** Design approved + implementation plan approved (grilled). Plan: `~/.claude/plans/ok-now-we-have-tingly-moth.md`
+**Author:** Dima Grossman (with Claude)
+
+## Summary
+
+`@novu/eve` makes an [Eve](https://eve.dev) agent (Vercel's filesystem-first
+"Next.js for agents") a first-class Novu "brain" through **a single unified Eve
+channel** — `novuChannel()`, the default export of `agent/channels/novu.ts`. The
+developer connects as many platforms as they want in the Novu dashboard (Slack,
+Teams, WhatsApp, in-app Inbox, email replies, …); all flow through this one
+channel. The agent's **identity, delivery, and multi-channel orchestration live
+in Novu**, while Eve drives the conversation. Delivery rides Novu's existing
+**agent reply flow**; no new transport protocol is invented.
+
+DX goal: Clerk-for-Next.js style — **one channel file + dashboard connection is
+the whole integration**, with progressively-disclosed power.
+
+### The seam that makes it native
+
+`@novu/framework` re-exports its card components **straight from `chat` (the
+Chat SDK)** — `packages/framework/src/resources/agent/index.ts:13` exports
+`Card, Button, Actions, Select, TextInput, …` from `'chat'`. Eve composes its own
+Slack cards from that *same* Chat SDK card-builder. So **Eve and Novu already
+speak one identical card vocabulary** — a card built once renders on both sides
+with zero translation.
+
+## Goals
+
+- One opinionated path: add `agent/channels/novu.ts`, connect platforms in the dashboard.
+- Unify user identity: the agent talks to a **Novu subscriber**, never a raw per-platform id. One subscriber can hold many concurrent cross-platform conversations.
+- Novu is the layer for (a) triggering multi-channel workflows that **run the developer's own code**, and (b) all delivery (provider credentials, fan-out, preferences, digest, per-platform rendering).
+- Cross-platform human-in-the-loop (approval/clarification/auth) with no per-platform work.
+- Keep Eve tools **pure and portable** — the same agent runs unchanged on web/CLI/Slack.
+
+## Non-Goals
+
+- Replacing Eve's conversation/runtime model. Eve remains the brain.
+- Per-channel `withNovu(channel)` wrappers (rejected in favor of the single channel).
+- Tool-side imperative Novu access (`getNovuContext` inside tools) — rejected to keep tools pure.
+- Consolidating `@novu/chat-adapter`'s duplicated bridge protocol into `@novu/framework` (future cleanup).
+- Building new Novu providers/platform integrations (configured in the dashboard).
+- `novuConnection()` workflow auto-discovery (north-star; deferred until Novu exposes an MCP that lists workflows).
+
+## Build on `@novu/framework`, not `@novu/chat-adapter`
+
+`@novu/framework` is the canonical Novu agent runtime contract. Relevant surface
+(`packages/framework/src/index.ts`):
+
+- `NovuRequestHandler` (`./handler`) — inbound: HMAC verify → parse `AgentBridgeRequest` → build `AgentContext` → dispatch → auto-reply if a handler returns content.
+- `AgentContext` (impl `AgentContextImpl`, `resources/agent/agent.context.ts`) — `reply()`, `resolve()`, signal batching (`{ type: 'trigger', workflowId, to?, payload? }`, `{ type: 'metadata', … }`), `getSubscriber()`, `getHistory()`.
+- `workflow` / `step` — code-first multi-channel workflow definitions; where developer code runs.
+- Card components (re-exported from `chat`): `Card`, `Button`, `Actions`, `Select`, `SelectOption`, `TextInput`, `CardLink`, `CardText`, `Divider`.
+- Protocol types: `AgentBridgeRequest`, `AgentReplyPayload`, `ReplyContent`, `ReplyHandle`, `Signal`, `TriggerSignal`, `AgentSubscriber`, `AgentConversation`, etc.
+
+`@novu/chat-adapter` is a **sibling** (Chat SDK ⇄ Novu): does *not* depend on
+`@novu/framework`, peer-depends on `chat`, carries its own copy of the bridge
+protocol. `@novu/eve` is the analogous sibling (Eve ⇄ Novu) and builds on
+`@novu/framework` directly — avoiding the `chat` peer dep and the Chat-SDK
+`onNewMention`/`postMessage` abstractions Eve doesn't use.
+
+## Eve facts the design relies on (from eve.dev docs)
+
+- An agent is a filesystem: `instructions.md`, `agent.ts` (`defineAgent`), `tools/`, `connections/`, `channels/`.
+- **Channels** = I/O edge (`defineChannel({ routes, events })` in `agent/channels/<id>.ts`); normalize input, own `continuationToken`, decide delivery. Built-in channels take options (e.g. `slackChannel({ credentials, events })`); `events` handlers receive `(eventData, channel, ctx)` and post via `channel.thread.post(...)`, `channel.postDirectMessage(...)`, `channel.state`.
+- **Connections** = credentialed external capabilities the model discovers via `connection__search` and calls as `connection__<conn>__<tool>` (`defineMcpClientConnection` / `defineOpenAPIConnection`). A service can be **both** a channel and a connection (Linear is).
+- Eve has **no unified card abstraction** — but composes Slack cards from the **Chat SDK card-builder** (same lineage as Novu's cards).
+- **Unified HITL protocol:** `defineTool({ needsApproval: always()/once()/never()/predicate })`, the built-in `ask_question({ prompt, options, allowFreeform })`, runtime event `input.requested` → durable park at `session.waiting` → resume via `session.send({ inputResponses: [{ requestId, optionId }] })`. OAuth via `authorization.required`/`authorization.completed`. Each channel renders these to native affordances.
+- Credentials via env (`process.env.*`) or Vercel Connect (`connectSlackCredentials("slack/my-agent")`, `connect("linear")`).
+- Runtime events: `session.started`, `message.delta`/`reasoning.appended`, `actions.requested`/`action.result`, `input.requested`, `authorization.required`/`completed`, `message.completed`, `session.completed`, `session.failed`, subagent events.
+
+## Architecture
+
+```
+        ┌──────────────── Novu Connect (unified layer) ─┐
+        │ many platforms · credentials · subscriber      │
+        │ identity · preferences · digest · per-platform │
+        │ rendering · delivery + fan-out                 │
+        └──────▲──────────────────────────────┬─────────┘
+   (1) AgentBridgeRequest (any platform)  (4) AgentReplyPayload + workflow triggers
+        (signed webhook; platform +            via AgentContext.reply() / signals
+         integrationIdentifier + conversationId)
+        ┌──────┴──────────────────────────────▼─────────┐
+        │  @novu/eve  →  single channel: agent/channels/  │
+        │                novu.ts  (novuChannel())         │
+        │  reuses @novu/framework: NovuRequestHandler,    │
+        │   AgentContext.reply()/signals, workflow/step,  │
+        │   Card/Button/Select                            │
+        │  adds: one defineChannel webhook route,         │
+        │   zero-config event handlers, HITL↔card map,    │
+        │   two-tier action round-trip, continuationToken │
+        │   ⇄ conversationId, subscriber→auth, novuTool,  │
+        │   channel.novu.*, novuView discovery            │
+        └──────▲──────────────────────────────┬─────────┘
+   (2) send(msg,{auth,continuationToken})  (3) Eve runtime events
+        ┌──────┴──────────────────────────────▼─────────┐
+        │              Eve agent (the brain)              │
+        └─────────────────────────────────────────────────┘
+```
+
+- **Inbound (1→2):** Novu owns every connected platform, sends a signed `AgentBridgeRequest` to the single `novu` webhook. `@novu/eve` runs it through `NovuRequestHandler` (verify + parse + `AgentContext`), normalizes to an Eve user message, sets `auth` from the subscriber, maps `conversationId` → `continuationToken`, calls `send()`. One endpoint, all platforms.
+- **Outbound (3→4):** observe Eve runtime events → `AgentContext` actions. Novu renders per-platform + delivers + fans out.
+
+**Ownership split:** `@novu/eve` owns only the bridge (Novu handler/context ⇄ Eve
+`defineChannel` + `send()` + events). Below is Novu (delivery, identity,
+providers, workflow engine, rendering); above is Eve (reasoning, pure tools,
+durable session).
+
+## Public API surface
+
+### 1. `novuChannel(options?)` — the unified channel (full zero-config default)
+
+Default export of `agent/channels/novu.ts`. Bare `novuChannel()` already:
+replies completed assistant messages as markdown, auto-renders Eve HITL as Novu
+cards, round-trips clicks, and resolves per `resolveOn`. You write `events` only
+to customize.
+
+```ts
+// agent/channels/novu.ts — the entire messaging integration
+import { novuChannel } from "@novu/eve";
+
+export default novuChannel();              // env keys + dashboard platforms; nothing else
+
+export default novuChannel({               // all optional
+  agentIdentifier: "support-bot",          // default: env NOVU_AGENT_IDENTIFIER
+  credentials: connectNovuCredentials("novu/my-agent"), // or env NOVU_SECRET_KEY
+  stream: true,                            // default false; opt-in ReplyHandle edits
+  resolveOn: "session.completed",
+  events: { /* Eve event handlers — see below */ },
+  onAction(action, channel, ctx) { /* custom (non-HITL) card clicks */ },
+});
+```
+
+### 2. `novuTool({ name, description, workflow })` — model-driven workflow triggers
+
+Authored, typed-per-workflow tool the model can call ("trigger + execute user
+code"). Gated by Eve's `needsApproval`. (North-star: a `novuConnection()` that
+auto-discovers all workflows as `connection__novu__<workflow>` tools, deferred
+until Novu exposes an MCP listing workflows.)
+
+```ts
+// agent/tools/escalate.ts
+import { novuTool } from "@novu/eve";
+export default novuTool({
+  name: "escalate",
+  description: "Alert the on-call engineer across their preferred channels.",
+  workflow: "on-call-escalation",   // payload typed from the workflow's schema
+});
+```
+
+### 3. `workflow` / `step` / card components — re-exported from `@novu/framework`
+
+```ts
+// novu/workflows/on-call-escalation.ts
+import { workflow, step } from "@novu/eve";
+export default workflow("on-call-escalation", async ({ payload, step }) => {
+  await step.inApp("alert", () => ({ body: payload.summary }));
+  await step.push("push", () => ({ title: "Escalation", body: payload.summary }));
+  // ← arbitrary developer code runs here
+});
+```
+
+### Credentials — `connectNovuCredentials(...)`
+
+Env baseline (`NOVU_SECRET_KEY` + `NOVU_AGENT_IDENTIFIER`, works self-host /
+non-Vercel) + optional Vercel Connect helper for a one-click, no-keys flow
+(mirrors `connectSlackCredentials`).
+
+## Customizing replies
+
+Two layers, both Eve-native. Tools stay pure throughout.
+
+**(a) Channel `events` handlers — the default seam** (mirrors `slackChannel({ events })`):
+
+```ts
+export default novuChannel({
+  events: {
+    "message.completed"(eventData, channel, ctx) {
+      if (eventData.finishReason === "tool-calls") return;
+      channel.thread.post(eventData.message);          // Eve-core surface
+    },
+    "input.requested"(eventData, channel, ctx) {
+      // override the default HITL→card rendering if desired
+    },
+  },
+});
+```
+
+The `channel` object = **Eve core** (`channel.thread.post(content)`,
+`channel.thread.stream(...)`, `channel.state`) **+ namespaced `channel.novu.*`**
+(`channel.novu.trigger(workflow, opts)`, `channel.novu.subscriber`,
+`channel.novu.setMetadata()`, `channel.novu.resolve()`). No tool-side
+`getNovuContext` — Novu access lives in handlers, where it belongs.
+
+**(b) Opt-in co-located per-tool renderer** — a **named sibling export**; the
+tool's `execute` stays pure:
+
+```ts
+// agent/tools/refund.ts
+import { defineTool } from "eve/tools";
+import { Card, CardText, Actions, Button } from "@novu/eve";
+
+export default defineTool({ /* pure execute, returns data */ });
+
+export const novuView = (result, ctx) =>
+  Card([CardText(`Refund ${result.id} ✅`),
+        Actions([Button("Undo", { action: "undo_refund" })])]);
+```
+
+`@novu/eve` auto-discovers `novuView` next to the tool and uses it for that
+tool's `action.result`; otherwise falls back to the default markdown reply.
+
+## Human-in-the-loop & the two-tier action round-trip
+
+Eve's unified HITL (`needsApproval`, `ask_question`, `input.requested`) is
+rendered by `@novu/eve` into Chat SDK cards (`Card`/`Button`/`Select`/
+`TextInput`) and delivered by Novu on the subscriber's preferred platform —
+identically across platforms, no per-platform branching. The agent code never
+mentions Novu; it just writes pure tools with `needsApproval` or calls
+`ask_question`.
+
+**Round-trip is two-tier:**
+1. **HITL-originated clicks** (from `ask_question`/approval/`input.requested`) auto-map to `inputResponses` and resume the durable session — zero wiring.
+2. **Custom/arbitrary action ids** (snooze, unsubscribe, quick-reply on a normal reply card) land in the channel **`onAction(action, channel, ctx)`** handler — the dev resumes via `channel`/`send()`, triggers a workflow, sets metadata, or ignores (no model wake).
+
+## Event → reply mapping (defaults)
+
+**Real Eve event names** (pinned against `eve@0.11.6` `ChannelEvents`, correcting
+the docs-inferred names): `turn.started`, `actions.requested`, `action.result`,
+`message.completed`, `message.appended`, `reasoning.appended`,
+`reasoning.completed`, `input.requested`, `turn.failed`, `turn.completed`,
+`session.failed`, `session.completed`, `session.waiting`,
+`authorization.required`, `authorization.completed`. (No `message.delta` — use
+`message.appended`; no `session.started` — use `turn.started`; HITL parks at
+`session.waiting`.)
+
+| Eve runtime event | Default Novu action |
+|---|---|
+| `turn.started` | resume/create conversation from `continuationToken` |
+| `message.appended` / `reasoning.appended` | if `stream:true`, throttled `ReplyHandle` edits; else buffer |
+| `message.completed` | `ctx.reply({ markdown })` (Novu renders per platform) |
+| `actions.requested` / `input.requested` | render `Card`/`Button`/`Select`/`TextInput`; round-trip per two-tier rules |
+| `session.waiting` | (HITL park) keep the rendered prompt live; await the user response |
+| `authorization.required` | `CardLink` to auth URL; `authorization.completed` resumes |
+| `session.completed` | `resolve(summary)` if `resolveOn` set |
+| `session.failed` / `turn.failed` | error reply + metadata; **not** resolved |
+
+## Identity binding
+
+- Inbound `AgentBridgeRequest` carries subscriber + conversation + platform.
+- Eve `auth` = principal derived from the subscriber; `continuationToken` encodes `{ conversationId, integrationIdentifier, platform }`, decoded on resume.
+- One subscriber → many concurrent cross-platform conversations, each its own Eve session keyed by `continuationToken`, all sharing the subscriber identity.
+- Eve never holds a raw per-platform user id → identity unified by construction.
+
+## Error handling & resilience
+
+- **Inbound:** invalid HMAC → `401`; replayed delivery id → dedupe + `200` no-op; malformed → `400`. Never invoke the agent unverified.
+- **Outbound:** reply failures → `AgentDeliveryError` (framework); bounded retry + backoff, then Eve-side error event/log; a failed delivery never resolves.
+- **Token drift:** missing/undecodable `continuationToken` → start fresh; log a correlation id (Eve session ↔ Novu conversation).
+- **Workflow trigger failures** (signals): isolated from the reply — log and continue.
+
+## Config & DX
+
+- Env-first; everything overridable via `novuChannel({...})` for multi-agent/region.
+- Platforms connected in the **Novu dashboard**, not in code (dashboard-first, zero-deps-state).
+- Streaming **off** by default; `stream: true` opts in where supported.
+
+## Testing strategy
+
+- **Unit:** signature verify (valid/invalid/replayed); `AgentBridgeRequest` → message + `auth` + `continuationToken` across platforms; event→reply mapping; HITL→card mapping; `inputResponses` round-trip; `novuView` discovery; `novuTool` trigger; token encode/decode.
+- **Integration:** mock `/v1/agents/:id/reply` + `/v1/events/trigger`; drive a fake Eve event stream; multi-platform inbound through the single route; HITL click → resume; custom action → `onAction`.
+- **E2E (smoke):** `examples/` Eve agent + Novu sandbox, two connected platforms.
+- Mirror `chat-adapter` test layout (`*.spec.ts` + `*.integration.spec.ts`).
+
+## Pinned against real Eve types (`eve@0.11.6`)
+
+- `defineChannel<TState, TCtx, …>({ state, context, routes, events, receive, fetchFile, metadata, kindHint })`. `routes` required; `events?: ChannelEvents<TCtx>`.
+- **The `channel` arg to event handlers = whatever `context(state, session: SessionHandle)` returns, intersected with `ChannelSessionOps` (`{ continuationToken, setContinuationToken(token) }`).** This is exactly where `channel.thread.*` and `channel.novu.*` get injected — by returning them from the `context()` factory.
+- Event handler shape: `(data, channel, ctx: SessionContext) => void | Promise<void>`; `session.failed` omits `ctx`.
+- Route handlers (`POST`/`GET`/`WS` from `eve/channels`) get `RouteHandlerArgs` with `send: SendFn`, `getSession`, etc. The lower-level `RouteContext` also exposes `agent.run(RunInput)` / `agent.deliver(DeliverInput)` / `agent.getEventStream(sessionId)` and `waitUntil`.
+- `defineChannel` returns an opaque `Channel`; the file path is the channel name (no `name` field). `kindHint` tags the adapter family (e.g. `slackChannel` passes `"slack"`).
+
+### Still to verify in later impl steps
+
+1. Exact `SendFn`/`SendOptions`/`SendPayload` and `Session`/`SessionHandle` shapes (`#channel/routes`, `#channel/session`) for the inbound `send()` call.
+2. `HandleMessageStreamEvent` per-event `data` shapes (`#protocol/message`) for the reply mapping, and the `eve/client` `inputResponses` resume path for the HITL round-trip.
+3. Tool sibling-export discovery for `novuView` (hook Eve's tool registration vs scan the tools dir).
+4. `@vercel/connect/eve` real helper shape to back `connectNovuCredentials` on Vercel (cf. `connectSlackCredentials`).
+
+## Implementation status (2026-06-19)
+
+**Done + verified** (`pnpm --filter @novu/eve build` green; 24 tests pass):
+- `packages/eve` scaffolded (`@novu/eve`, tsconfig, project.json, vitest.config) mirroring `chat-adapter`; `eve@0.11.6` added as dev + peer dependency; workspace install green.
+- `token.ts` (continuation-token ⇄ conversation codec) + tests.
+- `credentials.ts` (env-first resolution + `connectNovuCredentials`) + tests.
+- `signature.ts` (Novu `novu-signature` HMAC verify) + tests.
+- `reply-client.ts` — `NovuApiClient` (`reply()` → `/v1/agents/:id/reply`, `trigger()` → `/v1/events/trigger`).
+- `channel.ts` — **`novuChannel()`**: `defineChannel` with one POST webhook (verify → parse `AgentBridgeRequest` → `send()`), the `context()` factory exposing `channel.thread.post` + `channel.novu.{trigger,setMetadata,resolve,reply,subscriberId}`, and zero-config default delivery (`message.completed` → reply; `session.completed` → resolve when `resolveOn` set). Typechecks against real Eve + `@novu/framework` types.
+- `index.ts` exports the above + re-exports the `@novu/framework` surface.
+
+**Remaining follow-ups:**
+- `tool.ts` (`novuTool` — `defineTool` wrapper; deferred over the `StandardSchema` generic).
+- `hitl.ts` — map `input.requested`/`actions.requested` → cards; inbound `action`/`reaction` handling + two-tier round-trip (`inputResponses` vs `onAction`).
+- `views.ts` (`novuView` co-located renderer discovery), streaming (`stream:true` via `ReplyHandle`), inbound attachments (`UserContent`).
+- `channel.integration.spec.ts` (mock reply/trigger; multi-platform single-route; HITL round-trip) + `examples/` agent + README.
+
+## Package shape
+
+- New package `@novu/eve` (`packages/eve`), sibling to `@novu/chat-adapter`; `tsc` build, `vitest`, `biome`, nx `type:package`.
+- **Dependency:** `@novu/framework`. **Peer dependency:** `eve`. Re-exports the `@novu/framework` surface it builds on so Eve devs need a single dependency.

--- a/docs/superpowers/specs/2026-06-19-novu-eve-integration-design.md
+++ b/docs/superpowers/specs/2026-06-19-novu-eve-integration-design.md
@@ -291,20 +291,20 @@ the docs-inferred names): `turn.started`, `actions.requested`, `action.result`,
 
 ## Implementation status (2026-06-19)
 
-**Done + verified** (`pnpm --filter @novu/eve build` green; 24 tests pass):
+**Done + verified** (`pnpm --filter @novu/eve build` green; 32 tests pass; 3 commits on `feat/novu-eve-integration`):
 - `packages/eve` scaffolded (`@novu/eve`, tsconfig, project.json, vitest.config) mirroring `chat-adapter`; `eve@0.11.6` added as dev + peer dependency; workspace install green.
-- `token.ts` (continuation-token ⇄ conversation codec) + tests.
-- `credentials.ts` (env-first resolution + `connectNovuCredentials`) + tests.
-- `signature.ts` (Novu `novu-signature` HMAC verify) + tests.
+- `token.ts` — continuation-token ⇄ conversation codec + tests.
+- `credentials.ts` — env-first resolution + `connectNovuCredentials` + tests.
+- `signature.ts` — Novu `novu-signature` HMAC verify + tests.
 - `reply-client.ts` — `NovuApiClient` (`reply()` → `/v1/agents/:id/reply`, `trigger()` → `/v1/events/trigger`).
-- `channel.ts` — **`novuChannel()`**: `defineChannel` with one POST webhook (verify → parse `AgentBridgeRequest` → `send()`), the `context()` factory exposing `channel.thread.post` + `channel.novu.{trigger,setMetadata,resolve,reply,subscriberId}`, and zero-config default delivery (`message.completed` → reply; `session.completed` → resolve when `resolveOn` set). Typechecks against real Eve + `@novu/framework` types.
+- `channel.ts` — **`novuChannel()`**: `defineChannel` with one POST webhook (verify → parse `AgentBridgeRequest` → `send()`); `context()` factory exposing `channel.thread.post` + `channel.novu.{trigger,setMetadata,resolve,reply,subscriberId}`; zero-config default delivery (`message.completed` → reply; `session.completed` → resolve).
+- `tool.ts` — **`novuTool()`**: model-driven workflow trigger; pure execute + ack; recipient defaults to the conversation subscriber + tests.
+- `hitl.ts` + channel wiring — **cross-platform human-in-the-loop**: render `input.requested` → Novu cards (shared Chat SDK builders); two-tier inbound round-trip (HITL click → `inputResponses` resume; custom action id → `onAction`) + tests.
 - `index.ts` exports the above + re-exports the `@novu/framework` surface.
 
 **Remaining follow-ups:**
-- `tool.ts` (`novuTool` — `defineTool` wrapper; deferred over the `StandardSchema` generic).
-- `hitl.ts` — map `input.requested`/`actions.requested` → cards; inbound `action`/`reaction` handling + two-tier round-trip (`inputResponses` vs `onAction`).
-- `views.ts` (`novuView` co-located renderer discovery), streaming (`stream:true` via `ReplyHandle`), inbound attachments (`UserContent`).
-- `channel.integration.spec.ts` (mock reply/trigger; multi-platform single-route; HITL round-trip) + `examples/` agent + README.
+- `views.ts` (`novuView` co-located renderer discovery), streaming (`stream:true` via `ReplyHandle`), inbound attachments (`UserContent`), freeform HITL text capture.
+- `channel.integration.spec.ts` (mock reply/trigger; multi-platform single-route; HITL round-trip end-to-end) + `examples/` agent + README.
 
 ## Package shape
 

--- a/packages/eve/.gitignore
+++ b/packages/eve/.gitignore
@@ -1,0 +1,2 @@
+dist/
+*.tsbuildinfo

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@novu/eve",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Connect an Eve agent to Novu — a single unified Eve channel that rides Novu's agent reply flow for identity, multi-channel delivery, and cross-platform human-in-the-loop",
+  "license": "MIT",
+  "homepage": "https://github.com/novuhq/novu/tree/next/packages/eve#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/novuhq/novu.git",
+    "directory": "packages/eve"
+  },
+  "bugs": {
+    "url": "https://github.com/novuhq/novu/issues"
+  },
+  "keywords": [
+    "eve",
+    "novu",
+    "agent",
+    "channel",
+    "slack",
+    "teams",
+    "whatsapp",
+    "notifications"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "prepublishOnly": "pnpm build",
+    "prebuild": "rimraf dist tsconfig.tsbuildinfo",
+    "build": "tsc -p tsconfig.json",
+    "watch:build": "tsc -p tsconfig.json -w",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "biome check .",
+    "check:fix": "biome check --write ."
+  },
+  "dependencies": {
+    "@novu/framework": "workspace:*"
+  },
+  "peerDependencies": {
+    "eve": ">=0.11.0 <1"
+  },
+  "devDependencies": {
+    "eve": "0.11.6",
+    "rimraf": "~3.0.2",
+    "typescript": "5.6.2",
+    "vitest": "^1.2.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "nx": {
+    "tags": [
+      "type:package"
+    ]
+  }
+}

--- a/packages/eve/project.json
+++ b/packages/eve/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "@novu/eve",
+  "sourceRoot": "packages/eve/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @novu/eve run build",
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @novu/eve run test",
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx biome lint packages/eve"
+      }
+    }
+  },
+  "tags": ["type:package"]
+}

--- a/packages/eve/src/channel.ts
+++ b/packages/eve/src/channel.ts
@@ -1,0 +1,169 @@
+import { defineChannel, POST, type Channel, type ChannelEvents } from 'eve/channels';
+import type { AgentBridgeRequest, ReplyContent } from '@novu/framework';
+import { resolveNovuCredentials, type NovuCredentialsSource } from './credentials.js';
+import { NovuApiClient, type TriggerRecipient } from './reply-client.js';
+import { getSignatureHeader, verifyNovuSignature } from './signature.js';
+import { encodeContinuationToken } from './token.js';
+
+/**
+ * Durable per-session state seeded from the inbound bridge request. Carries the
+ * addressing needed to reply (`conversationId` + `integrationIdentifier`) and
+ * the unified subscriber so `channel.novu.*` can target it.
+ */
+export interface NovuSessionState {
+  readonly conversationId: string;
+  readonly integrationIdentifier: string;
+  readonly platform: string;
+  readonly subscriberId: string | null;
+}
+
+/** The Novu surface exposed on `channel.novu` inside event handlers. */
+export interface NovuChannelApi {
+  /** The unified Novu subscriber id for this conversation, if resolved. */
+  readonly subscriberId: string | null;
+  /** Fire a Novu workflow (defaults the recipient to this conversation's subscriber). */
+  trigger(workflowId: string, options?: { to?: TriggerRecipient; payload?: Record<string, unknown> }): Promise<void>;
+  /** Persist a value on the Novu conversation. */
+  setMetadata(key: string, value: unknown): Promise<void>;
+  /** Mark the Novu conversation resolved. */
+  resolve(summary?: string): Promise<void>;
+  /** Low-level: post a raw reply payload (markdown or card). */
+  reply(content: ReplyContent): Promise<void>;
+}
+
+/** Eve-core + Novu surface returned by the channel `context()` factory. */
+export interface NovuChannelContext {
+  readonly thread: {
+    /** Post an assistant reply. A string is sent as markdown; a `ReplyContent` is sent as-is. */
+    post(content: string | ReplyContent): Promise<void>;
+  };
+  readonly novu: NovuChannelApi;
+}
+
+export interface NovuChannelOptions {
+  /** Credentials source. Defaults to env (`NOVU_SECRET_KEY` / `NOVU_AGENT_IDENTIFIER` / `NOVU_API_BASE_URL`). */
+  readonly credentials?: NovuCredentialsSource;
+  /** Webhook route path. Defaults to `/`. */
+  readonly path?: string;
+  /** Auto-resolve the Novu conversation when the session completes. Defaults to off. */
+  readonly resolveOn?: 'session.completed' | 'never';
+  /** Override or extend the default event handlers. */
+  readonly events?: ChannelEvents<NovuChannelContext>;
+  /** Injectable fetch (tests). */
+  readonly fetch?: typeof fetch;
+}
+
+function buildContext(state: NovuSessionState, client: NovuApiClient): NovuChannelContext {
+  const reply = (content: ReplyContent) =>
+    client.reply({
+      conversationId: state.conversationId,
+      integrationIdentifier: state.integrationIdentifier,
+      reply: content,
+    });
+
+  return {
+    thread: {
+      post: (content) => reply(typeof content === 'string' ? { markdown: content } : content),
+    },
+    novu: {
+      subscriberId: state.subscriberId,
+      trigger: (workflowId, options = {}) =>
+        client.trigger(workflowId, {
+          to: options.to ?? state.subscriberId ?? undefined,
+          payload: options.payload,
+        }),
+      setMetadata: (key, value) =>
+        client.reply({
+          conversationId: state.conversationId,
+          integrationIdentifier: state.integrationIdentifier,
+          signals: [{ type: 'metadata', action: 'set', key, value }],
+        }),
+      resolve: (summary) =>
+        client.reply({
+          conversationId: state.conversationId,
+          integrationIdentifier: state.integrationIdentifier,
+          resolve: { summary },
+        }),
+      reply,
+    },
+  };
+}
+
+/**
+ * The single unified Novu channel. Place as the default export of
+ * `agent/channels/novu.ts`. One webhook route receives every platform connected
+ * in the Novu dashboard; identity is unified by the Novu subscriber.
+ *
+ * Zero-config: a bare `novuChannel()` already delivers completed assistant
+ * messages and (with `resolveOn`) resolves the conversation. Pass `events` to
+ * customize; each handler's `channel` exposes `channel.thread.*` and
+ * `channel.novu.*`.
+ */
+export function novuChannel(
+  options: NovuChannelOptions = {},
+): Channel<NovuSessionState, Record<string, unknown>, Record<string, unknown>> {
+  const credentials = options.credentials ?? {};
+  const client = new NovuApiClient(credentials, options.fetch);
+  const path = options.path ?? '/';
+  const resolveOn = options.resolveOn ?? 'never';
+
+  const defaults: ChannelEvents<NovuChannelContext> = {
+    async 'message.completed'(data, channel) {
+      if (data.finishReason === 'tool-calls') return;
+      if (data.message) await channel.thread.post(data.message);
+    },
+    async 'session.completed'(_data, channel) {
+      if (resolveOn === 'session.completed') await channel.novu.resolve();
+    },
+  };
+
+  return defineChannel<NovuSessionState, NovuChannelContext>({
+    context: (state) => buildContext(state, client),
+    events: { ...defaults, ...options.events },
+    routes: [
+      POST<NovuSessionState>(path, async (req, { send, waitUntil }) => {
+        const rawBody = await req.text();
+
+        const { secretKey } = await resolveNovuCredentials(credentials);
+        if (!verifyNovuSignature(getSignatureHeader(req), rawBody, secretKey)) {
+          return new Response('invalid signature', { status: 401 });
+        }
+
+        let bridge: AgentBridgeRequest;
+        try {
+          bridge = JSON.parse(rawBody) as AgentBridgeRequest;
+        } catch {
+          return new Response('invalid body', { status: 400 });
+        }
+
+        // First cut handles inbound messages; actions/reactions are a follow-up.
+        const text = bridge.message?.text ?? '';
+        if (!text) return Response.json({ ok: true, skipped: 'no-message' });
+
+        const state: NovuSessionState = {
+          conversationId: bridge.conversationId,
+          integrationIdentifier: bridge.integrationIdentifier,
+          platform: bridge.platform,
+          subscriberId: bridge.subscriber?.subscriberId ?? null,
+        };
+        const auth = bridge.subscriber
+          ? {
+              authenticator: 'novu',
+              principalId: bridge.subscriber.subscriberId,
+              principalType: 'subscriber',
+              attributes: {} as Record<string, string | readonly string[]>,
+            }
+          : null;
+
+        const continuationToken = encodeContinuationToken({
+          conversationId: bridge.conversationId,
+          integrationIdentifier: bridge.integrationIdentifier,
+          platform: bridge.platform,
+        });
+
+        waitUntil(send(text, { auth, continuationToken, state }));
+        return Response.json({ ok: true });
+      }),
+    ],
+  });
+}

--- a/packages/eve/src/channel.ts
+++ b/packages/eve/src/channel.ts
@@ -1,9 +1,10 @@
 import { defineChannel, POST, type Channel, type ChannelEvents } from 'eve/channels';
-import type { AgentBridgeRequest, ReplyContent } from '@novu/framework';
+import type { AgentAction, AgentBridgeRequest, ReplyContent } from '@novu/framework';
 import { resolveNovuCredentials, type NovuCredentialsSource } from './credentials.js';
 import { NovuApiClient, type TriggerRecipient } from './reply-client.js';
 import { getSignatureHeader, verifyNovuSignature } from './signature.js';
 import { encodeContinuationToken } from './token.js';
+import { decodeHitlActionId, renderInputRequests, toInputResponse, type RenderableInputRequest } from './hitl.js';
 
 /**
  * Durable per-session state seeded from the inbound bridge request. Carries the
@@ -40,6 +41,17 @@ export interface NovuChannelContext {
   readonly novu: NovuChannelApi;
 }
 
+/**
+ * Handler for tier-2 (custom, non-HITL) card actions — snooze, unsubscribe,
+ * quick-reply, etc. Receives the clicked action plus the channel surface and
+ * the conversation's `continuationToken`. HITL actions never reach here; they
+ * are auto-mapped to `inputResponses` and resume the session.
+ */
+export type NovuOnAction = (
+  action: AgentAction,
+  channel: NovuChannelContext & { readonly continuationToken: string },
+) => void | Promise<void>;
+
 export interface NovuChannelOptions {
   /** Credentials source. Defaults to env (`NOVU_SECRET_KEY` / `NOVU_AGENT_IDENTIFIER` / `NOVU_API_BASE_URL`). */
   readonly credentials?: NovuCredentialsSource;
@@ -49,6 +61,8 @@ export interface NovuChannelOptions {
   readonly resolveOn?: 'session.completed' | 'never';
   /** Override or extend the default event handlers. */
   readonly events?: ChannelEvents<NovuChannelContext>;
+  /** Handle custom (non-HITL) card action clicks. */
+  readonly onAction?: NovuOnAction;
   /** Injectable fetch (tests). */
   readonly fetch?: typeof fetch;
 }
@@ -112,6 +126,11 @@ export function novuChannel(
       if (data.finishReason === 'tool-calls') return;
       if (data.message) await channel.thread.post(data.message);
     },
+    async 'input.requested'(data, channel) {
+      // Cast decouples us from Eve's exact InputRequest shape; renderInputRequests
+      // reads only the structural subset it needs.
+      await channel.thread.post(renderInputRequests(data.requests as unknown as RenderableInputRequest[]));
+    },
     async 'session.completed'(_data, channel) {
       if (resolveOn === 'session.completed') await channel.novu.resolve();
     },
@@ -136,10 +155,6 @@ export function novuChannel(
           return new Response('invalid body', { status: 400 });
         }
 
-        // First cut handles inbound messages; actions/reactions are a follow-up.
-        const text = bridge.message?.text ?? '';
-        if (!text) return Response.json({ ok: true, skipped: 'no-message' });
-
         const state: NovuSessionState = {
           conversationId: bridge.conversationId,
           integrationIdentifier: bridge.integrationIdentifier,
@@ -154,13 +169,29 @@ export function novuChannel(
               attributes: {} as Record<string, string | readonly string[]>,
             }
           : null;
-
         const continuationToken = encodeContinuationToken({
           conversationId: bridge.conversationId,
           integrationIdentifier: bridge.integrationIdentifier,
           platform: bridge.platform,
         });
 
+        // Tier-1/tier-2 action round-trip.
+        if (bridge.action) {
+          const decoded = decodeHitlActionId(bridge.action.id);
+          if (decoded) {
+            // HITL: resume the parked session with the user's response.
+            const response = toInputResponse(decoded, bridge.action.value);
+            waitUntil(send({ inputResponses: [response] }, { auth, continuationToken, state }));
+            return Response.json({ ok: true });
+          }
+          if (options.onAction) {
+            await options.onAction(bridge.action, { ...buildContext(state, client), continuationToken });
+          }
+          return Response.json({ ok: true });
+        }
+
+        const text = bridge.message?.text ?? '';
+        if (!text) return Response.json({ ok: true, skipped: 'no-message' });
         waitUntil(send(text, { auth, continuationToken, state }));
         return Response.json({ ok: true });
       }),

--- a/packages/eve/src/credentials.spec.ts
+++ b/packages/eve/src/credentials.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { connectNovuCredentials, resolveNovuCredentials } from './credentials.js';
+
+const ENV_KEYS = ['NOVU_SECRET_KEY', 'NOVU_AGENT_IDENTIFIER', 'NOVU_API_BASE_URL'] as const;
+
+describe('resolveNovuCredentials', () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('resolves from env, defaulting the api base url', async () => {
+    process.env.NOVU_SECRET_KEY = 'sk_env';
+    process.env.NOVU_AGENT_IDENTIFIER = 'bot_env';
+    await expect(resolveNovuCredentials()).resolves.toEqual({
+      secretKey: 'sk_env',
+      agentIdentifier: 'bot_env',
+      apiBaseUrl: 'https://api.novu.co',
+    });
+  });
+
+  it('lets explicit input win over env', async () => {
+    process.env.NOVU_SECRET_KEY = 'sk_env';
+    process.env.NOVU_AGENT_IDENTIFIER = 'bot_env';
+    await expect(
+      resolveNovuCredentials({ secretKey: 'sk_explicit', apiBaseUrl: 'https://eu.api.novu.co' }),
+    ).resolves.toEqual({
+      secretKey: 'sk_explicit',
+      agentIdentifier: 'bot_env',
+      apiBaseUrl: 'https://eu.api.novu.co',
+    });
+  });
+
+  it('accepts a (possibly async) resolver function', async () => {
+    const creds = await resolveNovuCredentials(async () => ({ secretKey: 'sk_fn', agentIdentifier: 'bot_fn' }));
+    expect(creds).toEqual({ secretKey: 'sk_fn', agentIdentifier: 'bot_fn', apiBaseUrl: 'https://api.novu.co' });
+  });
+
+  it('throws a helpful error when the secret key is missing', async () => {
+    process.env.NOVU_AGENT_IDENTIFIER = 'bot_env';
+    await expect(resolveNovuCredentials()).rejects.toThrow(/NOVU_SECRET_KEY/);
+  });
+
+  it('throws a helpful error when the agent identifier is missing', async () => {
+    process.env.NOVU_SECRET_KEY = 'sk_env';
+    await expect(resolveNovuCredentials()).rejects.toThrow(/NOVU_AGENT_IDENTIFIER/);
+  });
+});
+
+describe('connectNovuCredentials', () => {
+  it('returns a lazy resolver that falls back to env', async () => {
+    process.env.NOVU_SECRET_KEY = 'sk_env';
+    process.env.NOVU_AGENT_IDENTIFIER = 'bot_env';
+    const resolver = connectNovuCredentials('novu/my-agent', { agentIdentifier: 'bot_override' });
+    await expect(resolveNovuCredentials(resolver)).resolves.toMatchObject({
+      secretKey: 'sk_env',
+      agentIdentifier: 'bot_override',
+    });
+    delete process.env.NOVU_SECRET_KEY;
+    delete process.env.NOVU_AGENT_IDENTIFIER;
+  });
+});

--- a/packages/eve/src/credentials.ts
+++ b/packages/eve/src/credentials.ts
@@ -1,0 +1,84 @@
+/**
+ * Novu credential resolution for the Eve channel.
+ *
+ * Env-first (works everywhere — self-host, non-Vercel): `NOVU_SECRET_KEY`,
+ * `NOVU_AGENT_IDENTIFIER`, `NOVU_API_BASE_URL`. Explicit options passed to
+ * `novuChannel({...})` win over env. {@link connectNovuCredentials} is the
+ * Vercel-native helper (mirrors Eve's `connectSlackCredentials`).
+ */
+
+const DEFAULT_API_BASE_URL = 'https://api.novu.co';
+
+/** Fully-resolved credentials needed to talk to Novu's agent reply flow. */
+export interface NovuCredentials {
+  readonly secretKey: string;
+  readonly agentIdentifier: string;
+  readonly apiBaseUrl: string;
+}
+
+/** Partial credentials supplied in code; missing fields fall back to env. */
+export interface NovuCredentialsInput {
+  readonly secretKey?: string;
+  readonly agentIdentifier?: string;
+  readonly apiBaseUrl?: string;
+}
+
+/**
+ * A credentials source: either resolved credentials, partial input (env fills
+ * the gaps), or a (possibly async) resolver — e.g. the Vercel Connect helper
+ * mints fresh credentials per call.
+ */
+export type NovuCredentialsSource =
+  | NovuCredentialsInput
+  | (() => NovuCredentials | NovuCredentialsInput | Promise<NovuCredentials | NovuCredentialsInput>);
+
+function fromInput(input: NovuCredentialsInput): NovuCredentials {
+  const secretKey = input.secretKey ?? process.env.NOVU_SECRET_KEY;
+  const agentIdentifier = input.agentIdentifier ?? process.env.NOVU_AGENT_IDENTIFIER;
+  const apiBaseUrl = input.apiBaseUrl ?? process.env.NOVU_API_BASE_URL ?? DEFAULT_API_BASE_URL;
+
+  if (!secretKey) {
+    throw new Error(
+      '@novu/eve: missing Novu secret key. Set NOVU_SECRET_KEY or pass `secretKey` to novuChannel({ credentials }).',
+    );
+  }
+  if (!agentIdentifier) {
+    throw new Error(
+      '@novu/eve: missing Novu agent identifier. Set NOVU_AGENT_IDENTIFIER or pass `agentIdentifier` to novuChannel({ credentials }).',
+    );
+  }
+  return { secretKey, agentIdentifier, apiBaseUrl };
+}
+
+/** Resolve a {@link NovuCredentialsSource} to concrete {@link NovuCredentials}. */
+export async function resolveNovuCredentials(source: NovuCredentialsSource = {}): Promise<NovuCredentials> {
+  const value = typeof source === 'function' ? await source() : source;
+  return fromInput(value);
+}
+
+/**
+ * Vercel-native credentials helper. On Vercel, `handle` names the connected Novu
+ * integration whose managed credentials are injected at runtime; off-Vercel it
+ * transparently falls back to env (+ any `overrides`). Mirrors Eve's
+ * `connectSlackCredentials("slack/my-agent")` ergonomics.
+ *
+ * Returns a resolver so credentials are read lazily (and can be refreshed),
+ * never captured at module-load time.
+ */
+export function connectNovuCredentials(
+  handle: string,
+  overrides: NovuCredentialsInput = {},
+): () => NovuCredentials {
+  return () =>
+    fromInput({
+      // `handle` reserves the Vercel Connect binding; env/overrides are the
+      // universal fallback so the same code runs locally and self-hosted.
+      secretKey: overrides.secretKey ?? process.env[`NOVU_SECRET_KEY_${handleEnvSuffix(handle)}`],
+      agentIdentifier: overrides.agentIdentifier,
+      apiBaseUrl: overrides.apiBaseUrl,
+    });
+}
+
+function handleEnvSuffix(handle: string): string {
+  return handle.replace(/[^a-zA-Z0-9]+/g, '_').toUpperCase();
+}

--- a/packages/eve/src/hitl.spec.ts
+++ b/packages/eve/src/hitl.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeHitlActionId,
+  encodeHitlActionId,
+  renderInputRequests,
+  toInputResponse,
+  type RenderableInputRequest,
+} from './hitl.js';
+
+describe('HITL action-id codec', () => {
+  it('round-trips requestId + optionId', () => {
+    const id = encodeHitlActionId('req_1', 'approve');
+    expect(decodeHitlActionId(id)).toEqual({ requestId: 'req_1', optionId: 'approve' });
+  });
+
+  it('returns null for non-HITL (custom tier-2) action ids', () => {
+    expect(decodeHitlActionId('snooze')).toBeNull();
+    expect(decodeHitlActionId('unsubscribe')).toBeNull();
+    expect(decodeHitlActionId(undefined)).toBeNull();
+  });
+
+  it('maps an option click to an inputResponse', () => {
+    const decoded = decodeHitlActionId(encodeHitlActionId('req_2', 'deny'))!;
+    expect(toInputResponse(decoded, undefined)).toEqual({ requestId: 'req_2', optionId: 'deny', text: undefined });
+  });
+
+  it('maps the freeform sentinel to a text inputResponse (no optionId)', () => {
+    const decoded = decodeHitlActionId(encodeHitlActionId('req_3', '__freeform__'))!;
+    expect(toInputResponse(decoded, 'ship it')).toEqual({ requestId: 'req_3', text: 'ship it' });
+  });
+});
+
+describe('renderInputRequests', () => {
+  it('renders a card (not markdown) with the prompt as title for a request with options', () => {
+    const requests: RenderableInputRequest[] = [
+      {
+        requestId: 'req_1',
+        prompt: 'Deploy to production?',
+        options: [
+          { id: 'approve', label: 'Approve', style: 'primary' },
+          { id: 'deny', label: 'Deny', style: 'danger' },
+        ],
+      },
+    ];
+    const content = renderInputRequests(requests);
+    expect(content.card).toBeTruthy();
+    expect(content.markdown).toBeUndefined();
+  });
+
+  it('returns empty markdown when there are no requests', () => {
+    expect(renderInputRequests([])).toEqual({ markdown: '' });
+  });
+});

--- a/packages/eve/src/hitl.ts
+++ b/packages/eve/src/hitl.ts
@@ -1,0 +1,90 @@
+import { Actions, Button, Card } from '@novu/framework';
+import type { CardChild, ReplyContent } from '@novu/framework';
+
+/**
+ * Human-in-the-loop bridge: render Eve's `input.requested` payloads as Novu
+ * interactive cards, and decode the resulting button click / freeform submit
+ * back into an Eve `inputResponses` entry.
+ *
+ * Button/input ids carry the `requestId` + `optionId` so an inbound action can
+ * be matched to the parked Eve request with no server-side state. A sentinel
+ * `optionId` marks the freeform text field.
+ */
+
+const ACTION_PREFIX = 'nh_';
+const FREEFORM_OPTION = '__freeform__';
+
+/** One pending input request, mirroring Eve's `InputRequest` (subset we render). */
+export interface RenderableInputRequest {
+  readonly requestId: string;
+  readonly prompt: string;
+  readonly allowFreeform?: boolean;
+  readonly display?: 'confirmation' | 'select' | 'text';
+  readonly options?: ReadonlyArray<{
+    readonly id: string;
+    readonly label: string;
+    readonly style?: 'default' | 'primary' | 'danger';
+  }>;
+}
+
+/** Decoded HITL action: which parked request + option a click maps to. */
+export interface DecodedHitlAction {
+  readonly requestId: string;
+  readonly optionId: string;
+}
+
+export function encodeHitlActionId(requestId: string, optionId: string): string {
+  return ACTION_PREFIX + Buffer.from(JSON.stringify({ r: requestId, o: optionId }), 'utf8').toString('base64url');
+}
+
+export function decodeHitlActionId(actionId: string | undefined | null): DecodedHitlAction | null {
+  if (!actionId || !actionId.startsWith(ACTION_PREFIX)) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(actionId.slice(ACTION_PREFIX.length), 'base64url').toString('utf8')) as {
+      r?: unknown;
+      o?: unknown;
+    };
+    if (typeof parsed.r !== 'string' || typeof parsed.o !== 'string') return null;
+    return { requestId: parsed.r, optionId: parsed.o };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Turn a decoded action + its platform `value` into the Eve `inputResponses`
+ * entry shape. A freeform submit carries the user's text; an option click
+ * carries the `optionId`.
+ */
+export function toInputResponse(
+  decoded: DecodedHitlAction,
+  value: string | undefined,
+): { requestId: string; optionId?: string; text?: string } {
+  if (decoded.optionId === FREEFORM_OPTION) {
+    return { requestId: decoded.requestId, text: value };
+  }
+  return { requestId: decoded.requestId, optionId: decoded.optionId, text: value };
+}
+
+/** Render pending input requests as a Novu card reply. */
+export function renderInputRequests(requests: ReadonlyArray<RenderableInputRequest>): ReplyContent {
+  // Eve emits requests one at a time in practice; render the first.
+  const req = requests[0];
+  if (!req) return { markdown: '' };
+
+  const buttons = (req.options ?? []).map((option) =>
+    Button({
+      id: encodeHitlActionId(req.requestId, option.id),
+      label: option.label,
+      value: option.id,
+      ...(option.style ? { style: option.style } : {}),
+    }),
+  );
+
+  // Card bodies render option buttons; freeform text capture (Eve `allowFreeform`)
+  // is a follow-up — those platforms accept a normal reply message instead.
+  const children: CardChild[] = [];
+  if (buttons.length) children.push(Actions(buttons));
+
+  return { card: Card({ title: req.prompt, children }) };
+}

--- a/packages/eve/src/index.ts
+++ b/packages/eve/src/index.ts
@@ -18,8 +18,17 @@ export {
   type NovuChannelOptions,
   type NovuChannelContext,
   type NovuChannelApi,
+  type NovuOnAction,
   type NovuSessionState,
 } from './channel.js';
+
+// Human-in-the-loop card rendering + action-id codec (advanced / testing).
+export {
+  renderInputRequests,
+  encodeHitlActionId,
+  decodeHitlActionId,
+  type RenderableInputRequest,
+} from './hitl.js';
 
 // Model-driven workflow trigger tool.
 export { novuTool, type NovuToolOptions } from './tool.js';

--- a/packages/eve/src/index.ts
+++ b/packages/eve/src/index.ts
@@ -1,0 +1,66 @@
+/**
+ * @novu/eve — connect an Eve agent to Novu.
+ *
+ * A single unified Eve channel (`novuChannel`) that rides Novu's agent reply
+ * flow: unified subscriber identity, multi-channel delivery, and cross-platform
+ * human-in-the-loop. Built on `@novu/framework` (not `@novu/chat-adapter`).
+ *
+ * The Eve-facing surface (`novuChannel`, `novuTool`, `connectNovuCredentials`,
+ * `NovuView`, the `channel.novu.*` object) is implemented against Eve's real
+ * types and added in subsequent modules. This entry point currently re-exports
+ * the `@novu/framework` building blocks Eve developers compose with, so they
+ * need only a single dependency.
+ */
+
+// The single unified Novu channel — default export of agent/channels/novu.ts.
+export {
+  novuChannel,
+  type NovuChannelOptions,
+  type NovuChannelContext,
+  type NovuChannelApi,
+  type NovuSessionState,
+} from './channel.js';
+
+// Connecting Novu: env-first credentials + the Vercel-native helper.
+export {
+  connectNovuCredentials,
+  resolveNovuCredentials,
+  type NovuCredentials,
+  type NovuCredentialsInput,
+  type NovuCredentialsSource,
+} from './credentials.js';
+
+// Code-first workflow definitions ("trigger + execute user code").
+export { workflow, step } from '@novu/framework';
+
+// Shared Chat SDK card vocabulary — identical to what Eve renders. A card built
+// once renders on both sides with no translation.
+export {
+  Actions,
+  Button,
+  Card,
+  CardLink,
+  CardText,
+  Divider,
+  Select,
+  SelectOption,
+  TextInput,
+} from '@novu/framework';
+
+// Agent runtime + reply-flow protocol types.
+export type {
+  Agent,
+  AgentAction,
+  AgentBridgeRequest,
+  AgentContext,
+  AgentConversation,
+  AgentReplyPayload,
+  AgentSubscriber,
+  CardChild,
+  CardElement,
+  MessageContent,
+  ReplyContent,
+  ReplyHandle,
+  Signal,
+  TriggerSignal,
+} from '@novu/framework';

--- a/packages/eve/src/index.ts
+++ b/packages/eve/src/index.ts
@@ -21,6 +21,9 @@ export {
   type NovuSessionState,
 } from './channel.js';
 
+// Model-driven workflow trigger tool.
+export { novuTool, type NovuToolOptions } from './tool.js';
+
 // Connecting Novu: env-first credentials + the Vercel-native helper.
 export {
   connectNovuCredentials,

--- a/packages/eve/src/reply-client.ts
+++ b/packages/eve/src/reply-client.ts
@@ -1,0 +1,55 @@
+import type { AgentReplyPayload } from '@novu/framework';
+import { resolveNovuCredentials, type NovuCredentialsSource } from './credentials.js';
+
+/** Recipient for a workflow trigger — a subscriberId, subscriber object, topic, or arrays thereof. */
+export type TriggerRecipient = unknown;
+
+/**
+ * Thin client for Novu's agent reply flow + workflow trigger endpoint.
+ *
+ * Credentials are resolved lazily per call (never captured at construction), so
+ * a Vercel Connect resolver can mint fresh credentials. The reply URL is derived
+ * solely from `apiBaseUrl` + `agentIdentifier` — a forged inbound request can
+ * never redirect the secret key to an attacker host.
+ */
+export class NovuApiClient {
+  private readonly source: NovuCredentialsSource;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(source: NovuCredentialsSource = {}, fetchImpl: typeof fetch = globalThis.fetch) {
+    this.source = source;
+    this.fetchImpl = fetchImpl;
+  }
+
+  /** POST an `AgentReplyPayload` to `/v1/agents/:id/reply`. */
+  async reply(payload: AgentReplyPayload): Promise<void> {
+    const { secretKey, agentIdentifier, apiBaseUrl } = await resolveNovuCredentials(this.source);
+    const base = apiBaseUrl.replace(/\/$/, '');
+    const url = `${base}/v1/agents/${encodeURIComponent(agentIdentifier)}/reply`;
+    await this.post(url, secretKey, payload, 'reply');
+  }
+
+  /** Fire a Novu workflow via `/v1/events/trigger`. */
+  async trigger(
+    workflowId: string,
+    options: { to?: TriggerRecipient; payload?: Record<string, unknown> } = {},
+  ): Promise<void> {
+    const { secretKey, apiBaseUrl } = await resolveNovuCredentials(this.source);
+    const base = apiBaseUrl.replace(/\/$/, '');
+    const body: Record<string, unknown> = { name: workflowId, payload: options.payload ?? {} };
+    if (options.to !== undefined) body.to = options.to;
+    await this.post(`${base}/v1/events/trigger`, secretKey, body, 'trigger');
+  }
+
+  private async post(url: string, secretKey: string, body: unknown, label: string): Promise<void> {
+    const response = await this.fetchImpl(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `ApiKey ${secretKey}` },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(`Novu ${label} failed (${response.status} ${response.statusText}): ${detail}`);
+    }
+  }
+}

--- a/packages/eve/src/signature.spec.ts
+++ b/packages/eve/src/signature.spec.ts
@@ -1,0 +1,45 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { verifyNovuSignature } from './signature.js';
+
+const SECRET = 'sk_test_secret';
+
+function sign(rawBody: string, timestamp: number, secret = SECRET): string {
+  const hmac = createHmac('sha256', secret).update(`${timestamp}.${rawBody}`).digest('hex');
+  return `t=${timestamp},v1=${hmac}`;
+}
+
+describe('verifyNovuSignature', () => {
+  const body = JSON.stringify({ hello: 'world' });
+  const now = 1_700_000_000_000;
+  const clock = () => now;
+
+  it('accepts a valid, fresh signature', () => {
+    expect(verifyNovuSignature(sign(body, now), body, SECRET, { now: clock })).toBe(true);
+  });
+
+  it('rejects a tampered body', () => {
+    expect(verifyNovuSignature(sign(body, now), `${body} `, SECRET, { now: clock })).toBe(false);
+  });
+
+  it('rejects a wrong secret', () => {
+    expect(verifyNovuSignature(sign(body, now, 'other'), body, SECRET, { now: clock })).toBe(false);
+  });
+
+  it('rejects an expired signature', () => {
+    const old = now - 6 * 60 * 1000;
+    expect(verifyNovuSignature(sign(body, old), body, SECRET, { now: clock })).toBe(false);
+  });
+
+  it('rejects a signature too far in the future', () => {
+    const future = now + 60 * 1000;
+    expect(verifyNovuSignature(sign(body, future), body, SECRET, { now: clock })).toBe(false);
+  });
+
+  it.each([null, '', 'garbage', 't=123', `v1=${'a'.repeat(64)}`])(
+    'rejects malformed header: %s',
+    (header) => {
+      expect(verifyNovuSignature(header, body, SECRET, { now: clock })).toBe(false);
+    },
+  );
+});

--- a/packages/eve/src/signature.ts
+++ b/packages/eve/src/signature.ts
@@ -1,0 +1,61 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Verifies Novu's `novu-signature` HMAC on inbound bridge requests.
+ *
+ * Scheme (Novu's `buildNovuSignatureHeader`):
+ *   header  = `t=<timestamp-ms>,v1=<hmac-hex>`
+ *   message = `<timestamp>.<rawBody>`
+ *   hmac    = HMAC-SHA256(secretKey, message) as lowercase hex
+ *
+ * `rawBody` MUST be the exact request body bytes (Novu signs
+ * `JSON.stringify(payload)` and sends those same bytes), so verify against
+ * `await request.text()` before parsing.
+ */
+
+const SIGNATURE_HEADER = 'novu-signature';
+const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_SKEW_MS = 30 * 1000;
+
+export interface VerifyOptions {
+  readonly maxAgeMs?: number;
+  /** Injectable clock for deterministic tests. */
+  readonly now?: () => number;
+}
+
+/** Read the `novu-signature` header from a `Request`. */
+export function getSignatureHeader(request: Request): string | null {
+  return request.headers.get(SIGNATURE_HEADER);
+}
+
+/** Constant-time verification of the `novu-signature` header against the raw body. */
+export function verifyNovuSignature(
+  signatureHeader: string | null,
+  rawBody: string,
+  secret: string,
+  options: VerifyOptions = {},
+): boolean {
+  if (!signatureHeader) return false;
+
+  const parts = signatureHeader.split(',');
+  const timestampPart = parts.find((p) => p.startsWith('t='));
+  const hmacPart = parts.find((p) => p.startsWith('v1='));
+  if (!timestampPart || !hmacPart) return false;
+
+  const timestamp = timestampPart.slice(2);
+  const receivedHmac = hmacPart.slice(3);
+
+  const now = options.now?.() ?? Date.now();
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const age = now - Number(timestamp);
+  if (Number.isNaN(age) || age > maxAgeMs || age < -MAX_FUTURE_SKEW_MS) return false;
+
+  const expectedHmac = createHmac('sha256', secret).update(`${timestamp}.${rawBody}`).digest('hex');
+  if (receivedHmac.length !== expectedHmac.length) return false;
+
+  const received = Buffer.from(receivedHmac, 'hex');
+  const expected = Buffer.from(expectedHmac, 'hex');
+  if (received.length !== expected.length) return false;
+
+  return timingSafeEqual(received, expected);
+}

--- a/packages/eve/src/token.spec.ts
+++ b/packages/eve/src/token.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { decodeContinuationToken, encodeContinuationToken, type NovuConversationRef } from './token.js';
+
+describe('continuation-token codec', () => {
+  it('round-trips a full conversation reference', () => {
+    const ref: NovuConversationRef = {
+      conversationId: 'conv_123',
+      integrationIdentifier: 'slack-prod',
+      platform: 'slack',
+    };
+    expect(decodeContinuationToken(encodeContinuationToken(ref))).toEqual(ref);
+  });
+
+  it('round-trips without a platform (omits the field rather than setting undefined awkwardly)', () => {
+    const ref: NovuConversationRef = { conversationId: 'c', integrationIdentifier: 'i' };
+    const decoded = decodeContinuationToken(encodeContinuationToken(ref));
+    expect(decoded).toEqual({ conversationId: 'c', integrationIdentifier: 'i', platform: undefined });
+  });
+
+  it('produces an opaque token that is not the raw ids', () => {
+    const token = encodeContinuationToken({ conversationId: 'conv_123', integrationIdentifier: 'slack' });
+    expect(token).not.toContain('conv_123');
+  });
+
+  it.each([undefined, null, '', 'not-base64url-$$$', Buffer.from('{"x":1}').toString('base64url')])(
+    'returns null for absent/undecodable token: %s',
+    (bad) => {
+      expect(decodeContinuationToken(bad as string | null | undefined)).toBeNull();
+    },
+  );
+});

--- a/packages/eve/src/token.ts
+++ b/packages/eve/src/token.ts
@@ -1,0 +1,55 @@
+/**
+ * Continuation-token codec.
+ *
+ * Eve identifies a durable session by its `continuationToken` (see
+ * `ChannelSessionOps` in `eve/channels`). We bind that 1:1 to the Novu
+ * conversation by encoding the conversation reference into the token, so every
+ * resume targets the correct Novu thread while a single Novu subscriber can
+ * hold many concurrent cross-platform conversations.
+ *
+ * The encoding is an opaque base64url JSON blob — callers must treat the token
+ * as opaque and only round-trip it through {@link encodeContinuationToken} /
+ * {@link decodeContinuationToken}.
+ */
+
+/** Reference to a single Novu conversation on a specific platform integration. */
+export interface NovuConversationRef {
+  readonly conversationId: string;
+  readonly integrationIdentifier: string;
+  /** Platform slug (e.g. `slack`, `teams`), when the bridge request carries it. */
+  readonly platform?: string;
+}
+
+interface EncodedShape {
+  readonly c: string;
+  readonly i: string;
+  readonly p?: string;
+}
+
+/** Encode a conversation reference into an opaque continuation token. */
+export function encodeContinuationToken(ref: NovuConversationRef): string {
+  const payload: EncodedShape = { c: ref.conversationId, i: ref.integrationIdentifier };
+  const withPlatform = ref.platform ? { ...payload, p: ref.platform } : payload;
+  return Buffer.from(JSON.stringify(withPlatform), 'utf8').toString('base64url');
+}
+
+/**
+ * Decode a continuation token back into a conversation reference. Returns
+ * `null` for an absent or undecodable token so callers can fall back to
+ * starting a fresh session instead of throwing.
+ */
+export function decodeContinuationToken(token: string | undefined | null): NovuConversationRef | null {
+  if (!token) return null;
+  try {
+    const json = Buffer.from(token, 'base64url').toString('utf8');
+    const parsed = JSON.parse(json) as Partial<EncodedShape> | null;
+    if (!parsed || typeof parsed.c !== 'string' || typeof parsed.i !== 'string') return null;
+    return {
+      conversationId: parsed.c,
+      integrationIdentifier: parsed.i,
+      platform: typeof parsed.p === 'string' ? parsed.p : undefined,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/eve/src/tool.spec.ts
+++ b/packages/eve/src/tool.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { novuTool } from './tool.js';
+
+const creds = { secretKey: 'sk_test', agentIdentifier: 'bot', apiBaseUrl: 'https://api.novu.co' };
+
+function okFetch() {
+  return vi.fn(async () => new Response('', { status: 200 }));
+}
+
+describe('novuTool', () => {
+  it('triggers the configured workflow via /v1/events/trigger with the model payload', async () => {
+    const fetchImpl = okFetch();
+    const tool = novuTool({ description: 'escalate', workflow: 'on-call', credentials: creds, fetch: fetchImpl });
+
+    // The Eve runtime invokes execute(input, ctx); ctx is unused here.
+    const result = await (tool.execute as (i: Record<string, unknown>, c: unknown) => Promise<unknown>)(
+      { to: 'sub_42', payload: { summary: 'disk full' } },
+      {},
+    );
+
+    expect(result).toEqual({ triggered: true, workflow: 'on-call' });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.novu.co/v1/events/trigger');
+    expect(init.headers).toMatchObject({ authorization: 'ApiKey sk_test' });
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'on-call', to: 'sub_42', payload: { summary: 'disk full' } });
+  });
+
+  it('forwards the whole input as payload when no explicit payload field is present', async () => {
+    const fetchImpl = okFetch();
+    const tool = novuTool({ description: 'notify', workflow: 'welcome', credentials: creds, fetch: fetchImpl });
+
+    await (tool.execute as (i: Record<string, unknown>, c: unknown) => Promise<unknown>)({ name: 'Ada' }, {});
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'welcome', payload: { name: 'Ada' } });
+  });
+});

--- a/packages/eve/src/tool.ts
+++ b/packages/eve/src/tool.ts
@@ -1,0 +1,46 @@
+import { defineTool } from 'eve/tools';
+import type { NovuCredentialsSource } from './credentials.js';
+import { NovuApiClient, type TriggerRecipient } from './reply-client.js';
+
+export interface NovuToolOptions {
+  /** Shown to the model so it knows when to fire this workflow. */
+  readonly description: string;
+  /** Novu workflow identifier to trigger (same id used in `workflow(...)`). */
+  readonly workflow: string;
+  /**
+   * Input schema for the tool (a Standard Schema, e.g. a Zod schema). The tool
+   * input may carry `to` (recipient override) and `payload`; anything else is
+   * forwarded as the workflow payload. Defaults to an open object.
+   */
+  readonly inputSchema?: unknown;
+  /** Credentials source. Defaults to env. */
+  readonly credentials?: NovuCredentialsSource;
+  /** Injectable fetch (tests). */
+  readonly fetch?: typeof fetch;
+}
+
+const DEFAULT_INPUT_SCHEMA = { type: 'object', additionalProperties: true };
+
+/**
+ * Authors an Eve tool the model can call to fire a Novu workflow — the
+ * model-driven "trigger + execute user code" path. Gate it with Eve's
+ * `needsApproval` on the tool file if you want a confirmation step.
+ *
+ * The tool stays pure: it performs a single side effect (the trigger) and
+ * returns an ack the model can reason over. The recipient defaults to the
+ * conversation's subscriber when the model omits `to`.
+ */
+export function novuTool(options: NovuToolOptions) {
+  const client = new NovuApiClient(options.credentials ?? {}, options.fetch);
+
+  return defineTool({
+    description: options.description,
+    inputSchema: (options.inputSchema ?? DEFAULT_INPUT_SCHEMA) as never,
+    async execute(input: Record<string, unknown>) {
+      const to = input.to as TriggerRecipient | undefined;
+      const payload = (input.payload as Record<string, unknown> | undefined) ?? input;
+      await client.trigger(options.workflow, { to, payload });
+      return { triggered: true, workflow: options.workflow };
+    },
+  });
+}

--- a/packages/eve/tsconfig.json
+++ b/packages/eve/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "nodenext",
+    "moduleDetection": "force",
+    "moduleResolution": "nodenext",
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "target": "ES2021",
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/node_modules/**", "**/*.spec.ts"]
+}

--- a/packages/eve/vitest.config.ts
+++ b/packages/eve/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3456,6 +3456,25 @@ importers:
         specifier: 5.6.2
         version: 5.6.2
 
+  packages/eve:
+    dependencies:
+      '@novu/framework':
+        specifier: workspace:*
+        version: link:../framework
+    devDependencies:
+      eve:
+        specifier: 0.11.6
+        version: 0.11.6(@opentelemetry/api@1.9.0)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.55.7(@typescript-eslint/types@8.39.1))(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.39.1))(typescript@5.6.2)(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(ai@7.0.0-beta.178(zod@4.3.6))(chokidar@4.0.3)(dotenv@17.4.1)(ioredis@5.11.1)(jiti@2.6.1)(lru-cache@11.5.1)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(svelte@5.55.7(@typescript-eslint/types@8.39.1))(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))(wrangler@4.68.1)
+      rimraf:
+        specifier: ~3.0.2
+        version: 3.0.2
+      typescript:
+        specifier: 5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.7(@edge-runtime/vm@3.0.3)(@opentelemetry/api@1.9.0)(@types/node@22.15.13)(happy-dom@20.8.9)(jsdom@20.0.3)(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/framework:
     dependencies:
       ajv:
@@ -4544,6 +4563,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.0-beta.109':
+    resolution: {integrity: sha512-W/1kLlPb6Bgbhwep3CA3R6do0HD7SXV5gyuz2XBLY1YABqgxYkw+IhEcjOYlmn9v+Tifjqy5yJqmWdSHMJhyPQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/langchain@2.0.73':
     resolution: {integrity: sha512-vvVRJdUk2QbnqUAxS2s51Uxnr9oSKO9DKM6Aj1hpr18eFesOdBy8sKLbrvIebaE/EBW6tQ197WP58LZQyKEIuA==}
     engines: {node: '>=18'}
@@ -4578,6 +4603,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.0-beta.49':
+    resolution: {integrity: sha512-7xnpAQLpW0KGIsh0CQERcIZuXEGqv7FtFW2BdFk14iuMxRMVpXhTVvEQyqkm6tWAbQ7OsGQJhO6M0Me9gHQ52g==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.3':
     resolution: {integrity: sha512-qGPYdoAuECaUXPrrz0BPX1SacZQuJ6zky0aakxpW89QW1hrY0eF4gcFm/3L9Pk8C5Fwe+RvBf2z7ZjDhaPjnlg==}
     engines: {node: '>=18'}
@@ -4589,6 +4620,10 @@ packages:
   '@ai-sdk/provider@3.0.7':
     resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.0-beta.19':
+    resolution: {integrity: sha512-Aca/KiGeRtMM7rOJ38Qio+Dc2V45PpiGoWgdrdtIkgM9zkhYpS043t0ggKoNOWgm/csv99XWGrfSF63PSkVeHw==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/react@3.0.51':
     resolution: {integrity: sha512-7nmCwEJM52NQZB4/ED8qJ4wbDg7EEWh94qJ7K9GSJxD6sWF3GOKrRZ5ivm4qNmKhY+JfCxCAxfghGY5mTKOsxw==}
@@ -7121,8 +7156,14 @@ packages:
     resolution: {integrity: sha512-SPfI1JeIRNs/4EEE2Oc0X6gG3RqjD1TnKu2lwmwFXq0435xgZGKhc3UiKkYAdoMn2dNFD73nlabMKHBRoMRpxg==}
     engines: {node: '>=14'}
 
+  '@emnapi/core@1.11.0':
+    resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
+
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
+
+  '@emnapi/runtime@1.11.0':
+    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
@@ -7132,6 +7173,9 @@ packages:
 
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/babel-plugin@11.10.6':
     resolution: {integrity: sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==}
@@ -8586,6 +8630,12 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nestjs/axios@4.0.1':
     resolution: {integrity: sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==}
@@ -10153,6 +10203,9 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
+
+  '@oxc-project/types@0.135.0':
+    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
 
   '@oxc-resolver/binding-darwin-arm64@5.3.0':
     resolution: {integrity: sha512-hXem5ZAguS7IlSiHg/LK0tEfLj4eUo+9U6DaFwwBEGd0L0VIF9LmuiHydRyOrdnnmi9iAAFMAn/wl2cUoiuruA==}
@@ -12102,8 +12155,106 @@ packages:
     peerDependencies:
       '@rjsf/utils': ^5.16.x
 
+  '@rolldown/binding-android-arm64@1.1.1':
+    resolution: {integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    resolution: {integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    resolution: {integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    resolution: {integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    resolution: {integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    resolution: {integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-commonjs@22.0.2':
     resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
@@ -14329,6 +14480,9 @@ packages:
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
@@ -15249,6 +15403,10 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vercel/static-config@2.0.17':
     resolution: {integrity: sha512-2f50OTVrN07x7pH+XNW0e7cj7T+Ufg+19+a2N3/XZBjQmV+FaMlmSLiaQ4tBxp2H8lWWHzENua7ZSSQPtRZ3/A==}
 
@@ -15506,6 +15664,9 @@ packages:
       webpack-dev-server:
         optional: true
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
@@ -15705,6 +15866,12 @@ packages:
   ai@6.0.68:
     resolution: {integrity: sha512-nrTOAXm+XUhi/NvkUbb5yRebf6+PBkZT8zkR2P57ot1f4IMGWMmBzk9JOSSSGiVeVUaakhOkLq/IUEtb71yWTw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.0-beta.178:
+    resolution: {integrity: sha512-kOfIbf23FDkvvfDHOS1gIjImBF9MlYut8fEMlps57vvS622VKL1PeEDLJ181aVd2LPSiDr3SupAMSzI2rEaW3w==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -17383,6 +17550,14 @@ packages:
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
+  crossws@0.4.6:
+    resolution: {integrity: sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
@@ -17724,6 +17899,29 @@ packages:
 
   dayjs@1.11.9:
     resolution: {integrity: sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==}
+
+  db0@0.3.4:
+    resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      better-sqlite3: '*'
+      drizzle-orm: '*'
+      mysql2: '*'
+      sqlite3: '*'
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mysql2:
+        optional: true
+      sqlite3:
+        optional: true
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -18361,6 +18559,24 @@ packages:
     resolution: {integrity: sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==}
     engines: {node: '>=10.17'}
 
+  env-runner@0.1.14:
+    resolution: {integrity: sha512-qdk5mmgFsd+zPg3r1bkZ+IbvpfUfypyDvNhMGypSMRpz7kOa/kI6SpW8fgyukuEM4Lo24M65r+1Ne0DtT7vFBA==}
+    hasBin: true
+    peerDependencies:
+      '@netlify/runtime': ^4.1.23
+      '@vercel/queue': ^0.2.0
+      miniflare: ^4.20260515.0
+      wrangler: ^4.0.0
+    peerDependenciesMeta:
+      '@netlify/runtime':
+        optional: true
+      '@vercel/queue':
+        optional: true
+      miniflare:
+        optional: true
+      wrangler:
+        optional: true
+
   envalid@8.0.0:
     resolution: {integrity: sha512-PGeYJnJB5naN0ME6SH8nFcDj9HVbLpYIfg1p5lAyM9T4cH2lwtu2fLbozC/bq+HUUOIFxhX/LP0/GmlqPHT4tQ==}
     engines: {node: '>=8.12'}
@@ -18584,6 +18800,47 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eve@0.11.6:
+    resolution: {integrity: sha512-GwQakJ9MmMAmqgcrQk36pwb4qez+S9Vmm5kSPxqD0zoGxIlUHPrcAFevj3tbw9U9PqNNBCLuzdahxTdgr5WfJA==}
+    engines: {node: '>=24'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/kit': ^2.60.1
+      ai: 7.0.0-beta.178
+      braintrust: ^3.0.0
+      just-bash: ^3.0.0
+      microsandbox: ^0.5.0
+      next: ^16.2.6
+      nuxt: ^4.0.0
+      react: ^19.0.0
+      svelte: 5.55.7
+      vite: ^8.0.0
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      braintrust:
+        optional: true
+      just-bash:
+        optional: true
+      microsandbox:
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vite:
+        optional: true
+      vue:
+        optional: true
+
   event-source-polyfill@1.0.31:
     resolution: {integrity: sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==}
 
@@ -18612,6 +18869,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@2.0.2:
@@ -18701,6 +18962,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   ext-list@2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
@@ -19506,6 +19770,16 @@ packages:
   h3@1.15.9:
     resolution: {integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==}
 
+  h3@2.0.1-rc.22:
+    resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -19652,6 +19926,9 @@ packages:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -19779,6 +20056,9 @@ packages:
 
   https@1.0.0:
     resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
+
+  httpxy@0.5.3:
+    resolution: {integrity: sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==}
 
   human-interval@2.0.1:
     resolution: {integrity: sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==}
@@ -22666,6 +22946,9 @@ packages:
       sass:
         optional: true
 
+  nf3@0.3.17:
+    resolution: {integrity: sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==}
+
   nice-napi@1.0.2:
     resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
     os: ['!win32']
@@ -22686,6 +22969,37 @@ packages:
 
   nise@6.1.5:
     resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
+
+  nitro@3.0.260610-beta:
+    resolution: {integrity: sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@vercel/queue': ^0.3.0
+      dotenv: '*'
+      giget: '*'
+      jiti: ^2.7.0
+      rollup: ^4.61.1
+      vite: ^7 || ^8
+      xml2js: ^0.6.2
+      zephyr-agent: ^0.2.0
+    peerDependenciesMeta:
+      '@vercel/queue':
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+      zephyr-agent:
+        optional: true
 
   no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
@@ -23049,6 +23363,15 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ocache@0.1.5:
+    resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
+
+  ofetch@2.0.0-alpha.3:
+    resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   ohm-js@16.6.0:
     resolution: {integrity: sha512-X9P4koSGa7swgVQ0gt71UCYtkAQGOjciJPJAz74kDxWt8nXbH5HrDOQG6qBDH7SR40ktNv4x61BwpTDE9q4lRA==}
@@ -25009,6 +25332,11 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  rolldown@1.1.1:
+    resolution: {integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@2.80.0:
     resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
     engines: {node: '>=10.0.0'}
@@ -25024,6 +25352,9 @@ packages:
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -25648,6 +25979,11 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@aws-sdk/client-sqs': ^3.971.0
+
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   sshpk@1.17.0:
     resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
@@ -26946,6 +27282,80 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
+  unstorage@2.0.0-alpha.7:
+    resolution: {integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.11.0
+      '@azure/cosmos': ^4.9.1
+      '@azure/data-tables': ^13.3.2
+      '@azure/identity': ^4.13.0
+      '@azure/keyvault-secrets': ^4.10.0
+      '@azure/storage-blob': ^12.31.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.13.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.36.2
+      '@vercel/blob': '>=0.27.3'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4 || ^5
+      db0: '>=0.3.4'
+      idb-keyval: ^6.2.2
+      ioredis: ^5.9.3
+      lru-cache: ^11.2.6
+      mongodb: ^6 || ^7
+      ofetch: '*'
+      uploadthing: ^7.7.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
+        optional: true
+      uploadthing:
+        optional: true
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -27911,6 +28321,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.20
 
+  '@ai-sdk/gateway@4.0.0-beta.109(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.19
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
   '@ai-sdk/langchain@2.0.73(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(@langchain/langgraph@1.1.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.20))(zod@3.25.20))(zod@3.25.20)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0)
@@ -27967,6 +28384,14 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.5
 
+  '@ai-sdk/provider-utils@5.0.0-beta.49(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.19
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/provider@3.0.3':
     dependencies:
       json-schema: 0.4.0
@@ -27976,6 +28401,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.7':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.0-beta.19':
     dependencies:
       json-schema: 0.4.0
 
@@ -28429,8 +28858,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -28783,11 +29212,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28826,6 +29255,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.575.0':
@@ -28914,11 +29344,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28957,7 +29387,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.575.0':
@@ -29174,7 +29603,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -29558,7 +29987,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -30236,7 +30665,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -32762,10 +33191,21 @@ snapshots:
     dependencies:
       '@edge-runtime/primitives': 3.0.3
 
+  '@emnapi/core@1.11.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.4.3':
     dependencies:
       '@emnapi/wasi-threads': 1.0.2
       tslib: 2.8.1
+
+  '@emnapi/runtime@1.11.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@1.4.3':
     dependencies:
@@ -32779,6 +33219,11 @@ snapshots:
   '@emnapi/wasi-threads@1.0.2':
     dependencies:
       tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emotion/babel-plugin@11.10.6':
     dependencies:
@@ -34840,6 +35285,13 @@ snapshots:
       '@emnapi/core': 1.4.3
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.9.0
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
+    dependencies:
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
 
   '@nestjs/axios@4.0.1(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.17.0)(rxjs@7.8.2)':
     dependencies:
@@ -37014,6 +37466,8 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+
+  '@oxc-project/types@0.135.0': {}
 
   '@oxc-resolver/binding-darwin-arm64@5.3.0':
     optional: true
@@ -39873,7 +40327,58 @@ snapshots:
       lodash: 4.18.1
       lodash-es: 4.18.1
 
+  '@rolldown/binding-android-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-commonjs@22.0.2(rollup@2.80.0)':
     dependencies:
@@ -42942,6 +43447,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
@@ -44027,6 +44537,8 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vercel/static-config@2.0.17':
     dependencies:
       ajv: 8.18.0
@@ -44545,6 +45057,8 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.7.26(@swc/helpers@0.5.15))(esbuild@0.28.1)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.9.0)(webpack@5.105.4)
 
+  '@workflow/serde@4.1.0': {}
+
   '@workflow/serde@4.1.0-beta.2': {}
 
   '@wry/context@0.4.4':
@@ -44783,6 +45297,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.13(zod@3.25.20)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.20
+
+  ai@7.0.0-beta.178(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.0-beta.109(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.0-beta.19
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.3.6)
+      zod: 4.3.6
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
@@ -46731,6 +47252,10 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  crossws@0.4.6(srvx@0.11.16):
+    optionalDependencies:
+      srvx: 0.11.16
+
   crypto-js@4.2.0: {}
 
   crypto-random-string@2.0.0: {}
@@ -47116,6 +47641,8 @@ snapshots:
   dayjs@1.11.19: {}
 
   dayjs@1.11.9: {}
+
+  db0@0.3.4: {}
 
   debug@2.6.9:
     dependencies:
@@ -47711,6 +48238,15 @@ snapshots:
       fromentries: 1.3.2
       java-properties: 1.0.2
 
+  env-runner@0.1.14(wrangler@4.68.1):
+    dependencies:
+      crossws: 0.4.6(srvx@0.11.16)
+      exsolve: 1.0.8
+      httpxy: 0.5.3
+      srvx: 0.11.16
+    optionalDependencies:
+      wrangler: 4.68.1
+
   envalid@8.0.0:
     dependencies:
       tslib: 2.6.2
@@ -48009,6 +48545,56 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eve@0.11.6(@opentelemetry/api@1.9.0)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.55.7(@typescript-eslint/types@8.39.1))(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.39.1))(typescript@5.6.2)(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(ai@7.0.0-beta.178(zod@4.3.6))(chokidar@4.0.3)(dotenv@17.4.1)(ioredis@5.11.1)(jiti@2.6.1)(lru-cache@11.5.1)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))(next@16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(svelte@5.55.7(@typescript-eslint/types@8.39.1))(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))(wrangler@4.68.1):
+    dependencies:
+      ai: 7.0.0-beta.178(zod@4.3.6)
+      nitro: 3.0.260610-beta(chokidar@4.0.3)(dotenv@17.4.1)(ioredis@5.11.1)(jiti@2.6.1)(lru-cache@11.5.1)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))(wrangler@4.68.1)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.55.7(@typescript-eslint/types@8.39.1))(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.39.1))(typescript@5.6.2)(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
+      next: 16.2.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      svelte: 5.55.7(@typescript-eslint/types@8.39.1)
+      vite: 6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/queue'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - dotenv
+      - drizzle-orm
+      - giget
+      - idb-keyval
+      - ioredis
+      - jiti
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - rollup
+      - sqlite3
+      - uploadthing
+      - wrangler
+      - xml2js
+      - zephyr-agent
+
   event-source-polyfill@1.0.31: {}
 
   event-stream@4.0.1:
@@ -48035,6 +48621,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@2.0.2: {}
 
@@ -48269,6 +48857,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  exsolve@1.0.8: {}
 
   ext-list@2.2.2:
     dependencies:
@@ -49314,6 +49904,13 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
+  h3@2.0.1-rc.22(crossws@0.4.6(srvx@0.11.16)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.16
+    optionalDependencies:
+      crossws: 0.4.6(srvx@0.11.16)
+
   hachure-fill@0.5.2: {}
 
   handlebars@4.7.9:
@@ -49545,6 +50142,8 @@ snapshots:
 
   hono@4.12.25: {}
 
+  hookable@6.1.1: {}
+
   hosted-git-info@2.8.9: {}
 
   hosted-git-info@4.1.0:
@@ -49737,6 +50336,8 @@ snapshots:
       - supports-color
 
   https@1.0.0: {}
+
+  httpxy@0.5.3: {}
 
   human-interval@2.0.1:
     dependencies:
@@ -53613,6 +54214,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nf3@0.3.17: {}
+
   nice-napi@1.0.2:
     dependencies:
       node-addon-api: 3.2.1
@@ -53649,6 +54252,58 @@ snapshots:
       '@sinonjs/fake-timers': 15.3.2
       just-extend: 6.2.0
       path-to-regexp: 8.4.2
+
+  nitro@3.0.260610-beta(chokidar@4.0.3)(dotenv@17.4.1)(ioredis@5.11.1)(jiti@2.6.1)(lru-cache@11.5.1)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))(vite@6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))(wrangler@4.68.1):
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.6(srvx@0.11.16)
+      db0: 0.3.4
+      env-runner: 0.1.14(wrangler@4.68.1)
+      h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.16))
+      hookable: 6.1.1
+      nf3: 0.3.17
+      ocache: 0.1.5
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      rolldown: 1.1.1
+      srvx: 0.11.16
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4)(ioredis@5.11.1)(lru-cache@11.5.1)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))(ofetch@2.0.0-alpha.3)
+    optionalDependencies:
+      dotenv: 17.4.1
+      jiti: 2.6.1
+      vite: 6.4.3(@types/node@22.15.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+      - wrangler
 
   no-case@2.3.2:
     dependencies:
@@ -54057,6 +54712,14 @@ snapshots:
   objectorarray@1.0.5: {}
 
   obug@2.1.1: {}
+
+  ocache@0.1.5:
+    dependencies:
+      ohash: 2.0.11
+
+  ofetch@2.0.0-alpha.3: {}
+
+  ohash@2.0.11: {}
 
   ohm-js@16.6.0: {}
 
@@ -56348,6 +57011,27 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  rolldown@1.1.1:
+    dependencies:
+      '@oxc-project/types': 0.135.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.1
+      '@rolldown/binding-darwin-arm64': 1.1.1
+      '@rolldown/binding-darwin-x64': 1.1.1
+      '@rolldown/binding-freebsd-x64': 1.1.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.1
+      '@rolldown/binding-linux-arm64-gnu': 1.1.1
+      '@rolldown/binding-linux-arm64-musl': 1.1.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.1
+      '@rolldown/binding-linux-s390x-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-musl': 1.1.1
+      '@rolldown/binding-openharmony-arm64': 1.1.1
+      '@rolldown/binding-wasm32-wasi': 1.1.1
+      '@rolldown/binding-win32-arm64-msvc': 1.1.1
+      '@rolldown/binding-win32-x64-msvc': 1.1.1
+
   rollup@2.80.0:
     optionalDependencies:
       fsevents: 2.3.3
@@ -56386,6 +57070,8 @@ snapshots:
   rope-sequence@1.3.4: {}
 
   rou3@0.7.12: {}
+
+  rou3@0.8.1: {}
 
   roughjs@4.6.6:
     dependencies:
@@ -57145,6 +57831,8 @@ snapshots:
   sqs-producer@8.0.4(@aws-sdk/client-sqs@3.996.0):
     dependencies:
       '@aws-sdk/client-sqs': 3.996.0
+
+  srvx@0.11.16: {}
 
   sshpk@1.17.0:
     dependencies:
@@ -58811,6 +59499,15 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  unstorage@2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4)(ioredis@5.11.1)(lru-cache@11.5.1)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))(ofetch@2.0.0-alpha.3):
+    optionalDependencies:
+      chokidar: 4.0.3
+      db0: 0.3.4
+      ioredis: 5.11.1
+      lru-cache: 11.5.1
+      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7)
+      ofetch: 2.0.0-alpha.3
 
   update-browserslist-db@1.2.3(browserslist@4.23.3):
     dependencies:


### PR DESCRIPTION
## Summary

Adds a new `@novu/eve` package that makes an [Eve](<https://eve.dev>) agent a first-class Novu "brain" through a **single unified Eve channel** — `novuChannel()`. The developer connects platforms (Slack, Teams, WhatsApp, in-app Inbox, email, …) in the Novu dashboard; all flow through this one channel. Agent **identity, delivery, and multi-channel orchestration live in Novu**, while **Eve drives the conversation**. Delivery rides Novu's existing agent reply flow — no new transport protocol is invented.

Built on `@novu/framework` (not `@novu/chat-adapter`), as a sibling package mirroring the `chat-adapter` layout. The key seam: `@novu/framework` re-exports its card components straight from the Chat SDK (`chat`), and Eve composes its Slack cards from that *same* card-builder — so Eve and Novu already speak one identical card vocabulary, no translation needed.

## What changed

New package `packages/eve` (`@novu/eve`), `eve@0.11.6` as dev + peer dependency:

* `channel.ts` — `novuChannel()`: `defineChannel` with one POST webhook (HMAC verify → parse `AgentBridgeRequest` → `send()`); `context()` factory exposing `channel.thread.post` + `channel.novu.{trigger,setMetadata,resolve,reply,subscriberId}`; zero-config default delivery (`message.completed` → reply, `session.completed` → resolve).
* `hitl.ts` — **cross-platform human-in-the-loop**: renders Eve's `input.requested` into Novu cards (shared Chat SDK builders); two-tier inbound round-trip (HITL click → `inputResponses` resume; custom action id → `onAction`).
* `tool.ts` — `novuTool()`: model-driven workflow trigger ("trigger + execute user code"), pure execute + ack, recipient defaults to the conversation subscriber.
* `token.ts` — continuation-token ⇄ conversation codec.
* `credentials.ts` — env-first resolution (`NOVU_SECRET_KEY` + `NOVU_AGENT_IDENTIFIER`) + `connectNovuCredentials`.
* `signature.ts` — Novu `novu-signature` HMAC verification.
* `reply-client.ts` — `NovuApiClient` (`reply()` → `/v1/agents/:id/reply`, `trigger()` → `/v1/events/trigger`).
* `index.ts` — exports the above + re-exports the `@novu/framework` surface (`workflow`/`step`, card components, protocol types) so Eve devs need a single dependency.
* Design spec: `docs/superpowers/specs/2026-06-19-novu-eve-integration-design.md`.

## Architecture

```mermaid
flowchart TD
  subgraph Novu["Novu Connect (unified layer)"]
    P["platforms · credentials · subscriber identity · preferences · delivery + fan-out"]
  end
  subgraph Eve["@novu/eve — single channel: novuChannel()"]
    B["NovuRequestHandler · AgentContext.reply()/signals · HITL↔card · token⇄conversationId"]
  end
  A["Eve agent (the brain)"]
  Novu -->|"(1) signed AgentBridgeRequest (any platform)"| Eve
  Eve -->|"(2) send(msg, {auth, continuationToken})"| A
  A -->|"(3) Eve runtime events"| Eve
  Eve -->|"(4) AgentReplyPayload + workflow triggers"| Novu
```

## Notes

* Additive only: brand-new package, no changes to existing apps/packages beyond `pnpm-lock.yaml`.
* No enterprise / community-edition gating needed (no runtime wiring into the API/worker yet).

## Test plan

- [X] `pnpm --filter @novu/eve build` green
- [X] `pnpm --filter @novu/eve test` — 32 unit tests pass (signature verify, token codec, credentials, HITL card mapping, `novuTool` trigger)
- [ ] Follow-ups (separate PRs): `views.ts` (`novuView` discovery), streaming via `ReplyHandle`, inbound attachments, freeform HITL text, `channel.integration.spec.ts`, `examples/` agent + README.

Made with [Cursor](<https://cursor.com>)

## What changed

The PR introduces `@novu/eve`, a new package that integrates Eve agents with Novu through a unified channel interface. It allows developers to connect Eve agents as a first-class "brain" within Novu, with agent identity, delivery, and orchestration managed in the dashboard while Eve drives conversation logic. The package includes webhook-based message handling, human-in-the-loop support, workflow triggering, HMAC signature verification, and continuation token management.

## Affected areas

* **eve** (new): Added complete `@novu/eve` package with core modules for channel integration (`novuChannel()`), HITL bidirectional bridging (mapping Eve input requests to Novu cards), workflow triggering (`novuTool()`), credential resolution with environment variable and handle-based overrides, HMAC-SHA256 signature verification, and continuation token encoding/decoding for session persistence. Package is built on `@novu/framework` as a sibling to `@novu/chat-adapter`.

## Key technical decisions

* Stateless HITL action encoding using deterministic base64url JSON payloads to avoid server-side session storage.
* Lazy credential resolution supporting both environment variables (`NOVU_SECRET_KEY`, `NOVU_AGENT_IDENTIFIER`) and Vercel-style handle-based suffixes for multi-tenant scenarios.
* HMAC-SHA256 signature verification with configurable timestamp freshness validation (max age window) and constant-time comparison for security.
* Subscriber-derived recipient defaulting for `novuTool()` workflow triggers, allowing implicit triggering to conversation participants.
* Two-tier action round-trip: HITL button clicks resume Eve sessions via `inputResponses`; arbitrary action IDs route through optional `onAction` handlers without re-invoking the model.

## Testing

Added 32 passing unit tests covering all core modules: channel webhook handling, credentials resolution, HITL action codec and card rendering, HMAC signature verification with tamper/expiration scenarios, continuation token round-trips, and workflow tool triggering.

### Greptile Summary

This PR introduces `@novu/eve`, a new standalone package that bridges Eve agents into Novu as a first-class channel. It is entirely additive — no existing packages are modified beyond `pnpm-lock.yaml`.

* `novuChannel()` (`channel.ts`) — a single unified Eve `defineChannel` webhook that performs HMAC verification, parses `AgentBridgeRequest`, routes HITL vs. custom actions, and exposes `channel.thread.*` / `channel.novu.*` helpers backed by a thin `NovuApiClient`.
* `novuTool()` (`tool.ts`) — an Eve `defineTool` wrapper that lets the model trigger Novu workflows; has a payload-construction bug when the model omits an explicit `payload` key (see inline comment).
* `connectNovuCredentials()` (`credentials.ts`) — Vercel Connect–style per-handle credential resolver; inconsistently skips the handle-suffixed env var for `agentIdentifier` while applying it for `secretKey` (see inline comment).

### Confidence Score: 3/5

New additive package with no changes to existing code, but two functional defects in the trigger and credential resolution paths need fixes before the package can be relied on.

The HMAC verification, token codec, and webhook routing are solid. Two bugs stand out: `novuTool` contaminates the Novu workflow payload with the `to` recipient key whenever the model uses the whole-input fallback, and `connectNovuCredentials` silently falls back to a global `NOVU_AGENT_IDENTIFIER` instead of the per-handle suffixed var, which would cause cross-tenant identifier bleed in multi-tenant Vercel Connect deployments. Both are straightforward single-line fixes but affect correctness on the changed paths.

`packages/eve/src/tool.ts` and `packages/eve/src/credentials.ts` need the targeted fixes; the rest of the package is clean.

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| packages/eve/src/tool.ts | novuTool() workflow trigger — `to` key leaks into the workflow payload when the model omits an explicit `payload` field, because the whole-input fallback includes all input keys including `to`. |
| packages/eve/src/credentials.ts | Credential resolution — `connectNovuCredentials` checks a handle-suffixed env var for `secretKey` but not for `agentIdentifier`, causing the global identifier to leak across tenants in multi-tenant Vercel Connect deployments. |
| packages/eve/src/channel.ts | Main novuChannel() webhook handler — HMAC verification, action routing (HITL vs custom), and session state construction look correct; waitUntil fire-and-forget pattern is appropriate for the Eve channel contract. |
| packages/eve/src/signature.ts | HMAC-SHA256 signature verification — correct constant-time comparison, timestamp freshness window, future-skew guard, and double-length check (hex string + decoded buffer) are all in place. |
| packages/eve/src/hitl.ts | HITL card rendering and action-id codec — deterministic base64url encoding is sound; `allowFreeform: true` with no options silently produces a non-interactive card (noted as future work but warrants a guard). |
| packages/eve/src/token.ts | Continuation-token codec — opaque base64url JSON round-trip with graceful null returns on malformed input; straightforward and well-tested. |
| packages/eve/src/reply-client.ts | Novu API client — lazy credential resolution per call, URL built from resolved apiBaseUrl (not from inbound request), error surfacing via thrown Error; all sound. |
| packages/eve/src/index.ts | Package barrel — re-exports novuChannel, novuTool, credentials helpers, and @novu/framework card/protocol types; no issues. |

</details>

### Sequence Diagram

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Novu as Novu Platform
    participant Channel as novuChannel() webhook
    participant Eve as Eve Runtime (send/waitUntil)
    participant Client as NovuApiClient

    Novu->>Channel: POST signed AgentBridgeRequest
    Channel->>Channel: verifyNovuSignature (HMAC-SHA256)
    alt action present
        Channel->>Channel: decodeHitlActionId
        alt HITL action
            Channel->>Eve: "waitUntil(send({inputResponses}, {auth, continuationToken, state}))"
        else custom action
            Channel->>Channel: onAction(action, context)
        end
    else message present
        Channel->>Eve: "waitUntil(send(text, {auth, continuationToken, state}))"
    end
    Channel-->>Novu: "200 { ok: true }"
    Eve->>Eve: run agent, emit events
    Eve->>Client: channel.thread.post / channel.novu.reply
    Client->>Novu: POST /v1/agents/:id/reply (AgentReplyPayload)
    Eve->>Client: channel.novu.trigger (optional)
    Client->>Novu: POST /v1/events/trigger
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Novu as Novu Platform
    participant Channel as novuChannel() webhook
    participant Eve as Eve Runtime (send/waitUntil)
    participant Client as NovuApiClient

    Novu->>Channel: POST signed AgentBridgeRequest
    Channel->>Channel: verifyNovuSignature (HMAC-SHA256)
    alt action present
        Channel->>Channel: decodeHitlActionId
        alt HITL action
            Channel->>Eve: "waitUntil(send({inputResponses}, {auth, continuationToken, state}))"
        else custom action
            Channel->>Channel: onAction(action, context)
        end
    else message present
        Channel->>Eve: "waitUntil(send(text, {auth, continuationToken, state}))"
    end
    Channel-->>Novu: "200 { ok: true }"
    Eve->>Eve: run agent, emit events
    Eve->>Client: channel.thread.post / channel.novu.reply
    Client->>Novu: POST /v1/agents/:id/reply (AgentReplyPayload)
    Eve->>Client: channel.novu.trigger (optional)
    Client->>Novu: POST /v1/events/trigger
```

<img src="https://camo.githubusercontent.com/7b58d0b1b405dbb5f8e8f9e186baa887dc0e1f286b6d6e6b00499fff86f7c59d/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f466978416c6c496e437572736f722e7376673f763d33 " alt="Fix All in Cursor" height="20" />

Prompt To Fix All With AI

```markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/eve/src/tool.ts:37-38
**`to` key leaks into the workflow payload on the whole-input fallback path**

When the model provides `{ to: 'sub_42', reason: 'disk full' }` without an explicit `payload` key, `payload` falls back to the entire `input` object — including `to`. The trigger body then becomes `{ name: workflow, to: 'sub_42', payload: { to: 'sub_42', reason: 'disk full' } }`, so the recipient ID contaminates the payload, potentially confusing downstream workflow step logic that inspects its payload. Strip the protocol keys before falling back to `input`.

```suggestion
      const to = input.to as TriggerRecipient | undefined;
      const explicitPayload = input.payload as Record<string, unknown> | undefined;
      // Strip the protocol keys so `to` never contaminates the workflow payload.
      const { to: _to, payload: _payload, ...restInput } = input;
      const payload = explicitPayload ?? restInput;
      await client.trigger(options.workflow, { to, payload });
```

### Issue 2 of 3
packages/eve/src/credentials.ts:65-74
**`connectNovuCredentials` never checks a handle-suffixed env var for `agentIdentifier`**

`NOVU_SECRET_KEY` is correctly keyed per handle (`NOVU_SECRET_KEY_NOVU_MY_AGENT`), but `agentIdentifier` is taken only from `overrides.agentIdentifier` or the global `NOVU_AGENT_IDENTIFIER`. In a multi-tenant Vercel Connect setup where each binding injects its own `NOVU_AGENT_IDENTIFIER_NOVU_MY_AGENT`, that variable is never read and the global identifier silently leaks across tenants.

```suggestion
      secretKey: overrides.secretKey ?? process.env[`NOVU_SECRET_KEY_${handleEnvSuffix(handle)}`],
      agentIdentifier:
        overrides.agentIdentifier ?? process.env[`NOVU_AGENT_IDENTIFIER_${handleEnvSuffix(handle)}`],
      apiBaseUrl: overrides.apiBaseUrl,
```

### Issue 3 of 3
packages/eve/src/hitl.ts:76-88
**`allowFreeform` requests with no options render an empty, non-interactive card**

When `allowFreeform: true` and `options` is absent or empty, `buttons` is `[]`, `children` stays empty, and the returned card has only a title — no actionable element. The `allowFreeform` field is declared on `RenderableInputRequest` but never read. A guard that returns `{ markdown: req.prompt }` for the freeform-only case would avoid silently sending a dead card until the full follow-up lands.
```

Reviews (1): Last reviewed commit: ["docs(eve): sync spec status — novuTool +..."](<https://github.com/novuhq/novu/commit/1cb97d307aad7864c1edd6a2c6f4ab3c323ba33d>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=39102330>)

> Greptile also left **3 inline comments** on this PR.