### PR TITLE
fix(api-service): remove setImmediate yielding in subscriber preferences hot path fixes NV-8111

### DIFF
--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -31,7 +31,6 @@ import {
   SeverityLevelEnum,
   WorkflowCriticalityEnum,
 } from '@novu/shared';
-import { chunk } from 'es-toolkit';
 import { GetSubscriberPreferenceCommand } from './get-subscriber-preference.command';
 
 @Injectable()
@@ -115,7 +114,7 @@ export class GetSubscriberPreference {
       return acc;
     }, {});
 
-    const workflowPreferences = await this.calculateWorkflowPreferences(
+    const workflowPreferences = this.calculateWorkflowPreferences(
       workflowList,
       workflowPreferenceSets,
       subscriberGlobalPreference,
@@ -144,72 +143,64 @@ export class GetSubscriberPreference {
   }
 
   @Instrument()
-  private async calculateWorkflowPreferences(
+  private calculateWorkflowPreferences(
     workflowList: NotificationTemplateEntity[],
     workflowPreferenceSets: Record<string, PreferenceSet>,
     subscriberGlobalPreference: PreferencesEntity | null,
     includeInactiveChannels: boolean
-  ): Promise<(ISubscriberPreferenceResponse | undefined)[]> {
-    const chunkSize = 30;
-    const results: (ISubscriberPreferenceResponse | undefined)[] = [];
+  ): ISubscriberPreferenceResponse[] {
+    /*
+     * Process all workflows synchronously. filterActive caps at 200 workflows and the
+     * CPU cost is ~1ms even at that ceiling (see NV-8111 profiling). The previous
+     * setImmediate-per-chunk yielding inflated NR-visible duration under concurrent load:
+     * each await queued behind thousands of other preference requests (~20-40ms per wait
+     * at moderate concurrency), which dominated p99 latency and saturated the event loop
+     * without reducing actual CPU work.
+     */
+    return workflowList
+      .map((workflow) => {
+        const preferences = workflowPreferenceSets[workflow._id];
 
-    const chunks = chunk(workflowList, chunkSize);
+        if (!preferences) {
+          return null;
+        }
 
-    for (const chunk of chunks) {
-      // Use setImmediate to yield to the event loop between chunks
-      await new Promise<void>((resolve) => {
-        setImmediate(() => resolve());
-      });
+        const merged = this.mergePreferences(preferences, subscriberGlobalPreference);
 
-      const chunkResults = chunk
-        .map((workflow) => {
-          const preferences = workflowPreferenceSets[workflow._id];
+        const includedChannels = this.getChannels(workflow, includeInactiveChannels);
 
-          if (!preferences) {
-            return null;
-          }
+        const initialChannels = filteredPreference(
+          {
+            email: true,
+            sms: true,
+            in_app: true,
+            chat: true,
+            push: true,
+          },
+          includedChannels
+        );
 
-          const merged = this.mergePreferences(preferences, subscriberGlobalPreference);
+        const { channels, overrides } = this.calculateChannelsAndOverrides(merged, initialChannels);
 
-          const includedChannels = this.getChannels(workflow, includeInactiveChannels);
-
-          const initialChannels = filteredPreference(
-            {
-              email: true,
-              sms: true,
-              in_app: true,
-              chat: true,
-              push: true,
-            },
-            includedChannels
-          );
-
-          const { channels, overrides } = this.calculateChannelsAndOverrides(merged, initialChannels);
-
-          const preference: ISubscriberPreferenceResponse = {
-            preference: {
-              channels,
-              enabled: true,
-              overrides,
-              ...(preferences.subscriberWorkflowPreference?.updatedAt && {
-                updatedAt: preferences.subscriberWorkflowPreference.updatedAt,
-              }),
-            },
-            template: mapTemplateConfiguration({
-              ...workflow,
-              critical: merged.preferences.all.readOnly,
+        const preference: ISubscriberPreferenceResponse = {
+          preference: {
+            channels,
+            enabled: true,
+            overrides,
+            ...(preferences.subscriberWorkflowPreference?.updatedAt && {
+              updatedAt: preferences.subscriberWorkflowPreference.updatedAt,
             }),
-            type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
-          };
+          },
+          template: {
+            ...mapTemplateConfiguration(workflow),
+            critical: merged.preferences.all.readOnly,
+          },
+          type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+        };
 
-          return preference;
-        })
-        .filter((item): item is ISubscriberPreferenceResponse => item !== null);
-
-      results.push(...chunkResults);
-    }
-
-    return results;
+        return preference;
+      })
+      .filter((item): item is ISubscriberPreferenceResponse => item !== null);
   }
 
   @Instrument()

--- a/packages/shared/src/utils/buildWorkflowPreferences.ts
+++ b/packages/shared/src/utils/buildWorkflowPreferences.ts
@@ -16,10 +16,18 @@ export const buildWorkflowPreferences = (
     return defaultPreferences;
   }
 
-  const defaultChannelPreference = {
-    // Only use the workflow-level enabled preference if defined
-    ...(inputPreferences?.all?.enabled !== undefined ? { enabled: inputPreferences.all.enabled } : {}),
-  };
+  const defaultChannelPreference =
+    inputPreferences.all?.enabled !== undefined ? { enabled: inputPreferences.all.enabled } : {};
+
+  const channels = { ...defaultPreferences.channels };
+
+  for (const channel of Object.values(ChannelTypeEnum)) {
+    channels[channel] = {
+      ...defaultPreferences.channels[channel],
+      ...defaultChannelPreference,
+      ...inputPreferences.channels?.[channel],
+    };
+  }
 
   return {
     ...defaultPreferences,
@@ -28,20 +36,7 @@ export const buildWorkflowPreferences = (
       // DeepPartial loosens json-logic types; assert back to the concrete workflow preference before merging.
       ...(inputPreferences.all as WorkflowPreference),
     },
-    channels: {
-      ...defaultPreferences.channels,
-      ...Object.values(ChannelTypeEnum).reduce(
-        (output, channel) => ({
-          ...output,
-          [channel]: {
-            ...defaultPreferences.channels[channel],
-            ...defaultChannelPreference,
-            ...inputPreferences?.channels?.[channel],
-          },
-        }),
-        {} as WorkflowPreferences['channels']
-      ),
-    },
+    channels,
   };
 };
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Follow-up to #11628 / [NV-8111](https://linear.app/novu/issue/NV-8111/api-cpu-saturation-on-get-v2subscriberssubscriberidpreferences-under). After deploy, New Relic still showed `calculateWorkflowPreferences` dominating request time (~685ms) with intermittent 20–30ms `mergePreferences` segments under concurrent load on orgs with ~50–60 workflows.

Profiling showed `mergePreferences` CPU is ~2µs per call — the NR spikes are event-loop queue wait mis-attributed to merge segments, not slow merge logic. The real issue was `setImmediate` yielding before every chunk in `calculateWorkflowPreferences`: under concurrency each `await` queued behind other preference requests (~37ms median per wait at 200 concurrent requests), inflating p99 latency while actual CPU work stays ~1ms even for 200 workflows.

**Changes:**
- Remove per-chunk `setImmediate` yielding; process workflows synchronously (`filterActive` caps at 200 workflows).
- Avoid spreading full workflow documents when mapping template config (only override `critical`).
- Reduce allocations in `buildWorkflowPreferences` (replace spread-in-reduce with a single channel loop).

```mermaid
sequenceDiagram
  participant NR as New Relic trace
  participant API as calculateWorkflowPreferences
  participant EL as Event loop queue

  Note over API,EL: Before (under load)
  API->>EL: await setImmediate (chunk 1)
  EL-->>API: wait ~37ms (queued behind other requests)
  API->>API: merge ~60 workflows (~0.4ms CPU)
  API->>EL: await setImmediate (chunk 2)
  EL-->>API: wait ~37ms again
  NR->>NR: attributes ~74ms+ to parent segment

  Note over API,EL: After
  API->>API: merge all workflows sync (~1ms CPU)
  NR->>NR: segment matches actual work
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The subscriber preferences endpoint performance was degraded by per-chunk `setImmediate` yielding in `calculateWorkflowPreferences`. Under concurrent load (200+ requests), each yield queued behind other preference requests, causing ~37ms median wait per workflow chunk despite actual CPU work being ~1ms. The fix removes per-chunk yielding and processes workflows synchronously, while avoiding unnecessary object spreading when mapping template configuration. Memory allocations in `buildWorkflowPreferences` are reduced by replacing inline reduce-based channel construction with a single precomputed loop.

## Affected areas

**api**: The `get-subscriber-preference` usecase was refactored to compute workflow preferences synchronously in a single pass instead of chunking with `setImmediate`, improving latency under concurrent load while maintaining identical API responses.

**shared**: The `buildWorkflowPreferences` utility was restructured to build channel preferences in a two-step process (compute default, then merge per-channel overrides), improving clarity and reducing memory allocations.

## Key technical decisions

- `calculateWorkflowPreferences` is now synchronous; workflows are processed in a single pass (capped at 200 by `filterActive`) instead of batched with event-loop yields.
- Template mapping avoids spreading full workflow documents; instead, only the `critical` field is overridden post-mapping.
- No API contract changes—preference responses are byte-identical to before.
- Removed dependency on `chunk` utility from `es-toolkit`.

## Testing

Existing unit tests in `packages/shared` pass without modification. No new tests were added because the functionality and output remain identical; this is a performance optimization with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — backend performance fix.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Byte-identical preference responses; no API contract change.
- `packages/shared` `buildWorkflowPreferences` change is allocation-only; existing unit tests pass.
- Expect NR `calculateWorkflowPreferences` and `mergePreferences` segment times to drop sharply under concurrent load after deploy.

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR speeds up subscriber preference calculation in the hot path. The main changes are:

- Removes per-chunk `setImmediate` yielding from workflow preference calculation.
- Processes workflow preferences synchronously after the active workflow cap.
- Maps template configuration without spreading full workflow documents.
- Rewrites workflow preference channel merging to reduce allocations.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to synchronous preference calculation and allocation reductions with no API contract changes identified.

No correctness issues were found in the modified hot path, and the implementation preserves the existing workflow cap and preference response shape while removing event-loop yielding overhead.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a before/after artifact comparison to observe changes in sourceMode.hasSetImmediate and isAsync, confirmed 180 responses with the same SHA256, and saved the shared-stem logs and executable harness under trex-artifacts.

<a href="https://app.greptile.com/trex/runs/11980416/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): remove setImmediate yielding i..."](https://github.com/novuhq/novu/commit/be289c9cca4bde224afc644e930bb54cc0bc05da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39253195)</sub>

<!-- /greptile_comment -->