### PR TITLE
feat(dashboard): add agent overview what's next section fixes NV-8115

### DIFF
--- a/apps/dashboard/.env.agent
+++ b/apps/dashboard/.env.agent
@@ -3,6 +3,8 @@ VITE_LAUNCH_DARKLY_CLIENT_SIDE_ID=
 
 # Provider-managed MCP ("Add from Claude"). Used when VITE_LAUNCH_DARKLY_CLIENT_SIDE_ID is unset.
 VITE_IS_MCP_PROVIDER_MANAGED_ENABLED=true
+# Agent overview "What's next" section. Vite env fallback when LD client id is unset.
+VITE_IS_AGENT_WHATS_NEXT_ENABLED=true
 VITE_HUBSPOT_EMBED=
 VITE_API_HOSTNAME=http://localhost:3000
 VITE_WEBSOCKET_HOSTNAME=http://localhost:3002

--- a/apps/dashboard/.example.env
+++ b/apps/dashboard/.example.env
@@ -3,6 +3,8 @@ VITE_LAUNCH_DARKLY_CLIENT_SIDE_ID=
 
 # Provider-managed MCP ("Add from Claude"). Vite env fallback when LD client id is unset.
 # VITE_IS_MCP_PROVIDER_MANAGED_ENABLED=true
+# Agent overview "What's next" section. Vite env fallback when LD client id is unset.
+# VITE_IS_AGENT_WHATS_NEXT_ENABLED=true
 VITE_HUBSPOT_EMBED=
 VITE_API_HOSTNAME=http://localhost:3000
 # VITE_AGENT_API_HOSTNAME=https://your-tunnel.ngrok.app

--- a/apps/dashboard/src/components/agents/agent-connected-overview.tsx
+++ b/apps/dashboard/src/components/agents/agent-connected-overview.tsx
@@ -1,5 +1,6 @@
 import type { AgentResponse } from '@/api/agents';
 import { AgentBehaviorSection } from './agent-behavior-section';
+import { AgentWhatsNextSection } from './agent-whats-next-section';
 import { ConnectedProvidersSection } from './connected-providers-section';
 import { RecentConversationsSection } from './recent-conversations-section';
 
@@ -10,6 +11,7 @@ type AgentConnectedOverviewProps = {
 export function AgentConnectedOverview({ agent }: AgentConnectedOverviewProps) {
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-4 w-full">
+      <AgentWhatsNextSection agent={agent} />
       <AgentBehaviorSection agent={agent} />
       <ConnectedProvidersSection agent={agent} />
       <RecentConversationsSection agent={agent} />

--- a/apps/dashboard/src/components/agents/agent-managed-overview.tsx
+++ b/apps/dashboard/src/components/agents/agent-managed-overview.tsx
@@ -1,4 +1,4 @@
-import { EmailProviderIdEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
@@ -7,9 +7,11 @@ import { useAgentDemoQuota } from '@/hooks/use-agent-demo-quota';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { RecentConversationsSection } from '../agents/recent-conversations-section';
 import { AgentSetupGuide } from './agent-setup-guide';
+import { AgentWhatsNextSection } from './agent-whats-next-section';
 import { ConnectedProvidersSection } from './connected-providers-section';
 import { DemoClaudeUpgradePanel } from './demo-claude-upgrade-panel';
 import { DemoQuotaBanner } from './demo-quota-banner';
+import { isUserFacingConnectedAgentIntegration } from './is-agent-integration-connected';
 import { McpsSection } from './mcps-section';
 import { SystemPromptSection } from './system-prompt-section';
 import { ToolsSection } from './tools-section';
@@ -40,11 +42,12 @@ export function AgentManagedOverview({ agent }: AgentManagedOverviewProps) {
   // guide would never surface for a freshly created managed agent.
   const hasConnectedChannel = useMemo(() => {
     const links = integrationsQuery.data?.data;
-    if (!links?.length) return false;
 
-    return links.some(
-      (link) => Boolean(link.connectedAt) && link.integration.providerId !== EmailProviderIdEnum.NovuAgent
-    );
+    if (!links?.length) {
+      return false;
+    }
+
+    return links.some(isUserFacingConnectedAgentIntegration);
   }, [integrationsQuery.data?.data]);
 
   const showSetupGuide = integrationsQuery.isSuccess && !hasConnectedChannel;
@@ -54,6 +57,7 @@ export function AgentManagedOverview({ agent }: AgentManagedOverviewProps) {
       {isDemoManagedClaudeEnabled && demoQuotaQuery.data ? (
         <DemoQuotaBanner quota={demoQuotaQuery.data} onUpgrade={() => setUpgradeOpen(true)} />
       ) : null}
+      <AgentWhatsNextSection agent={agent} />
       {showSetupGuide ? <AgentSetupGuide agent={agent} /> : <ConnectedProvidersSection agent={agent} />}
       <McpsSection agent={agent} />
       <SystemPromptSection agent={agent} />

--- a/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
@@ -1,0 +1,259 @@
+import { FeatureFlagsKeysEnum, providers as novuProviders } from '@novu/shared';
+import { useQuery } from '@tanstack/react-query';
+import { CircleDashed } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { RiArrowRightSLine } from 'react-icons/ri';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  type AgentIntegrationLink,
+  type AgentResponse,
+  getAgentIntegrationsQueryKey,
+  listAgentIntegrations,
+} from '@/api/agents';
+import { ProviderIcon } from '@/components/integrations/components/provider-icon';
+import { Button } from '@/components/primitives/button';
+import TruncatedText from '@/components/truncated-text';
+import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { buildRoute } from '@/utils/routes';
+import { cn } from '@/utils/ui';
+import { isUserFacingConnectedAgentIntegration } from './is-agent-integration-connected';
+import { SetupGuideCard } from './setup-guide-card';
+import { SetupStep } from './setup-guide-primitives';
+
+const COLLAPSED_LIST_MAX_HEIGHT_PX = 150;
+const BOTTOM_FADE_HEIGHT_PX = 43;
+const COLLAPSED_VISIBLE_CHANNEL_COUNT = 4;
+
+type AgentWhatsNextSectionProps = {
+  agent: AgentResponse;
+};
+
+function buildVerticalBottomFadeMask(showFade: boolean): string | undefined {
+  if (!showFade) {
+    return undefined;
+  }
+
+  const fadeStart = COLLAPSED_LIST_MAX_HEIGHT_PX - BOTTOM_FADE_HEIGHT_PX;
+
+  return `linear-gradient(to bottom, black 0, black ${fadeStart}px, transparent 100%)`;
+}
+
+function ConfigureChannelButton({ link, onConfigure }: { link: AgentIntegrationLink; onConfigure: () => void }) {
+  const providerMeta = novuProviders.find((p) => p.id === link.integration.providerId);
+  const displayName = providerMeta?.displayName ?? link.integration.name;
+
+  return (
+    <button
+      type="button"
+      onClick={onConfigure}
+      className={cn(
+        'flex w-full max-w-[210px] items-center gap-0.5 overflow-hidden rounded-md p-1.5',
+        'bg-bg-white bg-[linear-gradient(180deg,rgba(0,0,0,0)_30%,rgba(0,0,0,0.02)_100%)]',
+        'shadow-[0px_1px_3px_0px_rgba(14,18,27,0.12),0px_0px_0px_1px_#e1e4ea]',
+        'transition-shadow hover:shadow-[0px_1px_3px_0px_rgba(14,18,27,0.16),0px_0px_0px_1px_#cdd0d8]'
+      )}
+    >
+      <CircleDashed className="text-text-sub size-4 shrink-0" />
+      <span className="text-text-sub text-label-xs flex min-w-0 flex-1 items-center gap-1 px-1 font-medium">
+        <span className="shrink-0">Configure</span>
+        <span className="bg-bg-weak border-stroke-soft/50 flex min-w-0 shrink items-center gap-1 rounded border px-1 py-0.5">
+          <ProviderIcon
+            providerId={link.integration.providerId}
+            providerDisplayName={displayName}
+            className="size-[15px] shrink-0"
+          />
+          <TruncatedText className="text-text-strong min-w-0">{displayName}</TruncatedText>
+        </span>
+      </span>
+      <RiArrowRightSLine className="text-text-sub size-4 shrink-0" />
+    </button>
+  );
+}
+
+function ChannelList({
+  links,
+  onConfigure,
+}: {
+  links: AgentIntegrationLink[];
+  onConfigure: (link: AgentIntegrationLink) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [showBottomFade, setShowBottomFade] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const updateBottomFade = useCallback(() => {
+    const node = listRef.current;
+
+    if (!node || isExpanded) {
+      setShowBottomFade(false);
+
+      return;
+    }
+
+    const hasOverflow = node.scrollHeight > node.clientHeight + 1;
+    const isScrolledToBottom = node.scrollTop + node.clientHeight >= node.scrollHeight - 1;
+
+    setShowBottomFade(hasOverflow && !isScrolledToBottom);
+  }, [isExpanded]);
+
+  useEffect(() => {
+    updateBottomFade();
+  }, [links.length, isExpanded, updateBottomFade]);
+
+  useEffect(() => {
+    const node = listRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    node.addEventListener('scroll', updateBottomFade, { passive: true });
+
+    const resizeObserver = new ResizeObserver(updateBottomFade);
+    resizeObserver.observe(node);
+
+    return () => {
+      node.removeEventListener('scroll', updateBottomFade);
+      resizeObserver.disconnect();
+    };
+  }, [updateBottomFade]);
+
+  const handleConfigure = (link: AgentIntegrationLink) => {
+    onConfigure(link);
+  };
+
+  const handleShowAll = () => {
+    setIsExpanded(true);
+  };
+
+  const isCollapsible = links.length > COLLAPSED_VISIBLE_CHANNEL_COUNT;
+  const isListCollapsed = isCollapsible && !isExpanded;
+
+  return (
+    <div className="flex w-full max-w-[210px] flex-col gap-2.5">
+      <div
+        ref={listRef}
+        className={cn('flex w-full flex-col gap-2.5', isListCollapsed && 'max-h-[150px] overflow-y-auto')}
+        style={{
+          maskImage: buildVerticalBottomFadeMask(showBottomFade),
+          WebkitMaskImage: buildVerticalBottomFadeMask(showBottomFade),
+        }}
+      >
+        {links.map((link) => (
+          <ConfigureChannelButton key={link._id} link={link} onConfigure={() => handleConfigure(link)} />
+        ))}
+      </div>
+      {isListCollapsed ? (
+        <button
+          type="button"
+          onClick={handleShowAll}
+          className="text-text-sub hover:text-text-strong flex items-center gap-0.5 self-start transition-colors"
+        >
+          <span className="text-label-xs font-medium">Show all ({links.length})</span>
+          <RiArrowRightSLine className="size-4" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function AddChannelButton({ onAddChannel }: { onAddChannel: () => void }) {
+  return (
+    <Button
+      variant="secondary"
+      mode="outline"
+      size="xs"
+      type="button"
+      className="text-text-sub max-w-[210px] gap-1 px-1.5 py-1.5"
+      onClick={onAddChannel}
+      trailingIcon={RiArrowRightSLine}
+    >
+      Add channel
+    </Button>
+  );
+}
+
+export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
+  const isWhatsNextEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_AGENT_WHATS_NEXT_ENABLED);
+  const { currentEnvironment } = useEnvironment();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const agentRoutes = useAgentRoutes();
+
+  const integrationsQuery = useQuery({
+    queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier),
+    queryFn: () =>
+      listAgentIntegrations({
+        environment: requireEnvironment(currentEnvironment, 'No environment selected'),
+        agentIdentifier: agent.identifier,
+        limit: 100,
+      }),
+    enabled: Boolean(currentEnvironment && agent.identifier),
+  });
+
+  const links = integrationsQuery.data?.data ?? [];
+  const connectedLinks = useMemo(() => links.filter(isUserFacingConnectedAgentIntegration), [links]);
+
+  const integrationsTabPath = `${buildRoute(agentRoutes.detailsTab, {
+    environmentSlug: currentEnvironment?.slug ?? '',
+    agentIdentifier: encodeURIComponent(agent.identifier),
+    agentTab: 'integrations',
+  })}${location.search}`;
+
+  const handleConfigureChannel = useCallback(
+    (link: AgentIntegrationLink) => {
+      const integrationDetailPath = `${buildRoute(agentRoutes.integrationDetail, {
+        environmentSlug: currentEnvironment?.slug ?? '',
+        agentIdentifier: encodeURIComponent(agent.identifier),
+        integrationIdentifier: encodeURIComponent(link.integration.identifier),
+      })}${location.search}`;
+
+      navigate(integrationDetailPath);
+    },
+    [agent.identifier, agentRoutes.integrationDetail, currentEnvironment?.slug, location.search, navigate]
+  );
+
+  const handleAddChannel = useCallback(() => {
+    navigate(integrationsTabPath);
+  }, [integrationsTabPath, navigate]);
+
+  if (!isWhatsNextEnabled) {
+    return null;
+  }
+
+  if (integrationsQuery.isLoading || integrationsQuery.isError || connectedLinks.length === 0) {
+    return null;
+  }
+
+  const persistKey = `agent-whats-next:${agent.identifier}`;
+
+  return (
+    <SetupGuideCard label="What's next" persistKey={persistKey} className="min-w-0 flex-1">
+      <div className="relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-3 md:pr-6">
+        <div
+          className="absolute bottom-0 left-[22px] top-0 w-px"
+          style={{
+            background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+          }}
+        />
+        <SetupStep
+          index={1}
+          status="current"
+          sectionLabel="FOR YOUR USERS"
+          title="Setup channels for your users"
+          description="Setup the channels to let your users easily connect to this agent on wherever they are."
+          rightContent={<ChannelList links={connectedLinks} onConfigure={handleConfigureChannel} />}
+        />
+        <SetupStep
+          index={2}
+          status="current"
+          title="Add another channel"
+          description="Add another channel provider for your users to message and interact with your agent."
+          rightContent={<AddChannelButton onAddChannel={handleAddChannel} />}
+        />
+      </div>
+    </SetupGuideCard>
+  );
+}

--- a/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
@@ -22,22 +22,32 @@ import { isUserFacingConnectedAgentIntegration } from './is-agent-integration-co
 import { SetupGuideCard } from './setup-guide-card';
 import { SetupStep } from './setup-guide-primitives';
 
-const COLLAPSED_LIST_MAX_HEIGHT_PX = 150;
-const BOTTOM_FADE_HEIGHT_PX = 43;
+const FADE_HEIGHT_PX = 43;
 const COLLAPSED_VISIBLE_CHANNEL_COUNT = 4;
+// Collapsed height fits exactly 4 rows (matches the Figma "What's next" spec).
+const COLLAPSED_LIST_MAX_HEIGHT_PX = 150;
 
 type AgentWhatsNextSectionProps = {
   agent: AgentResponse;
 };
 
-function buildVerticalBottomFadeMask(showFade: boolean): string | undefined {
-  if (!showFade) {
+function buildVerticalFadeMask(
+  showTopFade: boolean,
+  showBottomFade: boolean,
+  listHeightPx: number
+): string | undefined {
+  if (!showTopFade && !showBottomFade) {
     return undefined;
   }
 
-  const fadeStart = COLLAPSED_LIST_MAX_HEIGHT_PX - BOTTOM_FADE_HEIGHT_PX;
+  const topStart = showTopFade ? 'transparent 0' : 'black 0';
+  const topStop = showTopFade ? `black ${FADE_HEIGHT_PX}px` : '';
+  const bottomStop = showBottomFade ? `black ${Math.max(0, listHeightPx - FADE_HEIGHT_PX)}px` : '';
+  const bottomEnd = showBottomFade ? 'transparent 100%' : 'black 100%';
 
-  return `linear-gradient(to bottom, black 0, black ${fadeStart}px, transparent 100%)`;
+  const stops = [topStart, topStop, bottomStop, bottomEnd].filter(Boolean).join(', ');
+
+  return `linear-gradient(to bottom, ${stops})`;
 }
 
 function ConfigureChannelButton({ link, onConfigure }: { link: AgentIntegrationLink; onConfigure: () => void }) {
@@ -49,7 +59,7 @@ function ConfigureChannelButton({ link, onConfigure }: { link: AgentIntegrationL
       type="button"
       onClick={onConfigure}
       className={cn(
-        'flex w-full max-w-[210px] items-center gap-0.5 overflow-hidden rounded-md p-1.5',
+        'flex w-full max-w-[210px] shrink-0 items-center gap-0.5 overflow-hidden rounded-md p-1.5',
         'bg-bg-white bg-[linear-gradient(180deg,rgba(0,0,0,0)_30%,rgba(0,0,0,0.02)_100%)]',
         'shadow-[0px_1px_3px_0px_rgba(14,18,27,0.12),0px_0px_0px_1px_#e1e4ea]',
         'transition-shadow hover:shadow-[0px_1px_3px_0px_rgba(14,18,27,0.16),0px_0px_0px_1px_#cdd0d8]'
@@ -80,27 +90,35 @@ function ChannelList({
   onConfigure: (link: AgentIntegrationLink) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showTopFade, setShowTopFade] = useState(false);
   const [showBottomFade, setShowBottomFade] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
 
-  const updateBottomFade = useCallback(() => {
+  const isCollapsible = links.length > COLLAPSED_VISIBLE_CHANNEL_COUNT;
+  // Collapsed: bounded + scrollable. Expanded: unbounded so the full list is revealed.
+  const listMaxHeightPx = isExpanded ? undefined : COLLAPSED_LIST_MAX_HEIGHT_PX;
+
+  const updateFades = useCallback(() => {
     const node = listRef.current;
 
-    if (!node || isExpanded) {
+    if (!node || !isCollapsible) {
+      setShowTopFade(false);
       setShowBottomFade(false);
 
       return;
     }
 
     const hasOverflow = node.scrollHeight > node.clientHeight + 1;
+    const isScrolledToTop = node.scrollTop <= 1;
     const isScrolledToBottom = node.scrollTop + node.clientHeight >= node.scrollHeight - 1;
 
+    setShowTopFade(hasOverflow && !isScrolledToTop);
     setShowBottomFade(hasOverflow && !isScrolledToBottom);
-  }, [isExpanded]);
+  }, [isCollapsible]);
 
   useEffect(() => {
-    updateBottomFade();
-  }, [links.length, isExpanded, updateBottomFade]);
+    updateFades();
+  }, [links.length, isExpanded, updateFades]);
 
   useEffect(() => {
     const node = listRef.current;
@@ -109,50 +127,52 @@ function ChannelList({
       return;
     }
 
-    node.addEventListener('scroll', updateBottomFade, { passive: true });
+    node.addEventListener('scroll', updateFades, { passive: true });
 
-    const resizeObserver = new ResizeObserver(updateBottomFade);
+    const resizeObserver = new ResizeObserver(updateFades);
     resizeObserver.observe(node);
 
     return () => {
-      node.removeEventListener('scroll', updateBottomFade);
+      node.removeEventListener('scroll', updateFades);
       resizeObserver.disconnect();
     };
-  }, [updateBottomFade]);
+  }, [updateFades]);
 
   const handleConfigure = (link: AgentIntegrationLink) => {
     onConfigure(link);
   };
 
-  const handleShowAll = () => {
-    setIsExpanded(true);
+  const handleToggle = () => {
+    setIsExpanded((prev) => !prev);
   };
-
-  const isCollapsible = links.length > COLLAPSED_VISIBLE_CHANNEL_COUNT;
-  const isListCollapsed = isCollapsible && !isExpanded;
 
   return (
     <div className="flex w-full max-w-[210px] flex-col gap-2.5">
       <div
         ref={listRef}
-        className={cn('flex w-full flex-col gap-2.5', isListCollapsed && 'max-h-[150px] overflow-y-auto')}
+        className={cn(
+          'flex w-full flex-col gap-2.5',
+          // 1px padding keeps each row's box-shadow border ring from being clipped by the overflow container.
+          isCollapsible && 'overflow-y-auto p-px'
+        )}
         style={{
-          maskImage: buildVerticalBottomFadeMask(showBottomFade),
-          WebkitMaskImage: buildVerticalBottomFadeMask(showBottomFade),
+          maxHeight: isCollapsible ? listMaxHeightPx : undefined,
+          maskImage: buildVerticalFadeMask(showTopFade, showBottomFade, COLLAPSED_LIST_MAX_HEIGHT_PX),
+          WebkitMaskImage: buildVerticalFadeMask(showTopFade, showBottomFade, COLLAPSED_LIST_MAX_HEIGHT_PX),
         }}
       >
         {links.map((link) => (
           <ConfigureChannelButton key={link._id} link={link} onConfigure={() => handleConfigure(link)} />
         ))}
       </div>
-      {isListCollapsed ? (
+      {isCollapsible ? (
         <button
           type="button"
-          onClick={handleShowAll}
+          onClick={handleToggle}
           className="text-text-sub hover:text-text-strong flex items-center gap-0.5 self-start transition-colors"
         >
-          <span className="text-label-xs font-medium">Show all ({links.length})</span>
-          <RiArrowRightSLine className="size-4" />
+          <span className="text-label-xs font-medium">{isExpanded ? 'Show less' : `Show all (${links.length})`}</span>
+          <RiArrowRightSLine className={cn('size-4 transition-transform', isExpanded && '-rotate-90')} />
         </button>
       ) : null}
     </div>

--- a/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
@@ -50,14 +50,20 @@ function buildVerticalFadeMask(
   return `linear-gradient(to bottom, ${stops})`;
 }
 
-function ConfigureChannelButton({ link, onConfigure }: { link: AgentIntegrationLink; onConfigure: () => void }) {
+function ConfigureChannelButton({
+  link,
+  onConfigure,
+}: {
+  link: AgentIntegrationLink;
+  onConfigure: (link: AgentIntegrationLink) => void;
+}) {
   const providerMeta = novuProviders.find((p) => p.id === link.integration.providerId);
   const displayName = providerMeta?.displayName ?? link.integration.name;
 
   return (
     <button
       type="button"
-      onClick={onConfigure}
+      onClick={() => onConfigure(link)}
       className={cn(
         'flex w-full max-w-[210px] shrink-0 items-center gap-0.5 overflow-hidden rounded-md p-1.5',
         'bg-bg-white bg-[linear-gradient(180deg,rgba(0,0,0,0)_30%,rgba(0,0,0,0.02)_100%)]',
@@ -138,10 +144,6 @@ function ChannelList({
     };
   }, [updateFades]);
 
-  const handleConfigure = (link: AgentIntegrationLink) => {
-    onConfigure(link);
-  };
-
   const handleToggle = () => {
     setIsExpanded((prev) => !prev);
   };
@@ -162,7 +164,7 @@ function ChannelList({
         }}
       >
         {links.map((link) => (
-          <ConfigureChannelButton key={link._id} link={link} onConfigure={() => handleConfigure(link)} />
+          <ConfigureChannelButton key={link._id} link={link} onConfigure={onConfigure} />
         ))}
       </div>
       {isCollapsible ? (

--- a/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
@@ -210,7 +210,7 @@ export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
         agentIdentifier: agent.identifier,
         limit: 100,
       }),
-    enabled: Boolean(currentEnvironment && agent.identifier),
+    enabled: Boolean(isWhatsNextEnabled && currentEnvironment && agent.identifier),
   });
 
   const links = integrationsQuery.data?.data ?? [];
@@ -247,7 +247,7 @@ export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
     return null;
   }
 
-  const persistKey = `agent-whats-next:${agent.identifier}`;
+  const persistKey = `agent-whats-next:${currentEnvironment?.slug ?? ''}:${agent.identifier}`;
 
   return (
     <SetupGuideCard label="What's next" persistKey={persistKey} className="min-w-0 flex-1">

--- a/apps/dashboard/src/components/agents/is-agent-integration-connected.ts
+++ b/apps/dashboard/src/components/agents/is-agent-integration-connected.ts
@@ -19,3 +19,13 @@ export function isAgentIntegrationConnected(link: Pick<AgentIntegrationLink, 'co
 
   return link.integration.providerId === EmailProviderIdEnum.NovuAgent;
 }
+
+/**
+ * User-configured channels only. Excludes the auto-provisioned Novu Email
+ * integration so setup/onboarding flows stay aligned with managed-agent state.
+ */
+export function isUserFacingConnectedAgentIntegration(
+  link: Pick<AgentIntegrationLink, 'connectedAt' | 'integration'>
+): boolean {
+  return Boolean(link.connectedAt) && link.integration.providerId !== EmailProviderIdEnum.NovuAgent;
+}

--- a/apps/dashboard/src/components/agents/is-agent-integration-connected.ts
+++ b/apps/dashboard/src/components/agents/is-agent-integration-connected.ts
@@ -1,6 +1,16 @@
 import { EmailProviderIdEnum } from '@novu/shared';
 import type { AgentIntegrationLink } from '@/api/agents';
 
+function hasMeaningfulConnectedAt(connectedAt: string | null | undefined): boolean {
+  if (!connectedAt) {
+    return false;
+  }
+
+  const timestampMs = new Date(connectedAt).getTime();
+
+  return !Number.isNaN(timestampMs) && timestampMs > 0;
+}
+
 /**
  * Returns whether an agent–integration link should be presented as "Connected"
  * in the dashboard.
@@ -15,7 +25,7 @@ import type { AgentIntegrationLink } from '@/api/agents';
  * agent that already has a working shared inbox.
  */
 export function isAgentIntegrationConnected(link: Pick<AgentIntegrationLink, 'connectedAt' | 'integration'>): boolean {
-  if (link.connectedAt) return true;
+  if (hasMeaningfulConnectedAt(link.connectedAt)) return true;
 
   return link.integration.providerId === EmailProviderIdEnum.NovuAgent;
 }
@@ -27,5 +37,5 @@ export function isAgentIntegrationConnected(link: Pick<AgentIntegrationLink, 'co
 export function isUserFacingConnectedAgentIntegration(
   link: Pick<AgentIntegrationLink, 'connectedAt' | 'integration'>
 ): boolean {
-  return Boolean(link.connectedAt) && link.integration.providerId !== EmailProviderIdEnum.NovuAgent;
+  return hasMeaningfulConnectedAt(link.connectedAt) && link.integration.providerId !== EmailProviderIdEnum.NovuAgent;
 }

--- a/apps/dashboard/src/components/agents/setup-guide-card.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-card.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
 import { cn } from '@/utils/ui';
 
@@ -7,18 +7,50 @@ type SetupGuideCardProps = {
   rightContent?: React.ReactNode;
   children: React.ReactNode;
   className?: string;
+  /** When set, persist collapsed/expanded state in localStorage under this key. */
+  persistKey?: string;
 };
 
-export function SetupGuideCard({ label, rightContent, children, className }: SetupGuideCardProps) {
-  const [isExpanded, setIsExpanded] = useState(true);
+function readPersistedExpanded(persistKey: string): boolean {
+  try {
+    const stored = localStorage.getItem(persistKey);
+
+    if (stored === 'false') {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+function writePersistedExpanded(persistKey: string, expanded: boolean) {
+  try {
+    localStorage.setItem(persistKey, String(expanded));
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
+export function SetupGuideCard({ label, rightContent, children, className, persistKey }: SetupGuideCardProps) {
+  const [isExpanded, setIsExpanded] = useState(() => (persistKey ? readPersistedExpanded(persistKey) : true));
+
+  const handleToggle = useCallback(() => {
+    setIsExpanded((prev) => {
+      const next = !prev;
+
+      if (persistKey) {
+        writePersistedExpanded(persistKey, next);
+      }
+
+      return next;
+    });
+  }, [persistKey]);
 
   return (
     <div className={cn('bg-bg-weak flex flex-col rounded-[10px] p-1', className)}>
-      <button
-        type="button"
-        className="flex w-full items-center justify-between px-2 py-1.5"
-        onClick={() => setIsExpanded((prev) => !prev)}
-      >
+      <button type="button" className="flex w-full items-center justify-between px-2 py-1.5" onClick={handleToggle}>
         <span className="font-code text-text-sub text-[12px] uppercase leading-4 tracking-[-0.24px]">{label}</span>
         <div className="flex items-center gap-2">
           {rightContent}

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -96,6 +96,8 @@ export enum FeatureFlagsKeysEnum {
   IS_MANAGED_AGENT_RUNTIME_ENABLED = 'IS_MANAGED_AGENT_RUNTIME_ENABLED',
   /** Enable Novu-managed demo Claude provider auto-provisioned on dev environments. Create the boolean in LaunchDarkly for cloud, or set `VITE_IS_DEMO_MANAGED_CLAUDE_ENABLED` when self-hosted. */
   IS_DEMO_MANAGED_CLAUDE_ENABLED = 'IS_DEMO_MANAGED_CLAUDE_ENABLED',
+  /** Enable the "What's next" section on the agent overview. Create the boolean in LaunchDarkly for cloud, or set `VITE_IS_AGENT_WHATS_NEXT_ENABLED` when self-hosted. */
+  IS_AGENT_WHATS_NEXT_ENABLED = 'IS_AGENT_WHATS_NEXT_ENABLED',
   /** Enable Microsoft Teams Quick Setup in the dashboard; create the boolean in LaunchDarkly for cloud, or set `VITE_IS_MSTEAMS_QUICK_SETUP_ENABLED` when self-hosted. */
   IS_MSTEAMS_QUICK_SETUP_ENABLED = 'IS_MSTEAMS_QUICK_SETUP_ENABLED',
   /** Enable Slack Quick Setup in the dashboard; create the boolean in LaunchDarkly for cloud, or set `VITE_IS_SLACK_QUICK_SETUP_ENABLED` when self-hosted. */


### PR DESCRIPTION
## Summary

- Adds a feature-flagged **What's next** section to connected and managed agent overviews, guiding users to configure existing channels and add new ones.
- Introduces `IS_AGENT_WHATS_NEXT_ENABLED` (LaunchDarkly + `VITE_IS_AGENT_WHATS_NEXT_ENABLED` fallback) and extends `SetupGuideCard` with optional `persistKey` for collapsed-state persistence.
- Aligns managed-overview channel detection via `isUserFacingConnectedAgentIntegration` so the section does not overlap with the setup guide on fresh managed agents.

## Architecture

```mermaid
flowchart TD
  A[Agent overview] --> B{IS_AGENT_WHATS_NEXT_ENABLED}
  B -->|off| C[Existing sections only]
  B -->|on| D[AgentWhatsNextSection]
  D --> E[listAgentIntegrations]
  E --> F{User-facing connected channels?}
  F -->|no| G[Render nothing]
  F -->|yes| H[Setup steps + channel actions]
  H --> I[Configure → integration detail]
  H --> J[Add channel → integrations tab]
```

## Test plan

- [ ] Enable `VITE_IS_AGENT_WHATS_NEXT_ENABLED=true` (or LD flag) and open a managed agent with at least one user-connected channel — **What's next** appears above connected channels / setup guide.
- [ ] Fresh managed agent (Novu email only) — setup guide shows; **What's next** does not.
- [ ] Click **Configure** on a channel — navigates to integration detail.
- [ ] Click **Add channel** — navigates to integrations tab.
- [ ] Collapse/expand **What's next** — state persists on reload (localStorage).
- [ ] Flag off — section hidden on both connected and managed overviews.

Linear: [NV-8115](https://linear.app/novu/issue/NV-8115/agent-overview-whats-next-section)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a feature-flagged **"What's next"** section to both the connected and managed agent overviews, guiding users to configure their existing channels and add new ones. It also extracts `isUserFacingConnectedAgentIntegration` so the managed-overview setup guide and the new section share the same channel-detection predicate.

- **`AgentWhatsNextSection`** — new component that queries integrations (gated by the LD/Vite flag), renders a collapsible `SetupGuideCard` with per-environment localStorage persistence, shows configure buttons for every user-connected channel, and an "Add channel" button.
- **`is-agent-integration-connected.ts`** — adds `isUserFacingConnectedAgentIntegration` alongside the existing helper, and tightens the `connectedAt` validation with `hasMeaningfulConnectedAt` (guards against invalid/epoch-zero timestamps).
- **`SetupGuideCard`** — gains an optional `persistKey` prop; collapse state is read lazily from `localStorage` on mount and written back on toggle, with private-mode and quota errors silently swallowed.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all changes are additive, fully gated behind a feature flag, and previous review feedback has been incorporated.

The new component only renders when the LD/Vite flag is on and connected channels exist, so there is no risk of regressions for existing users. The shared predicate extraction in is-agent-integration-connected.ts is a straightforward refactor with matching semantics. localStorage access is wrapped in try/catch, the integrations query is correctly gated by the flag, and the persistKey is scoped to environment + identifier.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/agent-whats-next-section.tsx | New feature-flagged component rendering "What's next" steps; query is properly gated by the flag, persistKey is environment-scoped, and the channel-list collapse/fade logic is sound. |
| apps/dashboard/src/components/agents/is-agent-integration-connected.ts | Adds isUserFacingConnectedAgentIntegration helper and tightens connectedAt validation with hasMeaningfulConnectedAt; logic is correct and well-documented. |
| apps/dashboard/src/components/agents/setup-guide-card.tsx | Adds optional persistKey prop with lazy-init useState + localStorage read/write, guarded against quota/private-mode errors; backward-compatible change. |
| apps/dashboard/src/components/agents/agent-managed-overview.tsx | Replaces inline channel-connected predicate with shared isUserFacingConnectedAgentIntegration; adds AgentWhatsNextSection above setup guide/connected providers. |
| apps/dashboard/src/components/agents/agent-connected-overview.tsx | Minimal change adding AgentWhatsNextSection at the top; no issues. |
| packages/shared/src/types/feature-flags.ts | Adds IS_AGENT_WHATS_NEXT_ENABLED enum entry with appropriate JSDoc linking the LD flag and VITE env fallback. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): reject epoch sentinel co..."](https://github.com/novuhq/novu/commit/873631d55bba6ee1bb5fab40f274990c479fe05e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39288643)</sub>

<!-- /greptile_comment -->