### PR TITLE
refactor(dashboard): streamline agent limit checks and improve connector initialization logic fixes NV-8105

### DIFF
--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -252,40 +252,33 @@ export function AgentsList() {
     void navigate(ROUTES.AGENTS_SETUP);
   }, [navigate]);
 
-  const handleAddAgentClick = useCallback(() => {
-    // Hard cap first — the API rejects creation outright at this point.
-    if (isAtCreationLimit) {
-      setCreationLimitDialogOpen(true);
+  const runIfWithinAgentLimits = useCallback(
+    (pending: 'create-dialog' | 'onboarding', action: () => void) => {
+      if (isAtCreationLimit) {
+        setCreationLimitDialogOpen(true);
 
-      return;
-    }
+        return;
+      }
 
-    if (isAtAgentLimit) {
-      pendingAfterLimitRef.current = 'create-dialog';
-      setLimitDialogOpen(true);
+      if (isAtAgentLimit) {
+        pendingAfterLimitRef.current = pending;
+        setLimitDialogOpen(true);
 
-      return;
-    }
+        return;
+      }
 
-    setCreateOpen(true);
-  }, [isAtAgentLimit, isAtCreationLimit]);
+      action();
+    },
+    [isAtAgentLimit, isAtCreationLimit]
+  );
 
   const handleEmptyStateSetupClick = useCallback(() => {
-    if (isAtCreationLimit) {
-      setCreationLimitDialogOpen(true);
+    runIfWithinAgentLimits('onboarding', goToAgentsSetup);
+  }, [runIfWithinAgentLimits, goToAgentsSetup]);
 
-      return;
-    }
-
-    if (isAtAgentLimit) {
-      pendingAfterLimitRef.current = 'onboarding';
-      setLimitDialogOpen(true);
-
-      return;
-    }
-
-    goToAgentsSetup();
-  }, [goToAgentsSetup, isAtAgentLimit, isAtCreationLimit]);
+  const handleAddAgentClick = useCallback(() => {
+    runIfWithinAgentLimits('create-dialog', () => setCreateOpen(true));
+  }, [runIfWithinAgentLimits]);
 
   const handleContinuePastAgentLimit = useCallback(() => {
     if (pendingAfterLimitRef.current === 'onboarding') {

--- a/apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx
@@ -20,6 +20,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives
 import { cn } from '@/utils/ui';
 import { getClaudeManagedAgentIntegrations } from './claude-managed-integrations';
 import { CONNECTOR_OPTIONS, type ConnectorId, type ConnectorOption, getConnectorById } from './connector-options';
+import { useShowManagedConnectorOptions } from './use-show-managed-connector-options';
 
 const GROUP_HEADING_CLASSNAME =
   '**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1';
@@ -33,6 +34,8 @@ type ConnectorIntegrationDropdownProps = {
   status?: ConnectorIntegrationStatus;
   showStatusBadge?: boolean;
   disabled?: boolean;
+  /** Test/Storybook override; production reads `IS_MANAGED_AGENT_RUNTIME_ENABLED`. */
+  showManagedOptionsOverride?: boolean;
   onSelectConnector: (id: ConnectorId) => void;
   onSelectIntegration: (integration: IIntegration) => void;
   onRequestSetupCredentials: (option: ConnectorOption) => void;
@@ -83,10 +86,12 @@ export function ConnectorIntegrationDropdown({
   status = 'idle',
   showStatusBadge = false,
   disabled,
+  showManagedOptionsOverride,
   onSelectConnector,
   onSelectIntegration,
   onRequestSetupCredentials,
 }: ConnectorIntegrationDropdownProps) {
+  const showManagedOptions = useShowManagedConnectorOptions(showManagedOptionsOverride);
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<'connectors' | 'integrations'>('connectors');
 
@@ -114,7 +119,8 @@ export function ConnectorIntegrationDropdown({
     setView('connectors');
   }, [open]);
 
-  const externalOptions = CONNECTOR_OPTIONS.filter((o) => o.group === 'external');
+  // Managed-runtime connectors are gated by `IS_MANAGED_AGENT_RUNTIME_ENABLED` (see hook above).
+  const externalOptions = showManagedOptions ? CONNECTOR_OPTIONS.filter((o) => o.group === 'external') : [];
   const customOptions = CONNECTOR_OPTIONS.filter((o) => o.group === 'custom');
 
   const handlePickConnector = (option: ConnectorOption) => {
@@ -189,9 +195,11 @@ export function ConnectorIntegrationDropdown({
 
   const connectorsView = (
     <>
-      <CommandGroup heading="External connectors" className={GROUP_HEADING_CLASSNAME}>
-        {externalOptions.map(renderConnectorItem)}
-      </CommandGroup>
+      {externalOptions.length > 0 ? (
+        <CommandGroup heading="External connectors" className={GROUP_HEADING_CLASSNAME}>
+          {externalOptions.map(renderConnectorItem)}
+        </CommandGroup>
+      ) : null}
       <CommandGroup heading="Custom code" className={GROUP_HEADING_CLASSNAME}>
         {customOptions.map(renderConnectorItem)}
       </CommandGroup>

--- a/apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx
@@ -17,10 +17,10 @@ import { isDemoIntegration } from '@/components/integrations/components/utils/he
 import { Badge } from '@/components/primitives/badge';
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/primitives/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
+import { useManagedAgentRuntimeEnabled } from '@/hooks/use-managed-agent-runtime-enabled';
 import { cn } from '@/utils/ui';
 import { getClaudeManagedAgentIntegrations } from './claude-managed-integrations';
 import { CONNECTOR_OPTIONS, type ConnectorId, type ConnectorOption, getConnectorById } from './connector-options';
-import { useShowManagedConnectorOptions } from './use-show-managed-connector-options';
 
 const GROUP_HEADING_CLASSNAME =
   '**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1';
@@ -91,7 +91,7 @@ export function ConnectorIntegrationDropdown({
   onSelectIntegration,
   onRequestSetupCredentials,
 }: ConnectorIntegrationDropdownProps) {
-  const showManagedOptions = useShowManagedConnectorOptions(showManagedOptionsOverride);
+  const isManagedRuntimeEnabled = useManagedAgentRuntimeEnabled(showManagedOptionsOverride);
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<'connectors' | 'integrations'>('connectors');
 
@@ -120,7 +120,7 @@ export function ConnectorIntegrationDropdown({
   }, [open]);
 
   // Managed-runtime connectors are gated by `IS_MANAGED_AGENT_RUNTIME_ENABLED` (see hook above).
-  const externalOptions = showManagedOptions ? CONNECTOR_OPTIONS.filter((o) => o.group === 'external') : [];
+  const externalOptions = isManagedRuntimeEnabled ? CONNECTOR_OPTIONS.filter((o) => o.group === 'external') : [];
   const customOptions = CONNECTOR_OPTIONS.filter((o) => o.group === 'custom');
 
   const handlePickConnector = (option: ConnectorOption) => {

--- a/apps/dashboard/src/components/agents/connectors/connector-options.tsx
+++ b/apps/dashboard/src/components/agents/connectors/connector-options.tsx
@@ -112,6 +112,16 @@ export const CONNECTOR_OPTIONS: ConnectorOption[] = [
   },
 ];
 
+export const DEFAULT_MANAGED_CONNECTOR_ID: ConnectorId = 'claude';
+
+export function pickInitialConnector(isManagedEnabled: boolean): ConnectorId {
+  if (isManagedEnabled) return DEFAULT_MANAGED_CONNECTOR_ID;
+
+  const fallback = CONNECTOR_OPTIONS.find((o) => !o.comingSoon && o.runtime === 'scratch');
+
+  return (fallback?.id ?? 'custom-scaffold') as ConnectorId;
+}
+
 export function getConnectorById(id: ConnectorId | undefined): ConnectorOption | undefined {
   if (!id) return undefined;
 

--- a/apps/dashboard/src/components/agents/connectors/connector-options.tsx
+++ b/apps/dashboard/src/components/agents/connectors/connector-options.tsx
@@ -119,7 +119,7 @@ export function pickInitialConnector(isManagedEnabled: boolean): ConnectorId {
 
   const fallback = CONNECTOR_OPTIONS.find((o) => !o.comingSoon && o.runtime === 'scratch');
 
-  return (fallback?.id ?? 'custom-scaffold') as ConnectorId;
+  return fallback?.id ?? 'custom-scaffold';
 }
 
 export function getConnectorById(id: ConnectorId | undefined): ConnectorOption | undefined {

--- a/apps/dashboard/src/components/agents/connectors/use-show-managed-connector-options.ts
+++ b/apps/dashboard/src/components/agents/connectors/use-show-managed-connector-options.ts
@@ -1,0 +1,8 @@
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+
+export function useShowManagedConnectorOptions(override?: boolean): boolean {
+  const fromFlag = useFeatureFlag(FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED, false);
+
+  return override ?? fromFlag;
+}

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -1,6 +1,5 @@
 import {
   AgentRuntimeProviderIdEnum,
-  FeatureFlagsKeysEnum,
   filterDemoConfigurableMcpIds,
   type IIntegration,
   IntegrationKindEnum,
@@ -26,7 +25,6 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { useEnvironment } from '@/context/environment/hooks';
 import { useAgentSuggestions } from '@/hooks/use-agent-suggestions';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { GenerationCancelledError, useGenerateManagedAgent } from '@/hooks/use-generate-managed-agent';
 import { useManagedClaudeCredentialsFlow } from '@/hooks/use-managed-claude-credentials-flow';
@@ -46,6 +44,7 @@ import {
   ConnectorIntegrationDropdown,
   type ConnectorIntegrationStatus,
 } from './connectors/connector-integration-dropdown';
+import { useManagedAgentRuntimeEnabled } from '@/hooks/use-managed-agent-runtime-enabled';
 import {
   type ConnectorId,
   type ConnectorOption,
@@ -157,7 +156,7 @@ export function CreateAgentDialog({
   initialInstructions,
   initialPrompt,
 }: CreateAgentDialogProps) {
-  const isManagedEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED, false);
+  const isManagedEnabled = useManagedAgentRuntimeEnabled();
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
   const { integrations } = useFetchIntegrations();

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -51,6 +51,7 @@ import {
   type ConnectorOption,
   getConnectorById,
   getConnectorIdForProviderId,
+  pickInitialConnector,
 } from './connectors/connector-options';
 import {
   type AgentTemplate,
@@ -84,8 +85,6 @@ type CreateAgentDialogProps = {
   /** When provided, the dialog opens in prompt mode with the textarea prefilled. */
   initialPrompt?: string;
 };
-
-const DEFAULT_CONNECTOR_ID: ConnectorId = 'claude';
 
 /**
  * Mirrors the onboarding step's `AgentGenerationMode` so the dialog reuses the same prompt /
@@ -170,7 +169,7 @@ export function CreateAgentDialog({
   const verifyMutation = useVerifyManagedCredentials();
   const { mutateAsync: createIntegration, isPending: isSavingIntegration } = useCreateIntegration();
 
-  const [connectorId, setConnectorId] = useState<ConnectorId>(DEFAULT_CONNECTOR_ID);
+  const [connectorId, setConnectorId] = useState<ConnectorId>(() => pickInitialConnector(isManagedEnabled));
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
   const [credentialsPanelVisible, setCredentialsPanelVisible] = useState(false);
   const [credentialsPanelExpanded, setCredentialsPanelExpanded] = useState(true);
@@ -248,18 +247,6 @@ export function CreateAgentDialog({
   }, [agentTemplates, isDemoProviderSelected]);
   const scope: 'create' | 'existing' = generationMode === 'existing' ? 'existing' : 'create';
   const showScopeTabs = isManagedClaudeConnector && !isDemoProviderSelected;
-  const showManagedOptions = isManagedEnabled;
-
-  // Hide managed connectors when the feature flag is off — the dropdown still lists them visually,
-  // but selecting a managed connector should be impossible. We achieve this by short-circuiting to
-  // 'custom-scaffold' when managed is disabled.
-  useEffect(() => {
-    if (!open) return;
-    if (showManagedOptions) return;
-    if (selectedConnector?.runtime !== 'claude') return;
-
-    setConnectorId('custom-scaffold');
-  }, [open, showManagedOptions, selectedConnector?.runtime]);
 
   const matchingAnthropicIntegrations = useMemo(() => {
     if (!selectedConnector?.providerId) return [];
@@ -306,7 +293,7 @@ export function CreateAgentDialog({
       return;
     }
 
-    if (preferAnyManagedIntegrationRef.current) {
+    if (preferAnyManagedIntegrationRef.current && isManagedEnabled) {
       const preferred = getPreferredClaudeManagedIntegration(integrations);
       if (preferred) {
         const connectorForPreferred = getConnectorIdForProviderId(preferred.providerId);
@@ -332,6 +319,7 @@ export function CreateAgentDialog({
     selectedIntegrationId,
     credentialsPanelVisible,
     integrations,
+    isManagedEnabled,
   ]);
 
   // Default integration name = "<Provider> <next-index>"
@@ -363,7 +351,7 @@ export function CreateAgentDialog({
   }, [open, initialName, initialInstructions, initialPrompt]);
 
   const reset = useCallback(() => {
-    setConnectorId(DEFAULT_CONNECTOR_ID);
+    setConnectorId(pickInitialConnector(isManagedEnabled));
     setSelectedIntegrationId(undefined);
     setCredentialsPanelVisible(false);
     setCredentialsPanelExpanded(true);
@@ -388,7 +376,7 @@ export function CreateAgentDialog({
       clearTimeout(savedBadgeTimerRef.current);
       savedBadgeTimerRef.current = null;
     }
-  }, [resetCredentials]);
+  }, [resetCredentials, isManagedEnabled]);
 
   const prevOpenRef = useRef(open);
 

--- a/apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx
@@ -65,7 +65,7 @@ export function ScratchAgentFields({
                 onIdentifierChange(slugify(nextName));
               }
             }}
-            placeholder="e.g. Wine Sommelier Agent"
+            placeholder="e.g. Customer Support Agent"
             hasError={Boolean(errors.name)}
             disabled={disabled}
             aria-invalid={errors.name ? true : undefined}
@@ -101,7 +101,7 @@ export function ScratchAgentFields({
               onIdentifierChange(e.target.value);
               onIdentifierTouched();
             }}
-            placeholder="e.g. wine-sommelier-agent"
+            placeholder="e.g. customer-support-agent"
             hasError={Boolean(errors.identifier)}
             disabled={disabled}
             aria-invalid={errors.identifier ? true : undefined}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -54,7 +54,7 @@ import { TelemetryEvent } from '@/utils/telemetry';
 import type { AgentGenerationMode } from './connect-agent-form';
 import { ConnectAgentForm } from './connect-agent-form';
 import { type ConnectSummary } from './connect-summary';
-import { CONNECTOR_OPTIONS, type ConnectorId, getConnectorById } from './connector-options';
+import { type ConnectorId, getConnectorById, pickInitialConnector } from './connector-options';
 import type { GenerationStep } from './generation-status';
 import type { TemplateSelection } from './template-dropdown';
 
@@ -70,20 +70,10 @@ const GENERATION_STEPS: ReadonlyArray<GenerationStep> = [
 
 export type { ConnectSummary } from './connect-summary';
 
-const DEFAULT_CONNECTOR: ConnectorId = 'claude';
-
 function resolveRuntime(connectorId: ConnectorId): RuntimeType {
   const runtime = getConnectorById(connectorId)?.runtime;
 
   return runtime ?? 'scratch';
-}
-
-function pickInitialConnector(isManagedEnabled: boolean): ConnectorId {
-  if (isManagedEnabled) return DEFAULT_CONNECTOR;
-
-  const fallback = CONNECTOR_OPTIONS.find((o) => !o.comingSoon && o.runtime === 'scratch');
-
-  return (fallback?.id ?? 'custom-scaffold') as ConnectorId;
 }
 
 function dropdownStatusFor(verify: VerifyStatus, hasIntegration: boolean): ConnectorIntegrationStatus {

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/agents/connectors/claude-managed-integrations';
 import { type ConnectorIntegrationStatus } from '@/components/agents/connectors/connector-integration-dropdown';
 import { type ConnectorOption } from '@/components/agents/connectors/connector-options';
+import { useManagedAgentRuntimeEnabled } from '@/hooks/use-managed-agent-runtime-enabled';
 import {
   type AgentTemplate,
   buildManagedIntegrationCredentials,
@@ -104,7 +105,6 @@ type ConnectAgentStepProps = {
   onAgentCreated: (agent: AgentResponse, summary: ConnectSummary) => void;
   onRuntimeChange?: (runtime: RuntimeType) => void;
   onPreviewChange?: (preview: ConnectAgentPreview) => void;
-  isManagedEnabled: boolean;
   /**
    * Optional template id (Sanity `id.current`) coming from an external deep-link. When it matches a
    * fetched template, the prompt + agent fields are prefilled once and the persisted id is cleared.
@@ -126,10 +126,10 @@ export function ConnectAgentStep({
   onAgentCreated,
   onRuntimeChange,
   onPreviewChange,
-  isManagedEnabled,
   agentTemplateId,
   simplifiedDemo,
 }: ConnectAgentStepProps) {
+  const isManagedEnabled = useManagedAgentRuntimeEnabled();
   const telemetry = useTelemetry();
   const queryClient = useQueryClient();
   const { currentEnvironment } = useEnvironment();

--- a/apps/dashboard/src/hooks/use-agent-suggestions.ts
+++ b/apps/dashboard/src/hooks/use-agent-suggestions.ts
@@ -1,11 +1,10 @@
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useRef } from 'react';
 import { AgentSuggestionResponse, fetchAgentSuggestions } from '@/api/ai';
 import { AGENT_TEMPLATES, type AgentTemplate } from '@/components/agents/create-agent-fields';
+import { useManagedAgentRuntimeEnabled } from '@/hooks/use-managed-agent-runtime-enabled';
 import { IS_AI_FEATURES_ENABLED } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
-import { useFeatureFlag } from './use-feature-flag';
 
 const QUERY_KEY = 'agent-suggestions';
 
@@ -27,7 +26,7 @@ function mapSuggestionToTemplate(suggestion: AgentSuggestionResponse): AgentTemp
  * the server.
  */
 export function useAgentSuggestions() {
-  const isManagedAgentRuntimeEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED);
+  const isManagedAgentRuntimeEnabled = useManagedAgentRuntimeEnabled();
   const { currentEnvironment } = useEnvironment();
   const refreshRef = useRef(false);
 

--- a/apps/dashboard/src/hooks/use-managed-agent-runtime-enabled.ts
+++ b/apps/dashboard/src/hooks/use-managed-agent-runtime-enabled.ts
@@ -1,7 +1,7 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 
-export function useShowManagedConnectorOptions(override?: boolean): boolean {
+export function useManagedAgentRuntimeEnabled(override?: boolean): boolean {
   const fromFlag = useFeatureFlag(FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED, false);
 
   return override ?? fromFlag;

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -126,7 +126,6 @@ function StepHeader({ current, onBack }: StepHeaderProps) {
 
 export function AgentsSetupPage() {
   const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
-  const isManagedEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED, false);
   const navigate = useNavigate();
   const telemetry = useTelemetry();
   const { currentOrganization } = useAuth();
@@ -463,7 +462,6 @@ export function AgentsSetupPage() {
                 <div className="relative pb-12">
                   <ConnectAgentStep
                     onAgentCreated={handleAgentCreated}
-                    isManagedEnabled={isManagedEnabled}
                     agentTemplateId={agentTemplateId}
                     simplifiedDemo
                   />


### PR DESCRIPTION
- Consolidated agent limit checks into a reusable function to reduce code duplication.
- Updated connector initialization to use a new utility function for better management of connector states based on feature flags.
- Adjusted placeholder text in ScratchAgentFields for clarity.
- Introduced a new hook to manage visibility of managed connector options based on feature flags.

### What changed? Why was the change needed?

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates agent limit-gate logic into a reusable `runIfWithinAgentLimits` helper, extracts a `useManagedAgentRuntimeEnabled` hook to centralise the `IS_MANAGED_AGENT_RUNTIME_ENABLED` flag read, and moves `pickInitialConnector` into `connector-options.tsx` to eliminate duplication across the dialog and onboarding step.

- **`agents-list.tsx`**: Two near-identical limit-check blocks are unified into `runIfWithinAgentLimits(pending, action)`, removing ~15 lines of duplication while preserving the same guard order.
- **`create-agent-dialog.tsx`**: `useState` initializer now calls `pickInitialConnector(isManagedEnabled)` instead of always defaulting to `'claude'`; the `preferAnyManagedIntegrationRef` path adds an `isManagedEnabled` guard so managed-integration auto-selection is skipped when the flag is off.
- **`connector-integration-dropdown.tsx`**: External connector group is gated behind the new hook; a `showManagedOptionsOverride` prop allows Storybook/test control.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are a straightforward refactor with no new runtime paths that could break in production.

All changed code is a consolidation of existing logic — no new feature behavior is introduced that wasn't already handled. The limit-guard refactor in agents-list is functionally equivalent to the original. The hook extraction and pickInitialConnector move produce the same runtime values as the code they replace.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/hooks/use-managed-agent-runtime-enabled.ts | New hook centralizing the IS_MANAGED_AGENT_RUNTIME_ENABLED flag read, with an optional boolean override for tests/Storybook; logic is correct and React-hook-safe. |
| apps/dashboard/src/components/agents/connectors/connector-options.tsx | Adds pickInitialConnector() and DEFAULT_MANAGED_CONNECTOR_ID; consolidates logic previously duplicated in two components; DEFAULT_MANAGED_CONNECTOR_ID is exported but only used inside the same file. |
| apps/dashboard/src/components/agents/create-agent-dialog.tsx | Removes the reactive useEffect that corrected a stale claude connector when managed-runtime flag was off; the useState initializer is a one-time snapshot, so async flag resolution can still leave the dialog on the wrong connector until close/reopen. |
| apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx | Gates external connector group behind useManagedAgentRuntimeEnabled; adds showManagedOptionsOverride prop for test/Storybook overrides; rendering logic is correct. |
| apps/dashboard/src/components/agents/agents-list.tsx | Extracts shared limit-gate logic into runIfWithinAgentLimits; correctly handles both pending values and the action callback; deps arrays look correct. |
| apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx | Removes isManagedEnabled prop and fetches the flag internally; eliminates prop-drilling from AgentsSetupPage without changing behavior. |
| apps/dashboard/src/pages/agents-setup-page.tsx | Drops the now-redundant IS_MANAGED_AGENT_RUNTIME_ENABLED flag read and the isManagedEnabled prop passed to ConnectAgentStep; clean removal. |
| apps/dashboard/src/hooks/use-agent-suggestions.ts | Replaces inline useFeatureFlag call with useManagedAgentRuntimeEnabled; no behavior change. |
| apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx | Placeholder text updated from wine-sommelier examples to customer-support examples for clarity. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["useManagedAgentRuntimeEnabled(override?)"] -->|"override ?? fromFlag"| B["IS_MANAGED_AGENT_RUNTIME_ENABLED flag"]
    A --> C["pickInitialConnector(isManagedEnabled)"]
    C -->|"true"| D["'claude' (DEFAULT_MANAGED_CONNECTOR_ID)"]
    C -->|"false"| E["first non-comingSoon scratch option → 'custom-scaffold'"]
    A --> F["ConnectorIntegrationDropdown"]
    F -->|"true"| G["externalOptions = CONNECTOR_OPTIONS.filter(external)"]
    F -->|"false"| H["externalOptions = []"]
    G --> I["Render 'External connectors' group"]
    H --> J["Hide 'External connectors' group"]
    A --> K["CreateAgentDialog\nstateInit + reset()"]
    A --> L["ConnectAgentStep (was prop, now internal)"]
    A --> M["useAgentSuggestions"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["useManagedAgentRuntimeEnabled(override?)"] -->|"override ?? fromFlag"| B["IS_MANAGED_AGENT_RUNTIME_ENABLED flag"]
    A --> C["pickInitialConnector(isManagedEnabled)"]
    C -->|"true"| D["'claude' (DEFAULT_MANAGED_CONNECTOR_ID)"]
    C -->|"false"| E["first non-comingSoon scratch option → 'custom-scaffold'"]
    A --> F["ConnectorIntegrationDropdown"]
    F -->|"true"| G["externalOptions = CONNECTOR_OPTIONS.filter(external)"]
    F -->|"false"| H["externalOptions = []"]
    G --> I["Render 'External connectors' group"]
    H --> J["Hide 'External connectors' group"]
    A --> K["CreateAgentDialog\nstateInit + reset()"]
    A --> L["ConnectAgentStep (was prop, now internal)"]
    A --> M["useAgentSuggestions"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor(dashboard): replace feature fla..."](https://github.com/novuhq/novu/commit/46575f75244333695ebb3b8d7170cde03fa0b58f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39304919)</sub>

<!-- /greptile_comment -->