### PR TITLE
fix(providers): set AfricasTalking SMS provider id

### DIFF
--- a/packages/providers/src/lib/sms/africas-talking/africas-talking.provider.spec.ts
+++ b/packages/providers/src/lib/sms/africas-talking/africas-talking.provider.spec.ts
@@ -1,5 +1,16 @@
+import { SmsProviderIdEnum } from '@novu/shared';
 import { expect, test, vi } from 'vitest';
 import { AfricasTalkingSmsProvider } from './africas-talking.provider';
+
+test('should expose the provider id', () => {
+  const provider = new AfricasTalkingSmsProvider({
+    apiKey: 'b664b089f04b72c56ac3b0a8ffbb6f3d18a82eb40c29d17b49b84433439fb127',
+    username: 'sandbox',
+    from: '1234',
+  });
+
+  expect(provider.id).toBe(SmsProviderIdEnum.AfricasTalking);
+});
 
 test(`should trigger Africa's Talking library correctly`, async () => {
   const provider = new AfricasTalkingSmsProvider({

--- a/packages/providers/src/lib/sms/africas-talking/africas-talking.provider.ts
+++ b/packages/providers/src/lib/sms/africas-talking/africas-talking.provider.ts
@@ -6,7 +6,7 @@ import { WithPassthrough } from '../../../utils/types';
 
 export class AfricasTalkingSmsProvider extends BaseProvider implements ISmsProvider {
   protected casing = CasingEnum.CAMEL_CASE;
-  id: SmsProviderIdEnum.AfricasTalking;
+  id = SmsProviderIdEnum.AfricasTalking;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
   private africasTalkingClient: AfricasTalking;
 


### PR DESCRIPTION
### What changed? Why was the change needed?

`AfricasTalkingSmsProvider.id` was declared with a `:` (a TypeScript class-field **type annotation**) instead of `=` (an assignment), so the field was never initialized — `provider.id` was `undefined` at runtime.

```ts
// packages/providers/src/lib/sms/africas-talking/africas-talking.provider.ts
- id: SmsProviderIdEnum.AfricasTalking;   // colon → type annotation, never assigned
+ id = SmsProviderIdEnum.AfricasTalking;  // equals → assigned, matches every other provider
```

`id` is part of the public `ISmsProvider` contract, so anything reading `provider.id` (logging, error reporting, provider lookup) got `undefined` for AfricasTalking while getting a real value for every other SMS provider. Every sibling provider uses an assignment (e.g. `afro-sms.provider.ts`: `id = SmsProviderIdEnum.AfroSms;`); repo-wide this `id:`-with-colon form appeared in exactly this one file.

This holds regardless of `useDefineForClassFields`: at the package's `ES2021` target the annotated field emits nothing; at ES2022+ it would emit `id = undefined`. Either way `provider.id === undefined`.

Added a unit test in `africas-talking.provider.spec.ts` asserting `provider.id === SmsProviderIdEnum.AfricasTalking` (the existing spec had no `id` assertion). It fails before this change (`undefined`) and passes after.

### Closes #11615

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the AfricasTalking SMS provider id and adds a test for it. The main changes are:

- Initializes `AfricasTalkingSmsProvider.id` with `SmsProviderIdEnum.AfricasTalking`.
- Adds a unit test that checks the provider exposes the expected id.

<h3>Confidence Score: 5/5</h3>

The change is small, localized, and covered by a focused unit test.

The provider id field is now assigned consistently with sibling providers, and the added test directly exercises the corrected runtime contract.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the transition from a provider with actualId omitted and equality false to a provider with actualId 'africas-talking', expectedId 'africas-talking', equality true, and an id present on the provider instance.

<a href="https://app.greptile.com/trex/runs/12025268/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(providers): set AfricasTalking SMS p..."](https://github.com/novuhq/novu/commit/d3b114080862ae66c5bed879a8b8e0acb391f05b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39325086)</sub>

<!-- /greptile_comment -->