### PR TITLE
ci(root): enable publishing ee images via oidc and also deploying to internal infrastructure

### DIFF
--- a/.github/workflows/prepare-enterprise-self-hosted-release.yml
+++ b/.github/workflows/prepare-enterprise-self-hosted-release.yml
@@ -115,7 +115,7 @@ jobs:
     needs: setup_matrix
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: Production
+    environment: prod-us
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/prepare-enterprise-self-hosted-release.yml
+++ b/.github/workflows/prepare-enterprise-self-hosted-release.yml
@@ -48,6 +48,11 @@ on:
         required: true
         type: boolean
         default: true
+      complete_linear_release:
+        description: "Complete Linear release"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -60,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      deploy_matrix: ${{ steps.set-deploy-matrix.outputs.deploy_matrix }}
     steps:
       - name: Validate Selected Services
         env:
@@ -111,11 +117,45 @@ jobs:
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
           echo "Building services: $matrix"
 
+      - name: Generate Deploy Matrix
+        id: set-deploy-matrix
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_BUILD_API: ${{ github.event.inputs.build_api }}
+          INPUT_BUILD_WORKER: ${{ github.event.inputs.build_worker }}
+          INPUT_BUILD_DASHBOARD: ${{ github.event.inputs.build_dashboard }}
+          INPUT_BUILD_WS: ${{ github.event.inputs.build_ws }}
+          INPUT_BUILD_INBOUND_MAIL: ${{ github.event.inputs.build_inbound_mail }}
+        run: |
+          deploy=()
+
+          if [ "$INPUT_BUILD_API" == "true" ]; then
+            deploy+=("{\"task_name\": \"novu-ee-api\", \"container_name\": \"novu-ee-api-container\", \"service_name\": \"novu-ee-api-service\", \"repo\": \"api-ee\", \"image_tag\": \"$INPUT_VERSION\"}")
+          fi
+          if [ "$INPUT_BUILD_WORKER" == "true" ]; then
+            deploy+=("{\"task_name\": \"novu-ee-worker\", \"container_name\": \"novu-ee-worker-container\", \"service_name\": \"novu-ee-worker-service\", \"repo\": \"worker-ee\", \"image_tag\": \"$INPUT_VERSION\"}")
+          fi
+          if [ "$INPUT_BUILD_WS" == "true" ]; then
+            deploy+=("{\"task_name\": \"novu-ee-ws\", \"container_name\": \"novu-ee-ws-container\", \"service_name\": \"novu-ee-ws-service\", \"repo\": \"ws-ee\", \"image_tag\": \"$INPUT_VERSION\"}")
+          fi
+          if [ "$INPUT_BUILD_DASHBOARD" == "true" ]; then
+            # Dashboard cluster runs the better-auth build of the dashboard image
+            deploy+=("{\"task_name\": \"novu-ee-dashboard\", \"container_name\": \"novu-ee-dashboard-container\", \"service_name\": \"novu-ee-dashboard-service\", \"repo\": \"dashboard-ee\", \"image_tag\": \"${INPUT_VERSION}-betterauth\"}")
+          fi
+          if [ "$INPUT_BUILD_INBOUND_MAIL" == "true" ]; then
+            deploy+=("{\"task_name\": \"novu-ee-inbound-mail\", \"container_name\": \"novu-ee-inbound-mail-container\", \"service_name\": \"novu-ee-inbound-mail-service\", \"repo\": \"inbound-mail-ee\", \"image_tag\": \"$INPUT_VERSION\"}")
+          fi
+
+          deploy_matrix="[$(IFS=','; echo "${deploy[*]}")]"
+
+          echo "deploy_matrix=$deploy_matrix" >> $GITHUB_OUTPUT
+          echo "Deploying services: $deploy_matrix"
+
   build_docker:
     needs: setup_matrix
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: prod-us
+    environment: novu-ee
     strategy:
       fail-fast: false
       matrix:
@@ -271,9 +311,57 @@ jobs:
           echo "Platform: linux/amd64 (x86)"
           echo "Type: Enterprise Self-hosted"
 
+  deploy:
+    name: Deploy to ECS (novu-ee-cluster)
+    needs: [setup_matrix, build_docker]
+    runs-on: ubuntu-latest
+    environment: novu-ee
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.setup_matrix.outputs.deploy_matrix) }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+          role-session-name: gha-ee-deploy-${{ github.run_id }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+
+      - name: Download task definition
+        env:
+          TASK_NAME: ${{ matrix.service.task_name }}
+        run: |
+          aws ecs describe-task-definition --task-definition "$TASK_NAME" \
+            --query taskDefinition > task-definition.json
+
+      - name: Render Amazon ECS task definition
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@39c13cf530718ffeb524ec8ee0c15882bcb13842
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ matrix.service.container_name }}
+          image: ${{ steps.login-ecr.outputs.registry }}/novu/${{ matrix.service.repo }}:${{ matrix.service.image_tag }}
+
+      - name: Deploy to Amazon ECS service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@3e7310352de91b71a906e60c22af629577546002
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: ${{ matrix.service.service_name }}
+          cluster: novu-ee-cluster
+          wait-for-service-stability: true
+
   linear_release_complete:
     name: Complete Linear Release (Enterprise)
     needs: build_docker
+    if: github.event.inputs.complete_linear_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### What changed? Why was the change needed?

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the enterprise self-hosted release workflow to publish and deploy EE images. The main changes are:

- Adds a manual input for completing the Linear release.
- Builds a separate ECS deploy matrix for selected EE services.
- Switches the Docker build job to the `novu-ee` environment.
- Adds an ECS deploy job for the `novu-ee-cluster`.
- Makes Linear release completion conditional on the new input.

<h3>Confidence Score: 3/5</h3>

The workflow changes are understandable but affect release automation, deployment targeting, and operator control paths that should be corrected before relying on this for routine releases.

Review focused on the single changed GitHub Actions workflow and identified several concrete release-flow regressions around input validation, environment configuration, secret scoping, and deployment behavior.

.github/workflows/prepare-enterprise-self-hosted-release.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the OIDC artifact, the base state includes id-token: \[REDACTED\], AWS role assumption via secrets.AWS\_DEPLOY\_ROLE\_ARN, ECR login, and docker push wiring.
- After the OIDC artifact, the head continues to publish EE images using the same OIDC publishing path and role assumption.
- Before the deploy artifact, the base has no deploy job or deploy matrix.
- After the deploy artifact, the head creates a deploy job, runs the deploy matrix generation for all selected services and the dashboard-only selection, and resolves the dashboard deployment to REGISTRY/novu/dashboard-ee:1.2.3-betterauth.

<a href="https://app.greptile.com/trex/runs/12046404/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0A.github%2Fworkflows%2Fprepare-enterprise-self-hosted-release.yml%3A123-151%0A**Validate%20before%20JSON**%20The%20deploy%20matrix%20writes%20%60github.event.inputs.version%60%20directly%20into%20JSON%20before%20the%20semver%20check%20in%20%60build_docker%60%20runs.%20If%20a%20manual%20dispatch%20includes%20a%20quote%2C%20backslash%2C%20or%20newline%2C%20%60setup_matrix%60%20can%20emit%20invalid%20JSON%20and%20the%20deploy%20matrix%20expansion%20fails%20with%20a%20parsing%20error%20instead%20of%20the%20workflow%20stopping%20at%20the%20intended%20version%20validation.%20Validate%20%60INPUT_VERSION%60%20in%20%60setup_matrix%60%20before%20constructing%20%60deploy_matrix%60%2C%20or%20build%20the%20JSON%20with%20an%20escaping%20tool%20such%20as%20%60jq%60.%0A%0A%23%23%23%20Issue%202%20of%205%0A.github%2Fworkflows%2Fprepare-enterprise-self-hosted-release.yml%3A330-332%0A**Use%20configured%20region**%20The%20new%20deploy%20job%20hardcodes%20%60aws-region%3A%20us-east-1%60%2C%20while%20the%20existing%20ECS%20deploy%20and%20rollback%20workflows%20use%20the%20environment%20variable%20%60vars.AWS_REGION%60%20with%20the%20same%20deploy%20role.%20If%20the%20%60novu-ee%60%20environment%20is%20configured%20for%20another%20region%2C%20this%20job%20will%20look%20up%20task%20definitions%20and%20services%20in%20%60us-east-1%60%2C%20so%20deployments%20can%20fail%20or%20target%20the%20wrong%20regional%20ECS%20infrastructure.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20role-to-assume%3A%20%24%7B%7B%20secrets.AWS_DEPLOY_ROLE_ARN%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20aws-region%3A%20%24%7B%7B%20vars.AWS_REGION%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20role-session-name%3A%20gha-ee-deploy-%24%7B%7B%20github.run_id%20%7D%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0A.github%2Fworkflows%2Fprepare-enterprise-self-hosted-release.yml%3A158%0A**Preserve%20build%20secrets**%20Moving%20%60build_docker%60%20from%20%60Production%60%20to%20%60novu-ee%60%20changes%20where%20this%20job%20reads%20environment-scoped%20secrets%20and%20variables%20from.%20This%20job%20still%20needs%20%60SUBMODULES_TOKEN%60%2C%20%60NX_CLOUD_ACCESS_TOKEN%60%2C%20%60BULL_MQ_PRO_NPM_TOKEN%60%2C%20and%20%60AWS_DEPLOY_ROLE_ARN%60%3B%20if%20any%20of%20those%20remain%20scoped%20only%20to%20%60Production%60%2C%20the%20image%20build%20or%20push%20fails%20before%20the%20new%20deploy%20job%20can%20run.%20Keep%20the%20build%20job%20in%20the%20environment%20that%20owns%20the%20build%20secrets%2C%20or%20make%20sure%20%60novu-ee%60%20contains%20the%20same%20required%20build%20secrets.%0A%0A%23%23%23%20Issue%204%20of%205%0A.github%2Fworkflows%2Fprepare-enterprise-self-hosted-release.yml%3A51-55%0A**Default%20preserves%20releases**%20The%20Linear%20completion%20job%20now%20only%20runs%20when%20%60complete_linear_release%60%20is%20explicitly%20set%20to%20%60true%60%2C%20but%20the%20new%20input%20defaults%20to%20%60false%60.%20Before%20this%20change%2C%20a%20successful%20manual%20enterprise%20release%20completed%20the%20Linear%20release%20automatically%2C%20and%20the%20companion%20enterprise%20Linear%20workflow%20still%20documents%20that%20this%20workflow%20syncs%20and%20completes%20the%20release%20after%20images%20are%20built.%20With%20the%20new%20default%2C%20normal%20dispatches%20can%20publish%20the%20EE%20images%20without%20completing%20the%20Linear%20release%20unless%20the%20operator%20notices%20the%20new%20checkbox.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20complete_linear_release%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Complete%20Linear%20release%22%0A%20%20%20%20%20%20%20%20required%3A%20true%0A%20%20%20%20%20%20%20%20type%3A%20boolean%0A%20%20%20%20%20%20%20%20default%3A%20true%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0A.github%2Fworkflows%2Fprepare-enterprise-self-hosted-release.yml%3A314-359%0A**Gate%20internal%20deploys**%20The%20new%20ECS%20deploy%20job%20runs%20after%20every%20successful%20image%20build%20with%20no%20dispatch%20input%20to%20skip%20deployment.%20This%20changes%20the%20release%20workflow%20from%20publishing%20selected%20EE%20images%20into%20also%20updating%20%60novu-ee-cluster%60%20for%20every%20selected%20service.%20When%20an%20operator%20needs%20to%20build%20or%20republish%20an%20image%20without%20changing%20internal%20infrastructure%2C%20this%20path%20still%20deploys%20it.%20Add%20an%20explicit%20deploy%20input%20and%20guard%20this%20job%20so%20publishing%20and%20internal%20deployment%20can%20be%20controlled%20separately.%0A%0A&pr=11641&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
.github/workflows/prepare-enterprise-self-hosted-release.yml:123-151
**Validate before JSON** The deploy matrix writes `github.event.inputs.version` directly into JSON before the semver check in `build_docker` runs. If a manual dispatch includes a quote, backslash, or newline, `setup_matrix` can emit invalid JSON and the deploy matrix expansion fails with a parsing error instead of the workflow stopping at the intended version validation. Validate `INPUT_VERSION` in `setup_matrix` before constructing `deploy_matrix`, or build the JSON with an escaping tool such as `jq`.

### Issue 2 of 5
.github/workflows/prepare-enterprise-self-hosted-release.yml:330-332
**Use configured region** The new deploy job hardcodes `aws-region: us-east-1`, while the existing ECS deploy and rollback workflows use the environment variable `vars.AWS_REGION` with the same deploy role. If the `novu-ee` environment is configured for another region, this job will look up task definitions and services in `us-east-1`, so deployments can fail or target the wrong regional ECS infrastructure.

```suggestion
          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
          aws-region: ${{ vars.AWS_REGION }}
          role-session-name: gha-ee-deploy-${{ github.run_id }}
```

### Issue 3 of 5
.github/workflows/prepare-enterprise-self-hosted-release.yml:158
**Preserve build secrets** Moving `build_docker` from `Production` to `novu-ee` changes where this job reads environment-scoped secrets and variables from. This job still needs `SUBMODULES_TOKEN`, `NX_CLOUD_ACCESS_TOKEN`, `BULL_MQ_PRO_NPM_TOKEN`, and `AWS_DEPLOY_ROLE_ARN`; if any of those remain scoped only to `Production`, the image build or push fails before the new deploy job can run. Keep the build job in the environment that owns the build secrets, or make sure `novu-ee` contains the same required build secrets.

### Issue 4 of 5
.github/workflows/prepare-enterprise-self-hosted-release.yml:51-55
**Default preserves releases** The Linear completion job now only runs when `complete_linear_release` is explicitly set to `true`, but the new input defaults to `false`. Before this change, a successful manual enterprise release completed the Linear release automatically, and the companion enterprise Linear workflow still documents that this workflow syncs and completes the release after images are built. With the new default, normal dispatches can publish the EE images without completing the Linear release unless the operator notices the new checkbox.

```suggestion
      complete_linear_release:
        description: "Complete Linear release"
        required: true
        type: boolean
        default: true
```

### Issue 5 of 5
.github/workflows/prepare-enterprise-self-hosted-release.yml:314-359
**Gate internal deploys** The new ECS deploy job runs after every successful image build with no dispatch input to skip deployment. This changes the release workflow from publishing selected EE images into also updating `novu-ee-cluster` for every selected service. When an operator needs to build or republish an image without changing internal infrastructure, this path still deploys it. Add an explicit deploy input and guard this job so publishing and internal deployment can be controlled separately.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(workflows): enhance deployment work..."](https://github.com/novuhq/novu/commit/1fce902b6755d103dfdf68bdbe884cde51556883) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39361344)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->