### PR TITLE
feat(api-service): add get preferences kill switch to v2 endpoints fixes NV-8116

### DIFF
--- a/apps/api/src/app/subscribers-v2/e2e/get-subscriber-preferences.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/get-subscriber-preferences.e2e.ts
@@ -228,6 +228,21 @@ describe('Get Subscriber Preferences - /subscribers/:subscriberId/preferences (G
     expect(workflows).to.be.an('array').with.lengthOf(1);
     expect(workflows[0].channels.email).to.equal(false);
   });
+
+  it('should return 503 when get preferences kill switch is enabled', async function () {
+    if (process.env.LAUNCH_DARKLY_SDK_KEY) {
+      this.skip();
+    }
+
+    (process.env as any).IS_GET_PREFERENCES_DISABLED = 'true';
+
+    const response = await session.testAgent.get(`/v2/subscribers/${subscriber.subscriberId}/preferences`);
+
+    expect(response.status).to.equal(503);
+    expect(response.body.message).to.include('Get preferences service is currently unavailable');
+
+    delete (process.env as any).IS_GET_PREFERENCES_DISABLED;
+  });
 });
 
 async function createSubscriberAndValidate(id: string = '') {

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -17,6 +17,7 @@ import {
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
   ExternalApiAccessible,
+  FeatureFlagsService,
   RequirePermissions,
   SubscriberResponseDto,
   UserSession,
@@ -62,6 +63,7 @@ import {
   GetSubscriberGlobalPreference,
   GetSubscriberGlobalPreferenceCommand,
 } from '../subscribers/usecases/get-subscriber-global-preference';
+import { assertGetPreferencesEnabled } from '../subscribers/utils/assert-get-preferences-enabled';
 import { ListSubscriberSubscriptionsQueryDto } from '../topics-v2/dtos/list-subscriber-subscriptions-query.dto';
 import { ListTopicSubscriptionsResponseDto } from '../topics-v2/dtos/list-topic-subscriptions-response.dto';
 import { ListSubscriberSubscriptionsCommand } from '../topics-v2/usecases/list-subscriber-subscriptions/list-subscriber-subscriptions.command';
@@ -127,7 +129,8 @@ export class SubscribersController {
     private updateNotificationActionUsecase: UpdateNotificationAction,
     private markNotificationsAsSeenUsecase: MarkNotificationsAsSeen,
     private updateAllNotificationsUsecase: UpdateAllNotifications,
-    private deleteAllNotificationsUsecase: DeleteAllNotifications
+    private deleteAllNotificationsUsecase: DeleteAllNotifications,
+    private featureFlagsService: FeatureFlagsService
   ) {}
 
   @Get('')
@@ -330,6 +333,8 @@ export class SubscribersController {
     @UserSession() user: UserSessionData,
     @Param('subscriberId') subscriberId: string
   ): Promise<SubscriberGlobalPreferenceDto> {
+    await assertGetPreferencesEnabled(this.featureFlagsService, user.organizationId, user.environmentId);
+
     const globalPreference = await this.getSubscriberGlobalPreference.execute(
       GetSubscriberGlobalPreferenceCommand.create({
         organizationId: user.organizationId,

--- a/apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.spec.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.spec.ts
@@ -1,0 +1,55 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { FeatureFlagsService, InMemoryLRUCacheService } from '@novu/application-generic';
+import { NotificationTemplateRepository, PreferencesRepository, SubscriberRepository } from '@novu/dal';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { GetSubscriberGlobalPreference } from '../../../subscribers/usecases/get-subscriber-global-preference';
+import { GetSubscriberPreference } from '../../../subscribers/usecases/get-subscriber-preference';
+import { GetSubscriberPreferencesCommand } from './get-subscriber-preferences.command';
+import { GetSubscriberPreferences } from './get-subscriber-preferences.usecase';
+
+describe('GetSubscriberPreferences', () => {
+  let getSubscriberPreferences: GetSubscriberPreferences;
+  let featureFlagsServiceMock: sinon.SinonStubbedInstance<FeatureFlagsService>;
+
+  beforeEach(() => {
+    featureFlagsServiceMock = sinon.createStubInstance(FeatureFlagsService);
+
+    getSubscriberPreferences = new GetSubscriberPreferences(
+      sinon.createStubInstance(GetSubscriberGlobalPreference) as any,
+      sinon.createStubInstance(GetSubscriberPreference) as any,
+      sinon.createStubInstance(SubscriberRepository) as any,
+      sinon.createStubInstance(NotificationTemplateRepository) as any,
+      sinon.createStubInstance(PreferencesRepository) as any,
+      featureFlagsServiceMock as any,
+      sinon.createStubInstance(InMemoryLRUCacheService) as any
+    );
+  });
+
+  it('should throw ServiceUnavailableException when get preferences kill switch is enabled', async () => {
+    featureFlagsServiceMock.getFlag.callsFake(async ({ key }) => {
+      if (key === FeatureFlagsKeysEnum.IS_GET_PREFERENCES_DISABLED) {
+        return true;
+      }
+
+      return false;
+    });
+
+    const command = GetSubscriberPreferencesCommand.create({
+      organizationId: 'org-id',
+      environmentId: 'env-id',
+      subscriberId: 'subscriber-id',
+    });
+
+    try {
+      await getSubscriberPreferences.execute(command);
+      expect.fail('Expected ServiceUnavailableException to be thrown');
+    } catch (error) {
+      expect(error).to.be.instanceOf(ServiceUnavailableException);
+      expect((error as ServiceUnavailableException).message).to.equal(
+        'Get preferences service is currently unavailable'
+      );
+    }
+  });
+});

--- a/apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.ts
@@ -25,6 +25,7 @@ import {
   GetSubscriberGlobalPreference,
   GetSubscriberGlobalPreferenceCommand,
 } from '../../../subscribers/usecases/get-subscriber-global-preference';
+import { assertGetPreferencesEnabled } from '../../../subscribers/utils/assert-get-preferences-enabled';
 import {
   GetSubscriberPreference,
   GetSubscriberPreferenceCommand,
@@ -47,6 +48,8 @@ export class GetSubscriberPreferences {
   ) {}
 
   async execute(command: GetSubscriberPreferencesCommand): Promise<GetSubscriberPreferencesDto> {
+    await assertGetPreferencesEnabled(this.featureFlagsService, command.organizationId, command.environmentId);
+
     const subscriber = await this.subscriberRepository.findBySubscriberId(
       command.environmentId,
       command.subscriberId,

--- a/apps/api/src/app/subscribers/usecases/get-preferences-by-level/get-preferences-by-level.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-preferences-by-level/get-preferences-by-level.usecase.ts
@@ -1,6 +1,7 @@
-import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { FeatureFlagsService } from '@novu/application-generic';
-import { FeatureFlagsKeysEnum, PreferenceLevelEnum, WorkflowCriticalityEnum } from '@novu/shared';
+import { PreferenceLevelEnum, WorkflowCriticalityEnum } from '@novu/shared';
+import { assertGetPreferencesEnabled } from '../../utils/assert-get-preferences-enabled';
 import {
   GetSubscriberGlobalPreference,
   GetSubscriberGlobalPreferenceCommand,
@@ -17,16 +18,7 @@ export class GetPreferencesByLevel {
   ) {}
 
   async execute(command: GetPreferencesByLevelCommand) {
-    const isGetPreferencesDisabled = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_GET_PREFERENCES_DISABLED,
-      defaultValue: false,
-      organization: { _id: command.organizationId },
-      environment: { _id: command.environmentId },
-    });
-
-    if (isGetPreferencesDisabled) {
-      throw new ServiceUnavailableException('Get preferences service is currently unavailable');
-    }
+    await assertGetPreferencesEnabled(this.featureFlagsService, command.organizationId, command.environmentId);
 
     if (command.level === PreferenceLevelEnum.GLOBAL) {
       const globalPreferenceCommand = GetSubscriberGlobalPreferenceCommand.create({

--- a/apps/api/src/app/subscribers/utils/assert-get-preferences-enabled.ts
+++ b/apps/api/src/app/subscribers/utils/assert-get-preferences-enabled.ts
@@ -1,0 +1,20 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { FeatureFlagsService } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+
+export async function assertGetPreferencesEnabled(
+  featureFlagsService: FeatureFlagsService,
+  organizationId: string,
+  environmentId: string
+): Promise<void> {
+  const isGetPreferencesDisabled = await featureFlagsService.getFlag({
+    key: FeatureFlagsKeysEnum.IS_GET_PREFERENCES_DISABLED,
+    defaultValue: false,
+    organization: { _id: organizationId },
+    environment: { _id: environmentId },
+  });
+
+  if (isGetPreferencesDisabled) {
+    throw new ServiceUnavailableException('Get preferences service is currently unavailable');
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the existing `IS_GET_PREFERENCES_DISABLED` feature flag to v2 GET subscriber preferences endpoints, matching the behavior already in place on v1.

When the flag is enabled for an organization/environment, affected endpoints return **503 Service Unavailable** with the message: `Get preferences service is currently unavailable`.

## Changes

- Extracted shared `assertGetPreferencesEnabled` helper used by both v1 and v2 code paths
- Applied kill switch to `GET /v2/subscribers/:subscriberId/preferences` via `GetSubscriberPreferences` usecase
- Applied kill switch to `GET /v2/subscribers/:subscriberId/preferences/global` in the v2 subscribers controller
- Refactored v1 `GetPreferencesByLevel` to use the shared helper (no behavior change)
- Added unit test for the kill switch behavior
- Added e2e test (runs when LaunchDarkly is not configured)

## Endpoints covered

| Endpoint | Method | Kill switch |
|---|---|---|
| `/v2/subscribers/:subscriberId/preferences` | GET | ✅ |
| `/v2/subscribers/:subscriberId/preferences/global` | GET | ✅ |

PATCH/PUT preference update endpoints are intentionally unchanged — the existing flag only disables **get** operations on v1 as well.

## Testing

- `pnpm --filter @novu/api-service build` ✅
- Unit test: `get-subscriber-preferences.usecase.spec.ts` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03b8a204-db4a-462a-9ee4-da7fe794bd44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b8a204-db4a-462a-9ee4-da7fe794bd44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing `IS_GET_PREFERENCES_DISABLED` feature-flag kill switch from v1 to the two v2 GET subscriber preferences endpoints by extracting a shared `assertGetPreferencesEnabled` helper and calling it in the `GetSubscriberPreferences` usecase and directly in the v2 controller for the global-preferences route.

- **New helper** (`assert-get-preferences-enabled.ts`): encapsulates the flag lookup and `ServiceUnavailableException` throw, replacing duplicated inline code in `GetPreferencesByLevel`.
- **v2 usecase** (`get-subscriber-preferences.usecase.ts`): kill switch added as the first step, short-circuiting before any DB I/O when the flag is on.
- **v2 controller** (`subscribers.controller.ts`): `FeatureFlagsService` injected and guard applied to the `GET /preferences/global` handler; unit and e2e tests added for the usecase path.

<h3>Confidence Score: 4/5</h3>

The kill-switch wiring and shared helper are correct; the only risky part is the e2e test cleanup.

The production code changes are clean and additive — the shared helper faithfully reproduces the original v1 logic, and both v2 endpoints are properly guarded. The concern is in the new e2e test: `IS_GET_PREFERENCES_DISABLED` is set inline but only deleted after the assertions; if either assertion throws, the env var stays set and every subsequent test in the suite will receive 503 responses instead of 200s, causing a cascade of unrelated test failures.

The e2e test file (`get-subscriber-preferences.e2e.ts`) needs a `try/finally` block or an `afterEach` cleanup for `IS_GET_PREFERENCES_DISABLED` to prevent test-suite pollution on assertion failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/subscribers/utils/assert-get-preferences-enabled.ts | New shared helper that extracts the `IS_GET_PREFERENCES_DISABLED` flag check and `ServiceUnavailableException` throw; clean and correct. |
| apps/api/src/app/subscribers/usecases/get-preferences-by-level/get-preferences-by-level.usecase.ts | Refactored to use the shared `assertGetPreferencesEnabled` helper; no behavior change. |
| apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.ts | Kill switch check added as the first step in `execute()`; correctly short-circuits before any DB I/O. |
| apps/api/src/app/subscribers-v2/subscribers.controller.ts | Injects `FeatureFlagsService` and calls `assertGetPreferencesEnabled` before the global-preference use-case; `featureFlagsService` is already declared as a module provider. |
| apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.spec.ts | New unit test; correctly stubs `FeatureFlagsService` and verifies `ServiceUnavailableException` is thrown when the flag is enabled. |
| apps/api/src/app/subscribers-v2/e2e/get-subscriber-preferences.e2e.ts | New kill-switch e2e test added, but env-var cleanup is not guarded — an assertion failure will leak `IS_GET_PREFERENCES_DISABLED` and corrupt the entire remaining test suite. Also missing a test for the `/preferences/global` endpoint. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GET /v2/subscribers/:id/preferences"] --> B["GetSubscriberPreferences.execute()"]
    B --> C{"assertGetPreferencesEnabled()"}
    C -- "flag ON" --> D["throw ServiceUnavailableException\n503 Service Unavailable"]
    C -- "flag OFF" --> E["Fetch subscriber, workflows,\nglobal preference"]
    E --> F["Return GetSubscriberPreferencesDto"]

    G["GET /v2/subscribers/:id/preferences/global"] --> H["SubscribersController.getSubscriberGlobalPreferences()"]
    H --> I{"assertGetPreferencesEnabled()"}
    I -- "flag ON" --> D
    I -- "flag OFF" --> J["GetSubscriberGlobalPreference.execute()"]
    J --> K["Return SubscriberGlobalPreferenceDto"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["GET /v2/subscribers/:id/preferences"] --> B["GetSubscriberPreferences.execute()"]
    B --> C{"assertGetPreferencesEnabled()"}
    C -- "flag ON" --> D["throw ServiceUnavailableException\n503 Service Unavailable"]
    C -- "flag OFF" --> E["Fetch subscriber, workflows,\nglobal preference"]
    E --> F["Return GetSubscriberPreferencesDto"]

    G["GET /v2/subscribers/:id/preferences/global"] --> H["SubscribersController.getSubscriberGlobalPreferences()"]
    H --> I{"assertGetPreferencesEnabled()"}
    I -- "flag ON" --> D
    I -- "flag OFF" --> J["GetSubscriberGlobalPreference.execute()"]
    J --> K["Return SubscriberGlobalPreferenceDto"]
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fsubscribers-v2%2Fe2e%2Fget-subscriber-preferences.e2e.ts%3A232-245%0A**Env-var%20leak%20on%20assertion%20failure**%0A%0A%60IS_GET_PREFERENCES_DISABLED%60%20is%20set%20before%20the%20assertions%20but%20only%20cleaned%20up%20inline%20at%20the%20end.%20If%20either%20%60expect%60%20call%20throws%2C%20the%20%60delete%60%20never%20executes%20and%20the%20flag%20remains%20set%20for%20every%20subsequent%20test%20in%20the%20suite%20%E2%80%94%20making%20them%20all%20return%20503%20and%20fail.%20The%20existing%20%60afterEach%60%20only%20removes%20%60IS_CONTEXT_PREFERENCES_ENABLED%60%2C%20so%20there%20is%20no%20safety%20net.%20Wrap%20the%20body%20in%20%60try%2Ffinally%60%20or%20add%20%60IS_GET_PREFERENCES_DISABLED%60%20to%20the%20%60afterEach%60%20teardown.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fsubscribers-v2%2Fe2e%2Fget-subscriber-preferences.e2e.ts%3A232-245%0A**Kill-switch%20e2e%20coverage%20gap%20for%20%60%2Fpreferences%2Fglobal%60**%0A%0AThe%20e2e%20test%20for%20the%20kill%20switch%20only%20exercises%20%60%2Fv2%2Fsubscribers%2F%3AsubscriberId%2Fpreferences%60%20%28the%20%60GetSubscriberPreferences%60%20usecase%29.%20The%20second%20endpoint%20protected%20by%20the%20same%20flag%20%E2%80%94%20%60GET%20%2Fv2%2Fsubscribers%2F%3AsubscriberId%2Fpreferences%2Fglobal%60%20%28handled%20directly%20in%20the%20controller%29%20%E2%80%94%20has%20no%20corresponding%20e2e%20test.%20A%20regression%20in%20the%20controller-level%20guard%20would%20go%20unnoticed.%0A%0A&pr=11644&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/subscribers-v2/e2e/get-subscriber-preferences.e2e.ts:232-245
**Env-var leak on assertion failure**

`IS_GET_PREFERENCES_DISABLED` is set before the assertions but only cleaned up inline at the end. If either `expect` call throws, the `delete` never executes and the flag remains set for every subsequent test in the suite — making them all return 503 and fail. The existing `afterEach` only removes `IS_CONTEXT_PREFERENCES_ENABLED`, so there is no safety net. Wrap the body in `try/finally` or add `IS_GET_PREFERENCES_DISABLED` to the `afterEach` teardown.

### Issue 2 of 2
apps/api/src/app/subscribers-v2/e2e/get-subscriber-preferences.e2e.ts:232-245
**Kill-switch e2e coverage gap for `/preferences/global`**

The e2e test for the kill switch only exercises `/v2/subscribers/:subscriberId/preferences` (the `GetSubscriberPreferences` usecase). The second endpoint protected by the same flag — `GET /v2/subscribers/:subscriberId/preferences/global` (handled directly in the controller) — has no corresponding e2e test. A regression in the controller-level guard would go unnoticed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api-service): add get preferences k..."](https://github.com/novuhq/novu/commit/c5c1078a4a6c6583df086b778e9e1e7f6388658d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39551789)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->