### PR TITLE
feat(api, application-generic): enhance workflow preferences retrieval with batch processing and caching improvements

### DIFF
--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -40,7 +40,8 @@ export class GetSubscriberPreference {
     private notificationTemplateRepository: NotificationTemplateRepository,
     private preferencesRepository: PreferencesRepository,
     private featureFlagsService: FeatureFlagsService,
-    private inMemoryLRUCacheService: InMemoryLRUCacheService
+    private inMemoryLRUCacheService: InMemoryLRUCacheService,
+    private getPreferences: GetPreferences
   ) {}
 
   @InstrumentUsecase()
@@ -296,27 +297,16 @@ export class GetSubscriberPreference {
           );
 
     const [
-      workflowResourcePreferences,
-      workflowUserPreferences,
+      { workflowResourcePreferences, workflowUserPreferences },
       subscriberWorkflowPreferences,
       subscriberGlobalPreferences,
     ] = await Promise.all([
-      this.preferencesRepository.findForComputation(
-        {
-          ...baseQuery,
-          _templateId: { $in: workflowIds },
-          type: PreferencesTypeEnum.WORKFLOW_RESOURCE,
-        },
-        readOptions
-      ),
-      this.preferencesRepository.findForComputation(
-        {
-          ...baseQuery,
-          _templateId: { $in: workflowIds },
-          type: PreferencesTypeEnum.USER_WORKFLOW,
-        },
-        readOptions
-      ),
+      this.getWorkflowLevelPreferences({
+        environmentId,
+        organizationId,
+        workflowIds,
+        readOptions,
+      }),
       this.preferencesRepository.findForComputation(
         {
           ...baseQuery,
@@ -336,6 +326,52 @@ export class GetSubscriberPreference {
       subscriberWorkflowPreferences,
       subscriberGlobalPreference: subscriberGlobalPreferences[0] ?? null,
     };
+  }
+
+  /**
+   * Resolves the subscriber-independent workflow-level preferences (WORKFLOW_RESOURCE and
+   * USER_WORKFLOW) for a set of workflows by delegating to the canonical, in-flight-coalesced
+   * `GetPreferences.getWorkflowPreferencesByIds` reader (shared with the single-workflow path),
+   * then flattens the per-workflow tuples into the two arrays the merge step consumes.
+   *
+   * The returned entries are shared cache references and must be treated as immutable; the merge
+   * pipeline (`MergePreferences`) only reads them and produces fresh objects.
+   */
+  @Instrument()
+  private async getWorkflowLevelPreferences({
+    environmentId,
+    organizationId,
+    workflowIds,
+    readOptions,
+  }: {
+    environmentId: string;
+    organizationId: string;
+    workflowIds: string[];
+    readOptions: { readPreference: 'secondaryPreferred' | 'primary' };
+  }): Promise<{
+    workflowResourcePreferences: PreferencesEntity[];
+    workflowUserPreferences: PreferencesEntity[];
+  }> {
+    const tuplesByWorkflowId = await this.getPreferences.getWorkflowPreferencesByIds({
+      environmentId,
+      organizationId,
+      workflowIds,
+      readOptions,
+    });
+
+    const workflowResourcePreferences: PreferencesEntity[] = [];
+    const workflowUserPreferences: PreferencesEntity[] = [];
+
+    for (const [workflowResourcePreference, workflowUserPreference] of tuplesByWorkflowId.values()) {
+      if (workflowResourcePreference) {
+        workflowResourcePreferences.push(workflowResourcePreference);
+      }
+      if (workflowUserPreference) {
+        workflowUserPreferences.push(workflowUserPreference);
+      }
+    }
+
+    return { workflowResourcePreferences, workflowUserPreferences };
   }
 
   @Instrument()

--- a/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.service.spec.ts
+++ b/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.service.spec.ts
@@ -249,6 +249,144 @@ describe('InMemoryLRUCacheService', () => {
     });
   });
 
+  describe('getMany', () => {
+    afterEach(() => {
+      service.invalidateAll(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES);
+    });
+
+    const buildFetchMissing = () =>
+      jest.fn(async (missingKeys: string[]) => {
+        const fetched = new Map<string, any>();
+        for (const key of missingKeys) {
+          fetched.set(key, [{ id: `resource-${key}` }, { id: `user-${key}` }]);
+        }
+
+        return fetched;
+      });
+
+    it('returns an empty map without fetching when given no keys', async () => {
+      const fetchMissing = buildFetchMissing();
+
+      const result = await service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, [], fetchMissing, {
+        environmentId: 'env1',
+      });
+
+      expect(result.size).toBe(0);
+      expect(fetchMissing).not.toHaveBeenCalled();
+    });
+
+    it('fetches all missing keys in a single batch call and caches them', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const fetchMissing = buildFetchMissing();
+
+      const result = await service.getMany(
+        InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
+        ['env1:wf_1', 'env1:wf_2'],
+        fetchMissing,
+        { environmentId: 'env1', organizationId: 'org1' }
+      );
+
+      expect(fetchMissing).toHaveBeenCalledTimes(1);
+      expect(fetchMissing).toHaveBeenCalledWith(['env1:wf_1', 'env1:wf_2']);
+      expect(featureFlagsService.getFlag).toHaveBeenCalledWith(
+        expect.objectContaining({ key: FeatureFlagsKeysEnum.IS_LRU_CACHE_ENABLED })
+      );
+      expect(result.get('env1:wf_1')).toEqual([{ id: 'resource-env1:wf_1' }, { id: 'user-env1:wf_1' }]);
+      expect(result.get('env1:wf_2')).toEqual([{ id: 'resource-env1:wf_2' }, { id: 'user-env1:wf_2' }]);
+    });
+
+    it('serves cache hits without calling fetchMissing again', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const fetchMissing = buildFetchMissing();
+
+      await service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, ['env1:wf_1'], fetchMissing, {
+        environmentId: 'env1',
+      });
+      const result = await service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, ['env1:wf_1'], fetchMissing, {
+        environmentId: 'env1',
+      });
+
+      expect(fetchMissing).toHaveBeenCalledTimes(1);
+      expect(result.get('env1:wf_1')).toEqual([{ id: 'resource-env1:wf_1' }, { id: 'user-env1:wf_1' }]);
+    });
+
+    it('only fetches the missing keys when the cache is partially warm', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      const fetchMissing = buildFetchMissing();
+
+      await service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, ['env1:wf_1'], fetchMissing, {
+        environmentId: 'env1',
+      });
+      const result = await service.getMany(
+        InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
+        ['env1:wf_1', 'env1:wf_2'],
+        fetchMissing,
+        { environmentId: 'env1' }
+      );
+
+      expect(fetchMissing).toHaveBeenCalledTimes(2);
+      expect(fetchMissing).toHaveBeenNthCalledWith(2, ['env1:wf_2']);
+      expect(result.size).toBe(2);
+    });
+
+    it('coalesces concurrent callers for the same key into a single fetch', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(true);
+      let fetchCount = 0;
+      const fetchMissing = jest.fn(
+        (missingKeys: string[]) =>
+          new Promise<Map<string, any>>((resolve) => {
+            setTimeout(() => {
+              fetchCount++;
+              const fetched = new Map<string, any>();
+              for (const key of missingKeys) {
+                fetched.set(key, [{ id: `resource-${fetchCount}` }, null]);
+              }
+              resolve(fetched);
+            }, 10);
+          })
+      );
+
+      const [result1, result2, result3] = await Promise.all([
+        service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, ['env1:wf_1'], fetchMissing, {
+          environmentId: 'env1',
+        }),
+        service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, ['env1:wf_1'], fetchMissing, {
+          environmentId: 'env1',
+        }),
+        service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, ['env1:wf_1'], fetchMissing, {
+          environmentId: 'env1',
+        }),
+      ]);
+
+      expect(fetchMissing).toHaveBeenCalledTimes(1);
+      expect(result1.get('env1:wf_1')).toEqual([{ id: 'resource-1' }, null]);
+      expect(result2.get('env1:wf_1')).toEqual([{ id: 'resource-1' }, null]);
+      expect(result3.get('env1:wf_1')).toEqual([{ id: 'resource-1' }, null]);
+    });
+
+    it('bypasses the cache and fetches every key when the feature flag is disabled', async () => {
+      featureFlagsService.getFlag.mockResolvedValue(false);
+      const fetchMissing = buildFetchMissing();
+
+      const result = await service.getMany(
+        InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
+        ['env1:wf_1', 'env1:wf_2'],
+        fetchMissing,
+        { environmentId: 'env1' }
+      );
+
+      expect(fetchMissing).toHaveBeenCalledTimes(1);
+      expect(fetchMissing).toHaveBeenCalledWith(['env1:wf_1', 'env1:wf_2']);
+      expect(result.size).toBe(2);
+
+      await service.getMany(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, ['env1:wf_1', 'env1:wf_2'], fetchMissing, {
+        environmentId: 'env1',
+      });
+
+      expect(fetchMissing).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('getIfCached', () => {
     it('should return undefined for non-existent key', () => {
       const result = service.getIfCached(InMemoryLRUCacheStore.WORKFLOW, 'nonexistent');

--- a/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.service.ts
+++ b/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.service.ts
@@ -6,7 +6,14 @@ import { CacheStoreDataTypeMap, InMemoryLRUCacheStore, STORE_CONFIGS, StoreConfi
 
 type EntityStore<T = unknown> = {
   cache: LRUCache<string, T>;
-  inflightRequests: Map<string, Promise<T>>;
+  /**
+   * In-flight fetches keyed by effective cache key, shared by `get()` and `getMany()` so
+   * concurrent callers coalesce onto one fetch. The resolved value is `T | undefined` because
+   * `getMany()` registers a promise per requested key and a batch fetch may legitimately omit a
+   * key (resolving `undefined`); `get()` treats an `undefined` resolution as a miss and falls
+   * back to its own fetch, so the two methods can safely share a store.
+   */
+  inflightRequests: Map<string, Promise<T | undefined>>;
   config: StoreConfig;
 };
 
@@ -45,7 +52,11 @@ export class InMemoryLRUCacheService {
 
     const inflightRequest = store.inflightRequests.get(effectiveKey);
     if (inflightRequest) {
-      return inflightRequest;
+      const inflightResult = await inflightRequest;
+      if (inflightResult !== undefined) {
+        return inflightResult;
+      }
+      // A shared `getMany()` batch had no value for this key — fall through to our own fetch.
     }
 
     const fetchPromise = fetchFn()
@@ -63,6 +74,93 @@ export class InMemoryLRUCacheService {
     store.inflightRequests.set(effectiveKey, fetchPromise);
 
     return fetchPromise;
+  }
+
+  /**
+   * Batch variant of `get()` that resolves many keys at once while preserving the same
+   * caching and in-flight coalescing semantics per key:
+   * - cache hits are served from memory,
+   * - keys with an in-flight fetch (from this or a concurrent call) reuse that promise,
+   * - only the remaining keys are passed to `fetchMissing` in a single call.
+   *
+   * This keeps the cold-cache/TTL-expiry path stampede-safe (K concurrent callers for the same
+   * key set trigger one `fetchMissing` per key, not K), which a manual `getIfCached()` + `set()`
+   * loop would lose. `fetchMissing` is expected to return an entry for every requested key.
+   */
+  async getMany<TStore extends InMemoryLRUCacheStore>(
+    storeName: TStore,
+    keys: string[],
+    fetchMissing: (missingKeys: string[]) => Promise<Map<string, CacheStoreDataTypeMap[TStore]>>,
+    opts?: GetOptions
+  ): Promise<Map<string, CacheStoreDataTypeMap[TStore]>> {
+    const result = new Map<string, CacheStoreDataTypeMap[TStore]>();
+
+    if (keys.length === 0) {
+      return result;
+    }
+
+    const store = this.getOrCreateStore<CacheStoreDataTypeMap[TStore]>(storeName);
+    const isCacheEnabled = await this.isCacheEnabled(store.config, opts);
+
+    if (!isCacheEnabled || opts?.skipCache) {
+      return fetchMissing(keys);
+    }
+
+    const pending: Array<{ key: string; promise: Promise<CacheStoreDataTypeMap[TStore] | undefined> }> = [];
+    const missingKeys: string[] = [];
+
+    for (const key of keys) {
+      const effectiveKey = this.resolveKey(key, opts?.cacheVariant);
+
+      const cached = store.cache.get(effectiveKey);
+      if (cached !== undefined) {
+        result.set(key, cached);
+        continue;
+      }
+
+      const inflightRequest = store.inflightRequests.get(effectiveKey);
+      if (inflightRequest) {
+        pending.push({ key, promise: inflightRequest });
+        continue;
+      }
+
+      missingKeys.push(key);
+    }
+
+    if (missingKeys.length > 0) {
+      const batchPromise = fetchMissing(missingKeys);
+
+      for (const key of missingKeys) {
+        const effectiveKey = this.resolveKey(key, opts?.cacheVariant);
+
+        const perKeyPromise = batchPromise
+          .then((fetched) => {
+            const value = fetched.get(key);
+            if (value !== null && value !== undefined) {
+              store.cache.set(effectiveKey, value);
+            }
+
+            return value;
+          })
+          .finally(() => {
+            store.inflightRequests.delete(effectiveKey);
+          });
+
+        store.inflightRequests.set(effectiveKey, perKeyPromise);
+        pending.push({ key, promise: perKeyPromise });
+      }
+    }
+
+    await Promise.all(
+      pending.map(async ({ key, promise }) => {
+        const value = await promise;
+        if (value !== undefined) {
+          result.set(key, value);
+        }
+      })
+    );
+
+    return result;
   }
 
   getIfCached<TStore extends InMemoryLRUCacheStore>(
@@ -124,7 +222,7 @@ export class InMemoryLRUCacheService {
           max: config.max,
           ttl: config.ttl,
         }),
-        inflightRequests: new Map<string, Promise<T>>(),
+        inflightRequests: new Map<string, Promise<T | undefined>>(),
         config,
       };
       STORES.set(storeName, store as EntityStore);

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -474,14 +474,13 @@ export class GetPreferences {
       return tuplesByWorkflowId;
     }
 
-    const preferences = await this.preferencesRepository.find(
+    const preferences = await this.preferencesRepository.findForComputation(
       {
         _environmentId: environmentId,
         _organizationId: organizationId,
         _templateId: { $in: workflowIds },
         type: { $in: [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW] },
       },
-      undefined,
       queryOptions
     );
 

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -11,7 +11,11 @@ import {
 } from '@novu/shared';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
 import { FeatureFlagsService } from '../../services/feature-flags';
-import { InMemoryLRUCacheService, InMemoryLRUCacheStore } from '../../services/in-memory-lru-cache';
+import {
+  InMemoryLRUCacheService,
+  InMemoryLRUCacheStore,
+  WorkflowPreferencesCacheData,
+} from '../../services/in-memory-lru-cache';
 import { MergePreferencesCommand } from '../merge-preferences/merge-preferences.command';
 import { MergePreferences } from '../merge-preferences/merge-preferences.usecase';
 import { GetPreferencesCommand } from './get-preferences.command';
@@ -293,39 +297,21 @@ export class GetPreferences {
 
     const queryOptions = { readPreference: 'secondaryPreferred' as const };
 
-    const cacheOptions = {
-      environmentId: command.environmentId,
-      organizationId: command.organizationId,
-    };
-
     let workflowResourcePreference: PreferencesEntity | null = null;
     let workflowUserPreference: PreferencesEntity | null = null;
 
     if (command.templateId) {
-      const workflowPreferences = await this.inMemoryLRUCacheService.get(
-        InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
-        `${command.environmentId}:${command.templateId}`,
-        async (): Promise<[PreferencesEntity | null, PreferencesEntity | null]> => {
-          const preferences = await this.preferencesRepository.find(
-            {
-              ...baseQuery,
-              _templateId: command.templateId,
-              type: { $in: [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW] },
-            },
-            undefined,
-            queryOptions
-          );
+      const workflowPreferencesById = await this.getWorkflowPreferencesByIds({
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        workflowIds: [command.templateId],
+        readOptions: queryOptions,
+      });
 
-          const workflowResourcePref =
-            preferences.find((p) => p.type === PreferencesTypeEnum.WORKFLOW_RESOURCE) ?? null;
-          const workflowUserPref = preferences.find((p) => p.type === PreferencesTypeEnum.USER_WORKFLOW) ?? null;
-
-          return [workflowResourcePref, workflowUserPref];
-        },
-        cacheOptions
-      );
-
-      [workflowResourcePreference, workflowUserPreference] = workflowPreferences;
+      [workflowResourcePreference, workflowUserPreference] = workflowPreferencesById.get(command.templateId) ?? [
+        null,
+        null,
+      ];
     }
 
     let subscriberWorkflowPreference: PreferencesEntity | null = null;
@@ -392,5 +378,128 @@ export class GetPreferences {
     }
 
     return result;
+  }
+
+  /**
+   * Canonical reader for the subscriber-independent workflow-level preferences
+   * (WORKFLOW_RESOURCE + USER_WORKFLOW), served from the shared WORKFLOW_PREFERENCES LRU store.
+   *
+   * This owns the single source of truth for the cache key scheme (`${environmentId}:${templateId}`)
+   * and the tuple positional contract (`[WORKFLOW_RESOURCE, USER_WORKFLOW]`), so both the
+   * single-workflow path (`getPreferencesFromDbOptimized`, N=1) and the multi-workflow
+   * subscriber-preferences path consume the exact same entries — warmth is shared in both
+   * directions and the contract cannot silently drift between call sites.
+   *
+   * Cache hits skip Mongo entirely; misses are fetched in a single batched `$in` query and
+   * coalesced per key via `getMany`, so concurrent callers do not stampede on a cold/expired key.
+   * Entries are shared references; callers must treat them as immutable (the merge pipeline does).
+   */
+  @Instrument()
+  public async getWorkflowPreferencesByIds({
+    environmentId,
+    organizationId,
+    workflowIds,
+    readOptions,
+  }: {
+    environmentId: string;
+    organizationId: string;
+    workflowIds: string[];
+    readOptions?: { readPreference?: 'secondaryPreferred' | 'primary' };
+  }): Promise<Map<string, WorkflowPreferencesCacheData>> {
+    const queryOptions = readOptions ?? { readPreference: 'secondaryPreferred' as const };
+    const cacheKey = (workflowId: string) => `${environmentId}:${workflowId}`;
+    const workflowIdByCacheKey = new Map(workflowIds.map((workflowId) => [cacheKey(workflowId), workflowId]));
+
+    const tuplesByCacheKey = await this.inMemoryLRUCacheService.getMany(
+      InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
+      [...workflowIdByCacheKey.keys()],
+      async (missingCacheKeys) => {
+        const missingWorkflowIds: string[] = [];
+        for (const missingCacheKey of missingCacheKeys) {
+          const workflowId = workflowIdByCacheKey.get(missingCacheKey);
+          // Every missing key originates from `workflowIdByCacheKey`, so this is always defined;
+          // the guard keeps the invariant explicit instead of relying on a cast.
+          if (workflowId !== undefined) {
+            missingWorkflowIds.push(workflowId);
+          }
+        }
+
+        const tuplesByWorkflowId = await this.fetchWorkflowPreferenceTuples({
+          environmentId,
+          organizationId,
+          workflowIds: missingWorkflowIds,
+          queryOptions,
+        });
+
+        const tuples = new Map<string, WorkflowPreferencesCacheData>();
+        for (const workflowId of missingWorkflowIds) {
+          tuples.set(cacheKey(workflowId), tuplesByWorkflowId.get(workflowId) ?? [null, null]);
+        }
+
+        return tuples;
+      },
+      { environmentId, organizationId }
+    );
+
+    const tuplesByWorkflowId = new Map<string, WorkflowPreferencesCacheData>();
+    for (const workflowId of workflowIds) {
+      const tuple = tuplesByCacheKey.get(cacheKey(workflowId));
+      if (tuple) {
+        tuplesByWorkflowId.set(workflowId, tuple);
+      }
+    }
+
+    return tuplesByWorkflowId;
+  }
+
+  /**
+   * Fetches WORKFLOW_RESOURCE + USER_WORKFLOW preferences for the given workflows in a single
+   * query and splits them into the canonical `[WORKFLOW_RESOURCE, USER_WORKFLOW]` tuple per
+   * workflow. Workflows with no preferences are omitted (the caller seeds `[null, null]`).
+   */
+  private async fetchWorkflowPreferenceTuples({
+    environmentId,
+    organizationId,
+    workflowIds,
+    queryOptions,
+  }: {
+    environmentId: string;
+    organizationId: string;
+    workflowIds: string[];
+    queryOptions: { readPreference?: 'secondaryPreferred' | 'primary' };
+  }): Promise<Map<string, WorkflowPreferencesCacheData>> {
+    const tuplesByWorkflowId = new Map<string, WorkflowPreferencesCacheData>();
+
+    if (workflowIds.length === 0) {
+      return tuplesByWorkflowId;
+    }
+
+    const preferences = await this.preferencesRepository.find(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        _templateId: { $in: workflowIds },
+        type: { $in: [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW] },
+      },
+      undefined,
+      queryOptions
+    );
+
+    for (const preference of preferences) {
+      const workflowId = preference._templateId;
+      if (workflowId === undefined) {
+        continue;
+      }
+
+      const tuple = tuplesByWorkflowId.get(workflowId) ?? [null, null];
+      if (preference.type === PreferencesTypeEnum.WORKFLOW_RESOURCE) {
+        tuple[0] = preference;
+      } else if (preference.type === PreferencesTypeEnum.USER_WORKFLOW) {
+        tuple[1] = preference;
+      }
+      tuplesByWorkflowId.set(workflowId, tuple);
+    }
+
+    return tuplesByWorkflowId;
   }
 }

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -444,7 +444,7 @@ export class GetPreferences {
     const tuplesByWorkflowId = new Map<string, WorkflowPreferencesCacheData>();
     for (const workflowId of workflowIds) {
       const tuple = tuplesByCacheKey.get(cacheKey(workflowId));
-      if (tuple) {
+      if (tuple !== undefined) {
         tuplesByWorkflowId.set(workflowId, tuple);
       }
     }

--- a/libs/application-generic/src/usecases/get-preferences/get-workflow-preferences-by-ids.spec.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-workflow-preferences-by-ids.spec.ts
@@ -21,13 +21,13 @@ function buildPreference(templateId: string, type: PreferencesTypeEnum): Prefere
 describe('GetPreferences.getWorkflowPreferencesByIds', () => {
   let getPreferences: GetPreferences;
   let cacheService: InMemoryLRUCacheService;
-  let find: jest.Mock;
+  let findForComputation: jest.Mock;
 
   beforeEach(() => {
     const featureFlagsService = { getFlag: jest.fn().mockResolvedValue(true) } as unknown as FeatureFlagsService;
     cacheService = new InMemoryLRUCacheService(featureFlagsService);
-    find = jest.fn();
-    const preferencesRepository = { find } as any;
+    findForComputation = jest.fn();
+    const preferencesRepository = { findForComputation } as any;
     getPreferences = new GetPreferences(preferencesRepository, featureFlagsService, cacheService);
   });
 
@@ -36,7 +36,7 @@ describe('GetPreferences.getWorkflowPreferencesByIds', () => {
   });
 
   it('queries missing workflows with a single $in and splits results into [resource, user] tuples', async () => {
-    find.mockResolvedValue([
+    findForComputation.mockResolvedValue([
       buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE),
       buildPreference('wf_1', PreferencesTypeEnum.USER_WORKFLOW),
       buildPreference('wf_2', PreferencesTypeEnum.WORKFLOW_RESOURCE),
@@ -48,8 +48,8 @@ describe('GetPreferences.getWorkflowPreferencesByIds', () => {
       workflowIds: ['wf_1', 'wf_2'],
     });
 
-    expect(find).toHaveBeenCalledTimes(1);
-    const query = find.mock.calls[0][0];
+    expect(findForComputation).toHaveBeenCalledTimes(1);
+    const query = findForComputation.mock.calls[0][0];
     expect(query._templateId.$in).toEqual(['wf_1', 'wf_2']);
     expect(query.type.$in).toEqual([PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW]);
 
@@ -61,7 +61,7 @@ describe('GetPreferences.getWorkflowPreferencesByIds', () => {
   });
 
   it('returns a [null, null] tuple for workflows without preferences and caches it', async () => {
-    find.mockResolvedValue([]);
+    findForComputation.mockResolvedValue([]);
 
     const result = await getPreferences.getWorkflowPreferencesByIds({
       environmentId: ENVIRONMENT_ID,
@@ -77,7 +77,7 @@ describe('GetPreferences.getWorkflowPreferencesByIds', () => {
   });
 
   it('serves cached workflows without re-querying and shares the single-workflow key scheme', async () => {
-    find.mockResolvedValue([buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE)]);
+    findForComputation.mockResolvedValue([buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE)]);
 
     await getPreferences.getWorkflowPreferencesByIds({
       environmentId: ENVIRONMENT_ID,
@@ -90,7 +90,7 @@ describe('GetPreferences.getWorkflowPreferencesByIds', () => {
       workflowIds: ['wf_1'],
     });
 
-    expect(find).toHaveBeenCalledTimes(1);
+    expect(findForComputation).toHaveBeenCalledTimes(1);
     expect(result.get('wf_1')).toEqual([buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE), null]);
     expect(cacheService.getIfCached(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, `${ENVIRONMENT_ID}:wf_1`)).toEqual([
       buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE),

--- a/libs/application-generic/src/usecases/get-preferences/get-workflow-preferences-by-ids.spec.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-workflow-preferences-by-ids.spec.ts
@@ -1,0 +1,100 @@
+import { PreferencesEntity } from '@novu/dal';
+import { PreferencesTypeEnum } from '@novu/shared';
+import { FeatureFlagsService } from '../../services/feature-flags';
+import { InMemoryLRUCacheService, InMemoryLRUCacheStore } from '../../services/in-memory-lru-cache';
+import { GetPreferences } from './get-preferences.usecase';
+
+const ENVIRONMENT_ID = 'env_1';
+const ORGANIZATION_ID = 'org_1';
+
+function buildPreference(templateId: string, type: PreferencesTypeEnum): PreferencesEntity {
+  return {
+    _id: `${type}_${templateId}`,
+    _templateId: templateId,
+    _environmentId: ENVIRONMENT_ID,
+    _organizationId: ORGANIZATION_ID,
+    type,
+    preferences: { all: { enabled: true } },
+  } as unknown as PreferencesEntity;
+}
+
+describe('GetPreferences.getWorkflowPreferencesByIds', () => {
+  let getPreferences: GetPreferences;
+  let cacheService: InMemoryLRUCacheService;
+  let find: jest.Mock;
+
+  beforeEach(() => {
+    const featureFlagsService = { getFlag: jest.fn().mockResolvedValue(true) } as unknown as FeatureFlagsService;
+    cacheService = new InMemoryLRUCacheService(featureFlagsService);
+    find = jest.fn();
+    const preferencesRepository = { find } as any;
+    getPreferences = new GetPreferences(preferencesRepository, featureFlagsService, cacheService);
+  });
+
+  afterEach(() => {
+    cacheService.invalidateAll(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES);
+  });
+
+  it('queries missing workflows with a single $in and splits results into [resource, user] tuples', async () => {
+    find.mockResolvedValue([
+      buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE),
+      buildPreference('wf_1', PreferencesTypeEnum.USER_WORKFLOW),
+      buildPreference('wf_2', PreferencesTypeEnum.WORKFLOW_RESOURCE),
+    ]);
+
+    const result = await getPreferences.getWorkflowPreferencesByIds({
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      workflowIds: ['wf_1', 'wf_2'],
+    });
+
+    expect(find).toHaveBeenCalledTimes(1);
+    const query = find.mock.calls[0][0];
+    expect(query._templateId.$in).toEqual(['wf_1', 'wf_2']);
+    expect(query.type.$in).toEqual([PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW]);
+
+    expect(result.get('wf_1')).toEqual([
+      buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE),
+      buildPreference('wf_1', PreferencesTypeEnum.USER_WORKFLOW),
+    ]);
+    expect(result.get('wf_2')).toEqual([buildPreference('wf_2', PreferencesTypeEnum.WORKFLOW_RESOURCE), null]);
+  });
+
+  it('returns a [null, null] tuple for workflows without preferences and caches it', async () => {
+    find.mockResolvedValue([]);
+
+    const result = await getPreferences.getWorkflowPreferencesByIds({
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      workflowIds: ['wf_empty'],
+    });
+
+    expect(result.get('wf_empty')).toEqual([null, null]);
+    expect(cacheService.getIfCached(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, `${ENVIRONMENT_ID}:wf_empty`)).toEqual([
+      null,
+      null,
+    ]);
+  });
+
+  it('serves cached workflows without re-querying and shares the single-workflow key scheme', async () => {
+    find.mockResolvedValue([buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE)]);
+
+    await getPreferences.getWorkflowPreferencesByIds({
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      workflowIds: ['wf_1'],
+    });
+    const result = await getPreferences.getWorkflowPreferencesByIds({
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      workflowIds: ['wf_1'],
+    });
+
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(result.get('wf_1')).toEqual([buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE), null]);
+    expect(cacheService.getIfCached(InMemoryLRUCacheStore.WORKFLOW_PREFERENCES, `${ENVIRONMENT_ID}:wf_1`)).toEqual([
+      buildPreference('wf_1', PreferencesTypeEnum.WORKFLOW_RESOURCE),
+      null,
+    ]);
+  });
+});


### PR DESCRIPTION
### What changed? Why was the change needed?

- Introduced `getWorkflowPreferencesByIds` method to fetch workflow-level preferences in a single query, improving efficiency.
- Updated `InMemoryLRUCacheService` to support batch fetching of multiple keys, reducing redundant database calls.
- Added tests for the new functionality to ensure correct behavior and caching logic.
- Refactored existing preference retrieval logic to utilize the new method, streamlining the codebase.

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds batched workflow preference lookup and updates the related cache behavior. The main changes are:

- New `getWorkflowPreferencesByIds` reader for workflow-level preference tuples.
- Batched `getMany` support in the in-memory LRU cache.
- Subscriber preference retrieval now reuses the shared workflow preference reader.
- Tests cover batched cache lookup and workflow preference tuple retrieval.

<h3>Confidence Score: 4/5</h3>

The changes are narrowly scoped to preference retrieval and cache batching, with no accepted code issues requiring changes before merge.

The modified paths include targeted tests for the new batch preference lookup and cache behavior, and no actionable defects were identified in the reviewed changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the workflow preferences batch test and reviewed the before/after logs to confirm HTTP 200 status and the computed results, including the \_templateId and type filters, plus contractPass=true.
- Executed the lru-getmany test using the harness and saved the harness at trex-artifacts/lru-getmany-harness.js for reuse in both runs.
- Compared two retrievals and verified that the after-output uses a single combined workflow-level query on the first retrieval and relies on the cache on the second retrieval, with identical channel summaries.

<a href="https://app.greptile.com/trex/runs/12164040/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(preferences): rename find metho..."](https://github.com/novuhq/novu/commit/117b85af608072479649714bd5daedc70e8fc398) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39574673)</sub>

<!-- /greptile_comment -->