### PR TITLE
fix(dashboard): center workflow blank state on page fixes NV-8123

### DIFF
--- a/apps/dashboard/src/components/workflow-list-empty.tsx
+++ b/apps/dashboard/src/components/workflow-list-empty.tsx
@@ -178,8 +178,8 @@ const WorkflowListEmptyDev = () => {
   const { environmentSlug } = useParams();
 
   return (
-    <div className="flex h-full w-full flex-col items-start justify-center">
-      <div className="flex flex-col gap-12 translate-x-1/4">
+    <div className="flex h-full w-full flex-col items-center justify-center">
+      <div className="flex flex-col gap-12">
         <WorkflowsIllustration className="w-34" />
 
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The blank/empty state on the Workflows page was not centered. The `WorkflowListEmptyDev` component used `items-start` (left-aligned) with a `translate-x-1/4` hack on the inner container, which did not properly center the content.

Fixed by replacing `items-start` with `items-center` and removing the `translate-x-1/4` transform, matching the centering approach already used by `WorkflowListEmptyProd` (`items-center justify-center`).

### Screenshots

**After fix — blank state centered:**

![Workflow blank state now centered](https://cursor.com/artifacts/c/art-1f5e424e-29c9-44d2-b94a-aa5be0cc62d4)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8123](https://linear.app/novu/issue/NV-8123/the-blank-state-on-the-workflow-page-is-not-centered)

<div><a href="https://cursor.com/agents/bc-2141a5ad-7803-4459-94fb-deba67685a3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2141a5ad-7803-4459-94fb-deba67685a3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the blank/empty state on the Workflows page not being centered for dev environments. The previous implementation used `items-start` with a `translate-x-1/4` transform hack to approximate centering, which was fragile and layout-dependent.

- Replaces `items-start` with `items-center` on the outer container of `WorkflowListEmptyDev`, matching the approach already used by `WorkflowListEmptyProd`.
- Removes the `translate-x-1/4` transform from the inner container, which is no longer needed once proper flexbox centering is applied.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a two-line Tailwind class swap with no functional or behavioral side effects.

The change removes a positional transform hack and replaces a mismatched flex alignment class with the correct one. Both WorkflowListEmptyDev and WorkflowListEmptyProd now use the same centering pattern, and there is no shared state, data fetching, or logic touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-list-empty.tsx | Two-line CSS class change: replaces `items-start` + `translate-x-1/4` hack with `items-center` for proper horizontal centering of the dev empty-state component. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["WorkflowListEmpty"] --> B{isProd?}
    B -- Yes --> C["WorkflowListEmptyProd\nitems-center justify-center gap-6"]
    B -- No --> D["WorkflowListEmptyDev\nitems-center justify-center\n(was: items-start + translate-x-1/4)"]
    C --> E["Centered blank state ✓"]
    D --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["WorkflowListEmpty"] --> B{isProd?}
    B -- Yes --> C["WorkflowListEmptyProd\nitems-center justify-center gap-6"]
    B -- No --> D["WorkflowListEmptyDev\nitems-center justify-center\n(was: items-start + translate-x-1/4)"]
    C --> E["Centered blank state ✓"]
    D --> E
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): center workflow blank st..."](https://github.com/novuhq/novu/commit/0a6e3ad10ac965269b22341d5ecc069cbee8d474) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39813784)</sub>

<!-- /greptile_comment -->