### PR TITLE
fix(api-service, dashboard, shared): enable and improve inbound mail UX on Self hosted EE fixes NV-8106

### DIFF
--- a/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
@@ -8,7 +8,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { AnalyticsService, encryptSecret, isAgentSharedInboxEnabled } from '@novu/application-generic';
+import { AnalyticsService, encryptSecret, isAgentEmailEnabled } from '@novu/application-generic';
 import {
   type AgentEntity,
   AgentIntegrationRepository,
@@ -172,7 +172,7 @@ export class AddAgentIntegration {
   }
 
   private async enforceEmailTier(organizationId: string): Promise<void> {
-    if (!isAgentSharedInboxEnabled()) {
+    if (!isAgentEmailEnabled()) {
       throw new ForbiddenException('Agent Novu Email is not available in this deployment.');
     }
 

--- a/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.service.ts
+++ b/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.service.ts
@@ -10,6 +10,7 @@ import {
 import {
   encryptSecret,
   generateAgentInboxRoutingKey,
+  isAgentEmailEnabled,
   isAgentSharedInboxEnabled,
   isValidAgentEmailSlugPrefix,
 } from '@novu/application-generic';
@@ -113,11 +114,19 @@ export class NovuEmailProvisioningService {
   }
 
   /**
-   * Mints the NovuAgent integration with a freshly-generated `inboxRoutingKey`.
-   * The key is globally unique under a partial index gated to NovuAgent rows
-   * (`{ 'credentials.inboxRoutingKey': 1 }`), so the lone failure mode of a
-   * duplicate-key collision is retried up to {@link ROUTING_KEY_MAX_ATTEMPTS}
-   * times before surfacing the error to the caller.
+   * Mints the NovuAgent integration.
+   *
+   * On shared-inbox deployments (cloud) a freshly-generated `inboxRoutingKey` is
+   * attached. The key is globally unique under a partial index gated to
+   * NovuAgent rows (`{ 'credentials.inboxRoutingKey': 1 }`), so the lone failure
+   * mode of a duplicate-key collision is retried up to
+   * {@link ROUTING_KEY_MAX_ATTEMPTS} times before surfacing the error.
+   *
+   * On non-shared-inbox deployments (self-hosted) there is no shared domain to
+   * route against, so we skip routing-key minting entirely and persist
+   * `sharedInboxDisabled: true`. Inbound is wired through a per-tenant verified
+   * Domain + DomainRoute(type=AGENT) instead. The outbound sender is optional
+   * here and assigned later via the agent email setup guide.
    */
   private async createNovuAgentIntegration({
     displayName,
@@ -133,35 +142,52 @@ export class NovuEmailProvisioningService {
     identifier: string;
     emailSlugPrefix: string;
     senderName: string;
-    outboundIntegrationId: string;
+    outboundIntegrationId?: string;
     environmentId: string;
     organizationId: string;
     session: ClientSession | null;
   }): Promise<IntegrationEntity> {
+    const baseCredentials = {
+      secretKey: encryptSecret(randomBytes(32).toString('hex')),
+      emailSlugPrefix,
+      senderName,
+      ...(outboundIntegrationId ? { outboundIntegrationId } : {}),
+    };
+
+    // The create envelope is identical across both branches; only `credentials`
+    // varies (shared-inbox routing key vs. self-hosted disabled flag). Build it
+    // once so the lone `as any` (a pre-existing DAL signature wart) lives in a
+    // single place. The cast is needed because the repository's `create` accepts
+    // a query type rather than a plain document.
+    const buildPayload = (credentials: Record<string, unknown>) =>
+      ({
+        providerId: EmailProviderIdEnum.NovuAgent,
+        channel: ChannelTypeEnum.EMAIL,
+        credentials,
+        configurations: {},
+        name: displayName,
+        identifier,
+        active: true,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      }) as any;
+
+    // Self-hosted: no shared domain to route against, so skip routing-key minting
+    // (and its collision loop) and persist the disabled flag. Inbound is wired
+    // through a per-tenant verified Domain + DomainRoute(type=AGENT).
+    if (!isAgentSharedInboxEnabled()) {
+      return this.integrationRepository.create(buildPayload({ ...baseCredentials, sharedInboxDisabled: true }), {
+        session,
+      });
+    }
+
     let lastError: unknown;
     for (let attempt = 0; attempt < ROUTING_KEY_MAX_ATTEMPTS; attempt += 1) {
       const inboxRoutingKey = generateAgentInboxRoutingKey();
       try {
-        return await this.integrationRepository.create(
-          {
-            providerId: EmailProviderIdEnum.NovuAgent,
-            channel: ChannelTypeEnum.EMAIL,
-            credentials: {
-              secretKey: encryptSecret(randomBytes(32).toString('hex')),
-              emailSlugPrefix,
-              inboxRoutingKey,
-              outboundIntegrationId,
-              senderName,
-            },
-            configurations: {},
-            name: displayName,
-            identifier,
-            active: true,
-            _environmentId: environmentId,
-            _organizationId: organizationId,
-          } as any,
-          { session }
-        );
+        return await this.integrationRepository.create(buildPayload({ ...baseCredentials, inboxRoutingKey }), {
+          session,
+        });
       } catch (err) {
         if (!isInboxRoutingKeyCollision(err)) {
           throw err;
@@ -186,14 +212,22 @@ export class NovuEmailProvisioningService {
    *      Development environments alongside the org. It's quota-limited but
    *      lets the agent reply out of the box without any user configuration.
    *
-   * We deliberately throw when neither exists rather than persisting an empty
-   * sentinel: every downstream path (send-agent-test-email + chat-sdk's
-   * `buildSendEmailCallback`) now assumes a concrete integration id, and a
-   * misconfigured env (custom non-prod env with no email seeded) is surfaced
-   * loudly so the user can fix it instead of silently routing through a
-   * synthetic demo that may also be unavailable.
+   * On shared-inbox deployments (cloud) we deliberately throw when neither
+   * exists rather than persisting an empty sentinel: every downstream path
+   * (send-agent-test-email + chat-sdk's `buildSendEmailCallback`) assumes a
+   * concrete integration id, and a misconfigured env (custom non-prod env with
+   * no email seeded) is surfaced loudly so the user can fix it instead of
+   * silently routing through a synthetic demo that may also be unavailable.
+   *
+   * On self-hosted there is no bundled Novu demo provider, so a fresh org has
+   * no outbound sender to attach yet. We return `undefined` and let the agent
+   * email setup guide assign a provider; sending stays gracefully blocked with
+   * a clear error until one is selected.
    */
-  private async resolveDefaultOutboundIntegrationId(environmentId: string, organizationId: string): Promise<string> {
+  private async resolveDefaultOutboundIntegrationId(
+    environmentId: string,
+    organizationId: string
+  ): Promise<string | undefined> {
     const primaryCustom = await this.integrationRepository.findOne({
       _environmentId: environmentId,
       _organizationId: organizationId,
@@ -213,9 +247,13 @@ export class NovuEmailProvisioningService {
     });
     if (novuDemo) return novuDemo._id;
 
-    throw new ConflictException(
-      'No outbound email integration available for this environment. Activate the Novu Email demo provider or configure a primary email integration.'
-    );
+    if (isAgentSharedInboxEnabled()) {
+      throw new ConflictException(
+        'No outbound email integration available for this environment. Activate the Novu Email demo provider or configure a primary email integration.'
+      );
+    }
+
+    return undefined;
   }
 
   /**
@@ -315,7 +353,7 @@ export class NovuEmailProvisioningService {
   }
 
   private async enforceEmailTier(organizationId: string): Promise<void> {
-    if (!isAgentSharedInboxEnabled()) {
+    if (!isAgentEmailEnabled()) {
       throw new ForbiddenException('Agent Novu Email is not available in this deployment.');
     }
 

--- a/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.spec.ts
+++ b/apps/api/src/app/agents/email/novu-email/find-or-create-novu-email/find-or-create-novu-email.spec.ts
@@ -227,4 +227,68 @@ describe('NovuEmailProvisioningService', () => {
       expect(integrationRepo.findOne.calledOnce).to.equal(true);
     });
   });
+
+  describe('self-hosted', () => {
+    beforeEach(() => {
+      // Self-hosted enterprise: isAgentEmailEnabled() is true (no shared domain
+      // needed) while isAgentSharedInboxEnabled() is false (IS_SELF_HOSTED).
+      process.env.IS_SELF_HOSTED = 'true';
+      delete process.env.NOVU_AGENT_SHARED_INBOUND_DOMAIN;
+    });
+
+    it('provisions without a routing key and persists sharedInboxDisabled, using a custom provider for outbound', async () => {
+      const primaryCustomIntegration = {
+        _id: 'ses-id',
+        providerId: 'ses',
+        channel: ChannelTypeEnum.EMAIL,
+        active: true,
+        primary: true,
+      } as IntegrationEntity;
+
+      integrationRepo.findOne.onFirstCall().resolves(primaryCustomIntegration);
+      integrationRepo.create.resolves({
+        _id: 'novu-agent-int-id',
+        providerId: EmailProviderIdEnum.NovuAgent,
+        channel: ChannelTypeEnum.EMAIL,
+        identifier: 'novu-email-xxx',
+        name: 'Novu Email',
+        active: true,
+        credentials: {},
+      });
+
+      await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
+
+      expect(integrationRepo.create.calledOnce).to.equal(true);
+      const createArg = integrationRepo.create.firstCall.args[0];
+      expect(createArg.providerId).to.equal(EmailProviderIdEnum.NovuAgent);
+      expect(createArg.credentials.sharedInboxDisabled).to.equal(true);
+      expect(createArg.credentials.inboxRoutingKey).to.equal(undefined);
+      expect(createArg.credentials.outboundIntegrationId).to.equal('ses-id');
+      expect(createArg.credentials.emailSlugPrefix).to.be.a('string');
+    });
+
+    it('provisions with no outboundIntegrationId (no ConflictException) when no provider exists', async () => {
+      // Self-hosted has no bundled Novu demo provider; both lookups miss.
+      integrationRepo.findOne.onFirstCall().resolves(null);
+      integrationRepo.findOne.onSecondCall().resolves(null);
+      integrationRepo.create.resolves({
+        _id: 'novu-agent-int-id',
+        providerId: EmailProviderIdEnum.NovuAgent,
+        channel: ChannelTypeEnum.EMAIL,
+        identifier: 'novu-email-xxx',
+        name: 'Novu Email',
+        active: true,
+        credentials: {},
+      });
+
+      const result = await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
+
+      expect(result.provisionedNewLink).to.equal(true);
+      expect(integrationRepo.create.calledOnce).to.equal(true);
+      const createArg = integrationRepo.create.firstCall.args[0];
+      expect(createArg.credentials.sharedInboxDisabled).to.equal(true);
+      expect(createArg.credentials.inboxRoutingKey).to.equal(undefined);
+      expect('outboundIntegrationId' in createArg.credentials).to.equal(false);
+    });
+  });
 });

--- a/apps/api/src/app/agents/shared/dtos/agent-integration-response.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-integration-response.dto.ts
@@ -44,7 +44,8 @@ export class AgentIntegrationResponseIntegrationDto {
   @ApiPropertyOptional({
     description:
       'When true, the worker drops inbound mail addressed to this agent on the shared `agentconnect.sh` domain. ' +
-      'Custom-domain routes still deliver. Only meaningful on cloud-enabled NovuAgent integrations.',
+      'Custom-domain routes still deliver. Meaningful on cloud-enabled NovuAgent integrations; on self-hosted it ' +
+      'is set defensively at provisioning time and is effectively redundant.',
   })
   sharedInboxDisabled?: boolean;
 }

--- a/apps/api/src/app/shared/interceptors/product-feature.interceptor.ts
+++ b/apps/api/src/app/shared/interceptors/product-feature.interceptor.ts
@@ -8,7 +8,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { isAgentSharedInboxEnabled, ProductFeature } from '@novu/application-generic';
+import { isAgentEmailEnabled, ProductFeature } from '@novu/application-generic';
 import { CommunityOrganizationRepository } from '@novu/dal';
 import {
   ApiServiceLevelEnum,
@@ -60,7 +60,7 @@ export class ProductFeatureInterceptor implements NestInterceptor {
       throw new HttpException('Payment Required', 402);
     }
 
-    if (requestedFeature === ProductFeatureKeyEnum.AGENT_EMAIL_INTEGRATION && !isAgentSharedInboxEnabled()) {
+    if (requestedFeature === ProductFeatureKeyEnum.AGENT_EMAIL_INTEGRATION && !isAgentEmailEnabled()) {
       throw new ForbiddenException('Agent Novu Email is not available in this deployment.');
     }
 

--- a/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
@@ -5,6 +5,7 @@ import { EmailConfigurationCardBody } from '@/components/agents/email-configurat
 import { EmailInboxCardBody } from '@/components/agents/email-inbox-card';
 import { EmailSetupGuide } from '@/components/agents/email-setup-guide';
 import { isAgentIntegrationConnected } from '@/components/agents/is-agent-integration-connected';
+import { IS_SELF_HOSTED_EE } from '@/config';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { AgentIntegrationGuideLayout } from './agent-integration-guide-layout';
 
@@ -41,7 +42,7 @@ export function EmailAgentIntegrationGuide({
     [integrationId, integrations]
   );
 
-  const showInboxSection = isSharedInboxEnabled && emailIntegration && integrationLink;
+  const showInboxSection = (isSharedInboxEnabled || IS_SELF_HOSTED_EE) && emailIntegration && integrationLink;
 
   return (
     <AgentIntegrationGuideLayout

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -5,7 +5,7 @@ import { RiInformation2Line, RiKey2Line, RiLoader4Line, RiMailSendLine } from 'r
 import { type AgentIntegrationLink, type AgentResponse, sendAgentTestEmail } from '@/api/agents';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_EE } from '@/config';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
@@ -128,11 +128,12 @@ export function EmailSetupGuide({
   // provider is an explicit upgrade rather than a prerequisite. For demo,
   // `needsCredentialsStep` stays false so the credentials step is skipped
   // naturally and the wizard advances straight to the inbound-address step.
-  // Self-hosted has no bundled Novu demo sender, so a freshly provisioned agent
-  // has no outbound provider selected. Treat picking one as a hard prerequisite
-  // there. On cloud the demo is selected by default, so this branch never fires
-  // and the step stays pre-completed exactly as before (zero behavioral delta).
-  const needsOutboundSelection = IS_SELF_HOSTED && !outboundId;
+  // Self-hosted Enterprise has no bundled Novu demo sender, so a freshly
+  // provisioned agent has no outbound provider selected. Treat picking one as a
+  // hard prerequisite there. On cloud the demo is selected by default, so this
+  // branch never fires and the step stays pre-completed exactly as before (zero
+  // behavioral delta).
+  const needsOutboundSelection = IS_SELF_HOSTED_EE && !outboundId;
 
   const firstIncompleteStep = useMemo(() => {
     if (needsOutboundSelection) return base;
@@ -163,7 +164,7 @@ export function EmailSetupGuide({
         sectionLabel="SETUP SENDING EMAILS"
         title="Setup providers to send emails."
         description={
-          IS_SELF_HOSTED
+          IS_SELF_HOSTED_EE
             ? 'Select an email provider (e.g. SendGrid, SES, Resend) so your agent can send replies.'
             : 'The Novu Email demo sender is used by default so your agent can reply out of the box. Switch to your own provider for higher volume later.'
         }

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -1,10 +1,11 @@
 import { EmailProviderIdEnum } from '@novu/shared';
 import { useMutation } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
-import { RiInformation2Fill, RiInformation2Line, RiKey2Line, RiLoader4Line, RiMailSendLine } from 'react-icons/ri';
+import { RiInformation2Line, RiKey2Line, RiLoader4Line, RiMailSendLine } from 'react-icons/ri';
 import { type AgentIntegrationLink, type AgentResponse, sendAgentTestEmail } from '@/api/agents';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
+import { IS_SELF_HOSTED } from '@/config';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
@@ -77,7 +78,6 @@ export function EmailSetupGuide({
     outboundId,
     configuredAddresses,
     domains,
-    isOutboundDemo,
     needsCredentialsStep,
     hasOutboundCredentials,
     outboundProviderConfig,
@@ -128,13 +128,22 @@ export function EmailSetupGuide({
   // provider is an explicit upgrade rather than a prerequisite. For demo,
   // `needsCredentialsStep` stays false so the credentials step is skipped
   // naturally and the wizard advances straight to the inbound-address step.
+  // Self-hosted has no bundled Novu demo sender, so a freshly provisioned agent
+  // has no outbound provider selected. Treat picking one as a hard prerequisite
+  // there. On cloud the demo is selected by default, so this branch never fires
+  // and the step stays pre-completed exactly as before (zero behavioral delta).
+  const needsOutboundSelection = IS_SELF_HOSTED && !outboundId;
+
   const firstIncompleteStep = useMemo(() => {
+    if (needsOutboundSelection) return base;
     if (needsCredentialsStep && !hasOutboundCredentials) return credentialsStepIndex;
     if (!hasAddresses) return inboundStepIndex;
     if (!testConnected) return testStepIndex;
 
     return testStepIndex + 1;
   }, [
+    needsOutboundSelection,
+    base,
     needsCredentialsStep,
     hasOutboundCredentials,
     credentialsStepIndex,
@@ -153,7 +162,11 @@ export function EmailSetupGuide({
         status={deriveStepStatus(base, firstIncompleteStep)}
         sectionLabel="SETUP SENDING EMAILS"
         title="Setup providers to send emails."
-        description="The Novu Email demo sender is used by default so your agent can reply out of the box. Switch to your own provider for higher volume later."
+        description={
+          IS_SELF_HOSTED
+            ? 'Select an email provider (e.g. SendGrid, SES, Resend) so your agent can send replies.'
+            : 'The Novu Email demo sender is used by default so your agent can reply out of the box. Switch to your own provider for higher volume later.'
+        }
         rightContent={
           <div className="flex w-full flex-col gap-1.5">
             <div className="text-text-strong text-label-xs flex items-center gap-1 font-medium leading-4">
@@ -319,17 +332,5 @@ export function EmailSetupGuide({
       {stepsColumn}
       {credentialsSidebar}
     </>
-  );
-}
-
-function DemoProviderHint() {
-  return (
-    <div className="bg-bg-weak border-stroke-weak text-text-sub flex items-start gap-2 rounded-md border px-2 py-1.5">
-      <RiInformation2Fill className="text-away-base mt-px size-3.5 shrink-0" aria-hidden />
-      <p className="text-paragraph-xs leading-4">
-        The demo sender is rate-limited and intended for testing only. Connect SendGrid, Resend, or another provider to
-        send at scale.
-      </p>
-    </div>
   );
 }

--- a/apps/dashboard/src/components/agents/provider-cards.tsx
+++ b/apps/dashboard/src/components/agents/provider-cards.tsx
@@ -18,7 +18,7 @@ import { useNavigate } from 'react-router-dom';
 import type { AgentIntegrationLink } from '@/api/agents';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
-import { IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
+import { IS_SELF_HOSTED, IS_SELF_HOSTED_CE, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { buildEdgeFadeMask, useHorizontalScrollEdges } from '@/hooks/use-horizontal-scroll-edges';
 import { useIsAgentEmailAvailable } from '@/hooks/use-is-agent-email-available';
@@ -358,7 +358,10 @@ export function ProviderCards({
   // Email (NovuAgent) is shown as a provider card too — it is auto-provisioned for every agent, so
   // it renders in the connected/selected state by default and leads the list.
   const items = useMemo(() => {
-    const built = buildCardItems(CONVERSATIONAL_PROVIDERS, integrations);
+    const built = buildCardItems(CONVERSATIONAL_PROVIDERS, integrations).filter(
+      // Agent email is Enterprise/Cloud-only — never surface the card on Community.
+      (item) => !(IS_SELF_HOSTED_CE && item.providerId === EmailProviderIdEnum.NovuAgent)
+    );
 
     return [...built].sort((left, right) => {
       if (left.providerId === EmailProviderIdEnum.NovuAgent) return -1;

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/components/primitives/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
-import { IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
+import { IS_SELF_HOSTED, IS_SELF_HOSTED_CE, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useIsAgentEmailAvailable } from '@/hooks/use-is-agent-email-available';
 import { useLinkAgentIntegration } from '@/hooks/use-link-agent-integration';
@@ -208,6 +208,11 @@ export function ProviderDropdown({
 
   const supported = useMemo(() => {
     let items = allSupported;
+
+    // Agent email is Enterprise/Cloud-only — never list the row on Community.
+    if (IS_SELF_HOSTED_CE) {
+      items = items.filter((item) => item.providerId !== EmailProviderIdEnum.NovuAgent);
+    }
 
     // NovuAgent is 1:1 per agent and the backend enforces it — hiding the row
     // once an instance is linked is an invariant the picker must always honor,

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -57,9 +57,13 @@ export const PLAIN_SUPPORT_CHAT_APP_ID = import.meta.env.VITE_PLAIN_SUPPORT_CHAT
 
 export const ONBOARDING_DEMO_WORKFLOW_ID = 'onboarding-demo-workflow';
 
-export const IS_SELF_HOSTED = (window._env_?.VITE_SELF_HOSTED || import.meta.env.VITE_SELF_HOSTED) === 'true';
+export const IS_SELF_HOSTED = import.meta.env.VITE_SELF_HOSTED === 'true';
 
-export const IS_ENTERPRISE = (window._env_?.VITE_NOVU_ENTERPRISE || import.meta.env.VITE_NOVU_ENTERPRISE) === 'true';
+export const IS_ENTERPRISE = import.meta.env.VITE_NOVU_ENTERPRISE === 'true';
+
+export const IS_SELF_HOSTED_EE = IS_SELF_HOSTED && IS_ENTERPRISE;
+
+export const IS_SELF_HOSTED_CE = IS_SELF_HOSTED && !IS_ENTERPRISE;
 
 export const IS_AI_FEATURES_ENABLED = !(IS_SELF_HOSTED && IS_ENTERPRISE);
 

--- a/apps/dashboard/src/hooks/use-is-agent-email-available.ts
+++ b/apps/dashboard/src/hooks/use-is-agent-email-available.ts
@@ -1,8 +1,13 @@
 import { ApiServiceLevelEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 
 export function useIsAgentEmailAvailable(): boolean {
   const { subscription } = useFetchSubscription();
+
+  if (IS_SELF_HOSTED_CE) {
+    return false;
+  }
 
   return getFeatureForTierAsBoolean(
     FeatureNameEnum.AGENT_EMAIL_INTEGRATION,

--- a/libs/application-generic/src/utils/agent-shared-inbox.spec.ts
+++ b/libs/application-generic/src/utils/agent-shared-inbox.spec.ts
@@ -2,6 +2,7 @@ import {
   buildAgentSharedInbox,
   generateAgentInboxRoutingKey,
   getSharedAgentDomain,
+  isAgentEmailEnabled,
   isAgentSharedInboxEnabled,
   isValidAgentEmailSlugPrefix,
   isValidAgentInboxRoutingKey,
@@ -78,6 +79,80 @@ describe('agent-shared-inbox helpers', () => {
           expect(isAgentSharedInboxEnabled()).toBe(false);
         });
       }
+    });
+  });
+
+  describe('isAgentEmailEnabled', () => {
+    // CI_EE_TEST also flips the enterprise flag, so it is pinned off here to keep
+    // each case controlled solely by NOVU_ENTERPRISE.
+    const CI_EE_TEST_KEY = 'CI_EE_TEST';
+
+    it('is enabled on cloud when enterprise and the shared domain is set (matches shared inbox gate)', () => {
+      withEnv(
+        {
+          [NOVU_ENTERPRISE_KEY]: 'true',
+          [CI_EE_TEST_KEY]: undefined,
+          [IS_SELF_HOSTED_KEY]: 'false',
+          [ENV_KEY]: 'agentconnect.sh',
+        },
+        () => {
+          expect(isAgentEmailEnabled()).toBe(true);
+        }
+      );
+    });
+
+    it('is disabled on degraded cloud when enterprise but the shared domain is missing (zero delta vs shared inbox gate)', () => {
+      withEnv(
+        {
+          [NOVU_ENTERPRISE_KEY]: 'true',
+          [CI_EE_TEST_KEY]: undefined,
+          [IS_SELF_HOSTED_KEY]: 'false',
+          [ENV_KEY]: undefined,
+        },
+        () => {
+          expect(isAgentEmailEnabled()).toBe(false);
+          expect(isAgentEmailEnabled()).toBe(isAgentSharedInboxEnabled());
+        }
+      );
+    });
+
+    it('is enabled on self-hosted enterprise regardless of the shared domain', () => {
+      withEnv(
+        {
+          [NOVU_ENTERPRISE_KEY]: 'true',
+          [CI_EE_TEST_KEY]: undefined,
+          [IS_SELF_HOSTED_KEY]: 'true',
+          [ENV_KEY]: undefined,
+        },
+        () => {
+          expect(isAgentEmailEnabled()).toBe(true);
+        }
+      );
+    });
+
+    it('is disabled for community (not enterprise), self-hosted or not', () => {
+      withEnv(
+        {
+          [NOVU_ENTERPRISE_KEY]: 'false',
+          [CI_EE_TEST_KEY]: undefined,
+          [IS_SELF_HOSTED_KEY]: 'true',
+          [ENV_KEY]: 'agentconnect.sh',
+        },
+        () => {
+          expect(isAgentEmailEnabled()).toBe(false);
+        }
+      );
+      withEnv(
+        {
+          [NOVU_ENTERPRISE_KEY]: 'false',
+          [CI_EE_TEST_KEY]: undefined,
+          [IS_SELF_HOSTED_KEY]: 'false',
+          [ENV_KEY]: 'agentconnect.sh',
+        },
+        () => {
+          expect(isAgentEmailEnabled()).toBe(false);
+        }
+      );
     });
   });
 

--- a/libs/application-generic/src/utils/agent-shared-inbox.ts
+++ b/libs/application-generic/src/utils/agent-shared-inbox.ts
@@ -49,6 +49,33 @@ export function isAgentSharedInboxEnabled(): boolean {
 }
 
 /**
+ * Whether agent email is available for the deployment at all (inbound via
+ * custom domains + outbound via a connected provider), independent of the
+ * cloud-only zero-config shared inbox.
+ *
+ * The `(isSelfHosted || hasDomain)` clause is a deliberate short-circuit so this
+ * gate is identical to `isAgentSharedInboxEnabled()` on every Cloud
+ * configuration — including the degraded case where the shared domain env var
+ * is missing/invalid — and only adds the self-hosted-enterprise case. Cloud
+ * therefore has a provable zero behavioral delta:
+ *
+ *   - Cloud + domain set (normal)        -> true  (same as shared inbox gate)
+ *   - Cloud + domain missing/invalid     -> false (same as shared inbox gate)
+ *   - Self-hosted + enterprise           -> true  (new: uses custom domains)
+ *   - Community (self-hosted or not)     -> false
+ *
+ * Self-hosted does not need the shared domain because inbound is wired through
+ * a per-tenant verified Domain + DomainRoute(type=AGENT).
+ */
+export function isAgentEmailEnabled(): boolean {
+  const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+  const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
+  const hasDomain = !!getSharedAgentDomainOrNull();
+
+  return isEnterprise && (isSelfHosted || hasDomain);
+}
+
+/**
  * Returns the configured shared inbound domain (e.g. `agentconnect.sh`).
  * Throws if the env var is not set — callers that may run in a degraded
  * configuration should gate on `isAgentSharedInboxEnabled()` first.

--- a/packages/shared/src/entities/integration/credential.interface.ts
+++ b/packages/shared/src/entities/integration/credential.interface.ts
@@ -77,13 +77,18 @@ export interface ICredentials {
    */
   inboxRoutingKey?: string;
   /**
-   * Cloud-only kill switch for the Novu shared inbox
+   * Kill switch for the Novu shared inbox
    * (`{emailSlugPrefix}-{inboxRoutingKey}@<shared-domain>`). When `true`, the
    * inbound worker drops mail addressed to this agent on the shared domain;
    * custom-domain routes for the same agent still deliver. Only meaningful on
-   * the NovuAgent email integration. Managed server-side via
-   * `PATCH /agents/:identifier/inbox/shared`; pinned through the generic
-   * integration update path.
+   * the NovuAgent email integration.
+   *
+   * On cloud this is a user-facing toggle managed via
+   * `PATCH /agents/:identifier/inbox/shared` (pinned through the generic
+   * integration update path). On self-hosted, where there is no shared inbox,
+   * it is set to `true` defensively at provisioning time and is effectively
+   * redundant (every reader also gates on `isAgentSharedInboxEnabled()` /
+   * `sharedInboundAddress`, both falsy self-hosted).
    */
   sharedInboxDisabled?: boolean;
   /** Claude Managed Agents: ID of the Anthropic environment tied to this integration. */


### PR DESCRIPTION
### What changed? Why was the change needed?

It fixes NV-8106
It fixes NV-8109

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables agent email for self-hosted Enterprise and updates the setup flow around inbound and outbound email. The main changes are:

- Adds a broader `isAgentEmailEnabled` gate separate from the cloud shared-inbox gate.
- Provisions self-hosted NovuAgent integrations without shared-inbox routing keys.
- Allows self-hosted agents to start without a default outbound provider.
- Updates dashboard setup steps to require provider selection on self-hosted EE.
- Hides the NovuAgent provider option on self-hosted Community.

<h3>Confidence Score: 4/5</h3>

The core backend changes are targeted, but the dashboard runtime environment regression can break self-hosted Enterprise gating until fixed.

The changed files cover a narrow feature path and the main issue is isolated to dashboard configuration flag resolution for runtime-injected Docker values.

apps/dashboard/src/config/index.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the runtime environment fallback by running a Node harness against the config module with runtime flags supplied by window.\_env\_.
- Investigated the startup blocker for gate/provisioning in agent-email-api and confirmed the blocker persisted across the before/after runs.
- Validated UI runtime validation using actual repository components and styles and captured the failure output showing pnpm/Node incompatibility.

<a href="https://app.greptile.com/trex/runs/12287179/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fconfig%2Findex.ts%3A60-62%0A**Restore%20runtime%20env%20fallback**%0A%60IS_SELF_HOSTED%60%20and%20%60IS_ENTERPRISE%60%20no%20longer%20read%20%60window._env_%60%2C%20unlike%20the%20surrounding%20runtime-configured%20dashboard%20values.%20In%20self-hosted%20Docker%20deployments%20these%20flags%20are%20injected%20after%20build%20via%20%60window._env_%60%2C%20so%20the%20bundle%20now%20treats%20EE%20installs%20as%20cloud%2Fnon-enterprise%20and%20leaves%20%60IS_SELF_HOSTED_EE%60%20and%20%60IS_SELF_HOSTED_CE%60%20false%2C%20breaking%20the%20new%20self-hosted%20agent%20email%20gating%20and%20upgrade%20behavior.%0A%0A&pr=11652&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/config/index.ts:60-62
**Restore runtime env fallback**
`IS_SELF_HOSTED` and `IS_ENTERPRISE` no longer read `window._env_`, unlike the surrounding runtime-configured dashboard values. In self-hosted Docker deployments these flags are injected after build via `window._env_`, so the bundle now treats EE installs as cloud/non-enterprise and leaves `IS_SELF_HOSTED_EE` and `IS_SELF_HOSTED_CE` false, breaking the new self-hosted agent email gating and upgrade behavior.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(dashboard): update self-hosted ..."](https://github.com/novuhq/novu/commit/66a547c7ce2816dddf3ed3b45bcb034a0fcf80ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39824135)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->