### PR TITLE
feat(framework): add @novu/framework/ai-sdk agent plugin fixes NV-8117

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
@@ -18,7 +18,7 @@ export class AgentReplyController {
   @HttpCode(HttpStatus.OK)
   @RequireAuthentication()
   @ExternalApiAccessible()
-  async handleAgentReply(
+  async handleAgentReplyHandler(
     @UserSession() user: UserSessionData,
     @Param('agentId') agentId: string,
     @Body() body: AgentReplyPayloadDto

--- a/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
@@ -12,7 +12,7 @@ import { HandleAgentReply } from './handle-agent-reply/handle-agent-reply.usecas
 @Controller('/agents')
 @ApiExcludeController()
 export class AgentReplyController {
-  constructor(private handleAgentReplyUsecase: HandleAgentReply) {}
+  constructor(private handleAgentReply: HandleAgentReply) {}
 
   @Post('/:agentId/reply')
   @HttpCode(HttpStatus.OK)
@@ -23,7 +23,7 @@ export class AgentReplyController {
     @Param('agentId') agentId: string,
     @Body() body: AgentReplyPayloadDto
   ) {
-    return this.handleAgentReplyUsecase.execute(
+    return this.handleAgentReply.execute(
       HandleAgentReplyCommand.create({
         userId: user._id,
         environmentId: user.environmentId,

--- a/packages/framework/ai-sdk/package.json
+++ b/packages/framework/ai-sdk/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../dist/cjs/ai-sdk/index.cjs",
+  "types": "../dist/cjs/ai-sdk/index.d.cts"
+}

--- a/packages/framework/cards/package.json
+++ b/packages/framework/cards/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../dist/cjs/cards.cjs",
+  "types": "../dist/cjs/cards.d.cts"
+}

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -9,6 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "sideEffects": false,
   "private": false,
   "repository": {
     "type": "git",
@@ -29,6 +30,8 @@
     "jsx-runtime",
     "jsx-dev-runtime",
     "validators",
+    "ai-sdk",
+    "cards",
     "README.md"
   ],
   "scripts": {
@@ -204,12 +207,33 @@
         "types": "./dist/esm/validators.d.ts",
         "default": "./dist/esm/validators.js"
       }
+    },
+    "./ai-sdk": {
+      "require": {
+        "types": "./dist/cjs/ai-sdk/index.d.cts",
+        "default": "./dist/cjs/ai-sdk/index.cjs"
+      },
+      "import": {
+        "types": "./dist/esm/ai-sdk/index.d.ts",
+        "default": "./dist/esm/ai-sdk/index.js"
+      }
+    },
+    "./cards": {
+      "require": {
+        "types": "./dist/cjs/cards.d.cts",
+        "default": "./dist/cjs/cards.cjs"
+      },
+      "import": {
+        "types": "./dist/esm/cards.d.ts",
+        "default": "./dist/esm/cards.js"
+      }
     }
   },
   "peerDependencies": {
     "@nestjs/common": ">=10.0.0",
     "@sveltejs/kit": ">=1.27.3",
     "@vercel/node": ">=2.15.9",
+    "ai": "^6.0.0",
     "aws-lambda": ">=1.0.7",
     "express": ">=4.19.2",
     "h3": ">=1.8.1",
@@ -242,6 +266,9 @@
     "next": {
       "optional": true
     },
+    "ai": {
+      "optional": true
+    },
     "zod": {
       "optional": true
     },
@@ -250,6 +277,7 @@
     }
   },
   "devDependencies": {
+    "@ai-sdk/openai": "3.0.46",
     "@apidevtools/json-schema-ref-parser": "11.6.4",
     "@arethetypeswrong/cli": "^0.17.4",
     "@nestjs/common": "11.1.24",
@@ -260,6 +288,7 @@
     "@types/pluralize": "^0.0.33",
     "@types/sanitize-html": "2.11.0",
     "@vercel/node": "^2.15.9",
+    "ai": "^6.0.208",
     "aws-lambda": "^1.0.7",
     "express": "^4.19.2",
     "h3": "^1.11.1",
@@ -274,11 +303,11 @@
     "zod-to-json-schema": "^3.23.3"
   },
   "dependencies": {
-    "chat": "4.30.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^2.1.1",
     "better-ajv-errors": "^1.2.0",
     "chalk": "^4.1.2",
+    "chat": "4.30.0",
     "cross-fetch": "^4.0.0",
     "json-schema-to-ts": "^3.0.0",
     "jsonrepair": "^3.13.1",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -9,7 +9,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
   "private": false,
   "repository": {
     "type": "git",
@@ -277,7 +276,6 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/openai": "3.0.46",
     "@apidevtools/json-schema-ref-parser": "11.6.4",
     "@arethetypeswrong/cli": "^0.17.4",
     "@nestjs/common": "11.1.24",

--- a/packages/framework/src/ai-sdk/ai-sdk-agent.test.ts
+++ b/packages/framework/src/ai-sdk/ai-sdk-agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { AgentMessageContext } from '../resources/agent/agent.types';
-import { aiSdkAgent } from './ai-sdk-agent';
+import { agent } from './ai-sdk-agent';
 import type { AiSdkResult } from './types';
 
 function fakeCtx() {
@@ -9,15 +9,15 @@ function fakeCtx() {
   return { reply } as unknown as AgentMessageContext & { reply: ReturnType<typeof vi.fn> };
 }
 
-describe('aiSdkAgent', () => {
+describe('agent', () => {
   it('accepts a bare function as onMessage and returns an Agent with the given id', () => {
-    const a = aiSdkAgent('support', async () => 'hi');
+    const a = agent('support', async () => 'hi');
     expect(a.id).toBe('support');
     expect(typeof a.handlers.onMessage).toBe('function');
   });
 
   it('accepts an object of handlers', () => {
-    const a = aiSdkAgent('support', {
+    const a = agent('support', {
       onMessage: async () => undefined,
       onAction: async () => undefined,
     });
@@ -27,34 +27,34 @@ describe('aiSdkAgent', () => {
 
   it('throws when onMessage is missing', () => {
     // @ts-expect-error intentionally invalid
-    expect(() => aiSdkAgent('support', {})).toThrow(/onMessage/);
+    expect(() => agent('support', {})).toThrow(/onMessage/);
   });
 
   it('passes through string returns for runtime replyIfPresent', async () => {
-    const agent = aiSdkAgent('support', async () => 'hello');
+    const supportAgent = agent('support', async () => 'hello');
     const ctx = fakeCtx();
 
-    const result = await agent.handlers.onMessage({} as never, ctx);
+    const result = await supportAgent.handlers.onMessage({} as never, ctx);
 
     expect(result).toBe('hello');
     expect(ctx.reply).not.toHaveBeenCalled();
   });
 
   it('auto-delivers AI SDK results and returns void', async () => {
-    const agent = aiSdkAgent('support', async () => ({
+    const supportAgent = agent('support', async () => ({
       text: Promise.resolve('model reply'),
       textStream: (async function* () {})(),
     }));
     const ctx = fakeCtx();
 
-    const result = await agent.handlers.onMessage({} as never, ctx);
+    const result = await supportAgent.handlers.onMessage({} as never, ctx);
 
     expect(result).toBeUndefined();
     expect(ctx.reply).toHaveBeenCalledWith('model reply');
   });
 
   it('auto-delivers generateText-style results', async () => {
-    const agent = aiSdkAgent(
+    const supportAgent = agent(
       'support',
       async () =>
         ({
@@ -64,7 +64,7 @@ describe('aiSdkAgent', () => {
     );
     const ctx = fakeCtx();
 
-    await agent.handlers.onMessage({} as never, ctx);
+    await supportAgent.handlers.onMessage({} as never, ctx);
 
     expect(ctx.reply).toHaveBeenCalledWith('done');
   });

--- a/packages/framework/src/ai-sdk/ai-sdk-agent.test.ts
+++ b/packages/framework/src/ai-sdk/ai-sdk-agent.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentMessageContext } from '../resources/agent/agent.types';
+import { aiSdkAgent } from './ai-sdk-agent';
+import type { AiSdkResult } from './types';
+
+function fakeCtx() {
+  const reply = vi.fn().mockResolvedValue({ messageId: 'm', platformThreadId: 'p' });
+
+  return { reply } as unknown as AgentMessageContext & { reply: ReturnType<typeof vi.fn> };
+}
+
+describe('aiSdkAgent', () => {
+  it('accepts a bare function as onMessage and returns an Agent with the given id', () => {
+    const a = aiSdkAgent('support', async () => 'hi');
+    expect(a.id).toBe('support');
+    expect(typeof a.handlers.onMessage).toBe('function');
+  });
+
+  it('accepts an object of handlers', () => {
+    const a = aiSdkAgent('support', {
+      onMessage: async () => undefined,
+      onAction: async () => undefined,
+    });
+    expect(typeof a.handlers.onMessage).toBe('function');
+    expect(typeof a.handlers.onAction).toBe('function');
+  });
+
+  it('throws when onMessage is missing', () => {
+    // @ts-expect-error intentionally invalid
+    expect(() => aiSdkAgent('support', {})).toThrow(/onMessage/);
+  });
+
+  it('passes through string returns for runtime replyIfPresent', async () => {
+    const agent = aiSdkAgent('support', async () => 'hello');
+    const ctx = fakeCtx();
+
+    const result = await agent.handlers.onMessage({} as never, ctx);
+
+    expect(result).toBe('hello');
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+
+  it('auto-delivers AI SDK results and returns void', async () => {
+    const agent = aiSdkAgent('support', async () => ({
+      text: Promise.resolve('model reply'),
+      textStream: (async function* () {})(),
+    }));
+    const ctx = fakeCtx();
+
+    const result = await agent.handlers.onMessage({} as never, ctx);
+
+    expect(result).toBeUndefined();
+    expect(ctx.reply).toHaveBeenCalledWith('model reply');
+  });
+
+  it('auto-delivers generateText-style results', async () => {
+    const agent = aiSdkAgent(
+      'support',
+      async () =>
+        ({
+          text: 'done',
+          steps: [],
+        }) as AiSdkResult
+    );
+    const ctx = fakeCtx();
+
+    await agent.handlers.onMessage({} as never, ctx);
+
+    expect(ctx.reply).toHaveBeenCalledWith('done');
+  });
+});

--- a/packages/framework/src/ai-sdk/ai-sdk-agent.ts
+++ b/packages/framework/src/ai-sdk/ai-sdk-agent.ts
@@ -1,0 +1,36 @@
+import { agent } from '../resources/agent/agent.resource';
+import type { Agent } from '../resources/agent/agent.types';
+import { deliverResult, isAiSdkResult } from './reply-mapper';
+import type { AiSdkAgentHandlers } from './types';
+
+type AiSdkMessageHandler = AiSdkAgentHandlers['onMessage'];
+
+function normalize(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHandlers): AiSdkAgentHandlers {
+  const normalized = typeof handlers === 'function' ? { onMessage: handlers } : handlers;
+  if (typeof normalized.onMessage !== 'function') {
+    throw new Error(`aiSdkAgent('${id}') requires an onMessage handler`);
+  }
+
+  return normalized;
+}
+
+export function aiSdkAgent(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHandlers): Agent {
+  const h = normalize(id, handlers);
+
+  return agent(id, {
+    onMessage: async (message, ctx) => {
+      const result = await h.onMessage(message, ctx);
+
+      if (isAiSdkResult(result)) {
+        await deliverResult(result, ctx);
+
+        return;
+      }
+
+      return result;
+    },
+    ...(h.onAction && { onAction: h.onAction }),
+    ...(h.onReaction && { onReaction: h.onReaction }),
+    ...(h.onResolve && { onResolve: h.onResolve }),
+  });
+}

--- a/packages/framework/src/ai-sdk/ai-sdk-agent.ts
+++ b/packages/framework/src/ai-sdk/ai-sdk-agent.ts
@@ -1,4 +1,4 @@
-import { agent } from '../resources/agent/agent.resource';
+import { agent as frameworkAgent } from '../resources/agent/agent.resource';
 import type { Agent } from '../resources/agent/agent.types';
 import { deliverResult, isAiSdkResult } from './reply-mapper';
 import type { AiSdkAgentHandlers } from './types';
@@ -8,16 +8,16 @@ type AiSdkMessageHandler = AiSdkAgentHandlers['onMessage'];
 function normalize(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHandlers): AiSdkAgentHandlers {
   const normalized = typeof handlers === 'function' ? { onMessage: handlers } : handlers;
   if (typeof normalized.onMessage !== 'function') {
-    throw new Error(`aiSdkAgent('${id}') requires an onMessage handler`);
+    throw new Error(`agent('${id}') requires an onMessage handler`);
   }
 
   return normalized;
 }
 
-export function aiSdkAgent(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHandlers): Agent {
+export function agent(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHandlers): Agent {
   const h = normalize(id, handlers);
 
-  return agent(id, {
+  return frameworkAgent(id, {
     onMessage: async (message, ctx) => {
       const result = await h.onMessage(message, ctx);
 

--- a/packages/framework/src/ai-sdk/history-mapper.test.ts
+++ b/packages/framework/src/ai-sdk/history-mapper.test.ts
@@ -4,8 +4,8 @@ import { toModelMessages } from './history-mapper';
 describe('toModelMessages', () => {
   it('maps agent role to assistant and others to user, in order', () => {
     const result = toModelMessages([
-      { role: 'user', type: 'text', content: 'hi', createdAt: '1' },
-      { role: 'agent', type: 'text', content: 'hello!', createdAt: '2' },
+      { role: 'user', type: 'message', content: 'hi', createdAt: '1' },
+      { role: 'agent', type: 'message', content: 'hello!', createdAt: '2' },
     ]);
 
     expect(result).toEqual([
@@ -16,8 +16,8 @@ describe('toModelMessages', () => {
 
   it('maps bridge sender roles (subscriber/agent) to user/assistant', () => {
     const result = toModelMessages([
-      { role: 'subscriber', type: 'text', content: 'hi', createdAt: '1' },
-      { role: 'agent', type: 'text', content: 'hello!', createdAt: '2' },
+      { role: 'subscriber', type: 'message', content: 'hi', createdAt: '1' },
+      { role: 'agent', type: 'message', content: 'hello!', createdAt: '2' },
     ]);
 
     expect(result).toEqual([
@@ -29,10 +29,20 @@ describe('toModelMessages', () => {
   it('skips system/metadata (signalData) entries', () => {
     const result = toModelMessages([
       { role: 'system', type: 'signal', content: '', signalData: { type: 'metadata' }, createdAt: '1' },
-      { role: 'user', type: 'text', content: 'q', createdAt: '2' },
+      { role: 'user', type: 'message', content: 'q', createdAt: '2' },
     ]);
 
     expect(result).toEqual([{ role: 'user', content: 'q' }]);
+  });
+
+  it('skips signal-type entries and empty content', () => {
+    const result = toModelMessages([
+      { role: 'system', type: 'signal', content: 'Conversation resolved', createdAt: '1' },
+      { role: 'user', type: 'message', content: '   ', createdAt: '2' },
+      { role: 'user', type: 'message', content: 'real question', createdAt: '3' },
+    ]);
+
+    expect(result).toEqual([{ role: 'user', content: 'real question' }]);
   });
 
   it('prepends a system message when provided', () => {
@@ -43,8 +53,8 @@ describe('toModelMessages', () => {
 
   it('prefixes sender name when multiple distinct human senders exist', () => {
     const result = toModelMessages([
-      { role: 'user', type: 'text', content: 'one', senderName: 'Alice', createdAt: '1' },
-      { role: 'user', type: 'text', content: 'two', senderName: 'Bob', createdAt: '2' },
+      { role: 'user', type: 'message', content: 'one', senderName: 'Alice', createdAt: '1' },
+      { role: 'user', type: 'message', content: 'two', senderName: 'Bob', createdAt: '2' },
     ]);
 
     expect(result).toEqual([

--- a/packages/framework/src/ai-sdk/history-mapper.test.ts
+++ b/packages/framework/src/ai-sdk/history-mapper.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { toModelMessages } from './history-mapper';
+
+describe('toModelMessages', () => {
+  it('maps agent role to assistant and others to user, in order', () => {
+    const result = toModelMessages([
+      { role: 'user', type: 'text', content: 'hi', createdAt: '1' },
+      { role: 'agent', type: 'text', content: 'hello!', createdAt: '2' },
+    ]);
+
+    expect(result).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello!' },
+    ]);
+  });
+
+  it('maps bridge sender roles (subscriber/agent) to user/assistant', () => {
+    const result = toModelMessages([
+      { role: 'subscriber', type: 'text', content: 'hi', createdAt: '1' },
+      { role: 'agent', type: 'text', content: 'hello!', createdAt: '2' },
+    ]);
+
+    expect(result).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello!' },
+    ]);
+  });
+
+  it('skips system/metadata (signalData) entries', () => {
+    const result = toModelMessages([
+      { role: 'system', type: 'signal', content: '', signalData: { type: 'metadata' }, createdAt: '1' },
+      { role: 'user', type: 'text', content: 'q', createdAt: '2' },
+    ]);
+
+    expect(result).toEqual([{ role: 'user', content: 'q' }]);
+  });
+
+  it('prepends a system message when provided', () => {
+    const result = toModelMessages([], 'You are support.');
+
+    expect(result[0]).toEqual({ role: 'system', content: 'You are support.' });
+  });
+
+  it('prefixes sender name when multiple distinct human senders exist', () => {
+    const result = toModelMessages([
+      { role: 'user', type: 'text', content: 'one', senderName: 'Alice', createdAt: '1' },
+      { role: 'user', type: 'text', content: 'two', senderName: 'Bob', createdAt: '2' },
+    ]);
+
+    expect(result).toEqual([
+      { role: 'user', content: 'Alice: one' },
+      { role: 'user', content: 'Bob: two' },
+    ]);
+  });
+});

--- a/packages/framework/src/ai-sdk/history-mapper.ts
+++ b/packages/framework/src/ai-sdk/history-mapper.ts
@@ -35,7 +35,7 @@ export function toModelMessages(history: AgentHistoryEntry[], system?: string): 
   const multiSender = distinctHumanSenders(history) > 1;
 
   for (const entry of history) {
-    if (entry.signalData || entry.role === 'system') {
+    if (entry.signalData || entry.role === 'system' || entry.type === 'signal' || !entry.content.trim()) {
       continue;
     }
 

--- a/packages/framework/src/ai-sdk/history-mapper.ts
+++ b/packages/framework/src/ai-sdk/history-mapper.ts
@@ -1,0 +1,50 @@
+import type { ModelMessage } from 'ai';
+import type { AgentHistoryEntry } from '../resources/agent/agent.types';
+
+function isAssistantRole(role: string): boolean {
+  return role === 'agent' || role === 'assistant';
+}
+
+function distinctHumanSenders(history: AgentHistoryEntry[]): number {
+  const names = new Set<string>();
+  for (const entry of history) {
+    if (!isAssistantRole(entry.role) && entry.role !== 'system' && entry.senderName) {
+      names.add(entry.senderName);
+    }
+  }
+
+  return names.size;
+}
+
+/**
+ * Map Novu conversation history into AI SDK `ModelMessage[]`.
+ * v1 is text-only: tool-call/tool-result replay from richContent is intentionally
+ * not reconstructed. System/metadata entries (carrying `signalData`) are skipped.
+ *
+ * The current inbound message is already appended to `history` by Novu before the
+ * bridge fires — do not append the handler's `message` arg again.
+ *
+ * TODO: hook up full tool calls and system messages
+ */
+export function toModelMessages(history: AgentHistoryEntry[], system?: string): ModelMessage[] {
+  const messages: ModelMessage[] = [];
+  if (system) {
+    messages.push({ role: 'system', content: system });
+  }
+
+  const multiSender = distinctHumanSenders(history) > 1;
+
+  for (const entry of history) {
+    if (entry.signalData || entry.role === 'system') {
+      continue;
+    }
+
+    const isAssistant = isAssistantRole(entry.role);
+    const text =
+      !isAssistant && multiSender && entry.senderName ? `${entry.senderName}: ${entry.content}` : entry.content;
+
+    messages.push({ role: isAssistant ? 'assistant' : 'user', content: text });
+  }
+
+  return messages;
+}

--- a/packages/framework/src/ai-sdk/index.ts
+++ b/packages/framework/src/ai-sdk/index.ts
@@ -1,3 +1,3 @@
-export { aiSdkAgent } from './ai-sdk-agent';
+export { agent } from './ai-sdk-agent';
 export { toModelMessages } from './history-mapper';
 export type { AiSdkAgentHandlers, AiSdkResult } from './types';

--- a/packages/framework/src/ai-sdk/index.ts
+++ b/packages/framework/src/ai-sdk/index.ts
@@ -1,2 +1,3 @@
+export { aiSdkAgent } from './ai-sdk-agent';
 export { toModelMessages } from './history-mapper';
 export type { AiSdkAgentHandlers, AiSdkResult } from './types';

--- a/packages/framework/src/ai-sdk/index.ts
+++ b/packages/framework/src/ai-sdk/index.ts
@@ -1,0 +1,3 @@
+export { agent as aiSdkAgent } from '../resources/agent';
+export { toModelMessages } from './history-mapper';
+export type { AiSdkAgentHandlers, AiSdkResult } from './types';

--- a/packages/framework/src/ai-sdk/index.ts
+++ b/packages/framework/src/ai-sdk/index.ts
@@ -1,3 +1,2 @@
-export { agent as aiSdkAgent } from '../resources/agent';
 export { toModelMessages } from './history-mapper';
 export type { AiSdkAgentHandlers, AiSdkResult } from './types';

--- a/packages/framework/src/ai-sdk/reply-mapper.test.ts
+++ b/packages/framework/src/ai-sdk/reply-mapper.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentContextBase } from '../resources/agent/agent.types';
+import { deliverResult, isAiSdkResult } from './reply-mapper';
+import type { AiSdkResult } from './types';
+
+function fakeCtx() {
+  const reply = vi.fn().mockResolvedValue({ messageId: 'm', platformThreadId: 'p' });
+
+  return { reply } as unknown as AgentContextBase & { reply: ReturnType<typeof vi.fn> };
+}
+
+describe('isAiSdkResult', () => {
+  it('recognizes a streamText-style result (has textStream)', () => {
+    expect(
+      isAiSdkResult({
+        text: Promise.resolve('hello'),
+        textStream: (async function* () {})(),
+      })
+    ).toBe(true);
+  });
+
+  it('recognizes a generateText-style result (has text and steps)', () => {
+    expect(isAiSdkResult({ text: 'hello', steps: [] })).toBe(true);
+  });
+
+  it('rejects a string, a CardElement, and void', () => {
+    expect(isAiSdkResult('hello')).toBe(false);
+    expect(isAiSdkResult({ type: 'card' })).toBe(false);
+    expect(isAiSdkResult(undefined)).toBe(false);
+  });
+
+  it('rejects objects with text but no textStream or steps', () => {
+    expect(isAiSdkResult({ text: 'hello' })).toBe(false);
+  });
+});
+
+describe('deliverResult', () => {
+  it('posts result.text as a single reply (streamText: Promise text)', async () => {
+    const ctx = fakeCtx();
+    const result = {
+      text: Promise.resolve('final answer'),
+      response: Promise.resolve({ messages: [] }),
+    } as AiSdkResult;
+
+    await deliverResult(result, ctx);
+
+    expect(ctx.reply).toHaveBeenCalledOnce();
+    expect(ctx.reply).toHaveBeenCalledWith('final answer');
+  });
+
+  it('posts result.text only, ignoring intermediate response.messages', async () => {
+    const ctx = fakeCtx();
+    const result = {
+      text: Promise.resolve('final only'),
+      response: Promise.resolve({
+        messages: [
+          { role: 'assistant', content: 'preamble' },
+          { role: 'assistant', content: 'ignored' },
+        ],
+      }),
+    } as AiSdkResult;
+
+    await deliverResult(result, ctx);
+
+    expect(ctx.reply).toHaveBeenCalledOnce();
+    expect(ctx.reply).toHaveBeenCalledWith('final only');
+  });
+
+  it('handles a generateText-style result (plain text string)', async () => {
+    const ctx = fakeCtx();
+    const result = {
+      text: 'answer',
+      response: { messages: [] },
+    } as AiSdkResult;
+
+    await deliverResult(result, ctx);
+
+    expect(ctx.reply).toHaveBeenCalledWith('answer');
+  });
+
+  it('posts nothing when result.text is empty or whitespace', async () => {
+    const ctx = fakeCtx();
+    const result = {
+      text: Promise.resolve('   '),
+      response: Promise.resolve({ messages: [] }),
+    } as AiSdkResult;
+
+    await deliverResult(result, ctx);
+
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+});

--- a/packages/framework/src/ai-sdk/reply-mapper.test.ts
+++ b/packages/framework/src/ai-sdk/reply-mapper.test.ts
@@ -32,6 +32,14 @@ describe('isAiSdkResult', () => {
   it('rejects objects with text but no textStream or steps', () => {
     expect(isAiSdkResult({ text: 'hello' })).toBe(false);
   });
+
+  it('rejects streamText-shaped objects missing text', () => {
+    expect(
+      isAiSdkResult({
+        textStream: (async function* () {})(),
+      })
+    ).toBe(false);
+  });
 });
 
 describe('deliverResult', () => {

--- a/packages/framework/src/ai-sdk/reply-mapper.ts
+++ b/packages/framework/src/ai-sdk/reply-mapper.ts
@@ -1,0 +1,28 @@
+import type { AgentContextBase } from '../resources/agent/agent.types';
+import type { AiSdkResult } from './types';
+
+function isCardElement(value: object): boolean {
+  return 'type' in value && (value as { type: string }).type === 'card';
+}
+
+export function isAiSdkResult(value: unknown): value is AiSdkResult {
+  if (typeof value !== 'object' || value === null || isCardElement(value)) {
+    return false;
+  }
+
+  if ('textStream' in value) {
+    return true;
+  }
+
+  return 'text' in value && 'steps' in value;
+}
+
+export async function deliverResult(result: AiSdkResult, ctx: AgentContextBase): Promise<void> {
+  const text = (await result.text).trim();
+
+  if (!text) {
+    return;
+  }
+
+  await ctx.reply(text);
+}

--- a/packages/framework/src/ai-sdk/reply-mapper.ts
+++ b/packages/framework/src/ai-sdk/reply-mapper.ts
@@ -11,7 +11,7 @@ export function isAiSdkResult(value: unknown): value is AiSdkResult {
   }
 
   if ('textStream' in value) {
-    return true;
+    return 'text' in value;
   }
 
   return 'text' in value && 'steps' in value;

--- a/packages/framework/src/ai-sdk/types.ts
+++ b/packages/framework/src/ai-sdk/types.ts
@@ -1,0 +1,17 @@
+import type { generateText, streamText } from 'ai';
+import type { AgentHandlers, AgentMessage, AgentMessageContext, MessageContent } from '../resources/agent';
+import type { Awaitable } from '../types/util.types';
+
+/** Result from `streamText()` or `generateText()`. Return from `onMessage` to reply with the model output. */
+export type AiSdkResult = ReturnType<typeof streamText> | Awaited<ReturnType<typeof generateText>>;
+
+/**
+ * Event handlers for an AI SDK agent.
+ *
+ * Same shape as `AgentHandlers`, except `onMessage` may also return a
+ * `streamText()` or `generateText()` result — Novu delivers the model output
+ * automatically.
+ */
+export type AiSdkAgentHandlers = Omit<AgentHandlers, 'onMessage'> & {
+  onMessage: (message: AgentMessage, ctx: AgentMessageContext) => Awaitable<MessageContent | AiSdkResult | void>;
+};

--- a/packages/framework/src/ai-sdk/types.ts
+++ b/packages/framework/src/ai-sdk/types.ts
@@ -1,5 +1,5 @@
 import type { generateText, streamText } from 'ai';
-import type { AgentHandlers, AgentMessage, AgentMessageContext, MessageContent } from '../resources/agent';
+import type { AgentHandlers, AgentMessage, AgentMessageContext, MessageContent } from '../resources/agent/agent.types';
 import type { Awaitable } from '../types/util.types';
 
 /** Result from `streamText()` or `generateText()`. Return from `onMessage` to reply with the model output. */

--- a/packages/framework/src/cards.ts
+++ b/packages/framework/src/cards.ts
@@ -1,0 +1,13 @@
+export type {
+  ActionsElement,
+  ButtonElement,
+  CardChild,
+  CardElement,
+  DividerElement,
+  LinkElement,
+  SelectElement,
+  SelectOptionElement,
+  TextElement,
+  TextInputElement,
+} from 'chat';
+export { Actions, Button, Card, CardLink, CardText, Divider, Select, SelectOption, TextInput } from 'chat';

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -21,18 +21,11 @@ import {
   SigningKeyNotFoundError,
 } from './errors';
 import { isPlatformError } from './errors/guard.errors';
-import type {
-  Agent,
-  AgentActionContext,
-  AgentBridgeRequest,
-  AgentMessageContext,
-  AgentReactionContext,
-  AgentResolveContext,
-  MessageContent,
-} from './resources/agent';
-import { AgentContextImpl, AgentDeliveryError, AgentEventEnum } from './resources/agent';
+import type { Agent, AgentBridgeRequest } from './resources/agent';
+import { dispatchAgentEvent } from './resources/agent/agent-dispatch';
 import type { Awaitable, EventTriggerParams, Workflow } from './types';
 import { createHmacSubtle, initApiClient, timingSafeEqual } from './utils';
+import { parseSignatureHeader } from './utils/bridge-signature';
 
 export interface ServeHandlerOptions {
   client?: Client;
@@ -231,14 +224,12 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
           return this.createResponse(HttpStatusEnum.NOT_FOUND, { error: `Agent '${agentId}' not registered` });
         }
 
-        const ctx = new AgentContextImpl(body as AgentBridgeRequest, this.client.secretKey);
-
-        const handlerPromise = this.runAgentHandler(registeredAgent, agentEvent, ctx).catch((err) => {
-          if (err instanceof AgentDeliveryError) {
-            this.client.logger.error(`[agent:${agentId}] ${err.message}`);
-          } else {
-            this.client.logger.error(`[agent:${agentId}] Handler error:`, err);
-          }
+        const handlerPromise = dispatchAgentEvent({
+          agent: registeredAgent,
+          event: agentEvent,
+          bridge: body as AgentBridgeRequest,
+          secretKey: this.client.secretKey,
+          logger: this.client.logger,
         });
 
         if (waitUntil) {
@@ -316,37 +307,6 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
     }
   }
 
-  private async runAgentHandler(registeredAgent: Agent, event: string, ctx: AgentContextImpl): Promise<void> {
-    const replyIfPresent = async (result: MessageContent | void) => {
-      if (result != null) await ctx.reply(result);
-    };
-
-    switch (event) {
-      case AgentEventEnum.ON_MESSAGE:
-        await replyIfPresent(await registeredAgent.handlers.onMessage(ctx.message!, ctx as AgentMessageContext));
-        break;
-      case AgentEventEnum.ON_ACTION:
-        if (registeredAgent.handlers.onAction) {
-          await replyIfPresent(await registeredAgent.handlers.onAction(ctx.action!, ctx as AgentActionContext));
-        }
-        break;
-      case AgentEventEnum.ON_REACTION:
-        if (registeredAgent.handlers.onReaction) {
-          await replyIfPresent(await registeredAgent.handlers.onReaction(ctx.reaction!, ctx as AgentReactionContext));
-        }
-        break;
-      case AgentEventEnum.ON_RESOLVE:
-        if (registeredAgent.handlers.onResolve) {
-          await replyIfPresent(await registeredAgent.handlers.onResolve(ctx as AgentResolveContext));
-        }
-        break;
-      default:
-        throw new InvalidActionError(event, AgentEventEnum);
-    }
-
-    await ctx.flush();
-  }
-
   private handleError(error: unknown): IActionResponse {
     if (isFrameworkError(error)) {
       if (error.statusCode >= 500) {
@@ -394,46 +354,4 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
       throw new SignatureMismatchError();
     }
   }
-}
-
-interface ParsedSignatureHeader {
-  t?: number;
-  v1?: string;
-}
-
-/**
- * Parse a `Novu-Signature` header into its named fields.
- *
- * Header format: `t=<unix-ms>,v1=<hex-hmac>` (order/whitespace tolerant).
- *
- * Splitting only on `=` was previously used here, which broke the timestamp
- * extraction (`timestamp` ended up as the literal string "t") and silently
- * disabled replay protection. We now split each comma-separated part on the
- * first `=` only and look up fields by name so additional or reordered fields
- * cannot bypass validation.
- */
-function parseSignatureHeader(header: string): ParsedSignatureHeader {
-  const fields: Record<string, string> = {};
-
-  for (const rawPart of header.split(',')) {
-    const part = rawPart.trim();
-    if (!part) continue;
-
-    const eqIdx = part.indexOf('=');
-    if (eqIdx <= 0) continue;
-
-    const key = part.slice(0, eqIdx);
-    const value = part.slice(eqIdx + 1);
-    if (key && value && !(key in fields)) {
-      fields[key] = value;
-    }
-  }
-
-  const tRaw = fields.t;
-  const t = tRaw !== undefined ? Number(tRaw) : NaN;
-
-  return {
-    t: Number.isFinite(t) ? t : undefined,
-    v1: fields.v1,
-  };
 }

--- a/packages/framework/src/resources/agent/agent-dispatch.ts
+++ b/packages/framework/src/resources/agent/agent-dispatch.ts
@@ -1,0 +1,67 @@
+import { InvalidActionError } from '../../errors/handler.errors';
+import { AgentContextImpl } from './agent.context';
+import { AgentDeliveryError } from './agent.errors';
+import type {
+  Agent,
+  AgentActionContext,
+  AgentBridgeRequest,
+  AgentMessageContext,
+  AgentReactionContext,
+  AgentResolveContext,
+  MessageContent,
+} from './agent.types';
+import { AgentEventEnum } from './agent.types';
+
+export interface DispatchAgentEventOptions {
+  agent: Agent;
+  event: string;
+  bridge: AgentBridgeRequest;
+  secretKey: string;
+  logger?: { error: (...args: unknown[]) => void };
+}
+
+export async function dispatchAgentEvent(options: DispatchAgentEventOptions): Promise<void> {
+  const ctx = new AgentContextImpl(options.bridge, options.secretKey);
+
+  try {
+    await runAgentHandler(options.agent, options.event, ctx);
+    await ctx.flush();
+  } catch (err) {
+    if (err instanceof AgentDeliveryError) {
+      options.logger?.error(`[agent:${options.agent.id}] ${err.message}`);
+    } else {
+      options.logger?.error(`[agent:${options.agent.id}] Handler error:`, err);
+    }
+  }
+}
+
+async function runAgentHandler(registeredAgent: Agent, event: string, ctx: AgentContextImpl): Promise<void> {
+  const replyIfPresent = async (result: MessageContent | void) => {
+    if (result != null) {
+      await ctx.reply(result);
+    }
+  };
+
+  switch (event) {
+    case AgentEventEnum.ON_MESSAGE:
+      await replyIfPresent(await registeredAgent.handlers.onMessage(ctx.message!, ctx as AgentMessageContext));
+      break;
+    case AgentEventEnum.ON_ACTION:
+      if (registeredAgent.handlers.onAction) {
+        await replyIfPresent(await registeredAgent.handlers.onAction(ctx.action!, ctx as AgentActionContext));
+      }
+      break;
+    case AgentEventEnum.ON_REACTION:
+      if (registeredAgent.handlers.onReaction) {
+        await replyIfPresent(await registeredAgent.handlers.onReaction(ctx.reaction!, ctx as AgentReactionContext));
+      }
+      break;
+    case AgentEventEnum.ON_RESOLVE:
+      if (registeredAgent.handlers.onResolve) {
+        await replyIfPresent(await registeredAgent.handlers.onResolve(ctx as AgentResolveContext));
+      }
+      break;
+    default:
+      throw new InvalidActionError(event, AgentEventEnum);
+  }
+}

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -1,5 +1,4 @@
 import type { Emoji } from 'chat';
-import { isJSX, toCardElement } from 'chat/jsx-runtime';
 import { AgentDeliveryError } from './agent.errors';
 import type {
   AddReactionPayload,
@@ -189,6 +188,8 @@ async function serializeContent(content: MessageContent, files?: FileRef[]): Pro
   if (typeof content === 'string') {
     return validFiles ? { markdown: content, files: validFiles } : { markdown: content };
   }
+
+  const { isJSX, toCardElement } = await import('chat/jsx-runtime');
 
   if (isJSX(content)) {
     const card = toCardElement(content);

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -214,7 +214,7 @@ export interface ReplyHandle {
   edit(content: MessageContent, options?: { files?: FileRef[] }): Promise<ReplyHandle>;
 }
 
-interface AgentContextBase {
+export interface AgentContextBase {
   /** Live state of the current conversation, including persisted metadata. */
   readonly conversation: AgentConversation;
   /**

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -21,6 +21,7 @@ export type {
   AgentAttachment,
   AgentBridgeRequest,
   AgentContext,
+  AgentContextBase,
   AgentConversation,
   AgentHandlers,
   AgentHistoryEntry,

--- a/packages/framework/src/utils/bridge-signature.ts
+++ b/packages/framework/src/utils/bridge-signature.ts
@@ -1,0 +1,45 @@
+interface ParsedSignatureHeader {
+  t?: number;
+  v1?: string;
+}
+
+/**
+ * Parse a `Novu-Signature` header into its named fields.
+ *
+ * Header format: `t=<unix-ms>,v1=<hex-hmac>` (order/whitespace tolerant).
+ *
+ * Splitting only on `=` was previously used here, which broke the timestamp
+ * extraction (`timestamp` ended up as the literal string "t") and silently
+ * disabled replay protection. We now split each comma-separated part on the
+ * first `=` only and look up fields by name so additional or reordered fields
+ * cannot bypass validation.
+ */
+export function parseSignatureHeader(header: string): ParsedSignatureHeader {
+  const fields: Record<string, string> = {};
+
+  for (const rawPart of header.split(',')) {
+    const part = rawPart.trim();
+    if (!part) {
+      continue;
+    }
+
+    const eqIdx = part.indexOf('=');
+    if (eqIdx <= 0) {
+      continue;
+    }
+
+    const key = part.slice(0, eqIdx);
+    const value = part.slice(eqIdx + 1);
+    if (key && value && !(key in fields)) {
+      fields[key] = value;
+    }
+  }
+
+  const tRaw = fields.t;
+  const t = tRaw !== undefined ? Number(tRaw) : Number.NaN;
+
+  return {
+    t: Number.isFinite(t) ? t : undefined,
+    v1: fields.v1,
+  };
+}

--- a/packages/framework/tsup.config.ts
+++ b/packages/framework/tsup.config.ts
@@ -13,6 +13,8 @@ const baseConfig: Options = {
     'src/step-resolver.ts',
     'src/validators.ts',
     ...frameworks.map((framework) => `src/servers/${framework}.ts`),
+    'src/ai-sdk/index.ts',
+    'src/cards.ts',
   ],
   sourcemap: false,
   clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3526,9 +3526,6 @@ importers:
         specifier: ^2.17.4
         version: 2.17.4
     devDependencies:
-      '@ai-sdk/openai':
-        specifier: 3.0.46
-        version: 3.0.46(zod@3.25.20)
       '@apidevtools/json-schema-ref-parser':
         specifier: 11.6.4
         version: 11.6.4
@@ -4606,20 +4603,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.46':
-    resolution: {integrity: sha512-8grBb4sAMU0MAC6uOOD/wP/+SyX/3MMS/Lf+ToGgeUzoF9oWU9dWBLkvgjXpn7Ro81bPDeycW2GCCT63V/Vnvg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/provider-utils@4.0.13':
     resolution: {integrity: sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.20':
-    resolution: {integrity: sha512-gpUIj9uDhIGbuo9afKEgQ074BWmhvK4THJAAeBjRnroTy2yQYo6rbtGD7pQDMZM8ouXPYmT/SCdkWVJ0KcpX8A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4656,10 +4641,6 @@ packages:
 
   '@ai-sdk/provider@3.0.7':
     resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/provider@3.0.8':
-    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@3.0.51':
@@ -28282,22 +28263,9 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.6(zod@4.3.5)
       zod: 4.3.5
 
-  '@ai-sdk/openai@3.0.46(zod@3.25.20)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.20(zod@3.25.20)
-      zod: 3.25.20
-
   '@ai-sdk/provider-utils@4.0.13(zod@3.25.20)':
     dependencies:
       '@ai-sdk/provider': 3.0.7
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 3.25.20
-
-  '@ai-sdk/provider-utils@4.0.20(zod@3.25.20)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.20
@@ -28372,10 +28340,6 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.7':
-    dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
@@ -32164,7 +32128,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       kysely: 0.28.17
       nanostores: 1.2.0
@@ -46147,7 +46111,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.6
       jose: 6.1.3
       kysely: 0.28.17
@@ -46165,15 +46129,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.2(zod@4.3.5):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,19 +356,19 @@ importers:
         version: 3.1048.0
       '@chat-adapter/slack':
         specifier: 4.30.0
-        version: 4.30.0(zod@3.25.20)
+        version: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       '@chat-adapter/state-ioredis':
         specifier: 4.30.0
-        version: 4.30.0(zod@3.25.20)
+        version: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       '@chat-adapter/teams':
         specifier: 4.30.0
-        version: 4.30.0(zod@3.25.20)
+        version: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       '@chat-adapter/telegram':
         specifier: 4.30.0
-        version: 4.30.0(zod@3.25.20)
+        version: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       '@chat-adapter/whatsapp':
         specifier: 4.30.0
-        version: 4.30.0(zod@3.25.20)
+        version: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       '@godaddy/terminus':
         specifier: ^4.12.1
         version: 4.12.1
@@ -497,7 +497,7 @@ importers:
         version: 4.10.4
       chat:
         specifier: 4.30.0
-        version: 4.30.0(zod@3.25.20)
+        version: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -3432,17 +3432,17 @@ importers:
     dependencies:
       '@chat-adapter/shared':
         specifier: 4.30.0
-        version: 4.30.0(zod@4.3.6)
+        version: 4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)
       chat:
         specifier: ^4.30.0
-        version: 4.30.0(zod@4.3.6)
+        version: 4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)
       react:
         specifier: '>=18.0.0 || >=19.0.0'
         version: 19.2.3
     devDependencies:
       '@chat-adapter/state-memory':
         specifier: 4.30.0
-        version: 4.30.0(zod@4.3.6)
+        version: 4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.8
@@ -3469,7 +3469,7 @@ importers:
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       chat:
         specifier: '>=4.30.0'
-        version: 4.30.0(zod@4.3.6)
+        version: 4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)
       hast-util-to-html:
         specifier: 9.0.5
         version: 9.0.5
@@ -3506,7 +3506,7 @@ importers:
         version: 4.1.2
       chat:
         specifier: 4.30.0
-        version: 4.30.0(zod@3.25.20)
+        version: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       cross-fetch:
         specifier: ^4.0.0
         version: 4.0.0(encoding@0.1.13)
@@ -3526,6 +3526,9 @@ importers:
         specifier: ^2.17.4
         version: 2.17.4
     devDependencies:
+      '@ai-sdk/openai':
+        specifier: 3.0.46
+        version: 3.0.46(zod@3.25.20)
       '@apidevtools/json-schema-ref-parser':
         specifier: 11.6.4
         version: 11.6.4
@@ -3556,6 +3559,9 @@ importers:
       '@vercel/node':
         specifier: ^2.15.9
         version: 2.15.10(@swc/core@1.7.26(@swc/helpers@0.5.15))(encoding@0.1.13)
+      ai:
+        specifier: ^6.0.208
+        version: 6.0.208(zod@3.25.20)
       aws-lambda:
         specifier: ^1.0.7
         version: 1.0.7
@@ -4554,6 +4560,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.133':
+    resolution: {integrity: sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.14':
     resolution: {integrity: sha512-udVpkDaQ00jMcBvtGGvmkEBU31XidsHB4E8HIF9l7/H7lyjOS/EtXzN2adoupDg5j1/VjjSI3Ny5P1zHUvLyMA==}
     engines: {node: '>=18'}
@@ -4594,8 +4606,26 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@3.0.46':
+    resolution: {integrity: sha512-8grBb4sAMU0MAC6uOOD/wP/+SyX/3MMS/Lf+ToGgeUzoF9oWU9dWBLkvgjXpn7Ro81bPDeycW2GCCT63V/Vnvg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.13':
     resolution: {integrity: sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.20':
+    resolution: {integrity: sha512-gpUIj9uDhIGbuo9afKEgQ074BWmhvK4THJAAeBjRnroTy2yQYo6rbtGD7pQDMZM8ouXPYmT/SCdkWVJ0KcpX8A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.30':
+    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4612,6 +4642,10 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
   '@ai-sdk/provider@3.0.3':
     resolution: {integrity: sha512-qGPYdoAuECaUXPrrz0BPX1SacZQuJ6zky0aakxpW89QW1hrY0eF4gcFm/3L9Pk8C5Fwe+RvBf2z7ZjDhaPjnlg==}
     engines: {node: '>=18'}
@@ -4622,6 +4656,10 @@ packages:
 
   '@ai-sdk/provider@3.0.7':
     resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@3.0.51':
@@ -15433,6 +15471,10 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vercel/static-config@2.0.17':
     resolution: {integrity: sha512-2f50OTVrN07x7pH+XNW0e7cj7T+Ufg+19+a2N3/XZBjQmV+FaMlmSLiaQ4tBxp2H8lWWHzENua7ZSSQPtRZ3/A==}
 
@@ -15902,6 +15944,12 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ai@6.0.208:
+    resolution: {integrity: sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ai@6.0.34:
     resolution: {integrity: sha512-Q8vGOaSg+Hsak8/m5pKXj6YOW+9ioF7BVUUfzuYEADq2uFyrJQBFoaDG4gc59/DWo/ko99vf0AjCF+sIdNTCmg==}
@@ -18831,6 +18879,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@2.0.2:
@@ -28152,6 +28204,21 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.6(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.133(zod@3.25.20)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@3.25.20)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.20
+
+  '@ai-sdk/gateway@3.0.133(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+    optional: true
+
   '@ai-sdk/gateway@3.0.14(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 3.0.3
@@ -28215,12 +28282,40 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.6(zod@4.3.5)
       zod: 4.3.5
 
+  '@ai-sdk/openai@3.0.46(zod@3.25.20)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.20(zod@3.25.20)
+      zod: 3.25.20
+
   '@ai-sdk/provider-utils@4.0.13(zod@3.25.20)':
     dependencies:
       '@ai-sdk/provider': 3.0.7
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.20
+
+  '@ai-sdk/provider-utils@4.0.20(zod@3.25.20)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.20
+
+  '@ai-sdk/provider-utils@4.0.30(zod@3.25.20)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 3.25.20
+
+  '@ai-sdk/provider-utils@4.0.30(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
+    optional: true
 
   '@ai-sdk/provider-utils@4.0.6(zod@3.25.20)':
     dependencies:
@@ -28264,6 +28359,10 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.5
 
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.3':
     dependencies:
       json-schema: 0.4.0
@@ -28273,6 +28372,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.7':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
@@ -32184,28 +32287,28 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
-  '@chat-adapter/shared@4.30.0(zod@3.25.20)':
+  '@chat-adapter/shared@4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)':
     dependencies:
-      chat: 4.30.0(zod@3.25.20)
+      chat: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/shared@4.30.0(zod@4.3.6)':
+  '@chat-adapter/shared@4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      chat: 4.30.0(zod@4.3.6)
+      chat: 4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.30.0(zod@3.25.20)':
+  '@chat-adapter/slack@4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)':
     dependencies:
-      '@chat-adapter/shared': 4.30.0(zod@3.25.20)
+      '@chat-adapter/shared': 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       '@slack/socket-mode': 2.0.7
       '@slack/web-api': 7.15.0
-      chat: 4.30.0(zod@3.25.20)
+      chat: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
     transitivePeerDependencies:
       - ai
       - bufferutil
@@ -32214,10 +32317,18 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@chat-adapter/state-ioredis@4.30.0(zod@3.25.20)':
+  '@chat-adapter/state-ioredis@4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)':
     dependencies:
-      chat: 4.30.0(zod@3.25.20)
+      chat: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       ioredis: 5.11.0
+    transitivePeerDependencies:
+      - ai
+      - supports-color
+      - zod
+
+  '@chat-adapter/state-memory@4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      chat: 4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -32231,41 +32342,33 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/state-memory@4.30.0(zod@4.3.6)':
+  '@chat-adapter/teams@4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)':
     dependencies:
-      chat: 4.30.0(zod@4.3.6)
-    transitivePeerDependencies:
-      - ai
-      - supports-color
-      - zod
-
-  '@chat-adapter/teams@4.30.0(zod@3.25.20)':
-    dependencies:
-      '@chat-adapter/shared': 4.30.0(zod@3.25.20)
+      '@chat-adapter/shared': 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
       '@microsoft/teams.api': 2.0.11
       '@microsoft/teams.apps': 2.0.11
       '@microsoft/teams.cards': 2.0.11
       '@microsoft/teams.graph-endpoints': 2.0.11
-      chat: 4.30.0(zod@3.25.20)
+      chat: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
     transitivePeerDependencies:
       - ai
       - debug
       - supports-color
       - zod
 
-  '@chat-adapter/telegram@4.30.0(zod@3.25.20)':
+  '@chat-adapter/telegram@4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)':
     dependencies:
-      '@chat-adapter/shared': 4.30.0(zod@3.25.20)
-      chat: 4.30.0(zod@3.25.20)
+      '@chat-adapter/shared': 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
+      chat: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/whatsapp@4.30.0(zod@3.25.20)':
+  '@chat-adapter/whatsapp@4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)':
     dependencies:
-      '@chat-adapter/shared': 4.30.0(zod@3.25.20)
-      chat: 4.30.0(zod@3.25.20)
+      '@chat-adapter/shared': 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
+      chat: 4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -44447,6 +44550,8 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vercel/static-config@2.0.17':
     dependencies:
       ajv: 8.18.0
@@ -45212,6 +45317,23 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ai@6.0.208(zod@3.25.20):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.133(zod@3.25.20)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@3.25.20)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.20
+
+  ai@6.0.208(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.133(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+    optional: true
 
   ai@6.0.34(zod@4.3.5):
     dependencies:
@@ -46482,6 +46604,36 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chat@4.30.0(ai@6.0.208(zod@3.25.20))(zod@3.25.20):
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    optionalDependencies:
+      ai: 6.0.208(zod@3.25.20)
+      zod: 3.25.20
+    transitivePeerDependencies:
+      - supports-color
+
+  chat@4.30.0(ai@6.0.208(zod@4.3.6))(zod@4.3.6):
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    optionalDependencies:
+      ai: 6.0.208(zod@4.3.6)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+
   chat@4.30.0(ai@6.0.50(zod@4.3.5))(zod@4.3.5):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
@@ -46494,34 +46646,6 @@ snapshots:
     optionalDependencies:
       ai: 6.0.50(zod@4.3.5)
       zod: 4.3.5
-    transitivePeerDependencies:
-      - supports-color
-
-  chat@4.30.0(zod@3.25.20):
-    dependencies:
-      '@workflow/serde': 4.1.0-beta.2
-      mdast-util-to-string: 4.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-stringify: 11.0.0
-      remend: 1.3.0
-      unified: 11.0.5
-    optionalDependencies:
-      zod: 3.25.20
-    transitivePeerDependencies:
-      - supports-color
-
-  chat@4.30.0(zod@4.3.6):
-    dependencies:
-      '@workflow/serde': 4.1.0-beta.2
-      mdast-util-to-string: 4.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-stringify: 11.0.0
-      remend: 1.3.0
-      unified: 11.0.5
-    optionalDependencies:
-      zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -48512,6 +48636,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@2.0.2: {}
 


### PR DESCRIPTION
## Summary

- Adds optional `@novu/framework/ai-sdk` subpath: `agent()`, `toModelMessages()`, and auto-delivery of `streamText()` / `generateText()` results via `result.text`.
- Extracts shared agent bridge dispatch (`agent-dispatch.ts`) and HMAC signature parsing (`bridge-signature.ts`) used by all bridge POSTs.
- Lazy-loads `chat/jsx-runtime` for card serialization to keep the ai-sdk path tree-shakable.
- Fixes `AgentReplyController` naming collision between the injected `HandleAgentReply` usecase and the route handler method (renamed to `handleAgentReplyHandler`) so Nest registers auth guards on `/v1/agents/:agentId/reply`.

## Architecture

```mermaid
sequenceDiagram
  participant Channel as Slack/Teams
  participant Novu as Novu API
  participant Bridge as Customer bridge
  participant AI as AI SDK

  Channel->>Novu: inbound message
  Novu->>Bridge: AgentBridgeRequest (HMAC)
  Bridge->>AI: streamText / generateText
  AI-->>Bridge: result.text
  Bridge->>Novu: POST /agents/:id/reply (ApiKey)
  Novu->>Channel: deliver reply
```

## Test plan

- [x] `pnpm exec vitest run` in `packages/framework` (ai-sdk + agent tests)
- [ ] `pnpm build` in `packages/framework`
- [ ] Manual: point agent bridge at `ai-sdk-slackbot-novu`, send Slack message, verify reply round-trip
- [ ] `apps/api/src/app/agents/e2e/agent-slack-roundtrip.e2e.ts` (ApiKey reply path)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds AI SDK support for framework agents and shares agent bridge utilities. The main changes are:

- New `@novu/framework/ai-sdk` subpath with `agent()` and `toModelMessages()` helpers.
- Automatic delivery of `streamText()` and `generateText()` results through `result.text`.
- New `@novu/framework/cards` subpath for card exports.
- Shared agent event dispatch and bridge signature parsing utilities.
- Lazy loading of `chat/jsx-runtime` for card serialization.
- Agent reply controller rename to avoid the Nest route-handler collision.

<h3>Confidence Score: 0/5</h3>

No merge-safety assessment was provided.

No confidence value was provided with the review artifacts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the T-Rex workflow to verify a code path, first observing an initial failure (Exit code 1) with the error 'Package subpath ./ai-sdk is not exported', then re-running to confirm a successful post-run (Exit code 0) with exports agent,toModelMessages and AI SDK-style result text delivered.
- Compared the bridge-dispatch signature behavior before and after; base checkout command, script hash, and initial signature validation path with 200 OK; after shows the same runtime with exit code 0.
- Validated the card-jsx lazy-load behavior by comparing before and after states; initial imports show 1 eager static import and no cards export, while after shows 0 eager imports, 1 lazy import, and exports for the cards package.
- Checked agent reply authentication guard metadata before and after; the base route and auth constraints on handleAgentReply remain intact after renaming to handleAgentReplyHandler, with 200 OK in both cases.

<a href="https://app.greptile.com/trex/runs/12305645/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(framework): address ai-sdk PR review..."](https://github.com/novuhq/novu/commit/8d71a14bf6b066b8d4f7d29a16741db02c4295ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39849023)</sub>

<!-- /greptile_comment -->