### PR TITLE
style(root): increase docs sidebar width to 16rem on large screens fixes DOC-365

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,7 +1,7 @@
 @media (min-width: 1024px) {
   #sidebar-content {
-    width: 15rem;
-    min-width: 15rem;
-    max-width: 15rem;
+    width: 16rem;
+    min-width: 16rem;
+    max-width: 16rem;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Increases the docs site sidebar (`#sidebar-content`) width from `15rem` to `16rem` on screens `>= 1024px`.

## Why

Provides slightly more room for sidebar navigation labels on larger screens.

## Changes

- Updated `width`, `min-width`, and `max-width` in `docs/style.css` within the existing `@media (min-width: 1024px)` breakpoint.

## Test plan

- [x] Verified CSS change is scoped to the large-screen media query only
- [ ] Visual check on docs site at `>= 1024px` viewport width
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1782411846228549?thread_ts=1782411846.228549&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-42cb6ab1-a093-529e-b21e-e6bf88e6996a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42cb6ab1-a093-529e-b21e-e6bf88e6996a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the docs sidebar (`#sidebar-content`) width from `15rem` to `16rem` on viewports ≥ 1024px to give navigation labels slightly more horizontal space.

- All three CSS box-model constraints (`width`, `min-width`, `max-width`) are updated consistently so the sidebar cannot flex outside the intended size.
- The change is confined to the existing large-screen media query and does not affect smaller viewports.

<h3>Confidence Score: 5/5</h3>

This is a single-file CSS tweak with no risk of functional regression.

The only change is bumping a sidebar width by 1rem inside a scoped media query. All three constraints (width, min-width, max-width) are updated together, so the sidebar cannot stretch outside the intended size. There is no JavaScript, no logic, and no other files touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/style.css | Sidebar width increased from 15rem to 16rem inside the existing @media (min-width: 1024px) breakpoint — a straightforward cosmetic tweak with no logic changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Browser viewport"] -->|"< 1024px"| B["No sidebar override\n(default styles apply)"]
    A -->|">= 1024px"| C["@media (min-width: 1024px)"]
    C --> D["#sidebar-content\nwidth: 16rem\nmin-width: 16rem\nmax-width: 16rem"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Browser viewport"] -->|"< 1024px"| B["No sidebar override\n(default styles apply)"]
    A -->|">= 1024px"| C["@media (min-width: 1024px)"]
    C --> D["#sidebar-content\nwidth: 16rem\nmin-width: 16rem\nmax-width: 16rem"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["style(docs): increase sidebar width to 1..."](https://github.com/novuhq/novu/commit/ad895edc07d8923c62f5065d4fce471a11deffdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39909827)</sub>

<!-- /greptile_comment -->