### PR TITLE
chore(root): add docs as valid PR title semantic scope fixes DOC-366

### DIFF
--- a/.cursor/rules/pullrequest.mdc
+++ b/.cursor/rules/pullrequest.mdc
@@ -11,7 +11,7 @@ alwaysApply: false
 - Examples: `feat(dashboard): add workflow trigger button fixes NOV-123`, `fix(api-service): handle null subscriber case fixes NOV-456`
 
 
-**Scopes**: `dashboard`, `api-service`, `worker`, `shared`, `js`, `react`, `react-native`, `nextjs`, `providers`, `root`
+**Scopes**: `dashboard`, `api-service`, `worker`, `shared`, `js`, `react`, `react-native`, `nextjs`, `providers`, `root`, `docs`
 
 **Description**: Summarize what changed and why. List breaking changes. Add screenshots for UI changes. For non-trivial logic or architecture changes, include a concise Mermaid diagram (flow, sequence, or component) so reviewers can grasp the change at a glance.
 

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -33,6 +33,8 @@ jobs:
         id: generate_scopes
         run: |
           scopes=$(pnpm m ls --json --depth=-1 | grep "name" | sed -e 's/.*\: \(.*\)/\1/' -e 's/@novu\///g' -e 's/[",]//g')
+          # Mintlify docs site (docs/) is not a pnpm workspace package.
+          scopes="$scopes"$'\n'"docs"
           echo 'SCOPES<<EOF' >> $GITHUB_ENV
           echo "$scopes" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

PR titles like `fix(docs): update API reference...` were failing the conventional commit lint because allowed scopes are generated from pnpm workspace package names. The Mintlify docs site (`docs/`) is not a workspace package, so `docs` was not in the allowed scope list.

This change appends `docs` to the generated scopes in the PR title lint workflow and documents it in the pull request rules.

### Test plan

- [x] Verified `docs` is appended to the scope list generated in `.github/workflows/conventional-commit.yml`
- [ ] CI `Lint PR title` check passes on this PR with `chore(root): ...` scope
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1782412002878949?thread_ts=1782412002.878949&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-b3a520c7-f32f-52c2-960c-e8b630769290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3a520c7-f32f-52c2-960c-e8b630769290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `docs` as an allowed semantic scope for PR titles. The main changes are:

- Appends `docs` to the generated scope list in the conventional commit workflow.
- Updates the pull request rules to document `docs` as a valid scope.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to CI title-scope configuration and related documentation.

The modified workflow and pull request rule text are narrowly scoped, straightforward, and align with the stated goal of allowing `docs` as a semantic scope.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base checkout was performed and the exact PNPM scope command failed due to a local Node/pnpm mismatch.
- Fallback workflow-equivalent scopes did not contain docs in the base run, and the docs title was INVALID.
- A head checkout was performed and the exact PNPM scope command encountered the same local runtime blocker.
- Fallback workflow-equivalent scopes detected the workflow docs append and included docs, with the docs title now VALID.
- The PR rules scopes include root and docs.
- Root-scoped control remained invalid in the executable workflow-equivalent validation; this was a control and not part of the claimed docs change.

<a href="https://app.greptile.com/trex/runs/12328617/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(root): add docs as valid PR title ..."](https://github.com/novuhq/novu/commit/7fb915f5c821e868b6b0535ac32e69861b16a9fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39910468)</sub>

<!-- /greptile_comment -->