### PR TITLE
docs(docs): remove duplicate mermaid diagrams alongside PNG images fixes DOC-368

### DIFF
--- a/docs/agents/conversations.mdx
+++ b/docs/agents/conversations.mdx
@@ -14,16 +14,6 @@ Every agent conversation follows the same state machine, regardless of agent typ
   ![Agent conversation lifecycle](/images/agents/conversations/lifecycle.png)
 </Frame>
 
-```mermaid
-stateDiagram-v2
-    [*] --> active: First message
-    active --> active: New messages
-    active --> resolved: "ctx.resolve() or platform closes"
-    resolved --> reopened: User sends new message
-    reopened --> active: Conversation resumes
-    reopened --> resolved: Resolved again
-```
-
 | State | What it means |
 | --- | --- |
 | **Active** | The conversation is ongoing. Messages increment the count, metadata can be updated, and the last activity timestamp is refreshed. |

--- a/docs/agents/custom-code-agent/concepts.mdx
+++ b/docs/agents/custom-code-agent/concepts.mdx
@@ -13,24 +13,6 @@ Users can message your agent, and your agent can message back. When someone inte
 
 ![Inbound message flow](/images/agents/custom-code-agent/concept-inbound-flow.png)
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant Provider as Chat Provider
-    participant Novu
-    participant Handler as Your Handler
-
-    User->>Provider: Send message
-    Provider->>Novu: Normalized webhook
-    Novu->>Novu: Identify user and load conversation
-    Novu->>Handler: Context object onMessage
-    Handler->>Handler: LLM or business logic
-    Handler->>Novu: ctx.reply and signals
-    Novu->>Provider: Deliver to thread
-    Novu->>Novu: Persist history and activity
-    Provider->>User: Show reply
-```
-
 | Step | What Novu does |
 | --- | --- |
 | **Receive and identify** | Normalizes the platform webhook. Maps the platform user (for example a Slack user ID) to a Novu subscriber when possible. Known users get full profiles; unknown users stay anonymous until resolved. |

--- a/docs/agents/custom-code-agent/setup-your-agent/overview.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/overview.mdx
@@ -29,24 +29,6 @@ A conversation starts when a user sends a message to your agent on a connected p
 
 ![Agent conversation flow](/images/agents/custom-code-agent/setup-your-agent/overview.png)
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant Provider as Connected Provider
-    participant Novu
-    participant Bridge as Bridge App
-
-    User->>Provider: Send message
-    Provider->>Novu: Inbound event
-    Novu->>Novu: Normalize and resolve subscriber
-    Novu->>Bridge: Invoke handler at bridge URL
-    Bridge->>Bridge: Process reply and signals
-    Bridge->>Novu: Return response
-    Novu->>Provider: Deliver to thread
-    Novu->>Novu: Record in dashboard
-    Provider->>User: Show reply
-```
-
 1. User sends a message on the provider (for example, Slack).
 2. Novu normalizes the event and resolves the subscriber when possible.
 3. Novu invokes the appropriate handler (`onMessage`, `onAction`, and so on) on your bridge URL.

--- a/docs/platform/developer/webhooks.mdx
+++ b/docs/platform/developer/webhooks.mdx
@@ -90,18 +90,6 @@ When your service experiences downtime or your endpoint is misconfigured, you ca
 
 ### Delivery attempts
 
-```mermaid
-stateDiagram-v2
-    [*] --> pending: Event occurs
-    pending --> delivered: "2xx response"
-    pending --> retrying: Delivery fails
-    retrying --> delivered: "2xx response"
-    retrying --> retrying: Exponential backoff
-    retrying --> disabled: "Fails for 5 consecutive days"
-    disabled --> pending: Manual re-enable
-    delivered --> [*]
-```
-
 When an event cannot be delivered, Novu retries using exponential backoff. Each message is attempted based on the following schedule, where each period is started following the failure of the preceding attempt:
 
 - Immediately


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

PR #11663 added supplementary Mermaid diagrams alongside existing PNG architecture images on several docs pages. That created redundant duplicate visuals for the same flows and state machines.

This PR removes the duplicate Mermaid blocks and keeps the existing PNG images (and `<Frame>` wrappers where present).

**Pages updated:**
- `docs/agents/conversations.mdx` — lifecycle state diagram (PNG kept)
- `docs/agents/custom-code-agent/concepts.mdx` — inbound flow sequence (PNG kept)
- `docs/agents/custom-code-agent/setup-your-agent/overview.mdx` — conversation flow sequence (PNG kept)
- `docs/platform/developer/webhooks.mdx` — delivery attempts state diagram (PNG kept)

Mermaid diagrams added in #11663 that do not duplicate existing images (framework intro, syncing, workflow lifecycle, preferences priority flow, etc.) are unchanged.

### Screenshots

N/A — docs content cleanup only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

Follow-up cleanup to #11663 / DOC-367.

</details>

### Test plan

- [x] `mint validate` passes locally
- [ ] Spot-check the four updated pages in `mint dev` to confirm PNG diagrams render and no duplicate Mermaid blocks appear

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65795ae-e819-48aa-ad4d-4454aa7b031a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65795ae-e819-48aa-ad4d-4454aa7b031a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes duplicate Mermaid diagrams from four documentation pages. The main changes are:

- Removed the conversation lifecycle Mermaid block from `docs/agents/conversations.mdx`.
- Removed the inbound flow Mermaid block from `docs/agents/custom-code-agent/concepts.mdx`.
- Removed the agent conversation flow Mermaid block from `docs/agents/custom-code-agent/setup-your-agent/overview.mdx`.
- Removed the webhook delivery attempts Mermaid block from `docs/platform/developer/webhooks.mdx`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are limited to removing redundant documentation diagrams while retaining the existing PNG assets.

The edited files are documentation-only MDX pages, and no functional application code or runtime behavior is affected.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Performed pre-run verification to ensure the four targeted pages contained one Mermaid block and the claimed PNG image, and that conversations.mdx included Frame.
- Performed post-run verification to confirm the pages now show MERMAID\_BLOCK\_COUNT: 0, the PNG image remains, and conversations.mdx still includes Frame.
- Recorded that both checks completed with exit code 0 and OVERALL\_RESULT: PASS.

<a href="https://app.greptile.com/trex/runs/12389942/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docs): remove duplicate mermaid dia..."](https://github.com/novuhq/novu/commit/848f83ed81f59c674e41557574ed78248a7eba4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40027304)</sub>

<!-- /greptile_comment -->