### PR TITLE
docs(docs): remove page sidebar icons, keep group icons only fixes DOC-369

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -35,7 +35,7 @@ Use Novu-specific terms consistently. For full definitions, see the [glossary](/
 - Code formatting for file names, commands, paths, and code references
 - Capitalize **Novu** and product names: Inbox, Framework, Dashboard
 - Include frontmatter `title` and `description` on MDX pages
-- Use icons on navigation groups only (set `"icon"` in `docs.json`), not on individual pages
+- Use icons on top-level navigation section titles only (set `"icon"` on groups in `docs.json`), not on individual pages or nested collapsible groups
 - For icons we use the [Lucide](https://lucide.dev/) library.
 - Prefer Mintlify components (`<Card>`, `<Columns>`, `<Steps>`, `<CodeGroup>`) over raw HTML
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -34,7 +34,8 @@ Use Novu-specific terms consistently. For full definitions, see the [glossary](/
 - Bold for UI elements: Click **Settings**
 - Code formatting for file names, commands, paths, and code references
 - Capitalize **Novu** and product names: Inbox, Framework, Dashboard
-- Include frontmatter `title`, `description`, and `icon` on MDX pages, matching existing docs
+- Include frontmatter `title` and `description` on MDX pages
+- Use icons on navigation groups only (set `"icon"` in `docs.json`), not on individual pages
 - For icons we use the [Lucide](https://lucide.dev/) library.
 - Prefer Mintlify components (`<Card>`, `<Columns>`, `<Steps>`, `<CodeGroup>`) over raw HTML
 

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Overview"
 description: "Connect your AI agents to chat platforms and communication channels with Novu's Agent Communication Infrastructure (ACI)."
-icon: "plug"
 ---
 
 

--- a/docs/agents/conversations.mdx
+++ b/docs/agents/conversations.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent Conversations"
 description: 'View agent conversations, their history, lifecycle, and observability in the Novu dashboard.'
-icon: "messages-square"
 ---
 
 Novu provides full observability for agent conversations across both managed agents and custom code agents. You can view and manage conversations in the Novu dashboard. Go to the Activity Feed page and switch to the **Agent Conversations** tab.

--- a/docs/agents/custom-code-agent/concepts.mdx
+++ b/docs/agents/custom-code-agent/concepts.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Concepts"
 description: 'Entities, lifecycle, and handler building blocks for a custom code agent with Novu.'
-icon: "brain"
 ---
 
 

--- a/docs/agents/custom-code-agent/connect-your-first-agent.mdx
+++ b/docs/agents/custom-code-agent/connect-your-first-agent.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Connect your first agent"
 description: 'Build a Pipeliner support agent with handlers, cards, metadata, an LLM, and conversation resolution.'
-icon: "sparkles"
 ---
 
 

--- a/docs/agents/custom-code-agent/going-to-production.mdx
+++ b/docs/agents/custom-code-agent/going-to-production.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Going to Production"
 description: 'Learn how to run a conversational agent on your local machine, test it in a development environment, and deploy it to production.'
-icon: "rocket"
 ---
 
 

--- a/docs/agents/custom-code-agent/quickstart.mdx
+++ b/docs/agents/custom-code-agent/quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Quickstart"
 description: 'Create your first agent and connect it to Slack in under 10 minutes.'
-icon: "zap"
 boost: 3
 ---
 

--- a/docs/agents/custom-code-agent/setup-your-agent/connect-components.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/connect-components.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Connect Components"
 description: 'Use prebuilt React components so your users can install and connect Slack, Microsoft Teams, Telegram and other communication platforms to your agent.'
-icon: "link"
 ---
 
 

--- a/docs/agents/custom-code-agent/setup-your-agent/create-an-agent.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/create-an-agent.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Create an agent"
 description: 'Create a new agent in the Novu dashboard and connect your first provider.'
-icon: "plus"
 ---
 
 

--- a/docs/agents/custom-code-agent/setup-your-agent/edit-sent-messages.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/edit-sent-messages.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Edit sent messages"
 description: 'Update a message in place after sending it with ctx.reply() and ReplyHandle.'
-icon: "pencil"
 ---
 
 

--- a/docs/agents/custom-code-agent/setup-your-agent/handle-events.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/handle-events.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Handlers and context"
 description: 'Event handlers and the context object your agent code receives on every turn.'
-icon: "mouse-pointer-click"
 ---
 
 

--- a/docs/agents/custom-code-agent/setup-your-agent/overview.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Overview"
 description: 'What you configure when setting up a Novu agent: dashboard settings, bridge, providers, and handler code.'
-icon: "compass"
 ---
 
 

--- a/docs/agents/custom-code-agent/setup-your-agent/reply.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/reply.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Reply"
 description: 'Send plain text, markdown, attachments, and interactive cards from agent handlers.'
-icon: "reply"
 ---
 
 

--- a/docs/agents/custom-code-agent/setup-your-agent/scaffold-your-project.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/scaffold-your-project.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Scaffold your project"
 description: 'Generate a Novu agent bridge application with the CLI and connect it to your dashboard agent.'
-icon: "terminal"
 ---
 
 

--- a/docs/agents/custom-code-agent/setup-your-agent/signals.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/signals.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Signals"
 description: 'Use signals in agent handlers for metadata, workflow triggers, and conversation resolution.'
-icon: "signal"
 ---
 
 

--- a/docs/agents/get-started/agents-and-providers.mdx
+++ b/docs/agents/get-started/agents-and-providers.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agents and providers"
 description: 'How agents and providers work together to enable agent communication across channels.'
-icon: "bot"
 ---
 
 ## Agents

--- a/docs/agents/get-started/mental-model.mdx
+++ b/docs/agents/get-started/mental-model.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Mental model"
 description: 'How inbound messages flow from a messaging platform through Novu to your agent code and back.'
-icon: "git-branch"
 ---
 
 

--- a/docs/agents/get-started/what-is-aci.mdx
+++ b/docs/agents/get-started/what-is-aci.mdx
@@ -1,7 +1,6 @@
 ---
 title: "What is ACI?"
 description: 'Learn what ACI is, what it solves, and how it helps agents communicate across channels.'
-icon: "circle-question-mark"
 ---
 
 

--- a/docs/agents/managed-agent/add-skills.mdx
+++ b/docs/agents/managed-agent/add-skills.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Add skills"
 description: 'Upload custom SKILL.md files to give your managed agent domain-specific instructions.'
-icon: "wrench"
 ---
 
 

--- a/docs/agents/managed-agent/concepts.mdx
+++ b/docs/agents/managed-agent/concepts.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Concepts"
 description: 'Connectors, MCP servers, skills, system prompts, and conversation flow for managed agents.'
-icon: "brain"
 ---
 
 

--- a/docs/agents/managed-agent/configure-mcp-servers.mdx
+++ b/docs/agents/managed-agent/configure-mcp-servers.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Configure MCP servers"
 description: 'Enable external tools like Linear, GitHub, and Notion on your managed agent using MCP servers.'
-icon: "link"
 ---
 
 

--- a/docs/agents/managed-agent/overview.mdx
+++ b/docs/agents/managed-agent/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Overview"
 description: 'What managed agents are, how they work, and when to use them.'
-icon: "compass"
 ---
 
 

--- a/docs/agents/managed-agent/quickstart.mdx
+++ b/docs/agents/managed-agent/quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Quickstart"
 description: 'Use the Novu CLI to create a managed agent, connect it to Slack, and get a reply in minutes.'
-icon: "zap"
 ---
 
 

--- a/docs/community/self-hosting-novu/data-migrations.mdx
+++ b/docs/community/self-hosting-novu/data-migrations.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Data Migrations'
 description: 'Learn how to update your database data through migrations.'
-icon: "database"
 ---
 
 On occasion, Novu may introduce features that require changes to the database schema or data. This usually happens when

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,8 +57,7 @@
                   "platform/quickstart/vanilla-js"
                 ]
               }
-            ],
-            "icon": "rocket"
+            ]
           },
           {
             "group": "Integrate <Inbox />",
@@ -388,8 +387,7 @@
               "agents/get-started/what-is-aci",
               "agents/get-started/mental-model",
               "agents/get-started/agents-and-providers"
-            ],
-            "icon": "rocket"
+            ]
           },
           {
             "group": "Managed Agent",
@@ -444,8 +442,7 @@
               "api-reference/rate-limiting",
               "api-reference/idempotency",
               "api-reference/payload-limits"
-            ],
-            "icon": "rocket"
+            ]
           },
           {
             "group": "Events",
@@ -740,8 +737,7 @@
                       "framework/quickstart/lambda"
                     ]
                   }
-                ],
-                "icon": "rocket"
+                ]
               },
               {
                 "group": "Core Concepts",
@@ -853,8 +849,7 @@
                   "community/self-hosted-and-novu-cloud",
                   "community/run-in-local-machine",
                   "community/add-a-new-provider"
-                ],
-                "icon": "rocket"
+                ]
               }
             ]
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,7 +35,6 @@
               "platform/how-novu-works",
               {
                 "group": "Core Concepts",
-                "icon": "blocks",
                 "pages": [
                   "platform/concepts/notification-event",
                   "platform/concepts/workflows",
@@ -49,7 +48,6 @@
               },
               {
                 "group": "Quickstart",
-                "icon": "zap",
                 "pages": [
                   "platform/quickstart/react",
                   "platform/quickstart/nextjs",
@@ -59,7 +57,8 @@
                   "platform/quickstart/vanilla-js"
                 ]
               }
-            ]
+            ],
+            "icon": "rocket"
           },
           {
             "group": "Integrate <Inbox />",
@@ -68,12 +67,13 @@
               "platform/inbox/setup-inbox",
               {
                 "group": "Features",
-                "icon": "blocks",
-                "pages": ["platform/inbox/features/snooze", "platform/inbox/features/schedule"]
+                "pages": [
+                  "platform/inbox/features/snooze",
+                  "platform/inbox/features/schedule"
+                ]
               },
               {
                 "group": "Customize and Configure",
-                "icon": "sliders-horizontal",
                 "pages": [
                   "platform/inbox/configuration/styling",
                   "platform/inbox/configuration/tabs",
@@ -85,7 +85,6 @@
               },
               {
                 "group": "Advanced Customization",
-                "icon": "wand",
                 "pages": [
                   "platform/inbox/advanced-customization/customize-bell",
                   "platform/inbox/advanced-customization/customize-popover",
@@ -97,7 +96,6 @@
               },
               {
                 "group": "Advanced Features",
-                "icon": "network",
                 "pages": [
                   "platform/inbox/advanced-features/localization",
                   "platform/inbox/advanced-features/multi-tenancy"
@@ -106,7 +104,8 @@
               "platform/inbox/headless-mode",
               "platform/inbox/prepare-for-production",
               "platform/inbox/migration-guide"
-            ]
+            ],
+            "icon": "inbox"
           },
           {
             "group": "Integrate <Subscription />",
@@ -115,7 +114,8 @@
               "platform/subscription/quickstart",
               "platform/subscription/customize-and-configure",
               "platform/subscription/headless-hooks"
-            ]
+            ],
+            "icon": "bell-ring"
           },
           {
             "group": "Build a Workflow",
@@ -129,7 +129,6 @@
                 "pages": [
                   {
                     "group": "Configure Action Steps",
-                    "icon": "package",
                     "pages": [
                       "platform/workflow/add-and-configure-steps/configure-action-steps/delay",
                       "platform/workflow/add-and-configure-steps/configure-action-steps/digest",
@@ -139,12 +138,10 @@
                   },
                   "platform/workflow/add-and-configure-steps/step-conditions",
                   "platform/workflow/add-and-configure-steps/code-steps"
-                ],
-                "icon": "copy-plus"
+                ]
               },
               {
                 "group": "Add Notification Content",
-                "icon": "package",
                 "pages": [
                   "platform/workflow/add-notification-content/channels-template-editors",
                   "platform/workflow/add-notification-content/personalize-content"
@@ -154,12 +151,10 @@
               "platform/workflow/monitor-and-debug-workflow",
               {
                 "group": "Advanced Features",
-                "icon": "sparkles",
                 "pages": [
                   "platform/workflow/advanced-features/translations",
                   {
                     "group": "Contexts",
-                    "icon": "package",
                     "pages": [
                       "platform/workflow/advanced-features/contexts/manage-contexts",
                       "platform/workflow/advanced-features/contexts/contexts-in-workflows"
@@ -167,7 +162,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "icon": "git-branch"
           },
           {
             "group": "Integrate Channels Providers",
@@ -177,7 +173,6 @@
               {
                 "group": "Chat",
                 "root": "platform/integrations/chat",
-                "icon": "message-square",
                 "pages": [
                   "platform/integrations/chat/discord",
                   "platform/integrations/chat/mattermost",
@@ -189,7 +184,6 @@
               },
               {
                 "group": "Email",
-                "icon": "mail",
                 "root": "platform/integrations/email",
                 "pages": [
                   "platform/integrations/email/sendgrid",
@@ -229,7 +223,6 @@
               },
               {
                 "group": "Push",
-                "icon": "smartphone",
                 "root": "platform/integrations/push",
                 "pages": [
                   "platform/integrations/push/fcm",
@@ -244,7 +237,6 @@
               },
               {
                 "group": "Sms",
-                "icon": "message-circle",
                 "root": "platform/integrations/sms",
                 "pages": [
                   "platform/integrations/sms/twilio",
@@ -273,7 +265,8 @@
                 ]
               },
               "platform/integrations/trigger-overrides"
-            ]
+            ],
+            "icon": "plug-zap"
           },
           {
             "group": "SDKs",
@@ -281,7 +274,6 @@
               "platform/sdks",
               {
                 "group": "@novu/react",
-                "icon": "library",
                 "pages": [
                   "platform/sdks/react",
                   {
@@ -302,7 +294,6 @@
               "platform/sdks/javascript",
               {
                 "group": "@novu/react-native",
-                "icon": "smartphone",
                 "root": "platform/sdks/react-native",
                 "pages": [
                   "platform/sdks/react-native",
@@ -321,7 +312,6 @@
               },
               {
                 "group": "Server-Side",
-                "icon": "server",
                 "root": "platform/sdks/server",
                 "pages": [
                   "platform/sdks/server/typescript",
@@ -335,7 +325,8 @@
                   "platform/sdks/server/ruby"
                 ]
               }
-            ]
+            ],
+            "icon": "code"
           },
           {
             "group": "Developer",
@@ -346,10 +337,13 @@
               "platform/developer/limits",
               {
                 "group": "Webhooks",
-                "icon": "webhook",
-                "pages": ["platform/developer/webhooks/event-types", "platform/developer/webhooks/connectors"]
+                "pages": [
+                  "platform/developer/webhooks/event-types",
+                  "platform/developer/webhooks/connectors"
+                ]
               }
-            ]
+            ],
+            "icon": "terminal"
           },
           {
             "group": "Account",
@@ -359,7 +353,8 @@
               "platform/account/manage-members",
               "platform/account/billing",
               "platform/account/sso"
-            ]
+            ],
+            "icon": "building-2"
           },
           {
             "group": "Build with AI",
@@ -367,7 +362,8 @@
               "platform/build-with-ai/mcp",
               "platform/build-with-ai/skills",
               "platform/build-with-ai/agent-toolkit"
-            ]
+            ],
+            "icon": "sparkles"
           },
           {
             "group": "Additional Resources",
@@ -376,7 +372,8 @@
               "platform/additional-resources/errors",
               "platform/additional-resources/security",
               "platform/additional-resources/legacy-documentation"
-            ]
+            ],
+            "icon": "book-open"
           }
         ]
       },
@@ -391,7 +388,8 @@
               "agents/get-started/what-is-aci",
               "agents/get-started/mental-model",
               "agents/get-started/agents-and-providers"
-            ]
+            ],
+            "icon": "rocket"
           },
           {
             "group": "Managed Agent",
@@ -401,7 +399,8 @@
               "agents/managed-agent/concepts",
               "agents/managed-agent/configure-mcp-servers",
               "agents/managed-agent/add-skills"
-            ]
+            ],
+            "icon": "bot"
           },
           {
             "group": "Custom Code Agent",
@@ -411,7 +410,6 @@
               "agents/custom-code-agent/connect-your-first-agent",
               {
                 "group": "Set up your Agent",
-                "icon": "blocks",
                 "pages": [
                   "agents/custom-code-agent/setup-your-agent/overview",
                   "agents/custom-code-agent/setup-your-agent/create-an-agent",
@@ -424,11 +422,15 @@
                 ]
               },
               "agents/custom-code-agent/going-to-production"
-            ]
+            ],
+            "icon": "code"
           },
           {
             "group": "Observability",
-            "pages": ["agents/conversations"]
+            "pages": [
+              "agents/conversations"
+            ],
+            "icon": "eye"
           }
         ]
       },
@@ -442,7 +444,8 @@
               "api-reference/rate-limiting",
               "api-reference/idempotency",
               "api-reference/payload-limits"
-            ]
+            ],
+            "icon": "rocket"
           },
           {
             "group": "Events",
@@ -451,7 +454,8 @@
               "api-reference/events/bulk-trigger-event",
               "api-reference/events/broadcast-event-to-all",
               "api-reference/events/cancel-triggered-event"
-            ]
+            ],
+            "icon": "zap"
           },
           {
             "group": "Subscribers",
@@ -476,7 +480,8 @@
               "api-reference/subscribers/update-subscriber-online-status",
               "api-reference/subscribers/retrieve-unseen-notifications-count",
               "api-reference/subscribers/update-notification-action-status"
-            ]
+            ],
+            "icon": "users"
           },
           {
             "group": "Inbox",
@@ -496,7 +501,8 @@
               "api-reference/subscribers/delete-all-notifications",
               "api-reference/subscribers/complete-a-notification-action",
               "api-reference/subscribers/revert-a-notification-action"
-            ]
+            ],
+            "icon": "inbox"
           },
           {
             "group": "Topics",
@@ -513,7 +519,8 @@
               "api-reference/topics/list-topic-subscriptions",
               "api-reference/topics/check-topic-subscriber",
               "api-reference/topics/retrieve-a-topic-subscription"
-            ]
+            ],
+            "icon": "hash"
           },
           {
             "group": "Notifications",
@@ -521,7 +528,8 @@
               "api-reference/notifications/notification-event-schema",
               "api-reference/notifications/list-all-events",
               "api-reference/notifications/retrieve-an-event"
-            ]
+            ],
+            "icon": "bell"
           },
           {
             "group": "Workflows",
@@ -535,7 +543,8 @@
               "api-reference/workflows/sync-a-workflow",
               "api-reference/workflows/retrieve-workflow-step",
               "api-reference/workflows/generate-a-step-preview"
-            ]
+            ],
+            "icon": "git-branch"
           },
           {
             "group": "Translations",
@@ -549,7 +558,8 @@
               "api-reference/translations/retrieve-master-translations-json",
               "api-reference/translations/upload-master-translations-json-file",
               "api-reference/translations/upload-translation-files"
-            ]
+            ],
+            "icon": "languages"
           },
           {
             "group": "Contexts",
@@ -560,7 +570,8 @@
               "api-reference/contexts/update-a-context",
               "api-reference/contexts/delete-a-context",
               "api-reference/contexts/list-all-contexts"
-            ]
+            ],
+            "icon": "layers"
           },
           {
             "group": "Environments",
@@ -573,7 +584,8 @@
               "api-reference/environments/list-environment-tags",
               "api-reference/environments/compare-resources-between-environments",
               "api-reference/environments/publish-resources-to-target-environment"
-            ]
+            ],
+            "icon": "server"
           },
           {
             "group": "Environment Variables",
@@ -585,7 +597,8 @@
               "api-reference/environment-variables/delete-a-variable",
               "api-reference/environment-variables/list-all-variables",
               "api-reference/environment-variables/retrieve-a-variable-usage"
-            ]
+            ],
+            "icon": "variable"
           },
           {
             "group": "Messages",
@@ -594,7 +607,8 @@
               "api-reference/messages/list-all-messages",
               "api-reference/messages/delete-a-message",
               "api-reference/messages/delete-messages-by-transactionid"
-            ]
+            ],
+            "icon": "message-square"
           },
           {
             "group": "Integrations",
@@ -608,7 +622,8 @@
               "api-reference/integrations/update-integration-as-primary",
               "api-reference/integrations/generate-chat-oauth-url",
               "api-reference/integrations/auto-configure-an-integration-for-inbound-webhooks"
-            ]
+            ],
+            "icon": "plug"
           },
           {
             "group": "Channel Connections",
@@ -618,7 +633,8 @@
               "api-reference/channel-connections/update-a-channel-connection",
               "api-reference/channel-connections/delete-a-channel-connection",
               "api-reference/channel-connections/list-all-channel-connections"
-            ]
+            ],
+            "icon": "link"
           },
           {
             "group": "Channel Endpoints",
@@ -628,11 +644,15 @@
               "api-reference/channel-endpoints/update-a-channel-endpoint",
               "api-reference/channel-endpoints/delete-a-channel-endpoint",
               "api-reference/channel-endpoints/list-all-channel-endpoints"
-            ]
+            ],
+            "icon": "radio"
           },
           {
             "group": "Activity",
-            "pages": ["api-reference/activity/track-activity-and-engagement-events"]
+            "pages": [
+              "api-reference/activity/track-activity-and-engagement-events"
+            ],
+            "icon": "activity"
           },
           {
             "group": "Layouts",
@@ -645,7 +665,8 @@
               "api-reference/layouts/list-all-layouts",
               "api-reference/layouts/retrieve-a-layout",
               "api-reference/layouts/update-a-layout"
-            ]
+            ],
+            "icon": "layout-template"
           }
         ],
         "openapi": "https://spec.speakeasy.com/novu/novu/json-development-with-code-samples"
@@ -658,23 +679,42 @@
             "groups": [
               {
                 "group": "Guides",
-                "pages": ["guides", "guides/inngest", "guides/triggerdotdev"]
+                "pages": [
+                  "guides",
+                  "guides/inngest",
+                  "guides/triggerdotdev"
+                ],
+                "icon": "book-open"
               },
               {
                 "group": "Inbound Webhooks",
-                "pages": ["guides/webhooks/clerk", "guides/webhooks/stripe", "guides/webhooks/segment"]
+                "pages": [
+                  "guides/webhooks/clerk",
+                  "guides/webhooks/stripe",
+                  "guides/webhooks/segment"
+                ],
+                "icon": "webhook"
               },
               {
                 "group": "Recipes",
-                "pages": ["guides/recipes/managing-workflows"]
+                "pages": [
+                  "guides/recipes/managing-workflows"
+                ],
+                "icon": "chef-hat"
               },
               {
                 "group": "Framework",
-                "pages": ["guides/framework/using-translations"]
+                "pages": [
+                  "guides/framework/using-translations"
+                ],
+                "icon": "blocks"
               },
               {
                 "group": "Migrate to Novu",
-                "pages": ["guides/migrate-from-courier-to-novu"]
+                "pages": [
+                  "guides/migrate-from-courier-to-novu"
+                ],
+                "icon": "arrow-right-left"
               }
             ]
           },
@@ -700,7 +740,8 @@
                       "framework/quickstart/lambda"
                     ]
                   }
-                ]
+                ],
+                "icon": "rocket"
               },
               {
                 "group": "Core Concepts",
@@ -711,7 +752,8 @@
                   "framework/tags",
                   "framework/payload",
                   "framework/controls"
-                ]
+                ],
+                "icon": "blocks"
               },
               {
                 "group": "Channels",
@@ -722,7 +764,8 @@
                   "framework/push-channel",
                   "framework/sms-channel",
                   "framework/chat-channel"
-                ]
+                ],
+                "icon": "radio"
               },
               {
                 "group": "Content",
@@ -732,12 +775,19 @@
                   "framework/content/remix-react-email",
                   "framework/content/svelte-email",
                   "framework/content/vue-email"
-                ]
+                ],
+                "icon": "file-text"
               },
               {
                 "group": "Advanced Features",
                 "boost": 0.1,
-                "pages": ["framework/digest", "framework/delay", "framework/custom", "framework/skip"]
+                "pages": [
+                  "framework/digest",
+                  "framework/delay",
+                  "framework/custom",
+                  "framework/skip"
+                ],
+                "icon": "sparkles"
               },
               {
                 "group": "API Reference",
@@ -763,7 +813,8 @@
                   "framework/schema/zod",
                   "framework/schema/json-schema",
                   "framework/schema/class-validator"
-                ]
+                ],
+                "icon": "code"
               },
               {
                 "group": "Deployment",
@@ -773,7 +824,8 @@
                   "framework/deployment/syncing",
                   "framework/deployment/cli",
                   "framework/deployment/actions"
-                ]
+                ],
+                "icon": "cloud-upload"
               }
             ]
           },
@@ -801,7 +853,8 @@
                   "community/self-hosted-and-novu-cloud",
                   "community/run-in-local-machine",
                   "community/add-a-new-provider"
-                ]
+                ],
+                "icon": "rocket"
               }
             ]
           }
@@ -823,7 +876,16 @@
     }
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "perplexity", "mcp", "cursor", "vscode"]
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
   },
   "footer": {
     "socials": {

--- a/docs/platform.mdx
+++ b/docs/platform.mdx
@@ -1,7 +1,6 @@
 ---
 title: Overview
 description: 'Explore the Novu notification infrastructure platform. Learn about workflows, subscribers, integrations, and the Inbox component.'
-icon: "layout-dashboard"
 ---
 
 Explore the Novu notification infrastructure platform. Learn about workflows, subscribers, integrations, and the Inbox component.

--- a/docs/platform/account/authentication.mdx
+++ b/docs/platform/account/authentication.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Authentication'
 description: 'Configure authentication for Novu with OAuth, SSO, MFA, and more. Available for Enterprise customers on Novu Cloud.'
-icon: "fingerprint"
 ---
 
 

--- a/docs/platform/account/billing.mdx
+++ b/docs/platform/account/billing.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Billing'
 description: 'Manage your billing and payment information, view invoices, and upgrade your subscription plan.'
-icon: "receipt-text"
 ---
 
 

--- a/docs/platform/account/manage-members.mdx
+++ b/docs/platform/account/manage-members.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Team members'
 description: 'How to invite, manage, update permissions for, and remove members from your Novu organization'
-icon: "users"
 ---
 
 You can manage the members of your organization from the **Settings** page in your Novu dashboard. From there, you can assign responsibilities, manage permissions, and control access to workflows and other features.

--- a/docs/platform/account/roles-and-permissions.mdx
+++ b/docs/platform/account/roles-and-permissions.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Roles and permissions'
 description: 'Learn how roles and permissions are managed within Novu organizations'
-icon: "user-check"
 ---
 Novu uses a role-based access control (RBAC) model at the [organization level](/platform/how-novu-works#organization-and-environments). Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard. Every user can belong to more than one organization, each with separate configurations and permissions.
 

--- a/docs/platform/account/sso.mdx
+++ b/docs/platform/account/sso.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'SAML SSO & SCIM'
 description: 'Enable SAML SSO and SCIM directory sync for your organization'
-icon: "scan-face"
 ---
 
 <Note>

--- a/docs/platform/additional-resources/errors.mdx
+++ b/docs/platform/additional-resources/errors.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Common errors'
 description: 'Understand common errors in your notification workflows and how to resolve them'
-icon: "triangle-alert"
 ---
 
 The Activity Feed page in the Novu dashboard displays all the events that occur when a workflow is triggered. Each triggered workflow includes a log for every step, showing whether a notification failed and why. Below are some common errors that you might encounter.

--- a/docs/platform/additional-resources/glossary.mdx
+++ b/docs/platform/additional-resources/glossary.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Glossary'
 description: 'Definitions'
-icon: "book-open"
 ---
 
 ## Introduction

--- a/docs/platform/additional-resources/legacy-documentation.mdx
+++ b/docs/platform/additional-resources/legacy-documentation.mdx
@@ -1,7 +1,6 @@
 ---
 title: v0.x Documentation
 description: 'Access the legacy v0.x Novu documentation for older versions of the platform.'
-icon: "arrow-right-to-line"
 ---
 
 ## v0.x documentation

--- a/docs/platform/additional-resources/security.mdx
+++ b/docs/platform/additional-resources/security.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Security and Compliance'
 description: 'Learn about Novu security certifications, compliance standards, data residency, and privacy policies'
-icon: "shield-check"
 ---
 
 ## How to Request SOC and ISO Reports

--- a/docs/platform/build-with-ai/agent-toolkit.mdx
+++ b/docs/platform/build-with-ai/agent-toolkit.mdx
@@ -1,7 +1,6 @@
 ---
 title: Agent Toolkit
 description: Expose Novu notification workflows as tools for LLM agents with the @novu/agent-toolkit package. Works with OpenAI, LangChain, and Vercel AI SDK.
-icon: "bot"
 ---
 
 ## What is the Agent Toolkit?

--- a/docs/platform/build-with-ai/mcp.mdx
+++ b/docs/platform/build-with-ai/mcp.mdx
@@ -1,7 +1,6 @@
 ---
 title: MCP Server
 description: Connect your AI tools to Novu using MCP and manage notifications using natural language.
-icon: "network"
 ---
 
 

--- a/docs/platform/build-with-ai/skills.mdx
+++ b/docs/platform/build-with-ai/skills.mdx
@@ -1,7 +1,6 @@
 ---
 title: Agent Skills
 description: Learn how to use Novu Agent Skills to help AI agents build multi-channel notification systems.
-icon: "unplug"
 ---
 
 

--- a/docs/platform/concepts/integrations.mdx
+++ b/docs/platform/concepts/integrations.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Integrations'
 description: 'Learn how Novu integrations connect you to third-party providers'
-icon: "blocks"
 ---
 
 In Novu, integrations are configured connections to third-party services that deliver notifications across supported channels, which are email, SMS, push, and chat.

--- a/docs/platform/concepts/notification-event.mdx
+++ b/docs/platform/concepts/notification-event.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Notification event'
 description: 'Learn about the Novu notifications lifecycle and the key entities that make up a notification.'
-icon: "bell-ring"
 ---
 
 In Novu, notifications are the core building blocks of your product’s communication experience. When your user receives a message via an in-app alert, an email, or a push notification, what they’re seeing is the final output of a notification.

--- a/docs/platform/concepts/preferences.mdx
+++ b/docs/platform/concepts/preferences.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Preferences'
 description: 'Learn how to manage subscriber preferences in Novu.'
-icon: "user-cog"
 ---
 
 Novu provides a way to store subscriber preferences. This allows subscribers, your users, to specify and manage their preferences and customize their notifications experience.

--- a/docs/platform/concepts/subscribers.mdx
+++ b/docs/platform/concepts/subscribers.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Subscribers'
 description: "Learn what a subscriber is in Novu, how they’re identified, and how they fit into the notification system."
-icon: "users"
 ---
 
 

--- a/docs/platform/concepts/tenants.mdx
+++ b/docs/platform/concepts/tenants.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Multi-tenancy'
 description: 'Learn about how to implement multi-tenant notifications in Novu'
-icon: "layers"
 ---
 
 

--- a/docs/platform/concepts/topics.mdx
+++ b/docs/platform/concepts/topics.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Topics'
 description: 'Learn how topics work in Novu and how they help you organize and target groups of subscribers efficiently.'
-icon: "folders"
 ---
 
 In Novu, a _topic_ is a way to group subscribers under a shared label so that you can broadcast a message to many users with a single workflow trigger. This fan-out mechanism removes the need to manage individual subscriber IDs for each notification, streamlining scenarios like product announcements, feature rollouts, or status updates.

--- a/docs/platform/concepts/trigger.mdx
+++ b/docs/platform/concepts/trigger.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Trigger'
 description: 'Managing Trigger Events from Request to Processing'
-icon: "play"
 ---
 
 ## Trigger Request

--- a/docs/platform/concepts/workflows.mdx
+++ b/docs/platform/concepts/workflows.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Workflows'
 description: 'Learn what workflows are and how they work in Novu.'
-icon: "workflow"
 ---
 
 In Novu, a workflow is the blueprint that defines the end-to-end process for delivering a notification to one or more subscribers. It acts as the central logic layer for routing messages across different channels such as email, SMS, in-app, push, or chat and controlling what notification to send, when to send it and through which channels they are sent.

--- a/docs/platform/developer/api-keys.mdx
+++ b/docs/platform/developer/api-keys.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'API keys'
 description: 'Manage authentication credentials and connection endpoints for your Novu integration.'
-icon: "key-round"
 ---
 
 Novu provides a set of keys and hostnames that your application uses to authenticate requests, send events to the Novu API, and to interact with the [`<Inbox />`](/platform/inbox).

--- a/docs/platform/developer/environment-variables.mdx
+++ b/docs/platform/developer/environment-variables.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Environment Variables'
 description: 'Create reusable, environment-scoped variables in the dashboard and reference them in workflows.'
-icon: "variable"
 ---
 
 Environment variables in Novu are named values you define once in the dashboard and reuse across workflows. Each [Novu environment](/platform/developer/environments) can hold its own value for the same variable, so Development and Production (and any custom environments) stay isolated without duplicating workflow logic.

--- a/docs/platform/developer/environments.mdx
+++ b/docs/platform/developer/environments.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Environments'
 description: 'Understanding and managing environments in Novu'
-icon: "git-fork"
 ---
 
 Novu uses environments to separate your workflows and its data. This lets you safely test changes, like a new workflow, in one environment before moving it to a live production environment.

--- a/docs/platform/developer/limits.mdx
+++ b/docs/platform/developer/limits.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Limits'
 description: 'System limits, quotas, and constraints for the Novu platform.'
-icon: "gauge"
 ---
 
 

--- a/docs/platform/developer/webhooks/connectors.mdx
+++ b/docs/platform/developer/webhooks/connectors.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Webhook connectors'
 description: 'Send Novu webhook events directly to data warehouses, analytics databases, and AWS messaging services.'
-icon: "plug"
 ---
 
 In addition to standard HTTP webhook endpoints, Novu supports webhook connectors that deliver events directly to third-party services. Use them to route Novu events to data warehouses, analytics databases, and AWS messaging services without building a custom receiver.

--- a/docs/platform/developer/webhooks/event-types.mdx
+++ b/docs/platform/developer/webhooks/event-types.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Event types'
 description: 'Learn more about the types of events that Novu sends webhook events for.'
-icon: "tags"
 ---
 
 Novu supports the following webhook event types:

--- a/docs/platform/how-novu-works.mdx
+++ b/docs/platform/how-novu-works.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'How Novu Works'
-icon: "brain"
 description: 'A high-level overview of Novu’s architecture: workflows, triggers, subscribers, and environments, and how they connect to support in-app and external channels.'
 ---
 

--- a/docs/platform/inbox.mdx
+++ b/docs/platform/inbox.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Introduction to Inbox'
 description: "Learn how to integrate Novu Inbox component, a pre-built notification center component for real-time in-app notifications in your application."
-icon: "inbox"
 ---
 
 

--- a/docs/platform/inbox/advanced-customization/conditional-display.mdx
+++ b/docs/platform/inbox/advanced-customization/conditional-display.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Conditional Display'
 description: "Learn how to apply conditional display logic to notifications."
-icon: "list-filter-plus"
 ---
 
 The Inbox component supports conditional display of notifications using the `renderNotification` prop. This function receives the full `notification` object and returns a custom React element.

--- a/docs/platform/inbox/advanced-customization/customize-bell.mdx
+++ b/docs/platform/inbox/advanced-customization/customize-bell.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Customize Bell Icon'
 description: "Learn how to fully customize the inbox component bell icon using your own components or third-party libraries."
-icon: "bell-ring"
 ---
 
 The Novu Inbox includes a default bell icon that triggers the notification popover when clicked. You can use this bell as a standalone component or customize it to match your application's design system.

--- a/docs/platform/inbox/advanced-customization/customize-notification-items.mdx
+++ b/docs/platform/inbox/advanced-customization/customize-notification-items.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Customize Notification Items'
 description: "Learn how to use render props in the Inbox component to customize the subject, body, avatar, default and custom actions, or the entire notification item."
-icon: "replace"
 ---
 
 Novu exposes render props to customize parts of the default Inbox notification item—subject, body, avatar, default/custom actions, or the entire notification.

--- a/docs/platform/inbox/advanced-customization/customize-popover.mdx
+++ b/docs/platform/inbox/advanced-customization/customize-popover.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Customize Popover'
 description: "Learn how to display the Inbox content outside the default popover and integrate it into your own custom popover or page layout."
-icon: "panels-top-left"
 ---
 
 The Inbox component provides a built-in popover triggered by its bell icon. In situations where you want more control over how and where notifications appear, you can display the notification feed directly or mount it inside your own custom popover, modal, or panel.

--- a/docs/platform/inbox/advanced-customization/html-in-notifications.mdx
+++ b/docs/platform/inbox/advanced-customization/html-in-notifications.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'HTML in Notifications'
 description: 'Learn how to enable and display raw HTML in the notification subject and body for rich formatting.'
-icon: "code"
 ---
 
 By default, Novu sanitizes the `subject` and `body` of all in-app step notifications to ensure that they are safe to display. This process prevents security risks by removing suspicious HTML tags (like `<script>`) and escaping HTML entities (like `&`, `<`, `>`).

--- a/docs/platform/inbox/advanced-customization/notification-click-behavior.mdx
+++ b/docs/platform/inbox/advanced-customization/notification-click-behavior.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Notification Click Behavior'
 description: "Learn how to configure routing and interaction behavior for notifications using routerPush and click handlers."
-icon: "mouse-pointer-click"
 ---
 
 The Inbox component provides props that can be used to manage navigation and event handling, giving you full control over how notifications behave when users interact with them.

--- a/docs/platform/inbox/advanced-features/localization.mdx
+++ b/docs/platform/inbox/advanced-features/localization.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Localization'
 description: 'Learn how to customize the Inbox UI for different languages using the localization prop.'
-icon: "globe"
 ---
 
 Localize the UI text of the Inbox component to align with your product’s voice or support multiple languages. This helps create a more consistent, accessible experience for subscribers across different regions.

--- a/docs/platform/inbox/advanced-features/multi-tenancy.mdx
+++ b/docs/platform/inbox/advanced-features/multi-tenancy.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Multi-tenancy'
 description: 'Learn how to use context to implement multi-tenant notifications to support different organizations or workspaces within your application.'
-icon: "building-2"
 ---
 
 Multi-tenancy in Novu lets you isolate notifications for different organizations, environments, or workspaces within the same Novu project. Instead of creating separate subscribers or workflows for each tenant, you can use [Contexts](/platform/workflow/advanced-features/contexts) to define and manage tenant boundaries.

--- a/docs/platform/inbox/configuration/data-object.mdx
+++ b/docs/platform/inbox/configuration/data-object.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Data Object'
 description: 'Learn how to use the data object to extend in-app notifications with custom metadata.'
-icon: "table"
 ---
 
 The _data object_ is a customizable key-value store available in the in-app step. You can use it to extend each Inbox component notification by embedding custom data. The data can then be used to personalize how messages appear in the Inbox component.

--- a/docs/platform/inbox/configuration/icons.mdx
+++ b/docs/platform/inbox/configuration/icons.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Icons'
 description: 'Learn how to override the default icons in the Inbox UI using the appearance prop.'
-icon: "sparkles"
 ---
 
 You can customize or replace all the default icons in the Inbox UI with custom icons from your preferred library, such as [react-icons](https://react-icons.github.io/react-icons/) or [Material Icons](https://mui.com/material-ui/material-icons/), to match your visual style using the icons' key in the `appearance` prop.

--- a/docs/platform/inbox/configuration/inbox-with-context.mdx
+++ b/docs/platform/inbox/configuration/inbox-with-context.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Inbox with Context'
 description: 'Learn how to use contexts in the Inbox component to filter and personalize notifications for your subscribers.'
-icon: "package"
 ---
 
 _Contexts_ let you scope each `<Inbox />` instance to a specific environment, tenant, or app within your product. When combined with workflow-level contexts, they ensure that each `<Inbox />` displays only the notifications relevant to that specific context.

--- a/docs/platform/inbox/configuration/preferences.mdx
+++ b/docs/platform/inbox/configuration/preferences.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Preferences'
 description: 'Learn how to configure and customize subscriber preferences in your application using the Novu Inbox component.'
-icon: "user-cog"
 ---
 
 The Preferences interface in the Inbox component lets subscribers customize how they receive notifications. By default, Novu renders a preferences icon inside the Inbox component, giving users access to global and workflow-specific settings directly from the UI.

--- a/docs/platform/inbox/configuration/styling.mdx
+++ b/docs/platform/inbox/configuration/styling.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Styling and Theming'
 description: 'Learn how to style the pre built Inbox component'
-icon: "palette"
 ---
 
 

--- a/docs/platform/inbox/configuration/tabs.mdx
+++ b/docs/platform/inbox/configuration/tabs.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Tabs'
 description: 'Learn what tabs are and how to filter multiple tabs in the Novu Inbox component.'
-icon: "folders"
 ---
 
 In the Inbox components, you can use Tabs to organize **Inbox** notifications into separate sections, creating a cleaner, more organized experience for your subscribers. Each tab displays a subset of in-app notifications based on defined rules, making it easier to surface important notifications.

--- a/docs/platform/inbox/features/schedule.mdx
+++ b/docs/platform/inbox/features/schedule.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Schedule'
 description: "Learn how subscribers can use the Schedule feature in the Inbox component to control when they receive notifications from email, SMS and push channels."
-icon: "calendar-check"
 ---
 
 The **Schedule** feature in the [`<Inbox />`](/platform/inbox) lets subscribers control when they want to receive notifications from email, SMS, and push channels.

--- a/docs/platform/inbox/features/snooze.mdx
+++ b/docs/platform/inbox/features/snooze.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Snooze'
 description: 'Allow users to temporarily hide notifications and resurface them later using built-in snooze functionality in the Inbox component.'
-icon: "clock"
 ---
 
 The `<Inbox />` component includes built-in support for snoozing notifications, which can be used to temporarily dismiss notifications and have them reappear at a more convenient time.

--- a/docs/platform/inbox/headless-mode.mdx
+++ b/docs/platform/inbox/headless-mode.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Headless Mode'
 description: 'Learn how to build custom Inbox UI for your application using Novu custom hooks'
-icon: "unplug"
 ---
 
 Build a fully custom notification inbox with Novu's headless React hooks without being constrained by the default [`<Inbox />`](/platform/inbox) UI or dependencies.

--- a/docs/platform/inbox/migration-guide.mdx
+++ b/docs/platform/inbox/migration-guide.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Migrate to the New Inbox'
 description: 'This guide outlines the key differences between the `@novu/notification-center` package and the new `@novu/react` package and how to migrate to the latest Inbox version.'
-icon: "refresh-ccw-dot"
 ---
 
 <Note>

--- a/docs/platform/inbox/prepare-for-production.mdx
+++ b/docs/platform/inbox/prepare-for-production.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Prepare for Production'
 description: "Learn how to prepare your Inbox for production by enabling HMAC encryption for security and managing Novu's branding."
-icon: "shield-check"
 ---
 
 Before deploying the Inbox UI to production, you should secure your integration and configure the correct environment. You can also remove Novu's branding from your notifications.

--- a/docs/platform/inbox/setup-inbox.mdx
+++ b/docs/platform/inbox/setup-inbox.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Set up the Inbox'
 description: "Learn how to integrate the Novu Inbox component into your application to display real-time notifications for your subscribers."
-icon: "bell"
 ---
 
 

--- a/docs/platform/integrations.mdx
+++ b/docs/platform/integrations.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Overview'
 description: 'Learn about the providers that Novu supports for Email, Push, SMS and Chant channels, and how to integrate them to send notifications and receive events.'
-icon: "layout-dashboard"
 ---
 
 Providers are the third-party services that deliver your notifications through the various channels. These are services such as SendGrid for email, Twilio for SMS, or Slack for chat.

--- a/docs/platform/integrations/chat.mdx
+++ b/docs/platform/integrations/chat.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Chat'
 description: "Configure and manage chat providers like Slack, Microsoft Teams, WhatsApp, and Discord with Novu's notification infrastructure."
-icon: "info"
 ---
 
 The Chat channel delivers messages to your subscribers via their preferred chat platforms and application.

--- a/docs/platform/integrations/chat/adding-chat.mdx
+++ b/docs/platform/integrations/chat/adding-chat.mdx
@@ -2,7 +2,6 @@
 title: 'Adding Chat Channel'
 sidebarTitle: 'Adding Chat Channel'
 description: 'Learn how to add the Chat channel to your application'
-icon: "circle-plus"
 ---
 
 

--- a/docs/platform/integrations/demo-integration.mdx
+++ b/docs/platform/integrations/demo-integration.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Demo Integrations'
 description: 'Learn about the default Novu Email and SMS provider.'
-icon: "presentation"
 ---
 
 Demo integrations are built-in, sandboxed providers for the email and SMS channels. Their purpose is to allow you to test your notification workflows immediately, without needing to sign up for or connect a real third-party provider.

--- a/docs/platform/integrations/email/adding-email.mdx
+++ b/docs/platform/integrations/email/adding-email.mdx
@@ -2,7 +2,6 @@
 title: 'Adding Email Channel'
 sidebarTitle: 'Adding Email Channel'
 description: 'Learn how to add the Email channel to your application'
-icon: "circle-plus"
 ---
 
 

--- a/docs/platform/integrations/email/writing-email-template.mdx
+++ b/docs/platform/integrations/email/writing-email-template.mdx
@@ -2,7 +2,6 @@
 title: 'Writing Email Template'
 sidebarTitle: 'Writing Email Template'
 description: 'Learn how to build email templates in Novu using the block editor, the code editor (custom HTML), or the API'
-icon: "file-pen"
 ---
 
 You can create email templates in Novu using the following methods:

--- a/docs/platform/integrations/sms/adding-sms.mdx
+++ b/docs/platform/integrations/sms/adding-sms.mdx
@@ -2,7 +2,6 @@
 title: 'Adding SMS Channel'
 sidebarTitle: 'Adding SMS Channel'
 description: 'Learn how to add the SMS channel to your application'
-icon: "circle-plus"
 ---
 
 

--- a/docs/platform/integrations/trigger-overrides.mdx
+++ b/docs/platform/integrations/trigger-overrides.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Trigger Overrides'
 description: 'Learn how to customize the behavior of your workflows at trigger time'
-icon: "sliders-vertical"
 ---
 
 

--- a/docs/platform/sdks.mdx
+++ b/docs/platform/sdks.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Overview'
 description: "Explore Novu's server-side and client-side SDKs for integrating notifications across multiple languages and frameworks."
-icon: "layout-dashboard"
 ---
 
 ## Server-side SDKs

--- a/docs/platform/sdks/javascript.mdx
+++ b/docs/platform/sdks/javascript.mdx
@@ -1,7 +1,6 @@
 ---
 title: '@novu/js'
 description: 'Complete API reference for the Novu JavaScript package'
-icon: "braces"
 ---
 
 

--- a/docs/platform/sdks/server/dotnet.mdx
+++ b/docs/platform/sdks/server/dotnet.mdx
@@ -1,7 +1,6 @@
 ---
 title: '.NET'
 description: 'Connect a .NET application to Novu'
-icon: "code"
 ---
 
 Novu's .NET SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your C#/.NET application.

--- a/docs/platform/sdks/server/go.mdx
+++ b/docs/platform/sdks/server/go.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Go SDK'
 description: 'Connect a Go application to Novu'
-icon: "code"
 ---
 
 

--- a/docs/platform/sdks/server/java.mdx
+++ b/docs/platform/sdks/server/java.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Java'
 description: 'Connect a Java application to Novu'
-icon: "coffee"
 ---
 
 Novu's Java SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your Java application.

--- a/docs/platform/sdks/server/kotlin.mdx
+++ b/docs/platform/sdks/server/kotlin.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Kotlin'
 description: 'Connect a Kotlin application to Novu'
-icon: "smartphone"
 ---
 
 <Warning>

--- a/docs/platform/sdks/server/laravel.mdx
+++ b/docs/platform/sdks/server/laravel.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Laravel'
 description: 'Connect a Laravel application to Novu'
-icon: "code"
 ---
 
 <Warning>

--- a/docs/platform/sdks/server/php.mdx
+++ b/docs/platform/sdks/server/php.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'PHP SDK'
 description: 'Connect a PHP application to Novu'
-icon: "code"
 ---
 
 

--- a/docs/platform/sdks/server/python.mdx
+++ b/docs/platform/sdks/server/python.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Python'
 description: 'Connect a Python application to Novu'
-icon: "code"
 ---
 
 

--- a/docs/platform/sdks/server/ruby.mdx
+++ b/docs/platform/sdks/server/ruby.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Ruby'
 description: 'Connect a Ruby application to Novu'
-icon: "gem"
 ---
 
 <Warning>

--- a/docs/platform/sdks/server/typescript.mdx
+++ b/docs/platform/sdks/server/typescript.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Typescript'
 description: 'Connect a TS/JS application to Novu'
-icon: "server"
 ---
 
 

--- a/docs/platform/subscription.mdx
+++ b/docs/platform/subscription.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Introduction'
 description: 'Learn what a Subscription is in Novu, how they fit into the notification system.'
-icon: "toggle-right"
 ---
 
 Subscriptions introduce topic-level settings that allow subscribers to decide exactly which notifications they want to receive or mute.

--- a/docs/platform/subscription/customize-and-configure.mdx
+++ b/docs/platform/subscription/customize-and-configure.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Customize and configure'
 description: "Learn how to filter visible preferences, customize styling, and use custom render functions."
-icon: "blocks"
 ---
 
 The Subscription UI works within the existing Novu environment and uses the same provider and styling architecture as the [`<Inbox />`](/platform/inbox) component.

--- a/docs/platform/subscription/headless-hooks.mdx
+++ b/docs/platform/subscription/headless-hooks.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Headless hooks'
 description: 'Build a fully custom Subscription interface using hooks.'
-icon: "code"
 ---
 
 Novu `@novu/react` package provides Subscription hooks that let you build your own custom subscription experiences from scratch.

--- a/docs/platform/subscription/quickstart.mdx
+++ b/docs/platform/subscription/quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Setup the Subscription'
 description: "Learn how to integrate and render the Subscription component in your React app to manage user preferences."
-icon: "zap"
 ---
 
 

--- a/docs/platform/what-is-novu.mdx
+++ b/docs/platform/what-is-novu.mdx
@@ -1,7 +1,6 @@
 ---
 title: What is Novu?
 description: The open-source notification infrastructure that simplifies in-app, email, chat, and push notifications.
-icon: "circle-question-mark"
 ---
 
 

--- a/docs/platform/workflow.mdx
+++ b/docs/platform/workflow.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Overview'
 description: 'Learn how to create, configure, and work with notification workflows in Novu.'
-icon: "workflow"
 ---
 
 Novu Workflows orchestrate how notifications move from application events to messages delivered across one or more channels. A workflow combines delivery logic, message content, and execution rules into a single notification pipeline.

--- a/docs/platform/workflow/add-and-configure-steps.mdx
+++ b/docs/platform/workflow/add-and-configure-steps.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Add and Configure Steps'
 description: 'Learn how workflow steps work in Novu, the different step types available, and how to add and execute steps in a notification workflow.'
-icon: "copy-plus"
 ---
 
 

--- a/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Code Steps'
 description: 'Learn how to add code steps to a workflow, publish them with the Novu CLI, and use code-managed steps with UI-managed steps in a workflow.'
-icon: "code"
 ---
 
 Novu allows you to write step handlers as TypeScript code in your project and publish them to Novu as serverless functions. Instead of configuring notification content in a visual editor, you define a handler file that returns the output for your step. Novu calls it at send time with the subscriber data, trigger payload, and any dashboard-defined controls.

--- a/docs/platform/workflow/add-and-configure-steps/configure-action-steps/delay.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/configure-action-steps/delay.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Delay Step'
 description: 'Learn how to use delay step to pause workflow execution.'
-icon: "timer"
 ---
 
 

--- a/docs/platform/workflow/add-and-configure-steps/configure-action-steps/digest.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/configure-action-steps/digest.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Digest Step'
 description: 'Batch multiple workflow trigger events into a single execution using configurable digest windows and grouping rules.'
-icon: "boxes"
 ---
 
 

--- a/docs/platform/workflow/add-and-configure-steps/configure-action-steps/http-step.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/configure-action-steps/http-step.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'HTTP Step'
 description: 'Learn how to use HTTP step to make external HTTP requests.'
-icon: "webhook"
 ---
 
 The HTTP step is an Action step that allows workflows to call external APIs during execution. This provides a native way to interact with systems outside Novu directly from your workflows. It is useful for tasks such as enriching data, enabling conditional branching based on external responses, or communicating with internal delivery systems.

--- a/docs/platform/workflow/add-and-configure-steps/configure-action-steps/throttle.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/configure-action-steps/throttle.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Throttle Step'
 description: 'Learn how to use the Throttle step in Novu workflows to control notification frequency.'
-icon: "gauge"
 ---
 
 After adding a Throttle step to a workflow, it limits the number of times a workflow is allowed to continue within a specified time window b. Once the execution limit is reached, the workflow stops at the Throttle step and downstream steps are skipped.

--- a/docs/platform/workflow/add-and-configure-steps/step-conditions.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/step-conditions.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Step Conditions'
 description: 'Create dynamic notification workflows using rule-based conditions. Control message delivery based on subscriber, payload, and workflow data.'
-icon: "list-filter"
 ---
 
 

--- a/docs/platform/workflow/add-notification-content/channels-template-editors.mdx
+++ b/docs/platform/workflow/add-notification-content/channels-template-editors.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Channels Template Editors'
 description: 'Learn how to design and configure notification content for email, in-app, push, and SMS.'
-icon: "layout-panel-top"
 ---
 
 

--- a/docs/platform/workflow/add-notification-content/personalize-content.mdx
+++ b/docs/platform/workflow/add-notification-content/personalize-content.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Personalize Content'
 description: 'Learn how to personalize notification content in Novu using template variables, context data, and LiquidJS filters across all channel template editors.'
-icon: "user-round-cog"
 ---
 
 

--- a/docs/platform/workflow/advanced-features/contexts.mdx
+++ b/docs/platform/workflow/advanced-features/contexts.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Context'
 description: "Learn what Contexts are in Novu, how they differ from payloads, and how they help you organize and personalize notifications across workflows."
-icon: "package"
 ---
 
 _Contexts_ are flexible, user-defined data objects that help you organize and personalize your notifications. They let you attach metadata, such as tenant, region, or app details, and enable contextual behavior to workflows, notifications, and other entities across Novu.

--- a/docs/platform/workflow/advanced-features/translations.mdx
+++ b/docs/platform/workflow/advanced-features/translations.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Translations'
 description: 'Learn how to translate your workflow step content into multiple languages'
-icon: "languages"
 ---
 
 Novu supports multi-language translations for workflows, allowing notifications to dynamically adapt to each of your subscriber's preferred language. You can enable, configure, and manage translations across your notification workflows from the Novu dashboard.

--- a/docs/platform/workflow/configure-workflow.mdx
+++ b/docs/platform/workflow/configure-workflow.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Configure Workflow'
 description: 'Configure workflow metadata, delivery preferences, and payload schema in the workflow editor.'
-icon: "cog"
 ---
 
 After creating a workflow, you are redirected to the workflow editor, where you configure workflow-level settings. You can also open any existing workflow from the Workflows page to access the editor.

--- a/docs/platform/workflow/create-a-workflow.mdx
+++ b/docs/platform/workflow/create-a-workflow.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Create a Workflow'
 description: 'Create a workflow and define its identifier, metadata, and initial configuration.'
-icon: "circle-plus"
 ---
 
 A workflow defines how Novu delivers notifications for a specific event. It contains the steps, templates, and rules that control how messages are sent across channels.

--- a/docs/platform/workflow/monitor-and-debug-workflow.mdx
+++ b/docs/platform/workflow/monitor-and-debug-workflow.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Monitor and Debug Workflow'
 description: "Learn how to monitor workflow executions and debug issues from the Novu Activity Feed."
-icon: "activity"
 ---
 
 The Novu Activity Feed tracks the full execution lifecycle after a workflow is triggered. It provides real-time visibility into how workflows run, helping you understand what happened and why.

--- a/docs/platform/workflow/trigger-workflow.mdx
+++ b/docs/platform/workflow/trigger-workflow.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Trigger Workflow'
 description: 'Learn how workflows are triggered in Novu using the Event API, including triggering workflows for individual subscribers, attaching context data, and broadcasting notifications to topics.'
-icon: "zap"
 ---
 
 Triggering a workflow starts the execution of a notification pipeline in Novu. A workflow is triggered when an event is sent to Novu.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up the Mintlify sidebar by removing icons from individual pages and nested collapsible groups. Icons now appear only on top-level section titles (e.g. **Integrate Inbox**, **Getting Started**, **Build a Workflow**).

## What changed

- Removed `icon` frontmatter from 113 MDX pages
- Removed icons from all nested collapsible groups (Features, Customize and Configure, Email, Chat, etc.)
- Added icons to top-level section titles in `docs/docs.json` across Platform, Agents, API Reference, and Resources tabs
- Updated `docs/AGENTS.md` style guide

## Why

The sidebar felt visually noisy with icons on every page link and nested folder. Section-level icons provide enough visual hierarchy without cluttering nested navigation.

## Test plan

- [ ] Confirm section titles like **Integrate Inbox** show an icon
- [ ] Confirm nested groups (Features, Customize and Configure, etc.) have no icons
- [ ] Confirm individual page links have no icons
- [ ] Verify in-page `<Card icon="...">` components are unaffected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b40876e5-b7b7-4f34-9f41-c01e7be1afca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b40876e5-b7b7-4f34-9f41-c01e7be1afca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleans up the Mintlify sidebar by stripping `icon` frontmatter from 113 MDX pages and removing icons from nested collapsible navigation groups, then re-adding icons exclusively to top-level section titles in `docs/docs.json`. The style guide in `docs/AGENTS.md` is updated to reflect the new convention.

- **Icon removal from MDX pages**: Every changed `.mdx` file simply deletes its `icon:` frontmatter line — content, title, and description are untouched.
- **Navigation restructuring**: Nested groups (Features, Customize and Configure, Email, Chat, etc.) lose their `icon` fields; parent top-level groups (Integrate Inbox, Build a Workflow, SDKs, Developer, Managed Agent, API Reference groups, etc.) gain an `icon` field instead.
- **AGENTS.md updated**: The contributor style guide now explicitly states icons belong only on top-level navigation groups in `docs.json`, not on individual pages or nested groups.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a documentation/navigation styling change with no functional code touched.

All 114 changed files are documentation assets (MDX pages, docs.json, AGENTS.md). Every edit is a single-line frontmatter deletion or a JSON field relocation. No application logic, APIs, tests, or build configuration are modified. The style change is internally consistent across all affected files.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Moves icon declarations from nested groups to top-level section groups and reformats several single-line arrays to multi-line for readability; no structural navigation changes. |
| docs/AGENTS.md | Updates contributor style guide to drop the `icon` frontmatter requirement from individual MDX pages and document the new top-level-groups-only icon convention. |
| docs/platform/inbox.mdx | Removes `icon: "inbox"` frontmatter; title and description unchanged. |
| docs/platform/workflow.mdx | Removes `icon: "workflow"` frontmatter; title and description unchanged. |
| docs/community/self-hosting-novu/data-migrations.mdx | Removes `icon: "database"` frontmatter; content unaffected. |
| docs/agents.mdx | Removes `icon: "plug"` frontmatter; title and description unchanged. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[docs.json Navigation] --> B[Top-Level Section Groups]
    A --> C[Nested Collapsible Groups]
    A --> D[Individual MDX Pages]

    B -->|Keep icon| B1["e.g. Integrate Inbox, Build a Workflow, SDKs, Developer"]
    C -->|Remove icon| C1["e.g. Features, Customize and Configure, Email / Chat / Push"]
    D -->|Remove icon frontmatter| D1["113 MDX pages - title + description kept"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[docs.json Navigation] --> B[Top-Level Section Groups]
    A --> C[Nested Collapsible Groups]
    A --> D[Individual MDX Pages]

    B -->|Keep icon| B1["e.g. Integrate Inbox, Build a Workflow, SDKs, Developer"]
    C -->|Remove icon| C1["e.g. Features, Customize and Configure, Email / Chat / Push"]
    D -->|Remove icon frontmatter| D1["113 MDX pages - title + description kept"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs: remove icons from Getting Started ..."](https://github.com/novuhq/novu/commit/050e329d99dc1c0e7ca4db80b05ddb0474a1239b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40027896)</sub>

<!-- /greptile_comment -->