### PR TITLE
feat(docs): redesign docs homepage landing page fixes DOC-370

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -899,11 +899,6 @@
   },
   "redirects": [
     {
-      "source": "/",
-      "destination": "/platform",
-      "permanent": true
-    },
-    {
       "source": "/content-creation-design/handlebars-helpers",
       "destination": "/platform/templates/handlebars-helpers",
       "permanent": true

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,218 @@
+---
+title: "Notification infrastructure for products and AI agents"
+sidebarTitle: "Welcome"
+description: "Novu powers the notifications your product sends and the conversations your AI agents have — on one open-source platform."
+mode: "custom"
+---
+
+<div className="docs-landing">
+
+<section className="docs-landing-hero">
+  <div className="docs-landing-container docs-landing-hero-inner">
+    <p className="docs-landing-eyebrow">Open-source notification infrastructure</p>
+    <h1 className="docs-landing-title">
+      Notifications for products.<br />
+      Conversations for AI agents.
+    </h1>
+    <p className="docs-landing-lead">
+      Novu handles product-to-user notifications and agent-to-user conversations on one unified platform — same subscribers, same channels, same delivery layer.
+    </p>
+    <div className="docs-landing-hero-actions">
+      <a className="docs-landing-cta docs-landing-cta-primary" href="/platform/quickstart/react">
+        Send a notification
+      </a>
+      <a className="docs-landing-cta docs-landing-cta-secondary" href="/agents/managed-agent/quickstart">
+        Build an agent
+      </a>
+    </div>
+    <div className="docs-landing-hero-visual">
+      <img
+        src="/images/hero-light.svg"
+        alt="Novu platform overview with notification workflows and channels."
+        className="docs-landing-hero-image docs-landing-hero-image-light"
+      />
+      <img
+        src="/images/hero-dark.svg"
+        alt="Novu platform overview with notification workflows and channels."
+        className="docs-landing-hero-image docs-landing-hero-image-dark"
+      />
+    </div>
+  </div>
+</section>
+
+<section className="docs-landing-section">
+  <div className="docs-landing-container">
+    <div className="docs-landing-section-header">
+      <p className="docs-landing-section-label">Two products, one platform</p>
+      <h2 className="docs-landing-section-title">Choose where to start</h2>
+      <p className="docs-landing-section-description">
+        Platform and Agents share subscribers, channels, and delivery infrastructure. What you learn in one carries directly into the other.
+      </p>
+    </div>
+
+    <Columns cols={2}>
+      <Card title="Platform" icon="layout-dashboard" href="/platform">
+        Notifications your product sends to users — workflows, preferences, and a drop-in Inbox across in-app, email, push, SMS, and chat.
+      </Card>
+      <Card title="Agents" icon="bot" href="/agents">
+        Conversations your AI agents run with users — ACI handles ingestion, identity, and delivery across Slack, Teams, WhatsApp, and more.
+      </Card>
+    </Columns>
+  </div>
+</section>
+
+<section className="docs-landing-section docs-landing-section-muted">
+  <div className="docs-landing-container">
+    <div className="docs-landing-split-header">
+      <div>
+        <p className="docs-landing-section-label">Platform</p>
+        <h2 className="docs-landing-section-title">Notifications your product sends</h2>
+        <p className="docs-landing-section-description">
+          Trigger one workflow and deliver everywhere. Novu routes notifications across channels, respects subscriber preferences, and gives you an embeddable Inbox so you ship notification UX in minutes.
+        </p>
+      </div>
+      <a className="docs-landing-text-link" href="/platform">
+        Explore Platform docs
+      </a>
+    </div>
+
+    <Columns cols={3}>
+      <Card title="React quickstart" icon="atom" href="/platform/quickstart/react">
+        Drop the Inbox component into a React app.
+      </Card>
+      <Card title="Next.js quickstart" icon="square-code" href="/platform/quickstart/nextjs">
+        Add real-time notifications to a Next.js project.
+      </Card>
+      <Card title="What is Novu?" icon="circle-question-mark" href="/platform/what-is-novu">
+        Workflows, subscribers, channels, and core concepts.
+      </Card>
+    </Columns>
+
+    <div className="docs-landing-feature-grid">
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Send transactional and product notifications across every channel</span>
+      </div>
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Let subscribers manage preferences per channel</span>
+      </div>
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Embed an Inbox without building a notification center</span>
+      </div>
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Stay vendor-neutral across SendGrid, Twilio, FCM, and more</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section className="docs-landing-section">
+  <div className="docs-landing-container">
+    <div className="docs-landing-split-header">
+      <div>
+        <p className="docs-landing-section-label">Agents</p>
+        <h2 className="docs-landing-section-title">Conversations your AI runs</h2>
+        <p className="docs-landing-section-description">
+          Novu Connect is built on <a href="/agents/get-started/what-is-aci">Agent Communication Infrastructure (ACI)</a>. Novu owns communication infrastructure — webhooks, identity, delivery, and conversation state. You own agent intelligence.
+        </p>
+      </div>
+      <a className="docs-landing-text-link" href="/agents">
+        Explore Agents docs
+      </a>
+    </div>
+
+    <Columns cols={2}>
+      <Card title="Managed agent" icon="sparkles" href="/agents/managed-agent/overview">
+        Spin up a fully managed agent powered by Claude. No custom server code required.
+      </Card>
+      <Card title="Custom code agent" icon="code" href="/agents/custom-code-agent/quickstart">
+        Bring your own logic with AI SDK, LangChain, OpenAI, or any runtime.
+      </Card>
+    </Columns>
+
+    <div className="docs-landing-feature-grid">
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Talk to users on Slack, Teams, WhatsApp, and the channels they already use</span>
+      </div>
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Hold stateful, context-aware conversations across sessions</span>
+      </div>
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Resolve identity across platforms without rebuilding auth</span>
+      </div>
+      <div className="docs-landing-feature">
+        <span className="docs-landing-feature-icon" aria-hidden="true" />
+        <span>Observe and debug live agent conversations in one place</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section className="docs-landing-section docs-landing-section-muted">
+  <div className="docs-landing-container">
+    <div className="docs-landing-section-header">
+      <p className="docs-landing-section-label">Shared foundations</p>
+      <h2 className="docs-landing-section-title">One infrastructure layer underneath</h2>
+    </div>
+
+    <Columns cols={3}>
+      <Card title="Subscribers" icon="users" href="/platform/concepts/subscribers">
+        One identity model for end users — whether you notify them or chat with them.
+      </Card>
+      <Card title="Channels" icon="radio" href="/platform/concepts/integrations">
+        Email, push, SMS, in-app, Slack, Teams, and WhatsApp — configured once, used everywhere.
+      </Card>
+      <Card title="Open source" icon="github" href="https://github.com/novuhq/novu">
+        Self-host or use Novu Cloud. The infrastructure is open and inspectable.
+      </Card>
+    </Columns>
+  </div>
+</section>
+
+<section className="docs-landing-section docs-landing-section-cta">
+  <div className="docs-landing-container">
+    <div className="docs-landing-section-header">
+      <h2 className="docs-landing-section-title">Start building in minutes</h2>
+      <p className="docs-landing-section-description">
+        Pick a path and follow a quickstart — most teams ship their first notification or agent message in under five minutes.
+      </p>
+    </div>
+
+    <Columns cols={2}>
+      <Card title="Send your first notification" icon="bell" href="/platform/quickstart/react">
+        Five-minute walkthrough from signup to a notification in your app.
+      </Card>
+      <Card title="Send your first agent message" icon="message-square" href="/agents/managed-agent/quickstart">
+        Connect a Slack provider and ship a working agent in under five minutes.
+      </Card>
+    </Columns>
+  </div>
+</section>
+
+<section className="docs-landing-section docs-landing-section-footer">
+  <div className="docs-landing-container">
+    <div className="docs-landing-section-header">
+      <h2 className="docs-landing-section-title">Join the community</h2>
+    </div>
+
+    <Columns cols={3}>
+      <Card title="Discord" icon="discord" href="https://discord.gg/novu">
+        Join hundreds of developers building with Novu.
+      </Card>
+      <Card title="X" icon="twitter" href="https://x.com/novuhq">
+        Follow along for product updates.
+      </Card>
+      <Card title="GitHub" icon="github" href="https://github.com/novuhq/novu">
+        Star the repo and contribute.
+      </Card>
+    </Columns>
+  </div>
+</section>
+
+</div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,3 +5,316 @@
     max-width: 16rem;
   }
 }
+
+/* Docs homepage landing page */
+html[data-current-path="/"] #content-area {
+  padding: 0;
+}
+
+.docs-landing {
+  color: #0e121b;
+}
+
+html.dark .docs-landing {
+  color: #f4f4f5;
+}
+
+.docs-landing-container {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 72rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.docs-landing-hero {
+  border-bottom: 1px solid #e4e4e7;
+  padding-bottom: 4rem;
+  padding-top: 3rem;
+}
+
+html.dark .docs-landing-hero {
+  border-bottom-color: #27272a;
+}
+
+.docs-landing-hero-inner {
+  text-align: center;
+}
+
+.docs-landing-eyebrow {
+  color: #52525b;
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+html.dark .docs-landing-eyebrow {
+  color: #a1a1aa;
+}
+
+.docs-landing-title {
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  margin: 1rem auto 0;
+  max-width: 18ch;
+}
+
+.docs-landing-lead {
+  color: #52525b;
+  font-size: 1.125rem;
+  line-height: 1.7;
+  margin: 1.25rem auto 0;
+  max-width: 42rem;
+}
+
+html.dark .docs-landing-lead {
+  color: #a1a1aa;
+}
+
+.docs-landing-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.docs-landing-cta {
+  border-radius: 0.5rem;
+  display: inline-flex;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  padding: 0.625rem 1.125rem;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.docs-landing-cta-primary {
+  background: #0e121b;
+  color: #ffffff;
+}
+
+.docs-landing-cta-primary:hover {
+  background: #27272a;
+  color: #ffffff;
+}
+
+html.dark .docs-landing-cta-primary {
+  background: #ffffff;
+  color: #0e121b;
+}
+
+html.dark .docs-landing-cta-primary:hover {
+  background: #e4e4e7;
+  color: #0e121b;
+}
+
+.docs-landing-cta-secondary {
+  background: transparent;
+  border: 1px solid #d4d4d8;
+  color: #0e121b;
+}
+
+.docs-landing-cta-secondary:hover {
+  background: #f4f4f5;
+  border-color: #a1a1aa;
+  color: #0e121b;
+}
+
+html.dark .docs-landing-cta-secondary {
+  border-color: #3f3f46;
+  color: #f4f4f5;
+}
+
+html.dark .docs-landing-cta-secondary:hover {
+  background: #18181b;
+  border-color: #52525b;
+  color: #f4f4f5;
+}
+
+.docs-landing-hero-visual {
+  margin-top: 3rem;
+}
+
+.docs-landing-hero-image {
+  border: 1px solid #e4e4e7;
+  border-radius: 1rem;
+  box-shadow: 0 24px 48px -24px rgba(14, 18, 27, 0.25);
+  display: block;
+  height: auto;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 100%;
+  width: 44rem;
+}
+
+html.dark .docs-landing-hero-image {
+  border-color: #27272a;
+  box-shadow: 0 24px 48px -24px rgba(0, 0, 0, 0.5);
+}
+
+.docs-landing-hero-image-light {
+  display: block;
+}
+
+.docs-landing-hero-image-dark {
+  display: none;
+}
+
+html.dark .docs-landing-hero-image-light {
+  display: none;
+}
+
+html.dark .docs-landing-hero-image-dark {
+  display: block;
+}
+
+.docs-landing-section {
+  padding-bottom: 4rem;
+  padding-top: 4rem;
+}
+
+.docs-landing-section-muted {
+  background: #fafafa;
+}
+
+html.dark .docs-landing-section-muted {
+  background: #09090b;
+}
+
+.docs-landing-section-cta {
+  border-top: 1px solid #e4e4e7;
+}
+
+html.dark .docs-landing-section-cta {
+  border-top-color: #27272a;
+}
+
+.docs-landing-section-footer {
+  border-top: 1px solid #e4e4e7;
+  padding-bottom: 5rem;
+}
+
+html.dark .docs-landing-section-footer {
+  border-top-color: #27272a;
+}
+
+.docs-landing-section-header {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.docs-landing-section-label {
+  color: #52525b;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+html.dark .docs-landing-section-label {
+  color: #a1a1aa;
+}
+
+.docs-landing-section-title {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0.75rem auto 0;
+  max-width: 28ch;
+}
+
+.docs-landing-section-description {
+  color: #52525b;
+  font-size: 1rem;
+  line-height: 1.7;
+  margin: 0.75rem auto 0;
+  max-width: 42rem;
+}
+
+html.dark .docs-landing-section-description {
+  color: #a1a1aa;
+}
+
+.docs-landing-section-description a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.docs-landing-split-header {
+  align-items: flex-end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+
+.docs-landing-split-header .docs-landing-section-title,
+.docs-landing-split-header .docs-landing-section-description {
+  margin-left: 0;
+  margin-right: 0;
+  max-width: none;
+  text-align: left;
+}
+
+.docs-landing-text-link {
+  color: #0e121b;
+  flex-shrink: 0;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.docs-landing-text-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+html.dark .docs-landing-text-link {
+  color: #f4f4f5;
+}
+
+.docs-landing-feature-grid {
+  display: grid;
+  gap: 0.875rem 1.5rem;
+  grid-template-columns: 1fr;
+  margin-top: 2rem;
+}
+
+@media (min-width: 768px) {
+  .docs-landing-feature-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.docs-landing-feature {
+  align-items: flex-start;
+  color: #3f3f46;
+  display: flex;
+  font-size: 0.9375rem;
+  gap: 0.75rem;
+  line-height: 1.6;
+}
+
+html.dark .docs-landing-feature {
+  color: #d4d4d8;
+}
+
+.docs-landing-feature-icon {
+  background: currentColor;
+  border-radius: 9999px;
+  display: inline-block;
+  flex-shrink: 0;
+  height: 0.375rem;
+  margin-top: 0.5rem;
+  width: 0.375rem;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Replaces the Mintlify agent draft landing page with a polished custom-layout homepage at `docs.novu.co/`.

The previous draft used `mode: "wide"` (sidebar still visible), unstructured bullet lists, and weak visual hierarchy. This PR:

- Adds `docs/index.mdx` with `mode: "custom"` for a full-width landing experience
- Introduces a hero with value prop, primary CTAs, and light/dark hero imagery
- Structures content into clear sections: Platform, Agents, shared foundations, quickstarts, and community
- Converts plain bullet lists into a styled feature grid with consistent spacing
- Removes the `/` → `/platform` redirect so the new page is the docs homepage

### Screenshots

**Light mode hero**

![Docs landing page hero in light mode](https://cursor.com/artifacts/c/art-8316f3b1-29ea-4c9d-82f7-af26fee5e225)

**Dark mode hero**

![Docs landing page hero in dark mode](https://cursor.com/artifacts/c/art-8d9aef60-c76b-4415-9cfb-ae6adf3c20cd)

**Product cards and Platform section**

![Platform and Agents product cards in dark mode](https://cursor.com/artifacts/c/art-5b1591e6-81ae-4663-a4bf-76de7c58f8c6)

**Shared foundations and lower sections**

![Shared foundations section in dark mode](https://cursor.com/artifacts/c/art-4e7a6afc-1915-4b3b-a0e7-4690180d0c64)

### Test plan

- [x] Ran `mintlify dev` locally and verified `/` renders without sidebar
- [x] Confirmed hero CTAs, product cards, quickstarts, and community links navigate correctly
- [x] Verified light and dark mode styling for hero image swap and section backgrounds
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GFC06JS3/p1782454239984999?thread_ts=1782454239.984999&cid=C06GFC06JS3)

<div><a href="https://cursor.com/agents/bc-d69ce699-d153-51ce-9fd4-4b69b7bd6f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d69ce699-d153-51ce-9fd4-4b69b7bd6f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the previous draft landing page with a polished, full-width custom-mode homepage (`index.mdx`) and removes the `/` → `/platform` permanent redirect that was blocking it. Both referenced hero images (`hero-light.svg` / `hero-dark.svg`) already exist in the repo, all Mintlify built-in components are used correctly, and the `circle-question-mark` Lucide icon is valid.

- **`docs/index.mdx`**: New `mode: \"custom\"` homepage with hero, two-product section cards, feature grids, shared-foundations section, quickstart CTAs, and community links — all wired to existing doc paths.
- **`docs/style.css`**: ~310 lines of scoped landing CSS covering light/dark theming, responsive grid, CTA buttons, and hero image toggling via `html.dark` class; relies on an undocumented Mintlify DOM selector to strip content-area padding.
- **`docs/docs.json`**: Single redirect entry removed; no other navigation changes are needed because Mintlify treats root `index.mdx` as the homepage by convention.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is purely a docs homepage redesign with no backend or SDK impact.

The landing page is well-structured, hero assets are confirmed in the repo, and Mintlify components are used correctly. Two minor issues hold it just below a clean score: a single sentence in the Agents section calls the product "Novu Connect" while the rest of the page consistently uses "Agents", and the CSS selector that strips content-area padding couples to undocumented Mintlify DOM internals that could silently break on a platform update.

The copy in `docs/index.mdx` around the Agents section description and the `html[data-current-path="/"] #content-area` rule in `docs/style.css` are worth a second look before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Removes the permanent `/` → `/platform` redirect; no other navigation changes needed since `index.mdx` at the root is automatically the Mintlify homepage. |
| docs/index.mdx | New custom-mode homepage with well-structured sections; hero SVG assets confirmed present. Minor copy inconsistency: "Novu Connect" in the Agents section conflicts with "Agents" used everywhere else. |
| docs/style.css | ~310 lines of landing-page CSS; solid light/dark mode theming. The `html[data-current-path="/"] #content-area` selector relies on undocumented Mintlify internal attribute and element ID. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User visits docs.novu.co/"] --> B["index.mdx - mode: custom"]
    B --> C["Hero Section"]
    C --> D["Two Product Cards: Platform and Agents"]
    D --> E["Platform Section - React QS, Next.js QS, Concepts"]
    D --> F["Agents Section - Managed Agent, Custom Code Agent"]
    E --> G["Shared Foundations - Subscribers, Channels, Open source"]
    F --> G
    G --> H["Quickstart CTAs"]
    H --> I["Community - Discord, X, GitHub"]
    C -->|"Send a notification"| J["/platform/quickstart/react"]
    C -->|"Build an agent"| K["/agents/managed-agent/quickstart"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User visits docs.novu.co/"] --> B["index.mdx - mode: custom"]
    B --> C["Hero Section"]
    C --> D["Two Product Cards: Platform and Agents"]
    D --> E["Platform Section - React QS, Next.js QS, Concepts"]
    D --> F["Agents Section - Managed Agent, Custom Code Agent"]
    E --> G["Shared Foundations - Subscribers, Channels, Open source"]
    F --> G
    G --> H["Quickstart CTAs"]
    H --> I["Community - Discord, X, GitHub"]
    C -->|"Send a notification"| J["/platform/quickstart/react"]
    C -->|"Build an agent"| K["/agents/managed-agent/quickstart"]
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Findex.mdx%3A133-135%0A**%22Novu%20Connect%22%20naming%20inconsistency**%0A%0AThe%20description%20says%20%22Novu%20Connect%20is%20built%20on%20Agent%20Communication%20Infrastructure%20%28ACI%29%22%2C%20but%20the%20product%20is%20called%20%22Agents%22%20everywhere%20else%20on%20this%20page%20%E2%80%94%20in%20the%20section%20label%2C%20section%20title%2C%20card%20title%2C%20and%20the%20CTA%20link%20text.%20A%20reader%20hitting%20this%20sentence%20after%20reading%20%22Agents%22%20will%20be%20confused%20about%20whether%20%22Novu%20Connect%22%20is%20a%20separate%20product.%20Either%20align%20to%20%22Agents%22%20or%20add%20a%20brief%20parenthetical%20explaining%20the%20relationship.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fstyle.css%3A10-12%0A**Reliance%20on%20undocumented%20Mintlify%20internals**%0A%0A%60data-current-path%60%20and%20%60%23content-area%60%20are%20internal%20Mintlify%20implementation%20details%20%E2%80%94%20not%20part%20of%20the%20documented%20customization%20API.%20If%20Mintlify%20renames%20the%20attribute%20or%20the%20element%20ID%20in%20a%20future%20platform%20update%2C%20the%20padding%20reset%20on%20the%20homepage%20will%20silently%20stop%20working%2C%20restoring%20the%20default%20content-area%20padding.%20Consider%20whether%20%60mode%3A%20%22custom%22%60%20already%20handles%20this%2C%20or%20document%20this%20selector%20as%20a%20known%20fragile%20point.%0A%0A%60%60%60suggestion%0A%2F*%20NOTE%3A%20data-current-path%20and%20%23content-area%20are%20Mintlify%20internals%3B%20may%20need%0A%20%20%20revisiting%20if%20the%20platform%20changes%20its%20DOM%20structure.%20*%2F%0Ahtml%5Bdata-current-path%3D%22%2F%22%5D%20%23content-area%20%7B%0A%20%20padding%3A%200%3B%0A%7D%0A%60%60%60%0A%0A&pr=11667&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/index.mdx:133-135
**"Novu Connect" naming inconsistency**

The description says "Novu Connect is built on Agent Communication Infrastructure (ACI)", but the product is called "Agents" everywhere else on this page — in the section label, section title, card title, and the CTA link text. A reader hitting this sentence after reading "Agents" will be confused about whether "Novu Connect" is a separate product. Either align to "Agents" or add a brief parenthetical explaining the relationship.

### Issue 2 of 2
docs/style.css:10-12
**Reliance on undocumented Mintlify internals**

`data-current-path` and `#content-area` are internal Mintlify implementation details — not part of the documented customization API. If Mintlify renames the attribute or the element ID in a future platform update, the padding reset on the homepage will silently stop working, restoring the default content-area padding. Consider whether `mode: "custom"` already handles this, or document this selector as a known fragile point.

```suggestion
/* NOTE: data-current-path and #content-area are Mintlify internals; may need
   revisiting if the platform changes its DOM structure. */
html[data-current-path="/"] #content-area {
  padding: 0;
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(docs): redesign docs homepage landi..."](https://github.com/novuhq/novu/commit/dc82cb63ca2f606d1e73ffc34bdb2a2feffc8f07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40031790)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->