### PR TITLE
docs(docs): restructure Novu MCP page following Mintlify MCP format fixes DOC-373

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -874,13 +874,11 @@
     "options": [
       "copy",
       "view",
-      "chatgpt",
-      "claude",
-      "perplexity",
-      "mcp",
-      "add-mcp",
       "cursor",
-      "vscode"
+      "claude",
+      "chatgpt",
+      "mcp",
+      "add-mcp"
     ]
   },
   "footer": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -878,6 +878,7 @@
       "claude",
       "perplexity",
       "mcp",
+      "add-mcp",
       "cursor",
       "vscode"
     ]

--- a/docs/platform/build-with-ai/mcp.mdx
+++ b/docs/platform/build-with-ai/mcp.mdx
@@ -264,9 +264,11 @@ Claude Desktop connects to remote MCP servers through a local proxy (`mcp-remote
 
 Any MCP-compatible tool can connect to the Novu MCP Server using these connection details:
 
-- **URL**: `https://mcp.novu.co/` (US) or `https://mcp.novu.co/?region=eu` (EU)
-- **Transport**: Streamable HTTP
-- **Authentication**: `Authorization: Bearer your-novu-api-key`
+| Setting | Value |
+| --- | --- |
+| **URL** | `https://mcp.novu.co/` (US) or `https://mcp.novu.co/?region=eu` (EU) |
+| **Transport** | Streamable HTTP |
+| **Authentication** | `Authorization: Bearer your-novu-api-key` |
 
   </Tab>
 </Tabs>

--- a/docs/platform/build-with-ai/mcp.mdx
+++ b/docs/platform/build-with-ai/mcp.mdx
@@ -1,271 +1,400 @@
 ---
-title: MCP Server
-description: Connect your AI tools to Novu using MCP and manage notifications using natural language.
+title: Novu MCP Server
+description: Connect AI tools to Novu at mcp.novu.co and manage notifications, workflows, and subscribers using natural language.
 ---
 
+The Novu MCP Server exposes Novu's notification infrastructure as tools that AI assistants can discover and use in real time. Connect your AI tool to `https://mcp.novu.co/` to manage subscribers, workflows, integrations, and delivery activity from natural-language prompts.
 
-The Novu MCP Server exposes Novu's notification infrastructure as tools that AI assistants can discover and use in real time. 
+<Note>
+  Novu also hosts a separate **documentation MCP server** at [docs.novu.co/mcp](https://docs.novu.co/mcp) that lets AI tools search and read this documentation site. The server on this page (`mcp.novu.co`) manages your Novu account — triggers, workflows, subscribers, and more.
+</Note>
 
-Once connected, you can use natural language to manage notifications in Novu directly from your AI tool.
-For example, you can prompt your AI assistant to:
+## About the Novu MCP server
 
-* Trigger workflows for specific subscribers  
-* Search and inspect subscriber data  
-* Update subscriber notification preferences  
-* Debug failed notifications and delivery issues  
-* Analyze notification activity and logs  
-* Create and manage workflows
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI applications to external services. The Novu MCP Server prepares your notification infrastructure for the broader AI ecosystem — any MCP-compatible client like Cursor, Claude Code, Codex, or VS Code can connect and act on your Novu environment.
 
-## How Novu MCP works
+Once connected, you can prompt your AI assistant to:
+
+- Trigger workflows for specific subscribers
+- Search and inspect subscriber data
+- Update subscriber notification preferences
+- Debug failed notifications and delivery issues
+- Analyze notification activity and logs
+- Create and manage workflows
+
+Some AI tools support both MCP and [Agent Skills](/platform/build-with-ai/skills). MCP gives your assistant live access to your Novu account, while skills instruct agents how to use Novu APIs and SDKs effectively. They are complementary — connect the MCP server for account operations and install skills for implementation guidance.
+
+## How the Novu MCP works
 
 The Novu MCP Server exposes your notification system as a set of tools.
 
 When your AI assistant connects:
+
 1. It authenticates using your API key.
 2. It discovers available tools.
 3. It executes actions based on your prompts.
 
 Instead of calling APIs directly, the AI translates your request into tool calls and executes them against your Novu environment.
 
-## Prerequisite
-To use the Novu MCP Server, you'll need:
+## Prerequisites
 
-* A [Novu API key](https://dashboard.novu.co/settings/api-keys)
-* An MCP-compatible AI tool (Cursor, Codex, Claude Code, Claude Desktop)
+To use the Novu MCP Server, you need:
+
+- A [Novu API key](https://dashboard.novu.co/settings/api-keys)
+- An MCP-compatible AI tool (Cursor, Codex, Claude Code, Claude Desktop, VS Code)
 
 <Note>
-  Some tools like Claude Desktop require Node.js to run MCP servers locally.
+  Some tools like Claude Desktop require Node.js to run MCP servers locally through the `mcp-remote` proxy.
 </Note>
+
+## Access the Novu MCP server
+
+The Novu MCP Server is hosted at `https://mcp.novu.co/` and uses **Streamable HTTP** transport. Authenticate every request by sending your secret key in the `Authorization` header as `Bearer your-novu-api-key`.
+
+| Setting | Value |
+| --- | --- |
+| **Transport** | Streamable HTTP |
+| **Authentication** | Bearer token (Novu secret key) |
+| **US endpoint** | `https://mcp.novu.co/` |
+| **EU endpoint** | `https://mcp.novu.co/?region=eu` |
+
+Your region is determined by your dashboard URL:
+
+| Dashboard URL | Region | MCP URL |
+| --- | --- | --- |
+| `dashboard.novu.co` | US | `https://mcp.novu.co/` |
+| `eu.dashboard.novu.co` | EU | `https://mcp.novu.co/?region=eu` |
+
+Use the MCP URL that matches your dashboard region in every configuration example below.
 
 ## Setup
 
-Follow these steps to setup the Novu MCP server:
+<Steps>
+  <Step title="Get your secret key">
+    Your secret key authenticates your AI tool with Novu.
 
-### 1. Get your secret key
+    1. Go to the [Novu Dashboard](https://dashboard.novu.co).
+    2. Navigate to **API Keys**.
+    3. Under **Secret Keys**, copy your secret key.
+  </Step>
 
-Your secret key authenticates your AI tool with Novu. To retrieve it:
-1. Go to the [Novu Dashboard](https://dashboard.novu.co)
-2. Navigate to **API Keys**
-3. Under **Secret Keys**, copy your secret key
+  <Step title="Identify your region">
+    Check your dashboard URL to choose the correct MCP endpoint. US accounts use `https://mcp.novu.co/`; EU accounts use `https://mcp.novu.co/?region=eu`.
+  </Step>
 
-### 2. Identify your region
+  <Step title="Configure your AI tool">
+    Follow the client-specific instructions in the next section. Replace `your-novu-api-key` with the secret key you copied, and use the MCP URL for your region.
+  </Step>
 
-Your region determines which URL your AI tool connects to. To identify it, check your dashboard URL:
+  <Step title="Test the connection">
+    Ask your assistant to run a simple prompt such as "Check my Novu API key status" or "Show me all my notification workflows." If you get results back, the server is connected.
+  </Step>
+</Steps>
 
-| Dashboard URL | Region | MCP URL |
-|---|---|---|
-| `dashboard.novu.co` | US | `https://mcp.novu.co/` |
-| `eu.dashboard.novu.co` | EU | `https://mcp.novu.co/?region=eu` |
- 
-The MCP URL above is what you'll use in the next step when configuring your tool.
+## Connect your AI tool
 
-### 3. Configure your tool
- 
-The following sections cover setup for the most common MCP-compatible AI tools. Before you start, keep two things in mind as you work through the examples:
- 
-- **Replace the API key.** Each example uses `your-novu-api-key` as a placeholder. Replace it with the API key you copied earlier.
-- **Use the correct URL for your region.** The examples use the US endpoint (`https://mcp.novu.co/`). If you're on the EU region, replace it with `https://mcp.novu.co/?region=eu`.
-#### Cursor
- 
-Cursor supports remote MCP servers through its built-in settings UI, which writes to an `mcp.json` file. To add the Novu MCP Server:
- 
-1. Open **Cursor Settings**, and select **Tools & Integrations**.
-2. Under **MCP Tools**, select **New MCP Server**. This opens your `mcp.json` file.
-3. Add the following to the `mcpServers` object:
-   ```json
-   {
-     "mcpServers": {
-       "novu": {
-         "url": "https://mcp.novu.co/",
-         "headers": {
-           "Authorization": "Bearer your-novu-api-key"
-         }
-       }
-     }
-   }
-   ```
- 
-4. Save the file. Cursor detects the new server automatically.
-#### Codex
- 
-Codex reads MCP configuration from `~/.codex/config.toml`. The CLI and IDE extension share this file, so you only need to configure the server once. To add the Novu MCP Server:
- 
-1. Export your API key as an environment variable in your shell:
-   ```bash
-   export NOVU_API_KEY="your-novu-api-key"
-   ```
- 
-2. Open `~/.codex/config.toml` in your preferred text editor and add the following:
-   ```toml
-   [mcp_servers.novu]
-   url = "https://mcp.novu.co/"
-   bearer_token_env_var = "NOVU_API_KEY"
-   ```
- 
-3. Save the file and restart Codex.
-To verify the connection, run `/mcp` inside the Codex TUI. You should see `novu` listed as a connected server.
- 
-#### Claude Code
- 
-Claude Code manages MCP servers through its `claude mcp` command. To add the Novu MCP Server:
- 
-1. In your terminal, run:
-   ```bash
-   claude mcp add --transport http novu https://mcp.novu.co/ \
-     --header "Authorization: Bearer your-novu-api-key"
-   ```
- 
-2. To make Novu available across all your projects instead of just the current one, add the `--scope user` flag:
-   ```bash
-   claude mcp add --scope user --transport http novu https://mcp.novu.co/ \
-     --header "Authorization: Bearer your-novu-api-key"
-   ```
- 
-3. Verify the connection by running `claude mcp list`. You can also run `/mcp` inside Claude Code to check server status.
-#### Claude Desktop
- 
-Claude Desktop connects to remote MCP servers through a local proxy (`mcp-remote`), which requires Node.js 18 or higher. To add the Novu MCP Server:
- 
-1. Open Claude Desktop, go to **Settings**, and find the **Developer** section.
-2. Select **Edit Config**. This opens your `claude_desktop_config.json` file.
-3. Add the following to the `mcpServers` object (or create the object if it doesn't exist):
-   ```json
-   {
-     "mcpServers": {
-       "novu": {
-         "command": "npx",
-         "args": [
-           "mcp-remote",
-           "https://mcp.novu.co/",
-           "--header",
-           "Authorization: Bearer ${NOVU_API_KEY}"
-         ],
-         "env": {
-           "NOVU_API_KEY": "your-novu-api-key"
-         }
-       }
-     }
-   }
-   ```
- 
-4. Save the file and restart Claude Desktop.
+<Tabs>
+  <Tab title="Cursor">
 
-#### Other tools
- 
-Any MCP-compatible tool can connect to the Novu MCP Server. Use the following connection details:
- 
-* **URL**:
-  * US: `https://mcp.novu.co/`
-  * EU: `https://mcp.novu.co/?region=eu`
-* **Transport**: Streamable HTTP (recommended).
-* **Authentication**: Send your API key in the `Authorization` header as `Bearer your-novu-api-key`.
+Cursor supports remote MCP servers through its built-in settings UI, which writes to an `mcp.json` file.
 
-## Test your setup
- 
-To verify that the connection works, try any of the prompts below in your AI assistant:
- 
-```
-"Check my Novu API key status"
-"Show me all my notification workflows"
-"Find subscriber with email user@example.com"
-```
- 
-If you get results back, the Novu MCP Server is connected and working.
+<Steps>
+  <Step title="Open MCP settings">
+    Open **Cursor Settings**, select **Tools & Integrations**, then under **MCP Tools** select **New MCP Server**. This opens your `mcp.json` file.
+  </Step>
 
-## Available tools
+  <Step title="Add the Novu MCP server">
+    Add the following to the `mcpServers` object:
 
-The Novu MCP server currently provides 23 tools for interacting with your Novu environment:
- 
+    ```json
+    {
+      "mcpServers": {
+        "novu": {
+          "url": "https://mcp.novu.co/",
+          "headers": {
+            "Authorization": "Bearer your-novu-api-key"
+          }
+        }
+      }
+    }
+    ```
+  </Step>
+
+  <Step title="Save and verify">
+    Save the file. Cursor detects the new server automatically. In Cursor's chat, ask "What MCP tools do you have available?" — you should see the Novu server listed.
+  </Step>
+</Steps>
+
+  </Tab>
+
+  <Tab title="VS Code">
+
+VS Code reads MCP configuration from `.vscode/mcp.json` in your workspace, or from user-level MCP settings.
+
+<Steps>
+  <Step title="Create mcp.json">
+    Create a `.vscode/mcp.json` file in your project (or open your user MCP settings).
+  </Step>
+
+  <Step title="Add the Novu MCP server">
+    Add the following configuration:
+
+    ```json
+    {
+      "servers": {
+        "novu": {
+          "type": "http",
+          "url": "https://mcp.novu.co/",
+          "headers": {
+            "Authorization": "Bearer your-novu-api-key"
+          }
+        }
+      }
+    }
+    ```
+  </Step>
+
+  <Step title="Reload and verify">
+    Reload VS Code and open the MCP panel. The `novu` server should appear as a connected server.
+  </Step>
+</Steps>
+
+  </Tab>
+
+  <Tab title="Codex">
+
+Codex reads MCP configuration from `~/.codex/config.toml`. The CLI and IDE extension share this file.
+
+<Steps>
+  <Step title="Export your API key">
+    Export your API key as an environment variable:
+
+    ```bash
+    export NOVU_API_KEY="your-novu-api-key"
+    ```
+  </Step>
+
+  <Step title="Add the Novu MCP server">
+    Open `~/.codex/config.toml` and add:
+
+    ```toml
+    [mcp_servers.novu]
+    url = "https://mcp.novu.co/"
+    bearer_token_env_var = "NOVU_API_KEY"
+    ```
+  </Step>
+
+  <Step title="Restart and verify">
+    Save the file and restart Codex. Run `/mcp` inside the Codex TUI — you should see `novu` listed as a connected server.
+  </Step>
+</Steps>
+
+  </Tab>
+
+  <Tab title="Claude Code">
+
+Claude Code manages MCP servers through its `claude mcp` command.
+
+<Steps>
+  <Step title="Add the Novu MCP server">
+    In your terminal, run:
+
+    ```bash
+    claude mcp add --transport http novu https://mcp.novu.co/ \
+      --header "Authorization: Bearer your-novu-api-key"
+    ```
+  </Step>
+
+  <Step title="Optional: make it global">
+    To make Novu available across all projects, add the `--scope user` flag:
+
+    ```bash
+    claude mcp add --scope user --transport http novu https://mcp.novu.co/ \
+      --header "Authorization: Bearer your-novu-api-key"
+    ```
+  </Step>
+
+  <Step title="Verify the connection">
+    Run `claude mcp list`, or run `/mcp` inside Claude Code to check server status.
+  </Step>
+</Steps>
+
+  </Tab>
+
+  <Tab title="Claude Desktop">
+
+Claude Desktop connects to remote MCP servers through a local proxy (`mcp-remote`), which requires Node.js 18 or higher.
+
+<Steps>
+  <Step title="Open Claude Desktop config">
+    Open Claude Desktop, go to **Settings**, find the **Developer** section, and select **Edit Config**. This opens your `claude_desktop_config.json` file.
+  </Step>
+
+  <Step title="Add the Novu MCP server">
+    Add the following to the `mcpServers` object (or create the object if it does not exist):
+
+    ```json
+    {
+      "mcpServers": {
+        "novu": {
+          "command": "npx",
+          "args": [
+            "mcp-remote",
+            "https://mcp.novu.co/",
+            "--header",
+            "Authorization: Bearer ${NOVU_API_KEY}"
+          ],
+          "env": {
+            "NOVU_API_KEY": "your-novu-api-key"
+          }
+        }
+      }
+    }
+    ```
+  </Step>
+
+  <Step title="Restart Claude Desktop">
+    Save the file and restart Claude Desktop.
+  </Step>
+</Steps>
+
+  </Tab>
+
+  <Tab title="Other tools">
+
+Any MCP-compatible tool can connect to the Novu MCP Server using these connection details:
+
+- **URL**: `https://mcp.novu.co/` (US) or `https://mcp.novu.co/?region=eu` (EU)
+- **Transport**: Streamable HTTP
+- **Authentication**: `Authorization: Bearer your-novu-api-key`
+
+  </Tab>
+</Tabs>
+
+## MCP tools
+
+The Novu MCP server provides tools for interacting with your Novu environment. Your AI assistant discovers tools at connection time through the MCP `tools/list` handshake.
+
+Agents determine when to call each tool based on your prompt. For example, a request to "find subscriber user@example.com" may call `find_subscribers`, while "send a welcome email" may call `trigger_workflow`.
+
 ### Core operations
- 
+
 These tools let you inspect your account configuration:
- 
+
 | Tool | Description |
-|---|---|
+| --- | --- |
 | `get_api_key_status` | Check API key status and region configuration |
 | `get_environments` | List development and production environments |
- 
+
 ### Subscriber management
- 
+
 These tools let you create, inspect, and manage your subscribers:
- 
+
 | Tool | Description |
-|---|---|
+| --- | --- |
 | `create_subscriber` | Create a new subscriber with attributes like name, email, phone, and custom data |
 | `get_subscriber` | Retrieve a single subscriber by their `subscriberId` |
 | `update_subscriber` | Update an existing subscriber's attributes |
 | `delete_subscriber` | Delete a subscriber by their `subscriberId` |
 | `find_subscribers` | Search for subscribers using various query parameters |
- 
+
 ### Preferences
- 
+
 These tools let you view and update how subscribers receive notifications:
- 
+
 | Tool | Description |
-|---|---|
+| --- | --- |
 | `get_subscriber_preferences` | Get subscriber notification preferences for all channels |
 | `update_subscriber_preferences` | Update subscriber notification preferences for specific channels |
- 
+
 ### Workflow management
- 
+
 These tools let you create, inspect, and manage notification workflows:
- 
+
 | Tool | Description |
-|---|---|
+| --- | --- |
 | `create_workflow` | Create a new workflow with comprehensive configuration including steps |
 | `get_workflow` | Get detailed information about a specific workflow |
 | `get_workflows` | Get all available workflows |
 | `update_workflow` | Update an existing workflow |
 | `delete_workflow` | Delete an existing workflow by its unique identifier |
- 
+
 ### Triggering and events
- 
+
 These tools let you execute workflows and manage pending notifications:
- 
+
 | Tool | Description |
-|---|---|
+| --- | --- |
 | `trigger_workflow` | Trigger a workflow to send notifications to a subscriber |
 | `bulk_trigger_workflow` | Trigger multiple workflows in a single API call |
 | `cancel_triggered_event` | Cancel a pending triggered event |
- 
+
 ### Notifications
- 
+
 These tools let you inspect delivery and execution data:
- 
+
 | Tool | Description |
-|---|---|
+| --- | --- |
 | `get_notification` | Get a specific notification by ID with detailed execution logs |
 | `get_notifications` | Get notifications and events with advanced filtering options |
- 
+
 ### Integrations
- 
+
 These tools let you manage the channel providers connected to your Novu account:
- 
+
 | Tool | Description |
-|---|---|
+| --- | --- |
 | `get_integrations` | List all channel integrations (email, SMS, push, chat, in-app) |
 | `get_active_integrations` | List only the active integrations |
 | `delete_integration` | Delete an integration by its `integrationId` |
 | `set_primary_integration` | Mark an integration as the primary for its channel |
 
+## Use multiple MCP servers
+
+You can connect both the Novu MCP server and the [Novu documentation MCP server](https://docs.novu.co/mcp) at the same time. Each server serves a different purpose:
+
+| Server | URL | Purpose |
+| --- | --- | --- |
+| Novu MCP | `https://mcp.novu.co/` | Manage your Novu account — workflows, subscribers, triggers |
+| Novu Docs MCP | `https://docs.novu.co/mcp` | Search and read Novu documentation |
+
+Connected MCP servers do not consume context until the AI calls a tool. Be specific in your prompts so the assistant uses the most relevant server — for example, "trigger my welcome workflow" uses the Novu MCP, while "how do I configure digest steps?" uses the Docs MCP.
+
 ## Troubleshooting
 
-If your setup isn't working, the following sections cover the most common issues.
+If your setup is not working, the following sections cover the most common issues.
 
 <AccordionGroup>
   <Accordion title="Authentication errors">
-  * Verify your API key is valid and has no extra spaces or line breaks
-  * Check that you're using the correct header format: `Authorization: Bearer your-api-key`
+    - Verify your API key is valid and has no extra spaces or line breaks.
+    - Check that you are using the correct header format: `Authorization: Bearer your-api-key`.
   </Accordion>
 
   <Accordion title="Empty results">
-  Confirm you're using the correct region. If your dashboard is at `eu.dashboard.novu.co`, you need the EU endpoint
+    Confirm you are using the correct region. If your dashboard is at `eu.dashboard.novu.co`, you need the EU endpoint (`https://mcp.novu.co/?region=eu`).
   </Accordion>
 
   <Accordion title="Connection issues">
-  * Restart your AI assistant after making configuration changes
-  * For Claude Desktop, ensure Node.js is installed and accessible from your terminal
-  * For Claude Code, run `claude mcp list` to confirm the server is registered
-  * For Codex, run `/mcp` in the TUI to check server status
+    - Restart your AI assistant after making configuration changes.
+    - For Claude Desktop, ensure Node.js is installed and accessible from your terminal.
+    - For Claude Code, run `claude mcp list` to confirm the server is registered.
+    - For Codex, run `/mcp` in the TUI to check server status.
   </Accordion>
 </AccordionGroup>
+
+## Related topics
+
+<Columns cols={2}>
+  <Card title="Agent Skills" href="/platform/build-with-ai/skills">
+    Give AI coding assistants implementation guidance for Novu SDKs and workflows.
+  </Card>
+  <Card title="Agent Toolkit" href="/platform/build-with-ai/agent-toolkit">
+    Embed Novu tools inside your own AI agents with the `@novu/agent-toolkit` package.
+  </Card>
+  <Card title="Novu Docs MCP" href="https://docs.novu.co/mcp">
+    Connect AI tools to search and read this documentation site.
+  </Card>
+  <Card title="API keys" href="/platform/developer/api-keys">
+    Learn how to create and manage the secret keys used to authenticate the MCP server.
+  </Card>
+</Columns>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restructures the Novu MCP Server documentation at `/platform/build-with-ai/mcp` to follow [Mintlify's Model Context Protocol documentation structure](https://www.mintlify.com/docs/ai/model-context-protocol).

## Changes

- Reorganize the `mcp.novu.co` setup guide using Mintlify components (`Steps`, `Tabs`, `Columns`, `Cards`, `AccordionGroup`)
- Add **VS Code** setup instructions alongside existing Cursor, Codex, Claude Code, and Claude Desktop guides
- Clarify the distinction between the **Novu Platform MCP** (`https://mcp.novu.co/`) and the **Novu Docs MCP** (`https://docs.novu.co/mcp`)
- Add an "Access the Novu MCP server" section with transport, authentication, and regional endpoint details
- Add a "Use multiple MCP servers" section explaining when to use each server
- Enable the `add-mcp` contextual menu option in `docs.json` per Mintlify recommendations

## Why

Mintlify's MCP documentation pattern helps users and AI agents discover connection details, understand tool behavior, and configure clients consistently. This brings the Novu MCP page in line with that structure while preserving all existing tool reference content.

## Linear

fixes DOC-373
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afe080cb-c9cc-4c69-a9b6-cc65bed31df3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afe080cb-c9cc-4c69-a9b6-cc65bed31df3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restructures the Novu MCP Server documentation page (`mcp.mdx`) to follow Mintlify's recommended MCP documentation format, replacing a flat layout with `Steps`, `Tabs`, `AccordionGroup`, and `Columns` components. It also adds VS Code as a supported client, clarifies the distinction between the Novu Platform MCP and the Novu Docs MCP, and enables the `add-mcp` contextual menu option in `docs.json`.

- **Restructured setup guide:** Client-specific instructions are now organized into separate tabs (Cursor, VS Code, Codex, Claude Code, Claude Desktop), each with their own `Steps` component, replacing the previous flat sequential layout.
- **New content sections:** Adds "Access the Novu MCP server" (transport/auth/endpoint reference table), "Use multiple MCP servers" (comparing `mcp.novu.co` vs `docs.novu.co/mcp`), and "Related topics" cards.
- **`docs.json` contextual options:** Reorders entries, removes `perplexity` and `vscode`, and introduces `add-mcp` to expose Mintlify's one-click MCP connection button.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all three findings are non-blocking documentation improvements.

The restructure is clean and the Mintlify component usage is correct throughout. The only concerns are a missing VS Code entry in the troubleshooting accordion, a missing warning about committing API keys in `.vscode/mcp.json`, and an unconfirmed intent behind removing the `vscode` contextual option while simultaneously adding VS Code as a setup tab. None of these cause the page to render incorrectly or break user workflows.

`docs/platform/build-with-ai/mcp.mdx` — VS Code tab and troubleshooting accordion. `docs/docs.json` — removal of `vscode` contextual option.

<details open><summary><h3>Security Review</h3></summary>

- The VS Code tab instructs users to store their raw Novu API key in `.vscode/mcp.json`, a workspace file that is typically committed to version control. If the file is pushed to a public or shared repository without being `.gitignore`d, the secret key would be exposed. A `<Warning>` callout is recommended before the VS Code `Steps` block.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/build-with-ai/mcp.mdx | Major restructure using Mintlify Steps/Tabs/Columns components; adds VS Code setup tab; clarifies Novu Platform MCP vs Docs MCP; adds regional endpoint table and 'Use multiple MCP servers' section. VS Code troubleshooting tip is missing, and the VS Code tab instructs users to place a live API key directly in `.vscode/mcp.json` without a warning about version-control exposure. |
| docs/docs.json | Reorders contextual options; replaces `vscode` and `perplexity` with `add-mcp`. Removal of `vscode` contextual option while adding VS Code as a setup tab may warrant confirmation. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant AITool as AI Tool (Cursor/VS Code/etc.)
    participant MCP as mcp.novu.co
    participant Novu as Novu Platform

    User->>AITool: Configure MCP server URL + API key
    AITool->>MCP: tools/list (Authorization: Bearer key)
    MCP->>AITool: List of 23 available tools
    User->>AITool: Natural-language prompt
    AITool->>MCP: tool_call (e.g. trigger_workflow)
    MCP->>Novu: API request
    Novu-->>MCP: API response
    MCP-->>AITool: Tool result
    AITool-->>User: Response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant AITool as AI Tool (Cursor/VS Code/etc.)
    participant MCP as mcp.novu.co
    participant Novu as Novu Platform

    User->>AITool: Configure MCP server URL + API key
    AITool->>MCP: tools/list (Authorization: Bearer key)
    MCP->>AITool: List of 23 available tools
    User->>AITool: Natural-language prompt
    AITool->>MCP: tool_call (e.g. trigger_workflow)
    MCP->>Novu: API request
    Novu-->>MCP: API response
    MCP-->>AITool: Tool result
    AITool-->>User: Response
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2Fplatform%2Fbuild-with-ai%2Fmcp.mdx%3A379-384%0AThe%20%22Connection%20issues%22%20troubleshooting%20accordion%20covers%20Claude%20Desktop%2C%20Claude%20Code%2C%20and%20Codex%20%E2%80%94%20but%20VS%20Code%20is%20newly%20added%20in%20this%20PR%20and%20has%20no%20entry.%20Users%20who%20follow%20the%20VS%20Code%20tab%20and%20run%20into%20issues%20%28e.g.%20the%20MCP%20panel%20not%20appearing%20after%20a%20reload%29%20will%20find%20no%20guidance%20here.%0A%0A%60%60%60suggestion%0A%20%20%3CAccordion%20title%3D%22Connection%20issues%22%3E%0A%20%20%20%20-%20Restart%20your%20AI%20assistant%20after%20making%20configuration%20changes.%0A%20%20%20%20-%20For%20Claude%20Desktop%2C%20ensure%20Node.js%20is%20installed%20and%20accessible%20from%20your%20terminal.%0A%20%20%20%20-%20For%20Claude%20Code%2C%20run%20%60claude%20mcp%20list%60%20to%20confirm%20the%20server%20is%20registered.%0A%20%20%20%20-%20For%20Codex%2C%20run%20%60%2Fmcp%60%20in%20the%20TUI%20to%20check%20server%20status.%0A%20%20%20%20-%20For%20VS%20Code%2C%20run%20the%20**MCP%3A%20List%20Servers**%20command%20from%20the%20Command%20Palette%20to%20confirm%20the%20server%20is%20registered.%0A%20%20%3C%2FAccordion%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2Fplatform%2Fbuild-with-ai%2Fmcp.mdx%3A132-155%0A%60.vscode%2Fmcp.json%60%20is%20a%20workspace%20file%20that%20developers%20commonly%20commit%20to%20version%20control.%20The%20current%20instructions%20tell%20users%20to%20place%20the%20raw%20API%20key%20inline%20in%20this%20file.%20VS%20Code's%20MCP%20input%20system%20%28%60%22inputs%22%60%29%20lets%20users%20store%20the%20key%20outside%20the%20file%20so%20it%20is%20never%20committed.%20Adding%20a%20%60%3CWarning%3E%60%20here%20would%20prevent%20users%20from%20accidentally%20leaking%20their%20Novu%20secret%20key%20into%20a%20public%20repository.%0A%0A%60%60%60suggestion%0AVS%20Code%20reads%20MCP%20configuration%20from%20%60.vscode%2Fmcp.json%60%20in%20your%20workspace%2C%20or%20from%20user-level%20MCP%20settings.%0A%0A%3CWarning%3E%0A%20%20%60.vscode%2Fmcp.json%60%20is%20a%20workspace%20file.%20Do%20not%20commit%20it%20to%20version%20control%20with%20a%20real%20API%20key.%20Add%20%60.vscode%2Fmcp.json%60%20to%20your%20%60.gitignore%60%2C%20or%20use%20user-level%20MCP%20settings%20instead%20of%20a%20workspace%20file.%0A%3C%2FWarning%3E%0A%0A%3CSteps%3E%0A%20%20%3CStep%20title%3D%22Create%20mcp.json%22%3E%0A%20%20%20%20Create%20a%20%60.vscode%2Fmcp.json%60%20file%20in%20your%20project%20%28or%20open%20your%20user%20MCP%20settings%29.%0A%20%20%3C%2FStep%3E%0A%0A%20%20%3CStep%20title%3D%22Add%20the%20Novu%20MCP%20server%22%3E%0A%20%20%20%20Add%20the%20following%20configuration%3A%0A%0A%20%20%20%20%60%60%60json%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22servers%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22novu%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22type%22%3A%20%22http%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22url%22%3A%20%22https%3A%2F%2Fmcp.novu.co%2F%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22headers%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Authorization%22%3A%20%22Bearer%20your-novu-api-key%22%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20%60%60%60%0A%20%20%3C%2FStep%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fdocs.json%3A874-882%0A**%60vscode%60%20contextual%20option%20removed%20alongside%20%60perplexity%60**%0A%0AThe%20original%20list%20included%20%60%22vscode%22%60%2C%20which%20enables%20the%20%22Open%20in%20VS%20Code%22%20contextual%20button%20that%20wires%20documentation%20context%20into%20VS%20Code%20Copilot%20chat.%20This%20PR%20replaces%20it%20with%20%60%22add-mcp%22%60%2C%20which%20is%20a%20different%20feature%20%E2%80%94%20it%20presents%20a%20one-click%20prompt%20to%20add%20the%20page's%20MCP%20server%20to%20the%20user's%20AI%20tool.%0A%0AIf%20the%20VS%20Code%20Copilot%20chat%20integration%20is%20being%20intentionally%20retired%20in%20favour%20of%20the%20generic%20%60add-mcp%60%20flow%2C%20this%20is%20fine.%20If%20both%20features%20are%20expected%20to%20be%20available%20%28VS%20Code%20tab%20is%20added%20to%20the%20MDX%20page%20in%20this%20same%20PR%29%2C%20consider%20whether%20%60%22vscode%22%60%20should%20be%20kept%20alongside%20%60%22add-mcp%22%60.%0A%0A&pr=11670&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docs/platform/build-with-ai/mcp.mdx:379-384
The "Connection issues" troubleshooting accordion covers Claude Desktop, Claude Code, and Codex — but VS Code is newly added in this PR and has no entry. Users who follow the VS Code tab and run into issues (e.g. the MCP panel not appearing after a reload) will find no guidance here.

```suggestion
  <Accordion title="Connection issues">
    - Restart your AI assistant after making configuration changes.
    - For Claude Desktop, ensure Node.js is installed and accessible from your terminal.
    - For Claude Code, run `claude mcp list` to confirm the server is registered.
    - For Codex, run `/mcp` in the TUI to check server status.
    - For VS Code, run the **MCP: List Servers** command from the Command Palette to confirm the server is registered.
  </Accordion>
```

### Issue 2 of 3
docs/platform/build-with-ai/mcp.mdx:132-155
`.vscode/mcp.json` is a workspace file that developers commonly commit to version control. The current instructions tell users to place the raw API key inline in this file. VS Code's MCP input system (`"inputs"`) lets users store the key outside the file so it is never committed. Adding a `<Warning>` here would prevent users from accidentally leaking their Novu secret key into a public repository.

```suggestion
VS Code reads MCP configuration from `.vscode/mcp.json` in your workspace, or from user-level MCP settings.

<Warning>
  `.vscode/mcp.json` is a workspace file. Do not commit it to version control with a real API key. Add `.vscode/mcp.json` to your `.gitignore`, or use user-level MCP settings instead of a workspace file.
</Warning>

<Steps>
  <Step title="Create mcp.json">
    Create a `.vscode/mcp.json` file in your project (or open your user MCP settings).
  </Step>

  <Step title="Add the Novu MCP server">
    Add the following configuration:

    ```json
    {
      "servers": {
        "novu": {
          "type": "http",
          "url": "https://mcp.novu.co/",
          "headers": {
            "Authorization": "Bearer your-novu-api-key"
          }
        }
      }
    }
    ```
  </Step>
```

### Issue 3 of 3
docs/docs.json:874-882
**`vscode` contextual option removed alongside `perplexity`**

The original list included `"vscode"`, which enables the "Open in VS Code" contextual button that wires documentation context into VS Code Copilot chat. This PR replaces it with `"add-mcp"`, which is a different feature — it presents a one-click prompt to add the page's MCP server to the user's AI tool.

If the VS Code Copilot chat integration is being intentionally retired in favour of the generic `add-mcp` flow, this is fine. If both features are expected to be available (VS Code tab is added to the MDX page in this same PR), consider whether `"vscode"` should be kept alongside `"add-mcp"`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docs): refine contextual menu MCP o..."](https://github.com/novuhq/novu/commit/39dcb18e17228b9ffee6dd521f8bdb7264e4c236) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40032377)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->