### PR TITLE
docs: add legacy docs redirects for /api and /get-started fixes DOC-374

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1150,6 +1150,11 @@
       "permanent": true
     },
     {
+      "source": "/api",
+      "destination": "/api-reference",
+      "permanent": true
+    },
+    {
       "source": "/api-reference/overview",
       "destination": "/api-reference",
       "permanent": true

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1125,6 +1125,11 @@
       "permanent": true
     },
     {
+      "source": "/get-started",
+      "destination": "/platform/quickstart/nextjs",
+      "permanent": true
+    },
+    {
       "source": "/quickstart/nextjs",
       "destination": "/platform/quickstart/nextjs",
       "permanent": true

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1130,6 +1130,11 @@
       "permanent": true
     },
     {
+      "source": "/quickstart",
+      "destination": "/platform/quickstart/nextjs",
+      "permanent": true
+    },
+    {
       "source": "/quickstart/nextjs",
       "destination": "/platform/quickstart/nextjs",
       "permanent": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Mintlify redirects for legacy docs URLs:

- `docs.novu.co/api` → `/api-reference`
- `docs.novu.co/get-started` → `/platform/quickstart/nextjs`
- `docs.novu.co/quickstart` → `/platform/quickstart/nextjs`

## Changes

- Added permanent redirect entries in `docs/docs.json`

## Why

Users and external links may still point to these legacy paths. Redirects ensure they land on the correct pages instead of 404s.

## Test plan

- [x] Validated `docs/docs.json` parses as valid JSON
- [ ] After Mintlify deploy, confirm:
  - `https://docs.novu.co/api` → `https://docs.novu.co/api-reference`
  - `https://docs.novu.co/get-started` → `https://docs.novu.co/platform/quickstart/nextjs`
  - `https://docs.novu.co/quickstart` → `https://docs.novu.co/platform/quickstart/nextjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d7ff3da-dd5f-4c2c-98e6-c4e54e709b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d7ff3da-dd5f-4c2c-98e6-c4e54e709b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds legacy docs redirects in the Mintlify configuration. The main changes are:

- Permanent redirect from `/api` to `/api-reference`.
- Permanent redirect from `/get-started` to `/platform/quickstart/nextjs`.
- Permanent redirect from `/quickstart` to `/platform/quickstart/nextjs`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to documentation redirect configuration.

The update only adds Mintlify redirect entries and the JSON configuration was validated as parseable.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before artifact to establish the initial state of the legacy docs redirects, which showed 81 redirects in docs/docs.json and no matches for /api, /get-started, or /quickstart.
- Compared the after artifact to confirm the final state, which showed 84 redirects and permanent matches for /api -\> /api-reference, /get-started -\> /platform/quickstart/nextjs, and /quickstart -\> /platform/quickstart/nextjs, with the validation commands exiting successfully.

<a href="https://app.greptile.com/trex/runs/12416862/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: redirect /quickstart to nextjs qui..."](https://github.com/novuhq/novu/commit/a20fa14604273973a63dbbbd15164329eb00245d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40080826)</sub>

<!-- /greptile_comment -->