### PR TITLE
fix(dashboard): remove Beta badge from contexts page fixes NV-8130

### DIFF
--- a/apps/dashboard/src/pages/contexts.tsx
+++ b/apps/dashboard/src/pages/contexts.tsx
@@ -3,7 +3,6 @@ import { AnimatedOutlet } from '@/components/animated-outlet';
 import { ContextList } from '@/components/contexts';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
-import { Badge } from '@/components/primitives/badge';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 
@@ -18,14 +17,7 @@ export const ContextsPage = () => {
     <>
       <PageMeta title="Contexts" />
       <DashboardLayout
-        headerStartItems={
-          <h1 className="text-foreground-950 flex items-center gap-1">
-            Contexts{' '}
-            <Badge color="gray" size="sm" variant="lighter">
-              BETA
-            </Badge>
-          </h1>
-        }
+        headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Contexts</h1>}
       >
         <ContextList />
         <AnimatedOutlet />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the "Beta" badge from the Contexts page header in the dashboard. Contexts is no longer in beta, so the label is no longer needed.

## Changes

- Removed the `Badge` component and its import from `apps/dashboard/src/pages/contexts.tsx`
- Simplified the page header to match other stable pages (e.g. Topics, Subscribers)

## Test plan

- [x] Verified no linter errors in the modified file
- [ ] Open the Contexts page in the dashboard and confirm the header shows "Contexts" without a Beta badge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7a9e39c-3691-44d1-a7ad-58797601e3c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7a9e39c-3691-44d1-a7ad-58797601e3c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the beta label from the dashboard Contexts page. The main changes are:

- Removed the unused `Badge` import from `apps/dashboard/src/pages/contexts.tsx`.
- Updated the Contexts page header to show only `Contexts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to removing a visual label and an unused import.

The diff is small, localized to a single dashboard page, and aligns with the stated product copy update.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to start the contexts-beta-badge Vite app; the startup failed with SyntaxError: The requested module 'node:util' does not provide an export named 'styleText' under Node v20.9.0.
- Inspected the header sources to verify the badge context layout; base header contains \<Badge\> BETA \</Badge\> and head header contains only \<h1 ...\>Contexts\</h1\>.
- Tried to capture before/after UI videos but could not produce valid recordings; the result is inconclusive.

<a href="https://app.greptile.com/trex/runs/12417235/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): remove Beta badge from c..."](https://github.com/novuhq/novu/commit/0846cec3331799339eda74c63d3b322e05ea9039) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40081783)</sub>

<!-- /greptile_comment -->