### PR TITLE
docs(docs): add authentication page and REST API overview fixes DOC-375

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,47 +1,91 @@
 ---
 title: 'Overview'
-description: "Complete Novu API reference covering authentication, endpoints, rate limits, and server-side integration for notifications."
+description: 'High-level overview of the Novu REST API, available resources, and links to OpenAPI, Postman, SDKs, and getting started guides.'
 ---
 
-<Note>
-  It's important to note that our API and backend SDK are intended for use exclusively in
-  server-side applications. **Attempting to use them in a client-side application will result in
-  Cross-Origin Resource Sharing (CORS) errors.** This restriction ensures the security and integrity
-  of our services.
-</Note>
-
-## Authentication
-
-Authentication for the Novu API involves the use of an API Key, which is a secure credential that is tied to your Novu account. This key should be included in the header of the request in the Authorization field as a string prefixed with 'ApiKey '.
-
-```bash
---header 'Authorization: ApiKey <NOVU_SECRET_KEY>'
-```
-
-For example, when using Novu in a Node.js application, the Novu package should be imported and initialized with the API key, as shown in this snippet:
-
-```javascript
-import { Novu } from '@novu/api';
-const novu = new Novu({
-  secretKey: "NOVU_SECRET_KEY",
-});
-```
-
-Replace `<NOVU_SECRET_KEY>` with your actual API Key, available in the API Key section of the Novu Dashboard.
-
-<Warning>
-  It is advised not to hardcode your credentials in a file in production environments. Use
-  environment variables instead.
-</Warning>
-
-## API Endpoints
-
-Novu provides a multitude of API endpoints that enable a variety of functionalities. the base URL for the Novu API is `https://api.novu.co/v1`.
+The Novu REST API lets you manage subscribers, trigger workflows, configure integrations, and operate your notification infrastructure from your backend. Use it directly with HTTP requests, or through one of our [server-side SDKs](/platform/sdks#server-side-sdks).
 
 <Note>
-  We offer two API options: the US API and the EU API. By default, our API documentation refers to the US API, which can be accessed at: https://api.novu.co/v1.
-
-  If you require the EU version, you can access it here: https://eu.api.novu.co/v1.
+  The REST API and server-side SDKs are intended for server-side applications only. Using them in client-side code causes Cross-Origin Resource Sharing (CORS) errors and exposes your secret key.
 </Note>
 
-For instance, to get tenant information, the endpoint to use would include the tenant's identifier and look like this `https://api.novu.co/v1/tenants/{identifier}`.
+## Base URL
+
+| Region | Base URL |
+| --- | --- |
+| **US (default)** | `https://api.novu.co/v1` |
+| **EU** | `https://eu.api.novu.co/v1` |
+
+All endpoints in this reference use the US base URL unless noted otherwise. See [Authentication](/api-reference/authentication) for regional WebSocket hostnames and credential setup.
+
+## API capabilities
+
+The REST API is organized around the core resources you use to build and operate notifications:
+
+<Columns cols={2}>
+  <Card title="Events" icon="zap" href="/api-reference/events/trigger-event">
+    Trigger, bulk trigger, broadcast, and cancel workflow executions.
+  </Card>
+  <Card title="Subscribers" icon="users" href="/api-reference/subscribers/create-a-subscriber">
+    Create, update, and manage notification recipients and their preferences.
+  </Card>
+  <Card title="Inbox" icon="inbox" href="/api-reference/subscribers/retrieve-subscriber-notifications">
+    Read, mark, archive, snooze, and manage in-app notifications.
+  </Card>
+  <Card title="Topics" icon="hash" href="/api-reference/topics/create-a-topic">
+    Group subscribers and send notifications to topic audiences.
+  </Card>
+  <Card title="Workflows" icon="git-branch" href="/api-reference/workflows/create-a-workflow">
+    Create, sync, and manage notification workflow definitions.
+  </Card>
+  <Card title="Integrations" icon="plug" href="/api-reference/integrations/create-an-integration">
+    Configure channel providers for email, SMS, push, and chat delivery.
+  </Card>
+  <Card title="Environments" icon="server" href="/api-reference/environments/list-all-environments">
+    Manage environments and publish resources between them.
+  </Card>
+  <Card title="Messages" icon="message-square" href="/api-reference/messages/list-all-messages">
+    List and delete sent messages across channels.
+  </Card>
+</Columns>
+
+Browse the sidebar for the full endpoint reference, including translations, contexts, layouts, channel connections, and activity tracking.
+
+## Developer resources
+
+Use these resources to explore, test, and integrate with the API:
+
+<Columns cols={2}>
+  <Card title="OpenAPI specification" icon="file-json" href="https://api.novu.co/openapi.json">
+    Machine-readable API schema for code generation, validation, and tooling.
+  </Card>
+  <Card title="Postman collection" icon="send" href="https://github.com/novuhq/novu-postman/blob/main/postman/novu_api_postman_collection.json">
+    Pre-built requests to test endpoints in Postman or compatible tools.
+  </Card>
+  <Card title="Server-side SDKs" icon="code" href="/platform/sdks#server-side-sdks">
+    Official SDKs for TypeScript, Python, Go, PHP, .NET, and Java.
+  </Card>
+  <Card title="Authentication" icon="key" href="/api-reference/authentication">
+    Set up API keys, environment credentials, and security best practices.
+  </Card>
+</Columns>
+
+### Import the Postman collection
+
+1. Clone or download the [novu-postman](https://github.com/novuhq/novu-postman) repository.
+2. Import `postman/novu_api_postman_collection.json` into Postman.
+3. Set the `secretKey` collection variable to your environment's secret key from the [API Keys](https://dashboard.novu.co/api-keys) page.
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Copy your environment's secret key from the [Novu Dashboard](https://dashboard.novu.co/api-keys). See [Authentication](/api-reference/authentication) for details on credential types and security.
+  </Step>
+  <Step title="Make your first request">
+    Trigger a workflow or create a subscriber using the REST API or an SDK. Start with [Trigger event](/api-reference/events/trigger-event) or [Create a subscriber](/api-reference/subscribers/create-a-subscriber).
+  </Step>
+  <Step title="Review API policies">
+    Understand [Rate limiting](/api-reference/rate-limiting), [Idempotency](/api-reference/idempotency), and [Payload limits](/api-reference/payload-limits) before building production integrations.
+  </Step>
+</Steps>

--- a/docs/api-reference/authentication.mdx
+++ b/docs/api-reference/authentication.mdx
@@ -1,0 +1,123 @@
+---
+title: 'Authentication'
+description: 'Authenticate REST API requests with your Novu secret key, manage environment credentials, and follow security best practices.'
+---
+
+The Novu REST API uses API key authentication. Every server-side request must include your environment's secret key in the `Authorization` header.
+
+<Note>
+  The REST API and server-side SDKs are intended for server-side applications only. Using them in client-side code causes Cross-Origin Resource Sharing (CORS) errors and exposes your secret key.
+</Note>
+
+## API key authentication
+
+Include your secret key in the `Authorization` header, prefixed with `ApiKey`:
+
+```bash
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+```
+
+Example request:
+
+```bash
+curl -X GET https://api.novu.co/v1/subscribers \
+  --header 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+```
+
+### Initialize the SDK
+
+When using a server-side SDK, pass your secret key during initialization:
+
+```javascript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({
+  secretKey: process.env.NOVU_SECRET_KEY,
+});
+```
+
+<Warning>
+  Do not hardcode credentials in source code. Store your secret key in environment variables or a secrets manager.
+</Warning>
+
+## Credential types
+
+Each Novu environment has two credentials. Use the right one for the context:
+
+| Credential | Visibility | Used for |
+| --- | --- | --- |
+| **Secret key** | Private | Authenticating REST API and server-side SDK requests |
+| **Application identifier** | Public | Initializing the [`<Inbox />`](/platform/inbox) component and client-side SDKs |
+
+The secret key grants full administrative access to your environment. Never expose it in frontend code, public repositories, or browser network requests.
+
+The application identifier is safe to use in client-side code. It identifies your application within Novu but does not authorize API requests on its own.
+
+## Find your API keys
+
+1. Log in to the [Novu Dashboard](https://dashboard.novu.co).
+2. Go to **Developer** → **API Keys**.
+3. Select the environment you want to use (Development, Production, or a custom environment).
+
+Each environment has its own secret key and application identifier. Use the credentials that match the environment you are targeting.
+
+![API Keys](/images/developer-tools/api-keys.png)
+
+<Card title="API keys" icon="key" href="/platform/developer/api-keys">
+  Learn more about application identifiers, secret keys, and API hostnames.
+</Card>
+
+## Environment-specific credentials
+
+API keys are scoped to a single environment. Requests authenticated with a secret key only access resources in that environment.
+
+- **Development** — Build and test workflows, subscribers, and integrations.
+- **Production** — Send live notifications to subscribers.
+- **Custom environments** — Available on Team and Enterprise plans for staging, QA, or other release stages.
+
+When you regenerate a secret key in the dashboard, the previous key is invalidated immediately. Update your environment variables before rotating keys in production.
+
+## API base URLs
+
+Use the base URL that matches your Novu Cloud region:
+
+| Region | Base URL |
+| --- | --- |
+| **US (default)** | `https://api.novu.co/v1` |
+| **EU** | `https://eu.api.novu.co/v1` |
+
+When using the EU region, also configure the WebSocket hostname for real-time Inbox updates:
+
+| Region | WebSocket URL |
+| --- | --- |
+| **US (default)** | `wss://ws.novu.co` |
+| **EU** | `wss://eu.socket.novu.co` |
+
+<Note>
+  Self-hosted deployments use your own API hostname. See [Self Hosting Novu](/community/self-hosting-novu/overview) for configuration details.
+</Note>
+
+## Security best practices
+
+- Store secret keys in environment variables or a secrets manager — never commit them to version control.
+- Use separate credentials for development and production environments.
+- Rotate secret keys from the dashboard if a key may have been exposed.
+- Restrict server-side API access to trusted backend services only.
+- Enable [HMAC encryption](/platform/inbox/prepare-for-production#secure-your-inbox-with-hmac-encryption) for Inbox to prevent subscriber impersonation in client-side applications.
+
+## Authentication errors
+
+If authentication fails, the API returns a `401 Unauthorized` response. Common causes:
+
+- Missing or malformed `Authorization` header
+- Secret key from a different environment than the target resources
+- Expired or regenerated secret key that has not been updated in your application
+
+Verify that your header uses the `ApiKey` prefix (not `Bearer`) and that the secret key matches the active environment.
+
+## Related documentation
+
+- [Overview](/api-reference) — REST API capabilities and developer resources
+- [Rate Limiting](/api-reference/rate-limiting) — Request limits by plan and endpoint category
+- [Idempotency](/api-reference/idempotency) — Requires API key authentication
+- [Environments](/platform/developer/environments) — How environments isolate resources and credentials

--- a/docs/api-reference/authentication.mdx
+++ b/docs/api-reference/authentication.mdx
@@ -119,5 +119,5 @@ Verify that your header uses the `ApiKey` prefix (not `Bearer`) and that the sec
 
 - [Overview](/api-reference) — REST API capabilities and developer resources
 - [Rate Limiting](/api-reference/rate-limiting) — Request limits by plan and endpoint category
-- [Idempotency](/api-reference/idempotency) — Requires API key authentication
+- [Idempotency](/api-reference/idempotency) — Prevent duplicate requests by replaying responses for the same idempotency key
 - [Environments](/platform/developer/environments) — How environments isolate resources and credentials

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -436,9 +436,10 @@
         "tab": "API Reference",
         "groups": [
           {
-            "group": "Getting Started",
+            "group": "Overview",
             "pages": [
               "api-reference",
+              "api-reference/authentication",
               "api-reference/rate-limiting",
               "api-reference/idempotency",
               "api-reference/payload-limits"
@@ -1167,6 +1168,11 @@
     {
       "source": "/api-reference/overview",
       "destination": "/api-reference",
+      "permanent": true
+    },
+    {
+      "source": "/api-reference/auth",
+      "destination": "/api-reference/authentication",
       "permanent": true
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The API Reference overview previously mixed authentication details with general API information. This change separates concerns and gives developers clearer entry points.

- Added a dedicated **Authentication** page under the API Reference **Overview** section with comprehensive guidance on API keys, credential types, environment scoping, regional base URLs, security best practices, and common auth errors
- Updated the **Overview** page to focus on REST API capabilities, developer resources, and getting started steps
- Renamed the API Reference navigation group from "Getting Started" to "Overview"
- Added redirects for `/api-reference/auth` → `/api-reference/authentication`

**Developer resources linked from the overview:**
- OpenAPI spec: https://api.novu.co/openapi.json
- Postman collection: https://github.com/novuhq/novu-postman/blob/main/postman/novu_api_postman_collection.json
- Server-side SDKs and related API policy pages (rate limiting, idempotency, payload limits)

### Screenshots

N/A — documentation content changes only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff4bc135-3fd8-42bb-bdf2-7d1dd1ae8e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff4bc135-3fd8-42bb-bdf2-7d1dd1ae8e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates API authentication guidance from the API Reference overview. The main changes are:

- Added a dedicated `Authentication` page for API keys, credential types, environment scoping, regional URLs, and common auth errors.
- Refocused the `Overview` page on REST API capabilities, developer resources, base URLs, and getting started steps.
- Renamed the API Reference navigation group to `Overview` and added a redirect from `/api-reference/auth` to `/api-reference/authentication`.

<h3>Confidence Score: 5/5</h3>

Documentation-only updates are safe to merge.

The changes are limited to MDX documentation content and navigation metadata, with no application logic or runtime behavior changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The API Reference navigation was updated to include api-reference/authentication, and a dedicated authentication page was created with sections for API key authentication, credential types, environment scoping, regional hosts, security best practices, and authentication errors.
- A navigation redirect test was run and passed, confirming that the API Reference starts with Overview and that /api-reference/auth redirects permanently to /api-reference/authentication.

<a href="https://app.greptile.com/trex/runs/12419023/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Update docs/api-reference/authentication..."](https://github.com/novuhq/novu/commit/7f959979019c7f3c67d01471d7e7bc8c1f159db9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40083891)</sub>

<!-- /greptile_comment -->