### PR TITLE
docs(docs): redirect /getting-started to Next.js quickstart fixes DOC-376

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1131,6 +1131,16 @@
       "permanent": true
     },
     {
+      "source": "/getting-started",
+      "destination": "/platform/quickstart/nextjs",
+      "permanent": true
+    },
+    {
+      "source": "/getting-started/:slug*",
+      "destination": "/platform/quickstart/nextjs",
+      "permanent": true
+    },
+    {
       "source": "/quickstart",
       "destination": "/platform/quickstart/nextjs",
       "permanent": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Mintlify redirects so legacy `docs.novu.co/getting-started` URLs resolve to the Next.js quickstart at `/platform/quickstart/nextjs`.

## Changes

- `/getting-started` → `/platform/quickstart/nextjs`
- `/getting-started/:slug*` → `/platform/quickstart/nextjs` (covers legacy `/getting-started/introduction` links)

Placed alongside existing `/get-started` and `/quickstart` redirects in `docs/docs.json`.

## Why

Legacy links in `apps/api/swagger-spec.json` and the Next.js starter template still point at `/getting-started/introduction`, which currently 404s.

## Verification

After Mintlify deploys on merge:

- `https://docs.novu.co/getting-started` → `/platform/quickstart/nextjs`
- `https://docs.novu.co/getting-started/introduction` → `/platform/quickstart/nextjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8c31949-3a51-49d5-a248-1c42df9c162f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8c31949-3a51-49d5-a248-1c42df9c162f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds redirects for legacy getting started docs URLs. The main changes are:

- Redirect `/getting-started` to `/platform/quickstart/nextjs`.
- Redirect `/getting-started/:slug*` to `/platform/quickstart/nextjs`.
- Keep the new redirects alongside existing quickstart redirects in `docs/docs.json`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to Mintlify documentation redirects.

The update is narrowly scoped to a docs configuration file and no code issues were identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The proof run executed four commands to verify route contract matches for /getting-started and /getting-started/introduction, and all commands exited with code 0.

<a href="https://app.greptile.com/trex/runs/12550910/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: redirect /getting-started to Next...."](https://github.com/novuhq/novu/commit/57198a55421f82ed47c0c8894e5fd3446dc34855) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40353640)</sub>

<!-- /greptile_comment -->