### PR TITLE
docs(inbox): sync styling page with appearance keys fixes DOC-378

### DIFF
--- a/docs/platform/inbox/configuration/styling.mdx
+++ b/docs/platform/inbox/configuration/styling.mdx
@@ -11,9 +11,10 @@ The appearance prop supports the following keys:
 - `variables`: Define global styling properties (for example, colors, fonts).
 - `elements`: Style individual UI components.
 - `icons`: Replace default icons with custom ones.
+- `animations`: Enable or disable UI animations.
 
 <Note>
-  Check out the [Inbox Playground](https://inbox.novu.co) to see how the Inbox looks with common design presets. It showcases pre-styled variants like Notion and Reddit. helpful for seeing what’s possible before you start customizing.
+  Check out the [Inbox Playground](https://inbox.novu.co) to see how the Inbox looks with common design presets. It showcases pre-styled variants like Notion and Reddit, which is helpful for seeing what’s possible before you start customizing.
 </Note>
 
 ### Understand style injection
@@ -96,8 +97,10 @@ export default Novu;
 | `colorCounterForeground` | `string` | The text color used in notification counters. |
 | `colorNeutral` | `string` | A neutral color used for borders or backgrounds. |
 | `colorShadow` | `string` | The color of shadows applied to elements. |
+| `colorRing` | `string` | The color used for focus rings on interactive elements. |
 | `fontSize` | `string` | The base font size for text in the inbox. |
 | `borderRadius` | `string` | The border radius applied to various elements. |
+| `colorStripes` | `string` | The accent color used for striped loading indicators. |
 
 ## Style the Inbox UI elements
 
@@ -129,11 +132,12 @@ Here's a list of some available elements that can be styled using the elements o
 | Day schedule copy menu       | `dayScheduleCopy__dropdownContent`      |
 | Time select drop-down list         | `timeSelect__dropdownTrigger`           |
 | Time select list             | `timeSelect__dropdownContent`           |
+| Inbox popover content        | `inbox__popoverContent`                 |
 
 <Note>
   **How to find other elements?**
 
-  Any selector that appears before the 🔔 emoji in the Devtools, can be targeted via the elements property in the appearance prop (stripping the `nv-` prefix). You can also use TS autocomplete to find the available elements.
+  Any selector that appears before the 🔔 emoji in the Devtools can be targeted via the `elements` property in the appearance prop (stripping the `nv-` prefix). You can also use TypeScript autocomplete to find the available elements. For the complete list of Inbox element keys, see the [React SDK appearance reference](/platform/sdks/react#appearance-configuration).
 </Note>
 
 <Tabs>
@@ -254,7 +258,7 @@ export default Novu;
 You can customize specific parts of the Inbox UI by providing callback functions for certain keys. This function receives contextual information such as unread counts, notification data, or preference details and let you apply styles dynamically based on runtime values from your application.
 
 <AccordionGroup>
-  <Accordion title="List of elemets that can be customize using the callback function">
+  <Accordion title="List of elements that can be customized using a callback function">
   | Key       | Context signature|
 |-----------|------------------|
 | **Bell**  |                  |
@@ -333,7 +337,8 @@ You can customize specific parts of the Inbox UI by providing callback functions
 | `scheduleContainer`                       | `(context: { schedule?: Schedule }) => string`                  |
 | `scheduleHeader`                          | `(context: { schedule?: Schedule }) => string`                  |
 | `scheduleLabelContainer`                  | `(context: { schedule?: Schedule }) => string`                  |
-| `scheduleLabelIcon`                       | `(context: { schedule?: Schedule }) => string`                  |
+| `scheduleLabelScheduleIcon`               | `(context: { schedule?: Schedule }) => string`                  |
+| `scheduleLabelInfoIcon`                   | `(context: { schedule?: Schedule }) => string`                  |
 | `scheduleLabel`                           | `(context: { schedule?: Schedule }) => string`                  |
 | `scheduleActionsContainer`                | `(context: { schedule?: Schedule }) => string`                  |
 | `scheduleActionsContainerRight`           | `(context: { schedule?: Schedule }) => string`                  |
@@ -489,7 +494,7 @@ This table lists severity element keys:
 
 ## Responsive Inbox using CSS media queries
 
-In mobile and smaller device, use `popoverContent` element and apply custom CSS class on it. Specify CSS media queries on this class and add this class in global CSS file so that it takes effect. In below example, we have applied media queries on the `novu-popover-content` class and added it in global CSS file.
+On mobile and smaller devices, use the `inbox__popoverContent` element and apply a custom CSS class to it. Specify CSS media queries on this class and add the class in a global CSS file so that it takes effect. In the example below, media queries are applied to the `novu-inbox-popover-content` class in a global CSS file.
 
 ```tsx title="ResponsiveInbox.tsx"
 import { Inbox } from '@novu/react';
@@ -501,7 +506,7 @@ const ResponsiveInbox = () => {
       subscriber="YOUR_SUBSCRIBER_ID"
       appearance={{
         elements: {
-          popoverContent: "novu-popover-content",
+          inbox__popoverContent: "novu-inbox-popover-content",
         },
       }}
     />
@@ -512,24 +517,24 @@ export default ResponsiveInbox;
 ```
 
 ```css title="global.css"
-.novu-popover-content {
+.novu-inbox-popover-content {
   max-width: 500px;
 }
 
 @media (max-width: 768px) {
-  .novu-popover-content {
+  .novu-inbox-popover-content {
     max-width: 350px;
   }
 }
 
 @media (max-width: 480px) {
-  .novu-popover-content {
+  .novu-inbox-popover-content {
     max-width: 250px;
   }
 }
 
 @media (max-width: 320px) {
-  .novu-popover-content {
+  .novu-inbox-popover-content {
     max-width: 200px;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reviewed `docs/platform/inbox/configuration/styling.mdx` against the Inbox appearance API in `packages/js/src/ui/config/appearanceKeys.ts` and `packages/js/src/ui/types.ts`.

The styling page had a few concrete mismatches with the actual available keys. This PR brings the page back in sync.

## Changes

- Document the `animations` appearance prop key
- Add missing design token variables: `colorRing` and `colorStripes`
- Fix incorrect schedule callback keys (`scheduleLabelIcon` → `scheduleLabelScheduleIcon` + `scheduleLabelInfoIcon`)
- Update the responsive Inbox example to target `inbox__popoverContent` instead of the generic `popoverContent` key
- Link to the React SDK appearance reference for the full element key list
- Minor copy/grammar fixes

## Verification

Compared docs content programmatically against:
- `commonAppearanceKeys` + `inboxAppearanceKeys` (245 total element keys)
- `Variables` type (14 variables)
- `InboxAppearanceCallback` (88 callback-capable keys)

The React SDK reference (`docs/platform/sdks/react.mdx`) already contains the complete key inventory and remains the canonical exhaustive list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03b68c74-b06f-4050-9f99-48a9ccf4a770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b68c74-b06f-4050-9f99-48a9ccf4a770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Inbox styling documentation to match the current appearance API. The main changes are:

- Adds the `animations` appearance prop key.
- Documents the `colorRing` and `colorStripes` variables.
- Replaces the old schedule callback key with `scheduleLabelScheduleIcon` and `scheduleLabelInfoIcon`.
- Updates the responsive Inbox example to use `inbox__popoverContent`.
- Links to the React SDK appearance reference for the full element key list.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is documentation-only and aligns the styling page with existing Inbox appearance API keys.

The modified file is limited to documentation, with no runtime code paths, migrations, configuration, or generated assets affected.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I inspected the before-state evidence and confirmed that the docs-sync-appearance-keys-01-before.txt showed multiple failures in the appearance keys checks.
- I updated the appearance-keys documentation to correct the documented keys, example, link, and copy, aligning it with the intended appearance reference.
- I re-ran the verification and confirmed that the after-state shows all checks passing (12/12) as indicated by the docs-sync-appearance-keys-02-after.txt.
- I captured and saved logs documenting the before and after results for review.

<a href="https://app.greptile.com/trex/runs/12552365/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(inbox): sync styling page with inbo..."](https://github.com/novuhq/novu/commit/21f72f94ebe3d3c7bedef2699503c3e589cb0fd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40356654)</sub>

<!-- /greptile_comment -->