### PR TITLE
fix(dashboard): prevent agent setup step text column from collapsing fixes NV-8138

### DIFF
--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -153,9 +153,7 @@ export function SetupStep({
           {extraContent}
         </div>
         {rightContent && (
-          <div className="flex min-h-0 w-full shrink-0 flex-col items-start md:max-w-[50%] lg:w-[420px] lg:max-w-none xl:w-[460px]">
-            {rightContent}
-          </div>
+          <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-start md:max-w-[460px]">{rightContent}</div>
         )}
       </div>
       {fullWidthContent}


### PR DESCRIPTION
## Summary

Fixes a regression in the **agent onboarding / overview setup guide** where each step's left text column (eyebrow + title + description) collapsed to a near-zero width, wrapping **one word per line**.

## Root cause

Introduced in NV-8125 (#11655, commit `8422391b0a`). The shared `SetupStep` right column was changed from a fluid, shrinkable column to a fixed-width, **non-shrinking** column sized by **viewport** breakpoints:

- before: `flex min-h-0 min-w-0 flex-1 ...`
- after: `flex min-h-0 w-full shrink-0 ... lg:w-[420px] lg:max-w-none xl:w-[460px]`

`SetupStep` renders inside a **narrow** container on the agent details page — the ~300px `AgentSidebarWidget`, the app nav, and card paddings consume most of the horizontal space. Because `lg:`/`xl:` are **viewport** breakpoints (not container-aware), once the browser window is >= 1024px the right column is pinned to a fixed 420/460px and refuses to shrink (`shrink-0`), starving the `flex-1` left column down to ~0 width.

## Fix

Make the right column fluid and shrinkable again, with a max-width cap to preserve the intent of not over-stretching the control on wide screens:

```
flex min-h-0 w-full min-w-0 flex-1 flex-col items-start md:max-w-[460px]
```

This is container-width agnostic, so it behaves correctly on both the narrow agent details page and the wide onboarding flow, and applies to every `SetupStep` consumer (email, Telegram, Slack, WhatsApp, Teams, listen/code steps).

## Before / After

| | Left column width | Result |
|---|---|---|
| Before | ~0-60px | title/description wrap one word per line |
| After | balanced (~50%, right capped at 460px) | normal multi-word lines |

## Testing

- Lint/format clean on the edited file (biome via lint-staged).
- Verified the flexbox behavior with an isolated side-by-side reproduction at the real-world condition (narrow ~480px steps container + wide viewport): the *before* classes collapse the left column to one-word-per-line; the *after* classes restore the balanced two-column layout.

CSS-only change; no logic or behavioral changes, no breaking changes.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a layout regression in the `SetupStep` component where the right column's `shrink-0` and viewport-fixed widths (`lg:w-[420px]`, `xl:w-[460px]`) starved the left text column to near-zero width inside the narrow `AgentSidebarWidget` container. The fix replaces the fixed/non-shrinking column with a fluid `flex-1 min-w-0 md:max-w-[460px]` approach.

- **Right column** was changed from `shrink-0` + viewport breakpoint widths to `flex-1 min-w-0 md:max-w-[460px]`, making it container-aware and able to shrink.
- Both left and right columns are now `flex-1`, splitting available space equally up to the 460 px cap, which restores balanced two-column layout on both the narrow agent details page and the wide onboarding flow.

<h3>Confidence Score: 5/5</h3>

This is a CSS-only, single-line change that restores balanced flex layout in a shared component with no logic or behavioral side effects.

The change removes a shrink-0 + viewport-fixed-width combination that was starving the left text column in narrow containers. The replacement flex-1 min-w-0 md:max-w-[460px] is container-agnostic and correct for both the narrow agent sidebar and the wide onboarding flow. The only note is that w-full is retained alongside flex-1, which is redundant but harmless.

No files require special attention; the single changed line is isolated to the right-column wrapper div inside SetupStep.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/setup-guide-primitives.tsx | Right column of SetupStep changed from shrink-0 + viewport-based fixed widths to flex-1 + min-w-0 + md:max-w-[460px], fixing the text collapse in narrow containers. The w-full class is kept alongside flex-1, which is slightly redundant in flex-row but needed for flex-col (mobile) stacking. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SetupStep container\nflex-row at md+] --> B[Left column\nflex-1 min-w-0]
    A --> C[Right column]

    subgraph Before
        C1["shrink-0 w-full\nlg:w-[420px] xl:w-[460px]"]
    end

    subgraph After
        C2["flex-1 min-w-0\nmd:max-w-[460px]"]
    end

    C --> Before
    C --> After

    Before -->|"Narrow container + lg viewport\nRight column pinned at 420px\nLeft column collapses to ~0"| D[❌ One word per line]
    After -->|"Both columns flex-1\nRight capped at 460px\nLeft gets remaining space"| E[✅ Balanced two-column layout]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SetupStep container\nflex-row at md+] --> B[Left column\nflex-1 min-w-0]
    A --> C[Right column]

    subgraph Before
        C1["shrink-0 w-full\nlg:w-[420px] xl:w-[460px]"]
    end

    subgraph After
        C2["flex-1 min-w-0\nmd:max-w-[460px]"]
    end

    C --> Before
    C --> After

    Before -->|"Narrow container + lg viewport\nRight column pinned at 420px\nLeft column collapses to ~0"| D[❌ One word per line]
    After -->|"Both columns flex-1\nRight capped at 460px\nLeft gets remaining space"| E[✅ Balanced two-column layout]
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Fsetup-guide-primitives.tsx%3A156%0AThe%20%60w-full%60%20class%20on%20a%20%60flex-1%60%20flex%20item%20is%20redundant%20in%20the%20flex-row%20layout%20%28md%2B%29.%20%60flex-1%60%20sets%20%60flex-basis%3A%200%25%60%20which%20overrides%20%60width%60%20in%20the%20flex%20algorithm%2C%20so%20%60w-full%60%20has%20no%20effect%20there.%20It%20does%20still%20apply%20in%20the%20mobile%20flex-col%20stacking%2C%20but%20Tailwind's%20%60flex-1%60%20already%20makes%20the%20item%20take%20full%20width%20in%20that%20context%20too.%20Dropping%20%60w-full%60%20keeps%20the%20intent%20clearer%20and%20avoids%20any%20cross-browser%20ambiguity%20when%20both%20are%20set.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%22flex%20min-h-0%20min-w-0%20flex-1%20flex-col%20items-start%20md%3Amax-w-%5B460px%5D%22%3E%7BrightContent%7D%3C%2Fdiv%3E%0A%60%60%60%0A%0A&pr=11688&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/agents/setup-guide-primitives.tsx:156
The `w-full` class on a `flex-1` flex item is redundant in the flex-row layout (md+). `flex-1` sets `flex-basis: 0%` which overrides `width` in the flex algorithm, so `w-full` has no effect there. It does still apply in the mobile flex-col stacking, but Tailwind's `flex-1` already makes the item take full width in that context too. Dropping `w-full` keeps the intent clearer and avoids any cross-browser ambiguity when both are set.

```suggestion
          <div className="flex min-h-0 min-w-0 flex-1 flex-col items-start md:max-w-[460px]">{rightContent}</div>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): prevent agent setup step..."](https://github.com/novuhq/novu/commit/ccc1d52326877a17a8f2a64964f270a6dc73c98d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40366789)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->