### PR TITLE
chore(js): add repository and homepage metadata fixes NV-8139

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@novu/js",
   "version": "3.17.0",
-  "repository": "https://github.com/novuhq/novu",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/novuhq/novu",
+    "directory": "packages/js"
+  },
+  "homepage": "https://novu.co",
   "description": "Novu JavaScript SDK for <Inbox />",
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `@novu/js` package.json metadata with `@novu/react` by adding structured repository metadata and a homepage field.

## Changes

- Updated `repository` from a plain URL string to a structured object with `type`, `url`, and `directory: "packages/js"`
- Added `homepage: "https://novu.co"`

## Why

This improves npm package discoverability and links the package back to its source directory in the monorepo, matching the metadata pattern already used by `@novu/react`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-092bab33-5ef6-4503-8e89-be429bd59fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-092bab33-5ef6-4503-8e89-be429bd59fe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `@novu/js` package metadata for npm. The main changes are:

- Structured `repository` metadata with `type`, `url`, and `directory` fields.
- Added a `homepage` field pointing to `https://novu.co`.
- Aligned `@novu/js` metadata with the existing `@novu/react` package pattern.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to package metadata and does not affect runtime code.

The updated fields are standard package metadata and align with the neighboring package pattern.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the Before log trex-artifacts/package-metadata-01-before.log to verify npm pack succeeded and base metadata were as expected (repository https://github.com/novuhq/novu; homepage absent).
- Reviewed the After log trex-artifacts/package-metadata-02-after.log to verify npm pack succeeded and head metadata reflects repository.type git, repository.url https://github.com/novu, directory packages/js, and homepage https://novu.co.
- Compared the Before and After logs to confirm the metadata evolved as expected from base to head.

<a href="https://app.greptile.com/trex/runs/12562238/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(js): add repository and homepage m..."](https://github.com/novuhq/novu/commit/a1db2ec955836c329a91672fa4111c1aa3c1d29e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40374079)</sub>

<!-- /greptile_comment -->