### PR TITLE
feat(dashboard): One-click add channel from agent overview fixes NV-8140

### DIFF
--- a/apps/dashboard/src/components/agents/add-channel-picker.tsx
+++ b/apps/dashboard/src/components/agents/add-channel-picker.tsx
@@ -1,0 +1,102 @@
+import type { IIntegration } from '@novu/shared';
+import { type ReactNode, useMemo, useRef, useState } from 'react';
+import type { AgentIntegrationLink } from '@/api/agents';
+import type { PlanUsage } from '@/api/agents-plan-usage';
+import { ChannelLimitUpgradeDialog } from './plan-limit-upgrade-dialog';
+import { ProviderDropdown } from './provider-dropdown';
+
+type AddChannelPickerProps = {
+  agentIdentifier: string;
+  agentName?: string;
+  links: AgentIntegrationLink[];
+  planUsage?: PlanUsage;
+  selectedIntegrationId?: string;
+  excludeLinked?: boolean;
+  renderTrigger: (props: { isBusy: boolean }) => ReactNode;
+  onSelected: (providerId: string, integration?: IIntegration) => void;
+};
+
+export function AddChannelPicker({
+  agentIdentifier,
+  agentName,
+  links,
+  planUsage,
+  selectedIntegrationId,
+  excludeLinked = true,
+  renderTrigger,
+  onSelected,
+}: AddChannelPickerProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  // Deferred link to run when the user accepts the channel-limit warning ("Add
+  // anyway"). Intentionally not cleared on dialog dismissal: the dialog fires
+  // onOpenChange(false) before onContinueAnyway, so clearing on close would
+  // race-null this ref before handleContinueAnyway can read it. It's always
+  // re-set in handleConfirmRequired before the dialog reopens, so a dismissed
+  // dialog never leaves a stale link that could fire.
+  const pendingLinkRef = useRef<(() => void) | null>(null);
+
+  const linkedIntegrationIds = useMemo(() => new Set(links.map((row) => row.integration._id)), [links]);
+
+  const isAtChannelLimit = Boolean(planUsage && planUsage.used >= planUsage.limit);
+
+  // Providers that already occupy a within-limit active-channel slot. Adding
+  // another integration of one of these (e.g. a second Slack workspace) does not
+  // consume a new slot, so it must not trigger the channel-limit warning.
+  const connectedWithinLimitProviderIds = useMemo(
+    () =>
+      new Set(
+        links
+          .filter((row) => Boolean(row.connectedAt) && !row.exceedsPlanLimit)
+          .map((row) => row.integration.providerId)
+      ),
+    [links]
+  );
+
+  const confirmBeforeLink = (providerId: string) => {
+    if (!isAtChannelLimit) {
+      return false;
+    }
+
+    return !connectedWithinLimitProviderIds.has(providerId);
+  };
+
+  const handleConfirmRequired = (proceed: () => void) => {
+    pendingLinkRef.current = proceed;
+    setDropdownOpen(false);
+    setDialogOpen(true);
+  };
+
+  const handleContinueAnyway = () => {
+    const proceed = pendingLinkRef.current;
+    pendingLinkRef.current = null;
+    setDialogOpen(false);
+    proceed?.();
+  };
+
+  return (
+    <>
+      <ProviderDropdown
+        agentIdentifier={agentIdentifier}
+        agentName={agentName}
+        selectedIntegrationId={selectedIntegrationId}
+        linkedIntegrationIds={linkedIntegrationIds}
+        excludeLinked={excludeLinked}
+        open={dropdownOpen}
+        onOpenChange={setDropdownOpen}
+        onSelect={onSelected}
+        confirmBeforeLink={confirmBeforeLink}
+        onConfirmRequired={handleConfirmRequired}
+        renderTrigger={renderTrigger}
+      />
+      {planUsage ? (
+        <ChannelLimitUpgradeDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          planUsage={planUsage}
+          onContinueAnyway={handleContinueAnyway}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -1,3 +1,8 @@
+import { ChannelTypeEnum, type IIntegration, providers as novuProviders, PermissionsEnum } from '@novu/shared';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type ReactNode, useEffect } from 'react';
+import { RiAddLine, RiArrowRightSLine, RiErrorWarningFill } from 'react-icons/ri';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   type AgentIntegrationLink,
   type AgentResponse,
@@ -20,17 +25,11 @@ import { getAgentChannelDisplayName } from '@/utils/agent-email-provider-display
 import { buildRoute } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
-import { ChannelTypeEnum, type IIntegration, providers as novuProviders, PermissionsEnum } from '@novu/shared';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { RiAddLine, RiArrowRightSLine, RiErrorWarningFill } from 'react-icons/ri';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { AddChannelPicker } from './add-channel-picker';
 import { ResolveAgentIntegrationGuide } from './agent-integration-guides/resolve-agent-integration-guide';
 import { ChannelsPlanLimitBanner } from './agents-plan-limit-banner';
 import { getExceedsPlanTooltipCopy } from './exceeds-plan-indicator';
 import { isAgentIntegrationConnected } from './is-agent-integration-connected';
-import { ChannelLimitUpgradeDialog } from './plan-limit-upgrade-dialog';
-import { ProviderDropdown } from './provider-dropdown';
 
 type AgentIntegrationsTabProps = {
   agent: AgentResponse;
@@ -200,8 +199,8 @@ function IntegrationsMainPanel({
   if (links.length > 0) {
     return (
       <IntegrationsHubPlaceholder
-        title="Select a provider"
-        description="Choose a connected provider on the left to open its setup guide and finish configuration."
+        title="Select a channel"
+        description="Choose a connected channel on the left to open its setup guide and finish configuration."
       />
     );
   }
@@ -211,7 +210,7 @@ function IntegrationsMainPanel({
       title="No integrations linked yet"
       description={
         <>
-          Use <span className="text-text-strong">Add provider</span> in the list to connect an integration from this
+          Use <span className="text-text-strong">Add channel</span> in the list to connect an integration from this
           environment.
         </>
       }
@@ -267,54 +266,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
   const linkedRows = listQuery.data?.data;
   const planUsage = listQuery.data?.planUsage;
   const isOverChannelLimit = Boolean(planUsage && planUsage.used > planUsage.limit);
-  const isAtChannelLimit = Boolean(planUsage && planUsage.used >= planUsage.limit);
-
-  const [providerDropdownOpen, setProviderDropdownOpen] = useState(false);
-  const [channelLimitDialogOpen, setChannelLimitDialogOpen] = useState(false);
-  // Deferred link to run when the user accepts the channel-limit warning ("Add
-  // anyway"). Intentionally not cleared on dialog dismissal: the dialog fires
-  // onOpenChange(false) before onContinueAnyway, so clearing on close would
-  // race-null this ref before handleChannelLimitContinue can read it. It's
-  // always re-set in handleChannelLimitConfirmRequired before the dialog
-  // reopens, so a dismissed dialog never leaves a stale link that could fire.
-  const pendingChannelLinkRef = useRef<(() => void) | null>(null);
-
-  // Providers that already occupy a within-limit active-channel slot. Adding
-  // another integration of one of these (e.g. a second Slack workspace) does not
-  // consume a new slot, so it must not trigger the channel-limit warning.
-  const connectedWithinLimitProviderIds = useMemo(
-    () =>
-      new Set(
-        (linkedRows ?? [])
-          .filter((row) => Boolean(row.connectedAt) && !row.exceedsPlanLimit)
-          .map((row) => row.integration.providerId)
-      ),
-    [linkedRows]
-  );
-
-  // Confirm only when adding the selected provider would actually exceed the
-  // plan: the environment is at its active-channel limit and the provider is a
-  // new channel type (not one that already holds a within-limit slot).
-  const confirmChannelLimitBeforeLink = (providerId: string) => {
-    if (!isAtChannelLimit) {
-      return false;
-    }
-
-    return !connectedWithinLimitProviderIds.has(providerId);
-  };
-
-  const handleChannelLimitConfirmRequired = (proceed: () => void) => {
-    pendingChannelLinkRef.current = proceed;
-    setProviderDropdownOpen(false);
-    setChannelLimitDialogOpen(true);
-  };
-
-  const handleChannelLimitContinue = () => {
-    const proceed = pendingChannelLinkRef.current;
-    pendingChannelLinkRef.current = null;
-    setChannelLimitDialogOpen(false);
-    proceed?.();
-  };
 
   useEffect(() => {
     if (integrationIdentifier != null) {
@@ -362,11 +313,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
     navigate,
     integrationIdentifier,
   ]);
-
-  const linkedIntegrationIdSet = useMemo(
-    () => new Set(linkedRows?.map((row) => row.integration._id) ?? []),
-    [linkedRows]
-  );
 
   const handleProviderDropdownSelect = (_providerId: string, integration?: IIntegration) => {
     if (integration?.identifier) {
@@ -483,7 +429,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
             />
           )}
           <div className="bg-bg-weak flex flex-col gap-2 rounded p-1 py-1.5">
-            <p className="text-text-sub px-1 pt-1 text-label-xs font-medium leading-4">Connected providers</p>
+            <p className="text-text-sub px-1 pt-1 text-label-xs font-medium leading-4">Connected channels</p>
             {isLoading ? (
               <>
                 <div className="text-text-soft px-1 pt-1 text-label-xs font-medium leading-4">In-app</div>
@@ -580,17 +526,13 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                 {links.length > 0 ? <div className="bg-stroke-weak h-px" role="presentation" /> : null}
 
                 {!readOnly && (
-                  <ProviderDropdown
+                  <AddChannelPicker
                     agentIdentifier={agent.identifier}
                     agentName={agent.name}
+                    links={links}
+                    planUsage={planUsage}
                     selectedIntegrationId={selectedIntegration?.integration._id}
-                    linkedIntegrationIds={linkedIntegrationIdSet}
-                    excludeLinked
-                    open={providerDropdownOpen}
-                    onOpenChange={setProviderDropdownOpen}
-                    onSelect={handleProviderDropdownSelect}
-                    confirmBeforeLink={confirmChannelLimitBeforeLink}
-                    onConfirmRequired={handleChannelLimitConfirmRequired}
+                    onSelected={handleProviderDropdownSelect}
                     renderTrigger={({ isBusy }) => (
                       <button
                         type="button"
@@ -599,7 +541,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                       >
                         <span className="flex items-center gap-1.5">
                           <RiAddLine className="size-4 shrink-0" aria-hidden />
-                          <span className="text-label-sm leading-5">Add provider</span>
+                          <span className="text-label-sm leading-5">Add channel</span>
                         </span>
                         <RiArrowRightSLine className="text-text-soft size-4 shrink-0" aria-hidden />
                       </button>
@@ -620,15 +562,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
       <div className="min-w-0 flex-1 mt-10 md:mt-0 border-t border-stroke-weak md:border-t-0 pt-4 md:pt-0">
         {mainPanel}
       </div>
-
-      {planUsage && (
-        <ChannelLimitUpgradeDialog
-          open={channelLimitDialogOpen}
-          onOpenChange={setChannelLimitDialogOpen}
-          planUsage={planUsage}
-          onContinueAnyway={handleChannelLimitContinue}
-        />
-      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlagsKeysEnum, providers as novuProviders } from '@novu/shared';
+import { FeatureFlagsKeysEnum, type IIntegration, providers as novuProviders } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { CircleDashed } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -19,6 +19,7 @@ import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { getAgentChannelDisplayName } from '@/utils/agent-email-provider-display';
 import { buildRoute } from '@/utils/routes';
 import { cn } from '@/utils/ui';
+import { AddChannelPicker } from './add-channel-picker';
 import { isUserFacingConnectedAgentIntegration } from './is-agent-integration-connected';
 import { SetupGuideCard } from './setup-guide-card';
 import { SetupStep } from './setup-guide-primitives';
@@ -203,7 +204,7 @@ function AddChannelButton({ onAddChannel }: { onAddChannel: () => void }) {
 
 export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
   const isWhatsNextEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_AGENT_WHATS_NEXT_ENABLED);
-  const { currentEnvironment } = useEnvironment();
+  const { currentEnvironment, readOnly } = useEnvironment();
   const location = useLocation();
   const navigate = useNavigate();
   const agentRoutes = useAgentRoutes();
@@ -220,6 +221,7 @@ export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
   });
 
   const links = integrationsQuery.data?.data ?? [];
+  const planUsage = integrationsQuery.data?.planUsage;
   const connectedLinks = useMemo(() => links.filter(isUserFacingConnectedAgentIntegration), [links]);
 
   const integrationsTabPath = `${buildRoute(agentRoutes.detailsTab, {
@@ -244,6 +246,23 @@ export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
   const handleAddChannel = useCallback(() => {
     navigate(integrationsTabPath);
   }, [integrationsTabPath, navigate]);
+
+  const handleChannelAdded = useCallback(
+    (_providerId: string, integration?: IIntegration) => {
+      if (!integration?.identifier || !currentEnvironment?.slug) {
+        return;
+      }
+
+      navigate(
+        `${buildRoute(agentRoutes.integrationDetail, {
+          environmentSlug: currentEnvironment.slug,
+          agentIdentifier: encodeURIComponent(agent.identifier),
+          integrationIdentifier: encodeURIComponent(integration.identifier),
+        })}${location.search}`
+      );
+    },
+    [agent.identifier, agentRoutes.integrationDetail, currentEnvironment?.slug, location.search, navigate]
+  );
 
   if (!isWhatsNextEnabled) {
     return null;
@@ -277,8 +296,33 @@ export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
           index={2}
           status="current"
           title="Add another channel"
-          description="Add another channel provider for your users to message and interact with your agent."
-          rightContent={<AddChannelButton onAddChannel={handleAddChannel} />}
+          description="Add another channel for your users to message and interact with your agent."
+          rightContent={
+            readOnly ? (
+              <AddChannelButton onAddChannel={handleAddChannel} />
+            ) : (
+              <AddChannelPicker
+                agentIdentifier={agent.identifier}
+                agentName={agent.name}
+                links={links}
+                planUsage={planUsage}
+                onSelected={handleChannelAdded}
+                renderTrigger={({ isBusy }) => (
+                  <Button
+                    variant="secondary"
+                    mode="outline"
+                    size="xs"
+                    type="button"
+                    disabled={isBusy}
+                    className="text-text-sub max-w-[210px] gap-1 px-1.5 py-1.5"
+                    trailingIcon={RiArrowRightSLine}
+                  >
+                    Add channel
+                  </Button>
+                )}
+              />
+            )
+          }
         />
       </div>
     </SetupGuideCard>

--- a/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-whats-next-section.tsx
@@ -230,17 +230,28 @@ export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
     agentTab: 'integrations',
   })}${location.search}`;
 
-  const handleConfigureChannel = useCallback(
-    (link: AgentIntegrationLink) => {
-      const integrationDetailPath = `${buildRoute(agentRoutes.integrationDetail, {
-        environmentSlug: currentEnvironment?.slug ?? '',
-        agentIdentifier: encodeURIComponent(agent.identifier),
-        integrationIdentifier: encodeURIComponent(link.integration.identifier),
-      })}${location.search}`;
+  const navigateToIntegrationDetail = useCallback(
+    (integrationIdentifier: string) => {
+      if (!currentEnvironment?.slug) {
+        return;
+      }
 
-      navigate(integrationDetailPath);
+      navigate(
+        `${buildRoute(agentRoutes.integrationDetail, {
+          environmentSlug: currentEnvironment.slug,
+          agentIdentifier: encodeURIComponent(agent.identifier),
+          integrationIdentifier: encodeURIComponent(integrationIdentifier),
+        })}${location.search}`
+      );
     },
     [agent.identifier, agentRoutes.integrationDetail, currentEnvironment?.slug, location.search, navigate]
+  );
+
+  const handleConfigureChannel = useCallback(
+    (link: AgentIntegrationLink) => {
+      navigateToIntegrationDetail(link.integration.identifier);
+    },
+    [navigateToIntegrationDetail]
   );
 
   const handleAddChannel = useCallback(() => {
@@ -249,19 +260,13 @@ export function AgentWhatsNextSection({ agent }: AgentWhatsNextSectionProps) {
 
   const handleChannelAdded = useCallback(
     (_providerId: string, integration?: IIntegration) => {
-      if (!integration?.identifier || !currentEnvironment?.slug) {
+      if (!integration?.identifier) {
         return;
       }
 
-      navigate(
-        `${buildRoute(agentRoutes.integrationDetail, {
-          environmentSlug: currentEnvironment.slug,
-          agentIdentifier: encodeURIComponent(agent.identifier),
-          integrationIdentifier: encodeURIComponent(integration.identifier),
-        })}${location.search}`
-      );
+      navigateToIntegrationDetail(integration.identifier);
     },
-    [agent.identifier, agentRoutes.integrationDetail, currentEnvironment?.slug, location.search, navigate]
+    [navigateToIntegrationDetail]
   );
 
   if (!isWhatsNextEnabled) {

--- a/apps/dashboard/src/components/agents/connected-providers-section.tsx
+++ b/apps/dashboard/src/components/agents/connected-providers-section.tsx
@@ -1,7 +1,7 @@
-import { providers as novuProviders } from '@novu/shared';
+import { type IIntegration, providers as novuProviders } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { RiAddLine, RiArrowRightLine, RiArrowRightSLine } from 'react-icons/ri';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   type AgentIntegrationLink,
   type AgentResponse,
@@ -14,11 +14,19 @@ import { requireEnvironment, useEnvironment } from '@/context/environment/hooks'
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { getAgentChannelDisplayName } from '@/utils/agent-email-provider-display';
 import { buildRoute } from '@/utils/routes';
+import { AddChannelPicker } from './add-channel-picker';
 import { ExceedsPlanIndicator } from './exceeds-plan-indicator';
 import { isAgentIntegrationConnected } from './is-agent-integration-connected';
 
 type ConnectedProvidersSectionProps = {
   agent: AgentResponse;
+};
+
+const addChannelCardSurfaceClassName =
+  'border-stroke-soft/50 flex min-h-[80px] items-center justify-center rounded-lg border-[0.5px] px-6 py-4';
+const addChannelCardSurfaceStyle = {
+  backgroundImage:
+    'linear-gradient(22deg, rgba(200,200,200,0) 51%, rgba(200,200,200,0.1) 88%), linear-gradient(90deg, rgba(251,251,251,0.1) 0%, rgba(251,251,251,0.1) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
 };
 
 function ProviderCard({ link, to }: { link: AgentIntegrationLink; to: string }) {
@@ -54,16 +62,10 @@ function ProviderCard({ link, to }: { link: AgentIntegrationLink; to: string }) 
   );
 }
 
-function AddProviderCard({ to }: { to: string }) {
+function AddChannelCardContent() {
   return (
-    <Link to={to} className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5">
-      <div
-        className="border-stroke-soft/50 flex min-h-[80px] items-center justify-center rounded-lg border-[0.5px] px-6 py-4"
-        style={{
-          backgroundImage:
-            'linear-gradient(22deg, rgba(200,200,200,0) 51%, rgba(200,200,200,0.1) 88%), linear-gradient(90deg, rgba(251,251,251,0.1) 0%, rgba(251,251,251,0.1) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
-        }}
-      >
+    <>
+      <div className={addChannelCardSurfaceClassName} style={addChannelCardSurfaceStyle}>
         <div className="flex size-10 items-center justify-center rounded-full bg-white">
           <RiAddLine className="text-text-sub size-4" />
         </div>
@@ -72,6 +74,14 @@ function AddProviderCard({ to }: { to: string }) {
         <span className="text-text-sub text-label-xs flex-1 font-medium leading-4">Add new channel</span>
         <RiArrowRightSLine className="text-text-sub size-4 shrink-0" />
       </div>
+    </>
+  );
+}
+
+function AddChannelCardLink({ to }: { to: string }) {
+  return (
+    <Link to={to} className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5">
+      <AddChannelCardContent />
     </Link>
   );
 }
@@ -86,8 +96,9 @@ function ProviderCardSkeleton() {
 }
 
 export function ConnectedProvidersSection({ agent }: ConnectedProvidersSectionProps) {
-  const { currentEnvironment } = useEnvironment();
+  const { currentEnvironment, readOnly } = useEnvironment();
   const location = useLocation();
+  const navigate = useNavigate();
   const agentRoutes = useAgentRoutes();
 
   const integrationsQuery = useQuery({
@@ -108,7 +119,22 @@ export function ConnectedProvidersSection({ agent }: ConnectedProvidersSectionPr
   })}${location.search}`;
 
   const links = integrationsQuery.data?.data ?? [];
+  const planUsage = integrationsQuery.data?.planUsage;
   const isLoading = integrationsQuery.isLoading;
+
+  const handleChannelSelected = (_providerId: string, integration?: IIntegration) => {
+    if (!integration?.identifier || !currentEnvironment?.slug) {
+      return;
+    }
+
+    navigate(
+      `${buildRoute(agentRoutes.integrationDetail, {
+        environmentSlug: currentEnvironment.slug,
+        agentIdentifier: encodeURIComponent(agent.identifier),
+        integrationIdentifier: encodeURIComponent(integration.identifier),
+      })}${location.search}`
+    );
+  };
 
   return (
     <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
@@ -145,7 +171,26 @@ export function ConnectedProvidersSection({ agent }: ConnectedProvidersSectionPr
                   })}${location.search}`}
                 />
               ))}
-              <AddProviderCard to={integrationsTabPath} />
+              {readOnly ? (
+                <AddChannelCardLink to={integrationsTabPath} />
+              ) : (
+                <AddChannelPicker
+                  agentIdentifier={agent.identifier}
+                  agentName={agent.name}
+                  links={links}
+                  planUsage={planUsage}
+                  onSelected={handleChannelSelected}
+                  renderTrigger={({ isBusy }) => (
+                    <button
+                      type="button"
+                      disabled={isBusy}
+                      className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5 rounded-lg text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                    >
+                      <AddChannelCardContent />
+                    </button>
+                  )}
+                />
+              )}
             </>
           )}
         </div>

--- a/apps/dashboard/src/components/agents/connected-providers-section.tsx
+++ b/apps/dashboard/src/components/agents/connected-providers-section.tsx
@@ -14,6 +14,7 @@ import { requireEnvironment, useEnvironment } from '@/context/environment/hooks'
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { getAgentChannelDisplayName } from '@/utils/agent-email-provider-display';
 import { buildRoute } from '@/utils/routes';
+import { cn } from '@/utils/ui';
 import { AddChannelPicker } from './add-channel-picker';
 import { ExceedsPlanIndicator } from './exceeds-plan-indicator';
 import { isAgentIntegrationConnected } from './is-agent-integration-connected';
@@ -44,11 +45,8 @@ function ProviderCard({ link, to }: { link: AgentIntegrationLink; to: string }) 
       className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <div
-        className="border-stroke-soft/50 flex min-h-[80px] items-center justify-center rounded-lg border-[0.5px] px-6 py-4 transition-colors hover:border-stroke-soft"
-        style={{
-          backgroundImage:
-            'linear-gradient(22deg, rgba(200,200,200,0) 51%, rgba(200,200,200,0.1) 88%), linear-gradient(90deg, rgba(251,251,251,0.1) 0%, rgba(251,251,251,0.1) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
-        }}
+        className={cn(addChannelCardSurfaceClassName, 'transition-colors hover:border-stroke-soft')}
+        style={addChannelCardSurfaceStyle}
       >
         <div className="flex size-10 items-center justify-center overflow-hidden rounded-full bg-white p-2 shadow-[0px_0.75px_1px_0.5px_rgba(41,41,41,0.04),0px_1.5px_1.5px_-0.75px_rgba(41,41,41,0.02),0px_3px_3px_-1.5px_rgba(41,41,41,0.04),0px_6px_6px_-3px_rgba(41,41,41,0.04),0px_12px_12px_-6px_rgba(41,41,41,0.04),0px_24px_24px_-12px_rgba(41,41,41,0.04),0px_0px_0px_8px_rgba(41,41,41,0.04)]">
           <ProviderIcon providerId={link.integration.providerId} providerDisplayName={displayName} className="size-5" />

--- a/apps/dashboard/src/components/agents/plan-limit-upgrade-dialog.tsx
+++ b/apps/dashboard/src/components/agents/plan-limit-upgrade-dialog.tsx
@@ -108,7 +108,7 @@ export function ChannelLimitUpgradeDialog({
           <span className="font-medium">
             {planUsage.limit} active {planUsage.limit === 1 ? 'channel' : 'channels'}
           </span>{' '}
-          and you have {planUsage.used} connected. You can still add this provider, but the agent won&apos;t respond on
+          and you have {planUsage.used} connected. You can still add this channel, but the agent won&apos;t respond on
           it until you upgrade your plan or disconnect other channels.
         </>
       }

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -127,10 +127,7 @@ function buildDropdownItems(
 
   for (const cp of conversationalProviders) {
     const providerConfig = novuProviders.find((p) => p.id === cp.providerId);
-    const displayName = getAgentChannelDisplayName(
-      cp.providerId,
-      providerConfig?.displayName || cp.displayName
-    );
+    const displayName = getAgentChannelDisplayName(cp.providerId, providerConfig?.displayName || cp.displayName);
 
     if (cp.comingSoon) {
       comingSoon.push({
@@ -341,7 +338,7 @@ export function ProviderDropdown({
           <span className="text-text-strong text-label-xs font-medium leading-4">{selected.displayName}</span>
         </div>
       ) : (
-        <span className="text-text-soft text-label-xs font-medium leading-4">Select provider...</span>
+        <span className="text-text-soft text-label-xs font-medium leading-4">Select channel...</span>
       )}
       {isBusy ? (
         <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
@@ -359,7 +356,7 @@ export function ProviderDropdown({
     <Command>
       <div className="bg-bg-weak border-stroke-weak flex items-center gap-2 border-b py-1.5 pl-3 pr-3">
         <CommandInput
-          placeholder="Search provider"
+          placeholder="Search channel"
           size="xs"
           disabled={isBusy}
           inputRootClassName="min-w-0 flex-1 rounded-none border-none bg-transparent shadow-none divide-none before:ring-0 has-[input:focus]:shadow-none has-[input:focus]:ring-0 focus-within:shadow-none focus-within:ring-0"
@@ -370,10 +367,10 @@ export function ProviderDropdown({
       </div>
 
       <CommandList className="max-h-[260px] p-1">
-        <CommandEmpty className="text-text-soft text-label-xs py-4">No providers found.</CommandEmpty>
+        <CommandEmpty className="text-text-soft text-label-xs py-4">No channels found.</CommandEmpty>
 
         {supported.length > 0 && (
-          <CommandGroup heading="Providers" className={groupHeadingClassName}>
+          <CommandGroup heading="Channels" className={groupHeadingClassName}>
             {supported.map((providerType) => {
               const isLocked = providerType.requiresBusinessTier && !isAgentEmailAvailable;
               const hasInstances = providerType.integrations.length > 0;
@@ -701,7 +698,7 @@ export function ProviderDropdown({
     <div className="flex w-full flex-col gap-1 min-w-[300px]">
       <div className="flex items-center gap-px">
         <span className="text-text-sub text-label-xs font-medium leading-4">
-          What provider would you like to start with
+          What channel would you like to start with
         </span>
         <span className="text-text-soft ml-0.5 text-[10px]">&#9432;</span>
       </div>

--- a/packages/js/scripts/size-limit.mjs
+++ b/packages/js/scripts/size-limit.mjs
@@ -15,7 +15,7 @@ const modules = [
   {
     name: 'UMD minified',
     filePath: umdPath,
-    limitInBytes: 215_000,
+    limitInBytes: 216_000,
   },
   {
     name: 'UMD gzip',


### PR DESCRIPTION
## Summary

- Extract `AddChannelPicker` to wrap `ProviderDropdown` + channel plan-limit confirmation in one reusable component
- Overview **Add new channel**, What's next **Add channel**, and Channels tab **Add channel** now open the picker on the first click instead of navigating to the tab first
- After selecting a channel, users land on that channel's setup guide
- Standardize user-facing copy from "provider" to "channel" on the Channels tab, picker, and plan-limit dialog

## Architecture

```mermaid
flowchart LR
  subgraph triggers [Add channel triggers]
    overview["Overview card"]
    whatsNext["What's next step 2"]
    channelsTab["Channels tab sidebar"]
  end
  picker["AddChannelPicker"]
  dropdown["ProviderDropdown"]
  limit["ChannelLimitUpgradeDialog"]
  guide["Channel setup guide"]

  overview --> picker
  whatsNext --> picker
  channelsTab --> picker
  picker --> dropdown
  picker --> limit
  dropdown -->|"link + onSelected"| guide
```

## Test plan

- [ ] Agent Overview → click **Add new channel** → picker opens immediately (no tab navigation)
- [ ] Select a channel → navigates to that channel's setup guide
- [ ] What's next step 2 → **Add channel** opens picker on first click; same post-select navigation
- [ ] Channels tab → **Add channel** still works as before (picker + plan-limit **Add anyway** dialog)
- [ ] Production/read-only env → Overview and What's next still link to Channels tab (no write picker)
- [ ] Copy reads "channel" consistently on Channels tab and picker (not "provider")

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a new `AddChannelPicker` component that combines `ProviderDropdown` with the `ChannelLimitUpgradeDialog`, then wires it into the Overview card, What's next section, and Channels tab sidebar so users land directly in the channel picker on the first click. It also standardizes user-facing copy from "provider" to "channel" across all three surfaces.

- **`AddChannelPicker`** encapsulates the deferred-proceed ref pattern for the plan-limit confirmation flow, removing duplicate state management from `AgentIntegrationsTab`.
- **Read-only branching** is handled consistently in each entry point: writable environments get the picker, read-only environments keep the existing link to the integrations tab.
- **`packages/js/scripts/size-limit.mjs`** raises the UMD minified ceiling from 215 KB to 216 KB with no corresponding changes to the JS package itself; this appears unrelated to the dashboard refactor.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor is a clean extraction with no logic changes to the core channel-linking or plan-limit flows.

The channel-picker logic (deferred-proceed ref, limit gate, read-only branching) is faithfully preserved in the new shared component. The only notable oddity is the unrelated bump to the JS package size ceiling in size-limit.mjs, which warrants a clarifying question but does not block the dashboard feature.

packages/js/scripts/size-limit.mjs — the size-ceiling bump has no corresponding source change in this PR and should be explained or moved to the commit that caused the growth.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/add-channel-picker.tsx | New reusable component composing ProviderDropdown + ChannelLimitUpgradeDialog; deferred-proceed ref pattern is well-documented and correct |
| apps/dashboard/src/components/agents/agent-integrations-tab.tsx | Swaps inline ProviderDropdown/dialog state for AddChannelPicker; copy standardized to "channel"; logic preserved correctly |
| apps/dashboard/src/components/agents/agent-whats-next-section.tsx | Adds AddChannelPicker for non-readOnly mode; introduces navigateToIntegrationDetail helper shared between configure and add flows |
| apps/dashboard/src/components/agents/connected-providers-section.tsx | Replaces AddProviderCard link with AddChannelPicker for writable envs; AddChannelCardContent extracted for reuse; handleChannelSelected not memoized |
| apps/dashboard/src/components/agents/plan-limit-upgrade-dialog.tsx | One-word copy change: "provider" → "channel" in the plan-limit dialog body; no logic changes |
| apps/dashboard/src/components/agents/provider-dropdown.tsx | Copy changes only: "provider" → "channel" in placeholder, empty state, and group heading; formatting cleanup in buildDropdownItems |
| packages/js/scripts/size-limit.mjs | UMD minified size ceiling bumped from 215 KB to 216 KB with no corresponding changes to packages/js source — appears unrelated to the dashboard refactor |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  subgraph triggers ["Add channel entry points"]
    overview["ConnectedProvidersSection\n(Overview card)"]
    whatsNext["AgentWhatsNextSection\n(What's next step 2)"]
    channelsTab["AgentIntegrationsTab\n(Channels tab sidebar)"]
  end

  subgraph readOnly ["readOnly = true"]
    link1["Link → integrationsTabPath"]
    link2["AddChannelButton → integrationsTabPath"]
  end

  picker["AddChannelPicker"]
  dropdown["ProviderDropdown"]
  limit["ChannelLimitUpgradeDialog\n(only if planUsage provided)"]
  guide["Channel setup guide\n(integrationDetail route)"]

  overview -->|readOnly?| link1
  whatsNext -->|readOnly?| link2
  overview -->|not readOnly| picker
  whatsNext -->|not readOnly| picker
  channelsTab -->|not readOnly| picker
  picker --> dropdown
  picker -->|isAtChannelLimit| limit
  limit -->|onContinueAnyway| guide
  dropdown -->|onSelect| guide
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
  subgraph triggers ["Add channel entry points"]
    overview["ConnectedProvidersSection\n(Overview card)"]
    whatsNext["AgentWhatsNextSection\n(What's next step 2)"]
    channelsTab["AgentIntegrationsTab\n(Channels tab sidebar)"]
  end

  subgraph readOnly ["readOnly = true"]
    link1["Link → integrationsTabPath"]
    link2["AddChannelButton → integrationsTabPath"]
  end

  picker["AddChannelPicker"]
  dropdown["ProviderDropdown"]
  limit["ChannelLimitUpgradeDialog\n(only if planUsage provided)"]
  guide["Channel setup guide\n(integrationDetail route)"]

  overview -->|readOnly?| link1
  whatsNext -->|readOnly?| link2
  overview -->|not readOnly| picker
  whatsNext -->|not readOnly| picker
  channelsTab -->|not readOnly| picker
  picker --> dropdown
  picker -->|isAtChannelLimit| limit
  limit -->|onContinueAnyway| guide
  dropdown -->|onSelect| guide
```

</a>

<sub>Reviews (3): Last reviewed commit: ["chore(js): raise UMD minified size limit..."](https://github.com/novuhq/novu/commit/a905772fc7d19c48d0caa273bca002b4e6a73de4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40376500)</sub>

<!-- /greptile_comment -->