### PR TITLE
docs(root): add Cursor skills for new channel onboarding flows fixes NV-8141

### DIFF
--- a/.cursor/skills/add-channel-connect-button/SKILL.md
+++ b/.cursor/skills/add-channel-connect-button/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: add-channel-connect-button
+description: >-
+  Build a new channel Connect button (e.g. WhatsApp, Discord, LINE) in @novu/js
+  and @novu/react following the existing SlackConnectButton, MsTeamsConnectButton,
+  and TelegramConnectButton pattern. Use when adding connect/disconnect UI for a
+  new chat channel/provider to the SDK — covering the SolidJS core component, the
+  React wrapper, the channelConnections (OAuth) vs channelEndpoints (deep-link)
+  data layer, the component registry, and package exports.
+---
+
+# Add a Channel Connect Button
+
+Build `<Channel>ConnectButton` for a new chat provider, mirroring `Slack`, `MsTeams`,
+and `Telegram`. The button lets a subscriber connect (open OAuth popup / deep link)
+and disconnect a channel, with loading + connected states.
+
+## Architecture (3 layers)
+
+```
+packages/js (SolidJS core)          packages/react (public wrapper)
+─────────────────────────           ──────────────────────────────
+<Channel>ConnectButton.tsx   ◄────  Default<Channel>ConnectButton.tsx  (Mounter → mountComponent)
+  uses a data hook                  <Channel>ConnectButton.tsx          (memo → NovuUI → withRenderer)
+  calls novu.channel*  SDK
+registered in Renderer.tsx
+```
+
+The React component mounts the SolidJS component by **name** through `novuUI.mountComponent`.
+That name must be registered in `packages/js/src/ui/components/Renderer.tsx`.
+
+## Step 0 — Pick the connection model (do this first)
+
+This single decision drives which SDK module, hook, and props you use.
+
+| | Connection-based — like **Slack, MS Teams** | Endpoint-based — like **Telegram** |
+|---|---|---|
+| Use when | Provider authorizes at **workspace/tenant** level via OAuth | Subscriber links by opening a **deep link**; no workspace auth |
+| SDK module | `novu.channelConnections` | `novu.channelEndpoints` |
+| Connect call | `generateConnectOAuthUrl()` → OAuth popup URL | `link({ integrationIdentifier })` → deep-link URL |
+| Detect / poll | `get(connectionIdentifier)` | `list({ providerId, integrationIdentifier, limit: 1 })` |
+| Data hook | reuse `useChannelConnection` | new `use<Channel>Connection` (list-based, copy `useTelegramConnection`) |
+| Extra props | `connectionIdentifier`, `context`, `scope`, `connectionMode`, `autoLinkUser` | none beyond the base props |
+| Identifier | `buildDefaultConnectionIdentifier(...)` from `components/constants.ts` | not needed |
+
+If unsure: OAuth/app-install provider → **connection-based**; bot deep-link/token provider → **endpoint-based**.
+
+## File checklist
+
+Copy the nearest sibling for your model (Slack/MS Teams = connection, Telegram = endpoint),
+then rename. Full templates: see [reference.md](reference.md).
+
+**Core — `packages/js`**
+- [ ] CREATE `src/ui/icons/<Channel>Colored.tsx` — brand icon (copy `TelegramColored.tsx`)
+- [ ] CREATE `src/ui/components/<channel>-connect-button/<Channel>ConnectButton.tsx`
+- [ ] CREATE *(endpoint model only)* `src/ui/api/hooks/use<Channel>Connection.ts`
+- [ ] EDIT `src/ui/components/Renderer.tsx` — import it, add to `novuComponents`, add the name string to `CHANNEL_COMPONENTS`
+- [ ] EDIT `src/ui/components/index.ts` — `export * from './<channel>-connect-button/<Channel>ConnectButton'`
+- [ ] EDIT `src/ui/index.ts` — re-export `<Channel>ConnectButtonProps` in the type block
+
+**React — `packages/react`**
+- [ ] CREATE `src/components/<channel>-connect-button/Default<Channel>ConnectButton.tsx`
+- [ ] CREATE `src/components/<channel>-connect-button/<Channel>ConnectButton.tsx`
+- [ ] EDIT `src/components/index.ts` — `export * from './<channel>-connect-button/<Channel>ConnectButton'`
+- [ ] EDIT `src/index.ts` — add the component to the value export block and `<Channel>ConnectButtonProps` to the type block
+
+**Usually NOT needed**
+- The `channelConnections` / `channelEndpoints` SDK modules already cover both models. Only add a new method under `packages/js/src/channel-*` if the provider needs a brand-new server call (rare). Backend lives in `apps/api/src/app/channel-connections/`.
+- Never edit `libs/internal-sdk` (auto-generated).
+
+## Button behavior contract
+
+Every connect button implements the same state machine — keep it identical:
+
+- **Initial load**: `<Show when={!loading()} fallback={<Loader/>}>`; derive `isConnected()` from the hook's connection/endpoint, and `isLoading() = loading() || actionLoading()`.
+- **Click when connected** → `disconnect(identifier)` → `onDisconnectSuccess()` / `onDisconnectError(err)`.
+- **Click when not connected** → `setActionLoading(true)`, get the URL, `window.open(url, '_blank', 'noopener,noreferrer')`, then start polling.
+- **Polling** → fixed interval (`2500ms`, `120_000ms` timeout) or backoff (see MS Teams). Use a one-shot `committed` flag / ref so only the **first** success-or-timeout fires side effects. Clear the timer in `onCleanup`.
+- **Resolve** → success: `mutate(found)` + `onConnectSuccess(identifier)`; timeout: `onConnectError(new Error(...))`.
+- **Appearance** → reuse the shared keys `channelConnectButtonContainer | Button | Inner | Icon | Label`, each passed `{ connected }` context. Icons go through `IconRendererWrapper` (keys `channelConnect` / `channelConnected`) with a fallback to `<Channel>Colored` / `CheckCircleFill`. **Do not add new appearance keys** — they are shared across all connect buttons.
+- **Base props** → `integrationIdentifier` (required), `subscriberId?`, `onConnectSuccess?`, `onConnectError?`, `onDisconnectSuccess?`, `onDisconnectError?`, `connectLabel?`, `connectedLabel?`.
+
+## Conventions & gotchas
+
+- The **core is SolidJS, not React**: signals over hooks, `<Show>` over ternaries, read props lazily (`() => props.x`), cleanup via `onCleanup`. The React layer is just a mounting shim.
+- The `name` in `mountComponent({ name: '<Channel>ConnectButton' })` **must** equal the key in `novuComponents` and be listed in `CHANNEL_COMPONENTS`, or it renders through the wrong path.
+- `<Channel>ConnectButtonProps` is defined in the core and imported by React from `@novu/js/ui` — do not redefine it.
+- Novu conventions: lowercase-dashed dirs, named exports, blank line before every `return`, no nested ternaries.
+- These packages are published — new exports are a **minor** bump; keep prop changes additive/backward-compatible.
+
+## Build & verify
+
+1. `pnpm build` (required after changing `packages/`).
+2. Type-check + lint the touched files.
+3. Manual test: add a page/tab in `playground/nextjs` (copy `src/components/telegram-end-user-connect.tsx`) that wraps `<Channel>ConnectButton` in `<NovuProvider>`, then connect/disconnect against a real integration.

--- a/.cursor/skills/add-channel-connect-button/reference.md
+++ b/.cursor/skills/add-channel-connect-button/reference.md
@@ -1,0 +1,301 @@
+# Reference — Channel Connect Button templates
+
+Placeholders: `<Channel>` = PascalCase (`Discord`), `<channel>` = kebab/lower (`discord`),
+`<provider>` = the provider id string used by the API (`discord`).
+
+Pick templates by model (see SKILL.md Step 0). Connection-based mirrors `SlackConnectButton` /
+`MsTeamsConnectButton`; endpoint-based mirrors `TelegramConnectButton`.
+
+---
+
+## 1. Brand icon — `packages/js/src/ui/icons/<Channel>Colored.tsx`
+
+Copy `TelegramColored.tsx` and swap the SVG paths. It receives a `class` prop.
+
+```tsx
+import type { JSX } from 'solid-js';
+
+export const DiscordColored = (props: { class?: string }): JSX.Element => {
+  return (
+    <svg class={props.class} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* brand paths */}
+    </svg>
+  );
+};
+```
+
+---
+
+## 2a. Data hook (endpoint model only) — `packages/js/src/ui/api/hooks/use<Channel>Connection.ts`
+
+Copy `useTelegramConnection.ts`. "Connected" = a subscriber endpoint exists for this
+`providerId` + `integrationIdentifier`. Connection-based buttons skip this and reuse
+`useChannelConnection`.
+
+```ts
+import { createEffect, createResource, createSignal } from 'solid-js';
+import type { ChannelEndpointResponse, LinkChannelEndpointArgs } from '../../../channel-connections/types';
+import { useNovu } from '../../context';
+
+const DISCORD_PROVIDER_ID = 'discord';
+
+export type UseDiscordConnectionOptions = {
+  integrationIdentifier: string;
+  subscriberId?: string;
+};
+
+export const useDiscordConnection = (options: UseDiscordConnectionOptions) => {
+  const novuAccessor = useNovu();
+  const [loading, setLoading] = createSignal(true);
+
+  const [endpoint, { mutate, refetch }] = createResource(
+    options,
+    async ({ integrationIdentifier, subscriberId }): Promise<ChannelEndpointResponse | null> => {
+      try {
+        if (!integrationIdentifier) {
+          return null;
+        }
+
+        const response = await novuAccessor().channelEndpoints.list({
+          integrationIdentifier,
+          providerId: DISCORD_PROVIDER_ID,
+          subscriberId,
+          limit: 1,
+        });
+
+        return response.data?.[0] ?? null;
+      } catch {
+        return null;
+      }
+    }
+  );
+
+  const link = async (args: LinkChannelEndpointArgs) => novuAccessor().channelEndpoints.link(args);
+
+  const disconnect = async (identifier: string) => {
+    setLoading(true);
+    const response = await novuAccessor().channelEndpoints.delete({ identifier });
+    if (!response.error) {
+      mutate(null);
+    }
+    setLoading(false);
+
+    return response;
+  };
+
+  createEffect(() => {
+    setLoading(endpoint.loading);
+  });
+
+  return { endpoint, loading, mutate, refetch, link, disconnect };
+};
+```
+
+---
+
+## 2b. Core component — `packages/js/src/ui/components/<channel>-connect-button/<Channel>ConnectButton.tsx`
+
+Read the full sibling for the exact JSX/appearance markup (it is verbose but identical
+across buttons). The two skeletons below show only what differs by model. Reuse the
+`buttonContent()` + `<Show>` markup verbatim from the sibling, swapping the icon and labels.
+
+### Endpoint model (copy `TelegramConnectButton.tsx`)
+
+```tsx
+const PROVIDER_ID = 'discord';
+const POLL_INTERVAL_MS = 2500;
+const POLL_TIMEOUT_MS = 120_000;
+
+export const DiscordConnectButton = (props: DiscordConnectButtonProps) => {
+  const novuAccessor = useNovu();
+  const integrationIdentifier = () => props.integrationIdentifier;
+  const resolvedSubscriberId = () => props.subscriberId ?? novuAccessor().subscriberId;
+  const { endpoint, loading, disconnect, mutate, link } = useDiscordConnection({
+    integrationIdentifier: integrationIdentifier(),
+    subscriberId: props.subscriberId,
+  });
+  // ...polling with a `committed` one-shot guard, then on click:
+  const result = await link({ integrationIdentifier: integrationIdentifier() });
+  if (result.data?.url) {
+    window.open(result.data.url, '_blank', 'noopener,noreferrer');
+    startPolling(); // polls channelEndpoints.list(...) until data[0] exists
+  }
+};
+```
+
+### Connection model (copy `SlackConnectButton.tsx` / `MsTeamsConnectButton.tsx`)
+
+```tsx
+const connectionMode = () => props.connectionMode ?? 'subscriber';
+const connectionIdentifier = () =>
+  props.connectionIdentifier ??
+  buildDefaultConnectionIdentifier(DEFAULT_DISCORD_CONNECTION_IDENTIFIER, resolvedSubscriberId());
+
+const { connection, loading, disconnect, mutate, generateConnectOAuthUrl } = useChannelConnection({
+  integrationIdentifier: integrationIdentifier(),
+  connectionIdentifier: connectionIdentifier(),
+  subscriberId: props.subscriberId,
+});
+// on click:
+const result = await generateConnectOAuthUrl({
+  integrationIdentifier: integrationIdentifier(),
+  connectionIdentifier: connectionIdentifier(),
+  connectionMode: connectionMode(),
+  autoLinkUser: props.autoLinkUser ?? true,
+});
+if (result.data?.url) {
+  window.open(result.data.url, '_blank', 'noopener,noreferrer');
+  startPolling(); // polls channelConnections.get(connectionIdentifier) until data exists
+}
+```
+
+Add a constant to `packages/js/src/ui/components/constants.ts` for the connection model:
+
+```ts
+export const DEFAULT_DISCORD_CONNECTION_IDENTIFIER = 'chconn-discord-default';
+```
+
+---
+
+## 3. Register + export in `packages/js`
+
+`src/ui/components/Renderer.tsx` — three edits:
+
+```tsx
+import { DiscordConnectButton } from './discord-connect-button/DiscordConnectButton';
+
+export const novuComponents = {
+  // ...existing
+  DiscordConnectButton,
+};
+
+const CHANNEL_COMPONENTS = [
+  // ...existing
+  'DiscordConnectButton',
+];
+```
+
+`src/ui/components/index.ts`:
+
+```ts
+export * from './discord-connect-button/DiscordConnectButton';
+```
+
+`src/ui/index.ts` — add the props type to the existing `*ConnectButtonProps` type export block.
+
+---
+
+## 4. React wrapper — `packages/react`
+
+`src/components/<channel>-connect-button/Default<Channel>ConnectButton.tsx` (copy Telegram's):
+
+```tsx
+import { DiscordConnectButtonProps } from '@novu/js/ui';
+import { useCallback } from 'react';
+import { useNovuUI } from '../../context/NovuUIContext';
+import { Mounter } from '../Mounter';
+
+export type DefaultDiscordConnectButtonProps = Pick<
+  DiscordConnectButtonProps,
+  | 'integrationIdentifier'
+  | 'subscriberId'
+  | 'onConnectSuccess'
+  | 'onConnectError'
+  | 'onDisconnectSuccess'
+  | 'onDisconnectError'
+  | 'connectLabel'
+  | 'connectedLabel'
+>;
+
+export const DefaultDiscordConnectButton = (props: DefaultDiscordConnectButtonProps) => {
+  const { novuUI } = useNovuUI();
+
+  const mount = useCallback(
+    (element: HTMLElement) =>
+      novuUI.mountComponent({
+        name: 'DiscordConnectButton', // MUST match novuComponents key
+        props: { ...props },
+        element,
+      }),
+    [novuUI, props]
+  );
+
+  return <Mounter mount={mount} />;
+};
+```
+
+`src/components/<channel>-connect-button/<Channel>ConnectButton.tsx` (copy Telegram's):
+
+```tsx
+import React, { useMemo } from 'react';
+import { useNovu } from '../../hooks/NovuProvider';
+import { NovuUI, NovuUIOptions } from '../NovuUI';
+import { withRenderer } from '../Renderer';
+import { DefaultDiscordConnectButton, DefaultDiscordConnectButtonProps } from './DefaultDiscordConnectButton';
+
+export type DiscordConnectButtonProps = DefaultDiscordConnectButtonProps &
+  Pick<NovuUIOptions, 'container' | 'appearance'>;
+
+const DiscordConnectButtonInternal = withRenderer<DiscordConnectButtonProps>((props) => {
+  const { container, appearance, ...defaultProps } = props;
+  const novu = useNovu();
+  const options: NovuUIOptions = useMemo(
+    () => ({ container, appearance, options: novu.options }),
+    [container, appearance, novu.options]
+  );
+
+  return (
+    <NovuUI options={options} novu={novu}>
+      <DefaultDiscordConnectButton {...defaultProps} />
+    </NovuUI>
+  );
+});
+
+DiscordConnectButtonInternal.displayName = 'DiscordConnectButtonInternal';
+
+export const DiscordConnectButton = React.memo((props: DiscordConnectButtonProps) => {
+  return <DiscordConnectButtonInternal {...props} />;
+});
+
+DiscordConnectButton.displayName = 'DiscordConnectButton';
+```
+
+`src/components/index.ts`:
+
+```ts
+export * from './discord-connect-button/DiscordConnectButton';
+```
+
+`src/index.ts` — add to both blocks:
+
+```ts
+export type { /* ... */ DiscordConnectButtonProps } from './components';
+export { /* ... */ DiscordConnectButton } from './components';
+```
+
+---
+
+## 5. Worked example — Discord (endpoint model)
+
+```
+Decision: bot deep-link, no workspace OAuth → endpoint-based (like Telegram).
+
+Create:
+  packages/js/src/ui/icons/DiscordColored.tsx
+  packages/js/src/ui/api/hooks/useDiscordConnection.ts
+  packages/js/src/ui/components/discord-connect-button/DiscordConnectButton.tsx
+  packages/react/src/components/discord-connect-button/DefaultDiscordConnectButton.tsx
+  packages/react/src/components/discord-connect-button/DiscordConnectButton.tsx
+Edit:
+  packages/js/src/ui/components/Renderer.tsx           (+import, +novuComponents, +CHANNEL_COMPONENTS)
+  packages/js/src/ui/components/index.ts               (+export)
+  packages/js/src/ui/index.ts                          (+DiscordConnectButtonProps type)
+  packages/react/src/components/index.ts               (+export)
+  packages/react/src/index.ts                          (+component, +props type)
+Then: pnpm build → wire into playground/nextjs → connect/disconnect test.
+```
+
+For a Discord **OAuth/app-install** flow instead, switch to the connection model: drop the
+custom hook, reuse `useChannelConnection`, add `connectionIdentifier`/`context`/`scope`/
+`connectionMode`/`autoLinkUser` props, add `DEFAULT_DISCORD_CONNECTION_IDENTIFIER` to
+`constants.ts`, and poll `channelConnections.get(...)`.

--- a/.cursor/skills/add-channel-setup-guide/SKILL.md
+++ b/.cursor/skills/add-channel-setup-guide/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: add-channel-setup-guide
+description: >-
+  Add a new chat channel's layer-1 setup guide — the in-dashboard
+  <Channel>SetupGuide that walks a developer through connecting the channel
+  itself (create app/bot → save credentials → install/verify → send first
+  message) with live connection detection — in apps/dashboard, following the
+  existing Slack, MS Teams, and Telegram guides. Use when a new agent channel
+  needs its numbered setup stepper, credential drawer wiring, and connectedAt
+  polling under components/agents.
+---
+
+# Add a Channel's Setup Guide (Layer 1)
+
+Layer 1 = connecting the **channel itself**: the numbered stepper a developer follows to
+create the provider app/bot, save its credentials in Novu, install/verify, and send a first
+message — with a live "Listening… / Connected" indicator. `ResolveAgentIntegrationGuide`
+renders this `<Channel>SetupGuide` as the **setup view** until the integration is connected,
+then swaps to the connected/"what's next" view (separate `add-channel-whats-next-onboarding` skill).
+
+Files live in `apps/dashboard/src/components/agents/`. Siblings: `slack-setup-guide.tsx` (quick/manual
+modes + manifest), `teams-setup-guide.tsx`, `telegram-setup-guide.tsx` (simplest), `whatsapp-setup-guide.tsx`.
+
+## How it works
+
+```
+<Channel>SetupGuide
+  ├─ useFetchIntegrations()         → find integration by _id + providerId
+  ├─ SetupStepperRail
+  │    └─ SetupStep × N             → create app · save creds · install/verify
+  │         └─ SetupButton / IntegrationCredentialsSidebar trigger
+  ├─ ListeningStatus                → polls listAgentIntegrations every 1s;
+  │                                    fires onConnected + confetti when connectedAt is set
+  └─ IntegrationCredentialsSidebar  → generic credential save (useUpdateIntegration)
+```
+
+**Connection is detected, not asserted.** A channel is "connected" only when the backend sets
+`connectedAt` on the integration link (on the first real inbound message). Saving credentials or
+finishing OAuth/install does **not** mean connected — keep those as separate local states.
+
+## Building blocks
+
+All from `setup-guide-primitives.tsx` and `setup-guide-step-utils.ts`:
+
+| Symbol | Role |
+|---|---|
+| `SetupStepperRail` | Vertical numbered rail wrapping the steps column |
+| `SetupStep` | One step: `index`, `status`, `title`, `description`, `rightContent?`, `extraContent?`, `fullWidthContent?`, `headerSlot?`, `dimmed?`, `sectionLabel?`, `inlineSectionLabel?` |
+| `SetupButton` | Secondary outline action; `href` opens a new tab, else `onClick`; supports `leadingIcon`, `disabled` |
+| `SetupModeToggle` + `SetupMode` (`'quick' \| 'manual'`) | Optional dual-path setup (Slack) |
+| `IntegrationCredentialsSidebar` | Drawer that saves provider credentials via the generic integration form; `onSaveSuccess`, `agentOnboarding` |
+| `ListeningStatus` | Polls `listAgentIntegrations`; fires `onConnected` + confetti on `connectedAt` |
+| `deriveStepStatus(i, firstIncomplete)` | → `'completed' \| 'current' \| 'upcoming'` |
+| `hasIntegrationCredentials(credentials)` | True once any string credential is saved |
+
+## Step 0 — Prerequisites
+
+- `ChatProviderIdEnum.<Channel>` exists in `@novu/shared`, and the provider exists in `packages/providers` (brand-new providers are ask-first).
+- The integration can be created/selected (the "add provider" flow passes you an `integrationId`).
+
+## File checklist
+
+Copy the closest sibling, then rename. Full template: see [reference.md](reference.md).
+
+- [ ] CREATE `apps/dashboard/src/components/agents/<channel>-setup-guide.tsx` — export `<Channel>SetupGuide`
+- [ ] EDIT `agent-integration-guides/resolve-agent-integration-guide.tsx` — in the setup `switch`, render `<Channel>SetupGuide ... embedded />` and set `setupDisplayName` (the `add-channel-whats-next-onboarding` skill covers the rest of this resolver)
+- [ ] *(optional)* Add a provider-specific server action in `@/api/agents` or `@/api/integrations` only if the channel needs webhook registration / quick-setup / subscriber-link beyond a plain credential save
+
+## Component contract
+
+Props: `{ agent: AgentResponse; integrationId: string; stepOffset?: number; onStepsCompleted?: () => void; embedded?: boolean }`
+(`stepOffset` defaults to 1; Overview mounts the guide at a higher base, the Integrations detail page at 1).
+
+State machine:
+1. Resolve `selectedIntegration` from `useFetchIntegrations()` by `_id === integrationId && providerId === ChatProviderIdEnum.<Channel>`.
+2. Track progress: `hasIntegrationCredentials(...)` ‖ a local `credentialsSavedLocally`, plus any install/connected flags. Reset all of it in `useEffect([integrationId])`.
+3. Derive `const base = stepOffset` → compute `firstIncompleteStep` → `deriveStepStatus(stepIndex, firstIncompleteStep)` per `SetupStep`.
+4. Render the steps in `SetupStepperRail`, then `ListeningStatus` (in a `pl-8` wrapper), then `IntegrationCredentialsSidebar`.
+5. `ListeningStatus.onConnected` → mark connected and call `onStepsCompleted?.()`.
+6. Provide both an `embedded` return (no Overview chrome — used by the resolver) and the standalone return.
+
+## Typical 3-step recipe
+
+1. **Create the app/bot** — `SetupButton href=` the provider console. Optional: a manifest (`CodeBlock`, escape injected values) or a quick-setup input that calls a server action.
+2. **Save credentials in Novu** — `SetupButton onClick={() => setIsCredentialsSidebarOpen(true)}`; the sidebar's `onSaveSuccess` flips `credentialsSavedLocally` (and may trigger a provider action like webhook registration).
+3. **Install / verify + send first message** — a provider connect button or copyable instructions; `ListeningStatus` watches for `connectedAt`.
+
+## Conventions & gotchas
+
+- Keep **installed/credentialed** and **connected** as distinct states — only `connectedAt` advances the final step (see the Slack guide's comments).
+- Server state through TanStack Query; after a mutation, invalidate `getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier)`.
+- Escape any value injected into a manifest/snippet (e.g. Slack YAML double-quoted strings).
+- Reset local state when `integrationId` changes so switching integrations doesn't leak progress.
+- Novu/dashboard conventions: `type` (not `interface`) on the frontend, named exports, blank line before every `return`, no nested ternaries, animations from `motion/react`. Don't build/start the dashboard (port 4201) — check types via diagnostics.
+
+## Build & verify
+
+1. Don't start the dashboard — check types via Cursor diagnostics.
+2. From the agent Integrations tab, add/open a `<Channel>` integration: confirm steps advance as credentials save, the credential drawer opens/saves, and "Listening…" flips to "Connected" with confetti once a real message lands.

--- a/.cursor/skills/add-channel-setup-guide/reference.md
+++ b/.cursor/skills/add-channel-setup-guide/reference.md
@@ -1,0 +1,206 @@
+# Reference — Channel Setup Guide (Layer-1) template
+
+Placeholders: `<Channel>` = PascalCase (`Discord`), `<channel>` = kebab/lower (`discord`).
+Path: `apps/dashboard/src/components/agents/<channel>-setup-guide.tsx`.
+
+Copy the closest sibling:
+- **Telegram** (`telegram-setup-guide.tsx`) — simplest: create bot → save token → send test. Best starting point.
+- **Slack** (`slack-setup-guide.tsx`) — adds `SetupModeToggle` (quick vs manual) + a generated manifest.
+- **MS Teams** (`teams-setup-guide.tsx`) — multi-credential Azure flow.
+
+---
+
+## Skeleton — `<channel>-setup-guide.tsx`
+
+```tsx
+import { ChatProviderIdEnum } from '@novu/shared';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RiKey2Line } from 'react-icons/ri';
+import type { AgentResponse } from '@/api/agents';
+import { useEnvironment } from '@/context/environment/hooks';
+import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
+import {
+  IntegrationCredentialsSidebar,
+  ListeningStatus,
+  SetupButton,
+  SetupStep,
+  SetupStepperRail,
+} from './setup-guide-primitives';
+import { deriveStepStatus, hasIntegrationCredentials } from './setup-guide-step-utils';
+
+export type DiscordSetupGuideProps = {
+  agent: AgentResponse;
+  integrationId: string;
+  stepOffset?: number;
+  onStepsCompleted?: () => void;
+  embedded?: boolean;
+};
+
+export function DiscordSetupGuide({
+  agent,
+  integrationId,
+  stepOffset = 1,
+  onStepsCompleted,
+  embedded = false,
+}: DiscordSetupGuideProps) {
+  const { currentEnvironment } = useEnvironment();
+  const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
+  const [credentialsSavedLocally, setCredentialsSavedLocally] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+
+  // Reset progress when the watched integration changes.
+  useEffect(() => {
+    setIsConnected(false);
+    setCredentialsSavedLocally(false);
+  }, [integrationId]);
+
+  const { integrations } = useFetchIntegrations();
+  const selectedIntegration = useMemo(
+    () => integrations?.find((i) => i._id === integrationId && i.providerId === ChatProviderIdEnum.Discord),
+    [integrations, integrationId]
+  );
+
+  const isCredentialsSaved = hasIntegrationCredentials(selectedIntegration?.credentials) || credentialsSavedLocally;
+
+  const base = stepOffset;
+  const firstIncompleteStep = useMemo(() => {
+    if (isConnected) return base + 2;
+    if (isCredentialsSaved) return base + 1;
+
+    return base;
+  }, [base, isCredentialsSaved, isConnected]);
+
+  const handleConnected = useCallback(() => {
+    setIsConnected(true);
+    onStepsCompleted?.();
+  }, [onStepsCompleted]);
+
+  const stepsColumn = (
+    <>
+      <SetupStep
+        index={base}
+        status={deriveStepStatus(base, firstIncompleteStep)}
+        title="Create a Discord app and bot"
+        description="Create an application in the Discord Developer Portal, add a bot, and copy its token."
+        rightContent={<SetupButton href="https://discord.com/developers/applications">Open Discord Portal</SetupButton>}
+      />
+
+      <SetupStep
+        index={base + 1}
+        status={deriveStepStatus(base + 1, firstIncompleteStep)}
+        title="Save the bot token in Novu"
+        description="Open the credentials form and paste the bot token."
+        rightContent={
+          <SetupButton leadingIcon={<RiKey2Line className="size-3.5" />} onClick={() => setIsCredentialsSidebarOpen(true)}>
+            Configure credentials
+          </SetupButton>
+        }
+      />
+
+      <SetupStep
+        index={base + 2}
+        status={deriveStepStatus(base + 2, firstIncompleteStep)}
+        dimmed={!isCredentialsSaved}
+        title="Send a test message"
+        description="Message your bot on Discord — your agent should respond."
+      />
+    </>
+  );
+
+  const listening = (
+    <ListeningStatus
+      agentIdentifier={agent.identifier}
+      watchedIntegrationId={integrationId}
+      onConnected={handleConnected}
+      connectedMessage="Discord is connected — your agent is ready to receive messages."
+      listeningMessage="Send a message to your bot on Discord to finish connecting."
+    />
+  );
+
+  const sidebar = (
+    <IntegrationCredentialsSidebar
+      integrationId={integrationId}
+      isOpen={isCredentialsSidebarOpen}
+      onClose={() => setIsCredentialsSidebarOpen(false)}
+      onSaveSuccess={() => setCredentialsSavedLocally(true)}
+      agentOnboarding
+    />
+  );
+
+  if (embedded) {
+    return (
+      <div className="flex flex-col gap-0">
+        <SetupStepperRail className="py-6 pb-3 pr-3 md:pr-6">{stepsColumn}</SetupStepperRail>
+        <div className="pl-8">{listening}</div>
+        {sidebar}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <SetupStepperRail>{stepsColumn}</SetupStepperRail>
+      <div className="pl-8">{listening}</div>
+      {sidebar}
+    </>
+  );
+}
+```
+
+---
+
+## Optional add-ons (by sibling)
+
+**Quick vs manual mode (Slack).** Add `const [setupMode, setSetupMode] = useState<SetupMode>('quick')`, render
+`<SetupModeToggle mode={setupMode} onChange={setSetupMode} />` (typically gated by a feature flag), and switch
+between two `stepsColumn` variants.
+
+**Generated manifest (Slack).** Build a YAML string (escape double-quoted values), render it with
+`<CodeBlock language="shell" title="…-manifest.yaml" />` inside `fullWidthContent`, and deep-link the provider
+console with the manifest in the query string.
+
+**Provider server action (Telegram/Slack).** After credentials save, call a `@/api/agents` /
+`@/api/integrations` helper via `useMutation` (e.g. register a webhook, run quick setup, issue a subscriber
+deep-link), then `queryClient.invalidateQueries({ queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier) })`.
+Wire it from the sidebar's `onSaveSuccess`.
+
+**Embedded credential extras (Telegram).** `IntegrationCredentialsSidebar` accepts `agentIdentifier` and
+`testSubscriberId` to render provider-specific paste UI (e.g. the Telegram mobile QR) and a `submitLabel`.
+
+---
+
+## Wire the resolver — `agent-integration-guides/resolve-agent-integration-guide.tsx`
+
+Add to the **setup** `switch` (the connected-view wiring is covered by `add-channel-whats-next-onboarding`):
+
+```tsx
+import { DiscordSetupGuide } from '@/components/agents/discord-setup-guide';
+
+case ChatProviderIdEnum.Discord:
+  setupGuide = <DiscordSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+  setupDisplayName = 'Discord';
+  break;
+```
+
+---
+
+## Worked example — Discord
+
+```
+Prereqs: ChatProviderIdEnum.Discord exists · Discord provider in packages/providers.
+
+Create:
+  apps/dashboard/src/components/agents/discord-setup-guide.tsx
+Edit:
+  agent-integration-guides/resolve-agent-integration-guide.tsx   (+setup-switch case, +import)
+Verify: open a non-connected Discord integration → 3 steps, save token via drawer, "Listening…" → "Connected"
+        on first inbound message. Types via diagnostics.
+```
+
+## Connection-detection note
+
+`ListeningStatus` polls `listAgentIntegrations` every second and only treats the channel as connected when the
+matching link's `connectedAt` is set by the backend. Do **not** wire `onConnected` to credential-save or
+OAuth-install callbacks — those are earlier, separate states. This mirrors the Slack guide, which keeps
+`isSlackAppInstalled` (OAuth done) distinct from workspace-connected (first real message received).

--- a/.cursor/skills/add-channel-whats-next-onboarding/SKILL.md
+++ b/.cursor/skills/add-channel-whats-next-onboarding/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: add-channel-whats-next-onboarding
+description: >-
+  Add a new chat channel's layer-2 dashboard onboarding — the connected-state
+  "What's next" / "FOR YOUR USERS" developer-rollout guide plus its connected
+  details page — in apps/dashboard, following the existing Slack, MS Teams, and
+  Telegram pattern. Use when a connected agent integration needs a per-provider
+  "what's next" guide (recap + dev steps with @novu/react ConnectButton snippet),
+  a <Channel>AgentConnectedDetails view, and the resolver/registry wiring under
+  components/agents/agent-integration-guides.
+---
+
+# Add a Channel's "What's Next" (Layer-2) Onboarding
+
+Layer 2 = what a developer sees **after** their channel integration is connected: the
+**"What's next" / "FOR YOUR USERS"** guide that helps them roll the agent out to their own
+end users (install `@novu/react`, drop in the `<Channel>ConnectButton`), plus the connected
+channel **details** page. Layer 1 (connecting the channel itself) is the separate
+`<channel>-setup-guide.tsx` — out of scope here.
+
+All files live in `apps/dashboard/src/components/agents/agent-integration-guides/`.
+
+## Architecture
+
+```
+ResolveAgentIntegrationGuide            (switch on providerId — the registry)
+        │
+        ▼
+AgentIntegrationGuideTransition         (setup ↔ connected; in-session "Continue" step)
+        │
+        ├─ setup view (LAYER 1) ──────  <Channel>SetupGuide   (prerequisite, separate skill)
+        │
+        └─ connected view (LAYER 2) ──  <Channel>AgentConnectedDetails
+                                              │
+                                              ▼
+                                        AgentConnectedDetailsShell      (shared chrome + flag gate)
+                                              ├─ AgentChannelWhatsNextGuide   (renders the config)
+                                              │       └─ resolveChannelWhatsNextConfig → build<Channel>WhatsNextConfig
+                                              └─ provider credential sections (children render-prop)
+```
+
+The guide is **data-driven**: each provider contributes a `build<Channel>WhatsNextConfig(ctx)`
+that returns `{ recapSteps, devSteps }`. The shell and renderer never change.
+
+## Step 0 — Prerequisites
+
+Before adding layer 2, confirm:
+- The channel has a `ChatProviderIdEnum` entry in `@novu/shared` (adding a brand-new provider id is `packages/providers` territory — ask first).
+- A layer-1 `<channel>-setup-guide.tsx` exists (the connect-the-channel flow).
+- A `<Channel>ConnectButton` exists in `@novu/react` (see the `add-channel-connect-button` skill) — the dev step embeds its snippet.
+
+## File checklist
+
+Copy the nearest sibling: **Telegram** = simplest (endpoint/deep-link), **Slack** = workspace + a distribution link, **MS Teams** = org distribution component + own feature flag. Full templates: see [reference.md](reference.md).
+
+**Create**
+- [ ] `whats-next/<channel>-whats-next-config.tsx` — `build<Channel>WhatsNextConfig(ctx): ChannelWhatsNextConfig`
+- [ ] `<channel>-agent-connected-details.tsx` — `<Channel>AgentConnectedDetails` via `AgentConnectedDetailsShell`
+
+**Edit**
+- [ ] `whats-next/whats-next-config.ts` — register the builder in `WHATS_NEXT_CONFIG_BUILDERS[ChatProviderIdEnum.<Channel>]`
+- [ ] `resolve-agent-integration-guide.tsx` — add a `case` to **both** switches: the setup `switch` (render `<Channel>SetupGuide`, set `setupDisplayName`) and `renderConnectedView` (render `<Channel>AgentConnectedDetails`)
+- [ ] `agent-provider-display-name.ts` — add the display-name `case`
+
+**Optional**
+- [ ] Add `IS_AGENT_<CHANNEL>_WHATS_NEXT_ENABLED` only if this channel needs to ship independently of the umbrella flag (see Feature flags below).
+
+## The config contract
+
+`build<Channel>WhatsNextConfig(ctx: WhatsNextConfigContext): ChannelWhatsNextConfig`
+
+- `ctx` → `{ agent, integrationLink, credentials?, applicationIdentifier? }`.
+- Returns `{ recapSteps: WhatsNextStep[]; devSteps: WhatsNextStep[] }`.
+- **recapSteps** mirror the completed layer-1 setup steps (title + description only); the renderer collapses them behind "Show all N instructions".
+- **devSteps** are the new rollout steps. Convention: first dev step carries `sectionLabel: 'FOR YOUR USERS'` (or `'DISTRIBUTE YOUR BOT'` for org-level distribution), then **install `@novu/react`** (with a `PrebuiltPromptBanner` in `headerSlot`), then **add the `<Channel>ConnectButton` snippet** (`CodeBlock`).
+
+`WhatsNextStep` fields: `title`, `description`, `sectionLabel?`, `headerSlot?`, `rightContent?`, `extraContent?`, `fullWidthContent?`, `status?` (`'completed' | 'current' | 'upcoming'`).
+
+The renderer flips each dev step to `completed` once a real end-user connection exists
+(`useChannelFirstConnectedEndpoint`) and shows the "Your users are connecting" footer.
+
+## Feature flags
+
+- Default: the guide rides the umbrella `IS_AGENT_WHATS_NEXT_ENABLED` flag — no flag work needed.
+- Independent rollout (like MS Teams): add `IS_AGENT_<CHANNEL>_WHATS_NEXT_ENABLED`, then gate it in two places — `AgentConnectedDetailsShell.showWhatsNext` and `ResolveAgentIntegrationGuide.hasUserRolloutPhase`. `providerHasWhatsNextPhase(providerId)` already returns true once the builder is registered.
+
+## Conventions & gotchas
+
+- The config file is the only place with provider-specific copy/snippets. Keep the shell, transition, and renderer untouched.
+- **Escape JSX attribute values** in the connect snippet (each sibling has an escape helper) and source `applicationIdentifier` from the environment with a `<YOUR_NOVU_APPLICATION_IDENTIFIER>` fallback; `integrationIdentifier` comes from `integrationLink.integration.identifier`.
+- `PrebuiltPromptBanner` `source` must be unique: `agent-channel-whats-next-<channel>`.
+- Connected details: pull credentials from the shell's `children` render-prop `{ credentials, integrationName, isLoading }`; surface only safe fields with `ReadOnlyField` (mark secrets `secret`, never expose internal webhook secrets).
+- Don't confuse this with `agent-whats-next-section.tsx` (the Overview-tab summary card) — that's a separate, simpler surface.
+- Dashboard conventions: TanStack Query for server state, Radix/shadcn + Tailwind (no inline `style` except dynamic values), React Router. Novu conventions: `type` (not `interface`) on the frontend, named exports, blank line before every `return`, no nested ternaries.
+
+## Build & verify
+
+1. Do **not** build/start the dashboard — it runs on port 4201. Check types via Cursor diagnostics.
+2. Open a connected `<Channel>` integration's detail page; confirm the recap collapses, the dev steps render with a working prompt banner + copyable snippet, and the "Your users are connecting" footer appears once a real user connects.
+3. If you added a per-provider flag, verify the guide hides when it's off.

--- a/.cursor/skills/add-channel-whats-next-onboarding/reference.md
+++ b/.cursor/skills/add-channel-whats-next-onboarding/reference.md
@@ -1,0 +1,288 @@
+# Reference — Channel "What's Next" (Layer-2) templates
+
+Placeholders: `<Channel>` = PascalCase (`Discord`), `<channel>` = kebab/lower (`discord`).
+All paths are under `apps/dashboard/src/components/agents/agent-integration-guides/`.
+
+Pick the closest sibling to copy:
+- **Telegram** — simplest; bot/deep-link, no workspace distribution step.
+- **Slack** — workspace install + a "FOR YOUR USERS" distribution link built from `credentials`.
+- **MS Teams** — org-wide distribution component + its own feature flag.
+
+---
+
+## 1. Config — `whats-next/<channel>-whats-next-config.tsx`
+
+Copy `telegram-whats-next-config.tsx`. Build the snippet from the `@novu/react`
+`<Channel>ConnectButton`, escape attribute values, and return recap + dev steps.
+
+```tsx
+import { PrebuiltPromptBanner } from '@/components/onboarding/connect-agent/prebuilt-prompt-banner';
+import { CodeBlock } from '@/components/primitives/code-block';
+import type { ChannelWhatsNextConfig, WhatsNextConfigContext } from './whats-next-types';
+
+const DISCORD_REACT_PACKAGE = '@novu/react';
+const APPLICATION_IDENTIFIER_PLACEHOLDER = '<YOUR_NOVU_APPLICATION_IDENTIFIER>';
+
+function escapeJsxStringAttributeValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function buildDiscordConnectSnippet(integrationIdentifier: string, applicationIdentifier: string): string {
+  const app = escapeJsxStringAttributeValue(applicationIdentifier);
+  const integration = escapeJsxStringAttributeValue(integrationIdentifier);
+
+  return `import { NovuProvider, DiscordConnectButton } from '${DISCORD_REACT_PACKAGE}';
+
+<NovuProvider applicationIdentifier="${app}" subscriberId="YOUR_SUBSCRIBER_ID">
+  <DiscordConnectButton
+    integrationIdentifier="${integration}"
+    connectLabel="Connect Discord \u2197"
+    connectedLabel="Connected to Discord"
+  />
+</NovuProvider>;`;
+}
+
+function buildDiscordPrompt(integrationIdentifier: string, agentName: string, applicationIdentifier: string): string {
+  return `Add the Novu DiscordConnectButton from @novu/react to my app so each of my end users can connect "${agentName}" to their own Discord.
+
+Context: I'm already signed in to the Novu dashboard and the "${agentName}" Discord integration already exists. This is purely a frontend code integration — do NOT run the Novu CLI, the agent-onboarding flow, or keyless mode.
+
+Requirements:
+- Install @novu/react with my project's package manager.
+- Render <DiscordConnectButton /> inside a <NovuProvider> configured for the currently signed-in end user.
+- Use applicationIdentifier="${applicationIdentifier}" and integrationIdentifier="${integrationIdentifier}". Store applicationIdentifier in an environment variable.
+- Each user gets their own connection, so pass the authenticated user's id as subscriberId; source it from my app's existing auth.
+- Follow my app's existing framework, routing, styling, and TypeScript conventions.`;
+}
+
+export function buildDiscordWhatsNextConfig({
+  agent,
+  integrationLink,
+  applicationIdentifier,
+}: WhatsNextConfigContext): ChannelWhatsNextConfig {
+  const integrationIdentifier = integrationLink.integration.identifier;
+  const appId = applicationIdentifier || APPLICATION_IDENTIFIER_PLACEHOLDER;
+  const connectSnippet = buildDiscordConnectSnippet(integrationIdentifier, appId);
+  const prompt = buildDiscordPrompt(integrationIdentifier, agent.name, appId);
+
+  return {
+    recapSteps: [
+      { title: 'Create a Discord app and bot', description: 'You created a Discord application and bot token.' },
+      { title: 'Save the bot token to the integration', description: 'The bot token was saved to this integration.' },
+      { title: 'Send a test message', description: 'You verified the agent can reach you on Discord.' },
+    ],
+    devSteps: [
+      {
+        sectionLabel: 'FOR YOUR USERS',
+        title: (
+          <span className="flex flex-wrap items-center gap-1.5">
+            <span>Install</span>
+            <code className="bg-bg-weak text-text-strong rounded px-1.5 py-0.5 font-code text-[12px]">
+              {DISCORD_REACT_PACKAGE}
+            </code>
+          </span>
+        ),
+        description: `The NPM package ${DISCORD_REACT_PACKAGE} SDK to integrate Novu components in your application.`,
+        headerSlot: <PrebuiltPromptBanner prompt={prompt} source="agent-channel-whats-next-discord" />,
+        fullWidthContent: (
+          <div className="pt-3">
+            <CodeBlock code={`npm install ${DISCORD_REACT_PACKAGE}`} language="shell" title="Terminal" />
+          </div>
+        ),
+      },
+      {
+        title: 'Add Discord connect button to your application',
+        description:
+          'DiscordConnectButton is a pre-built UI component in the @novu/react SDK that links a subscriber to your Discord bot.',
+        fullWidthContent: (
+          <div className="pt-3">
+            <CodeBlock code={connectSnippet} language="tsx" title="main.tsx" />
+          </div>
+        ),
+      },
+    ],
+  };
+}
+```
+
+**Distribution variant** (Slack/MS Teams): add a first dev step with
+`rightContent: <SetupButton href={...}>Enable …</SetupButton>` (import `SetupButton` from
+`../../setup-guide-primitives`), building the URL from `credentials` (e.g. Slack `applicationId`,
+MS Teams `clientId`). MS Teams also renders a `fullWidthContent: <MsTeamsDistribution .../>`.
+
+---
+
+## 2. Register the builder — `whats-next/whats-next-config.ts`
+
+```ts
+import { buildDiscordWhatsNextConfig } from './discord-whats-next-config';
+
+const WHATS_NEXT_CONFIG_BUILDERS: Partial<Record<string, ChannelWhatsNextConfigBuilder>> = {
+  // ...existing
+  [ChatProviderIdEnum.Discord]: buildDiscordWhatsNextConfig,
+};
+```
+
+`providerHasWhatsNextPhase` and `resolveChannelWhatsNextConfig` pick it up automatically.
+
+---
+
+## 3. Connected details — `<channel>-agent-connected-details.tsx`
+
+Copy `telegram-agent-connected-details.tsx`. Wrap `AgentConnectedDetailsShell` and supply
+provider credential sections via the render-prop. The shell renders the "What's next" guide.
+
+```tsx
+import { ChatProviderIdEnum, type ICredentials } from '@novu/shared';
+import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
+import {
+  AgentConnectedDetailsShell,
+  DetailSection,
+  FieldSkeleton,
+  ReadOnlyField,
+} from './agent-connected-details-shell';
+
+type DiscordAgentConnectedDetailsProps = {
+  agent: AgentResponse;
+  integrationLink: AgentIntegrationLink;
+  canRemoveIntegration: boolean;
+  onRequestRemoveIntegration?: () => void;
+  isRemovingIntegration?: boolean;
+  justConnected?: boolean;
+};
+
+export function DiscordAgentConnectedDetails({
+  agent,
+  integrationLink,
+  canRemoveIntegration,
+  onRequestRemoveIntegration,
+  isRemovingIntegration,
+  justConnected = false,
+}: DiscordAgentConnectedDetailsProps) {
+  return (
+    <AgentConnectedDetailsShell
+      agent={agent}
+      integrationLink={integrationLink}
+      providerId={ChatProviderIdEnum.Discord}
+      providerDisplayName="Discord"
+      canRemoveIntegration={canRemoveIntegration}
+      onRequestRemoveIntegration={onRequestRemoveIntegration}
+      isRemovingIntegration={isRemovingIntegration}
+      justConnected={justConnected}
+    >
+      {({ credentials, integrationName, isLoading }) => (
+        <DiscordDetailSections
+          credentials={credentials}
+          isLoading={isLoading}
+          botName={integrationName ?? integrationLink.integration.name}
+        />
+      )}
+    </AgentConnectedDetailsShell>
+  );
+}
+
+function DiscordDetailSections({
+  credentials,
+  isLoading,
+  botName,
+}: {
+  credentials?: ICredentials;
+  isLoading: boolean;
+  botName: string;
+}) {
+  const botToken = (credentials?.apiToken as string | undefined) ?? '';
+
+  return (
+    <DetailSection title="Discord bot">
+      <ReadOnlyField label="Bot name" value={botName} mono={false} info="Your connected Discord bot." />
+      {isLoading ? <FieldSkeleton /> : <ReadOnlyField label="Bot Token" value={botToken} required secret />}
+    </DetailSection>
+  );
+}
+```
+
+---
+
+## 4. Wire the resolver — `resolve-agent-integration-guide.tsx`
+
+Two switches need a new `case` (plus the imports):
+
+```tsx
+import { DiscordSetupGuide } from '@/components/agents/discord-setup-guide';      // layer-1 (prereq)
+import { DiscordAgentConnectedDetails } from './discord-agent-connected-details';
+
+// setup switch:
+case ChatProviderIdEnum.Discord:
+  setupGuide = <DiscordSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+  setupDisplayName = 'Discord';
+  break;
+
+// renderConnectedView switch:
+case ChatProviderIdEnum.Discord:
+  return (
+    <DiscordAgentConnectedDetails
+      agent={agent}
+      integrationLink={integrationLink}
+      canRemoveIntegration={canRemoveIntegration}
+      onRequestRemoveIntegration={onRequestRemoveIntegration}
+      isRemovingIntegration={isRemovingIntegration}
+      justConnected={justConnected}
+    />
+  );
+```
+
+---
+
+## 5. Display name — `agent-provider-display-name.ts`
+
+```ts
+case ChatProviderIdEnum.Discord:
+  return 'Discord';
+```
+
+---
+
+## 6. Optional feature flag (independent rollout)
+
+Mirror MS Teams. Add `IS_AGENT_DISCORD_WHATS_NEXT_ENABLED` to `FeatureFlagsKeysEnum`, then:
+
+```tsx
+// agent-connected-details-shell.tsx
+const isDiscordWhatsNextEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_AGENT_DISCORD_WHATS_NEXT_ENABLED);
+const showWhatsNext =
+  providerId === ChatProviderIdEnum.Discord ? isDiscordWhatsNextEnabled : isWhatsNextEnabled;
+
+// resolve-agent-integration-guide.tsx — extend hasUserRolloutPhase the same way.
+```
+
+Skip this entirely to ride the umbrella `IS_AGENT_WHATS_NEXT_ENABLED` flag.
+
+---
+
+## 7. Worked example — Discord (no dedicated flag)
+
+```
+Prereqs: ChatProviderIdEnum.Discord exists · discord-setup-guide.tsx exists · DiscordConnectButton in @novu/react.
+
+Create:
+  agent-integration-guides/whats-next/discord-whats-next-config.tsx
+  agent-integration-guides/discord-agent-connected-details.tsx
+Edit:
+  agent-integration-guides/whats-next/whats-next-config.ts   (+register builder)
+  agent-integration-guides/resolve-agent-integration-guide.tsx (+2 cases, +imports)
+  agent-integration-guides/agent-provider-display-name.ts    (+case)
+Verify: open a connected Discord integration → recap collapses, dev steps + prompt banner + snippet render,
+        "Your users are connecting" footer appears after a real user connects. Types via diagnostics.
+```
+
+## Building blocks (import map)
+
+| Symbol | From |
+|---|---|
+| `ChannelWhatsNextConfig`, `WhatsNextStep`, `WhatsNextConfigContext` | `whats-next/whats-next-types.ts` |
+| `SetupStep`, `SetupButton`, `ListeningStatusView`, `CompletedStepIndicator` | `../../setup-guide-primitives` |
+| `StepStatus` (`'completed' \| 'current' \| 'upcoming'`) | `../../setup-guide-step-utils` |
+| `AgentConnectedDetailsShell`, `DetailSection`, `ReadOnlyField`, `FieldSkeleton` | `./agent-connected-details-shell` |
+| `PrebuiltPromptBanner` | `@/components/onboarding/connect-agent/prebuilt-prompt-banner` |
+| `CodeBlock` | `@/components/primitives/code-block` |
+| `useChannelFirstConnectedEndpoint` | `@/hooks/use-channel-first-connected-endpoint` |


### PR DESCRIPTION
## Summary

- Add three project Cursor skills that document how to implement a new chat channel end-to-end, based on the existing Slack, MS Teams, and Telegram patterns.
- **`add-channel-connect-button`** — build `<Channel>ConnectButton` in `@novu/js` + `@novu/react` (connection-based vs endpoint-based models, component registry, exports).
- **`add-channel-setup-guide`** — dashboard layer-1 `<channel>-setup-guide.tsx` (numbered stepper, credential drawer, `connectedAt` polling).
- **`add-channel-whats-next-onboarding`** — dashboard layer-2 "What's next" / "FOR YOUR USERS" guide (config builder registry, connected details shell).

```mermaid
flowchart LR
    A["add-channel-connect-button<br/>SDK ConnectButton"] --> B["add-channel-setup-guide<br/>Layer 1: connect channel"]
    B --> C["add-channel-whats-next-onboarding<br/>Layer 2: roll out to users"]
```

## Test plan

- [ ] Open each `SKILL.md` under `.cursor/skills/add-channel-*` and confirm frontmatter, file checklists, and reference links render correctly
- [ ] Invoke skills in Cursor (e.g. "add Discord connect button") and verify the agent follows the documented file paths and conventions
- [ ] Confirm no application code changes — skills only

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Cursor skills for building new chat channel onboarding flows. The main changes are:

- SDK connect button guidance for `@novu/js` and `@novu/react`.
- Dashboard layer-1 setup guide templates for connecting a channel.
- Dashboard layer-2 “what’s next” templates for connected-state user rollout.

<h3>Confidence Score: 4/5</h3>

The change is documentation-only, but one setup-guide code template would generate onboarding flows that never mark the final step complete after connection.

The review is focused on a small set of Cursor skill files, and the identified template logic issue was confirmed with a targeted execution of the documented step-status calculation.

.cursor/skills/add-channel-setup-guide/reference.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Node repro script to reproduce the documented firstIncompleteStep and deriveStepStatus logic for the three-step setup guide, and observed that the final step remained current after connection, triggering an assertion.
- Validated the add-channel-connect-button flow with a before/after script and logs, showing base checkout failed due to missing skill files, and head checkout passed after the files were added.
- Validated the add-channel-setup-guide flow with a before/after validation, where the before state lacked required files and the after state passed with both files present and all checks passing.
- Validated the add-channel-whats-next-onboarding flow with a before/after validation, where the before state failed due to missing files, and the after state passed on head with zero failures.

<a href="https://app.greptile.com/trex/runs/12571205/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.cursor%2Fskills%2Fadd-channel-setup-guide%2Freference.md%3A68-69%0A**Final%20step%20never%20completes**%0AWhen%20%60isConnected%60%20becomes%20true%2C%20%60firstIncompleteStep%60%20is%20set%20to%20%60base%20%2B%202%60%2C%20which%20is%20the%20index%20of%20the%20last%20step.%20%60deriveStepStatus%28base%20%2B%202%2C%20firstIncompleteStep%29%60%20returns%20%60current%60%2C%20so%20generated%20setup%20guides%20leave%20the%20final%20%60Send%20a%20test%20message%60%20step%20active%20after%20connection.%20The%20three-step%20flow%20needs%20to%20advance%20past%20the%20last%20step.%0A%0A&pr=11692&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.cursor/skills/add-channel-setup-guide/reference.md:68-69
**Final step never completes**
When `isConnected` becomes true, `firstIncompleteStep` is set to `base + 2`, which is the index of the last step. `deriveStepStatus(base + 2, firstIncompleteStep)` returns `current`, so generated setup guides leave the final `Send a test message` step active after connection. The three-step flow needs to advance past the last step.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(root): add Cursor skills for new ch..."](https://github.com/novuhq/novu/commit/b2d997dc8f8fdf88138c2a97de125de3a6817548) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40391699)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->