### PR TITLE
fix(shared): self-hosted SSRF allow list for internal bridge URLs

### DIFF
--- a/apps/api/src/app/bridge/bridge.controller.ts
+++ b/apps/api/src/app/bridge/bridge.controller.ts
@@ -29,6 +29,7 @@ import { ControlValuesRepository, EnvironmentRepository, NotificationTemplateRep
 import { HttpHeaderKeysEnum } from '@novu/framework/internal';
 import {
   ControlValuesLevelEnum,
+  isOutboundSsrfProtectionEnabled,
   PermissionsEnum,
   ResourceOriginEnum,
   ResourceTypeEnum,
@@ -242,7 +243,7 @@ export class BridgeController {
           statelessBridgeUrl: body.bridgeUrl,
           // User-supplied bridgeUrl: enforce DNS-pinned SSRF guard at connect
           // time so IP-literal private addresses cannot reach internal hosts.
-          enforceSsrfProtection: true,
+          enforceSsrfProtection: isOutboundSsrfProtectionEnabled(),
         })
       );
 

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -28,6 +28,7 @@ import { DiscoverOutput, DiscoverStepOutput, DiscoverWorkflowOutput, GetActionEn
 import {
   buildWorkflowPreferences,
   ControlValuesLevelEnum,
+  isOutboundSsrfProtectionEnabled,
   ResourceOriginEnum,
   ResourceTypeEnum,
   SeverityLevelEnum,
@@ -121,7 +122,7 @@ export class Sync {
         // User-supplied bridgeUrl: pin the connection to a validated public
         // IP and re-validate on every redirect, so IP literals like
         // 127.0.0.1 / 169.254.169.254 / fc00::/7 cannot reach internal hosts.
-        enforceSsrfProtection: true,
+        enforceSsrfProtection: isOutboundSsrfProtectionEnabled(),
       })) as DiscoverOutput;
     } catch (error) {
       if (error instanceof HttpException) {

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -34,6 +34,7 @@ import {
 import { DiscoverWorkflowOutput, GetActionEnum } from '@novu/framework/internal';
 import {
   FeatureFlagsKeysEnum,
+  isOutboundSsrfProtectionEnabled,
   ResourceOriginEnum,
   TriggerEventStatusEnum,
   TriggerRecipientsPayload,
@@ -310,7 +311,7 @@ export class ParseEventRequest {
         // 127.0.0.1 / 169.254.169.254 / fc00::/7 cannot reach internal hosts.
         // The downstream EXECUTE call from the worker enforces the same guard
         // — see `apps/worker/src/app/workflow/usecases/execute-bridge-job`.
-        enforceSsrfProtection: true,
+        enforceSsrfProtection: isOutboundSsrfProtectionEnabled(),
       })
     )) as ExecuteBridgeRequestDto<GetActionEnum.DISCOVER>;
 

--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -15,6 +15,7 @@ import {
   shouldIncludeBody,
 } from '@novu/application-generic';
 import { createLiquidEngine } from '@novu/framework/internal';
+import { isOutboundSsrfProtectionEnabled } from '@novu/shared';
 import { Liquid } from 'liquidjs';
 import { TestHttpEndpointResponseDto } from '../../dtos/test-http-endpoint.dto';
 import { TestHttpEndpointCommand } from './test-http-endpoint.command';
@@ -128,7 +129,7 @@ export class TestHttpEndpointUsecase {
         ...(hasBody ? { body: resolvedBody } : {}),
         timeout: 30_000,
         responseType: 'text',
-        enforceSsrfProtection: true,
+        enforceSsrfProtection: isOutboundSsrfProtectionEnabled(),
       });
       const durationMs = Math.round(performance.now() - startTime);
 

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -38,6 +38,7 @@ import {
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
   ITriggerPayload,
+  isOutboundSsrfProtectionEnabled,
   JobStatusEnum,
   ResourceOriginEnum,
   ResourceTypeEnum,
@@ -246,7 +247,9 @@ export class ExecuteBridgeJob {
       // (stateless bridgeUrl on the job, or the environment's stored bridge
       // URL). This blocks internal hosts even if a malicious URL was persisted
       // before validation landed or queued by an older API release.
-      enforceSsrfProtection: !!statelessBridgeUrl || workflowOrigin === ResourceOriginEnum.EXTERNAL,
+      enforceSsrfProtection:
+        isOutboundSsrfProtectionEnabled() &&
+        (!!statelessBridgeUrl || workflowOrigin === ResourceOriginEnum.EXTERNAL),
       processError: async (response) => {
         await this.createExecutionDetails.execute({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -26,6 +26,7 @@ import {
   DeliveryLifecycleStatusEnum,
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
+  isOutboundSsrfProtectionEnabled,
   ResourceOriginEnum,
 } from '@novu/shared';
 import Ajv from 'ajv';
@@ -216,7 +217,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
         headers: mergedHeaders,
         timeout,
         responseType: 'text',
-        enforceSsrfProtection: true,
+        enforceSsrfProtection: isOutboundSsrfProtectionEnabled(),
         ...(hasBody ? { body: bodyObject } : {}),
       });
 

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
@@ -7,7 +7,7 @@ import {
   isFrameworkError,
   PostActionEnum,
 } from '@novu/framework/internal';
-import { ResourceOriginEnum } from '@novu/shared';
+import { isOutboundSsrfProtectionEnabled, ResourceOriginEnum } from '@novu/shared';
 import { HttpRequestHeaderKeysEnum } from '../../http';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
 import { PinoLogger } from '../../logging';
@@ -107,9 +107,10 @@ export class ExecuteFrameworkRequest {
     this.logger.debug(`Making bridge request to \`${url}\``);
 
     const enforceSsrfProtection =
-      command.enforceSsrfProtection === true ||
-      !!command.statelessBridgeUrl ||
-      command.workflowOrigin === ResourceOriginEnum.EXTERNAL;
+      isOutboundSsrfProtectionEnabled() &&
+      (command.enforceSsrfProtection === true ||
+        !!command.statelessBridgeUrl ||
+        command.workflowOrigin === ResourceOriginEnum.EXTERNAL);
 
     try {
       const response = await this.httpClient.request<ExecuteBridgeRequestDto<T>>({

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -26,10 +26,15 @@ import { Readable } from 'node:stream';
 import { LRUCache } from 'lru-cache';
 
 type PrivateIpClassificationModule = typeof import('@novu/shared/dist/cjs/utils/private-ip-classification');
+type OutboundSsrfAllowListModule = typeof import('@novu/shared/dist/cjs/utils/outbound-ssrf-allow-list');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { isPrivateIp, normalizeHostnameForLookup } =
   require('@novu/shared/utils/private-ip-classification') as PrivateIpClassificationModule;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { isAddressAllowedByOutboundAllowList, isHostnameAllowedByOutboundAllowList } =
+  require('@novu/shared/utils/outbound-ssrf-allow-list') as OutboundSsrfAllowListModule;
 
 export { isPrivateIp, normalizeHostnameForLookup };
 
@@ -157,7 +162,15 @@ export async function resolvePublicAddresses(
     }
   }
 
+  if (isHostnameAllowedByOutboundAllowList(normalized)) {
+    return addresses;
+  }
+
   for (const { address } of addresses) {
+    if (isAddressAllowedByOutboundAllowList(address)) {
+      continue;
+    }
+
     if (isPrivateIp(address)) {
       throw new SsrfBlockedError(
         'PRIVATE_IP',
@@ -237,47 +250,6 @@ export interface SafeOutboundJsonResponse<T = unknown> {
   statusMessage: string;
   headers: http.IncomingHttpHeaders;
   body: T;
-}
-
-function getTestAllowList(): Set<string> {
-  const raw = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-  if (!raw) return new Set<string>();
-
-  return new Set(
-    raw
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-  );
-}
-
-async function resolveWithTestAllowList(hostname: string): Promise<dns.LookupAddress[]> {
-  const allowList = getTestAllowList();
-  if (allowList.size === 0) {
-    return resolvePublicAddresses(hostname);
-  }
-
-  let addresses: dns.LookupAddress[];
-  try {
-    addresses = await dns.promises.lookup(hostname.toLowerCase(), { all: true });
-  } catch {
-    throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${hostname}".`, {
-      hostname,
-    });
-  }
-
-  for (const { address } of addresses) {
-    if (allowList.has(address)) continue;
-    if (isPrivateIp(address)) {
-      throw new SsrfBlockedError(
-        'PRIVATE_IP',
-        `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
-        { hostname, resolvedAddress: address }
-      );
-    }
-  }
-
-  return addresses;
 }
 
 const SENSITIVE_HEADER_PATTERNS = [
@@ -475,7 +447,7 @@ export async function safeOutboundRequest(options: SafeOutboundRequestOptions): 
       currentBody = undefined;
     }
 
-    const addresses = await resolveWithTestAllowList(parsed.hostname);
+    const addresses = await resolvePublicAddresses(parsed.hostname);
     const chosen = addresses[0];
     if (!chosen) {
       throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${parsed.hostname}".`, {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/esm/utils/private-ip-classification.js",
       "types": "./dist/esm/utils/private-ip-classification.d.ts"
     },
+    "./utils/outbound-ssrf-allow-list": {
+      "require": "./dist/cjs/utils/outbound-ssrf-allow-list.js",
+      "import": "./dist/esm/utils/outbound-ssrf-allow-list.js",
+      "types": "./dist/esm/utils/outbound-ssrf-allow-list.d.ts"
+    },
     "./utils/ssrf-url-validation": {
       "require": "./dist/cjs/utils/ssrf-url-validation.js",
       "import": "./dist/esm/utils/ssrf-url-validation.js",

--- a/packages/shared/src/utils/outbound-ssrf-allow-list.spec.ts
+++ b/packages/shared/src/utils/outbound-ssrf-allow-list.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  isAddressAllowedByOutboundAllowList,
+  isHostnameAllowedByOutboundAllowList,
+  isOutboundAddressAllowed,
+  resetOutboundSsrfAllowListCacheForTests,
+} from './outbound-ssrf-allow-list';
+
+const PRODUCTION_ENV_KEY = 'NOVU_SAFE_OUTBOUND_ALLOW';
+const TEST_ENV_KEY = 'NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS';
+
+function withAllowList(env: Record<string, string | undefined>, fn: () => void) {
+  const previous: Record<string, string | undefined> = {
+    [PRODUCTION_ENV_KEY]: process.env[PRODUCTION_ENV_KEY],
+    [TEST_ENV_KEY]: process.env[TEST_ENV_KEY],
+  };
+
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  resetOutboundSsrfAllowListCacheForTests();
+
+  try {
+    fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    resetOutboundSsrfAllowListCacheForTests();
+  }
+}
+
+describe('outbound-ssrf-allow-list', () => {
+  afterEach(() => {
+    delete process.env[PRODUCTION_ENV_KEY];
+    delete process.env[TEST_ENV_KEY];
+    resetOutboundSsrfAllowListCacheForTests();
+  });
+
+  it('allows exact IPs from the production env var', () => {
+    withAllowList({ [PRODUCTION_ENV_KEY]: '10.0.0.5,192.168.1.20' }, () => {
+      expect(isAddressAllowedByOutboundAllowList('10.0.0.5')).toBe(true);
+      expect(isAddressAllowedByOutboundAllowList('192.168.1.20')).toBe(true);
+      expect(isAddressAllowedByOutboundAllowList('10.0.0.6')).toBe(false);
+    });
+  });
+
+  it('allows CIDR ranges', () => {
+    withAllowList({ [PRODUCTION_ENV_KEY]: '10.0.0.0/8,192.168.0.0/16' }, () => {
+      expect(isAddressAllowedByOutboundAllowList('10.42.1.5')).toBe(true);
+      expect(isAddressAllowedByOutboundAllowList('192.168.50.10')).toBe(true);
+      expect(isAddressAllowedByOutboundAllowList('172.16.0.1')).toBe(false);
+    });
+  });
+
+  it('allows exact hostnames', () => {
+    withAllowList({ [PRODUCTION_ENV_KEY]: 'bridge.internal' }, () => {
+      expect(isHostnameAllowedByOutboundAllowList('bridge.internal')).toBe(true);
+      expect(isHostnameAllowedByOutboundAllowList('other.internal')).toBe(false);
+    });
+  });
+
+  it('allows Kubernetes service DNS suffixes', () => {
+    withAllowList({ [PRODUCTION_ENV_KEY]: '.svc.cluster.local' }, () => {
+      expect(isHostnameAllowedByOutboundAllowList('my-bridge.my-namespace.svc.cluster.local')).toBe(true);
+      expect(isHostnameAllowedByOutboundAllowList('svc.cluster.local')).toBe(true);
+      expect(isHostnameAllowedByOutboundAllowList('example.com')).toBe(false);
+    });
+  });
+
+  it('allows wildcard namespace suffixes', () => {
+    withAllowList({ [PRODUCTION_ENV_KEY]: '*.my-namespace.svc.cluster.local' }, () => {
+      expect(isHostnameAllowedByOutboundAllowList('my-bridge.my-namespace.svc.cluster.local')).toBe(true);
+      expect(isHostnameAllowedByOutboundAllowList('other-namespace.svc.cluster.local')).toBe(false);
+    });
+  });
+
+  it('merges production and legacy test IP allow lists', () => {
+    withAllowList(
+      {
+        [PRODUCTION_ENV_KEY]: '.svc.cluster.local',
+        [TEST_ENV_KEY]: '127.0.0.1',
+      },
+      () => {
+        expect(isOutboundAddressAllowed('bridge.ns.svc.cluster.local', '10.0.0.5')).toBe(true);
+        expect(isOutboundAddressAllowed('example.com', '127.0.0.1')).toBe(true);
+        expect(isOutboundAddressAllowed('example.com', '10.0.0.5')).toBe(false);
+      }
+    );
+  });
+});

--- a/packages/shared/src/utils/outbound-ssrf-allow-list.ts
+++ b/packages/shared/src/utils/outbound-ssrf-allow-list.ts
@@ -1,0 +1,151 @@
+import { BlockList, isIP } from 'node:net';
+
+const PRODUCTION_ENV_KEY = 'NOVU_SAFE_OUTBOUND_ALLOW';
+const TEST_ENV_KEY = 'NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS';
+
+type ParsedAllowEntry =
+  | { type: 'ip'; value: string }
+  | { type: 'cidr'; blocklist: BlockList }
+  | { type: 'hostname'; value: string }
+  | { type: 'hostname-suffix'; suffix: string };
+
+let cachedEntries: ParsedAllowEntry[] | null = null;
+let cachedEnvRaw: string | undefined;
+
+function parseCidr(entry: string): BlockList | null {
+  const match = entry.match(/^([^/]+)\/(\d+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const network = match[1];
+  const prefixStr = match[2];
+
+  if (!network || !prefixStr) {
+    return null;
+  }
+
+  const prefix = Number(prefixStr);
+  const family = isIP(network);
+
+  if (family === 0 || !Number.isInteger(prefix)) {
+    return null;
+  }
+
+  const blocklist = new BlockList();
+
+  try {
+    blocklist.addSubnet(network, prefix, family === 4 ? 'ipv4' : 'ipv6');
+
+    return blocklist;
+  } catch {
+    return null;
+  }
+}
+
+function parseEntry(raw: string): ParsedAllowEntry | null {
+  const entry = raw.trim();
+
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.startsWith('*.')) {
+    return { type: 'hostname-suffix', suffix: entry.slice(1).toLowerCase() };
+  }
+
+  if (entry.startsWith('.')) {
+    return { type: 'hostname-suffix', suffix: entry.toLowerCase() };
+  }
+
+  if (entry.includes('/')) {
+    const blocklist = parseCidr(entry);
+
+    if (blocklist) {
+      return { type: 'cidr', blocklist };
+    }
+
+    return null;
+  }
+
+  if (isIP(entry) !== 0) {
+    return { type: 'ip', value: entry };
+  }
+
+  if (/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/i.test(entry)) {
+    return { type: 'hostname', value: entry.toLowerCase() };
+  }
+
+  return null;
+}
+
+function getCombinedAllowListRaw(): string {
+  const production = process.env[PRODUCTION_ENV_KEY] ?? '';
+  const test = process.env[TEST_ENV_KEY] ?? '';
+
+  return [production, test].filter(Boolean).join(',');
+}
+
+function getAllowListEntries(): ParsedAllowEntry[] {
+  const combined = getCombinedAllowListRaw();
+
+  if (cachedEnvRaw === combined && cachedEntries) {
+    return cachedEntries;
+  }
+
+  cachedEnvRaw = combined;
+  cachedEntries = combined
+    .split(',')
+    .map(parseEntry)
+    .filter((entry): entry is ParsedAllowEntry => entry !== null);
+
+  return cachedEntries;
+}
+
+/** @internal Test helper — clears the parsed allow-list cache between cases. */
+export function resetOutboundSsrfAllowListCacheForTests(): void {
+  cachedEntries = null;
+  cachedEnvRaw = undefined;
+}
+
+export function isHostnameAllowedByOutboundAllowList(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+
+  for (const entry of getAllowListEntries()) {
+    if (entry.type === 'hostname' && normalized === entry.value) {
+      return true;
+    }
+
+    if (entry.type === 'hostname-suffix') {
+      const bareSuffix = entry.suffix.startsWith('.') ? entry.suffix.slice(1) : entry.suffix;
+
+      if (normalized === bareSuffix || normalized.endsWith(entry.suffix)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function isAddressAllowedByOutboundAllowList(address: string): boolean {
+  for (const entry of getAllowListEntries()) {
+    if (entry.type === 'ip' && entry.value === address) {
+      return true;
+    }
+
+    if (entry.type === 'cidr') {
+      const family = isIP(address);
+
+      if (family !== 0 && entry.blocklist.check(address, family === 4 ? 'ipv4' : 'ipv6')) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function isOutboundAddressAllowed(hostname: string, address: string): boolean {
+  return isHostnameAllowedByOutboundAllowList(hostname) || isAddressAllowedByOutboundAllowList(address);
+}

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -1,9 +1,11 @@
 import * as dns from 'node:dns';
 import * as http from 'node:http';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetOutboundSsrfAllowListCacheForTests } from './outbound-ssrf-allow-list';
 import { safeOutboundJsonRequest, safeOutboundRequest } from './safe-outbound-http';
 
 const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+const ORIGINAL_PRODUCTION_ALLOW = process.env.NOVU_SAFE_OUTBOUND_ALLOW;
 beforeAll(() => {
   process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
 });
@@ -13,6 +15,14 @@ afterAll(() => {
   } else {
     process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
   }
+
+  if (ORIGINAL_PRODUCTION_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_ALLOW;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_ALLOW = ORIGINAL_PRODUCTION_ALLOW;
+  }
+
+  resetOutboundSsrfAllowListCacheForTests();
 });
 
 describe('safe-outbound-http', () => {
@@ -174,6 +184,21 @@ describe('safe-outbound-http', () => {
       await expect(safeOutboundRequest({ url: 'https://mapped.invalid/' })).rejects.toMatchObject({
         reason: 'PRIVATE_IP',
       });
+    });
+
+    it('allows private ClusterIP targets when the hostname suffix is allow-listed', async () => {
+      process.env.NOVU_SAFE_OUTBOUND_ALLOW = '.svc.cluster.local';
+      resetOutboundSsrfAllowListCacheForTests();
+
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+
+      const response = await safeOutboundJsonRequest<{ ok: boolean; path: string }>({
+        url: `http://my-bridge.my-namespace.svc.cluster.local:${new URL(upstreamUrl).port}/ping`,
+        method: 'GET',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({ ok: true, path: '/ping' });
     });
   });
 

--- a/packages/shared/src/utils/safe-outbound-http.ts
+++ b/packages/shared/src/utils/safe-outbound-http.ts
@@ -1,27 +1,7 @@
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { Readable } from 'node:stream';
-import { assertSafeOutboundUrl, isPrivateIp, resolvePublicAddresses, SsrfBlockedError } from './ssrf-url-validation';
-
-/**
- * Test-only escape hatch: when this env var is set, the SSRF policy treats
- * the listed IPs as public. This exists so test suites can run a real HTTP
- * server bound to 127.0.0.1 and exercise the connect/redirect path. Setting
- * this in production is unsupported and dangerous.
- *
- * Read lazily so tests can opt in after importing the module.
- */
-function getTestAllowList(): Set<string> {
-  const raw = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-  if (!raw) return new Set<string>();
-
-  return new Set(
-    raw
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-  );
-}
+import { assertSafeOutboundUrl, resolvePublicAddresses, SsrfBlockedError } from './ssrf-url-validation';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_REDIRECTS = 3;
@@ -108,7 +88,7 @@ export async function safeOutboundRequest(options: SafeOutboundRequestOptions): 
       currentBody = undefined;
     }
 
-    const addresses = await resolveWithTestAllowList(parsed.hostname);
+    const addresses = await resolvePublicAddresses(parsed.hostname);
     const chosen = addresses[0];
     if (!chosen) {
       throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${parsed.hostname}".`, {
@@ -396,39 +376,3 @@ function headerString(value: string | string[] | undefined): string | undefined 
   return Array.isArray(value) ? value[0] : value;
 }
 
-/**
- * Wrapper around {@link resolvePublicAddresses} that applies the test-only
- * IP allow list. Production has no allow list, so this collapses to the same
- * call. Tests can opt specific loopback IPs in to exercise the real network
- * path without disabling the policy globally.
- */
-async function resolveWithTestAllowList(hostname: string) {
-  const allowList = getTestAllowList();
-  if (allowList.size === 0) {
-    return resolvePublicAddresses(hostname);
-  }
-
-  // Mirror resolvePublicAddresses, but treat allow-listed addresses as public.
-  const dns = await import('node:dns');
-  let addresses: { address: string; family: number }[];
-  try {
-    addresses = await dns.promises.lookup(hostname.toLowerCase(), { all: true });
-  } catch {
-    throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${hostname}".`, {
-      hostname,
-    });
-  }
-
-  for (const { address } of addresses) {
-    if (allowList.has(address)) continue;
-    if (isPrivateIp(address)) {
-      throw new SsrfBlockedError(
-        'PRIVATE_IP',
-        `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
-        { hostname, resolvedAddress: address }
-      );
-    }
-  }
-
-  return addresses;
-}

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -1,6 +1,7 @@
 import * as dns from 'node:dns';
 import { isIP } from 'node:net';
 import { LRUCache } from 'lru-cache';
+import { isAddressAllowedByOutboundAllowList, isHostnameAllowedByOutboundAllowList } from './outbound-ssrf-allow-list';
 import { isPrivateIp, normalizeHostnameForLookup } from './private-ip-classification';
 
 export { isPrivateIp, normalizeHostnameForLookup };
@@ -171,7 +172,15 @@ export async function resolvePublicAddresses(
     }
   }
 
+  if (isHostnameAllowedByOutboundAllowList(normalized)) {
+    return addresses;
+  }
+
   for (const { address } of addresses) {
+    if (isAddressAllowedByOutboundAllowList(address)) {
+      continue;
+    }
+
     if (isPrivateIp(address)) {
       throw new SsrfBlockedError(
         'PRIVATE_IP',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Self-hosted users upgrading to 3.17 were blocked from bridge sync when using Kubernetes internal service URLs (e.g. `http://my-bridge.my-namespace.svc.cluster.local:5000`) because outbound SSRF protection was hardcoded on, even though `isOutboundSsrfProtectionEnabled()` is designed to disable it for self-hosted deployments.

This PR:

1. **Gates SSRF enforcement** behind `isOutboundSsrfProtectionEnabled()` across bridge sync, bridge validation, event triggers, HTTP request steps, and the execute-bridge pipeline — so community/self-hosted installs can reach trusted internal services without workarounds.
2. **Adds `NOVU_SAFE_OUTBOUND_ALLOW`** for deployments that still run SSRF protection but need explicit exceptions. Supports comma-separated entries:
   - Exact IPs: `10.0.0.5`
   - CIDR ranges: `10.0.0.0/8`, `192.168.0.0/16`
   - Exact hostnames: `bridge.internal`
   - Hostname suffixes: `.svc.cluster.local` or `*.my-namespace.svc.cluster.local`
3. **Merges the legacy test allow list** (`NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS`) into the same resolver so existing test suites keep working.

## Example (Kubernetes bridge)

```bash
# Optional — only needed when SSRF protection is enabled but internal DNS must be allowed
NOVU_SAFE_OUTBOUND_ALLOW=.svc.cluster.local
```

For standard self-hosted community installs, setting `IS_SELF_HOSTED=true` is sufficient; SSRF protection is skipped automatically.

## Flow

```mermaid
flowchart TD
  A[Outbound HTTP request] --> B{isOutboundSsrfProtectionEnabled?}
  B -->|No self-hosted| C[Standard HTTP client]
  B -->|Yes cloud| D[SSRF-safe DNS-pinned client]
  D --> E{Hostname or IP in NOVU_SAFE_OUTBOUND_ALLOW?}
  E -->|Yes| F[Allow even if private IP]
  E -->|No| G{Private IP?}
  G -->|Yes| H[Block]
  G -->|No| F
```

## Testing

- `pnpm --filter @novu/shared build`
- `npx vitest run src/utils/outbound-ssrf-allow-list.spec.ts src/utils/safe-outbound-http.spec.ts src/utils/env.spec.ts`
- Full monorepo `pnpm build`

## Linear

Linear MCP was not authenticated in this environment — please attach the appropriate NV ticket before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1782724397235569?thread_ts=1782724397.235569&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-9bda5f38-c050-5a58-8754-f323bb6ad111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bda5f38-c050-5a58-8754-f323bb6ad111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates outbound SSRF handling for bridge and HTTP request flows. The main changes are:

- Gates SSRF enforcement behind `isOutboundSsrfProtectionEnabled()` across API and worker call sites.
- Adds `NOVU_SAFE_OUTBOUND_ALLOW` support for exact IPs, CIDR ranges, hostnames, and hostname suffixes.
- Moves production and legacy test allow-list checks into shared DNS resolution.
- Adds tests for allow-list parsing and safe outbound HTTP requests to private service targets.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to outbound SSRF enforcement and allow-list handling, with no review comments requiring changes before merge.

The implementation is covered by targeted tests for allow-list parsing and safe outbound HTTP behavior, and no blocking correctness issues were identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the baseline SSRF gating tests on the base checkout to verify that a private literal is blocked and that production allow-list cases fail.
- Checked out the head branch, built, and ran the SSRF gating tests to verify that private literals remain blocked and production allow-list formats return 200, with the legacy exact IP also returning 200.
- Compared the baseline and head results against the PR contract and confirmed the delta matches the expected behavior described in the PR.
- Inspected the SSRF gating artifacts produced by the tests, confirming that the before/after/enterprise scenarios align with the expected gating behavior.

<a href="https://app.greptile.com/trex/runs/12612515/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): allow self-hosted SSRF exce..."](https://github.com/novuhq/novu/commit/3a8931e9c43b527c4de57b309384c78c63a935da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40476050)</sub>

<!-- /greptile_comment -->