### PR TITLE
fix(dashboard): redirect unauthenticated inbox embed visitors to landing page

### DIFF
--- a/apps/dashboard/src/pages/landing-1-signup.tsx
+++ b/apps/dashboard/src/pages/landing-1-signup.tsx
@@ -1,9 +1,12 @@
 import { SignUp as SignUpForm } from '@clerk/react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { useSearchParams } from 'react-router-dom';
 import { RegionPicker } from '@/components/auth/region-picker';
 import { PageMeta } from '@/components/page-meta';
+import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { clerkLandingSignupAppearance } from '@/utils/clerk-appearance';
+import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { IS_SELF_HOSTED } from '../config';
 import { useSegment } from '../context/segment';
@@ -178,6 +181,17 @@ function Testimonial() {
 }
 
 function RightPanel() {
+  const [searchParams] = useSearchParams();
+  const signInUrl = useMemo(() => {
+    const redirectUrl = readClerkRedirectUrlParam(searchParams);
+
+    if (redirectUrl) {
+      return appendRedirectUrlParam(ROUTES.SIGN_IN, redirectUrl);
+    }
+
+    return ROUTES.SIGN_IN;
+  }, [searchParams]);
+
   return (
     <div className="relative flex min-h-[600px] flex-1 flex-col overflow-hidden bg-[#08080c] lg:min-h-0 lg:w-1/2">
       <RightPanelBackground />
@@ -190,7 +204,7 @@ function RightPanel() {
         <div className="flex w-full max-w-[512px] flex-col items-center gap-5">
           <SignUpForm
             path={ROUTES.LANDING_1_SIGN_UP}
-            signInUrl={ROUTES.SIGN_IN}
+            signInUrl={signInUrl}
             appearance={clerkLandingSignupAppearance}
             forceRedirectUrl={ROUTES.SIGNUP_ORGANIZATION_LIST}
           />

--- a/apps/dashboard/src/routes/onboarding.tsx
+++ b/apps/dashboard/src/routes/onboarding.tsx
@@ -1,16 +1,39 @@
-import { Show } from '@clerk/react';
+import { Show, useAuth } from '@clerk/react';
+import { Navigate, useLocation } from 'react-router-dom';
 import { AnimatedOutlet } from '@/components/animated-outlet';
+import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
+import { ROUTES } from '@/utils/routes';
 import { AuthLayout } from '../components/auth-layout';
 import { EnvironmentProvider } from '../context/environment/environment-provider';
 
+function OnboardingSignedOutRedirect() {
+  const location = useLocation();
+  const returnUrl = `${location.pathname}${location.search}${location.hash}`;
+  const landingUrl = appendRedirectUrlParam(`${ROUTES.LANDING_1_SIGN_UP}${location.search}`, returnUrl);
+  const { pathname, search } = new URL(landingUrl, window.location.origin);
+
+  return <Navigate to={`${pathname}${search}`} replace />;
+}
+
 export const OnboardingParentRoute = () => {
+  const { isLoaded } = useAuth();
+
+  if (!isLoaded) {
+    return null;
+  }
+
   return (
-    <Show when="signed-in">
-      <EnvironmentProvider>
-        <AuthLayout>
-          <AnimatedOutlet />
-        </AuthLayout>
-      </EnvironmentProvider>
-    </Show>
+    <>
+      <Show when="signed-in">
+        <EnvironmentProvider>
+          <AuthLayout>
+            <AnimatedOutlet />
+          </AuthLayout>
+        </EnvironmentProvider>
+      </Show>
+      <Show when="signed-out">
+        <OnboardingSignedOutRedirect />
+      </Show>
+    </>
   );
 };

--- a/apps/dashboard/src/utils/better-auth/index.tsx
+++ b/apps/dashboard/src/utils/better-auth/index.tsx
@@ -1,6 +1,7 @@
 import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { ROUTES } from '@/utils/routes';
 import { EE_AUTH_PROVIDER, IS_SELF_HOSTED } from '../../config';
 import { AuthContext, type BetterAuthOrganization, type BetterAuthUser } from './auth-context';
@@ -357,12 +358,15 @@ export function SignedOut({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
-export function RedirectToSignIn() {
+export function RedirectToSignIn({ redirectUrl }: { redirectUrl?: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    navigate(ROUTES.SIGN_IN);
-  }, [navigate]);
+    const signInTarget = redirectUrl ? appendRedirectUrlParam(ROUTES.SIGN_IN, redirectUrl) : ROUTES.SIGN_IN;
+    const { pathname, search } = new URL(signInTarget, window.location.origin);
+
+    navigate(`${pathname}${search}`);
+  }, [navigate, redirectUrl]);
 
   return null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the blank page reported when trial users click the **Connect your Inbox** CTA in marketing emails while signed out (`/onboarding/inbox/embed`).

`OnboardingParentRoute` only rendered content for signed-in users, so signed-out visitors saw an empty screen.

## Changes

- Redirect signed-out onboarding visitors to `/landing-1/signup` with UTM params preserved
- Append `redirect_url` so users can return to the inbox embed step after authentication
- Forward `redirect_url` through the landing page sign-in link
- Teach better-auth `RedirectToSignIn` to honor `redirectUrl` (parity with Clerk)

## Flow

```mermaid
sequenceDiagram
  participant User
  participant InboxEmbed as /onboarding/inbox/embed
  participant Landing as /landing-1/signup
  participant SignIn as /auth/sign-in

  User->>InboxEmbed: Visit (signed out)
  InboxEmbed->>Landing: Redirect with UTM + redirect_url
  alt New user
    User->>Landing: Sign up
  else Existing user
    User->>SignIn: Sign in (redirect_url preserved)
    SignIn->>InboxEmbed: Return after auth
  end
```

## Test plan

- [x] Open `/onboarding/inbox/embed?utm_*` in an incognito session
- [x] Confirm redirect to `/landing-1/signup` (no blank page)
- [x] Confirm `redirect_url` and UTM params are present in the URL

![Redirect to landing signup with redirect_url](https://cursor.com/artifacts/c/art-f4883853-d3d9-4ab8-becb-5446014655ae)

## Linear

Linear MCP was unavailable in this environment — please attach a ticket ID (e.g. `fixes NV-XXX`) before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1782474006434749?thread_ts=1782474006.434749&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-2e5cf5d0-93ab-53ef-b862-1a14ab865d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5cf5d0-93ab-53ef-b862-1a14ab865d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a blank page shown to unauthenticated users who land on `/onboarding/inbox/embed` (e.g., via marketing email CTAs). The root cause was that `OnboardingParentRoute` wrapped its content only in `<Show when="signed-in">` with no signed-out handler.

- Adds `<Show when="signed-out">` rendering `OnboardingSignedOutRedirect`, which bounces the visitor to `/landing-1/signup` with UTM params forwarded and a `redirect_url` pointing back to the inbox embed page so the user can return after auth.
- Forwards `redirect_url` through the landing page's Clerk `SignUp` sign-in link so existing users also land back on the embed after signing in.
- Extends the better-auth `RedirectToSignIn` component with an optional `redirectUrl` prop (backward-compatible) to match Clerk parity.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is narrowly scoped to the unauthenticated onboarding path and does not touch auth token handling or session management.

All three files make targeted, easy-to-follow changes. The signed-out redirect in onboarding.tsx correctly waits for Clerk to finish loading, uses replace navigation to avoid polluting history, and forwards UTM params plus a round-trip redirect_url. The better-auth change is a backward-compatible extension. The one style inconsistency — landing-1-signup.tsx passing an absolute URL as Clerk's signInUrl while every other callsite strips it to pathname+search — is harmless in practice but worth tidying up.

apps/dashboard/src/pages/landing-1-signup.tsx — the signInUrl construction could be made consistent with the rest of the PR.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/onboarding.tsx | Adds signed-out redirect logic with isLoaded guard to prevent blank page; URL construction is correct and the replace navigation avoids history pollution. |
| apps/dashboard/src/pages/landing-1-signup.tsx | Forwards redirect_url to the sign-in link; appendRedirectUrlParam returns an absolute URL that is used directly as Clerk's signInUrl prop rather than being stripped to pathname+search as done elsewhere. |
| apps/dashboard/src/utils/better-auth/index.tsx | Backward-compatible addition of optional redirectUrl prop to RedirectToSignIn; correctly decomposes the absolute URL from appendRedirectUrlParam before calling navigate. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant OnboardingRoute as /onboarding/inbox/embed
  participant Landing as /landing-1/signup
  participant SignIn as /auth/sign-in

  User->>OnboardingRoute: Visit (signed out)
  Note over OnboardingRoute: isLoaded=false → null (no flash)
  Note over OnboardingRoute: isLoaded=true, signed-out → OnboardingSignedOutRedirect
  OnboardingRoute->>Landing: Navigate replace (UTM params + redirect_url)
  alt New user signs up
    User->>Landing: Completes sign-up form
    Landing-->>User: forceRedirectUrl → /auth/organization-list
  else Existing user clicks Sign in
    Landing->>SignIn: signInUrl with redirect_url preserved
    User->>SignIn: Completes sign-in
    SignIn-->>OnboardingRoute: Redirect to redirect_url
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant OnboardingRoute as /onboarding/inbox/embed
  participant Landing as /landing-1/signup
  participant SignIn as /auth/sign-in

  User->>OnboardingRoute: Visit (signed out)
  Note over OnboardingRoute: isLoaded=false → null (no flash)
  Note over OnboardingRoute: isLoaded=true, signed-out → OnboardingSignedOutRedirect
  OnboardingRoute->>Landing: Navigate replace (UTM params + redirect_url)
  alt New user signs up
    User->>Landing: Completes sign-up form
    Landing-->>User: forceRedirectUrl → /auth/organization-list
  else Existing user clicks Sign in
    Landing->>SignIn: signInUrl with redirect_url preserved
    User->>SignIn: Completes sign-in
    SignIn-->>OnboardingRoute: Redirect to redirect_url
  end
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fpages%2Flanding-1-signup.tsx%3A185-193%0A%60appendRedirectUrlParam%60%20returns%20an%20absolute%20URL%20%28e.g.%20%60https%3A%2F%2Fapp.novu.co%2Fauth%2Fsign-in%3Fredirect_url%3D%E2%80%A6%60%29.%20Clerk's%20%60signInUrl%60%20prop%20accepts%20absolute%20URLs%2C%20so%20this%20works%2C%20but%20it%20silently%20bakes%20in%20the%20origin%20at%20render%20time.%20The%20rest%20of%20the%20PR%20%28both%20%60onboarding.tsx%60%20and%20%60better-auth%2Findex.tsx%60%29%20strips%20the%20result%20back%20to%20%60pathname%20%2B%20search%60%20before%20use.%20Extracting%20%60pathname%20%2B%20search%60%20here%20too%20keeps%20the%20pattern%20consistent%20and%20avoids%20any%20edge-case%20mismatch%20if%20the%20component%20ever%20renders%20server-side%20or%20in%20tests%20with%20a%20different%20origin.%0A%0A%60%60%60suggestion%0A%20%20const%20signInUrl%20%3D%20useMemo%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20const%20redirectUrl%20%3D%20readClerkRedirectUrlParam%28searchParams%29%3B%0A%0A%20%20%20%20if%20%28redirectUrl%29%20%7B%0A%20%20%20%20%20%20const%20absolute%20%3D%20appendRedirectUrlParam%28ROUTES.SIGN_IN%2C%20redirectUrl%29%3B%0A%20%20%20%20%20%20const%20%7B%20pathname%2C%20search%20%7D%20%3D%20new%20URL%28absolute%2C%20window.location.origin%29%3B%0A%0A%20%20%20%20%20%20return%20%60%24%7Bpathname%7D%24%7Bsearch%7D%60%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20return%20ROUTES.SIGN_IN%3B%0A%20%20%7D%2C%20%5BsearchParams%5D%29%3B%0A%60%60%60%0A%0A&pr=11705&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/pages/landing-1-signup.tsx:185-193
`appendRedirectUrlParam` returns an absolute URL (e.g. `https://app.novu.co/auth/sign-in?redirect_url=…`). Clerk's `signInUrl` prop accepts absolute URLs, so this works, but it silently bakes in the origin at render time. The rest of the PR (both `onboarding.tsx` and `better-auth/index.tsx`) strips the result back to `pathname + search` before use. Extracting `pathname + search` here too keeps the pattern consistent and avoids any edge-case mismatch if the component ever renders server-side or in tests with a different origin.

```suggestion
  const signInUrl = useMemo(() => {
    const redirectUrl = readClerkRedirectUrlParam(searchParams);

    if (redirectUrl) {
      const absolute = appendRedirectUrlParam(ROUTES.SIGN_IN, redirectUrl);
      const { pathname, search } = new URL(absolute, window.location.origin);

      return `${pathname}${search}`;
    }

    return ROUTES.SIGN_IN;
  }, [searchParams]);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): redirect unauthenticated..."](https://github.com/novuhq/novu/commit/41262372d7439dae3cb327074c38b3cc89a0c5c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40478695)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->