### PR TITLE
fix(api-service): fire onReaction for reactions on agent messages fixes NV-8142

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -276,6 +276,21 @@ export class AgentConversationService {
     return this.activityRepository.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
   }
 
+  /** Fallback lookup when reaction thread ids do not match the stored conversation thread. */
+  async findSourceActivityForIntegration(
+    environmentId: string,
+    organizationId: string,
+    integrationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.activityRepository.findByPlatformMessageIdForIntegration(
+      environmentId,
+      organizationId,
+      integrationId,
+      platformMessageId
+    );
+  }
+
   async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
     return this.activityRepository.countAgentMessages(environmentId, conversationId);
   }

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { ConversationActivitySenderTypeEnum } from '@novu/dal';
 import { ManagedRuntime } from '../../managed-runtime/managed.runtime';
 import { AgentEventEnum } from '../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
@@ -59,7 +60,7 @@ describe('AgentInboundHandler', () => {
       persistInboundMessage: sinon.stub().resolves({ _id: 'activity1' }),
       persistAgentMessage: sinon.stub().resolves({ _id: 'agent-activity1' }),
       setFirstPlatformMessageId: sinon.stub().resolves(undefined),
-      findByPlatformThread: sinon.stub().resolves(conversation),
+      findByPlatformThread: overrides.findByPlatformThread ?? sinon.stub().resolves(conversation),
       getHistory: sinon.stub().resolves(overrides.history ?? []),
       findSourceActivity: sinon
         .stub()
@@ -67,6 +68,9 @@ describe('AgentInboundHandler', () => {
           async (_environmentId: string, _conversationId: string, platformMessageId: string) =>
             (overrides.history ?? []).find((activity: any) => activity?.platformMessageId === platformMessageId) ?? null
         ),
+      findSourceActivityForIntegration:
+        overrides.findSourceActivityForIntegration ?? sinon.stub().resolves(null),
+      getConversation: overrides.getConversation ?? sinon.stub().resolves(conversation),
       countAgentMessages: sinon.stub().resolves(0),
     };
     const bridgeExecutor = {
@@ -834,6 +838,51 @@ describe('AgentInboundHandler', () => {
       expect(attachmentStorage.storeInbound.firstCall.args[1].platformMessageId).to.equal('source-msg');
       const params = bridgeExecutor.execute.firstCall.args[0];
       expect(params.reaction.sourceMessageStoredAttachments).to.deep.equal(storedAttachments);
+    });
+
+    it('should resolve conversation via reacted agent message when thread id does not match', async () => {
+      const storedConversation = {
+        _id: 'conversation1',
+        channels: [{ platformThreadId: 'slack:D123:user-root-ts', platform: 'slack', _integrationId: 'integration1' }],
+      };
+      const agentActivity = {
+        _conversationId: 'conversation1',
+        platformMessageId: 'agent-reply-ts',
+        platformThreadId: 'slack:D123:user-root-ts',
+        senderType: ConversationActivitySenderTypeEnum.AGENT,
+        senderId: 'agent1',
+        senderName: 'Support Bot',
+        content: 'Here is my answer',
+        createdAt: new Date().toISOString(),
+      };
+      const findByPlatformThread = sinon.stub().callsFake(async (_env, _org, _agent, _integration, threadId) =>
+        threadId === 'slack:D123:user-root-ts' ? storedConversation : null
+      );
+      const findSourceActivityForIntegration = sinon.stub().resolves(agentActivity);
+      const { handler, bridgeExecutor, conversationService } = makeHandler({
+        findByPlatformThread,
+        findSourceActivityForIntegration,
+        getConversation: sinon.stub().resolves(storedConversation),
+      });
+
+      await handler.handleReaction('agent1', config as any, {
+        emoji: { name: 'thumbs_up', toJSON: () => 'thumbs_up', toString: () => 'thumbs_up' },
+        added: true,
+        messageId: 'agent-reply-ts',
+        thread: {
+          id: 'slack:D123:agent-reply-ts',
+          channelId: 'slack:D123',
+          isDM: true,
+        },
+      } as any);
+
+      expect(conversationService.findSourceActivityForIntegration.calledOnce).to.equal(true);
+      expect(bridgeExecutor.execute.calledOnce).to.equal(true);
+      const params = bridgeExecutor.execute.firstCall.args[0];
+      expect(params.event).to.equal(AgentEventEnum.ON_REACTION);
+      expect(params.platformContext.threadId).to.equal('slack:D123:user-root-ts');
+      expect(params.reaction.sourceMessage.text).to.equal('Here is my answer');
+      expect(params.reaction.sourceMessage.author.isBot).to.equal(true);
     });
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -44,6 +44,7 @@ import { ConversationActivationService } from '../conversation/conversation-acti
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { BridgeReaction } from '../runtime/bridge-executor.service';
 import type { ConversationTurn } from '../runtime/conversation-turn';
+import { applyPlatformThreadIdToThread } from '../runtime/platform-thread.util';
 import { RuntimeResolver } from '../runtime/runtime-resolver.service';
 import { InboundDispatcher } from './inbound.dispatcher';
 import { isLinkButtonActionId, PlanLimitGateService } from './plan-limit-gate.service';
@@ -165,6 +166,45 @@ function getInboundPlatformThreadId(platform: AgentPlatformEnum, thread: Thread,
   }
 
   return `${thread.id}${threadRoot}`;
+}
+
+function resolveReactionPlatformThreadId(
+  platform: AgentPlatformEnum,
+  thread: Thread,
+  message: Message | undefined,
+  messageId: string
+): string {
+  if (message) {
+    return getInboundPlatformThreadId(platform, thread, message);
+  }
+
+  // Slack DM reactions may arrive with an empty-root SDK thread id (`slack:D123:`).
+  // Inbound messages patch that using the message ts; mirror that for reactions
+  // when the reacted-to message is the thread root.
+  if (platform === AgentPlatformEnum.SLACK && thread.isDM && thread.id.endsWith(':') && messageId) {
+    return `${thread.id}${messageId}`;
+  }
+
+  return thread.id;
+}
+
+function buildSourceMessageFromActivity(activity: ConversationActivityEntity): Message {
+  const isBot = activity.senderType === ConversationActivitySenderTypeEnum.AGENT;
+
+  return {
+    id: activity.platformMessageId ?? '',
+    text: activity.content,
+    author: {
+      userId: activity.senderId,
+      fullName: activity.senderName ?? activity.senderId,
+      userName: activity.senderName ?? activity.senderId,
+      isBot,
+    },
+    attachments: [],
+    metadata: {
+      dateSent: activity.createdAt ? new Date(activity.createdAt) : new Date(),
+    },
+  } as Message;
 }
 
 function mapStoredAttachmentsFromRichContent(richContent?: Record<string, unknown>): StoredAttachment[] {
@@ -860,20 +900,49 @@ export class AgentInboundHandler implements OnModuleInit {
   }
 
   async handleReaction(agentId: string, config: ResolvedAgentConfig, event: InboundReactionEvent): Promise<void> {
-    const threadId = event.thread?.id;
-    if (!threadId) {
+    if (!event.thread?.id) {
       this.logger.warn(`[agent:${agentId}] Reaction received without thread context, skipping`);
 
       return;
     }
 
-    const conversation = await this.conversationService.findByPlatformThread(
+    let platformThreadId = resolveReactionPlatformThreadId(
+      config.platform,
+      event.thread,
+      event.message,
+      event.messageId
+    );
+
+    let conversation = await this.conversationService.findByPlatformThread(
       config.environmentId,
       config.organizationId,
       config.agentId,
       config.integrationId,
-      threadId
+      platformThreadId
     );
+
+    let sourceActivity: ConversationActivityEntity | null = null;
+
+    if (!conversation) {
+      sourceActivity = await this.conversationService.findSourceActivityForIntegration(
+        config.environmentId,
+        config.organizationId,
+        config.integrationId,
+        event.messageId
+      );
+
+      if (sourceActivity) {
+        conversation = await this.conversationService.getConversation(
+          sourceActivity._conversationId,
+          config.environmentId,
+          config.organizationId
+        );
+
+        if (conversation) {
+          platformThreadId = this.conversationService.getPrimaryChannel(conversation).platformThreadId;
+        }
+      }
+    }
 
     if (!conversation) {
       return;
@@ -895,21 +964,28 @@ export class AgentInboundHandler implements OnModuleInit {
       ? await this.resolveSubscriberId(agentId, config, platformUserId, 'resolve-subscriber-reaction')
       : null;
 
-    const [subscriber, sourceActivity] = await Promise.all([
-      subscriberId
-        ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
-        : Promise.resolve(null),
-      this.conversationService.findSourceActivity(config.environmentId, conversation._id, event.messageId),
-    ]);
+    if (!sourceActivity) {
+      sourceActivity = await this.conversationService.findSourceActivity(
+        config.environmentId,
+        conversation._id,
+        event.messageId
+      );
+    }
+
+    const subscriber = subscriberId
+      ? await this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
+      : null;
+
+    const sourceMessage = event.message ?? (sourceActivity ? buildSourceMessageFromActivity(sourceActivity) : undefined);
 
     let sourceMessageStoredAttachments = extractStoredAttachments(sourceActivity);
 
-    if (!sourceMessageStoredAttachments && event.message?.attachments?.length) {
-      sourceMessageStoredAttachments = await this.attachmentStorage.storeInbound(event.message.attachments, {
+    if (!sourceMessageStoredAttachments && sourceMessage?.attachments?.length) {
+      sourceMessageStoredAttachments = await this.attachmentStorage.storeInbound(sourceMessage.attachments, {
         organizationId: config.organizationId,
         environmentId: config.environmentId,
         conversationId: String(conversation._id),
-        platformMessageId: event.message.id ?? event.messageId ?? `unknown-${Date.now()}`,
+        platformMessageId: sourceMessage.id ?? event.messageId ?? `unknown-${Date.now()}`,
         platform: config.platform,
       });
     }
@@ -918,11 +994,14 @@ export class AgentInboundHandler implements OnModuleInit {
       emoji: event.emoji.name,
       added: event.added,
       messageId: event.messageId,
-      sourceMessage: event.message,
+      sourceMessage,
       sourceMessageStoredAttachments: sourceMessageStoredAttachments?.length
         ? sourceMessageStoredAttachments
         : undefined,
     };
+
+    const thread = event.thread ?? ({ id: platformThreadId, channelId: '', isDM: false } as Thread);
+    applyPlatformThreadIdToThread(thread, platformThreadId);
 
     const runtime = this.runtimeResolver.resolve(null);
     const turn: ConversationTurn = {
@@ -933,8 +1012,8 @@ export class AgentInboundHandler implements OnModuleInit {
       subscriber,
       message: null,
       event: AgentEventEnum.ON_REACTION,
-      thread: event.thread ?? ({ id: threadId, channelId: '', isDM: false } as Thread),
-      platformThreadId: threadId,
+      thread,
+      platformThreadId,
       reaction: reactionPayload,
     };
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -193,6 +193,7 @@ function buildSourceMessageFromActivity(activity: ConversationActivityEntity): M
 
   return {
     id: activity.platformMessageId ?? '',
+    threadId: activity.platformThreadId,
     text: activity.content,
     author: {
       userId: activity.senderId,
@@ -204,7 +205,7 @@ function buildSourceMessageFromActivity(activity: ConversationActivityEntity): M
     metadata: {
       dateSent: activity.createdAt ? new Date(activity.createdAt) : new Date(),
     },
-  } as Message;
+  } as unknown as Message;
 }
 
 function mapStoredAttachmentsFromRichContent(richContent?: Record<string, unknown>): StoredAttachment[] {
@@ -938,8 +939,16 @@ export class AgentInboundHandler implements OnModuleInit {
           config.organizationId
         );
 
-        if (conversation) {
-          platformThreadId = this.conversationService.getPrimaryChannel(conversation).platformThreadId;
+        if (!conversation || String(conversation._agentId) !== String(config.agentId)) {
+          conversation = null;
+          sourceActivity = null;
+        } else {
+          const primaryChannel = conversation.channels?.[0];
+          if (!primaryChannel) {
+            return;
+          }
+
+          platformThreadId = primaryChannel.platformThreadId;
         }
       }
     }
@@ -964,17 +973,16 @@ export class AgentInboundHandler implements OnModuleInit {
       ? await this.resolveSubscriberId(agentId, config, platformUserId, 'resolve-subscriber-reaction')
       : null;
 
-    if (!sourceActivity) {
-      sourceActivity = await this.conversationService.findSourceActivity(
-        config.environmentId,
-        conversation._id,
-        event.messageId
-      );
-    }
+    const [subscriber, resolvedSourceActivity] = await Promise.all([
+      subscriberId
+        ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
+        : Promise.resolve(null),
+      sourceActivity
+        ? Promise.resolve(sourceActivity)
+        : this.conversationService.findSourceActivity(config.environmentId, conversation._id, event.messageId),
+    ]);
 
-    const subscriber = subscriberId
-      ? await this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
-      : null;
+    sourceActivity = resolvedSourceActivity;
 
     const sourceMessage = event.message ?? (sourceActivity ? buildSourceMessageFromActivity(sourceActivity) : undefined);
 

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -61,6 +61,27 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     );
   }
 
+  /**
+   * Resolves a reacted-to message when the inbound thread id does not match the
+   * conversation's stored platform thread (common for reactions on agent replies).
+   */
+  async findByPlatformMessageIdForIntegration(
+    environmentId: string,
+    organizationId: string,
+    integrationId: string,
+    platformMessageId: string
+  ): Promise<ConversationActivityEntity | null> {
+    return this.findOne(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        _integrationId: integrationId,
+        platformMessageId,
+      },
+      '*'
+    );
+  }
+
   async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
     return this.count({
       _environmentId: environmentId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `onReaction` not firing when a user adds an emoji reaction to an agent's message.

Reactions on user messages worked because the inbound thread id matched the stored conversation. Reactions on agent replies often arrive with a different platform thread id (for example when Slack resolves the reacted message ts instead of the conversation root), so the handler silently skipped dispatch.

## Changes

- Normalize reaction thread ids for Slack DMs the same way inbound messages do when the SDK thread id has an empty root suffix.
- Fall back to locating the conversation via the reacted message's `platformMessageId` when a direct thread lookup misses.
- Hydrate `reaction.sourceMessage` from stored conversation activity when the chat adapter does not include the reacted message payload (common for agent-authored messages).
- Restore parallel subscriber and source-activity lookups after fallback resolution.
- Verify fallback conversation belongs to the requesting agent before dispatching.
- Guard against conversations with no channels instead of throwing from `getPrimaryChannel`.

## Testing

- Added unit coverage in `inbound-turn.handler.spec.ts` for the agent-message reaction fallback path.
- `pnpm --filter @novu/api-service build` — passes
- `pnpm test -- --grep 'handleReaction'` — 3 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8142](https://linear.app/novu/issue/NV-8142/onreaction-event-handler-is-not-called-if-an-emoji-reaction-is-added)

<div><a href="https://cursor.com/agents/bc-8a98d4fc-a6d3-4cb6-878d-3e9febdd64c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a98d4fc-a6d3-4cb6-878d-3e9febdd64c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `onReaction` not firing when a user reacts to an agent's reply by adding a fallback conversation-resolution path to `handleReaction`. The root cause was that Slack (and potentially other platforms) delivers reaction events with a thread id referencing the reacted message's timestamp rather than the conversation root, so the primary `findByPlatformThread` lookup silently returned nothing for agent-authored messages.

- **Fallback lookup**: when `findByPlatformThread` misses, the handler now calls `findSourceActivityForIntegration` to locate the stored activity by `platformMessageId` across the integration, then re-derives the conversation and canonical thread id from the stored activity's primary channel. A `String(_agentId)` ownership check guards the fallback path.
- **Thread id normalisation**: `resolveReactionPlatformThreadId` mirrors the existing inbound-message logic for Slack DM empty-root thread ids, patching the thread id with `messageId` when the SDK provides a bare `slack:D123:` prefix.
- **Source-message hydration**: `buildSourceMessageFromActivity` constructs a synthetic `Message` from the stored activity so `reaction.sourceMessage` is populated even when the chat adapter omits the reacted message payload (the common case for agent replies).

<h3>Confidence Score: 4/5</h3>

Safe to merge for the happy-path fix; the test coverage gap around the ownership check is worth addressing before the fallback path is relied upon in adversarial conditions.

The core fix is well-reasoned and the ownership guard provides an important security boundary for the broader fallback DB query. However, the new test does not actually exercise that guard — both sides are undefined in the fixture — so a regression in the ownership check would go undetected. The production logic itself looks correct.

inbound-turn.handler.spec.ts — the new test's conversation fixture and config both lack agentId, leaving the ownership-verification branch untested.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Core fix: adds fallback conversation resolution via platformMessageId, normalises Slack DM reaction thread ids, builds sourceMessage from stored activity, and restores parallel subscriber/activity lookups. Logic is sound; the fallback DB query (without _agentId scope) is mitigated by an in-memory ownership check on the returned conversation. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts | Adds a new test covering the agent-message reaction fallback path, and makes findByPlatformThread/findSourceActivityForIntegration/getConversation overridable in makeHandler. The new test does not set _agentId on the conversation fixture or agentId on config, so the ownership-verification gate at line 942 is not exercised by the test. |
| libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts | Adds findByPlatformMessageIdForIntegration scoped by _environmentId, _organizationId, _integrationId, and platformMessageId. Deliberately broader than the primary findByPlatformMessageId (which additionally scopes by _conversationId); handler compensates with an in-memory _agentId ownership check. |
| apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts | Thin service wrapper for the new repository method; straightforward delegation with no logic changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleReaction called] --> B{event.thread.id present?}
    B -- No --> Z[return - warn]
    B -- Yes --> C[resolveReactionPlatformThreadId]
    C --> D{Slack DM + empty root + messageId?}
    D -- Yes --> E[thread.id + messageId]
    D -- No --> F[thread.id as-is]
    E --> G[findByPlatformThread]
    F --> G
    G --> H{conversation found?}
    H -- Yes --> M[continue to dispatch]
    H -- No --> I[findSourceActivityForIntegration by platformMessageId]
    I --> J{sourceActivity found?}
    J -- No --> Z2[return - no conversation]
    J -- Yes --> K[getConversation via _conversationId]
    K --> L{conversation exists AND agentId matches?}
    L -- No --> Z2
    L -- Yes --> L2{primaryChannel exists?}
    L2 -- No --> Z3[return - no primary channel]
    L2 -- Yes --> L3[platformThreadId = primaryChannel.platformThreadId]
    L3 --> M
    M --> N[Promise.all: subscriber + sourceActivity resolution]
    N --> O[build sourceMessage from activity or event.message]
    O --> P[applyPlatformThreadIdToThread]
    P --> Q[runtime.dispatch turn]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[handleReaction called] --> B{event.thread.id present?}
    B -- No --> Z[return - warn]
    B -- Yes --> C[resolveReactionPlatformThreadId]
    C --> D{Slack DM + empty root + messageId?}
    D -- Yes --> E[thread.id + messageId]
    D -- No --> F[thread.id as-is]
    E --> G[findByPlatformThread]
    F --> G
    G --> H{conversation found?}
    H -- Yes --> M[continue to dispatch]
    H -- No --> I[findSourceActivityForIntegration by platformMessageId]
    I --> J{sourceActivity found?}
    J -- No --> Z2[return - no conversation]
    J -- Yes --> K[getConversation via _conversationId]
    K --> L{conversation exists AND agentId matches?}
    L -- No --> Z2
    L -- Yes --> L2{primaryChannel exists?}
    L2 -- No --> Z3[return - no primary channel]
    L2 -- Yes --> L3[platformThreadId = primaryChannel.platformThreadId]
    L3 --> M
    M --> N[Promise.all: subscriber + sourceActivity resolution]
    N --> O[build sourceMessage from activity or event.message]
    O --> P[applyPlatformThreadIdToThread]
    P --> Q[runtime.dispatch turn]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): address review feedbac..."](https://github.com/novuhq/novu/commit/678ce0d7ab204afc35cf8c2f1aaca2c6e27972dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40529348)</sub>

<!-- /greptile_comment -->