### PR TITLE
feat(dashboard): support actor variables in step content editor fixes NV-8143

### DIFF
--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -13,7 +13,7 @@ import {
   WorkflowCreationSourceEnum,
   WorkflowResponseDto,
 } from '@novu/api/models/components';
-import { buildWorkflowSchema, DEFAULT_ARRAY_ELEMENTS, EmailControlType } from '@novu/application-generic';
+import { buildActorSchema, buildWorkflowSchema, DEFAULT_ARRAY_ELEMENTS, EmailControlType } from '@novu/application-generic';
 import { EnvironmentRepository, NotificationTemplateEntity, NotificationTemplateRepository } from '@novu/dal';
 import { CronExpressionEnum, RedirectTargetEnum, StepTypeEnum, slugify } from '@novu/shared';
 import { UserSession } from '@novu/testing';
@@ -27,6 +27,17 @@ const TEST_WORKFLOW_NAME = 'Test Workflow Name';
 const SUBJECT_TEST_PAYLOAD = '{{payload.subject.test.payload}}';
 const PLACEHOLDER_SUBJECT_INAPP = '{{payload.subject}}';
 const PLACEHOLDER_SUBJECT_INAPP_PAYLOAD_VALUE = 'this is the replacement text for the placeholder';
+
+const EXPECTED_MOCK_ACTOR_PREVIEW = {
+  firstName: 'Jane',
+  lastName: 'Actor',
+  email: 'actor@example.com',
+  phone: '+1234567890',
+  avatar: 'https://example.com/avatar.png',
+  locale: 'en_US',
+  timezone: 'America/New_York',
+  data: {},
+};
 
 describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v2', async () => {
   let session: UserSession;
@@ -180,6 +191,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
             required: ['subscriberId'],
             additionalProperties: false,
           },
+          actor: buildActorSchema(undefined),
           steps: {
             type: 'object',
             properties: {},
@@ -271,6 +283,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           timezone: 'America/New_York',
           data: {},
         },
+        actor: EXPECTED_MOCK_ACTOR_PREVIEW,
         payload: {
           placeholder: {
             body: 'This is a body',
@@ -471,6 +484,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
             required: ['subscriberId'],
             type: 'object',
           },
+          actor: buildActorSchema(undefined),
           steps: {
             type: 'object',
             properties: {},
@@ -533,6 +547,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           timezone: 'America/New_York',
           data: {},
         },
+        actor: EXPECTED_MOCK_ACTOR_PREVIEW,
         payload: {
           placeholder: {
             body: 'Default body text',

--- a/apps/dashboard/src/components/preview-actor-section.tsx
+++ b/apps/dashboard/src/components/preview-actor-section.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { RiInformation2Line, RiRefreshLine } from 'react-icons/ri';
+import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
+import { SubscriberAutocomplete } from '@/components/subscribers/subscriber-autocomplete';
+import { Button } from './primitives/button';
+import { ACCORDION_STYLES } from './workflow-editor/steps/constants/preview-context.constants';
+import { EditableJsonViewer } from './workflow-editor/steps/shared/editable-json-viewer/editable-json-viewer';
+import { ActorSectionProps } from './workflow-editor/steps/types/preview-context.types';
+
+export function PreviewActorSection({
+  error,
+  actor,
+  schema,
+  onUpdate,
+  onActorSelect,
+  onClearPersisted,
+}: ActorSectionProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  return (
+    <AccordionItem value="actor" className={ACCORDION_STYLES.item}>
+      <AccordionTrigger
+        className={ACCORDION_STYLES.trigger}
+        rightSlot={
+          onClearPersisted ? (
+            <div className="mr-2">
+              <Button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClearPersisted();
+                }}
+                type="button"
+                variant="secondary"
+                mode="ghost"
+                size="2xs"
+                className="text-foreground-600 gap-1"
+              >
+                <RiRefreshLine className="h-3 w-3" />
+                Reset defaults
+              </Button>
+            </div>
+          ) : null
+        }
+      >
+        <div className="flex w-full items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-0.5">
+              Actor
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-foreground-400 inline-block hover:cursor-help">
+                    <RiInformation2Line className="size-3" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  The actor sent during workflow trigger. Use actor variables like {'{{actor.firstName}}'} in step
+                  content.
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          </div>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className="flex flex-col gap-2">
+        <SubscriberAutocomplete
+          value={searchQuery}
+          onChange={setSearchQuery}
+          onSelectSubscriber={(subscriber) => {
+            onActorSelect(subscriber);
+            setSearchQuery('');
+          }}
+          size="xs"
+          className="w-full"
+        />
+        <div className="flex flex-1 flex-col gap-2 overflow-auto">
+          <EditableJsonViewer
+            value={actor}
+            onChange={(updatedData) => onUpdate('actor', updatedData)}
+            schema={schema}
+            className={ACCORDION_STYLES.jsonViewer}
+          />
+          {error && <p className="text-destructive text-xs">{error}</p>}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/apps/dashboard/src/components/variable/hooks/use-create-variable.tsx
+++ b/apps/dashboard/src/components/variable/hooks/use-create-variable.tsx
@@ -10,7 +10,7 @@ import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { useWorkflowSchema } from '@/components/workflow-editor/workflow-schema-provider';
 import { useEnvironment } from '@/context/environment/hooks';
 
-type VariableType = 'payload' | 'subscriber' | 'context';
+type VariableType = 'payload' | 'subscriber' | 'actor' | 'context';
 
 interface VariableInfo {
   type: VariableType;
@@ -22,6 +22,7 @@ interface VariableInfo {
 const VARIABLE_PREFIXES = {
   PAYLOAD: 'payload.',
   SUBSCRIBER: 'subscriber.data.',
+  ACTOR: 'actor.data.',
   CONTEXT: 'context.',
 } as const;
 
@@ -32,6 +33,7 @@ function parseVariablePath(variablePath: string): VariableInfo | null {
   const prefixMap: Array<{ prefix: string; type: VariableType }> = [
     { prefix: VARIABLE_PREFIXES.PAYLOAD, type: 'payload' },
     { prefix: VARIABLE_PREFIXES.SUBSCRIBER, type: 'subscriber' },
+    { prefix: VARIABLE_PREFIXES.ACTOR, type: 'actor' },
     { prefix: VARIABLE_PREFIXES.CONTEXT, type: 'context' },
   ];
 
@@ -98,7 +100,7 @@ export const useCreateVariable = () => {
   const editorValue = stepEditor?.editorValue;
   const setEditorValue = stepEditor?.setEditorValue;
 
-  const { savePersistedSubscriber, savePersistedContext } = usePersistedPreviewContext({
+  const { savePersistedSubscriber, savePersistedActor, savePersistedContext } = usePersistedPreviewContext({
     workflowId: workflow?.workflowId || '',
     environmentId: currentEnvironment?._id || '',
   });
@@ -138,6 +140,28 @@ export const useCreateVariable = () => {
       savePersistedSubscriber(updatedSubscriber);
     },
     [setEditorValue, editorValue, savePersistedSubscriber]
+  );
+
+  const handleActorVariable = useCallback(
+    (variableInfo: VariableInfo) => {
+      if (!editorValue || !setEditorValue) return;
+
+      const currentPreviewData = parseJsonValue(editorValue);
+      const currentActor = currentPreviewData.actor || {};
+      const currentActorData = currentActor.data || {};
+
+      const newVariable = variableInfo.key
+        .split('.')
+        .reduceRight((value, key) => ({ [key]: value }), 'example_value' as unknown);
+
+      const updatedActorData = merge({}, currentActorData, newVariable);
+      const updatedActor = { ...currentActor, data: updatedActorData };
+      const newPreviewData = { ...currentPreviewData, actor: updatedActor };
+
+      setEditorValue(JSON.stringify(newPreviewData, null, 2));
+      savePersistedActor(updatedActor);
+    },
+    [setEditorValue, editorValue, savePersistedActor]
   );
 
   const handleContextVariable = useCallback(
@@ -185,6 +209,7 @@ export const useCreateVariable = () => {
         const handlers = {
           payload: handlePayloadVariable,
           subscriber: handleSubscriberVariable,
+          actor: handleActorVariable,
           context: handleContextVariable,
         } as const;
 
@@ -198,7 +223,7 @@ export const useCreateVariable = () => {
         showErrorToast(`Failed to create ${variableInfo.type} variable: ${error}`);
       }
     },
-    [workflow, handlePayloadVariable, handleSubscriberVariable, handleContextVariable]
+    [workflow, handlePayloadVariable, handleSubscriberVariable, handleActorVariable, handleContextVariable]
   );
 
   const openSchemaDrawer = useCallback((variableName?: string) => {

--- a/apps/dashboard/src/components/workflow-editor/steps/components/index.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/components/index.ts
@@ -1,3 +1,4 @@
+export { PreviewActorSection } from '../../../preview-actor-section';
 export { PreviewContextSection } from '../../../preview-context-section';
 export { PreviewEnvSection } from '../../../preview-env-section';
 export { PreviewSubscriberSection } from '../../../preview-subscriber-section';

--- a/apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts
@@ -37,4 +37,4 @@ export const ACCORDION_STYLES = {
   jsonViewer: 'border-neutral-alpha-200 bg-background text-foreground-600 rounded-lg border border-solid',
 } as const;
 
-export const DEFAULT_ACCORDION_VALUES = ['payload', 'subscriber', 'actor', 'step-results', 'context', 'env'];
+export const DEFAULT_ACCORDION_VALUES = ['payload', 'subscriber', 'step-results', 'context', 'env'];

--- a/apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts
@@ -37,4 +37,4 @@ export const ACCORDION_STYLES = {
   jsonViewer: 'border-neutral-alpha-200 bg-background text-foreground-600 rounded-lg border border-solid',
 } as const;
 
-export const DEFAULT_ACCORDION_VALUES = ['payload', 'subscriber', 'step-results', 'context', 'env'];
+export const DEFAULT_ACCORDION_VALUES = ['payload', 'subscriber', 'actor', 'step-results', 'context', 'env'];

--- a/apps/dashboard/src/components/workflow-editor/steps/hooks/use-persisted-preview-context.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/hooks/use-persisted-preview-context.ts
@@ -3,12 +3,15 @@ import { useEffect } from 'react';
 import { PayloadData, PreviewSubscriberData } from '../types/preview-context.types';
 import {
   cleanupExpiredPreviewData,
+  clearActorData,
   clearContextData,
   clearPayloadData,
   clearSubscriberData,
+  loadActorData,
   loadContextData,
   loadPayloadData,
   loadSubscriberData,
+  saveActorData,
   saveContextData,
   savePayloadData,
   saveSubscriberData,
@@ -60,6 +63,24 @@ export function usePersistedPreviewContext({ workflowId, environmentId }: UsePer
     clearSubscriberData(workflowId, environmentId);
   };
 
+  const loadPersistedActor = (): PreviewSubscriberData | null => {
+    if (!workflowId || !environmentId) return null;
+
+    return loadActorData(workflowId, environmentId);
+  };
+
+  const savePersistedActor = (actor: PreviewSubscriberData) => {
+    if (!workflowId || !environmentId) return;
+
+    saveActorData(workflowId, environmentId, actor);
+  };
+
+  const clearPersistedActor = () => {
+    if (!workflowId || !environmentId) return;
+
+    clearActorData(workflowId, environmentId);
+  };
+
   const loadPersistedContext = (): ContextPayload | null => {
     if (!workflowId || !environmentId) return null;
 
@@ -85,6 +106,9 @@ export function usePersistedPreviewContext({ workflowId, environmentId }: UsePer
     loadPersistedSubscriber,
     savePersistedSubscriber,
     clearPersistedSubscriber,
+    loadPersistedActor,
+    savePersistedActor,
+    clearPersistedActor,
     loadPersistedContext,
     savePersistedContext,
     clearPersistedContext,

--- a/apps/dashboard/src/components/workflow-editor/steps/hooks/use-preview-data-initialization.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/hooks/use-preview-data-initialization.ts
@@ -14,6 +14,7 @@ type InitializationProps = {
   isPayloadSchemaEnabled: boolean;
   loadPersistedPayload: () => PayloadData | null;
   loadPersistedSubscriber: () => PreviewSubscriberData | null;
+  loadPersistedActor: () => PreviewSubscriberData | null;
   loadPersistedContext: () => ContextPayload | null;
 };
 
@@ -27,6 +28,7 @@ export function usePreviewDataInitialization({
   isPayloadSchemaEnabled,
   loadPersistedPayload,
   loadPersistedSubscriber,
+  loadPersistedActor,
   loadPersistedContext,
 }: InitializationProps) {
   const isInitializedRef = useRef(false);
@@ -52,6 +54,7 @@ export function usePreviewDataInitialization({
           {
             payload: persistedPayload,
             subscriber: {},
+            actor: {},
             steps: {},
             context: {},
             env: {},
@@ -59,6 +62,7 @@ export function usePreviewDataInitialization({
           {
             payload: workflow.payloadExample as PayloadData,
             subscriber: {},
+            actor: {},
             steps: {},
             context: {},
             env: {},
@@ -83,6 +87,13 @@ export function usePreviewDataInitialization({
 
       if (persistedSubscriber) {
         finalData.subscriber = persistedSubscriber;
+        hasChanges = true;
+      }
+
+      const persistedActor = loadPersistedActor();
+
+      if (persistedActor) {
+        finalData.actor = persistedActor;
         hasChanges = true;
       }
 
@@ -114,6 +125,7 @@ export function usePreviewDataInitialization({
     isPayloadSchemaEnabled,
     loadPersistedPayload,
     loadPersistedSubscriber,
+    loadPersistedActor,
     loadPersistedContext,
     onChange,
   ]);

--- a/apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx
@@ -1,4 +1,4 @@
-import { ISubscriberResponseDto } from '@novu/shared';
+import { DEFAULT_LOCALE, ISubscriberResponseDto } from '@novu/shared';
 import { JSONSchema7 } from 'json-schema';
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -30,7 +30,7 @@ import {
   PreviewSubscriberData,
   ValidationErrors,
 } from './types/preview-context.types';
-import { createSubscriberData, parseJsonValue } from './utils/preview-context.utils';
+import { createDefaultActorData, createSubscriberData, parseJsonValue } from './utils/preview-context.utils';
 
 function usePrevious<T>(value: T): T | undefined {
   const ref = useRef<T | undefined>(undefined);
@@ -124,6 +124,12 @@ export function PreviewContextPanel({
     selectedLocale,
     organizationSettings?.data?.defaultLocale
   );
+
+  const createDefaultActorDataWithLocale = useCallback(() => {
+    const defaultLocale = selectedLocale || organizationSettings?.data?.defaultLocale || DEFAULT_LOCALE;
+
+    return createDefaultActorData(defaultLocale);
+  }, [selectedLocale, organizationSettings?.data?.defaultLocale]);
 
   const {
     loadPersistedPayload,
@@ -262,8 +268,8 @@ export function PreviewContextPanel({
 
   const handleClearPersistedActor = useCallback(() => {
     clearPersistedActor();
-    updatePreviewSection('actor', {});
-  }, [clearPersistedActor, updatePreviewSection]);
+    updatePreviewSection('actor', createDefaultActorDataWithLocale());
+  }, [clearPersistedActor, updatePreviewSection, createDefaultActorDataWithLocale]);
 
   const handleClearPersistedContext = useCallback(() => {
     clearPersistedContext();

--- a/apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx
@@ -13,6 +13,7 @@ import { StepTypeEnum } from '@/utils/enums';
 import { usePreviewContext } from '../../../hooks/use-preview-context';
 import { PayloadSchemaDrawer } from '../payload-schema-drawer';
 import {
+  PreviewActorSection,
   PreviewContextSection,
   PreviewEnvSection,
   PreviewPayloadSection,
@@ -107,6 +108,7 @@ export function PreviewContextPanel({
     () => ({
       payload: workflow?.payloadSchema,
       subscriber: previewSchema?.properties?.subscriber as JSONSchema7 | undefined,
+      actor: previewSchema?.properties?.actor as JSONSchema7 | undefined,
       context: previewSchema?.properties?.context as JSONSchema7 | undefined,
       steps: previewSchema?.properties?.steps as JSONSchema7 | undefined,
       env: previewSchema?.properties?.env as JSONSchema7 | undefined,
@@ -130,6 +132,9 @@ export function PreviewContextPanel({
     loadPersistedSubscriber,
     savePersistedSubscriber,
     clearPersistedSubscriber,
+    loadPersistedActor,
+    savePersistedActor,
+    clearPersistedActor,
     loadPersistedContext,
     savePersistedContext,
     clearPersistedContext,
@@ -146,6 +151,7 @@ export function PreviewContextPanel({
       defaultAccordionValue: DEFAULT_ACCORDION_VALUES,
       defaultErrors: {
         subscriber: null,
+        actor: null,
         payload: null,
         steps: null,
         context: null,
@@ -159,6 +165,10 @@ export function PreviewContextPanel({
 
         if (data.subscriber !== undefined) {
           savePersistedSubscriber(data.subscriber);
+        }
+
+        if (data.actor !== undefined) {
+          savePersistedActor(data.actor);
         }
 
         if (data.context !== undefined) {
@@ -181,6 +191,7 @@ export function PreviewContextPanel({
     isPayloadSchemaEnabled,
     loadPersistedPayload,
     loadPersistedSubscriber,
+    loadPersistedActor,
     loadPersistedContext,
   });
 
@@ -227,6 +238,14 @@ export function PreviewContextPanel({
     [updatePreviewSection, selectedLocale, onLocaleChange]
   );
 
+  const handleActorSelection = useCallback(
+    (subscriber: ISubscriberResponseDto) => {
+      const actorData = createSubscriberData(subscriber);
+      updatePreviewSection('actor', actorData);
+    },
+    [updatePreviewSection]
+  );
+
   const handleClearPersistedPayload = useCallback(() => {
     clearPersistedPayload();
 
@@ -240,6 +259,11 @@ export function PreviewContextPanel({
     clearPersistedSubscriber();
     updatePreviewSection('subscriber', createDefaultSubscriberData());
   }, [clearPersistedSubscriber, updatePreviewSection, createDefaultSubscriberData]);
+
+  const handleClearPersistedActor = useCallback(() => {
+    clearPersistedActor();
+    updatePreviewSection('actor', {});
+  }, [clearPersistedActor, updatePreviewSection]);
 
   const handleClearPersistedContext = useCallback(() => {
     clearPersistedContext();
@@ -270,6 +294,15 @@ export function PreviewContextPanel({
           schema={schemas.subscriber}
           onSubscriberSelect={handleSubscriberSelection}
           onClearPersisted={canClearPersisted ? handleClearPersistedSubscriber : undefined}
+        />
+
+        <PreviewActorSection
+          error={errors.actor}
+          actor={previewContext.actor}
+          schema={schemas.actor}
+          onUpdate={updatePreviewSection}
+          onActorSelect={handleActorSelection}
+          onClearPersisted={canClearPersisted ? handleClearPersistedActor : undefined}
         />
 
         <PreviewStepResultsSection

--- a/apps/dashboard/src/components/workflow-editor/steps/types/preview-context.types.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/types/preview-context.types.ts
@@ -20,6 +20,7 @@ export type EnvData = Record<string, string>;
 export type ParsedData = {
   payload: PayloadData;
   subscriber: PreviewSubscriberData;
+  actor: PreviewSubscriberData;
   steps: StepsData;
   context: ContextPayload;
   env: EnvData;
@@ -28,6 +29,7 @@ export type ParsedData = {
 export type ValidationErrors = {
   payload: string | null;
   subscriber: string | null;
+  actor: string | null;
   steps: string | null;
   context: string | null;
   env: string | null;
@@ -48,6 +50,15 @@ export type PayloadSectionProps = AccordionSectionProps & {
 
 export type StepResultsSectionProps = AccordionSectionProps & {
   currentStepId?: string;
+};
+
+export type ActorSectionProps = Omit<AccordionSectionProps, 'errors' | 'localParsedData' | 'onUpdate'> & {
+  error: string | null;
+  actor: Partial<SubscriberDto>;
+  schema?: JSONSchema7;
+  onUpdate: (section: 'actor', data: PreviewSubscriberData) => void;
+  onActorSelect: (subscriber: ISubscriberResponseDto) => void;
+  onClearPersisted?: () => void;
 };
 
 export type SubscriberSectionProps = Omit<AccordionSectionProps, 'errors' | 'localParsedData' | 'onUpdate'> & {

--- a/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context-storage.utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context-storage.utils.ts
@@ -19,6 +19,10 @@ function getSubscriberStorageKey(workflowId: string, environmentId: string): str
   return `preview-subscriber-${workflowId}-${environmentId}`;
 }
 
+function getActorStorageKey(workflowId: string, environmentId: string): string {
+  return `preview-actor-${workflowId}-${environmentId}`;
+}
+
 function getContextStorageKey(workflowId: string, environmentId: string): string {
   return `preview-context-data-${workflowId}-${environmentId}`;
 }
@@ -31,6 +35,11 @@ export function savePayloadData(workflowId: string, environmentId: string, paylo
 export function saveSubscriberData(workflowId: string, environmentId: string, subscriber: PreviewSubscriberData): void {
   const storageKey = getSubscriberStorageKey(workflowId, environmentId);
   saveToStorage(storageKey, subscriber, 'subscriber');
+}
+
+export function saveActorData(workflowId: string, environmentId: string, actor: PreviewSubscriberData): void {
+  const storageKey = getActorStorageKey(workflowId, environmentId);
+  saveToStorage(storageKey, actor, 'actor');
 }
 
 export function saveContextData(workflowId: string, environmentId: string, context: ContextPayload): void {
@@ -48,6 +57,11 @@ export function loadSubscriberData(workflowId: string, environmentId: string): P
   return loadFromStorage<PreviewSubscriberData>(storageKey, 'subscriber');
 }
 
+export function loadActorData(workflowId: string, environmentId: string): PreviewSubscriberData | null {
+  const storageKey = getActorStorageKey(workflowId, environmentId);
+  return loadFromStorage<PreviewSubscriberData>(storageKey, 'actor');
+}
+
 export function loadContextData(workflowId: string, environmentId: string): ContextPayload | null {
   const storageKey = getContextStorageKey(workflowId, environmentId);
   return loadFromStorage<ContextPayload>(storageKey, 'context');
@@ -57,6 +71,7 @@ export function mergePreviewContextData(persistedData: ParsedData, serverDefault
   return {
     payload: mergeObjectData(persistedData.payload, serverDefaults.payload),
     subscriber: mergeObjectData(persistedData.subscriber, serverDefaults.subscriber),
+    actor: mergeObjectData(persistedData.actor, serverDefaults.actor),
     steps: mergeObjectData(persistedData.steps, serverDefaults.steps),
     context: mergeObjectData(persistedData.context, serverDefaults.context),
     env: mergeObjectData(persistedData.env, serverDefaults.env),
@@ -103,6 +118,11 @@ export function clearSubscriberData(workflowId: string, environmentId: string): 
   clearFromStorage(storageKey, 'subscriber data');
 }
 
+export function clearActorData(workflowId: string, environmentId: string): void {
+  const storageKey = getActorStorageKey(workflowId, environmentId);
+  clearFromStorage(storageKey, 'actor data');
+}
+
 export function clearContextData(workflowId: string, environmentId: string): void {
   const storageKey = getContextStorageKey(workflowId, environmentId);
   clearFromStorage(storageKey, 'context data');
@@ -111,7 +131,7 @@ export function clearContextData(workflowId: string, environmentId: string): voi
 export function cleanupExpiredPreviewData(): void {
   try {
     const keysToRemove: string[] = [];
-    const prefixes = ['preview-context-data-', 'preview-payload-', 'preview-subscriber-'];
+    const prefixes = ['preview-context-data-', 'preview-payload-', 'preview-subscriber-', 'preview-actor-'];
 
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);

--- a/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context.utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context.utils.ts
@@ -26,6 +26,20 @@ export function parseJsonValue(value: string): ParsedData {
   }
 }
 
+export function createDefaultActorData(locale: string = DEFAULT_LOCALE): PreviewSubscriberData {
+  return {
+    subscriberId: 'actor-123',
+    firstName: 'Jane',
+    lastName: 'Actor',
+    email: 'actor@example.com',
+    phone: '+1234567890',
+    avatar: 'https://example.com/avatar.png',
+    locale,
+    timezone: 'America/New_York',
+    data: {},
+  };
+}
+
 export function createSubscriberData(subscriber: ISubscriberResponseDto): PreviewSubscriberData {
   return {
     subscriberId: subscriber.subscriberId,

--- a/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context.utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context.utils.ts
@@ -9,6 +9,7 @@ export function parseJsonValue(value: string): ParsedData {
     return {
       payload: parsed.payload || {},
       subscriber: parsed.subscriber || {},
+      actor: parsed.actor || {},
       steps: parsed.steps || {},
       context: parsed.context || {},
       env: parsed.env || {},
@@ -17,6 +18,7 @@ export function parseJsonValue(value: string): ParsedData {
     return {
       payload: {},
       subscriber: {},
+      actor: {},
       steps: {},
       context: {},
       env: {},

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-content.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-content.tsx
@@ -64,10 +64,11 @@ export function TestWorkflowContent({
       <div className="bg-bg-weak flex-1 min-h-0 overflow-auto">
         <Accordion type="multiple" value={accordionValue} onValueChange={setAccordionValue}>
           <PreviewPayloadSection
-            errors={{ payload: null, subscriber: null, steps: null, context: null, env: null }}
+            errors={{ payload: null, subscriber: null, actor: null, steps: null, context: null, env: null }}
             localParsedData={{
               payload: payloadData,
               subscriber: subscriberData ?? {},
+              actor: {},
               steps: {},
               context: contextData ?? {},
               env: {},

--- a/apps/dashboard/src/utils/liquid-autocomplete.tsx
+++ b/apps/dashboard/src/utils/liquid-autocomplete.tsx
@@ -26,6 +26,7 @@ export interface CompletionOption {
 // Novu JIT namespaces
 const PAYLOAD_NAMESPACE = 'payload';
 const SUBSCRIBER_DATA_NAMESPACE = 'subscriber.data';
+const ACTOR_DATA_NAMESPACE = 'actor.data';
 const CONTEXT_NAMESPACE = 'context';
 const STEP_PAYLOAD_REGEX = /^steps\.[a-zA-Z0-9_-]+\.events/;
 
@@ -215,7 +216,15 @@ const createInfoPanel = ({ component }: { component: React.ReactNode }) => {
  *    Invalid:
  *    - subscriber.someOtherField (must use valid subscriber field)
  *
- * 3. Step Variables:
+ * 3. Actor Variables:
+ *    Valid:
+ *    - actor.data.
+ *    - actor.data.anyNewField (allows any new field)
+ *    - actor.firstName
+ *    - actor.email
+ *    - actor.subscriberId
+ *
+ * 4. Step Variables:
  *    Valid:
  *    - steps.
  *    - steps.digest-step (must be existing step ID)
@@ -383,7 +392,7 @@ function getMatchingVariables(
   }, []);
 
   // Create JIT variables based on the search text e.g. payload.foo, subscriber.data.foo, context.tenant.data, steps.digest-step.events.0.payload.foo
-  const baseNamespaces = [PAYLOAD_NAMESPACE, SUBSCRIBER_DATA_NAMESPACE, ...stepPayloadNamespaces];
+  const baseNamespaces = [PAYLOAD_NAMESPACE, SUBSCRIBER_DATA_NAMESPACE, ACTOR_DATA_NAMESPACE, ...stepPayloadNamespaces];
   const namespaces = isContextEnabled ? [...baseNamespaces, CONTEXT_NAMESPACE] : baseNamespaces;
 
   const jitVariables = createJitVariables({

--- a/libs/application-generic/src/dtos/workflow/preview-payload.dto.ts
+++ b/libs/application-generic/src/dtos/workflow/preview-payload.dto.ts
@@ -16,6 +16,15 @@ export class PreviewPayloadDto {
   subscriber?: SubscriberResponseDtoOptional;
 
   @ApiPropertyOptional({
+    description: 'Partial actor information',
+    type: SubscriberResponseDtoOptional,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SubscriberResponseDtoOptional)
+  actor?: SubscriberResponseDtoOptional;
+
+  @ApiPropertyOptional({
     description: 'Payload data',
     type: 'object',
     additionalProperties: true,

--- a/libs/application-generic/src/usecases/build-variable-schema/build-available-variable-schema.usecase.ts
+++ b/libs/application-generic/src/usecases/build-variable-schema/build-available-variable-schema.usecase.ts
@@ -14,6 +14,7 @@ import { PreviewPayloadDto } from '../../dtos/workflow/preview-payload.dto';
 import { resolveEnvironmentVariables } from '../../encryption/encrypt-environment-variable';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
 import {
+  buildActorSchema,
   buildContextSchema,
   buildEnvSchema,
   buildSubscriberSchema,
@@ -73,7 +74,7 @@ export class BuildVariableSchemaUsecase {
     }
 
     const optimisticControlValues = Object.values(command.optimisticControlValues || {});
-    const { payload, subscriber, context } = await this.createVariablesObject.execute(
+    const { payload, subscriber, actor, context } = await this.createVariablesObject.execute(
       CreateVariablesObjectCommand.create({
         environmentId: command.environmentId,
         organizationId: command.organizationId,
@@ -84,10 +85,16 @@ export class BuildVariableSchemaUsecase {
     const {
       payload: finalPayload,
       subscriber: finalSubscriber,
+      actor: finalActor,
       context: finalContext,
     } = previewData
-      ? this.mergePreviewData({ payload, subscriber, context }, previewData)
-      : { payload: payload || {}, subscriber: subscriber || {}, context: context || {} };
+      ? this.mergePreviewData({ payload, subscriber, actor, context }, previewData)
+      : {
+          payload: payload || {},
+          subscriber: subscriber || {},
+          actor: actor || {},
+          context: context || {},
+        };
 
     const effectiveSteps = this.buildEffectiveSteps(workflow, optimisticSteps);
 
@@ -115,6 +122,7 @@ export class BuildVariableSchemaUsecase {
       properties: {
         workflow: buildWorkflowSchema(),
         subscriber: buildSubscriberSchema(finalSubscriber),
+        actor: buildActorSchema(finalActor),
         steps: buildPreviousStepsSchema({
           previousSteps,
           payloadSchema: effectivePayloadSchema,
@@ -203,12 +211,18 @@ export class BuildVariableSchemaUsecase {
    * Merges preview data with extracted variables for preview scenarios
    */
   private mergePreviewData(
-    extracted: { payload?: unknown; subscriber?: unknown; context?: unknown },
+    extracted: { payload?: unknown; subscriber?: unknown; actor?: unknown; context?: unknown },
     previewData?: PreviewPayloadDto
-  ): { payload: Record<string, unknown>; subscriber: Record<string, unknown>; context: Record<string, unknown> } {
+  ): {
+    payload: Record<string, unknown>;
+    subscriber: Record<string, unknown>;
+    actor: Record<string, unknown>;
+    context: Record<string, unknown>;
+  } {
     return {
       payload: { ...((extracted.payload as Record<string, unknown>) || {}), ...(previewData?.payload || {}) },
       subscriber: { ...((extracted.subscriber as Record<string, unknown>) || {}), ...(previewData?.subscriber || {}) },
+      actor: { ...((extracted.actor as Record<string, unknown>) || {}), ...(previewData?.actor || {}) },
       context: { ...((extracted.context as Record<string, unknown>) || {}), ...(previewData?.context || {}) },
     };
   }

--- a/libs/application-generic/src/usecases/preview-step/preview-step.command.ts
+++ b/libs/application-generic/src/usecases/preview-step/preview-step.command.ts
@@ -11,6 +11,7 @@ export class PreviewStepCommand extends EnvironmentWithUserCommand {
   payload: Record<string, unknown>;
   context?: ContextResolved;
   subscriber?: SubscriberResponseDtoOptional;
+  actor?: SubscriberResponseDtoOptional;
   workflowOrigin: ResourceOriginEnum;
   state?: FrameworkPreviousStepsOutputState[];
   skipLayoutRendering?: boolean;

--- a/libs/application-generic/src/usecases/preview-step/preview-step.usecase.ts
+++ b/libs/application-generic/src/usecases/preview-step/preview-step.usecase.ts
@@ -43,6 +43,7 @@ export class PreviewStep {
       payload: command.payload || {},
       state: command.state || [],
       subscriber: command.subscriber || {},
+      ...(command.actor && { actor: command.actor }),
       context: command.context || {},
       stepId: command.stepId,
       workflowId: command.workflowId,

--- a/libs/application-generic/src/usecases/preview/preview.usecase.ts
+++ b/libs/application-generic/src/usecases/preview/preview.usecase.ts
@@ -306,6 +306,7 @@ export class PreviewUsecase {
       PreviewStepCommand.create({
         payload: previewPayloadExample.payload || {},
         subscriber: previewPayloadExample.subscriber,
+        actor: previewPayloadExample.actor,
         controls: controlValues || {},
         context: previewPayloadExample.context as ContextResolved,
         environmentId: command.user.environmentId,

--- a/libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts
+++ b/libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts
@@ -120,6 +120,16 @@ export class MockDataGeneratorService {
     });
   }
 
+  createFullActorObject(): Record<string, unknown> {
+    return {
+      ...this.createFullSubscriberObject(),
+      subscriberId: 'actor-123',
+      firstName: 'Jane',
+      lastName: 'Actor',
+      email: 'actor@example.com',
+    };
+  }
+
   /**
    * Creates a complete subscriber object with all standard fields populated,
    * used when V2 template editor requires full subscriber context for previews.

--- a/libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts
+++ b/libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts
@@ -122,11 +122,15 @@ export class MockDataGeneratorService {
 
   createFullActorObject(): Record<string, unknown> {
     return {
-      ...this.createFullSubscriberObject(),
       subscriberId: 'actor-123',
       firstName: 'Jane',
       lastName: 'Actor',
       email: 'actor@example.com',
+      phone: '+1234567890',
+      avatar: 'https://example.com/avatar.png',
+      locale: DEFAULT_LOCALE,
+      timezone: 'America/New_York',
+      data: {},
     };
   }
 

--- a/libs/application-generic/src/usecases/preview/services/payload-merger.service.ts
+++ b/libs/application-generic/src/usecases/preview/services/payload-merger.service.ts
@@ -120,6 +120,11 @@ export class PayloadMergerService {
 
     mergedPayload.subscriber = merge({}, fullSubscriberSchema, userSubscriberData);
 
+    const fullActorSchema = this.mockDataGenerator.createFullActorObject();
+    const userActorData = (userPayloadExample?.actor as Record<string, unknown>) || {};
+
+    mergedPayload.actor = merge({}, fullActorSchema, userActorData);
+
     mergedPayload.context = this.resolveContext(userPayloadExample?.context);
 
     if (workflow && stepIdOrInternalId) {
@@ -208,6 +213,11 @@ export class PayloadMergerService {
     const userSubscriberData = (userPayloadExample?.subscriber as Record<string, unknown>) || {};
 
     finalPayload.subscriber = merge({}, fullSubscriberSchema, userSubscriberData);
+
+    const fullActorSchema = this.mockDataGenerator.createFullActorObject();
+    const userActorData = (userPayloadExample?.actor as Record<string, unknown>) || {};
+
+    finalPayload.actor = merge({}, fullActorSchema, userActorData);
 
     finalPayload.context = this.resolveContext(userPayloadExample?.context);
 

--- a/libs/application-generic/src/usecases/preview/services/preview-payload-processor.service.ts
+++ b/libs/application-generic/src/usecases/preview/services/preview-payload-processor.service.ts
@@ -22,13 +22,17 @@ export class PreviewPayloadProcessorService {
       reorderedPayload.subscriber = cleanedPayloadExample.subscriber;
     }
 
+    if (cleanedPayloadExample.actor !== undefined) {
+      reorderedPayload.actor = cleanedPayloadExample.actor;
+    }
+
     if (cleanedPayloadExample.context !== undefined) {
       reorderedPayload.context = cleanedPayloadExample.context;
     }
 
     // Add remaining keys
     Object.keys(cleanedPayloadExample).forEach((key) => {
-      if (key !== 'payload' && key !== 'subscriber' && key !== 'context') {
+      if (key !== 'payload' && key !== 'subscriber' && key !== 'actor' && key !== 'context') {
         reorderedPayload[key] = cleanedPayloadExample[key];
       }
     });

--- a/libs/application-generic/src/utils/create-schema.ts
+++ b/libs/application-generic/src/utils/create-schema.ts
@@ -60,6 +60,15 @@ export function buildVariablesSchema(object: unknown) {
   return schema;
 }
 
+export const buildActorSchema = (actor: unknown) => {
+  const subscriberSchema = buildSubscriberSchema(actor);
+
+  return {
+    ...subscriberSchema,
+    description: 'Schema representing the actor entity sent during workflow trigger',
+  };
+};
+
 export const buildSubscriberSchema = (subscriber: unknown) => {
   return {
     type: JsonSchemaTypeEnum.OBJECT,

--- a/libs/application-generic/src/utils/template-parser/parser-utils.ts
+++ b/libs/application-generic/src/utils/template-parser/parser-utils.ts
@@ -34,6 +34,7 @@ export const DIGEST_EVENTS_VARIABLE_PATTERN = /^steps\.[^.]+\.events$/;
 export const DIGEST_EVENTS_PAYLOAD_VARIABLE_PATTERN = /^steps\.[^.]+\.events\.payload\./;
 export const VALID_DYNAMIC_PATHS = [
   'subscriber.data.',
+  'actor.data.',
   'payload.',
   'context.',
   'env.',

--- a/libs/internal-sdk/src/models/components/previewpayloaddto.ts
+++ b/libs/internal-sdk/src/models/components/previewpayloaddto.ts
@@ -32,6 +32,10 @@ export type PreviewPayloadDto = {
    */
   subscriber?: SubscriberResponseDtoOptional | undefined;
   /**
+   * Partial actor information
+   */
+  actor?: SubscriberResponseDtoOptional | undefined;
+  /**
    * Payload data
    */
   payload?: { [k: string]: any } | undefined;
@@ -136,6 +140,7 @@ export const PreviewPayloadDto$inboundSchema: z.ZodType<
   unknown
 > = z.object({
   subscriber: SubscriberResponseDtoOptional$inboundSchema.optional(),
+  actor: SubscriberResponseDtoOptional$inboundSchema.optional(),
   payload: z.record(z.any()).optional(),
   steps: z.record(z.any()).optional(),
   context: z.record(
@@ -149,6 +154,7 @@ export const PreviewPayloadDto$inboundSchema: z.ZodType<
 /** @internal */
 export type PreviewPayloadDto$Outbound = {
   subscriber?: SubscriberResponseDtoOptional$Outbound | undefined;
+  actor?: SubscriberResponseDtoOptional$Outbound | undefined;
   payload?: { [k: string]: any } | undefined;
   steps?: { [k: string]: any } | undefined;
   context?:
@@ -164,6 +170,7 @@ export const PreviewPayloadDto$outboundSchema: z.ZodType<
   PreviewPayloadDto
 > = z.object({
   subscriber: SubscriberResponseDtoOptional$outboundSchema.optional(),
+  actor: SubscriberResponseDtoOptional$outboundSchema.optional(),
   payload: z.record(z.any()).optional(),
   steps: z.record(z.any()).optional(),
   context: z.record(

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -759,6 +759,7 @@ export class Client {
         },
         payload: event.payload,
         subscriber: event.subscriber,
+        ...(event.actor && { actor: event.actor }),
         context: event.context,
         steps: buildSteps(event.state),
         env: event.env ?? {},

--- a/packages/framework/src/types/execution.types.ts
+++ b/packages/framework/src/types/execution.types.ts
@@ -12,6 +12,7 @@ export type Event = {
   state: State[];
   action: Exclude<PostActionEnum, PostActionEnum.TRIGGER>;
   subscriber: Subscriber;
+  actor?: Subscriber;
   context: ContextResolved;
   /** User-defined env vars merged with environment system variables (name, type). */
   env: EnvironmentSystemVariables & Record<string, string>;

--- a/packages/shared/src/dto/workflows/preview-step-response.dto.ts
+++ b/packages/shared/src/dto/workflows/preview-step-response.dto.ts
@@ -130,6 +130,7 @@ export type PreviewError = {
 
 export class PreviewPayload {
   subscriber?: Partial<SubscriberDto>;
+  actor?: Partial<SubscriberDto>;
   payload?: Record<string, unknown>;
   context?: ContextPayload;
   steps?: Record<string, unknown>; // step.stepId.unknown


### PR DESCRIPTION
## Summary

Restores actor variable support in the new dashboard step content editor. Templates can again use variables like `{{actor.firstName}}`, `{{actor.email}}`, and `{{actor.subscriberId}}` that resolve from the actor sent during workflow trigger.

## What changed

### Backend / shared

* Added `buildActorSchema` (mirrors subscriber schema) and included `actor` in workflow variable schema generation
* Extended preview payload DTOs and merger to carry actor mock/user data through preview
* Passed `actor` into preview step execution and framework Liquid rendering context
* Allowed `actor.data.*` as a valid dynamic variable path in the liquid parser

### Dashboard

* Added an **Actor** section to the step preview context panel (subscriber picker + JSON editor)
* Persisted actor preview data in local storage alongside subscriber/context
* Enabled actor variable autocomplete and JIT creation for `actor.data.*` fields

## Why

The old dashboard supported actor variables via `TemplateSystemVariables` / `SystemVariablesWithTypes.actor`, but the new editor's variable schema only exposed `subscriber`, `payload`, `context`, `steps`, and `env`. Actor variables were rejected as invalid and omitted from preview rendering.

## Test plan

- [X] Built `@novu/shared`, `@novu/framework`, and `@novu/application-generic`
- [ ] Open a workflow step editor and insert `{{actor.firstName}}` — variable should validate and autocomplete
- [ ] Set actor data in the preview context panel and confirm preview renders substituted values
- [ ] Trigger a workflow with an actor and verify runtime delivery still substitutes actor fields

```mermaid
flowchart LR
  A[Step editor template] --> B[Variable schema includes actor]
  B --> C[Validation + autocomplete]
  C --> D[Preview context actor data]
  D --> E[Preview API]
  E --> F[Framework compileControls renderVariables.actor]
  F --> G[Rendered preview]
```

Linear Issue: [NV-8143](https://linear.app/novu/issue/NV-8143/support-of-actor-variables-in-step-content-editor-new-dashbaord)

[<img src="https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/451abacc-43d4-4211-8242-a4ad30025cda/e5cf08f1-138d-4468-bc64-bd0566831019?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC80NTFhYmFjYy00M2Q0LTQyMTEtODI0Mi1hNGFkMzAwMjVjZGEvZTVjZjA4ZjEtMTM4ZC00NDY4LWJjNjQtYmQwNTY2ODMxMDE5IiwiaWF0IjoxNzgyNzQ0MjIwLCJleHAiOjE4MTQzMTQ3ODB9.n70dUZ73FFUPIh1flK8GR1c4KQ6Uezswd3jlgzOuH4s " alt="Open in Web" width="114" data-linear-height="28" />](<https://cursor.com/agents/bc-2691009f-f2f3-47c8-a393-a130f457a450>) [<img src="https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/2bebd658-43d7-4d70-8d3e-3f3b7c24c1a1/86eb1aac-fbd9-4dc8-b3db-f978a1424dc5?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC8yYmViZDY1OC00M2Q3LTRkNzAtOGQzZS0zZjNiN2MyNGMxYTEvODZlYjFhYWMtZmJkOS00ZGM4LWIzZGItZjk3OGExNDI0ZGM1IiwiaWF0IjoxNzgyNzQ0MjIwLCJleHAiOjE4MTQzMTQ3ODB9.QxoEp_i1HCKCjB-ww2Sx0P1Cpn1KMDTfvGb6kKENuj4 " alt="Open in Cursor" width="131" data-linear-height="28" />](<https://cursor.com/background-agent?bcId=bc-2691009f-f2f3-47c8-a393-a130f457a450>)

### Greptile Summary

This PR restores actor variable support across the full stack — from Liquid template validation and autocomplete in the dashboard editor, through the preview API payload pipeline, to the framework's `renderVariables` context — by mirroring the existing subscriber pattern for a new `actor` namespace.

* **Backend**: `buildActorSchema` added to the variable schema; `actor` field plumbed through `PreviewPayloadDto`, `PreviewStepCommand`, `PayloadMergerService`, and `framework/client.ts`'s Liquid context. `actor.data.` whitelisted as a valid dynamic path in the parser.
* **Dashboard**: New `PreviewActorSection` component with subscriber picker and JSON editor; actor data persisted to `localStorage` alongside subscriber/context; `actor.data.*` added to JIT autocomplete namespaces.

### Confidence Score: 4/5

The change is additive and follows established patterns; no existing behaviour is altered, and actor support integrates cleanly end-to-end.

The core data flow — schema building, preview payload merging, Liquid rendering, and localStorage persistence — is implemented correctly and symmetrically with subscriber. Three minor quality issues were found: the actor JSON editor shows an empty object after reset while the backend still uses full mock data (display/data mismatch), the actor accordion is always expanded even for workflows that never reference actor variables, and createFullActorObject silently inherits future subscriber mock fields via spread. None of these affect correctness of rendered output.

apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx (actor reset logic) and libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts (actor mock construction).

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/dashboard/src/components/preview-actor-section.tsx | New Actor preview section component – mirrors PreviewSubscriberSection with a subscriber picker and JSON editor; straightforward and consistent with existing patterns. |
| apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx | Wires up actor persistence, selection, and reset in the panel; handleClearPersistedActor resets to {} instead of default actor data, inconsistent with subscriber reset behavior. |
| apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts | Adds 'actor' to DEFAULT_ACCORDION_VALUES, causing the accordion to always open on load even for workflows with no actor variables. |
| libs/application-generic/src/usecases/build-variable-schema/build-available-variable-schema.usecase.ts | Correctly destructures actor from createVariablesObject and passes it through mergePreviewData; buildActorSchema added to the returned schema. |
| libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts | createFullActorObject spreads full subscriber mock then overrides select fields – any future subscriber fields will silently bleed into actor mock data. |
| libs/application-generic/src/usecases/preview/services/payload-merger.service.ts | Actor merging added symmetrically in both mergeForVariableSchemaBuilding and mergeForPreviewExecution, consistent with subscriber handling. |
| packages/framework/src/client.ts | Conditionally spreads actor into the Liquid renderVariables context when present; safe and matches how subscriber is handled. |

</details>

### Sequence Diagram

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Editor as Step Editor (Dashboard)
    participant AutoComplete as liquid-autocomplete
    participant PreviewPanel as PreviewContextPanel
    participant LocalStorage as localStorage
    participant PreviewAPI as Preview API
    participant PayloadMerger as PayloadMergerService
    participant Framework as framework/client.ts (Liquid)

    Editor->>AutoComplete: "user types {{actor.*}}"
    AutoComplete-->>Editor: "suggest actor fields + JIT actor.data.*"

    Editor->>PreviewPanel: user sets actor data
    PreviewPanel->>LocalStorage: saveActorData(workflowId, envId, actor)

    Editor->>PreviewAPI: "POST /preview { previewPayload: { actor, subscriber, payload } }"
    PreviewAPI->>PayloadMerger: merge(fullActorMock, userActorData)
    PayloadMerger-->>PreviewAPI: merged actor object

    PreviewAPI->>Framework: "executeStep({ actor, subscriber, payload, ... })"
    Framework->>Framework: "renderVariables = { actor, subscriber, ... }"
    Framework-->>PreviewAPI: rendered step content
    PreviewAPI-->>Editor: preview response
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Editor as Step Editor (Dashboard)
    participant AutoComplete as liquid-autocomplete
    participant PreviewPanel as PreviewContextPanel
    participant LocalStorage as localStorage
    participant PreviewAPI as Preview API
    participant PayloadMerger as PayloadMergerService
    participant Framework as framework/client.ts (Liquid)

    Editor->>AutoComplete: "user types {{actor.*}}"
    AutoComplete-->>Editor: "suggest actor fields + JIT actor.data.*"

    Editor->>PreviewPanel: user sets actor data
    PreviewPanel->>LocalStorage: saveActorData(workflowId, envId, actor)

    Editor->>PreviewAPI: "POST /preview { previewPayload: { actor, subscriber, payload } }"
    PreviewAPI->>PayloadMerger: merge(fullActorMock, userActorData)
    PayloadMerger-->>PreviewAPI: merged actor object

    PreviewAPI->>Framework: "executeStep({ actor, subscriber, payload, ... })"
    Framework->>Framework: "renderVariables = { actor, subscriber, ... }"
    Framework-->>PreviewAPI: rendered step content
    PreviewAPI-->>Editor: preview response
```

<details><summary>Comments Outside Diff (1)</summary>

1. `apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts`, line 197 ([link](<https://github.com/novuhq/novu/blob/3d4e8558554ea9895d61a48e06488549b4f18d60/apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts#L197>))

   [![P2](https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/ee24d540-de4a-416b-bfd0-643455061c75/8cff2ce3-781d-438f-b9c1-211e6c284a85?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC9lZTI0ZDU0MC1kZTRhLTQxNmItYmZkMC02NDM0NTUwNjFjNzUvOGNmZjJjZTMtNzgxZC00MzhmLWI5YzEtMjExZTZjMjg0YTg1IiwiaWF0IjoxNzgyNzQ0MjIwLCJleHAiOjE4MTQzMTQ3ODB9.2k-osETZa34YU19w79X0ERNQVIM-Rac2hnTlCcuwm2A)](<#>) **Actor accordion open by default for all workflows**

   `'actor'` is added to `DEFAULT_ACCORDION_VALUES`, so the Actor section is always expanded on first load, even for workflows that never use actor variables. This could make the panel feel noisier for the common case. Subscriber, context, and env sections are open by default because they always apply; actor is optional. Consider either removing `'actor'` from the defaults, or only including it when the workflow's step content actually references an `actor.*` variable.

   +++ Prompt To Fix With AI

   ```markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts
   Line: 197
   
   Comment:
   **Actor accordion open by default for all workflows**
   
   `'actor'` is added to `DEFAULT_ACCORDION_VALUES`, so the Actor section is always expanded on first load, even for workflows that never use actor variables. This could make the panel feel noisier for the common case. Subscriber, context, and env sections are open by default because they always apply; actor is optional. Consider either removing `'actor'` from the defaults, or only including it when the workflow's step content actually references an `actor.*` variable.
   
   How can I resolve this? If you propose a fix, please make it concise.
   ```

   +++

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   [<img src="https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/11403aca-dcdc-40e8-a2bd-c4b711f48640/121a6188-2fc3-480d-9440-34aca984ede2?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC8xMTQwM2FjYS1kY2RjLTQwZTgtYTJiZC1jNGI3MTFmNDg2NDAvMTIxYTYxODgtMmZjMy00ODBkLTk0NDAtMzRhY2E5ODRlZGUyIiwiaWF0IjoxNzgyNzQ0MjIwLCJleHAiOjE4MTQzMTQ3ODB9._iF9lPsnrouCwvSrrM7CgJYcNdn2hA0ehsVfvizh_lw " alt="Fix in Cursor" height="20" />](<https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fcomponents%2Fworkflow-editor%2Fsteps%2Fconstants%2Fpreview-context.constants.ts%0ALine%3A%20197%0A%0AComment%3A%0A**Actor%20accordion%20open%20by%20default%20for%20all%20workflows**%0A%0A%60'actor'%60%20is%20added%20to%20%60DEFAULT_ACCORDION_VALUES%60%2C%20so%20the%20Actor%20section%20is%20always%20expanded%20on%20first%20load%2C%20even%20for%20workflows%20that%20never%20use%20actor%20variables.%20This%20could%20make%20the%20panel%20feel%20noisier%20for%20the%20common%20case.%20Subscriber%2C%20context%2C%20and%20env%20sections%20are%20open%20by%20default%20because%20they%20always%20apply%3B%20actor%20is%20optional.%20Consider%20either%20removing%20%60'actor'%60%20from%20the%20defaults%2C%20or%20only%20including%20it%20when%20the%20workflow's%20step%20content%20actually%20references%20an%20%60actor.*%60%20variable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11709&platform=github>)

</details>

[<img src="https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/f904ade3-d20d-4b97-aa56-8ef88c5925f0/c1d7d1a8-e112-4eab-8a59-7a086d5f087f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC9mOTA0YWRlMy1kMjBkLTRiOTctYWE1Ni04ZWY4OGM1OTI1ZjAvYzFkN2QxYTgtZTExMi00ZWFiLThhNTktN2EwODZkNWYwODdmIiwiaWF0IjoxNzgyNzQ0MjIwLCJleHAiOjE4MTQzMTQ3ODB9.ZG3o4AULIHZwTHJmATMnfDwK9vL3FS0UvYWH42FN6fM " alt="Fix All in Cursor" height="20" />](<https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fworkflow-editor%2Fsteps%2Fpreview-context-panel.tsx%3A263-266%0A**Actor%20reset%20shows%20empty%20JSON%20while%20subscriber%20reset%20shows%20populated%20defaults**%0A%0A%60handleClearPersistedSubscriber%60%20resets%20to%20%60createDefaultSubscriberData%28%29%60%20%28populated%20defaults%20shown%20in%20the%20editor%29%2C%20but%20%60handleClearPersistedActor%60%20resets%20to%20%60%7B%7D%60.%20After%20a%20user%20clicks%20%22Reset%20defaults%22%20on%20the%20Actor%20section%2C%20the%20JSON%20editor%20will%20display%20%60%7B%7D%60%2C%20which%20looks%20broken%2Fempty%20even%20though%20the%20backend's%20%60PayloadMergerService%60%20will%20still%20merge%20in%20the%20full%20mock%20actor%20object%20during%20preview%20execution.%20The%20discrepancy%20between%20the%20displayed%20value%20and%20the%20actual%20preview%20input%20is%20likely%20to%20confuse%20users.%20Consider%20introducing%20a%20%60createDefaultActorData%28%29%60%20%28parallel%20to%20%60createDefaultSubscriberData%60%29%20and%20using%20it%20here.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fworkflow-editor%2Fsteps%2Fconstants%2Fpreview-context.constants.ts%3A197%0A**Actor%20accordion%20open%20by%20default%20for%20all%20workflows**%0A%0A%60'actor'%60%20is%20added%20to%20%60DEFAULT_ACCORDION_VALUES%60%2C%20so%20the%20Actor%20section%20is%20always%20expanded%20on%20first%20load%2C%20even%20for%20workflows%20that%20never%20use%20actor%20variables.%20This%20could%20make%20the%20panel%20feel%20noisier%20for%20the%20common%20case.%20Subscriber%2C%20context%2C%20and%20env%20sections%20are%20open%20by%20default%20because%20they%20always%20apply%3B%20actor%20is%20optional.%20Consider%20either%20removing%20%60'actor'%60%20from%20the%20defaults%2C%20or%20only%20including%20it%20when%20the%20workflow's%20step%20content%20actually%20references%20an%20%60actor.*%60%20variable.%0A%0A%23%23%23%20Issue%203%20of%203%0Alibs%2Fapplication-generic%2Fsrc%2Fusecases%2Fpreview%2Fservices%2Fmock-data-generator.service.ts%3A123-131%0A**%60createFullActorObject%60%20spreads%20the%20full%20subscriber%20mock%20then%20overrides%20a%20subset%20of%20fields**%0A%0A%60createFullSubscriberObject%28%29%60%20returns%20an%20object%20that%20already%20has%20%60subscriberId%3A%20'123456'%60%2C%20%60firstName%3A%20'John'%60%2C%20%60lastName%3A%20'Doe'%60%2C%20%60email%3A%20'john%40example.com'%60.%20These%20are%20then%20overridden%20by%20the%20actor-specific%20values.%20The%20spread%20means%20any%20future%20field%20added%20to%20%60createFullSubscriberObject%60%20%28e.g.%20%60phone%60%2C%20%60avatar%60%2C%20%60locale%60%29%20automatically%20bleeds%20into%20the%20actor%20mock%20with%20subscriber-branded%20values%2C%20which%20may%20produce%20misleading%20preview%20data.%20Consider%20constructing%20the%20actor%20object%20from%20scratch%20%28or%20only%20spreading%20a%20shared%20minimal%20base%29%20to%20keep%20mock%20data%20intentional.%0A%0A&pr=11709&platform=github>)

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx:263-266
**Actor reset shows empty JSON while subscriber reset shows populated defaults**

`handleClearPersistedSubscriber` resets to `createDefaultSubscriberData()` (populated defaults shown in the editor), but `handleClearPersistedActor` resets to `{}`. After a user clicks "Reset defaults" on the Actor section, the JSON editor will display `{}`, which looks broken/empty even though the backend's `PayloadMergerService` will still merge in the full mock actor object during preview execution. The discrepancy between the displayed value and the actual preview input is likely to confuse users. Consider introducing a `createDefaultActorData()` (parallel to `createDefaultSubscriberData`) and using it here.

### Issue 2 of 3
apps/dashboard/src/components/workflow-editor/steps/constants/preview-context.constants.ts:197
**Actor accordion open by default for all workflows**

`'actor'` is added to `DEFAULT_ACCORDION_VALUES`, so the Actor section is always expanded on first load, even for workflows that never use actor variables. This could make the panel feel noisier for the common case. Subscriber, context, and env sections are open by default because they always apply; actor is optional. Consider either removing `'actor'` from the defaults, or only including it when the workflow's step content actually references an `actor.*` variable.

### Issue 3 of 3
libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts:123-131
**`createFullActorObject` spreads the full subscriber mock then overrides a subset of fields**

`createFullSubscriberObject()` returns an object that already has `subscriberId: '123456'`, `firstName: 'John'`, `lastName: 'Doe'`, `email: 'john@example.com'`. These are then overridden by the actor-specific values. The spread means any future field added to `createFullSubscriberObject` (e.g. `phone`, `avatar`, `locale`) automatically bleeds into the actor mock with subscriber-branded values, which may produce misleading preview data. Consider constructing the actor object from scratch (or only spreading a shared minimal base) to keep mock data intentional.

```

</details>

Reviews (1): Last reviewed commit: ["feat(dashboard): support actor variables..."](<https://github.com/novuhq/novu/commit/3d4e8558554ea9895d61a48e06488549b4f18d60>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=40531170>)

> Greptile also left **2 inline comments** on this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores full actor variable support across the stack — schema generation, Liquid rendering, preview API, and dashboard UI — by mirroring the existing subscriber pattern under a new `actor` namespace.

- **Backend**: `buildActorSchema` added to the variable schema; `actor` plumbed through `PreviewPayloadDto`, `PreviewStepCommand`, `PayloadMergerService`, and `framework/client.ts`'s Liquid context; `actor.data.*` whitelisted as a valid dynamic path.
- **Dashboard**: New `PreviewActorSection` component with subscriber picker and JSON editor; actor data persisted to `localStorage` alongside subscriber/context; `actor.data.*` added to JIT autocomplete and variable creation namespaces.

<h3>Confidence Score: 5/5</h3>

Additive change that mirrors the well-established subscriber pattern end-to-end; no existing behaviour is modified.

The implementation follows the subscriber pattern symmetrically across schema building, payload merging, Liquid rendering, and localStorage persistence. The actor mock is constructed independently from scratch rather than derived from subscriber data. The conditional spread in `framework/client.ts` ensures actor is only injected when present, preserving production safety.

`libs/application-generic/src/utils/create-schema.ts` — actor schema property descriptions still reference "Subscriber's..." language (cosmetic, not a logic issue).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/utils/create-schema.ts | Adds `buildActorSchema` by delegating to `buildSubscriberSchema`; property-level descriptions still reference "Subscriber's first name", "Unique identifier for the subscriber", etc. |
| libs/application-generic/src/usecases/preview/services/payload-merger.service.ts | Actor merging added symmetrically in both `mergeWithPayloadSchema` and `mergeWithoutPayloadSchema`, consistent with how subscriber is handled; logic is correct. |
| libs/application-generic/src/usecases/preview/services/mock-data-generator.service.ts | Adds `createFullActorObject()` constructed from scratch with distinct actor-specific values; does not spread from subscriber mock. |
| apps/dashboard/src/components/preview-actor-section.tsx | New Actor preview section component — mirrors `PreviewSubscriberSection` with subscriber picker and JSON editor; straightforward and consistent with existing patterns. |
| apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx | Wires up actor persistence, selection, and reset; `handleClearPersistedActor` correctly resets to `createDefaultActorDataWithLocale()`, matching the subscriber reset pattern. |
| packages/framework/src/client.ts | Actor conditionally spread into Liquid `renderVariables` context only when present; safe and symmetrical with subscriber handling. |
| apps/dashboard/src/utils/liquid-autocomplete.tsx | Adds `actor.data` as a JIT autocomplete namespace alongside `payload` and `subscriber.data`; correct and minimal change. |
| apps/dashboard/src/components/variable/hooks/use-create-variable.tsx | Adds `actor` variable type and `handleActorVariable` callback mirroring subscriber handling; dependency array and handler dispatch are correct. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dashboard as Dashboard Editor
    participant AutoComplete as liquid-autocomplete
    participant Panel as PreviewContextPanel
    participant Storage as localStorage
    participant API as Preview API
    participant Merger as PayloadMergerService
    participant Framework as framework/client.ts

    Dashboard->>AutoComplete: "user types {{actor.*}}"
    AutoComplete-->>Dashboard: "suggest actor fields + JIT actor.data.*"

    Dashboard->>Panel: user sets actor data
    Panel->>Storage: saveActorData(workflowId, envId, actor)

    Dashboard->>API: "POST /preview { previewPayload: { actor, subscriber, payload } }"
    API->>Merger: merge(createFullActorObject(), userActorData)
    Merger-->>API: merged actor object

    API->>Framework: "executeStep({ actor, subscriber, payload, ... })"
    Framework->>Framework: "renderVariables = { actor, subscriber, ... }"
    Framework-->>API: rendered step content
    API-->>Dashboard: preview response with previewPayloadExample.actor
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dashboard as Dashboard Editor
    participant AutoComplete as liquid-autocomplete
    participant Panel as PreviewContextPanel
    participant Storage as localStorage
    participant API as Preview API
    participant Merger as PayloadMergerService
    participant Framework as framework/client.ts

    Dashboard->>AutoComplete: "user types {{actor.*}}"
    AutoComplete-->>Dashboard: "suggest actor fields + JIT actor.data.*"

    Dashboard->>Panel: user sets actor data
    Panel->>Storage: saveActorData(workflowId, envId, actor)

    Dashboard->>API: "POST /preview { previewPayload: { actor, subscriber, payload } }"
    API->>Merger: merge(createFullActorObject(), userActorData)
    Merger-->>API: merged actor object

    API->>Framework: "executeStep({ actor, subscriber, payload, ... })"
    Framework->>Framework: "renderVariables = { actor, subscriber, ... }"
    Framework-->>API: rendered step content
    API-->>Dashboard: preview response with previewPayloadExample.actor
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): resolve actor preview bu..."](https://github.com/novuhq/novu/commit/678132bf4a00535d83a55a182a3a2fe7a092e0aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40531170)</sub>

<!-- /greptile_comment -->