### PR TITLE
feat(dashboard): open Mintlify docs assistant from Command K fixes NV-8146

### DIFF
--- a/apps/dashboard/src/components/command-palette/command-palette.tsx
+++ b/apps/dashboard/src/components/command-palette/command-palette.tsx
@@ -16,9 +16,9 @@ import {
   RiSparklingLine,
   RiUserLine,
 } from 'react-icons/ri';
-import { useAiDrawer } from '@/components/ai-drawer';
 import { IS_AI_FEATURES_ENABLED } from '@/config';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { openDocsAssistant } from '@/utils/docs-assistant';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 import { Button } from '../primitives/button';
@@ -105,14 +105,13 @@ function CommandFooter({ commands }: { commands: CommandType[] }) {
 
 export function CommandPalette() {
   const { isOpen, closeCommandPalette } = useCommandPalette();
-  const { openAiDrawer } = useAiDrawer();
   const track = useTelemetry();
   const [search, setSearch] = useState('');
   const commandGroups = useCommandRegistry(search);
 
   // Create a flat list of all commands for easy lookup
   const allCommands = commandGroups.flatMap((group) => group.commands);
-  const hasInkeep = IS_AI_FEATURES_ENABLED && !!import.meta.env.VITE_INKEEP_API_KEY;
+  const showDocsAssistant = IS_AI_FEATURES_ENABLED;
 
   // Reset search when dialog closes
   useEffect(() => {
@@ -121,16 +120,16 @@ export function CommandPalette() {
     }
   }, [isOpen]);
 
-  const openAiDrawerWithQuery = useCallback(() => {
+  const openDocsAssistantWithQuery = useCallback(() => {
     track(TelemetryEvent.COMMAND_PALETTE_COMMAND_SELECTED, {
       commandId: 'help-ai-search',
       commandLabel: `Ask AI "${search}"`,
       commandCategory: 'help',
     });
 
-    openAiDrawer(search);
+    openDocsAssistant(search);
     closeCommandPalette();
-  }, [search, openAiDrawer, closeCommandPalette, track]);
+  }, [search, closeCommandPalette, track]);
 
   const executeCommand = useCallback(
     async (command: CommandType) => {
@@ -207,11 +206,11 @@ export function CommandPalette() {
           </CommandMenu.Group>
         ))}
 
-        {hasInkeep && search.trim() && (
+        {showDocsAssistant && search.trim() && (
           <CommandMenu.Group heading="AI Assistant" className="px-2.5">
             <CommandMenu.Item
               value={`Ask AI ${search} ai assistant help question`}
-              onSelect={openAiDrawerWithQuery}
+              onSelect={openDocsAssistantWithQuery}
               className="px-1.5 rounded-8"
             >
               <div className="flex items-center gap-1.5 flex-1">

--- a/apps/dashboard/src/components/command-palette/commands/help-commands.tsx
+++ b/apps/dashboard/src/components/command-palette/commands/help-commands.tsx
@@ -1,13 +1,12 @@
 import { RiBookOpenLine, RiChat1Line, RiSparklingLine } from 'react-icons/ri';
-import { useAiDrawer } from '@/components/ai-drawer';
 import { IS_AI_FEATURES_ENABLED } from '@/config';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { openDocsAssistant } from '@/utils/docs-assistant';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { Command, CommandExecutionContext } from '../command-types';
 
 export function useHelpCommands(_context: CommandExecutionContext): Command[] {
   const track = useTelemetry();
-  const { openAiDrawer } = useAiDrawer();
 
   const commands: Command[] = [
     {
@@ -41,17 +40,17 @@ export function useHelpCommands(_context: CommandExecutionContext): Command[] {
     },
   ];
 
-  if (IS_AI_FEATURES_ENABLED && import.meta.env.VITE_INKEEP_API_KEY) {
+  if (IS_AI_FEATURES_ENABLED) {
     commands.push({
       id: 'help-ai-search',
       label: 'Ask Novu AI',
-      description: 'Get instant answers powered by AI',
+      description: 'Get instant answers from the Novu documentation assistant',
       category: 'help',
       icon: <RiSparklingLine />,
       priority: 'high',
-      keywords: ['ai', 'ask', 'search', 'help', 'question', 'assistant', 'inkeep'],
+      keywords: ['ai', 'ask', 'search', 'help', 'question', 'assistant', 'docs'],
       execute: () => {
-        openAiDrawer();
+        openDocsAssistant();
       },
     });
   }

--- a/apps/dashboard/src/utils/docs-assistant.ts
+++ b/apps/dashboard/src/utils/docs-assistant.ts
@@ -1,0 +1,15 @@
+const DOCS_ASSISTANT_BASE_URL = 'https://docs.novu.co/platform';
+
+export function getDocsAssistantUrl(query?: string): string {
+  const trimmedQuery = query?.trim();
+
+  if (!trimmedQuery) {
+    return `${DOCS_ASSISTANT_BASE_URL}?assistant`;
+  }
+
+  return `${DOCS_ASSISTANT_BASE_URL}?assistant=${encodeURIComponent(trimmedQuery)}`;
+}
+
+export function openDocsAssistant(query?: string): void {
+  window.open(getDocsAssistantUrl(query), '_blank', 'noopener,noreferrer');
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the Command K "Ask AI" fallback away from the in-app Inkeep assistant to the Mintlify docs assistant on `https://docs.novu.co/platform`.

When a user types a query that doesn't match any command, selecting **Ask AI "{query}"** now opens a new browser tab with the Mintlify assistant prefilled via the `?assistant=` URL parameter.

## Changes

- Added `openDocsAssistant()` utility in `apps/dashboard/src/utils/docs-assistant.ts`
- Updated Command Palette fallback action to open the docs assistant in a new tab
- Updated the "Ask Novu AI" help command to use the docs assistant instead of the AI drawer
- Removed dependency on `VITE_INKEEP_API_KEY` for Command K AI search (still gated by `IS_AI_FEATURES_ENABLED`)

## Example URL

```
https://docs.novu.co/platform?assistant=How%20do%20I%20trigger%20a%20workflow%3F
```

## Testing

- Open Command K (⌘K)
- Type a query that doesn't match existing commands
- Select **Ask AI "{query}"**
- Verify a new tab opens to `docs.novu.co/platform` with the assistant open and the query prefilled

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1120bda9-0699-4ecb-8156-dc4b013ff8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1120bda9-0699-4ecb-8156-dc4b013ff8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves Command K AI help actions to the Mintlify docs assistant. The main changes are:

- Adds a shared `docs-assistant` utility for building and opening assistant URLs.
- Opens unmatched Command K queries in a new `docs.novu.co/platform` tab with the query encoded in `assistant`.
- Updates the `Ask Novu AI` help command to use the docs assistant instead of the in-app AI drawer.
- Keeps AI command visibility behind `IS_AI_FEATURES_ENABLED` without requiring the Inkeep API key.

<h3>Confidence Score: 5/5</h3>

The change is narrow and limited to Command K help actions opening the external docs assistant.

The touched files are small, the behavior is straightforward URL construction and tab opening, and no review comments were identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run a real Vite/Playwright dashboard harness, but the repository dev server could not start because the installed pnpm requires Node \>=22.13 while the environment has Node v20.9.0.
- T-Rex ran a source-level harness against both requested commits, including the changed docs-assistant.ts URL function.
- T-Rex saved before/after command outputs and the runner script used for the source-level harness.
- T-Rex concluded there was no contract mismatch in head from the source-level harness run.
- T-Rex compared the before/after states for the docs-assistant flow and observed the head changes described in the after state.
- T-Rex noted that the head now gates docs-assistant differently, with hasInkeepGate false, commandVisibleWithoutInkeep true, and an external docs URL opened via window.open.

<a href="https://app.greptile.com/trex/runs/12741626/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): open Mintlify docs assi..."](https://github.com/novuhq/novu/commit/1868214792e2bf5d683f167793f7265a6a5fe7ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40746307)</sub>

<!-- /greptile_comment -->