### PR TITLE
fix(dashboard): open prod inbox integration config drawer fixes NV-8147

### DIFF
--- a/apps/dashboard/src/components/integrations/components/integration-card.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-card.tsx
@@ -1,6 +1,7 @@
 import {
   ApiServiceLevelEnum,
   ChannelTypeEnum,
+  EnvironmentTypeEnum,
   type IEnvironment,
   type IIntegration,
   type IProviderConfig,
@@ -47,7 +48,12 @@ export function IntegrationCard({
   const { subscription } = useFetchSubscription();
 
   const handleConfigureClick = (e: React.MouseEvent<HTMLElement>) => {
-    if (integration.channel === ChannelTypeEnum.IN_APP && !integration.connected) {
+    const shouldRedirectToInboxOnboarding =
+      integration.channel === ChannelTypeEnum.IN_APP &&
+      !integration.connected &&
+      environment.type === EnvironmentTypeEnum.DEV;
+
+    if (shouldRedirectToInboxOnboarding) {
       e.preventDefault();
 
       navigate(ROUTES.INBOX_EMBED + `?environmentId=${environment._id}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the issue where clicking an unconnected **Production** In-App Inbox integration card redirected users to the onboarding wizard instead of the integration settings drawer (where the HMAC Security toggle lives).

## Problem

The integration card routed all unconnected In-App integrations to `/onboarding/inbox/embed`, regardless of environment. Production integrations often remain `connected: false` until a real client app initializes a session, so customers could not reach integration settings (including the HMAC toggle) from the Integration Store.

## Solution

Limit the onboarding redirect to **Development** environment In-App integrations only. Production (and other non-dev) integrations now open the regular config drawer on click.

```mermaid
flowchart TD
  A[Click In-App integration card] --> B{IN_APP && !connected && DEV?}
  B -->|Yes| C[Onboarding wizard]
  B -->|No| D[Integration config drawer]
  D --> E[HMAC Security toggle]
```

## Test plan

- [x] Dashboard typecheck passes
- [ ] Open Integration Store with unconnected Prod In-App card → opens config drawer with HMAC toggle
- [ ] Open Integration Store with unconnected Dev In-App card → still redirects to onboarding wizard
- [ ] Connected In-App cards (any env) → open config drawer as before
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8147](https://linear.app/novu/issue/NV-8147/unable-to-find-hmac-security-toggle-for-in-app-inbox)

<div><a href="https://cursor.com/agents/bc-d65e5eee-6da6-41aa-9daa-33c3f22545d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d65e5eee-6da6-41aa-9daa-33c3f22545d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how unconnected In-App integration cards route from the Integration Store.

- Redirects unconnected In-App integrations to inbox onboarding only in development environments.
- Opens the regular integration config drawer for production and other non-development environments.
- Keeps connected In-App integrations on the existing config drawer path.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to the integration card click behavior and aligns with the described environment-specific routing intent.

No issues were identified in the changed routing condition, and the modification preserves the existing drawer path for production, non-development, and connected integrations.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex updated the head predicate for In-App navigation to include environment.type === EnvironmentTypeEnum.DEV, so unconnected Production In-App opened the drawer, unconnected Development In-App still navigated to /onboarding/inbox/embed?environmentId=env-dev, and connected In-App continued to open the drawer.

<a href="https://app.greptile.com/trex/runs/12743457/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): open prod inbox integrat..."](https://github.com/novuhq/novu/commit/ef198b16a5bbbfd6395ad16afa3bccda7e80b497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40750696)</sub>

<!-- /greptile_comment -->