### PR TITLE
fix(api-service): format agent powered-by branding as muted footnote fixes NV-8064

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -7,7 +7,10 @@ import { AgentConfigResolver, ResolvedAgentConfig } from '../../channels/agent-c
 import type { ReplyContentDto } from '../../shared/dtos/agent-reply-payload.dto';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { esmImport } from '../../shared/util/esm-import';
-import { buildPoweredByWatermark, contentHasPoweredByWatermark } from '../../shared/util/novu-powered-by-watermark';
+import {
+  buildBrandedMarkdownReply,
+  contentHasPoweredByWatermark,
+} from '../../shared/util/novu-powered-by-watermark';
 import { type AgentActionTokenBinding, AgentActionTokenService } from '../action-token/agent-action-token.service';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { ChatInstanceRegistry } from '../ingress/chat-instance.registry';
@@ -509,10 +512,10 @@ export class OutboundGateway {
   }
 
   /**
-   * Appends the "Powered by Novu" watermark as the last line of outbound text
-   * messages for organizations that have not removed Novu branding (free plan).
-   * Pro and above can disable it via the existing `removeNovuBranding` org
-   * setting, resolved once per delivery by `AgentConfigResolver`.
+   * Wraps outbound markdown replies with a muted "Powered by Novu" footnote for
+   * organizations that have not removed Novu branding (free plan). Pro and above
+   * can disable it via the existing `removeNovuBranding` org setting, resolved
+   * once per delivery by `AgentConfigResolver`.
    *
    * Only plain markdown replies are branded — cards/action messages are left
    * untouched.
@@ -526,9 +529,9 @@ export class OutboundGateway {
       return content;
     }
 
-    const watermark = buildPoweredByWatermark(branding.agentIdentifier, branding.platform);
+    const card = buildBrandedMarkdownReply(content.markdown, branding.agentIdentifier, branding.platform);
 
-    return { ...content, markdown: `${content.markdown}\n\n${watermark}` };
+    return { ...content, card: card as unknown as Record<string, unknown>, markdown: undefined };
   }
 
   /**

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { AgentPlatformEnum } from '../enums/agent-platform.enum';
 import {
+  buildBrandedMarkdownReply,
   buildPoweredByWatermark,
   contentHasPoweredByWatermark,
   NOVU_AGENT_POWERED_URL,
@@ -16,16 +17,34 @@ describe('novu-powered-by-watermark', () => {
     expect(watermark.length).to.be.greaterThan(NOVU_AGENT_POWERED_WATERMARK_TEXT.length);
   });
 
-  it('returns attributed markdown link on Slack', () => {
+  it('returns attributed markdown link on Slack with only Novu linked', () => {
     const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.SLACK);
 
-    expect(watermark).to.include('[Powered by Novu](');
+    expect(watermark.startsWith('Powered by [Novu](')).to.equal(true);
+    expect(watermark).to.not.include('[Powered by Novu](');
     expect(watermark).to.include(NOVU_AGENT_POWERED_URL);
     expect(watermark).to.include('utm_source=my-agent');
     expect(watermark).to.include('utm_channel=slack');
   });
 
+  it('wraps markdown in a card with a muted watermark footnote', () => {
+    const card = buildBrandedMarkdownReply('Hello there', 'my-agent', AgentPlatformEnum.SLACK);
+
+    expect(card.type).to.equal('card');
+    expect(card.children).to.have.length(2);
+    expect(card.children[0]).to.deep.equal({ type: 'text', content: 'Hello there' });
+    expect(card.children[1]?.type).to.equal('text');
+    expect((card.children[1] as { style?: string }).style).to.equal('muted');
+    expect((card.children[1] as { content?: string }).content).to.include('Powered by [Novu](');
+  });
+
   it('detects attributed watermark in markdown', () => {
+    const markdown = `Hello\n\nPowered by [Novu](${NOVU_AGENT_POWERED_URL}?utm_campaign=agent-powered)`;
+
+    expect(contentHasPoweredByWatermark(markdown)).to.equal(true);
+  });
+
+  it('detects legacy attributed watermark in markdown', () => {
     const markdown = `Hello\n\n[Powered by Novu](${NOVU_AGENT_POWERED_URL}?utm_campaign=agent-powered)`;
 
     expect(contentHasPoweredByWatermark(markdown)).to.equal(true);

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -1,3 +1,4 @@
+import type { CardElement } from 'chat';
 import { supportsMarkdownLinks } from '../enums/agent-platform.enum';
 import { buildAttributedNovuUrl } from './novu-attribution-url';
 
@@ -7,18 +8,39 @@ export const NOVU_AGENT_POWERED_WATERMARK_TEXT = 'Powered by Novu';
 
 const NOVU_POWERED_WATERMARK_MARKER = '\u200B';
 
-const ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `[${NOVU_AGENT_POWERED_WATERMARK_TEXT}](${NOVU_AGENT_POWERED_URL}`;
+const ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `Powered by [Novu](${NOVU_AGENT_POWERED_URL}`;
+
+const LEGACY_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `[${NOVU_AGENT_POWERED_WATERMARK_TEXT}](${NOVU_AGENT_POWERED_URL}`;
 
 export function buildPoweredByWatermark(agentIdentifier: string, platform: string): string {
   if (!supportsMarkdownLinks(platform)) {
     return `${NOVU_AGENT_POWERED_WATERMARK_TEXT}${NOVU_POWERED_WATERMARK_MARKER}`;
   }
 
-  return `[Powered by Novu](${buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform)})`;
+  return `Powered by [Novu](${buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform)})`;
+}
+
+export function buildBrandedMarkdownReply(
+  markdown: string,
+  agentIdentifier: string,
+  platform: string
+): CardElement {
+  const watermark = buildPoweredByWatermark(agentIdentifier, platform);
+
+  return {
+    type: 'card',
+    children: [
+      { type: 'text', content: markdown },
+      { type: 'text', content: watermark, style: 'muted' },
+    ],
+  };
 }
 
 export function contentHasPoweredByWatermark(markdown: string): boolean {
-  if (markdown.includes(ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX)) {
+  if (
+    markdown.includes(ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX) ||
+    markdown.includes(LEGACY_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX)
+  ) {
     return true;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Formats free-plan agent outbound branding as a muted footnote instead of inline body text, and links only **Novu** (not the full "Powered by Novu" phrase).

## What changed

- `buildPoweredByWatermark` now emits `Powered by [Novu](url)` instead of `[Powered by Novu](url)`
- `buildBrandedMarkdownReply` wraps markdown replies in a chat-sdk card with:
  - main body text
  - a `style: "muted"` footnote line for the powered-by attribution
- `OutboundGateway.applyOutboundBranding` uses the card wrapper so Slack renders the footnote as a context block (small, dimmed text) and Teams renders it as subtle text

## Why

Channel messages previously showed "Powered by Novu" as a full-size linked line in the message body. The desired UX matches a footnote pattern (similar to "Sent with Plain"): smaller, secondary text at the bottom with only the product name linked.

## Test plan

- [x] `pnpm test -- --grep "novu-powered-by-watermark"` (8 passing)
- [ ] Verify Slack agent reply shows muted footnote with only "Novu" linked
- [ ] Verify Pro+ orgs with `removeNovuBranding` still receive unbranded replies

```mermaid
flowchart LR
  A[Agent markdown reply] --> B[applyOutboundBranding]
  B --> C[Card body text]
  B --> D[Muted footnote: Powered by Novu link]
  C --> E[Platform adapter]
  D --> E
  E --> F[Slack context block / Teams subtle text]
```
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8064](https://linear.app/novu/issue/NV-8064/channel-message-format-powered-by-text-to-be-footnote)

<div><a href="https://cursor.com/agents/bc-2683f3f4-013d-44cf-85e7-0d17c1aaef27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2683f3f4-013d-44cf-85e7-0d17c1aaef27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes agent outbound branding into a muted footnote. The main changes are:

- `buildPoweredByWatermark` now links only `Novu` in the attribution text.
- Plain markdown replies are wrapped in a chat card with body text and a muted powered-by line.
- Watermark tests now cover the new card format and legacy watermark detection.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to outbound branding formatting and is covered by focused watermark tests.

The modified utility and gateway behavior align with the described card-based footnote rendering, and the added tests cover branded markdown, watermark construction, and legacy watermark detection paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.
- T-Rex captured branding card rendering tests, including the before/after logs and the harness used for both revisions.
- T-Rex captured platform-footnote rendering tests, including before/after logs that show how footnotes render and link to Novu.

<a href="https://app.greptile.com/trex/runs/12745405/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): format agent powered-b..."](https://github.com/novuhq/novu/commit/34b41dfc58e6c7248c17672324dda85f864bb41b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40754324)</sub>

<!-- /greptile_comment -->