### PR TITLE
docs(docs): improve DPA discoverability, HMAC examples, and release notes links fixes DOC-380

### DIFF
--- a/docs/community.mdx
+++ b/docs/community.mdx
@@ -28,6 +28,13 @@ There are many ways to get involved:
 
 [Learn how to get involved with your new favorite open source project](/community/get-involved)
 
+### Release notes
+
+Stay up to date with Novu releases and changes:
+
+- Browse [GitHub releases](https://github.com/novuhq/novu/releases) for version tags, release notes, and changelogs
+- See the [Novu changelog](https://go.novu.co/changelog?utm_source=docs) for a curated summary of new features and fixes
+
 ## Novu Cloud, or Novu Project?
 
 The Novu Project is our fully open source, community backed project. It is a complete notifications infrastructure platform that offers all the core components you need to implement notifications.

--- a/docs/community/changelog.mdx
+++ b/docs/community/changelog.mdx
@@ -6,6 +6,12 @@ description: "See the most recent changes and learn about how to shape Novu's fu
 
 <Columns cols={2}>
   <Card
+    title="GitHub releases"
+    icon="github"
+    href="https://github.com/novuhq/novu/releases">
+    Browse version tags, release notes, and changelogs for every Novu release.
+  </Card>
+  <Card
     title="Novu's Changelog"
     icon="map"
     href="https://go.novu.co/changelog?utm_source=docs">

--- a/docs/community/self-hosted-and-novu-cloud.mdx
+++ b/docs/community/self-hosted-and-novu-cloud.mdx
@@ -69,10 +69,12 @@ Below you will find a table that outlines the best available Novu Cloud Tier, co
 | Features | Community Self-Hosted | Novu Cloud |
 | ---------- | ---------- | ----------------------- |
 | Custom security reviews | ❌ | ✅ |
-| Data Processing Agreements | ❌ | Custom | |
+| Data Processing Agreements | ❌ | [Download DPA & SCC template](https://novu.co/dpa) |
 | GDPR | Installation dependent | ✅ |
 | HIPAA BAA | ❌ | ✅ |
 | SOC 2 / ISO 27001 | ❌ | ✅ |
+
+For compliance certifications, data residency, and security documentation, see [Security and Compliance](/platform/additional-resources/security).
 
 ## Ready to Scale? Upgrade to Novu Cloud
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -849,6 +849,7 @@
                   "community/get-involved",
                   "community/code-of-conduct",
                   "community/roadmap",
+                  "community/changelog",
                   "community/self-hosted-and-novu-cloud",
                   "community/run-in-local-machine",
                   "community/add-a-new-provider"

--- a/docs/platform/additional-resources/security.mdx
+++ b/docs/platform/additional-resources/security.mdx
@@ -37,6 +37,8 @@ Novu Cloud is HIPAA compliant and we offer Business Associate Agreements (BAA) f
 
 Yes, Novu is fully GDPR compliant. You can see the complete compliance report on our [Trust Center](https://trust.novu.co/). Novu provides separate data residency options in both the EU and the US to support your compliance needs.
 
+Novu Cloud customers can download our Data Processing Agreement (DPA) and Standard Contractual Clauses (SCC) template at [novu.co/dpa](https://novu.co/dpa).
+
 ## Data Residency
 
 ### Available Regions
@@ -83,6 +85,7 @@ We regularly work with large enterprises and are happy to provide guidance on va
 If you have specific concerns about PII, you have several options:
 - Use our **open source** version for full control
 - Choose the **Novu Hybrid-Cloud** enterprise plan
+- Download our [Data Processing Agreement (DPA)](https://novu.co/dpa) and Standard Contractual Clauses (SCC) template
 - Contact us at sales@novu.co, support@novu.co, or via [Discord](https://discord.novu.co)
 
 ## Reporting Security Vulnerabilities

--- a/docs/platform/inbox/prepare-for-production.mdx
+++ b/docs/platform/inbox/prepare-for-production.mdx
@@ -140,8 +140,8 @@ subscriber_hash = OpenSSL::HMAC.hexdigest('SHA256', novu_secret_key, subscriber_
 ```java title="utils/HmacHash.java"
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.HexFormat;
 
 public class HmacHash {
   public static String getSubscriberHash(String subscriberId, String novuSecretKey) throws Exception {
@@ -150,7 +150,7 @@ public class HmacHash {
 
     byte[] hash = mac.doFinal(subscriberId.getBytes(StandardCharsets.UTF_8));
 
-    return HexFormat.of().formatHex(hash);
+    return String.format("%064x", new BigInteger(1, hash));
   }
 }
 ```
@@ -168,7 +168,7 @@ string novuSecretKey = Environment.GetEnvironmentVariable("NOVU_SECRET_KEY");
 
 using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(novuSecretKey));
 byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(subscriberId));
-string subscriberHash = Convert.ToHexString(hash).ToLower();
+string subscriberHash = BitConverter.ToString(hash).Replace("-", "").ToLower();
 ```
   </Tab>
 </Tabs>

--- a/docs/platform/inbox/prepare-for-production.mdx
+++ b/docs/platform/inbox/prepare-for-production.mdx
@@ -47,11 +47,13 @@ Activate the HMAC security feature within your Novu in-app provider settings.
 
 ### 2. Generate HMAC hash on the server side
 
-Next, use your secret key from the API Keys page on the Novu dashboard to generate an HMAC hash of the `subscriberId` on the server side.
+Next, use your secret key from the [API Keys](https://dashboard.novu.co/api-keys) page on the Novu dashboard to generate an HMAC-SHA256 hash of the `subscriberId` on the server side.
+
+The hash is computed as `HMAC-SHA256(secretKey, subscriberId)` and returned as a lowercase hex string.
 
 <Tabs>
-  <Tab title="Without Context">
-```tsx title="utils/hmac-hash.ts"
+  <Tab title="Node.js">
+```typescript title="utils/hmac-hash.ts"
 import { createHmac } from 'crypto';
 
 // The subscriberId of the logged-in user
@@ -61,13 +63,119 @@ const subscriberId = 'REPLACE_WITH_SUBSCRIBER_ID';
 const novuSecretKey = process.env.NOVU_SECRET_KEY;
 
 // Generate the HMAC hash
-const hmacHash = createHmac('sha256', novuSecretKey)
+const subscriberHash = createHmac('sha256', novuSecretKey)
   .update(subscriberId)
   .digest('hex');
 ```
-</Tab>
-<Tab title="With Context">
-We need to use `canonicalize` here cause context is a dynamic object. `canonicalize` is used to serialize the JSON in a way that the order of keys or whitespaces etc doesn’t matter. The library should be based on [RFC-8259](https://datatracker.ietf.org/doc/html/rfc8259).
+  </Tab>
+  <Tab title="Python">
+```python title="utils/hmac_hash.py"
+import hashlib
+import hmac
+import os
+
+# The subscriberId of the logged-in user
+subscriber_id = 'REPLACE_WITH_SUBSCRIBER_ID'
+
+# The secret key from your Novu API Keys page
+novu_secret_key = os.environ['NOVU_SECRET_KEY']
+
+# Generate the HMAC hash
+subscriber_hash = hmac.new(
+    novu_secret_key.encode('utf-8'),
+    subscriber_id.encode('utf-8'),
+    hashlib.sha256
+).hexdigest()
+```
+  </Tab>
+  <Tab title="Go">
+```go title="utils/hmac_hash.go"
+import (
+    "crypto/hmac"
+    "crypto/sha256"
+    "encoding/hex"
+    "os"
+)
+
+// The subscriberId of the logged-in user
+subscriberID := "REPLACE_WITH_SUBSCRIBER_ID"
+
+// The secret key from your Novu API Keys page
+novuSecretKey := os.Getenv("NOVU_SECRET_KEY")
+
+mac := hmac.New(sha256.New, []byte(novuSecretKey))
+mac.Write([]byte(subscriberID))
+subscriberHash := hex.EncodeToString(mac.Sum(nil))
+```
+  </Tab>
+  <Tab title="PHP">
+```php title="utils/hmac-hash.php"
+<?php
+
+// The subscriberId of the logged-in user
+$subscriberId = 'REPLACE_WITH_SUBSCRIBER_ID';
+
+// The secret key from your Novu API Keys page
+$novuSecretKey = getenv('NOVU_SECRET_KEY');
+
+// Generate the HMAC hash
+$subscriberHash = hash_hmac('sha256', $subscriberId, $novuSecretKey);
+```
+  </Tab>
+  <Tab title="Ruby">
+```ruby title="utils/hmac_hash.rb"
+require 'openssl'
+
+# The subscriberId of the logged-in user
+subscriber_id = 'REPLACE_WITH_SUBSCRIBER_ID'
+
+# The secret key from your Novu API Keys page
+novu_secret_key = ENV['NOVU_SECRET_KEY']
+
+# Generate the HMAC hash
+subscriber_hash = OpenSSL::HMAC.hexdigest('SHA256', novu_secret_key, subscriber_id)
+```
+  </Tab>
+  <Tab title="Java">
+```java title="utils/HmacHash.java"
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+public class HmacHash {
+  public static String getSubscriberHash(String subscriberId, String novuSecretKey) throws Exception {
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(new SecretKeySpec(novuSecretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+
+    byte[] hash = mac.doFinal(subscriberId.getBytes(StandardCharsets.UTF_8));
+
+    return HexFormat.of().formatHex(hash);
+  }
+}
+```
+  </Tab>
+  <Tab title="C#">
+```csharp title="Utils/HmacHash.cs"
+using System.Security.Cryptography;
+using System.Text;
+
+// The subscriberId of the logged-in user
+string subscriberId = "REPLACE_WITH_SUBSCRIBER_ID";
+
+// The secret key from your Novu API Keys page
+string novuSecretKey = Environment.GetEnvironmentVariable("NOVU_SECRET_KEY");
+
+using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(novuSecretKey));
+byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(subscriberId));
+string subscriberHash = Convert.ToHexString(hash).ToLower();
+```
+  </Tab>
+</Tabs>
+
+#### With context
+
+If you use [Inbox with context](/platform/inbox/configuration/inbox-with-context), also generate a hash for the context object. Context must be serialized as canonical JSON ([RFC-8259](https://datatracker.ietf.org/doc/html/rfc8259)) so key order and whitespace do not affect the hash.
 
 ```tsx title="utils/hmac-hash.ts"
 import { createHmac } from 'crypto';
@@ -99,8 +207,6 @@ const contextHash = createHmac('sha256', novuSecretKey)
   .update(canonicalize(context))
   .digest('hex');
 ```
-</Tab>
-</Tabs>
 
 <Warning>
   Keep `NOVU_SECRET_KEY` secure and never expose it to the client.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Addresses three documentation gaps from the Jun 28–30 customer feedback digest:

1. **DPA not discoverable** — Free-plan EU customers could not find the DPA/SCC template without contacting support. Added links to [novu.co/dpa](https://novu.co/dpa) on the security/compliance page and in the community cloud vs self-hosted comparison.
2. **HMAC code examples** — Added copy-paste HMAC-SHA256 examples for Node.js, Python, Go, PHP, Ruby, Java, and C# in the Inbox production guide, with explicit `createHmac('sha256', secret).update(subscriberId)` pattern.
3. **Release notes discoverability** — Added GitHub releases link to the community overview and changelog page, and added the changelog page to community navigation.

### Screenshots

N/A — documentation-only changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06L08A4USH/p1782822697964719?thread_ts=1782822697.964719&cid=C06L08A4USH)

<div><a href="https://cursor.com/agents/bc-a77ba119-9a00-561a-97b7-3f022492e3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a77ba119-9a00-561a-97b7-3f022492e3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR addresses three discoverability gaps identified from customer feedback: DPA/SCC links added to the security and self-hosted comparison pages, multi-language HMAC-SHA256 examples added for seven languages in the Inbox production guide, and GitHub releases linked from the community overview and changelog page (with changelog added to the nav).

- **DPA discoverability**: Two direct links to `novu.co/dpa` added in `security.mdx` and `self-hosted-and-novu-cloud.mdx`, and a pre-existing stray trailing `|` in the compliance table is also cleaned up.
- **HMAC examples**: The single Node.js tab is replaced with tabs for Node.js, Python, Go, PHP, Ruby, Java, and C#; the "With context" variant is promoted to a standalone section beneath the tabs.
- **Release notes**: GitHub releases card added to `changelog.mdx`, a "Release notes" section added to `community.mdx`, and `community/changelog` is wired into `docs.json` navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation additions with no impact on runtime behavior.

Every change is prose, MDX markup, or navigation config. The HMAC computations across all seven language snippets are logically correct. The one Go snippet omits a package declaration and function wrapper (making it non-compilable as a standalone file), but this does not affect any running system.

docs/platform/inbox/prepare-for-production.mdx — the Go tab snippet should be wrapped in a package and function so it compiles without modification.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/inbox/prepare-for-production.mdx | Expands HMAC examples from a single Node.js tab to seven languages; all HMAC computations are logically correct, but the Go snippet is missing a package declaration and function wrapper, making it non-compilable as written. |
| docs/community/self-hosted-and-novu-cloud.mdx | Fixes a stray trailing pipe in the DPA table row and adds a direct link to novu.co/dpa; also adds a cross-reference to the security page. |
| docs/platform/additional-resources/security.mdx | Adds two DPA/SCC references (one in the GDPR section, one in the PII options list) linking to novu.co/dpa. |
| docs/community.mdx | Adds a "Release notes" section with links to GitHub releases and the changelog page. |
| docs/community/changelog.mdx | Adds a GitHub releases card alongside the existing changelog card. |
| docs/docs.json | Adds community/changelog to the navigation sidebar so the changelog page is reachable from the community section. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer Feedback Digest\nJun 28-30] --> B[DPA Not Discoverable]
    A --> C[HMAC Examples Missing]
    A --> D[Release Notes Hard to Find]

    B --> B1[security.mdx\nAdded DPA/SCC link in GDPR section\nAdded DPA link in PII options]
    B --> B2[self-hosted-and-novu-cloud.mdx\nFixed table row + DPA link\nAdded security page cross-ref]

    C --> C1[prepare-for-production.mdx\nNode.js · Python · Go · PHP\nRuby · Java · C# tabs]

    D --> D1[community.mdx\nAdded Release notes section]
    D --> D2[changelog.mdx\nAdded GitHub releases card]
    D --> D3[docs.json\nAdded changelog to nav]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Customer Feedback Digest\nJun 28-30] --> B[DPA Not Discoverable]
    A --> C[HMAC Examples Missing]
    A --> D[Release Notes Hard to Find]

    B --> B1[security.mdx\nAdded DPA/SCC link in GDPR section\nAdded DPA link in PII options]
    B --> B2[self-hosted-and-novu-cloud.mdx\nFixed table row + DPA link\nAdded security page cross-ref]

    C --> C1[prepare-for-production.mdx\nNode.js · Python · Go · PHP\nRuby · Java · C# tabs]

    D --> D1[community.mdx\nAdded Release notes section]
    D --> D2[changelog.mdx\nAdded GitHub releases card]
    D --> D3[docs.json\nAdded changelog to nav]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs(docs): use Java 8+ and .NET Core co..."](https://github.com/novuhq/novu/commit/02cf16290139311d2bcb92ef96a52c483868a721) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40799539)</sub>

<!-- /greptile_comment -->