### PR TITLE
docs(docs): add agent runtime quickstart pages fixes DOC-384

### DIFF
--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -51,9 +51,34 @@ ACI turns channel-specific messages into a standard communication flow between t
 
 ## Start building
 
-<Card href="/agents/managed-agent/quickstart" title="Quickstart" icon="zap">
-  Follow the quickstart to create your first agent, connect a Slack provider, and send your first message in under 5 minutes.
-</Card>
+Pick a quickstart for the runtime or framework you want to use. Each guide focuses on wiring your agent brain — create an agent and connect a channel first using the linked setup guides.
+
+<Columns cols={2}>
+  <Card href="/agents/quickstart/claude-managed" title="Claude managed agent" icon="sparkles">
+    Run a fully managed agent on Anthropic Claude with no bridge code.
+  </Card>
+  <Card href="/agents/quickstart/aws-claude-managed" title="AWS Claude managed agent" icon="cloud">
+    Run a managed agent on AWS Claude Platform.
+  </Card>
+  <Card href="/agents/quickstart/ai-sdk" title="AI SDK" icon="zap">
+    Wire your handler to the Vercel AI SDK with `@novu/framework/ai-sdk`.
+  </Card>
+  <Card href="/agents/quickstart/langchain" title="LangChain" icon="link">
+    Invoke a LangChain chat model from your agent handler.
+  </Card>
+  <Card href="/agents/quickstart/openai-sdk" title="OpenAI SDK" icon="bot">
+    Call the OpenAI Node SDK directly from your handler.
+  </Card>
+  <Card href="/agents/quickstart/custom-code" title="Custom code" icon="square-code">
+    Build handler logic with `@novu/framework` — no LLM required.
+  </Card>
+  <Card href="/agents/quickstart/chat-sdk" title="Chat SDK" icon="messages-square">
+    Use Vercel Chat SDK with `@novu/chat-sdk-adapter`.
+  </Card>
+  <Card href="/agents/custom-code-agent/quickstart" title="Custom code setup" icon="plug">
+    Create an agent, connect Slack, and scaffold a bridge app.
+  </Card>
+</Columns>
 
 ## Learn more
 

--- a/docs/agents/quickstart/ai-sdk.mdx
+++ b/docs/agents/quickstart/ai-sdk.mdx
@@ -1,0 +1,92 @@
+---
+title: 'AI SDK'
+description: 'Wire a custom code agent to the Vercel AI SDK using @novu/framework/ai-sdk and generateText().'
+---
+
+
+Connect your agent handler to the [Vercel AI SDK](https://sdk.vercel.ai/) with the Novu AI SDK wrapper. Return a `generateText()` or `streamText()` result from `onMessage` and Novu delivers the model output to the connected channel automatically.
+
+<Note>
+  This guide covers agent runtime wiring only. To create an agent, connect a channel like Slack, and scaffold a bridge app first, follow the [Custom code quickstart](/agents/custom-code-agent/quickstart).
+</Note>
+
+<Steps>
+
+<Step>
+
+## Install dependencies
+
+In your bridge project, install the AI SDK and a model provider:
+
+```package-install
+npm install ai @ai-sdk/openai
+```
+
+Add your model API key to `.env.local`:
+
+```bash
+OPENAI_API_KEY=sk-...
+```
+
+</Step>
+
+<Step>
+
+## Wire the agent handler
+
+Replace the demo handler in `app/novu/agents/support-agent.tsx` with an AI SDK call. Import `agent` and `toModelMessages` from `@novu/framework/ai-sdk` — not `@novu/framework` directly:
+
+```tsx title="app/novu/agents/support-agent.tsx"
+import { agent, toModelMessages } from '@novu/framework/ai-sdk';
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+export const supportAgent = agent('support-agent', {
+  onMessage: async (message, ctx) => {
+    return generateText({
+      model: openai('gpt-4o-mini'),
+      system: 'You are a helpful support agent. Keep replies concise.',
+      messages: toModelMessages(ctx.history),
+    });
+  },
+});
+```
+
+The agent id (`support-agent`) must match the **Identifier** you set in the Novu dashboard.
+
+When you return a `generateText()` result, Novu calls `ctx.reply()` with the model text for you. You can still return a plain string or JSX card instead.
+
+</Step>
+
+<Step>
+
+## Run locally
+
+Start the bridge app with the dev tunnel:
+
+```bash
+npm run dev:novu
+```
+
+Send a message on your connected channel. The agent replies using the AI SDK.
+
+</Step>
+
+</Steps>
+
+## Next steps
+
+<Columns cols={2}>
+  <Card icon="book-open" href="/agents/custom-code-agent/connect-your-first-agent" title="Connect your first agent">
+    Full tutorial with cards, metadata, and conversation resolution.
+  </Card>
+  <Card icon="code" href="/agents/custom-code-agent/setup-your-agent/handle-events" title="Handle events">
+    `onMessage`, `onAction`, and the full context API reference.
+  </Card>
+  <Card icon="zap" href="/agents/quickstart/openai-sdk" title="OpenAI SDK">
+    Use the OpenAI Node SDK directly instead of the AI SDK wrapper.
+  </Card>
+  <Card icon="rocket" href="/agents/custom-code-agent/going-to-production" title="Going to production">
+    Deploy your bridge app and switch from local to production.
+  </Card>
+</Columns>

--- a/docs/agents/quickstart/aws-claude-managed.mdx
+++ b/docs/agents/quickstart/aws-claude-managed.mdx
@@ -1,0 +1,81 @@
+---
+title: 'AWS Claude managed agent'
+description: 'Create a managed agent on AWS Claude Platform with npx novu connect --runtime claude-aws.'
+---
+
+
+Run a fully managed agent on [AWS Claude Platform](https://aws.amazon.com/bedrock/claude/). Novu forwards conversation context to your AWS-hosted Claude runtime. You configure credentials and the agent from the dashboard — no bridge application required.
+
+<Note>
+  Agents are currently in private beta. Contact [support@novu.co](mailto:support@novu.co) for access.
+</Note>
+
+<Steps>
+
+<Step>
+
+## Run the CLI
+
+In your terminal:
+
+```bash
+npx novu connect --runtime claude-aws
+```
+
+When prompted for **Where your agent runs?**, select **AWS Claude Managed Agent**.
+
+</Step>
+
+<Step>
+
+## Add AWS Claude credentials
+
+The CLI prompts for your AWS Claude Platform credentials. You can also pass them non-interactively:
+
+```bash
+npx novu connect --runtime claude-aws \
+  --aws-claude-api-key <YOUR_AWS_CLAUDE_API_KEY> \
+  --aws-claude-region <YOUR_REGION> \
+  --aws-claude-workspace-id <YOUR_WORKSPACE_ID>
+```
+
+Novu stores the credentials as an agent-runtime integration backed by the `AnthropicAws` provider.
+
+</Step>
+
+<Step>
+
+## Describe your agent
+
+Type a description of what the agent should do. Novu generates a system prompt, tools, MCP servers, and skills from your description. Review the generated config and confirm creation.
+
+</Step>
+
+<Step>
+
+## Connect a channel
+
+When prompted to pick a channel, select **Slack** (or another supported provider) and follow the setup flow. For Slack, paste a [Slack App Configuration Token](https://api.slack.com/apps) when asked, then install the app in your workspace.
+
+Once connected, send a message to your agent. Claude on AWS processes it and Novu delivers the reply.
+
+</Step>
+
+</Steps>
+
+## Next steps
+
+<Columns cols={2}>
+  <Card icon="zap" href="/agents/managed-agent/quickstart" title="Managed agent quickstart">
+    Full walkthrough with demo credentials and Slack setup.
+  </Card>
+  <Card icon="sparkles" href="/agents/quickstart/claude-managed" title="Claude managed agent">
+    Use Anthropic directly instead of AWS Claude Platform.
+  </Card>
+  <Card icon="brain" href="/agents/managed-agent/concepts" title="Concepts">
+    Connectors, MCP servers, skills, and conversation flow.
+  </Card>
+  <Card icon="link" href="/agents/managed-agent/configure-mcp-servers" title="Configure MCP servers">
+    Connect Linear, GitHub, Notion, and other external tools.
+  </Card>
+</Columns>

--- a/docs/agents/quickstart/chat-sdk.mdx
+++ b/docs/agents/quickstart/chat-sdk.mdx
@@ -1,0 +1,109 @@
+---
+title: 'Chat SDK'
+description: 'Build a multi-channel agent with Vercel Chat SDK and @novu/chat-sdk-adapter instead of @novu/framework handlers.'
+---
+
+
+Use the [Chat SDK](https://github.com/vercel-labs/chat) with [`@novu/chat-sdk-adapter`](https://www.npmjs.com/package/@novu/chat-sdk-adapter) when you prefer the Chat SDK event model over `@novu/framework` handlers. Novu acts as a Chat SDK adapter that routes messages to and from connected channels.
+
+<Note>
+  This guide covers the Chat SDK wiring pattern. To create an agent and connect a channel first, follow the [Custom code quickstart](/agents/custom-code-agent/quickstart) or run `npx novu connect --runtime chat-sdk` to scaffold and connect in one flow.
+</Note>
+
+<Steps>
+
+<Step>
+
+## Scaffold with the CLI
+
+The fastest path is the Novu CLI, which scaffolds a Chat SDK project and connects your agent:
+
+```bash
+npx novu connect --runtime chat-sdk
+```
+
+Or scaffold manually:
+
+```bash
+npx novu@latest init -t chat-sdk \
+  --secret-key=<NOVU_SECRET_KEY> \
+  --api-url=<NOVU_API_URL>
+```
+
+</Step>
+
+<Step>
+
+## Wire the Novu adapter
+
+Create the adapter and register message handlers in `lib/novu/agent.ts`:
+
+```tsx title="lib/novu/agent.ts"
+import { createMemoryState } from '@chat-adapter/state-memory';
+import { createNovuAdapter, getNovuContext } from '@novu/chat-sdk-adapter';
+import { Chat, type Adapter, type StateAdapter } from 'chat';
+
+export function registerHandlers(chat: Chat): void {
+  chat.onSubscribedMessage(async (thread, message) => {
+    const novu = getNovuContext(thread);
+    const history = await novu.getHistory();
+
+    await thread.post(`Got it (${novu.platform}): ${message.text}`);
+  });
+}
+
+export function getNovuAgent(): Promise<{ chat: Chat; novu: Adapter }> {
+  const novu = createNovuAdapter({
+    apiKey: process.env.NOVU_SECRET_KEY!,
+    agentIdentifier: process.env.NOVU_AGENT_IDENTIFIER!,
+    bridgeSecret: process.env.NOVU_SECRET_KEY!,
+  });
+
+  const chat = new Chat({
+    userName: process.env.NOVU_AGENT_IDENTIFIER!,
+    adapters: { novu: novu as unknown as Adapter },
+    state: createMemoryState() as unknown as StateAdapter,
+  });
+
+  registerHandlers(chat);
+
+  return chat.initialize().then(() => ({ chat, novu: novu as unknown as Adapter }));
+}
+```
+
+Use `getNovuContext(thread)` to access subscriber info, conversation history, `resolve()`, and `trigger()` from inside Chat SDK handlers.
+
+</Step>
+
+<Step>
+
+## Run locally
+
+Set `NOVU_SECRET_KEY` and `NOVU_AGENT_IDENTIFIER` in `.env.local`, then start the dev server:
+
+```bash
+npm run dev:novu
+```
+
+Send a message on your connected channel to test the Chat SDK agent.
+
+</Step>
+
+</Steps>
+
+## Next steps
+
+<Columns cols={2}>
+  <Card icon="github" href="https://github.com/novuhq/novu-chat-sdk-example" title="Example repo">
+    Full Chat SDK + Novu adapter example project.
+  </Card>
+  <Card icon="zap" href="/agents/quickstart/ai-sdk" title="AI SDK">
+    Prefer `@novu/framework` handlers? Start with the AI SDK quickstart.
+  </Card>
+  <Card icon="code" href="/agents/custom-code-agent/setup-your-agent/handle-events" title="Handle events">
+    Compare Chat SDK events with framework handler APIs.
+  </Card>
+  <Card icon="rocket" href="/agents/custom-code-agent/going-to-production" title="Going to production">
+    Deploy your Chat SDK bridge app.
+  </Card>
+</Columns>

--- a/docs/agents/quickstart/claude-managed.mdx
+++ b/docs/agents/quickstart/claude-managed.mdx
@@ -1,0 +1,84 @@
+---
+title: 'Claude managed agent'
+description: 'Create a Claude managed agent with npx novu connect — no bridge code or handler required.'
+---
+
+
+Run a fully managed agent powered by [Claude](https://www.anthropic.com/claude). Novu forwards conversation context to Anthropic, and Claude handles reasoning, tool use, MCP servers, and skills. You configure the agent from the dashboard — no bridge application required.
+
+<Note>
+  Agents are currently in private beta. Contact [support@novu.co](mailto:support@novu.co) for access.
+</Note>
+
+<Steps>
+
+<Step>
+
+## Run the CLI
+
+In your terminal:
+
+```bash
+npx novu connect --runtime claude
+```
+
+When prompted for **Where your agent runs?**, select **Claude Managed Agent**.
+
+</Step>
+
+<Step>
+
+## Add Anthropic credentials
+
+The CLI prompts for your Anthropic API key. You can also pass it non-interactively:
+
+```bash
+npx novu connect --runtime claude --anthropic-api-key sk-ant-...
+```
+
+Novu stores the credentials as an agent-runtime integration. Claude runs your agent's system prompt, built-in tools, MCP servers, and custom skills on Anthropic's platform.
+
+</Step>
+
+<Step>
+
+## Describe your agent
+
+Type a description of what the agent should do. Novu generates a system prompt, tools, MCP servers, and skills from your description. Review the generated config and confirm creation.
+
+Example prompt:
+
+```text
+Create a support agent that answers product questions, searches documentation, and escalates billing issues. Keep replies concise and link to relevant docs.
+```
+
+</Step>
+
+<Step>
+
+## Connect a channel
+
+When prompted to pick a channel, select **Slack** (or another supported provider) and follow the setup flow. For Slack, paste a [Slack App Configuration Token](https://api.slack.com/apps) when asked, then install the app in your workspace.
+
+Once connected, send a message to your agent on the channel. Claude processes it and Novu delivers the reply.
+
+</Step>
+
+</Steps>
+
+## Next steps
+
+<Columns cols={2}>
+  <Card icon="zap" href="/agents/managed-agent/quickstart" title="Managed agent quickstart">
+    Full walkthrough with demo credentials and Slack setup.
+  </Card>
+  <Card icon="brain" href="/agents/managed-agent/concepts" title="Concepts">
+    Connectors, MCP servers, skills, and conversation flow.
+  </Card>
+  <Card icon="link" href="/agents/managed-agent/configure-mcp-servers" title="Configure MCP servers">
+    Connect Linear, GitHub, Notion, and other external tools.
+  </Card>
+  <Card icon="cloud" href="/agents/quickstart/aws-claude-managed" title="AWS Claude managed agent">
+    Run Claude on AWS Claude Platform instead of Anthropic directly.
+  </Card>
+</Columns>

--- a/docs/agents/quickstart/custom-code.mdx
+++ b/docs/agents/quickstart/custom-code.mdx
@@ -1,0 +1,103 @@
+---
+title: 'Custom code'
+description: 'Build a Novu agent handler with @novu/framework — no LLM required to get your first reply working.'
+---
+
+
+Use `@novu/framework` directly when you want full control over agent logic. Return strings, Markdown, or JSX cards from `onMessage` and `onAction` without wrapping a specific LLM SDK.
+
+<Note>
+  This guide covers the agent handler pattern. To create an agent, connect a channel like Slack, and scaffold a bridge app first, follow the [Custom code quickstart](/agents/custom-code-agent/quickstart).
+</Note>
+
+<Steps>
+
+<Step>
+
+## Scaffold the bridge app
+
+If you have not scaffolded yet, run the command from your agent setup page in the Novu dashboard:
+
+```bash
+npx novu@latest init -t agent \
+  --agent-identifier support-agent \
+  --secret-key=<NOVU_SECRET_KEY> \
+  --api-url=<NOVU_API_URL>
+```
+
+This creates a Next.js bridge app with `app/novu/agents/support-agent.tsx` and `app/api/novu/route.ts`.
+
+</Step>
+
+<Step>
+
+## Define the agent handler
+
+Edit `app/novu/agents/support-agent.tsx`. The scaffold includes a demo handler with cards and metadata — here is the minimal starting point:
+
+```tsx title="app/novu/agents/support-agent.tsx"
+/** @jsxImportSource @novu/framework */
+import { agent } from '@novu/framework';
+
+export const supportAgent = agent('support-agent', {
+  onMessage: async (message, ctx) => {
+    return `You said: ${message.text}`;
+  },
+});
+```
+
+Add the JSX pragma at the top if you plan to return interactive cards later. For string-only replies, you can omit it.
+
+The agent id must match the **Identifier** in the Novu dashboard.
+
+</Step>
+
+<Step>
+
+## Serve the bridge endpoint
+
+The scaffold creates `app/api/novu/route.ts`:
+
+```tsx title="app/api/novu/route.ts"
+import { serve } from '@novu/framework/next';
+import { supportAgent } from '../../novu/agents';
+
+export const { GET, POST, OPTIONS } = serve({ agents: [supportAgent] });
+```
+
+Make sure `app/novu/agents/index.ts` re-exports your agent so the route picks it up.
+
+</Step>
+
+<Step>
+
+## Run locally
+
+On the agent detail page in the Novu dashboard, set the bridge to **Local**. Then start the dev tunnel:
+
+```bash
+npm run dev:novu
+```
+
+Send a message on your connected channel. Your handler code runs and the reply is delivered back to the thread.
+
+</Step>
+
+</Steps>
+
+## Next steps
+
+<Columns cols={2}>
+  <Card icon="zap" href="/agents/quickstart/ai-sdk" title="AI SDK">
+    Add an LLM with the Vercel AI SDK wrapper.
+  </Card>
+  <Card icon="book-open" href="/agents/custom-code-agent/connect-your-first-agent" title="Connect your first agent">
+    Full tutorial with cards, metadata, and conversation resolution.
+  </Card>
+  <Card icon="messages-square" href="/agents/custom-code-agent/setup-your-agent/reply" title="Reply">
+    Send Markdown, cards, attachments, and typing indicators.
+  </Card>
+  <Card icon="rocket" href="/agents/custom-code-agent/going-to-production" title="Going to production">
+    Deploy your bridge app to production.
+  </Card>
+</Columns>

--- a/docs/agents/quickstart/langchain.mdx
+++ b/docs/agents/quickstart/langchain.mdx
@@ -1,0 +1,105 @@
+---
+title: 'LangChain'
+description: 'Invoke a LangChain chat model from a Novu agent handler using ctx.history as message context.'
+---
+
+
+Run a [LangChain](https://js.langchain.com/) chat model inside your Novu agent handler. Map `ctx.history` to LangChain messages and return the model output as a string reply.
+
+<Note>
+  This guide covers agent runtime wiring only. To create an agent, connect a channel like Slack, and scaffold a bridge app first, follow the [Custom code quickstart](/agents/custom-code-agent/quickstart).
+</Note>
+
+<Steps>
+
+<Step>
+
+## Install dependencies
+
+In your bridge project:
+
+```package-install
+npm install @langchain/core @langchain/openai
+```
+
+Add your API key to `.env.local`:
+
+```bash
+OPENAI_API_KEY=sk-...
+```
+
+</Step>
+
+<Step>
+
+## Wire the agent handler
+
+Update `app/novu/agents/support-agent.tsx` to invoke a LangChain chat model:
+
+```tsx title="app/novu/agents/support-agent.tsx"
+import { agent } from '@novu/framework';
+import { AIMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { ChatOpenAI } from '@langchain/openai';
+
+const model = new ChatOpenAI({ model: 'gpt-4o-mini' });
+
+function toLangChainMessage(entry: { role: string; content: string }) {
+  if (entry.role === 'system') {
+    return new SystemMessage(entry.content);
+  }
+
+  if (entry.role === 'agent' || entry.role === 'assistant') {
+    return new AIMessage(entry.content);
+  }
+
+  return new HumanMessage(entry.content);
+}
+
+export const supportAgent = agent('support-agent', {
+  onMessage: async (message, ctx) => {
+    const response = await model.invoke([
+      new SystemMessage('You are a helpful support agent. Keep replies concise.'),
+      ...ctx.history.map(toLangChainMessage),
+    ]);
+
+    return typeof response.content === 'string' ? response.content : String(response.content);
+  },
+});
+```
+
+The agent id must match the **Identifier** in the Novu dashboard.
+
+</Step>
+
+<Step>
+
+## Run locally
+
+Start the bridge app with the dev tunnel:
+
+```bash
+npm run dev:novu
+```
+
+Send a message on your connected channel to test the LangChain-powered reply.
+
+</Step>
+
+</Steps>
+
+## Next steps
+
+<Columns cols={2}>
+  <Card icon="zap" href="/agents/quickstart/ai-sdk" title="AI SDK">
+    Use the Vercel AI SDK wrapper with built-in history mapping.
+  </Card>
+  <Card icon="book-open" href="/agents/custom-code-agent/connect-your-first-agent" title="Connect your first agent">
+    Full tutorial with cards, metadata, and conversation resolution.
+  </Card>
+  <Card icon="code" href="/agents/custom-code-agent/setup-your-agent/handle-events" title="Handle events">
+    Context API reference for handlers and conversation state.
+  </Card>
+  <Card icon="rocket" href="/agents/custom-code-agent/going-to-production" title="Going to production">
+    Deploy your bridge app to production.
+  </Card>
+</Columns>

--- a/docs/agents/quickstart/openai-sdk.mdx
+++ b/docs/agents/quickstart/openai-sdk.mdx
@@ -1,0 +1,106 @@
+---
+title: 'OpenAI SDK'
+description: 'Call the OpenAI Node SDK from a Novu agent handler and reply with ctx.history as conversation context.'
+---
+
+
+Use the [OpenAI Node SDK](https://github.com/openai/openai-node) directly inside a Novu agent handler. Map `ctx.history` to OpenAI message format and return the model response as a string.
+
+<Note>
+  This guide covers agent runtime wiring only. To create an agent, connect a channel like Slack, and scaffold a bridge app first, follow the [Custom code quickstart](/agents/custom-code-agent/quickstart).
+</Note>
+
+<Steps>
+
+<Step>
+
+## Install dependencies
+
+In your bridge project:
+
+```package-install
+npm install openai
+```
+
+Add your API key to `.env.local`:
+
+```bash
+OPENAI_API_KEY=sk-...
+```
+
+</Step>
+
+<Step>
+
+## Wire the agent handler
+
+Update `app/novu/agents/support-agent.tsx` to call the OpenAI chat completions API:
+
+```tsx title="app/novu/agents/support-agent.tsx"
+import { agent } from '@novu/framework';
+import OpenAI from 'openai';
+
+const openai = new OpenAI();
+
+function toOpenAiRole(role: string): 'assistant' | 'user' {
+  if (role === 'agent' || role === 'assistant') {
+    return 'assistant';
+  }
+
+  return 'user';
+}
+
+export const supportAgent = agent('support-agent', {
+  onMessage: async (message, ctx) => {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'You are a helpful support agent. Keep replies concise.' },
+        ...ctx.history.map((entry) => ({
+          role: toOpenAiRole(entry.role),
+          content: entry.content,
+        })),
+      ],
+    });
+
+    return response.choices[0]?.message?.content ?? 'Sorry, I could not generate a reply.';
+  },
+});
+```
+
+The agent id must match the **Identifier** in the Novu dashboard. Novu already includes the current inbound message in `ctx.history` — do not append `message.text` again.
+
+</Step>
+
+<Step>
+
+## Run locally
+
+Start the bridge app with the dev tunnel:
+
+```bash
+npm run dev:novu
+```
+
+Send a message on your connected channel to test the OpenAI-powered reply.
+
+</Step>
+
+</Steps>
+
+## Next steps
+
+<Columns cols={2}>
+  <Card icon="zap" href="/agents/quickstart/ai-sdk" title="AI SDK">
+    Use the Vercel AI SDK wrapper for automatic reply delivery and streaming.
+  </Card>
+  <Card icon="book-open" href="/agents/custom-code-agent/connect-your-first-agent" title="Connect your first agent">
+    Full tutorial with cards, metadata, and conversation resolution.
+  </Card>
+  <Card icon="code" href="/agents/custom-code-agent/setup-your-agent/handle-events" title="Handle events">
+    Context API reference for `ctx.history`, metadata, and triggers.
+  </Card>
+  <Card icon="rocket" href="/agents/custom-code-agent/going-to-production" title="Going to production">
+    Deploy your bridge app to production.
+  </Card>
+</Columns>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -386,7 +386,19 @@
               "agents",
               "agents/get-started/what-is-aci",
               "agents/get-started/mental-model",
-              "agents/get-started/agents-and-providers"
+              "agents/get-started/agents-and-providers",
+              {
+                "group": "Quickstart",
+                "pages": [
+                  "agents/quickstart/claude-managed",
+                  "agents/quickstart/aws-claude-managed",
+                  "agents/quickstart/ai-sdk",
+                  "agents/quickstart/langchain",
+                  "agents/quickstart/openai-sdk",
+                  "agents/quickstart/custom-code",
+                  "agents/quickstart/chat-sdk"
+                ]
+              }
             ]
           },
           {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Quickstart** dropdown under **Agents → Get Started**, mirroring the Platform docs pattern. Each page is a focused runtime/framework guide with verified SDK snippets — channel setup stays in the existing custom code and managed agent quickstarts.

## Pages added

| Page | Focus |
|------|-------|
| Claude managed agent | `npx novu connect --runtime claude` |
| AWS Claude managed agent | `npx novu connect --runtime claude-aws` |
| AI SDK | `@novu/framework/ai-sdk` + `generateText()` |
| LangChain | `@langchain/openai` in `@novu/framework` handler |
| OpenAI SDK | OpenAI Node SDK + `ctx.history` mapping |
| Custom code | Minimal `@novu/framework` handler pattern |
| Chat SDK | `@novu/chat-sdk-adapter` wiring |

## Other changes

- Updated `docs/docs.json` navigation with the new Quickstart group
- Updated `docs/agents.mdx` overview with cards linking to each runtime quickstart

## Test plan

- [ ] Verify Mintlify nav renders **Get Started → Quickstart** with all 7 pages
- [ ] Confirm code snippets match current `@novu/framework`, `@novu/framework/ai-sdk`, and `@novu/chat-sdk-adapter` APIs
- [ ] Check internal links resolve correctly from the agents overview page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d112ea6-dab6-4c58-af79-dc812ff0e99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d112ea6-dab6-4c58-af79-dc812ff0e99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds new Agent runtime quickstart docs and links them into the Agents section. The main changes are:

- Added seven quickstart pages for managed Claude, AWS Claude, AI SDK, LangChain, OpenAI SDK, custom code, and Chat SDK.
- Updated `docs/docs.json` with a new Agents → Get Started → Quickstart navigation group.
- Updated `docs/agents.mdx` with cards that route readers to each quickstart.

<h3>Confidence Score: 4/5</h3>

Docs-only changes are generally safe to merge once the unused variable in the Chat SDK snippet is removed or used.

The navigation and new pages are straightforward documentation additions, with one snippet issue that can break strict TypeScript copy-paste usage.

docs/agents/quickstart/chat-sdk.mdx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial run showed that quickstart navigation entries and overview routes were absent, and after changes the head state included all requested quickstart nav entries and route titles, while Mintlify reported a blocking error.
- The quickstart snippets test was executed, showing the before result with seven missing exists and EXIT\_CODE 1, and the after result with seven exists true, all checks ok, and EXIT\_CODE 0, with the validator script saved for reference.
- The internal links check was run and updated to configure seven quickstart routes, with SUMMARY checked and zero failures.

<a href="https://app.greptile.com/trex/runs/12780504/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fagents%2Fquickstart%2Fchat-sdk.mdx%3A49-51%0A**Remove%20unused%20history**%0AThe%20quickstart%20assigns%20%60history%60%20but%20never%20reads%20it%2C%20so%20readers%20copying%20this%20into%20a%20TypeScript%20project%20with%20%60noUnusedLocals%60%20enabled%20get%20a%20compile%20error%20before%20the%20adapter%20can%20run.%20Either%20use%20the%20history%20in%20the%20reply%20or%20remove%20this%20line%20from%20the%20snippet.%0A%0A&pr=11725&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/agents/quickstart/chat-sdk.mdx:49-51
**Remove unused history**
The quickstart assigns `history` but never reads it, so readers copying this into a TypeScript project with `noUnusedLocals` enabled get a compile error before the adapter can run. Either use the history in the reply or remove this line from the snippet.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docs): add agent runtime quickstart..."](https://github.com/novuhq/novu/commit/2e03438298e389acaf67ab810376f5bb75f453da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40821488)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->