### PR TITLE
fix(dashboard): use root dashboard URL for trial inbox marketing CTA fixes NV-8152

### DIFF
--- a/apps/dashboard/src/routes/onboarding.tsx
+++ b/apps/dashboard/src/routes/onboarding.tsx
@@ -1,10 +1,17 @@
 import { RedirectToSignIn, Show, useAuth } from '@clerk/react';
+import { useLocation } from 'react-router-dom';
 import { AnimatedOutlet } from '@/components/animated-outlet';
 import { AuthLayout } from '../components/auth-layout';
 import { EnvironmentProvider } from '../context/environment/environment-provider';
+import { ROUTES } from '../utils/routes';
 
 export const OnboardingParentRoute = () => {
   const { isLoaded } = useAuth();
+  const location = useLocation();
+  const signedOutRedirectUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}${ROUTES.ROOT}${location.search}${location.hash}`
+      : undefined;
 
   if (!isLoaded) {
     return null;
@@ -20,7 +27,7 @@ export const OnboardingParentRoute = () => {
         </EnvironmentProvider>
       </Show>
       <Show when="signed-out">
-        <RedirectToSignIn redirectUrl={typeof window !== 'undefined' ? window.location.href : undefined} />
+        <RedirectToSignIn redirectUrl={signedOutRedirectUrl} />
       </Show>
     </>
   );

--- a/apps/dashboard/src/routes/onboarding.tsx
+++ b/apps/dashboard/src/routes/onboarding.tsx
@@ -1,16 +1,39 @@
-import { Show } from '@clerk/react';
+import { Show, useAuth } from '@clerk/react';
+import { Navigate, useLocation } from 'react-router-dom';
 import { AnimatedOutlet } from '@/components/animated-outlet';
+import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { AuthLayout } from '../components/auth-layout';
 import { EnvironmentProvider } from '../context/environment/environment-provider';
+import { ROUTES } from '../utils/routes';
+
+function OnboardingSignedOutRedirect() {
+  const location = useLocation();
+  const dashboardDestination = `${ROUTES.ROOT}${location.search}${location.hash}`;
+  const signInUrl = appendRedirectUrlParam(ROUTES.SIGN_IN, dashboardDestination);
+  const { pathname, search } = new URL(signInUrl, window.location.origin);
+
+  return <Navigate to={`${pathname}${search}`} replace />;
+}
 
 export const OnboardingParentRoute = () => {
+  const { isLoaded } = useAuth();
+
+  if (!isLoaded) {
+    return null;
+  }
+
   return (
-    <Show when="signed-in">
-      <EnvironmentProvider>
-        <AuthLayout>
-          <AnimatedOutlet />
-        </AuthLayout>
-      </EnvironmentProvider>
-    </Show>
+    <>
+      <Show when="signed-in">
+        <EnvironmentProvider>
+          <AuthLayout>
+            <AnimatedOutlet />
+          </AuthLayout>
+        </EnvironmentProvider>
+      </Show>
+      <Show when="signed-out">
+        <OnboardingSignedOutRedirect />
+      </Show>
+    </>
   );
 };

--- a/apps/dashboard/src/routes/onboarding.tsx
+++ b/apps/dashboard/src/routes/onboarding.tsx
@@ -1,19 +1,7 @@
-import { Show, useAuth } from '@clerk/react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { RedirectToSignIn, Show, useAuth } from '@clerk/react';
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { AuthLayout } from '../components/auth-layout';
 import { EnvironmentProvider } from '../context/environment/environment-provider';
-import { ROUTES } from '../utils/routes';
-
-function OnboardingSignedOutRedirect() {
-  const location = useLocation();
-  const dashboardDestination = `${ROUTES.ROOT}${location.search}${location.hash}`;
-  const signInUrl = appendRedirectUrlParam(ROUTES.SIGN_IN, dashboardDestination);
-  const { pathname, search } = new URL(signInUrl, window.location.origin);
-
-  return <Navigate to={`${pathname}${search}`} replace />;
-}
 
 export const OnboardingParentRoute = () => {
   const { isLoaded } = useAuth();
@@ -32,7 +20,7 @@ export const OnboardingParentRoute = () => {
         </EnvironmentProvider>
       </Show>
       <Show when="signed-out">
-        <OnboardingSignedOutRedirect />
+        <RedirectToSignIn redirectUrl={typeof window !== 'undefined' ? window.location.href : undefined} />
       </Show>
     </>
   );

--- a/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
@@ -1,13 +1,34 @@
 import { useId, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { IS_ENTERPRISE } from '@/config';
+import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
 
+function resolveSameOriginRedirectUrl(redirectUrl: string | null): string | null {
+  if (!redirectUrl) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(redirectUrl, window.location.origin);
+
+    if (parsed.origin !== window.location.origin) {
+      return null;
+    }
+
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}
+
 export function SignIn() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const postSignInRedirectUrl = resolveSameOriginRedirectUrl(readClerkRedirectUrlParam(searchParams));
   const emailId = useId();
   const passwordId = useId();
   const [email, setEmail] = useState('');
@@ -67,6 +88,12 @@ export function SignIn() {
 
       if (pendingInvitationId) {
         window.location.href = `${ROUTES.INVITATION_ACCEPT}?id=${pendingInvitationId}`;
+
+        return;
+      }
+
+      if (postSignInRedirectUrl) {
+        window.location.href = postSignInRedirectUrl;
 
         return;
       }

--- a/apps/dashboard/src/utils/better-auth/index.tsx
+++ b/apps/dashboard/src/utils/better-auth/index.tsx
@@ -1,6 +1,7 @@
 import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { ROUTES } from '@/utils/routes';
 import { EE_AUTH_PROVIDER, IS_SELF_HOSTED } from '../../config';
 import { AuthContext, type BetterAuthOrganization, type BetterAuthUser } from './auth-context';
@@ -357,12 +358,15 @@ export function SignedOut({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
-export function RedirectToSignIn() {
+export function RedirectToSignIn({ redirectUrl }: { redirectUrl?: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    navigate(ROUTES.SIGN_IN);
-  }, [navigate]);
+    const signInTarget = redirectUrl ? appendRedirectUrlParam(ROUTES.SIGN_IN, redirectUrl) : ROUTES.SIGN_IN;
+    const { pathname, search } = new URL(signInTarget, window.location.origin);
+
+    navigate(`${pathname}${search}`);
+  }, [navigate, redirectUrl]);
 
   return null;
 }

--- a/packages/shared/src/ui/marketing.ts
+++ b/packages/shared/src/ui/marketing.ts
@@ -1,1 +1,19 @@
 export const UTM_CAMPAIGN_QUERY_PARAM = '?utm_campaign=in-app';
+
+export const TRIAL_JOURNEY_INBOX_EMAIL_UTM = {
+  utm_source: 'nurturing',
+  utm_medium: 'email',
+  utm_campaign: 'trial-journey',
+  utm_content: '02-inbox-v1',
+} as const;
+
+/** Root dashboard URL for the trial journey "Connect your Inbox" marketing CTA. */
+export function buildTrialJourneyDashboardUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+
+  for (const [key, value] of Object.entries(TRIAL_JOURNEY_INBOX_EMAIL_UTM)) {
+    url.searchParams.set(key, value);
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Trial journey **Connect your Inbox** emails should send users to the root dashboard, not `/onboarding/inbox/embed`.

The trial journey email template lives in **Customer.io** (not versioned in this repo). This PR adds the canonical root-dashboard CTA URL in code and fixes signed-out visitors hitting legacy onboarding links.

## Changes

### Canonical marketing CTA URL (`packages/shared/src/ui/marketing.ts`)
- Added `buildTrialJourneyDashboardUrl()` — root dashboard URL with trial journey UTM params
- **Customer.io update (manual):** change the CTA href from:
  - `https://dashboard.novu.co/onboarding/inbox/embed?utm_source=nurturing&utm_medium=email&utm_campaign=trial-journey&utm_content=02-inbox-v1`
  - to `https://dashboard.novu.co/?utm_source=nurturing&utm_medium=email&utm_campaign=trial-journey&utm_content=02-inbox-v1`

### Onboarding route (`apps/dashboard/src/routes/onboarding.tsx`)
- Signed-out visitors to `/onboarding/*` use the standard `RedirectToSignIn` flow
- Legacy email links redirect to root dashboard (`/`) with UTM params preserved, not back to the old embed path

### Auth parity (`apps/dashboard/src/utils/better-auth/`)
- `RedirectToSignIn` honors `redirectUrl` in self-hosted/agent environments
- Better Auth sign-in reads `redirect_url` after login so the root-dashboard destination is not lost

## Test plan

- [ ] Open `/onboarding/inbox/embed?utm_*` in an incognito session
- [ ] Confirm redirect to sign-in (not a blank page)
- [ ] After sign-in, confirm redirect to `/?utm_*` (not `/onboarding/inbox/embed`)
- [ ] Update Customer.io trial journey email CTA to root dashboard URL
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1782474006434749?thread_ts=1782474006.434749&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-2e5cf5d0-93ab-53ef-b862-1a14ab865d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5cf5d0-93ab-53ef-b862-1a14ab865d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the trial inbox marketing CTA and sign-in redirect flow. The main changes are:

- Redirect signed-out `/onboarding/*` visitors through the normal sign-in flow.
- Preserve UTM query parameters while sending legacy onboarding links to the root dashboard.
- Add Better Auth support for reading and applying same-origin `redirect_url` after sign-in.
- Add shared trial journey UTM constants and a helper for building the root dashboard CTA URL.

<h3>Confidence Score: 5/5</h3>

The changed redirect and CTA helpers are narrowly scoped and align with the intended trial inbox marketing flow.

No blocking correctness or security issues were identified in the reviewed changes, and the behavior described by the PR is localized to onboarding redirects, Better Auth redirect handling, and shared marketing URL construction.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the base onboarding RedirectToSignIn flow now includes a redirect\_url parameter and resolves post-auth destination to the root URL with UTMs.
- Validated that the dashboard helper exports and URL generation produce a canonical root dashboard URL with all four UTMs and includesLegacyEmbedPath set to false.

<a href="https://app.greptile.com/trex/runs/12783787/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): honor redirect\_url for l..."](https://github.com/novuhq/novu/commit/c8b637980d2a9dd4afe5143356e450af8f253945) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40821545)</sub>

<!-- /greptile_comment -->