### PR TITLE
feat(docs): add Novu docs homepage with hero and image cards

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,7 +4,7 @@
   "name": "Novu",
   "description": "The open-source notification infrastructure for agents and products. Send, receive, and track notifications across channels.",
   "colors": {
-    "primary": "#0e121b",
+    "primary": "#FF006A",
     "light": "#FFFFFF",
     "dark": "#FFFFFF"
   },
@@ -16,7 +16,7 @@
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg",
-    "href": "https://novu.co"
+    "href": "/"
   },
   "navigation": {
     "global": {
@@ -958,11 +958,6 @@
     }
   },
   "redirects": [
-    {
-      "source": "/",
-      "destination": "/platform",
-      "permanent": true
-    },
     {
       "source": "/content-creation-design/handlebars-helpers",
       "destination": "/platform/templates/handlebars-helpers",

--- a/docs/images/docs-home-card-agents.svg
+++ b/docs/images/docs-home-card-agents.svg
@@ -1,0 +1,39 @@
+<svg width="480" height="200" viewBox="0 0 480 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <clipPath id="agents-clip">
+      <rect width="480" height="200" rx="0"/>
+    </clipPath>
+    <pattern id="agents-dots" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#FBC9DE"/>
+    </pattern>
+    <radialGradient id="agents-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 100) rotate(90) scale(95)">
+      <stop stop-color="#E300BD" stop-opacity="0.14"/>
+      <stop offset="1" stop-color="#E300BD" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <g clip-path="url(#agents-clip)">
+    <rect width="480" height="200" fill="#FFF6FA"/>
+    <rect width="480" height="200" fill="url(#agents-dots)"/>
+    <circle cx="240" cy="100" r="95" fill="url(#agents-glow)"/>
+  </g>
+
+  <!-- reply bubble (back) -->
+  <path d="M298 54h36c7.2 0 13 5.8 13 13v20c0 7.2-5.8 13-13 13h-7l-6.5 11-5-11h-17.5c-7.2 0-13-5.8-13-13V67c0-7.2 5.8-13 13-13Z" fill="#FFBA33" opacity="0.85"/>
+
+  <!-- main conversation bubble -->
+  <path d="M186 60h100c9 0 16.5 7.5 16.5 16.5v42c0 9-7.5 16.5-16.5 16.5h-46l-11.5 18-5-18H186c-9 0-16.5-7.5-16.5-16.5v-42C169.5 67.5 177 60 186 60Z" fill="white" stroke="#FF006A" stroke-width="3"/>
+
+  <!-- bot face -->
+  <rect x="206" y="72" width="11" height="11" rx="2.5" fill="#FBD2E3"/>
+  <circle cx="236" cy="74" r="3.2" fill="#FF006A"/>
+  <line x1="236" y1="74" x2="236" y2="82" stroke="#FF006A" stroke-width="2.5" stroke-linecap="round"/>
+  <rect x="212" y="82" width="48" height="30" rx="11" fill="#FF006A"/>
+  <circle cx="227" cy="97" r="4" fill="white"/>
+  <circle cx="247" cy="97" r="4" fill="white"/>
+
+  <!-- typing dots -->
+  <circle cx="200" cy="126" r="3.2" fill="#FBC9DE"/>
+  <circle cx="211" cy="126" r="3.2" fill="#FBC9DE"/>
+  <circle cx="222" cy="126" r="3.2" fill="#FBC9DE"/>
+</svg>

--- a/docs/images/docs-home-card-platform.svg
+++ b/docs/images/docs-home-card-platform.svg
@@ -1,0 +1,34 @@
+<svg width="480" height="200" viewBox="0 0 480 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <clipPath id="platform-clip">
+      <rect width="480" height="200" rx="0"/>
+    </clipPath>
+    <pattern id="platform-dots" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#FBC9DE"/>
+    </pattern>
+    <radialGradient id="platform-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 100) rotate(90) scale(95)">
+      <stop stop-color="#FF006A" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#FF006A" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <g clip-path="url(#platform-clip)">
+    <rect width="480" height="200" fill="#FFF6FA"/>
+    <rect width="480" height="200" fill="url(#platform-dots)"/>
+    <circle cx="240" cy="100" r="95" fill="url(#platform-glow)"/>
+  </g>
+
+  <!-- notification panel -->
+  <rect x="185" y="32" width="110" height="136" rx="16" fill="white" stroke="#FF006A" stroke-width="3"/>
+  <rect x="199" y="48" width="82" height="10" rx="5" fill="#FBD2E3"/>
+
+  <!-- bell -->
+  <circle cx="240" cy="96" r="22" fill="#FF006A"/>
+  <path d="M240 83c-6.4 0-11.2 5.2-11.2 11.6v5.2c0 2.4-1 4.6-2.6 6.3l-1.4 1.3h30.4l-1.4-1.3c-1.6-1.7-2.6-3.9-2.6-6.3v-5.2c0-6.4-4.8-11.6-11.2-11.6Z" fill="white"/>
+  <path d="M235.2 109h9.6c0 2.6-2.2 4.8-4.8 4.8s-4.8-2.2-4.8-4.8Z" fill="white"/>
+  <circle cx="255" cy="78" r="6.5" fill="#FFBA33" stroke="white" stroke-width="2"/>
+
+  <!-- notification rows -->
+  <rect x="199" y="136" width="82" height="8" rx="4" fill="#FBD2E3"/>
+  <rect x="199" y="150" width="64" height="8" rx="4" fill="#FCE3EE"/>
+</svg>

--- a/docs/images/docs-home-hero-placeholder.svg
+++ b/docs/images/docs-home-hero-placeholder.svg
@@ -1,0 +1,38 @@
+<svg width="1600" height="520" viewBox="0 0 1600 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="520" fill="white"/>
+  <defs>
+    <linearGradient id="novu-soft" x1="0" y1="0" x2="1600" y2="520" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF006A" stop-opacity="0.12"/>
+      <stop offset="0.48" stop-color="#E300BD" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#FFBA33" stop-opacity="0.11"/>
+    </linearGradient>
+    <radialGradient id="novu-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 228) rotate(90) scale(260 560)">
+      <stop stop-color="#FF006A" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#FF006A" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="520" fill="url(#novu-soft)"/>
+  <rect width="1600" height="520" fill="url(#novu-glow)"/>
+  <g opacity="0.33" stroke="#FF006A" stroke-width="2">
+    <path d="M151 209L322 128L421 298L249 379L151 209Z"/>
+    <path d="M188 226L274 278L383 150"/>
+    <path d="M1167 148H1354C1370.57 148 1384 161.431 1384 178V331C1384 347.569 1370.57 361 1354 361H1167C1150.43 361 1137 347.569 1137 331V178C1137 161.431 1150.43 148 1167 148Z"/>
+    <path d="M1177 179L1260 253L1344 179"/>
+    <path d="M809 48L916 110V233L809 295L702 233V110L809 48Z"/>
+    <path d="M702 110L809 172L916 110"/>
+    <path d="M809 172V295"/>
+    <path d="M514 182C566 124 663 128 711 191C752 245 724 330 654 348L623 412L576 358C520 353 477 323 464 278C454 244 470 211 514 182Z"/>
+    <path d="M1085 95C1046 102 1019 139 1026 178C1033 217 1070 244 1109 237C1148 230 1175 193 1168 154C1161 115 1124 88 1085 95Z"/>
+    <path d="M1083 151L1112 184L1068 194"/>
+  </g>
+  <g opacity="0.22" stroke="#E300BD" stroke-width="2">
+    <path d="M41 42H171C193.091 42 211 59.9086 211 82V156"/>
+    <path d="M1394 34H1535C1557.09 34 1575 51.9086 1575 74V156"/>
+    <path d="M37 443H190C212.091 443 230 425.091 230 403V366"/>
+    <path d="M1416 430H1545C1567.09 430 1585 412.091 1585 390V309"/>
+    <circle cx="342" cy="126" r="9"/>
+    <circle cx="1354" cy="148" r="9"/>
+    <circle cx="655" cy="348" r="9"/>
+    <circle cx="1026" cy="178" r="9"/>
+  </g>
+</svg>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,111 @@
+---
+title: "Documentation"
+description: "Build the communication infrastructure for agents and products"
+---
+
+<Columns cols={2}>
+  <Card title="Start with Platform" img="/images/docs-home-card-platform.svg" href="/platform">
+    Build notification workflows for Inbox, email, SMS, push, and chat.
+  </Card>
+  <Card title="Start with Agents" img="/images/docs-home-card-agents.svg" href="/agents">
+    Connect agent brains to messaging providers with Agent Communication Infrastructure.
+  </Card>
+</Columns>
+
+## Choose your path
+
+<Tabs>
+  <Tab title="Platform">
+
+The Novu Platform helps you send the right message to the right subscriber on the right channel. Define workflows, trigger events, render content, respect preferences, and inspect delivery.
+
+<Columns cols={2}>
+  <Card title="React quickstart" icon="rocket" href="/platform/quickstart/react">
+    Add the Novu Inbox to a React application and send your first notification.
+  </Card>
+  <Card title="Workflows" icon="git-branch" href="/platform/concepts/workflows">
+    Learn how workflows model notification logic across channels and steps.
+  </Card>
+  <Card title="Inbox" icon="inbox" href="/platform/inbox">
+    Embed a real-time notification feed that subscribers can read, archive, snooze, and configure.
+  </Card>
+  <Card title="Integrations" icon="plug" href="/platform/integrations">
+    Connect providers for email, SMS, chat, push, and in-app delivery.
+  </Card>
+</Columns>
+
+  </Tab>
+  <Tab title="Agents">
+
+Novu Agents gives your AI agent a communication layer. Agent Communication Infrastructure receives provider webhooks, normalizes messages, resolves identity, preserves conversation state, and delivers replies back to the original thread.
+
+<Note>
+  Agents are currently in private beta. Contact support@novu.co to get access.
+</Note>
+
+<Columns cols={2}>
+  <Card title="What is ACI?" icon="circle-question-mark" href="/agents/get-started/what-is-aci">
+    Understand the infrastructure layer between messaging providers and agent intelligence.
+  </Card>
+  <Card title="Managed agent quickstart" icon="sparkles" href="/agents/managed-agent/quickstart">
+    Create an agent, connect a provider, and send your first message.
+  </Card>
+  <Card title="Custom code agent" icon="square-code" href="/agents/custom-code-agent/quickstart">
+    Bring your own LLM, tools, runtime, and business logic.
+  </Card>
+  <Card title="Conversation observability" icon="messages-square" href="/agents/conversations">
+    Inspect agent conversations, message history, participants, and provider context.
+  </Card>
+</Columns>
+
+  </Tab>
+</Tabs>
+
+## How Novu fits together
+
+<Columns cols={3}>
+  <Card title="Trigger outbound notifications" icon="send" href="/platform/workflow/trigger-workflow">
+    Call Novu from your application when something important happens.
+  </Card>
+  <Card title="Connect inbound conversations" icon="messages-square" href="/agents/get-started/mental-model">
+    Let subscribers message your agent from the channels they already use.
+  </Card>
+  <Card title="Operate the whole system" icon="activity" href="/agents/conversations">
+    Monitor notifications, conversations, providers, and delivery behavior from Novu.
+  </Card>
+</Columns>
+
+<Frame caption="Novu provides the communication infrastructure between applications, subscribers, providers, and agents.">
+  ![Novu communication infrastructure](/images/hero-light.svg)
+</Frame>
+
+## Build with your stack
+
+<Columns cols={2}>
+  <Card title="Client SDKs" icon="monitor-smartphone" href="/platform/sdks#web-and-mobile-sdks">
+    Add Inbox and notification UI to React, JavaScript, and React Native apps.
+  </Card>
+  <Card title="Server SDKs" icon="server" href="/platform/sdks#server-side-sdks">
+    Trigger notifications and call the API from TypeScript, Python, Go, PHP, .NET, Java, Kotlin, Laravel, and Ruby.
+  </Card>
+  <Card title="API reference" icon="braces" href="/api-reference">
+    Explore Novu REST APIs for events, subscribers, workflows, integrations, messages, and more.
+  </Card>
+  <Card title="Framework" icon="blocks" href="/framework">
+    Build notification workflows as code with the Novu Framework.
+  </Card>
+</Columns>
+
+## Community
+
+<Columns cols={3}>
+  <Card title="GitHub" icon="github" href="https://github.com/novuhq/novu">
+    Star Novu, inspect the source, and contribute to the project.
+  </Card>
+  <Card title="Discord" icon="messages-square" href="https://discord.gg/novu">
+    Ask questions and build with the Novu community.
+  </Card>
+  <Card title="Changelog" icon="newspaper" href="https://go.novu.co/changelog?utm_source=docs_home">
+    Follow product updates, SDK releases, and platform improvements.
+  </Card>
+</Columns>

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,3 +5,83 @@
     max-width: 16rem;
   }
 }
+
+#navbar nav a[aria-current="location"],
+#navbar nav button[data-state="open"],
+[role="tab"][data-state="active"] {
+  color: rgb(var(--primary));
+}
+
+#navbar nav a[aria-current="location"] {
+  background-color: rgb(var(--primary) / 0.08);
+}
+
+@media (min-width: 1280px) {
+  #navbar nav[aria-label="Main"] {
+    position: absolute;
+    left: max(15rem, calc(50vw - 340px));
+  }
+}
+
+html[data-current-path="/"] #content-area {
+  max-width: 984px;
+  padding-top: 0;
+}
+
+html[data-current-path="/"] #content-side-layout,
+html[data-current-path="/"] #page-context-menu {
+  display: none !important;
+}
+
+html[data-current-path="/"] #header {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  min-height: 300px;
+  margin: 0 0 2.5rem;
+  padding: 4.5rem 1.5rem 3rem;
+  overflow: hidden;
+  place-items: center;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+html[data-current-path="/"] #header::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  pointer-events: none;
+  opacity: 0.45;
+  background: url("/images/docs-home-hero-placeholder.svg") center center / cover no-repeat;
+}
+
+.dark[data-current-path="/"] #header::before {
+  opacity: 0.3;
+}
+
+html[data-current-path="/"] #header > div {
+  max-width: 760px;
+  text-align: center;
+}
+
+html[data-current-path="/"] #page-title,
+html[data-current-path="/"] #header h1 {
+  margin-bottom: 0 !important;
+  font-size: clamp(1.625rem, 2.5vw, 2.25rem) !important;
+  line-height: 1.05 !important;
+  letter-spacing: -0.02em !important;
+}
+
+html[data-current-path="/"] #header .prose {
+  max-width: 820px;
+  margin: 0.4rem auto 0 !important;
+  font-size: clamp(1rem, 1.35vw, 1.25rem) !important;
+  line-height: 1.35 !important;
+  color: rgb(87 79 83);
+}
+
+.dark[data-current-path="/"] #header .prose {
+  color: rgb(213 206 209);
+}


### PR DESCRIPTION
## Summary
- Adds a dedicated docs homepage (`docs/index.mdx`) instead of redirecting `/` straight to `/platform`
- Branded hero: full-bleed illustration background, condensed title/tagline sized and spaced to sit inside the artwork at all viewport widths
- "Start with Platform" / "Start with Agents" cards now use illustrated `img` cards (new `docs-home-card-platform.svg` / `docs-home-card-agents.svg`) instead of plain icon cards, matching Mintlify's own card pattern
- `docs.json`: primary color updated to Novu pink, logo now links to `/`, removed the old `/` -> `/platform` redirect

## Test plan
- [x] Verified hero renders correctly with tagline inside the background at desktop (1280px, 1920px), tablet (768px), and mobile (420px) widths via local Mintlify preview + Playwright screenshots
- [x] Verified image cards render and stack correctly on mobile
- [x] Visual review on preview deploy

Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a dedicated docs homepage (`docs/index.mdx`) replacing the previous hard redirect from `/` to `/platform`, adds a branded hero layout via custom CSS, and ships illustrated SVG cards for the Platform and Agents entry points.

- **`docs.json`**: Primary color updated to Novu pink (`#FF006A`), logo href changed from the marketing site to `/`, and the permanent `/` → `/platform` redirect removed.
- **`docs/index.mdx`**: New homepage with illustrated hero cards, tabbed Platform/Agents sections, a \"How Novu fits together\" overview, SDK/API links, and community cards.
- **`docs/style.css`**: Homepage-scoped CSS hides the sidebar/TOC, stretches the header into a full-bleed hero, and applies dark-mode opacity to the background image.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a documentation-only change with no impact on application code or APIs.

All changes are confined to the docs site: a new MDX homepage, three SVG assets, a CSS file, and a config update. No redirects are broken (the removed `/` → `/platform` redirect is replaced by the new homepage). The open visual issues (card SVG dark-mode backgrounds, previously flagged hero/CSS concerns) are cosmetic and do not block functionality.

The two card SVGs (`docs-home-card-platform.svg`, `docs-home-card-agents.svg`) and `docs-home-hero-placeholder.svg` warrant a visual check in dark mode before the preview deploy sign-off.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Updates primary brand color to Novu pink (#FF006A), changes logo href from external marketing site to internal /, and removes the permanent / → /platform redirect to make room for the new homepage |
| docs/index.mdx | New docs homepage with illustrated hero cards, tabbed Platform/Agents paths, and community links; references /images/hero-light.svg unconditionally (dark-mode concern flagged in previous review thread) |
| docs/style.css | Adds homepage-scoped layout rules (hero header, hidden sidebar/TOC, centered content); dark-mode selectors omit the html qualifier inconsistent with light-mode counterparts (flagged in prior review threads) |
| docs/images/docs-home-card-platform.svg | New illustrated card SVG for Platform path; background rect is hard-coded to light pink (#FFF6FA) with no dark-mode adaptation |
| docs/images/docs-home-card-agents.svg | New illustrated card SVG for Agents path; same hard-coded light-pink background issue as the platform card |
| docs/images/docs-home-hero-placeholder.svg | New hero background SVG; contains a solid white base rect that bleeds through in dark mode even at reduced opacity (flagged in prior review thread) |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits /] --> B[docs/index.mdx homepage]
    B --> C{Choose path}
    C --> D[Start with Platform\n/platform]
    C --> E[Start with Agents\n/agents]
    D --> D1[React quickstart]
    D --> D2[Workflows]
    D --> D3[Inbox]
    D --> D4[Integrations]
    E --> E1[What is ACI?]
    E --> E2[Managed agent quickstart]
    E --> E3[Custom code agent]
    E --> E4[Conversation observability]
    B --> F[How Novu fits together]
    F --> F1[Trigger outbound]
    F --> F2[Connect inbound]
    F --> F3[Operate system]
    B --> G[Build with your stack]
    G --> G1[Client SDKs]
    G --> G2[Server SDKs]
    G --> G3[API reference]
    G --> G4[Framework]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User visits /] --> B[docs/index.mdx homepage]
    B --> C{Choose path}
    C --> D[Start with Platform\n/platform]
    C --> E[Start with Agents\n/agents]
    D --> D1[React quickstart]
    D --> D2[Workflows]
    D --> D3[Inbox]
    D --> D4[Integrations]
    E --> E1[What is ACI?]
    E --> E2[Managed agent quickstart]
    E --> E3[Custom code agent]
    E --> E4[Conversation observability]
    B --> F[How Novu fits together]
    F --> F1[Trigger outbound]
    F --> F2[Connect inbound]
    F --> F3[Operate system]
    B --> G[Build with your stack]
    G --> G1[Client SDKs]
    G --> G2[Server SDKs]
    G --> G3[API reference]
    G --> G4[Framework]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into docs/homepage-r..."](https://github.com/novuhq/novu/commit/fa178a9d1cbb360f8957514faeb236bfc25fde77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40832141)</sub>

<!-- /greptile_comment -->