### PR TITLE
fix(docs): unify Getting Started nav and remove AI setup callouts fixes DOC-387

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -395,7 +395,7 @@
         "tab": "Agents",
         "groups": [
           {
-            "group": "Get Started",
+            "group": "Getting Started",
             "boost": 3,
             "pages": [
               "agents",
@@ -451,7 +451,7 @@
         "tab": "API Reference",
         "groups": [
           {
-            "group": "Overview",
+            "group": "Getting Started",
             "pages": [
               "api-reference",
               "api-reference/authentication",

--- a/docs/platform/inbox/setup-inbox.mdx
+++ b/docs/platform/inbox/setup-inbox.mdx
@@ -23,12 +23,6 @@ To get started, install the Inbox UI:
   </Tab>
 </Tabs>
 
-## Use AI to set up faster
-
-<Note>
-  Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from **API Keys** and **Subscribers** in the Novu dashboard. For other frameworks, see the [Quickstart](/platform/quickstart/nextjs) guides.
-</Note>
-
 <Tabs>
   <Tab title="Next.js">
 <Prompt description="Add Novu Inbox to my Next.js app" icon="sparkles" actions={["copy", "cursor"]}>
@@ -37,8 +31,6 @@ To get started, install the Inbox UI:
 Install `@novu/nextjs`. Add the `<Inbox />` component to your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/nextjs
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 
@@ -107,8 +99,6 @@ If any fails, revise.
 Install `@novu/react`. Add the `<Inbox />` component to your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/react
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 

--- a/docs/platform/quickstart/angular.mdx
+++ b/docs/platform/quickstart/angular.mdx
@@ -11,20 +11,12 @@ Add real-time in-app notifications to Angular using the Novu Inbox component and
   This guide uses @novu/js javascript sdk to build the Inbox component in Angular. Novu currently does not support native Angular Inbox component.
 </Note>
 
-## Use AI to set up faster
-
-<Note>
-  Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from **API Keys** and **Subscribers** in the Novu dashboard.
-</Note>
-
 <Prompt description="Add Novu Inbox to my Angular app" icon="sparkles" actions={["copy", "cursor"]}>
 # Add Novu Inbox to Angular App
 
 Install `@novu/js`. Mount the Inbox in your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/angular
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 

--- a/docs/platform/quickstart/nextjs.mdx
+++ b/docs/platform/quickstart/nextjs.mdx
@@ -7,20 +7,12 @@ sidebarTitle: 'Next.js'
 
 Add real-time in-app notifications to Next.js in under 10 minutes using the Novu Inbox component.
 
-## Use AI to set up faster
-
-<Note>
-  Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from **API Keys** and **Subscribers** in the Novu dashboard.
-</Note>
-
 <Prompt description="Add Novu Inbox to my Next.js app" icon="sparkles" actions={["copy", "cursor"]}>
 # Add Novu Inbox to Next.js App
 
 Install `@novu/nextjs`. Add the `<Inbox />` component to your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/nextjs
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 

--- a/docs/platform/quickstart/react.mdx
+++ b/docs/platform/quickstart/react.mdx
@@ -7,20 +7,12 @@ sidebarTitle: 'React'
 
 Add real-time in-app notifications to React in under 10 minutes using the Novu Inbox component.
 
-## Use AI to set up faster
-
-<Note>
-  Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from **API Keys** and **Subscribers** in the Novu dashboard.
-</Note>
-
 <Prompt description="Add Novu Inbox to my React app" icon="sparkles" actions={["copy", "cursor"]}>
 # Add Novu Inbox to React App
 
 Install `@novu/react`. Add the `<Inbox />` component to your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/react
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 

--- a/docs/platform/quickstart/remix.mdx
+++ b/docs/platform/quickstart/remix.mdx
@@ -7,20 +7,12 @@ sidebarTitle: 'Remix'
 
 Add real-time in-app notifications to Remix in under 10 minutes using the Novu Inbox component.
 
-## Use AI to set up faster
-
-<Note>
-  Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from **API Keys** and **Subscribers** in the Novu dashboard.
-</Note>
-
 <Prompt description="Add Novu Inbox to my Remix app" icon="sparkles" actions={["copy", "cursor"]}>
 # Add Novu Inbox to Remix App
 
 Install `@novu/react`. Add the `<Inbox />` component to your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/remix
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 

--- a/docs/platform/quickstart/vanilla-js.mdx
+++ b/docs/platform/quickstart/vanilla-js.mdx
@@ -7,20 +7,12 @@ sidebarTitle: 'Vanilla JS'
 
 Add real-time in-app notifications to a Vanilla JS and HTML project using the Novu Inbox component.
 
-## Use AI to set up faster
-
-<Note>
-  Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from **API Keys** and **Subscribers** in the Novu dashboard.
-</Note>
-
 <Prompt description="Add Novu Inbox to my JavaScript app" icon="sparkles" actions={["copy", "cursor"]}>
 # Add Novu Inbox to JavaScript App
 
 Install `@novu/js`. Mount the Inbox in your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/vanilla-js
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 

--- a/docs/platform/quickstart/vue.mdx
+++ b/docs/platform/quickstart/vue.mdx
@@ -11,20 +11,12 @@ Add real-time in-app notifications to Vue using the Novu Inbox component and the
   This guide uses @novu/js javascript sdk to build the Inbox component in Vue. Novu currently does not support native Vue Inbox component.
 </Note>
 
-## Use AI to set up faster
-
-<Note>
-  Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from **API Keys** and **Subscribers** in the Novu dashboard.
-</Note>
-
 <Prompt description="Add Novu Inbox to my Vue app" icon="sparkles" actions={["copy", "cursor"]}>
 # Add Novu Inbox to Vue App
 
 Install `@novu/js`. Mount the Inbox in your header, navbar, or sidebar.
 
 Latest docs: https://docs.novu.co/platform/quickstart/vue
-
-Replace `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` with values from the Novu dashboard (**API Keys** and **Subscribers**).
 
 ## Install
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unifies docs navigation and removes redundant AI setup callouts from quickstart pages.

### Navigation
Unifies the first sidebar section title across all docs tabs to **Getting Started**:
- **Agents** tab: `Get Started` → `Getting Started`
- **API Reference** tab: `Overview` → `Getting Started`

### Quickstart cleanup
Removes the **Use AI to set up faster** section headings and replace-note callouts from:
- All platform quickstart guides (Next.js, React, Remix, Angular, Vue, Vanilla JS)
- Inbox setup guide

The `<Prompt>` AI integration blocks remain; only the redundant titles and `<Note>` replace instructions were removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b9a05dd-e461-4ccb-8f34-c8b86d38eaf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b9a05dd-e461-4ccb-8f34-c8b86d38eaf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the docs navigation labels and trims repeated AI setup copy from Inbox quickstarts. The main changes are:

- Renames the first Agents sidebar group to `Getting Started`.
- Renames the API Reference overview group to `Getting Started`.
- Removes `Use AI to set up faster` headings and replacement notes from Inbox setup and platform quickstarts.
- Keeps the existing `<Prompt>` blocks in each quickstart page.

<h3>Confidence Score: 4/5</h3>

The changes are documentation-only and should be safe to merge once the placeholder substitution guidance is restored near the AI prompt blocks.

The touched files are scoped to docs navigation and quickstart copy, with one consistency issue affecting how users interpret placeholder values in prompts.

docs/platform/quickstart/nextjs.mdx and the parallel quickstart/setup pages with the same prompt pattern need a concise replacement note.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after docs navigation logs to verify the Agents and API Reference first sidebar groups both show Getting Started after the change.
- Checked the before and after AI cleanup logs to verify the removal of the heading and replacement guidance while \<Prompt\> markers remain.
- Noted that rendering a Mintlify UI capture was not attempted because the repository lacks a local docs app package, so real MDX files from the commits were used for evidence.

<a href="https://app.greptile.com/trex/runs/12793963/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fplatform%2Fquickstart%2Fnextjs.mdx%3A10%0A**Restore%20placeholder%20guidance**%0AThe%20docs%20project%20guidance%20for%20AI%20prompt%20blocks%20says%20to%20add%20a%20%60%3CNote%3E%60%20near%20the%20first%20prompt%20telling%20users%20to%20substitute%20dashboard%20values%2C%20but%20this%20page%20now%20opens%20directly%20with%20a%20prompt%20containing%20%60YOUR_APPLICATION_IDENTIFIER%60%20and%20%60YOUR_SUBSCRIBER_ID%60%20and%20no%20nearby%20substitution%20note.%20The%20same%20pattern%20appears%20in%20the%20other%20changed%20quickstarts%20and%20%60docs%2Fplatform%2Finbox%2Fsetup-inbox.mdx%60%2C%20so%20please%20keep%20a%20concise%20replacement%20note%20outside%20the%20prompt%20while%20removing%20the%20redundant%20heading.%0A%0A&pr=11735&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/platform/quickstart/nextjs.mdx:10
**Restore placeholder guidance**
The docs project guidance for AI prompt blocks says to add a `<Note>` near the first prompt telling users to substitute dashboard values, but this page now opens directly with a prompt containing `YOUR_APPLICATION_IDENTIFIER` and `YOUR_SUBSCRIBER_ID` and no nearby substitution note. The same pattern appears in the other changed quickstarts and `docs/platform/inbox/setup-inbox.mdx`, so please keep a concise replacement note outside the prompt while removing the redundant heading.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): remove Use AI to set up faste..."](https://github.com/novuhq/novu/commit/efbf2496e96c95a711c2deb4fa24a99a98b9786a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40860859)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->