### PR TITLE
docs: align roles and permissions table with code fixes DOC-388

### DIFF
--- a/docs/platform/account/roles-and-permissions.mdx
+++ b/docs/platform/account/roles-and-permissions.mdx
@@ -10,42 +10,102 @@ When you invite a team member to your organization, you can assign them a role t
   This feature is available to users on the Team and Enterprise pricing plans, and it is supported on both the new dashboard and the legacy dashboard.
 </Note>
 
-Below is an overview of the four roles available in Novu:
-- **Owner**. For your primary account administrator. This role has full access across the platform, including organization-level settings, billing, API keys, environment management, and user administration. Each Novu organization must have at least one owner.
+## Roles overview
 
-- **Admin**. For users who manage configuration and operational aspects of Novu. Admins can manage workflows, integrations, subscribers, environments, API keys, team members, and organization settings. They do not have access to billing.
+Novu includes four organization roles. Use the cards below for a quick summary, then expand the permission groups to compare access across roles.
 
-- **Author**. For users who design and update notification workflows. Authors can create and modify workflows, manage integrations, subscribers, topics, agents, bridges, and environment variables, and trigger events. They do not have access to organization-level settings, billing, API keys, webhooks, or member management.
+<Columns cols={2}>
+  <Card title="Owner" icon="crown">
+    Primary account administrator with full access across the platform, including billing, API keys, environment management, and user administration. Each organization must have at least one owner.
+  </Card>
+  <Card title="Admin" icon="shield">
+    Manages configuration and day-to-day operations, including workflows, integrations, subscribers, environments, API keys, team members, and organization settings. Does not have access to billing.
+  </Card>
+  <Card title="Author" icon="pen-line">
+    Designs and updates notification workflows. Can manage workflows, integrations, subscribers, topics, agents, bridges, and environment variables, and trigger events. Does not have access to organization settings, billing, API keys, webhooks, or member management.
+  </Card>
+  <Card title="Viewer" icon="eye">
+    Read-only access to workflows, agents, integrations, environments, logs, and messages. Cannot create, update, or delete resources.
+  </Card>
+</Columns>
 
-- **Viewer**. For read-only users. Viewers can view workflows, agents, integrations, environments, logs, and messages, but cannot create, update, or delete resources.
+## Permissions by category
 
-## Roles and permissions table
+<Note>
+  Access levels: <Badge icon="eye" color="blue" size="sm" stroke>Read</Badge> view only · <Badge icon="check" color="green" size="sm">Write</Badge> read, create, update, and delete · <Badge icon="ban" color="gray" size="sm" stroke disabled>No access</Badge>
+</Note>
 
-Below is a detailed table showing which permissions are associated with each role.
+<AccordionGroup>
+  <Accordion title="Workflows and delivery" icon="git-branch">
+    | Permission | Viewer | Author | Admin | Owner |
+    | --- | --- | --- | --- | --- |
+    | Create and manage workflows | Read | Write | Write | Write |
+    | Create and manage messages | Read | Read | Write | Write |
+    | Create and manage topics | Read | Write | Write | Write |
+    | Trigger events | No access | Write | Write | Write |
+    | View notifications | Read | Read | Read | Read |
+    | Environment variables | Read | Write | Write | Write |
+  </Accordion>
 
-Legend:
-- 📖 - Read access
-- ✏️ - Write (full access: read, write, delete)
-- ❌ - No access
+  <Accordion title="Integrations and webhooks" icon="plug">
+    | Permission | Viewer | Author | Admin | Owner |
+    | --- | --- | --- | --- | --- |
+    | Manage integrations | Read | Write | Write | Write |
+    | Create and manage webhooks | No access | No access | Write | Write |
+    | Manage bridges | No access | Write | Write | Write |
+    | Manage partner integrations | No access | No access | Write | Write |
+  </Accordion>
 
-| Permission                      | **Viewer** | **Author** | **Admin** | **Owner** |
-| ------------------------------ | ---------- | ---------- | --------- | --------- |
-| Create and manage environments | ❌         | ❌         | ✏️         | ✏️         |
-| Create and manage messages     | 📖         | 📖         | ✏️         | ✏️         |
-| Create and manage topics       | 📖         | ✏️         | ✏️         | ✏️         |
-| Create and manage webhooks     | ❌         | ❌         | ✏️         | ✏️         |
-| Create and manage workflows    | 📖         | ✏️         | ✏️         | ✏️         |
-| Manage agents                  | 📖         | ✏️         | ✏️         | ✏️         |
-| Manage API keys                | ❌         | ❌         | ✏️         | ✏️         |
-| Manage billing                 | ❌         | ❌         | ❌         | ✏️         |
-| Manage bridges                 | ❌         | ✏️         | ✏️         | ✏️         |
-| Manage custom domains          | ❌         | ❌         | ✏️         | ✏️         |
-| Manage integrations            | 📖         | ✏️         | ✏️         | ✏️         |
-| Manage organization metadata   | ❌         | ❌         | ✏️         | ✏️         |
-| Manage organization profile    | ❌         | ❌         | ✏️         | ✏️         |
-| Manage partner integrations    | ❌         | ❌         | ✏️         | ✏️         |
-| Manage subscribers             | 📖         | ✏️         | ✏️         | ✏️         |
-| Trigger events                 | ❌         | ✏️         | ✏️         | ✏️         |
-| View and manage team members   | 📖         | 📖         | ✏️         | ✏️         |
-| View notifications             | 📖         | 📖         | 📖         | 📖         |
-| Environment variables          | 📖         | ✏️         | ✏️         | ✏️         |
+  <Accordion title="Subscribers and agents" icon="users">
+    | Permission | Viewer | Author | Admin | Owner |
+    | --- | --- | --- | --- | --- |
+    | Manage subscribers | Read | Write | Write | Write |
+    | Manage agents | Read | Write | Write | Write |
+  </Accordion>
+
+  <Accordion title="Organization and billing" icon="building-2">
+    | Permission | Viewer | Author | Admin | Owner |
+    | --- | --- | --- | --- | --- |
+    | Create and manage environments | No access | No access | Write | Write |
+    | Manage API keys | No access | No access | Write | Write |
+    | Manage custom domains | No access | No access | Write | Write |
+    | Manage organization metadata | No access | No access | Write | Write |
+    | Manage organization profile | No access | No access | Write | Write |
+    | View and manage team members | Read | Read | Write | Write |
+    | Manage billing | No access | No access | No access | Write |
+  </Accordion>
+</AccordionGroup>
+
+<Tabs sync={false}>
+  <Tab title="Viewer" icon="eye">
+    **Can view**
+    - Workflows, messages, topics, notifications, and environment variables
+    - Integrations, subscribers, and agents
+    - Team members
+
+    **Cannot access**
+    - Webhooks, bridges, partner integrations, environments, API keys, custom domains, organization settings, billing, or event triggering
+  </Tab>
+  <Tab title="Author" icon="pen-line">
+    **Can manage**
+    - Workflows, topics, subscribers, agents, integrations, bridges, and environment variables
+    - Event triggering
+
+    **Can view only**
+    - Messages, notifications, and team members
+
+    **Cannot access**
+    - Webhooks, partner integrations, environments, API keys, custom domains, organization settings, or billing
+  </Tab>
+  <Tab title="Admin" icon="shield">
+    **Can manage**
+    - Everything except billing, including environments, API keys, custom domains, organization settings, and team members
+
+    **Cannot access**
+    - Billing
+  </Tab>
+  <Tab title="Owner" icon="crown">
+    **Can manage**
+    - Full access across the organization, including billing
+  </Tab>
+</Tabs>

--- a/docs/platform/account/roles-and-permissions.mdx
+++ b/docs/platform/account/roles-and-permissions.mdx
@@ -10,102 +10,45 @@ When you invite a team member to your organization, you can assign them a role t
   This feature is available to users on the Team and Enterprise pricing plans, and it is supported on both the new dashboard and the legacy dashboard.
 </Note>
 
-## Roles overview
+## Roles
 
-Novu includes four organization roles. Use the cards below for a quick summary, then expand the permission groups to compare access across roles.
-
-<Columns cols={2}>
-  <Card title="Owner" icon="crown">
-    Primary account administrator with full access across the platform, including billing, API keys, environment management, and user administration. Each organization must have at least one owner.
-  </Card>
-  <Card title="Admin" icon="shield">
-    Manages configuration and day-to-day operations, including workflows, integrations, subscribers, environments, API keys, team members, and organization settings. Does not have access to billing.
-  </Card>
-  <Card title="Author" icon="pen-line">
-    Designs and updates notification workflows. Can manage workflows, integrations, subscribers, topics, agents, bridges, and environment variables, and trigger events. Does not have access to organization settings, billing, API keys, webhooks, or member management.
-  </Card>
-  <Card title="Viewer" icon="eye">
-    Read-only access to workflows, agents, integrations, environments, logs, and messages. Cannot create, update, or delete resources.
-  </Card>
+<Columns cols={4}>
+  <Card title="Owner" icon="crown" description="Full access, including billing." />
+  <Card title="Admin" icon="shield" description="Operations and org settings. No billing." />
+  <Card title="Author" icon="pen-line" description="Build workflows and trigger events." />
+  <Card title="Viewer" icon="eye" description="Read-only dashboard access." />
 </Columns>
 
-## Permissions by category
+## Permissions matrix
+
+Compare access across roles at a glance. Scroll the table to review every permission.
 
 <Note>
-  Access levels: <Badge icon="eye" color="blue" size="sm" stroke>Read</Badge> view only · <Badge icon="check" color="green" size="sm">Write</Badge> read, create, update, and delete · <Badge icon="ban" color="gray" size="sm" stroke disabled>No access</Badge>
+  <Badge icon="check" color="green" size="sm">Write</Badge> create, read, update, and delete · <Badge icon="eye" color="blue" size="sm" stroke>Read</Badge> view only · <Badge icon="ban" color="gray" size="sm" stroke disabled>—</Badge> no access
 </Note>
 
-<AccordionGroup>
-  <Accordion title="Workflows and delivery" icon="git-branch">
-    | Permission | Viewer | Author | Admin | Owner |
-    | --- | --- | --- | --- | --- |
-    | Create and manage workflows | Read | Write | Write | Write |
-    | Create and manage messages | Read | Read | Write | Write |
-    | Create and manage topics | Read | Write | Write | Write |
-    | Trigger events | No access | Write | Write | Write |
-    | View notifications | Read | Read | Read | Read |
-    | Environment variables | Read | Write | Write | Write |
-  </Accordion>
-
-  <Accordion title="Integrations and webhooks" icon="plug">
-    | Permission | Viewer | Author | Admin | Owner |
-    | --- | --- | --- | --- | --- |
-    | Manage integrations | Read | Write | Write | Write |
-    | Create and manage webhooks | No access | No access | Write | Write |
-    | Manage bridges | No access | Write | Write | Write |
-    | Manage partner integrations | No access | No access | Write | Write |
-  </Accordion>
-
-  <Accordion title="Subscribers and agents" icon="users">
-    | Permission | Viewer | Author | Admin | Owner |
-    | --- | --- | --- | --- | --- |
-    | Manage subscribers | Read | Write | Write | Write |
-    | Manage agents | Read | Write | Write | Write |
-  </Accordion>
-
-  <Accordion title="Organization and billing" icon="building-2">
-    | Permission | Viewer | Author | Admin | Owner |
-    | --- | --- | --- | --- | --- |
-    | Create and manage environments | No access | No access | Write | Write |
-    | Manage API keys | No access | No access | Write | Write |
-    | Manage custom domains | No access | No access | Write | Write |
-    | Manage organization metadata | No access | No access | Write | Write |
-    | Manage organization profile | No access | No access | Write | Write |
-    | View and manage team members | Read | Read | Write | Write |
-    | Manage billing | No access | No access | No access | Write |
-  </Accordion>
-</AccordionGroup>
-
-<Tabs sync={false}>
-  <Tab title="Viewer" icon="eye">
-    **Can view**
-    - Workflows, messages, topics, notifications, and environment variables
-    - Integrations, subscribers, and agents
-    - Team members
-
-    **Cannot access**
-    - Webhooks, bridges, partner integrations, environments, API keys, custom domains, organization settings, billing, or event triggering
-  </Tab>
-  <Tab title="Author" icon="pen-line">
-    **Can manage**
-    - Workflows, topics, subscribers, agents, integrations, bridges, and environment variables
-    - Event triggering
-
-    **Can view only**
-    - Messages, notifications, and team members
-
-    **Cannot access**
-    - Webhooks, partner integrations, environments, API keys, custom domains, organization settings, or billing
-  </Tab>
-  <Tab title="Admin" icon="shield">
-    **Can manage**
-    - Everything except billing, including environments, API keys, custom domains, organization settings, and team members
-
-    **Cannot access**
-    - Billing
-  </Tab>
-  <Tab title="Owner" icon="crown">
-    **Can manage**
-    - Full access across the organization, including billing
-  </Tab>
-</Tabs>
+| Permission | Viewer | Author | Admin | Owner |
+| --- | --- | --- | --- | --- |
+| **Workflows and delivery** | | | | |
+| Create and manage workflows | Read | Write | Write | Write |
+| Create and manage messages | Read | Read | Write | Write |
+| Create and manage topics | Read | Write | Write | Write |
+| Trigger events | — | Write | Write | Write |
+| View notifications | Read | Read | Read | Read |
+| Environment variables | Read | Write | Write | Write |
+| **Integrations and webhooks** | | | | |
+| Manage integrations | Read | Write | Write | Write |
+| Create and manage webhooks | — | — | Write | Write |
+| Manage bridges | — | Write | Write | Write |
+| Manage partner integrations | — | — | Write | Write |
+| **Subscribers and agents** | | | | |
+| Manage subscribers | Read | Write | Write | Write |
+| Manage agents | Read | Write | Write | Write |
+| **Organization and billing** | | | | |
+| Create and manage environments | — | — | Write | Write |
+| Manage API keys | — | — | Write | Write |
+| Manage custom domains | — | — | Write | Write |
+| Manage organization metadata | — | — | Write | Write |
+| Manage organization profile | — | — | Write | Write |
+| View and manage team members | Read | Read | Write | Write |
+| Manage billing | — | — | — | Write |

--- a/docs/platform/account/roles-and-permissions.mdx
+++ b/docs/platform/account/roles-and-permissions.mdx
@@ -13,11 +13,11 @@ When you invite a team member to your organization, you can assign them a role t
 Below is an overview of the four roles available in Novu:
 - **Owner**. For your primary account administrator. This role has full access across the platform, including organization-level settings, billing, API keys, environment management, and user administration. Each Novu organization must have at least one owner.
 
-- **Admin**. For users who manage configuration and operational aspects of Novu. Admins can manage workflows, integrations, subscribers, environments, and message logs. They do not have access to billing.
+- **Admin**. For users who manage configuration and operational aspects of Novu. Admins can manage workflows, integrations, subscribers, environments, API keys, team members, and organization settings. They do not have access to billing.
 
-- **Author**. For users who design and update notification workflows. Authors can create and modify workflows, preview steps, manage topics, and trigger events. They do not have access to organization-level settings, billing, or member management.
+- **Author**. For users who design and update notification workflows. Authors can create and modify workflows, manage integrations, subscribers, topics, agents, bridges, and environment variables, and trigger events. They do not have access to organization-level settings, billing, API keys, webhooks, or member management.
 
-- **Viewer**. For read-only users. Viewers can view workflows, environments, logs, and messages, but cannot create, update, or delete resources.
+- **Viewer**. For read-only users. Viewers can view workflows, agents, integrations, environments, logs, and messages, but cannot create, update, or delete resources.
 
 ## Roles and permissions table
 
@@ -31,20 +31,21 @@ Legend:
 | Permission                      | **Viewer** | **Author** | **Admin** | **Owner** |
 | ------------------------------ | ---------- | ---------- | --------- | --------- |
 | Create and manage environments | ❌         | ❌         | ✏️         | ✏️         |
-| Create and manage messages     | 📖         | ✏️         | ✏️         | ✏️         |
+| Create and manage messages     | 📖         | 📖         | ✏️         | ✏️         |
 | Create and manage topics       | 📖         | ✏️         | ✏️         | ✏️         |
-| Create and manage webhooks     | 📖         | 📖         | ✏️         | ✏️         |
+| Create and manage webhooks     | ❌         | ❌         | ✏️         | ✏️         |
 | Create and manage workflows    | 📖         | ✏️         | ✏️         | ✏️         |
+| Manage agents                  | 📖         | ✏️         | ✏️         | ✏️         |
 | Manage API keys                | ❌         | ❌         | ✏️         | ✏️         |
 | Manage billing                 | ❌         | ❌         | ❌         | ✏️         |
-| Manage bridges                 | ❌         | ❌         | ✏️         | ✏️         |
-| Manage custom domains          | 📖         | 📖         | ✏️         | ✏️         |
-| Manage integrations            | 📖         | 📖         | ✏️         | ✏️         |
-| Manage organization metadata   | ❌         | ❌         | ❌         | ✏️         |
-| Manage organization profile    | ❌         | ❌         | ❌         | ✏️         |
-| Manage partner integrations    | 📖         | 📖         | ✏️         | ✏️         |
+| Manage bridges                 | ❌         | ✏️         | ✏️         | ✏️         |
+| Manage custom domains          | ❌         | ❌         | ✏️         | ✏️         |
+| Manage integrations            | 📖         | ✏️         | ✏️         | ✏️         |
+| Manage organization metadata   | ❌         | ❌         | ✏️         | ✏️         |
+| Manage organization profile    | ❌         | ❌         | ✏️         | ✏️         |
+| Manage partner integrations    | ❌         | ❌         | ✏️         | ✏️         |
 | Manage subscribers             | 📖         | ✏️         | ✏️         | ✏️         |
 | Trigger events                 | ❌         | ✏️         | ✏️         | ✏️         |
-| View and manage team members   | 📖         | 📖         | 📖         | ✏️         |
+| View and manage team members   | 📖         | 📖         | ✏️         | ✏️         |
 | View notifications             | 📖         | 📖         | 📖         | 📖         |
-| Environment Variables          | 📖         | ✏️         | ✏️         | ✏️         |
+| Environment variables          | 📖         | ✏️         | ✏️         | ✏️         |

--- a/docs/platform/account/roles-and-permissions.mdx
+++ b/docs/platform/account/roles-and-permissions.mdx
@@ -2,6 +2,10 @@
 title: 'Roles and permissions'
 description: 'Learn how roles and permissions are managed within Novu organizations'
 ---
+export const AccessWrite = () => <Badge icon="check" color="green" size="sm">Write</Badge>;
+export const AccessRead = () => <Badge icon="eye" color="blue" size="sm" stroke>Read</Badge>;
+export const AccessNone = () => <Badge icon="ban" color="gray" size="sm" stroke disabled>—</Badge>;
+
 Novu uses a role-based access control (RBAC) model at the [organization level](/platform/how-novu-works#organization-and-environments). Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard. Every user can belong to more than one organization, each with separate configurations and permissions.
 
 When you invite a team member to your organization, you can assign them a role that determines the actions they can perform within that organization. You can later update their role from the [Team section](https://dashboard.novu.co/settings/team) in your organization settings.
@@ -21,34 +25,30 @@ When you invite a team member to your organization, you can assign them a role t
 
 ## Permissions matrix
 
-Compare access across roles at a glance. Scroll the table to review every permission.
-
-<Note>
-  <Badge icon="check" color="green" size="sm">Write</Badge> create, read, update, and delete · <Badge icon="eye" color="blue" size="sm" stroke>Read</Badge> view only · <Badge icon="ban" color="gray" size="sm" stroke disabled>—</Badge> no access
-</Note>
+Compare access across roles at a glance.
 
 | Permission | Viewer | Author | Admin | Owner |
 | --- | --- | --- | --- | --- |
 | **Workflows and delivery** | | | | |
-| Create and manage workflows | Read | Write | Write | Write |
-| Create and manage messages | Read | Read | Write | Write |
-| Create and manage topics | Read | Write | Write | Write |
-| Trigger events | — | Write | Write | Write |
-| View notifications | Read | Read | Read | Read |
-| Environment variables | Read | Write | Write | Write |
+| Create and manage workflows | <AccessRead /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
+| Create and manage messages | <AccessRead /> | <AccessRead /> | <AccessWrite /> | <AccessWrite /> |
+| Create and manage topics | <AccessRead /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
+| Trigger events | <AccessNone /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
+| View notifications | <AccessRead /> | <AccessRead /> | <AccessRead /> | <AccessRead /> |
+| Environment variables | <AccessRead /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
 | **Integrations and webhooks** | | | | |
-| Manage integrations | Read | Write | Write | Write |
-| Create and manage webhooks | — | — | Write | Write |
-| Manage bridges | — | Write | Write | Write |
-| Manage partner integrations | — | — | Write | Write |
+| Manage integrations | <AccessRead /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
+| Create and manage webhooks | <AccessNone /> | <AccessNone /> | <AccessWrite /> | <AccessWrite /> |
+| Manage bridges | <AccessNone /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
+| Manage partner integrations | <AccessNone /> | <AccessNone /> | <AccessWrite /> | <AccessWrite /> |
 | **Subscribers and agents** | | | | |
-| Manage subscribers | Read | Write | Write | Write |
-| Manage agents | Read | Write | Write | Write |
+| Manage subscribers | <AccessRead /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
+| Manage agents | <AccessRead /> | <AccessWrite /> | <AccessWrite /> | <AccessWrite /> |
 | **Organization and billing** | | | | |
-| Create and manage environments | — | — | Write | Write |
-| Manage API keys | — | — | Write | Write |
-| Manage custom domains | — | — | Write | Write |
-| Manage organization metadata | — | — | Write | Write |
-| Manage organization profile | — | — | Write | Write |
-| View and manage team members | Read | Read | Write | Write |
-| Manage billing | — | — | — | Write |
+| Create and manage environments | <AccessNone /> | <AccessNone /> | <AccessWrite /> | <AccessWrite /> |
+| Manage API keys | <AccessNone /> | <AccessNone /> | <AccessWrite /> | <AccessWrite /> |
+| Manage custom domains | <AccessNone /> | <AccessNone /> | <AccessWrite /> | <AccessWrite /> |
+| Manage organization metadata | <AccessNone /> | <AccessNone /> | <AccessWrite /> | <AccessWrite /> |
+| Manage organization profile | <AccessNone /> | <AccessNone /> | <AccessWrite /> | <AccessWrite /> |
+| View and manage team members | <AccessRead /> | <AccessRead /> | <AccessWrite /> | <AccessWrite /> |
+| Manage billing | <AccessNone /> | <AccessNone /> | <AccessNone /> | <AccessWrite /> |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The [roles and permissions](https://docs.novu.co/platform/account/roles-and-permissions) page was out of sync with the source-of-truth `ROLE_PERMISSIONS` map in `packages/shared/src/types/auth.ts`.

This PR updates the permissions content to match what the dashboard and API enforce today, and simplifies the page layout so permissions are easier to skim.

## Changes

### Permissions table corrections

| Permission | Previous doc issue | Updated to match code |
| --- | --- | --- |
| Create and manage messages | Author had write access | Author is read-only (`MESSAGE_READ`) |
| Create and manage webhooks | Viewer/Author had read access | Viewer/Author have no webhook permissions |
| Manage bridges | Author had no access | Author has `BRIDGE_WRITE` |
| Manage custom domains | Viewer/Author had read access | Viewer/Author have no domain settings permissions |
| Manage integrations | Author had read-only access | Author has full integration access |
| Manage organization metadata | Admin had no access | Admin has `ORG_METADATA_WRITE` |
| Manage organization profile | Admin had no access | Admin has `ORG_SETTINGS_WRITE` |
| Manage partner integrations | Viewer/Author had read access | Viewer/Author have no partner integration permissions |
| View and manage team members | Admin was read-only | Admin can manage members via `ORG_SETTINGS_WRITE` |
| Manage agents | Missing row | Added (`AGENT_READ` / `AGENT_WRITE`) |

### Page layout

- **Compact role cards** — four one-line summaries in a single row (`cols={4}`)
- **Single visible permissions matrix** — all permissions shown at once with in-table section headers (no accordions or tabs)
- **Badge legend** — Write / Read / no access at the top of the matrix

## Source of truth

`packages/shared/src/types/auth.ts` → `ROLE_PERMISSIONS`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae30ec39-66b3-4044-9f7b-cf0738a8eeb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae30ec39-66b3-4044-9f7b-cf0738a8eeb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the roles and permissions documentation page. The main changes are:

- Replaces the role overview list with compact role cards.
- Adds reusable badge components for write, read, and no-access states.
- Converts the permissions content into one visible matrix grouped by feature area.
- Updates most role access entries to match `ROLE_PERMISSIONS` in `packages/shared/src/types/auth.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The change is limited to documentation content and layout for the roles and permissions page, with no application runtime or permission-enforcement code modified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after permissions matrix evidence to verify the old emoji table with mismatched cells and missing 'Manage agents' was replaced by a normalized MDX matrix that passes the expected permission contract.
- Compared the base prose UI and the head commit, confirming the head now uses four columns with Owner/Admin/Author/Viewer cards, a single matrix, four section header rows, and badge components for AccessWrite, AccessRead, and AccessNone within cells.

<a href="https://app.greptile.com/trex/runs/12796872/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Viewer and Author team-member access still contradicts ROLE_PERMISSIONS**

   - **Bug**
     - In the head revision, `docs/platform/account/roles-and-permissions.mdx` line 74 documents `View and manage team members | Read | Read | Write | Write`. The source-of-truth ROLE_PERMISSIONS map grants ORG_SETTINGS_READ/WRITE only to Admin and Owner, so Viewer and Author should be documented as `No access` for this row.
   - **Cause**
     - The updated MDX kept Viewer/Author read access in the team-member row even though neither role includes ORG_SETTINGS_READ or ORG_SETTINGS_WRITE in packages/shared/src/types/auth.ts.
   - **Fix**
     - Change the `View and manage team members` row to `No access | No access | Write | Write` and update the Viewer/Author quick-scan summaries if they are intended to describe team-member access from the same permission source.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["docs: use access badges in permissions m..."](https://github.com/novuhq/novu/commit/220b8aa993129a76111fb0f3f2540aa52f4aad62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40861352)</sub>

<!-- /greptile_comment -->