### PR TITLE
docs(docs): update authentication and organizations docs fixes DOC-390

### DIFF
--- a/docs/community/self-hosted-and-novu-cloud.mdx
+++ b/docs/community/self-hosted-and-novu-cloud.mdx
@@ -63,7 +63,7 @@ Below you will find a table that outlines the best available Novu Cloud Tier, co
 | Max team members | 1 | Custom |
 | Multi-Factor Authentication (MFA) | ❌ | ✅ |
 | Role-Based Access Control (RBAC) | ❌ | ✅ |
-| Standard SAML (Google, Github) | ❌ | ✅ |
+| Social sign-in (Google, GitHub) | ❌ | ✅ |
 
 ### Compliance
 | Features | Community Self-Hosted | Novu Cloud |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -363,6 +363,7 @@
             "group": "Account",
             "pages": [
               "platform/account/authentication",
+              "platform/account/organizations",
               "platform/account/roles-and-permissions",
               "platform/account/manage-members",
               "platform/account/billing",

--- a/docs/platform/account/authentication.mdx
+++ b/docs/platform/account/authentication.mdx
@@ -1,59 +1,90 @@
 ---
 title: 'Authentication'
-description: 'Configure authentication for Novu with OAuth, SSO, MFA, and more. Available for Enterprise customers on Novu Cloud.'
+description: 'Sign in to Novu Cloud with Google, GitHub, email and password, or enterprise OIDC and SAML. Learn about MFA, sessions, and account security.'
 ---
 
-
 <Note>
-  This feature is only available to Enterprise customers on our [Cloud
-  platform](https://dashboard.novu.co/?utm_campaign=docs_account_authentication). For more
-  information, please see our [Enterprise plan](https://novu.co/pricing) in the pricing page.
+  Dashboard authentication described here applies to [Novu Cloud](https://dashboard.novu.co). Self-hosted deployments use email and password only. See [Self-Hosted and Novu Cloud](/community/self-hosted-and-novu-cloud) for a full comparison.
 </Note>
 
-## Key capabilities
+Novu Cloud handles sign-in, session management, and account security for the dashboard. After you authenticate, you can access every [organization](/platform/account/organizations) you belong to and switch between them without signing in again.
 
-### Out-of-the-box OAuth providers
+## Sign-in methods
 
-Currently providing authentication via Github, with the plan to expand to a number of other providers such as:
+Novu Cloud supports the following ways to create an account and sign in:
 
-- Google
-- Facebook
-- Apple
-- Microsoft
-- LinkedIn
+### Email and password
 
-### SSO, SAML and OpenID connect
+Create an account with your email address and a password. Novu sends a verification email before your account is fully activated. Use this method if you prefer a traditional credential-based sign-in or if your organization does not use SSO.
 
-Novu provides a streamlined implementation of SAML and OpenID Connect protocols, allowing integration with a wide range of enterprise IdPs. Arrange setup of known providers like Okta, Microsoft Entra ID, Google workspace or a custom SSO provider.
+### Google and GitHub
 
-Novu adheres to industry-standard security protocols to ensure secure and reliable user authentication.
+Sign up or sign in with your existing **Google** or **GitHub** account. Social sign-in links your Novu account to the provider you choose, so you do not need a separate password.
 
-### Advanced security features
+### Enterprise SSO (OIDC and SAML)
+
+Enterprise customers can connect a corporate identity provider using **OpenID Connect (OIDC)** or **SAML 2.0**. This lets your team sign in with credentials managed by your organization—common providers include Okta, Microsoft Entra ID, and Google Workspace.
+
+For setup details, see [SAML SSO & SCIM](/platform/account/sso).
+
+## Multi-factor authentication (MFA)
+
+Add a second verification step to protect your account. Novu supports:
+
+- **Authenticator app (TOTP)** — Use an app such as Google Authenticator or 1Password to generate time-based codes.
+- **SMS verification code** — Receive a one-time code by text message where enabled.
+
+Users can enable MFA from their account security settings. Enterprise customers can require MFA for all organization members—contact [support@novu.co](mailto:support@novu.co) to configure organization-wide MFA policies.
+
+## Session management
+
+Novu manages authenticated sessions with industry-standard security practices:
+
+- **Active sessions** — View devices and browsers where you are currently signed in.
+- **Session revocation** — Sign out of a specific device or end all active sessions from your account settings.
+- **Automatic expiration** — Sessions expire after a period of inactivity to reduce the risk of unauthorized access.
+
+## Authorization after sign-in
+
+Authentication confirms who you are. [Authorization](/platform/account/roles-and-permissions) controls what you can do inside each organization:
+
+- Each organization has its own [roles and permissions](/platform/account/roles-and-permissions) (Owner, Admin, Author, Viewer).
+- [Team members](/platform/account/manage-members) are invited and managed per organization.
+- Enterprise customers can use [SAML SSO and SCIM](/platform/account/sso) for centralized provisioning and offboarding.
+
+## Best practices
 
 <AccordionGroup>
-  <Accordion title="Multi-Factor Authentication (MFA)">
-    Robust MFA options including SMS passcodes, authenticator apps, hardware keys, and recovery
-    codes, enhancing security and reducing the risk of unauthorized access.
+  <Accordion title="Prefer SSO for teams">
+    If your company uses a corporate identity provider, enable [OIDC or SAML SSO](/platform/account/sso) so access is governed by your existing IT policies, including password rotation and account deactivation.
   </Accordion>
-  <Accordion title="Session Management">
-    Comprehensive session management features including active device monitoring, session
-    revocation, and adaptive session durations to balance security and user convenience.
+  <Accordion title="Enable MFA for privileged roles">
+    Require MFA for users with Owner or Admin roles. These accounts can manage billing, API keys, and team membership.
+  </Accordion>
+  <Accordion title="Use verified domains for onboarding">
+    Add a [verified domain](/platform/account/manage-members#add-a-verified-domain-for-automatic-or-request-based-onboarding) so colleagues with your company email can join your organization through a controlled process instead of ad-hoc sign-ups.
+  </Accordion>
+  <Accordion title="Remove access promptly">
+    When someone leaves your team, remove them from the organization or rely on SCIM deprovisioning so their dashboard access is revoked immediately.
+  </Accordion>
+  <Accordion title="Choose the right data region at sign-up">
+    Select your preferred [data region](/platform/additional-resources/security#available-regions) when creating your account. Region selection affects where your notification data is stored.
   </Accordion>
 </AccordionGroup>
 
-### User management and customization
+## Related topics
 
 <Columns cols={2}>
-  <Card title="Roles and permissions">
-    Detailed control over user roles and permissions to tailor access levels and ensure appropriate
-    access control.
+  <Card title="Organizations" icon="building-2" href="/platform/account/organizations">
+    How organizations work, creating orgs, and switching between them.
   </Card>
-  <Card title="User invitations and Onboarding">
-    Smooth onboarding processes with customizable invitation workflows, ensuring a positive initial
-    user experience.
+  <Card title="Roles and permissions" icon="shield" href="/platform/account/roles-and-permissions">
+    Role-based access control for dashboard actions.
   </Card>
-  <Card title="Profile management">
-    Intuitive profile management for users to update their information and authentication methods
-    easily.
+  <Card title="Team members" icon="users" href="/platform/account/manage-members">
+    Invite, manage, and remove organization members.
+  </Card>
+  <Card title="Security and compliance" icon="lock" href="/platform/additional-resources/security">
+    SOC 2, ISO 27001, GDPR, HIPAA, and data residency.
   </Card>
 </Columns>

--- a/docs/platform/account/manage-members.mdx
+++ b/docs/platform/account/manage-members.mdx
@@ -5,6 +5,8 @@ description: 'How to invite, manage, update permissions for, and remove members 
 
 You can manage the members of your organization from the **Settings** page in your Novu dashboard. From there, you can assign responsibilities, manage permissions, and control access to workflows and other features.
 
+For an overview of how organizations work—including creating orgs, switching between them, and verified domains—see [Organizations](/platform/account/organizations).
+
 Only members with the **Owner** role can invite or manage members.
 
 ![Managing organization members](/images/account/managing-members-overview.png)

--- a/docs/platform/account/organizations.mdx
+++ b/docs/platform/account/organizations.mdx
@@ -1,0 +1,95 @@
+---
+title: 'Organizations'
+description: 'Learn how Novu organizations work: creating orgs, switching between them, verified domains, and how they relate to environments and billing.'
+---
+
+An **organization** is the top-level account in Novu. Workflows, subscribers, integrations, API keys, and team members all belong to an organization and are further scoped to [environments](/platform/how-novu-works#organization-and-environments) within it.
+
+<Note>
+  Organization management features such as team invitations, role-based access control, and verified domains are available on Novu Cloud. RBAC requires a Team or Enterprise plan. See [Roles and permissions](/platform/account/roles-and-permissions) for plan details.
+</Note>
+
+## How organizations fit in Novu
+
+```mermaid
+flowchart TD
+  User[Your account] --> Org1[Organization A]
+  User --> Org2[Organization B]
+  Org1 --> Dev1[Development environment]
+  Org1 --> Prod1[Production environment]
+  Org2 --> Dev2[Development environment]
+  Org2 --> Prod2[Production environment]
+```
+
+Each organization is fully isolated. Switching organizations changes which workflows, subscribers, logs, and settings you see in the dashboard—your sign-in session stays the same.
+
+## Creating an organization
+
+When you sign up for Novu Cloud, you are prompted to create your first organization. You can create additional organizations later from the organization switcher in the dashboard sidebar.
+
+Each organization includes:
+
+- **Environments** — Development and Production by default, with custom environments on paid plans.
+- **Independent resources** — Workflows, subscribers, topics, integrations, and API keys are scoped per environment.
+- **Team membership** — Invite colleagues and assign [roles](/platform/account/roles-and-permissions).
+- **Billing** — Subscription plans are tied to the organization. See [Billing](/platform/account/billing).
+
+## Switching between organizations
+
+If you belong to more than one organization, use the **organization switcher** in the sidebar to change context. You can hold different roles in each organization—for example, Owner in your company's org and Viewer in a partner's org.
+
+## Organization settings
+
+Organization owners can manage profile and configuration from **Settings** > **Organization**:
+
+- **Organization name and profile** — Update how your organization appears in the dashboard.
+- **Branding and integrations** — Customize Inbox branding on paid plans. See [Prepare for production](/platform/inbox/prepare-for-production).
+- **Verified domains** — Allow colleagues with your company email domain to join automatically or by request.
+
+## Verified domains
+
+Verified domains simplify team onboarding. After you verify ownership of a company email domain (for example, `acme.com`), users who sign up with that domain can:
+
+- **Join automatically**, or
+- **Request to join**, depending on your organization's configuration.
+
+Approved joiners are assigned the Viewer role by default. Owners review and approve join requests from **Settings** > **Team** > **Requests**.
+
+For step-by-step setup, see [Add a verified domain](/platform/account/manage-members#add-a-verified-domain-for-automatic-or-request-based-onboarding).
+
+<Note>
+  Public email domains such as `gmail.com` cannot be verified. At least one Owner must already belong to the domain before verification.
+</Note>
+
+## Team access and authorization
+
+Within each organization, access is controlled by roles:
+
+| Topic | Description |
+| ----- | ----------- |
+| [Roles and permissions](/platform/account/roles-and-permissions) | Owner, Admin, Author, and Viewer roles with a detailed permissions matrix. |
+| [Team members](/platform/account/manage-members) | Invite, update roles, and remove members. |
+| [SAML SSO & SCIM](/platform/account/sso) | Enterprise SSO and directory sync for centralized provisioning. |
+
+Only **Owners** can invite members, manage verified domains, update billing, and change organization-level settings.
+
+## Enterprise organization features
+
+Enterprise customers on Novu Cloud can extend organization security with:
+
+- **SAML or OIDC SSO** — Sign in through your corporate identity provider.
+- **SCIM directory sync** — Automatically provision and deprovision users from Okta, Entra ID, or similar systems.
+- **Organization-wide MFA** — Require multi-factor authentication for all members.
+
+Contact [support@novu.co](mailto:support@novu.co) or your Slack Connect channel to enable these features.
+
+## Related topics
+
+<Columns cols={2}>
+  <Card title="Authentication" icon="key" href="/platform/account/authentication">
+    Sign-in methods, MFA, and session management for Novu Cloud accounts.
+  </Card>
+  <Card title="How Novu works" icon="sitemap" href="/platform/how-novu-works">
+    Architecture overview including organizations and environments.
+  </Card>
+</Columns>

--- a/docs/platform/account/roles-and-permissions.mdx
+++ b/docs/platform/account/roles-and-permissions.mdx
@@ -2,7 +2,7 @@
 title: 'Roles and permissions'
 description: 'Learn how roles and permissions are managed within Novu organizations'
 ---
-Novu uses a role-based access control (RBAC) model at the [organization level](/platform/how-novu-works#organization-and-environments). Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard. Every user can belong to more than one organization, each with separate configurations and permissions.
+Novu uses a role-based access control (RBAC) model at the [organization level](/platform/account/organizations). Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard. Every user can belong to more than one organization, each with separate configurations and permissions.
 
 When you invite a team member to your organization, you can assign them a role that determines the actions they can perform within that organization. You can later update their role from the [Team section](https://dashboard.novu.co/settings/team) in your organization settings.
 

--- a/docs/platform/account/sso.mdx
+++ b/docs/platform/account/sso.mdx
@@ -1,15 +1,17 @@
 ---
 title: 'SAML SSO & SCIM'
-description: 'Enable SAML SSO and SCIM directory sync for your organization'
+description: 'Enable SAML SSO, OIDC, and SCIM directory sync for your organization'
 ---
 
 <Note>
   This feature is only available to Enterprise customers on our Cloud platform. For more information, please visit our [Enterprise Plan](https://novu.co/pricing) page.
 </Note>
 
+Enterprise customers can connect Novu to a corporate identity provider so team members sign in with existing organizational credentials. For standard sign-in options (Google, GitHub, email and password), see [Authentication](/platform/account/authentication). For organization setup and team access, see [Organizations](/platform/account/organizations).
+
 ## SAML SSO
 
-Novu supports SAML SSO so your team can sign in with your existing SAML 2.0 identity provider. Common setups include:
+Novu supports SAML SSO so your team can sign in with your existing SAML 2.0 identity provider. Novu also supports **OpenID Connect (OIDC)** for enterprise SSO. Common setups include:
 
 - Okta
 - Microsoft Entra ID (formerly Azure AD)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Novu Cloud account documentation to reflect current authentication capabilities and adds a dedicated organizations page.

## Changes

### Authentication page
- Removed the outdated "planned providers" list (Facebook, Apple, Microsoft, LinkedIn)
- Documents current sign-in methods: **Google**, **GitHub**, **email and password**, and **OIDC/SAML** (Enterprise)
- Adds sections on MFA, session management, authorization vs authentication, and security best practices
- Corrects the availability note — basic auth applies to all Novu Cloud users, not only Enterprise

### New Organizations page
- Explains how organizations relate to environments and billing
- Covers creating orgs, switching between them, verified domains, and enterprise SSO/SCIM
- Includes a Mermaid diagram showing account → organization → environment hierarchy

### Cross-links and cleanup
- Added Organizations to the Account nav in `docs.json`
- Cross-linked manage-members, roles-and-permissions, and SSO pages
- Renamed "Standard SAML (Google, Github)" to "Social sign-in (Google, GitHub)" in the self-hosted vs cloud comparison matrix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bb79d5-e56a-41ac-acdb-2d6120b9999a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bb79d5-e56a-41ac-acdb-2d6120b9999a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Novu Cloud account documentation to reflect the current authentication landscape and adds a new dedicated Organizations page. The changes replace outdated "planned providers" copy with accurate sign-in method descriptions and improve cross-linking across the account section.

- **Authentication page** is rewritten to document Google, GitHub, email/password, and enterprise OIDC/SAML sign-in methods, plus MFA, session management, and best-practice accordions; the old note restricting auth to Enterprise customers is corrected.
- **Organizations page** (new) explains the account → org → environment hierarchy with a Mermaid diagram, covers creating/switching orgs, verified domains, and enterprise SSO/SCIM.
- **Navigation and cross-links** are updated: Organizations is added to `docs.json`, and `roles-and-permissions.mdx`, `manage-members.mdx`, and `sso.mdx` all gain contextual links to the new page.

<h3>Confidence Score: 5/5</h3>

Documentation-only changes with no runtime impact; safe to merge.

All changes are documentation updates. The new Organizations page is internally consistent, cross-links across pages resolve to real destinations, and the accuracy corrections (removing the outdated planned-providers list, fixing the 'Standard SAML (Google, Github)' row label) are straightforward improvements with no functional risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/account/authentication.mdx | Major overhaul removing outdated 'planned providers' list and replacing it with accurate current sign-in methods, MFA, session management, and best practices sections. |
| docs/platform/account/organizations.mdx | New page explaining organization hierarchy, creating/switching orgs, verified domains, and enterprise SSO/SCIM; includes a Mermaid diagram. Content is internally consistent and links are plausible. |
| docs/community/self-hosted-and-novu-cloud.mdx | Single row label corrected from misleading 'Standard SAML (Google, Github)' to accurate 'Social sign-in (Google, GitHub)'. |
| docs/docs.json | Adds the new Organizations page to the Account navigation group in the correct position. |
| docs/platform/account/sso.mdx | Updated description to include OIDC, added introductory paragraph with cross-links to authentication and organizations pages. |
| docs/platform/account/roles-and-permissions.mdx | Updated single internal link to point to the new organizations page instead of the generic how-novu-works anchor. |
| docs/platform/account/manage-members.mdx | Added one cross-link sentence pointing readers to the new Organizations page for org-level context. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User signs in\nGoogle / GitHub / Email+Password / SSO] --> B[Novu Cloud Session]
    B --> C{Organization switcher}
    C --> D[Organization A]
    C --> E[Organization B]
    D --> F[Development env]
    D --> G[Production env]
    E --> H[Development env]
    E --> I[Production env]
    D --> J[Roles: Owner / Admin / Author / Viewer]
    J --> K[Billing, API keys, team members, workflows...]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User signs in\nGoogle / GitHub / Email+Password / SSO] --> B[Novu Cloud Session]
    B --> C{Organization switcher}
    C --> D[Organization A]
    C --> E[Organization B]
    D --> F[Development env]
    D --> G[Production env]
    E --> H[Development env]
    E --> I[Production env]
    D --> J[Roles: Owner / Admin / Author / Viewer]
    J --> K[Billing, API keys, team members, workflows...]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs(docs): resolve merge conflict and f..."](https://github.com/novuhq/novu/commit/1f5116cb46f2c8527667208fc6aba32804c78e08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40864698)</sub>

<!-- /greptile_comment -->