### PR TITLE
docs(billing): add Enterprise on-premises section fixes DOC-392

### DIFF
--- a/docs/platform/account/billing.mdx
+++ b/docs/platform/account/billing.mdx
@@ -59,6 +59,24 @@ For full feature comparisons, visit the [Novu pricing page](https://novu.co/pric
 
 Higher tiers add capabilities such as custom environments, longer activity feed retention, RBAC, SSO, and advanced compliance. Plan-specific feature gates are noted throughout the docs — for example, [custom environments](/platform/developer/environments), [webhooks](/platform/developer/webhooks), and [SAML SSO](/platform/account/sso).
 
+## Enterprise Edition on-premises
+
+In addition to Novu Cloud, Novu offers an **Enterprise Edition** that you can deploy on your own infrastructure. Enterprise on-premises includes the same capabilities available on Novu Cloud — SSO, RBAC, audit controls, compliance features, and priority support — while keeping data and workloads inside your environment.
+
+This option is a strong fit when you need:
+
+- **Local data residency** — Keep subscriber data, notification content, and activity logs within your network or region.
+- **Strict compliance requirements** — Meet regulatory and security standards common in banking, finance, healthcare, government, and other regulated industries.
+- **Operational control** — Run Novu alongside your existing infrastructure, security policies, and deployment processes.
+
+Enterprise on-premises is licensed separately from Novu Cloud subscriptions. Pricing is based on your deployment size, support needs, and contract terms.
+
+<Card title="Talk to sales about Enterprise on-premises" icon="building-2" href="https://novu.co/contact-us">
+  Book a meeting with the Novu team to discuss on-premises deployment, compliance requirements, and custom pricing.
+</Card>
+
+For a full comparison of Novu Cloud, Community self-hosted, and Enterprise options, see [Self-Hosted and Novu Cloud](/community/self-hosted-and-novu-cloud).
+
 ## Manage billing in the dashboard
 
 Organization Owners can manage subscriptions from **Settings** > **Billing** in the Novu dashboard, or go directly to [dashboard.novu.co/settings/billing](https://dashboard.novu.co/settings/billing).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **Enterprise Edition on-premises** section to the billing documentation page so readers evaluating plans understand that Novu offers a licensed on-prem deployment alongside Novu Cloud.

## Changes

- New section after **Plans at a glance** covering:
  - Enterprise on-premises includes the same capabilities as Novu Cloud (SSO, RBAC, audit controls, compliance, priority support)
  - Use cases: local data residency, strict compliance (banking, finance, healthcare, government), operational control
  - Separate licensing from Novu Cloud subscriptions
- CTA card linking to [novu.co/contact-us](https://novu.co/contact-us) to book a meeting with sales
- Cross-link to [Self-Hosted and Novu Cloud](/community/self-hosted-and-novu-cloud) for deployment comparison

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb66ae51-8092-428b-b130-6e21743f3fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb66ae51-8092-428b-b130-6e21743f3fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only addition to `docs/platform/account/billing.mdx`. It inserts an "Enterprise Edition on-premises" section between the plan comparison table and the billing-dashboard guidance so readers evaluating deployment options understand the separately-licensed on-prem path.

- Adds a prose description, three use-case bullets (data residency, compliance, operational control), a Mintlify `<Card>` CTA linking to `novu.co/contact-us`, and a cross-reference to the self-hosted vs. Cloud comparison page.
- New content is consistent with the existing FAQ entry that already mentions "Enterprise self-hosted" with SSO, RBAC, and audit controls.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code execution paths — safe to merge.

The change adds a self-contained prose section, a Mintlify Card component, and a cross-link. The new content is accurate and consistent with the existing FAQ entry that already describes the same Enterprise self-hosted feature set. All internal and external links reference pages that are already cited elsewhere in the file.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/account/billing.mdx | Adds an "Enterprise Edition on-premises" section with use-case bullets, a sales CTA card, and a cross-link to the self-hosted comparison page — content is accurate, consistent with existing FAQs, and correctly placed after "Plans at a glance" |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Evaluating Novu] --> B{Deployment preference?}
    B -->|Managed| C[Novu Cloud]
    B -->|Self-managed| D{License needed?}
    C --> E[Free / Pro / Team / Enterprise plans]
    D -->|Open-source, no cost| F[Community self-hosted]
    D -->|SSO, RBAC, compliance, support| G[Enterprise Edition on-premises]
    G --> H[Contact sales — novu.co/contact-us]
    F --> I[deploy-with-docker]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Evaluating Novu] --> B{Deployment preference?}
    B -->|Managed| C[Novu Cloud]
    B -->|Self-managed| D{License needed?}
    C --> E[Free / Pro / Team / Enterprise plans]
    D -->|Open-source, no cost| F[Community self-hosted]
    D -->|SSO, RBAC, compliance, support| G[Enterprise Edition on-premises]
    G --> H[Contact sales — novu.co/contact-us]
    F --> I[deploy-with-docker]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(billing): add Enterprise on-premise..."](https://github.com/novuhq/novu/commit/6f42fbe178a5f6a11737695e71812fb64b87f7cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40875464)</sub>

<!-- /greptile_comment -->