### PR TITLE
fix(worker): enhance SendMessageEmail use case with control values fetching and content handling improvements fixes NV-8153

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -6,6 +6,8 @@ import {
   CreateExecutionDetails,
   CreateExecutionDetailsCommand,
   DetailEnum,
+  dashboardSanitizeControlValues,
+  EmailControlType,
   FeatureFlagsService,
   GetLayoutCommandV0,
   GetLayoutUseCaseV0,
@@ -14,17 +16,20 @@ import {
   InstrumentUsecase,
   MailFactory,
   messageWebhookMapper,
+  PinoLogger,
   SelectIntegration,
   SelectVariant,
   SendWebhookMessage,
 } from '@novu/application-generic';
 import {
+  ControlValuesRepository,
   EnvironmentEntity,
   EnvironmentRepository,
   IntegrationEntity,
   LayoutRepository,
   MessageEntity,
   MessageRepository,
+  NotificationTemplateRepository,
   OrganizationEntity,
   SubscriberRepository,
   UserEntity,
@@ -32,6 +37,7 @@ import {
 import { EmailOutput } from '@novu/framework/internal';
 import {
   ChannelTypeEnum,
+  ControlValuesLevelEnum,
   DeliveryLifecycleDetail,
   DeliveryLifecycleStatusEnum,
   EmailProviderIdEnum,
@@ -40,6 +46,7 @@ import {
   FeatureFlagsKeysEnum,
   IAttachmentOptions,
   IEmailOptions,
+  ResourceOriginEnum,
   safeJsonStringify,
   WebhookEventEnum,
   WebhookObjectTypeEnum,
@@ -70,7 +77,10 @@ export class SendMessageEmail extends SendMessageBase {
     protected moduleRef: ModuleRef,
     private featureFlagService: FeatureFlagsService,
     private getLayoutUseCaseV0: GetLayoutUseCaseV0,
-    private sendWebhookMessage: SendWebhookMessage
+    private sendWebhookMessage: SendWebhookMessage,
+    private controlValuesRepository: ControlValuesRepository,
+    private notificationTemplateRepository: NotificationTemplateRepository,
+    private logger: PinoLogger
   ) {
     super(
       messageRepository,
@@ -81,6 +91,7 @@ export class SendMessageEmail extends SendMessageBase {
       selectVariant,
       moduleRef
     );
+    this.logger.setContext(this.constructor.name);
   }
 
   @InstrumentUsecase()
@@ -275,6 +286,10 @@ export class SendMessageEmail extends SendMessageBase {
       };
     }
 
+    if (content !== undefined) {
+      payload.content = content;
+    }
+
     if (this.storeContent()) {
       await this.messageRepository.update(
         {
@@ -373,6 +388,14 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     if (integration.providerId === EmailProviderIdEnum.EmailWebhook) {
+      if (!hasEmailTemplateContent(payload.content)) {
+        const emailControlValues = await this.fetchEmailControlValues(command);
+
+        if (typeof emailControlValues.body === 'string' && emailControlValues.body) {
+          payload.content = emailControlValues.body;
+        }
+      }
+
       mailData.payloadDetails = payload;
     }
 
@@ -613,6 +636,38 @@ export class SendMessageEmail extends SendMessageBase {
     }
   }
 
+  private async fetchEmailControlValues(command: SendMessageChannelCommand): Promise<EmailControlType> {
+    const workflow =
+      command.workflow ??
+      (command._templateId
+        ? await this.notificationTemplateRepository.findById(command._templateId, command.environmentId)
+        : null);
+
+    if (!workflow) {
+      return { body: '', subject: '', editorType: 'block' };
+    }
+
+    const controlsEntity = await this.controlValuesRepository.findOne({
+      _organizationId: command.organizationId,
+      _workflowId: workflow._id,
+      _stepId: command.step._templateId ?? command.step._id,
+      level: ControlValuesLevelEnum.STEP_CONTROLS,
+    });
+
+    const rawControls = controlsEntity?.controls;
+
+    if (!rawControls) {
+      return { body: '', subject: '', editorType: 'block' };
+    }
+
+    if (workflow.origin === ResourceOriginEnum.NOVU_CLOUD) {
+      return (dashboardSanitizeControlValues(this.logger, rawControls, command.step?.template?.type) ??
+        {}) as EmailControlType;
+    }
+
+    return rawControls as EmailControlType;
+  }
+
   @Instrument()
   private async getOverrideLayoutId(command: SendMessageChannelCommand, isBridge: boolean) {
     const { overrides, step } = command;
@@ -723,6 +778,22 @@ export class SendMessageEmail extends SendMessageBase {
       providerId: integration.providerId,
     };
   }
+}
+
+function hasEmailTemplateContent(content: unknown): boolean {
+  if (content == null) {
+    return false;
+  }
+
+  if (typeof content === 'string') {
+    return content.length > 0;
+  }
+
+  if (Array.isArray(content)) {
+    return content.length > 0;
+  }
+
+  return true;
 }
 
 function hasEmailOverrideRecipients(emailOverrides?: Record<string, unknown>): boolean {


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances `SendMessageEmail` to fetch email control values from the database as a fallback when the EmailWebhook provider receives a message with no compiled content, and moves the `payload.content` update to after compilation rather than before.

- Adds `ControlValuesRepository`, `NotificationTemplateRepository`, and `PinoLogger` as new injected dependencies; introduces `fetchEmailControlValues` to resolve stored step controls (with `dashboardSanitizeControlValues` applied for NOVU_CLOUD workflows) and `hasEmailTemplateContent` to guard against overwriting already-populated content.
- For the EmailWebhook provider path, if `payload.content` is empty the new code fetches the stored body from control values and uses it as the outgoing content; the `payload.content = content` assignment is also moved to run after template compilation so it reflects the compiled result rather than the raw template value.

<h3>Confidence Score: 3/5</h3>

The EmailWebhook content-fallback path has two correctness gaps that can silently deliver wrong data to webhook consumers — one via cross-environment DB reads and one via a JSON placeholder being forwarded as real email body content.

The missing `_environmentId` filter means the repository query is not scoped to the active environment, so in multi-environment setups a production control-values record can be returned for a staging send (or vice versa). Separately, when the stored body is empty, `sanitizeEmail` replaces it with the TipTap empty-document sentinel JSON before returning to the caller, which then passes the truthy-string check and sets that JSON as `payload.content` — forwarding placeholder markup to the EmailWebhook consumer instead of leaving the content absent. Both issues are confined to the EmailWebhook provider path.

apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts — the new `fetchEmailControlValues` method and the EmailWebhook content-injection block

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts | Adds control-values fetching fallback for EmailWebhook content and updates `payload.content` after compilation; missing `_environmentId` in the DB query and an empty-body sentinel value being treated as real content are both present. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant E as execute()
    participant C as CompileEmailTemplate
    participant H as hasEmailTemplateContent
    participant F as fetchEmailControlValues
    participant CVR as ControlValuesRepository
    participant NTR as NotificationTemplateRepository
    participant S as dashboardSanitizeControlValues

    E->>C: compile (non-bridge path)
    C-->>E: "{ html, content, subject, senderName }"
    E->>E: "if content !== undefined → payload.content = content"
    E->>E: create mailData with html
    alt integration is EmailWebhook
        E->>H: hasEmailTemplateContent(payload.content)
        H-->>E: false (content is empty)
        E->>F: fetchEmailControlValues(command)
        F->>NTR: findById(_templateId, environmentId)
        NTR-->>F: workflow
        F->>CVR: "findOne({ _organizationId, _workflowId, _stepId, level }) ⚠️ missing _environmentId"
        CVR-->>F: controlsEntity
        alt "workflow.origin === NOVU_CLOUD"
            F->>S: dashboardSanitizeControlValues(logger, rawControls, stepType)
            S-->>F: EmailControlType (body may be EMPTY_TIP_TAP sentinel ⚠️)
        end
        F-->>E: EmailControlType
        E->>E: "if body is truthy string → payload.content = body"
        E->>E: "mailData.payloadDetails = payload"
    end
    E->>E: sendMessage(integration, mailData, ...)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant E as execute()
    participant C as CompileEmailTemplate
    participant H as hasEmailTemplateContent
    participant F as fetchEmailControlValues
    participant CVR as ControlValuesRepository
    participant NTR as NotificationTemplateRepository
    participant S as dashboardSanitizeControlValues

    E->>C: compile (non-bridge path)
    C-->>E: "{ html, content, subject, senderName }"
    E->>E: "if content !== undefined → payload.content = content"
    E->>E: create mailData with html
    alt integration is EmailWebhook
        E->>H: hasEmailTemplateContent(payload.content)
        H-->>E: false (content is empty)
        E->>F: fetchEmailControlValues(command)
        F->>NTR: findById(_templateId, environmentId)
        NTR-->>F: workflow
        F->>CVR: "findOne({ _organizationId, _workflowId, _stepId, level }) ⚠️ missing _environmentId"
        CVR-->>F: controlsEntity
        alt "workflow.origin === NOVU_CLOUD"
            F->>S: dashboardSanitizeControlValues(logger, rawControls, stepType)
            S-->>F: EmailControlType (body may be EMPTY_TIP_TAP sentinel ⚠️)
        end
        F-->>E: EmailControlType
        E->>E: "if body is truthy string → payload.content = body"
        E->>E: "mailData.payloadDetails = payload"
    end
    E->>E: sendMessage(integration, mailData, ...)
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Fsend-message%2Fsend-message-email.usecase.ts%3A650-655%0A**Missing%20%60_environmentId%60%20filter%20%E2%80%94%20can%20return%20data%20from%20wrong%20environment**%0A%0AThe%20%60controlValuesRepository.findOne%60%20call%20omits%20%60_environmentId%60%2C%20so%20it%20can%20match%20a%20control-values%20document%20from%20any%20environment%20%28e.g.%20production%29%20when%20the%20message%20is%20being%20sent%20in%20staging%2C%20or%20vice%20versa.%20Compare%20to%20%60UpsertControlValuesUseCase%60%20%28line%2012%29%20and%20%60BuildStepDataUseCase%60%20%28line%20115%29%20which%20both%20include%20%60_environmentId%3A%20command.environmentId%60%20in%20their%20queries.%20%60ControlValuesLevelEnum.STEP_CONTROLS%60%20records%20are%20keyed%20on%20environment%2C%20so%20omitting%20this%20filter%20can%20return%20wrong%20content%20silently.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20controlsEntity%20%3D%20await%20this.controlValuesRepository.findOne%28%7B%0A%20%20%20%20%20%20_environmentId%3A%20command.environmentId%2C%0A%20%20%20%20%20%20_organizationId%3A%20command.organizationId%2C%0A%20%20%20%20%20%20_workflowId%3A%20workflow._id%2C%0A%20%20%20%20%20%20_stepId%3A%20command.step._templateId%20%3F%3F%20command.step._id%2C%0A%20%20%20%20%20%20level%3A%20ControlValuesLevelEnum.STEP_CONTROLS%2C%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Fsend-message%2Fsend-message-email.usecase.ts%3A391-397%0A**Empty%20body%20replaced%20with%20TipTap%20JSON%20sentinel%2C%20then%20treated%20as%20real%20content**%0A%0AWhen%20%60workflow.origin%20%3D%3D%3D%20ResourceOriginEnum.NOVU_CLOUD%60%2C%20%60fetchEmailControlValues%60%20calls%20%60dashboardSanitizeControlValues%60%20%E2%86%92%20%60sanitizeEmail%60%2C%20which%20uses%20%60sanitizeEmptyInput%28controlValues.body%2C%20EMPTY_TIP_TAP%29%60.%20If%20the%20stored%20body%20is%20an%20empty%20string%20or%20null%2C%20%60isEmpty%60%20returns%20%60true%60%20and%20the%20function%20returns%20the%20TipTap%20empty-document%20JSON%20%60%7B%22type%22%3A%22doc%22%2C%22content%22%3A%5B%7B%22type%22%3A%22paragraph%22%7D%5D%7D%60.%20Back%20in%20the%20caller%2C%20%60typeof%20emailControlValues.body%20%3D%3D%3D%20'string'%20%26%26%20emailControlValues.body%60%20evaluates%20to%20%60true%60%20for%20that%20JSON%20string%2C%20so%20%60payload.content%60%20is%20set%20to%20that%20sentinel.%20The%20EmailWebhook%20provider%20then%20forwards%20this%20JSON%20as%20the%20email%20body%20instead%20of%20receiving%20empty%2Fabsent%20content.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!hasEmailTemplateContent%28payload.content%29%29%20%7B%0A%20%20%20%20%20%20%20%20const%20emailControlValues%20%3D%20await%20this.fetchEmailControlValues%28command%29%3B%0A%20%20%20%20%20%20%20%20const%20EMPTY_TIP_TAP%20%3D%20JSON.stringify%28%7B%20type%3A%20'doc'%2C%20content%3A%20%5B%7B%20type%3A%20'paragraph'%20%7D%5D%20%7D%29%3B%0A%0A%20%20%20%20%20%20%20%20if%20%28%0A%20%20%20%20%20%20%20%20%20%20typeof%20emailControlValues.body%20%3D%3D%3D%20'string'%20%26%26%0A%20%20%20%20%20%20%20%20%20%20emailControlValues.body%20%26%26%0A%20%20%20%20%20%20%20%20%20%20emailControlValues.body%20!%3D%3D%20EMPTY_TIP_TAP%0A%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20payload.content%20%3D%20emailControlValues.body%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=11741&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts:650-655
**Missing `_environmentId` filter — can return data from wrong environment**

The `controlValuesRepository.findOne` call omits `_environmentId`, so it can match a control-values document from any environment (e.g. production) when the message is being sent in staging, or vice versa. Compare to `UpsertControlValuesUseCase` (line 12) and `BuildStepDataUseCase` (line 115) which both include `_environmentId: command.environmentId` in their queries. `ControlValuesLevelEnum.STEP_CONTROLS` records are keyed on environment, so omitting this filter can return wrong content silently.

```suggestion
    const controlsEntity = await this.controlValuesRepository.findOne({
      _environmentId: command.environmentId,
      _organizationId: command.organizationId,
      _workflowId: workflow._id,
      _stepId: command.step._templateId ?? command.step._id,
      level: ControlValuesLevelEnum.STEP_CONTROLS,
    });
```

### Issue 2 of 2
apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts:391-397
**Empty body replaced with TipTap JSON sentinel, then treated as real content**

When `workflow.origin === ResourceOriginEnum.NOVU_CLOUD`, `fetchEmailControlValues` calls `dashboardSanitizeControlValues` → `sanitizeEmail`, which uses `sanitizeEmptyInput(controlValues.body, EMPTY_TIP_TAP)`. If the stored body is an empty string or null, `isEmpty` returns `true` and the function returns the TipTap empty-document JSON `{"type":"doc","content":[{"type":"paragraph"}]}`. Back in the caller, `typeof emailControlValues.body === 'string' && emailControlValues.body` evaluates to `true` for that JSON string, so `payload.content` is set to that sentinel. The EmailWebhook provider then forwards this JSON as the email body instead of receiving empty/absent content.

```suggestion
      if (!hasEmailTemplateContent(payload.content)) {
        const emailControlValues = await this.fetchEmailControlValues(command);
        const EMPTY_TIP_TAP = JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] });

        if (
          typeof emailControlValues.body === 'string' &&
          emailControlValues.body &&
          emailControlValues.body !== EMPTY_TIP_TAP
        ) {
          payload.content = emailControlValues.body;
        }
      }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;next&#39; into NV-8153"](https://github.com/novuhq/novu/commit/0de3f42792415080d8ad9e0f66eb116d22de42de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40878051)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->