### PR TITLE
fix(worker): populate email-webhook payloadDetails content for v2 workflows fixes NV-8153

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.spec.ts
@@ -140,6 +140,7 @@ describe('SendMessageEmail - email-webhook payloadDetails', () => {
     expect(mailData.payloadDetails).to.exist;
     expect(mailData.payloadDetails.content).to.equal(renderedEmailBody);
     expect(mailData.payloadDetails.subject).to.equal('Welcome Ada!');
+    expect(command.step?.template?.content).to.equal('');
   });
 
   it('should preserve legacy payloadDetails content for v0 workflows without bridge output', async () => {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.spec.ts
@@ -1,0 +1,177 @@
+import { MailFactory } from '@novu/application-generic';
+import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { SendMessageChannelCommand } from './send-message-channel.command';
+import { SendMessageEmail } from './send-message-email.usecase';
+import { SendMessageStatus } from './send-message-type.usecase';
+
+describe('SendMessageEmail - email-webhook payloadDetails', () => {
+  const renderedEmailBody = '<html><body><p>Hello Ada from email webhook test</p></body></html>';
+
+  function buildUsecase() {
+    const createExecutionDetails = { execute: sinon.stub().resolves(undefined) };
+    const messageRepository = {
+      create: sinon.stub().resolves({ _id: 'msg_1' }),
+      update: sinon.stub().resolves(undefined),
+    };
+    const compileEmailTemplateUsecase = { execute: sinon.stub() };
+    const sendWebhookMessage = { execute: sinon.stub().resolves(undefined) };
+    const featureFlagService = {
+      getFlag: sinon.stub().resolves(true),
+    };
+
+    const usecase = new SendMessageEmail(
+      {} as never,
+      {} as never,
+      messageRepository as never,
+      {} as never,
+      createExecutionDetails as never,
+      compileEmailTemplateUsecase as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      featureFlagService as never,
+      {} as never,
+      sendWebhookMessage as never
+    );
+
+    sinon.stub(usecase as never, 'getIntegration').resolves({
+      _id: 'integration_1',
+      providerId: EmailProviderIdEnum.EmailWebhook,
+      credentials: {
+        from: 'no-reply@test.com',
+        webhookUrl: 'http://127.0.0.1:9999/email-webhook',
+        secretKey: 'test-secret',
+      },
+    });
+    sinon.stub(usecase as never, 'processVariants').resolves(undefined);
+    sinon.stub(usecase as never, 'getOverrideLayoutId').resolves(undefined);
+    sinon.stub(usecase as never, 'sendSelectedIntegrationExecution').resolves(undefined);
+    sinon.stub(usecase as never, 'initiateTranslations').resolves(undefined);
+    sinon.stub(usecase as never, 'storeContent').returns(false);
+    sinon.stub(usecase as never, 'buildEmailProviderOverrides').returns({});
+
+    return { usecase, compileEmailTemplateUsecase };
+  }
+
+  function buildCommand({
+    bridgeBody,
+    templateContent = '',
+    templateSubject = 'Welcome {{payload.name}}!',
+  }: {
+    bridgeBody?: string;
+    templateContent?: string;
+    templateSubject?: string;
+  }) {
+    return SendMessageChannelCommand.create({
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      identifier: 'wf-identifier',
+      payload: { name: 'Ada' },
+      overrides: {},
+      transactionId: 'txn_1',
+      notificationId: 'notif_1',
+      _templateId: 'tpl_1',
+      subscriberId: 'sub_1',
+      _subscriberId: '_sub_1',
+      jobId: 'job_1',
+      tags: [],
+      contextKeys: [],
+      compileContext: {
+        subscriber: { subscriberId: 'sub_1', email: 'subscriber@test.com', locale: 'en' },
+      } as never,
+      bridgeData: bridgeBody
+        ? ({
+            outputs: {
+              subject: 'Welcome Ada!',
+              body: bridgeBody,
+            },
+          } as never)
+        : undefined,
+      step: {
+        stepId: 'email-step',
+        template: {
+          _id: 'mt_1',
+          type: ChannelTypeEnum.EMAIL,
+          subject: templateSubject,
+          content: templateContent,
+          contentType: 'editor',
+        },
+      } as never,
+      job: {
+        _id: 'job_1',
+        _environmentId: 'env_1',
+        _organizationId: 'org_1',
+        _subscriberId: '_sub_1',
+        subscriberId: 'sub_1',
+        _notificationId: 'notif_1',
+        _templateId: 'tpl_1',
+        transactionId: 'txn_1',
+        identifier: 'wf-identifier',
+        type: ChannelTypeEnum.EMAIL,
+        step: { stepId: 'email-step' },
+      } as never,
+    });
+  }
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should populate payloadDetails.content with rendered bridge body for v2 workflows', async () => {
+    const { usecase } = buildUsecase();
+    const command = buildCommand({ bridgeBody: renderedEmailBody });
+    const sendStub = sinon.stub().resolves({ id: 'msg_1' });
+
+    sinon.stub(MailFactory.prototype, 'getHandler').returns({
+      send: sendStub,
+    } as never);
+
+    const result = await usecase.execute(command);
+
+    expect(result.status).to.equal(SendMessageStatus.SUCCESS);
+    expect(sendStub.calledOnce).to.equal(true);
+
+    const mailData = sendStub.firstCall.args[0];
+
+    expect(mailData.payloadDetails).to.exist;
+    expect(mailData.payloadDetails.content).to.equal(renderedEmailBody);
+    expect(mailData.payloadDetails.subject).to.equal('Welcome Ada!');
+  });
+
+  it('should preserve legacy payloadDetails content for v0 workflows without bridge output', async () => {
+    const templateContent = 'Hello {{payload.name}}';
+    const templateSubject = 'Template subject {{payload.name}}';
+    const compiledContent = '<p>Compiled legacy HTML for Ada</p>';
+    const { usecase, compileEmailTemplateUsecase } = buildUsecase();
+    const command = buildCommand({
+      templateContent,
+      templateSubject,
+    });
+
+    compileEmailTemplateUsecase.execute.resolves({
+      html: `<html><body>${compiledContent}</body></html>`,
+      content: compiledContent,
+      subject: 'Final legacy compiled subject for Ada',
+      senderName: 'Novu',
+    });
+
+    const sendStub = sinon.stub().resolves({ id: 'msg_1' });
+
+    sinon.stub(MailFactory.prototype, 'getHandler').returns({
+      send: sendStub,
+    } as never);
+
+    const result = await usecase.execute(command);
+
+    expect(result.status).to.equal(SendMessageStatus.SUCCESS);
+
+    const mailData = sendStub.firstCall.args[0];
+
+    expect(mailData.payloadDetails.content).to.equal(templateContent);
+    expect(mailData.payloadDetails.subject).to.equal(templateSubject);
+  });
+});

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -373,10 +373,9 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     if (integration.providerId === EmailProviderIdEnum.EmailWebhook) {
-      payload.subject = subject;
-      payload.content = command.bridgeData
-        ? (bridgeOutputs as EmailOutput)?.body || html || ''
-        : (content ?? html ?? step.template.content);
+      if (command.bridgeData) {
+        payload.content = (bridgeOutputs as EmailOutput)?.body || html || '';
+      }
 
       mailData.payloadDetails = payload;
     }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -373,11 +373,12 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     if (integration.providerId === EmailProviderIdEnum.EmailWebhook) {
-      if (command.bridgeData) {
-        payload.content = (bridgeOutputs as EmailOutput)?.body || html || '';
-      }
-
-      mailData.payloadDetails = payload;
+      mailData.payloadDetails = command.bridgeData
+        ? {
+            ...payload,
+            content: (bridgeOutputs as EmailOutput)?.body || html || '',
+          }
+        : payload;
     }
 
     return await this.sendMessage(integration, mailData, message, command);

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -373,6 +373,11 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     if (integration.providerId === EmailProviderIdEnum.EmailWebhook) {
+      payload.subject = subject;
+      payload.content = command.bridgeData
+        ? (bridgeOutputs as EmailOutput)?.body || html || ''
+        : (content ?? html ?? step.template.content);
+
       mailData.payloadDetails = payload;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes empty `content` in email-webhook `payloadDetails` when sending emails from new dashboard (v2) workflows, while preserving legacy v0 payload behavior.

## Problem

New dashboard workflows store email body in control values and render it via the bridge/framework path. The message template's `content` field is intentionally empty (`''`), but `SendMessageEmail` was passing that raw template value into `payloadDetails.content` for the email-webhook provider.

The old dashboard populated `content` because template compilation mutated the in-memory blocks array referenced by `payload.content`. Bridge-based v2 workflows skip that compilation path, leaving `content` as an empty string while `subject` and rendered HTML were correct.

## Solution

For email-webhook integrations, populate `payloadDetails.content` **only when bridge output is present** (v2 workflows):

```typescript
if (command.bridgeData) {
  payload.content = (bridgeOutputs as EmailOutput)?.body || html || '';
}
```

Legacy v0 workflows without bridge output keep the existing `payloadDetails` subject/content contract unchanged.

## Test plan

- [x] Worker spec: v2 bridge workflow populates `payloadDetails.content` with rendered HTML
- [x] Worker spec: legacy v0 workflow preserves template `payloadDetails.content` and `subject`
- [ ] Trigger a v2 workflow email step with email-webhook integration and verify `payloadDetails.content` contains rendered HTML
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8153](https://linear.app/novu/issue/NV-8153/content-field-is-empty-in-new-dashboard-workflow-emails)

<div><a href="https://cursor.com/agents/bc-444bb308-ba6b-4b8d-b328-340dc95b41f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-444bb308-ba6b-4b8d-b328-340dc95b41f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an empty `content` field in `payloadDetails` for email-webhook integrations when using v2 (new dashboard) workflows, while keeping the legacy v0 payload behavior intact.

- **Core fix** (`send-message-email.usecase.ts`): When `command.bridgeData` is present, `mailData.payloadDetails` is now constructed by spreading the base `payload` object and overriding `content` with `bridgeOutputs.body || html || ''`; without bridge data the original `payload` is passed through unchanged, preserving the existing v0 contract.
- **New spec** (`send-message-email.usecase.spec.ts`): Adds unit tests that exercise the v2 path (expects `payloadDetails.content` to equal the rendered bridge body) and the v0 path (expects raw template `content` and `subject` to be forwarded as-is).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the email-webhook provider's payloadDetails assembly and does not affect the actual email delivery path.

The fix is a small conditional spread that only runs when command.bridgeData is present and integration.providerId === EmailProviderIdEnum.EmailWebhook. The value assigned (bridgeOutputs.body || html || '') mirrors the same expression already used for mailData.html (line 356), so the content is consistent. The v0 path is entirely untouched. Both paths are covered by new unit tests.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts | Targeted 5-line fix: conditionally overrides payloadDetails.content with the rendered bridge body for v2 workflows; v0 path is unchanged. |
| apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.spec.ts | New spec file covering both v2 bridge and v0 legacy payloadDetails scenarios; uses sinon stubs for private methods and MailFactory.getHandler. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SendMessageEmail.execute] --> B{command.bridgeData present?}
    B -- Yes / v2 --> C[Skip compileEmailTemplateUsecase\nhtml = undefined]
    B -- No / v0 --> D[Run compileEmailTemplateUsecase\nhtml = compiled HTML\ncontent = compiled content]
    C --> E[bridgeOutputs = command.bridgeData.outputs]
    D --> F[payload unchanged\ncontent = step.template.content]
    E --> G{integration = EmailWebhook?}
    F --> G
    G -- Yes v2 --> H[payloadDetails = spread payload + content overridden with bridgeOutputs.body]
    G -- Yes v0 --> I[payloadDetails = payload as-is]
    G -- No --> J[No payloadDetails set]
    H --> K[sendMessage]
    I --> K
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SendMessageEmail.execute] --> B{command.bridgeData present?}
    B -- Yes / v2 --> C[Skip compileEmailTemplateUsecase\nhtml = undefined]
    B -- No / v0 --> D[Run compileEmailTemplateUsecase\nhtml = compiled HTML\ncontent = compiled content]
    C --> E[bridgeOutputs = command.bridgeData.outputs]
    D --> F[payload unchanged\ncontent = step.template.content]
    E --> G{integration = EmailWebhook?}
    F --> G
    G -- Yes v2 --> H[payloadDetails = spread payload + content overridden with bridgeOutputs.body]
    G -- Yes v0 --> I[payloadDetails = payload as-is]
    G -- No --> J[No payloadDetails set]
    H --> K[sendMessage]
    I --> K
    J --> K
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Legacy email-webhook payloadDetails subject/content changed from pre-change behavior**

   - **Bug**
     - The requested contract says legacy/v1 email-webhook payloads should remain behaviorally unchanged. The before/after run shows base legacy payloadDetails carried the template payload values (`Template subject {{name}}`, `<p>Template legacy {{name}}</p>`), while head rewrites them to the final compiled subject/content (`Final legacy compiled subject for Grace`, `<p>Compiled legacy HTML for Grace</p>`). This is a user-visible provider request payloadDetails contract change for legacy email-webhook integrations.
   - **Cause**
     - The new email-webhook branch in `apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts` unconditionally assigns `payload.subject = subject` and, when `command.bridgeData` is absent, assigns `payload.content = (content ?? html ?? step.template.content)`. That code path also runs for legacy/v1 email-webhook sends, not just bridge/v2 sends.
   - **Fix**
     - If legacy/v1 must remain unchanged, scope the payloadDetails subject/content rewrites to bridge/v2 workflows only, or preserve the previous `payload` object for non-bridge sends. If compiled subject/content is intentionally desired for legacy too, update the contract/request because the executed behavior is not unchanged.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(worker): set email-webhook payloadDe..."](https://github.com/novuhq/novu/commit/b9a55443893db20dbedae66daeb721cf1bb38cb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40880348)</sub>

<!-- /greptile_comment -->