### PR TITLE
docs(docs): add multi-SDK server-side examples across platform docs fixes DOC-397

### DIFF
--- a/docs/community/self-hosting-novu/deploy-with-docker.mdx
+++ b/docs/community/self-hosting-novu/deploy-with-docker.mdx
@@ -125,28 +125,127 @@ To test notifications, create and trigger a workflow from your self-hosted Novu 
 
 For more information on customizing the Inbox component, refer to the [Inbox documentation](/inbox/overview).
 
-## Initializing the Node SDK
+## Initializing the Server SDK
 
-When using a self-hosted Novu deployment with your backend services, you need to configure the Node SDK to connect to your Docker-hosted Novu instance.
+When using a self-hosted Novu deployment with your backend services, configure the server SDK to connect to your Docker-hosted Novu API instance.
 
 ### Install the package
 
-```bash
-npm install @novu/api
-```
+<Tabs>
+  <Tab title="Node.js">
+    ```bash
+    npm install @novu/api
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```bash
+    pip install novu-py
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```bash
+    go get github.com/novuhq/novu-go
+    ```
+  </Tab>
+  <Tab title="PHP">
+    ```bash
+    composer require novuhq/novu
+    ```
+  </Tab>
+  <Tab title=".NET">
+    ```bash
+    dotnet add package Novu
+    ```
+  </Tab>
+  <Tab title="Java">
+    Maven:
+    ```xml
+    <dependency>
+      <groupId>co.novu</groupId>
+      <artifactId>novu-java</artifactId>
+      <version>LATEST</version>
+    </dependency>
+    ```
+  </Tab>
+</Tabs>
 
 ### Initialize the SDK
 
 Configure the SDK with your self-hosted backend URL:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
 const novu = new Novu({
-  secretKey: "<YOUR_SECRET_KEY_HERE>", // Your Novu API key from the dashboard
-  serverURL: "http://<your-docker-host>:3000", // URL of your self-hosted Novu API instance
+  secretKey: '<YOUR_SECRET_KEY_HERE>',
+  serverURL: 'http://<your-docker-host>:3000',
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+novu = Novu(
+    secret_key=os.getenv('NOVU_SECRET_KEY', ''),
+    server_url='http://<your-docker-host>:3000',
+)
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    novugo "github.com/novuhq/novu-go"
+    "os"
+)
+
+s := novugo.New(
+    novugo.WithServerURL("http://<your-docker-host>:3000"),
+    novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")),
+)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+
+$novu = novu\Novu::builder()
+    ->setServerURL('http://<your-docker-host>:3000')
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+
+var novu = new NovuSDK(
+    serverUrl: "http://<your-docker-host>:3000",
+    secretKey: "<YOUR_SECRET_KEY_HERE>"
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+
+Novu novu = Novu.builder()
+    .serverUrl("http://<your-docker-host>:3000")
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+# Set your self-hosted API base URL for REST calls
+export NOVU_API_URL=http://<your-docker-host>:3000
+export NOVU_SECRET_KEY=<YOUR_SECRET_KEY_HERE>
+```
+  </Tab>
+</Tabs>
 
 ### Configure for different environments
 
@@ -156,19 +255,85 @@ Adjust the `backendUrl` based on your deployment:
 
 Once initialized, you can trigger notification events:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
-await novu.trigger({ 
-  workflowId: 'workflowId', 
-  to: {
-    subscriberId: 'subscriberId',
-  },
+await novu.trigger({
+  workflowId: 'workflowId',
+  to: { subscriberId: 'subscriberId' },
   payload: {
-    // Your custom payload data
     name: 'John Doe',
     orderId: 'ORDER_ID_123',
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+    workflow_id='workflowId',
+    to={'subscriber_id': 'subscriberId'},
+    payload={'name': 'John Doe', 'orderId': 'ORDER_ID_123'},
+))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+        "name": "John Doe", "orderId": "ORDER_ID_123",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$novu->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: ['name' => 'John Doe', 'orderId' => 'ORDER_ID_123'],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await novu.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto { SubscriberId = "subscriberId" }),
+    Payload = new Dictionary<string, object>() {
+        { "name", "John Doe" }, { "orderId", "ORDER_ID_123" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("workflowId")
+    .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+    .payload(Map.of("name", "John Doe", "orderId", "ORDER_ID_123"))
+    .build()).call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'http://<your-docker-host>:3000/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "workflowId",
+  "to": { "subscriberId": "subscriberId" },
+  "payload": { "name": "John Doe", "orderId": "ORDER_ID_123" }
+}'
+```
+  </Tab>
+</Tabs>
 
 For more information on using the Node SDK, refer to the [Server-Side SDKs documentation](/sdks/overview).
 
@@ -288,24 +453,112 @@ When deploying to a VPS, consider these additional security measures:
 
 ### Triggering events with custom installation
 
-When self-hosting Novu, in order to trigger an event you must first create a new `Novu` object and configure it with the proper `backendUrl`.
+When self-hosting Novu, configure your server SDK with the self-hosted `serverURL` (or `server_url`) before triggering events.
 
-```tsx
-import { Novu } from '@novu/api';  
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
 
 const novu = new Novu({
   secretKey: '<YOUR_SECRET_KEY_HERE>',
-  serverURL: '<REPLACE_WITH_SELF_HOSTED_BACKEND_URL>',
+  serverURL: 'http://<your-docker-host>:3000',
 });
 
 await novu.trigger({
   workflowId: 'workflowId',
-  to: {
-    subscriberId: 'subscriberId',
-  },
+  to: { subscriberId: 'subscriberId' },
   payload: {},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+from novu_py import Novu
+
+novu = Novu(
+    secret_key='<YOUR_SECRET_KEY_HERE>',
+    server_url='http://<your-docker-host>:3000',
+)
+
+novu.trigger(trigger_event_request_dto={
+    'workflow_id': 'workflowId',
+    'to': {'subscriber_id': 'subscriberId'},
+    'payload': {},
+})
+```
+  </Tab>
+  <Tab title="Go">
+```go
+s := novugo.New(
+    novugo.WithServerURL("http://<your-docker-host>:3000"),
+    novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")),
+)
+
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$novu = novu\Novu::builder()
+    ->setServerURL('http://<your-docker-host>:3000')
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$novu->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: [],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+var novu = new NovuSDK(
+    serverUrl: "http://<your-docker-host>:3000",
+    secretKey: "<YOUR_SECRET_KEY_HERE>"
+);
+
+await novu.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto { SubscriberId = "subscriberId" }),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+Novu novu = Novu.builder()
+    .serverUrl("http://<your-docker-host>:3000")
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("workflowId")
+    .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+    .build()).call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'http://<your-docker-host>:3000/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "workflowId",
+  "to": { "subscriberId": "subscriberId" },
+  "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Caching
 

--- a/docs/guides/inngest.mdx
+++ b/docs/guides/inngest.mdx
@@ -43,13 +43,60 @@ This guide teaches you how to:
     
     Import Novu's SDK and provide the credentials to initialize the Novu instance.
     
+    <Tabs>
+      <Tab title="Node.js">
     ```typescript
+    import { Novu } from '@novu/api';
 
-    
-    const novu = new Novu({ 
-      secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
+    const novu = new Novu({
+      secretKey: process.env.NOVU_SECRET_KEY,
     });
     ```
+      </Tab>
+      <Tab title="Python">
+    ```python
+    import os
+    from novu_py import Novu
+
+    novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
+    ```
+      </Tab>
+      <Tab title="Go">
+    ```go
+    import (
+        novugo "github.com/novuhq/novu-go"
+        "os"
+    )
+
+    novu := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+    ```
+      </Tab>
+      <Tab title="PHP">
+    ```php
+    use novu;
+
+    $novu = novu\Novu::builder()
+        ->setSecurity(getenv('NOVU_SECRET_KEY'))
+        ->build();
+    ```
+      </Tab>
+      <Tab title=".NET">
+    ```csharp
+    using Novu;
+
+    var novu = new NovuSDK(secretKey: Environment.GetEnvironmentVariable("NOVU_SECRET_KEY")!);
+    ```
+      </Tab>
+      <Tab title="Java">
+    ```java
+    import co.novu.Novu;
+
+    Novu novu = Novu.builder()
+        .secretKey(System.getenv("NOVU_SECRET_KEY"))
+        .build();
+    ```
+      </Tab>
+    </Tabs>
     
     For the sake of this guide, we will create a new dedicated functions for 2 common Novu actions:
     
@@ -80,33 +127,108 @@ When calling Novu's `trigger` method, you must provide the following information
 
 Here's a simple Inngest function that triggers a Novu workflow when the function is being invoked. It assumes the function invoke receives a `userId` and `email` in its payload.
 
-```tsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { inngest } from "./client";
 import { Novu } from "@novu/api";
 
-const novu = new Novu({ 
-    secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
-  });
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
 export const sendNotification = inngest.createFunction(
   { id: "send-notification" },
   { event: "test/hello.world" },
   async ({ event, step }) => {
     await step.run("send-welcome-email", async () => {
-        await novu.trigger({
-            workflowId: "welcome-email",
-            to: {
-                subscriberId: event.data.userId,
-                email: event.data.email,
-            },
-            payload: {},
-        });
+      await novu.trigger({
+        workflowId: "welcome-email",
+        to: {
+          subscriberId: event.data.userId,
+          email: event.data.email,
+        },
+        payload: {},
+      });
     });
 
     return { message: `Welcome email sent to ${event.data.email}!` };
   },
 );
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="welcome-email",
+        to={"subscriber_id": user_id, "email": email},
+        payload={},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "welcome-email",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: userID,
+        Email:        email,
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'welcome-email',
+        to: new Components\SubscriberPayloadDto(subscriberId: $userId, email: $email),
+        payload: [],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "welcome-email",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = userId,
+        Email = email,
+    }),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("welcome-email")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId(userId)
+            .email(email)
+            .build()))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "welcome-email",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Adding Dynamic Content with `payload`
 
@@ -129,49 +251,132 @@ To achieve this, you would pass the `userName` and `functionName` in the `payloa
 
 Let's modify the previous function to accept more data (like a user's `name`) in its own payload and pass relevant parts to the Novu `trigger` payload.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { inngest } from "./client";
 import { Novu } from "@novu/api";
 
-const novu = new Novu({ 
-  secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
-});
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
-export const sendNotification = inngest.createFunction(  
+export const sendNotification = inngest.createFunction(
   { id: "send-notification" },
   { event: "test/hello.world" },
   async ({ event, step }) => {
     await step.run("send-welcome-email", async () => {
-      try {
-        // Construct the payload specifically for Novu
-        const novuPayload = {
-          userName: event.data.userName,   // Map 'name' from task payload to 'userName' for the template
-          functionName: `Data Processing Function #${event.id}`, // Can include static text or transform data
-        };
+      const novuPayload = {
+        userName: event.data.userName,
+        functionName: `Data Processing Function #${event.id}`,
+      };
 
-        await novu.trigger({
-          workflowId: "inbox-test", // Use the appropriate workflow ID
-          to: {
-            subscriberId: event.data.userId,
-            email: event.data.email,
-          },
-          payload: {
-            ...novuPayload,
-          },
-        });
+      await novu.trigger({
+        workflowId: "inbox-test",
+        to: {
+          subscriberId: event.data.userId,
+          email: event.data.email,
+        },
+        payload: { ...novuPayload },
+      });
 
-        console.log("Novu workflow triggered successfully with payload:", novuPayload);
-        return novuPayload;
-
-      } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error triggering Novu';
-        console.error("Failed to trigger Novu workflow with payload:", errorMessage, error);
-        throw new Error(`Novu trigger failed: ${errorMessage}`);
-      }
+      return novuPayload;
     });
   },
 );
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="inbox-test",
+        to={"subscriber_id": user_id, "email": email},
+        payload={
+            "userName": user_name,
+            "functionName": f"Data Processing Function #{event_id}",
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "inbox-test",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: userID,
+        Email:        email,
+    }),
+    Payload: map[string]any{
+        "userName":     userName,
+        "functionName": fmt.Sprintf("Data Processing Function #%s", eventID),
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'inbox-test',
+        to: new Components\SubscriberPayloadDto(subscriberId: $userId, email: $email),
+        payload: [
+            'userName' => $userName,
+            'functionName' => "Data Processing Function #{$eventId}",
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "inbox-test",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = userId,
+        Email = email,
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "userName", userName },
+        { "functionName", $"Data Processing Function #{eventId}" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("inbox-test")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId(userId)
+            .email(email)
+            .build()))
+        .payload(Map.ofEntries(
+            Map.entry("userName", userName),
+            Map.entry("functionName", "Data Processing Function #" + eventId)))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "inbox-test",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": {
+    "userName": "Jane",
+    "functionName": "Data Processing Function #evt_123"
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Add a New Subscriber to Novu
 
@@ -197,57 +402,135 @@ Create or update a subscriber in Novu when:
 
 Below is a task that creates a Novu subscriber using a Inngest task. It also supports optional fields like `phone` and `avatar`.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { inngest } from "./client";
 import { Novu } from "@novu/api";
 
-const novu = new Novu({ 
-  secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
-});
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
-export const createSubscriber = inngest.createFunction(  
+export const createSubscriber = inngest.createFunction(
   { id: "create-subscriber" },
   { event: "app/account.created" },
   async ({ event, step }) => {
     await step.run("create-subscriber", async () => {
-      try {
-        // Construct the payload specifically for Novu
-        const subscriberPayload = Object.fromEntries(
-          Object.entries({
-            subscriberId: event.data.userId,
-            email: event.data.email,
-            firstName: event.data.firstName,
-            lastName: event.data.lastName,
-            phone: event.data.phone,
-            avatar: event.data.avatar,
-            locale: event.data.locale,
-            data: event.data.userName ? { userName: event.data.userName } : undefined
-          }).filter(([, value]) => value !== undefined)
-        ) as {
-          subscriberId: string;
-          email?: string;
-          firstName?: string;
-          lastName?: string;
-          phone?: string;
-          avatar?: string;
-          locale?: string;
-          data?: { userName: string };
-        };
+      const subscriberPayload = {
+        subscriberId: event.data.userId,
+        email: event.data.email,
+        firstName: event.data.firstName,
+        lastName: event.data.lastName,
+        phone: event.data.phone,
+        avatar: event.data.avatar,
+        locale: event.data.locale,
+        data: event.data.userName ? { userName: event.data.userName } : undefined,
+      };
 
-        await novu.subscribers.create(subscriberPayload);
-
-        console.log("Novu subscriber created successfully with payload:", subscriberPayload);
-        return subscriberPayload;
-
-      } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error creating Novu subscriber';
-        console.error("Failed to create Novu subscriber with payload:", errorMessage, error);
-        throw new Error(`Novu subscriber creation failed: ${errorMessage}`);
-      }
+      await novu.subscribers.create(subscriberPayload);
+      return subscriberPayload;
     });
   },
 );
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.create(
+        create_subscriber_request_dto=novu_py.CreateSubscriberRequestDto(
+            subscriber_id=user_id,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            phone=phone,
+            avatar=avatar,
+            locale=locale,
+            data={"userName": user_name} if user_name else None,
+        )
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Subscribers.Create(context.Background(), components.CreateSubscriberRequestDto{
+    SubscriberID: userID,
+    Email:        email,
+    FirstName:    firstName,
+    LastName:     lastName,
+    Phone:        phone,
+    Avatar:       avatar,
+    Locale:       locale,
+    Data: map[string]any{
+        "userName": userName,
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->subscribers->create(
+    createSubscriberRequestDto: new Components\CreateSubscriberRequestDto(
+        subscriberId: $userId,
+        email: $email,
+        firstName: $firstName,
+        lastName: $lastName,
+        phone: $phone,
+        avatar: $avatar,
+        locale: $locale,
+        data: ['userName' => $userName],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.Subscribers.CreateAsync(createSubscriberRequestDto: new CreateSubscriberRequestDto() {
+    SubscriberId = userId,
+    Email = email,
+    FirstName = firstName,
+    LastName = lastName,
+    Phone = phone,
+    Avatar = avatar,
+    Locale = locale,
+    Data = new Dictionary<string, object>() { { "userName", userName } },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.subscribers().create()
+    .body(CreateSubscriberRequestDto.builder()
+        .subscriberId(userId)
+        .email(email)
+        .firstName(firstName)
+        .lastName(lastName)
+        .phone(phone)
+        .avatar(avatar)
+        .locale(locale)
+        .data(Map.of("userName", userName))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v2/subscribers' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "subscriberId": "user_id",
+  "email": "user@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "data": { "userName": "jane" }
+}'
+```
+  </Tab>
+</Tabs>
 
 ---
 
@@ -306,9 +589,7 @@ export const inngest = new Inngest({ id: "video-processing-app" });
 // --- End Inngest Client Setup ---
 
 // --- Novu Client Setup ---
-const novu = new Novu({ 
-  secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
-});
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 // --- End Novu Client Setup ---
 
 // --- Combined Inngest Function ---
@@ -388,24 +669,16 @@ export const processVideoAndNotify = inngest.createFunction(
 
       console.log(`Attempting to send Novu notification for videoId: ${videoId} to user: ${userId}`);
 
-      // Construct a relevant payload for your Novu template
       const novuPayload = {
         userName: userName,
         videoId: videoId,
-        summarySnippet: summary.substring(0, 100) + (summary.length > 100 ? "..." : ""), // Send a preview
-        // Add any other data your Novu template needs, e.g., a link to view the full video/summary
-        // videoUrl: `https://yourapp.com/videos/${videoId}`
+        summarySnippet: summary.substring(0, 100) + (summary.length > 100 ? "..." : ""),
       };
 
       try {
         const triggerResult = await novu.trigger({
-          // Ensure this workflow ID exists in your Novu dashboard
           workflowId: "video-processed-notification",
-          to: {
-            subscriberId: userId, // Crucial for identifying the user in Novu
-            email: email, // Can be used by Novu email channel
-            // Add other channels like phone if needed and available
-          },
+          to: { subscriberId: userId, email: email },
           payload: novuPayload,
         });
 
@@ -465,6 +738,97 @@ handleVideoUpload({
 });
 */
 ```
+
+The Novu trigger call inside the implementation example maps to these SDK equivalents:
+
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+await novu.trigger({
+  workflowId: "video-processed-notification",
+  to: { subscriberId: userId, email: email },
+  payload: {
+    userName: userName,
+    videoId: videoId,
+    summarySnippet: summary.substring(0, 100) + "...",
+  },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+    workflow_id="video-processed-notification",
+    to={"subscriber_id": user_id, "email": email},
+    payload={
+        "userName": user_name,
+        "videoId": video_id,
+        "summarySnippet": summary[:100] + "...",
+    },
+))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "video-processed-notification",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: userID,
+        Email:        email,
+    }),
+    Payload: map[string]any{
+        "userName": userName, "videoId": videoID, "summarySnippet": summary[:100] + "...",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$novu->trigger(triggerEventRequestDto: new Components\TriggerEventRequestDto(
+    workflowId: 'video-processed-notification',
+    to: new Components\SubscriberPayloadDto(subscriberId: $userId, email: $email),
+    payload: [
+        'userName' => $userName,
+        'videoId' => $videoId,
+        'summarySnippet' => substr($summary, 0, 100) . '...',
+    ],
+));
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await novu.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "video-processed-notification",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto { SubscriberId = userId, Email = email }),
+    Payload = new Dictionary<string, object>() {
+        { "userName", userName }, { "videoId", videoId }, { "summarySnippet", summary[..100] + "..." },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("video-processed-notification")
+    .to(To2.of(SubscriberPayloadDto.builder().subscriberId(userId).email(email).build()))
+    .payload(Map.of(
+        "userName", userName, "videoId", videoId, "summarySnippet", summary.substring(0, 100) + "..."))
+    .build()).call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "video-processed-notification",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": { "userName": "Alice", "videoId": "vid_123", "summarySnippet": "..." }
+}'
+```
+  </Tab>
+</Tabs>
 
 ---
 

--- a/docs/guides/migrate-from-courier-to-novu.mdx
+++ b/docs/guides/migrate-from-courier-to-novu.mdx
@@ -49,20 +49,133 @@ We recommend a phased approach to migrate safely without dropping any messages.
 
     *If you prefer to sync ahead of time, you can easily script it:*
 
+    *If you prefer to sync ahead of time, you can easily script it:*
+
+    <Tabs>
+      <Tab title="Node.js">
     ```typescript
+    import { Novu } from '@novu/api';
 
-    const novu = new Novu({ secretKey: 'YOUR_NOVU_API_KEY' });
+    const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
-    // Translating a Courier profile to a Novu subscriber
     await novu.subscribers.create({
-      subscriberId: 'usr_123', // Your internal user ID
+      subscriberId: 'usr_123',
       email: 'alex@example.com',
       phone: '+15551234567',
-      data: {
-        subscriptionTier: 'premium' // Custom data
-      }
+      data: { subscriptionTier: 'premium' },
     });
     ```
+      </Tab>
+      <Tab title="Python">
+    ```python
+    import os
+    import novu_py
+    from novu_py import Novu
+
+    with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+        novu.subscribers.create(
+            create_subscriber_request_dto=novu_py.CreateSubscriberRequestDto(
+                subscriber_id="usr_123",
+                email="alex@example.com",
+                phone="+15551234567",
+                data={"subscriptionTier": "premium"},
+            )
+        )
+    ```
+      </Tab>
+      <Tab title="Go">
+    ```go
+    import (
+        "context"
+        "os"
+
+        novugo "github.com/novuhq/novu-go"
+        "github.com/novuhq/novu-go/models/components"
+    )
+
+    s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+    _, err := s.Subscribers.Create(context.Background(), components.CreateSubscriberRequestDto{
+        SubscriberID: "usr_123",
+        Email:        "alex@example.com",
+        Phone:        "+15551234567",
+        Data: map[string]any{
+            "subscriptionTier": "premium",
+        },
+    }, nil)
+    ```
+      </Tab>
+      <Tab title="PHP">
+    ```php
+    use novu;
+    use novu\Models\Components;
+
+    $sdk = novu\Novu::builder()
+        ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+        ->build();
+
+    $sdk->subscribers->create(
+        createSubscriberRequestDto: new Components\CreateSubscriberRequestDto(
+            subscriberId: 'usr_123',
+            email: 'alex@example.com',
+            phone: '+15551234567',
+            data: ['subscriptionTier' => 'premium'],
+        ),
+    );
+    ```
+      </Tab>
+      <Tab title=".NET">
+    ```csharp
+    using Novu;
+    using Novu.Models.Components;
+    using System.Collections.Generic;
+
+    var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+    await sdk.Subscribers.CreateAsync(createSubscriberRequestDto: new CreateSubscriberRequestDto() {
+        SubscriberId = "usr_123",
+        Email = "alex@example.com",
+        Phone = "+15551234567",
+        Data = new Dictionary<string, object>() {
+            { "subscriptionTier", "premium" },
+        },
+    });
+    ```
+      </Tab>
+      <Tab title="Java">
+    ```java
+    import co.novu.Novu;
+    import co.novu.models.components.*;
+    import java.util.Map;
+
+    Novu novu = Novu.builder()
+        .secretKey("<YOUR_SECRET_KEY_HERE>")
+        .build();
+
+    novu.subscribers().create()
+        .body(CreateSubscriberRequestDto.builder()
+            .subscriberId("usr_123")
+            .email("alex@example.com")
+            .phone("+15551234567")
+            .data(Map.of("subscriptionTier", "premium"))
+            .build())
+        .call();
+    ```
+      </Tab>
+      <Tab title="cURL">
+    ```bash
+    curl -X POST 'https://api.novu.co/v2/subscribers' \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+    -d '{
+      "subscriberId": "usr_123",
+      "email": "alex@example.com",
+      "phone": "+15551234567",
+      "data": { "subscriptionTier": "premium" }
+    }'
+    ```
+      </Tab>
+    </Tabs>
 
     You can also use the [Bulk Import API](/api-reference/subscribers/bulk-create-subscribers) to import your subscribers in bulk.
   </Step>
@@ -132,71 +245,132 @@ We recommend a phased approach to migrate safely without dropping any messages.
 
     <Tabs>
       <Tab title="Node.js">
-      ```javascript
+      ```typescript
+      import { Novu } from '@novu/api';
 
-      const novu = new Novu({ secretKey: 'YOUR_SECRET_KEY' });
+      const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
-      // Replaces courier.send()
       await novu.trigger({
         workflowId: 'weekly-digest',
-        to: { 
+        to: {
           subscriberId: 'usr_123',
-          // Pass details inline for easy lazy migration
-          email: 'alex@example.com' 
+          email: 'alex@example.com',
         },
         payload: {
-          activityType: 'login'
-        }
+          activityType: 'login',
+        },
       });
       ```
       </Tab>
       <Tab title="Python">
       ```python
+      import os
       import novu_py
       from novu_py import Novu
-      import os
-       
-      with Novu(
-      secret_key=os.getenv("NOVU_SECRET_KEY", ""),
-      ) as novu:
-       
-          res = novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
-              workflow_id="workflow_identifier",
-              to={
-                  "subscriber_id": "subscriber_unique_identifier",
-                  "first_name": "Albert",
-                  "last_name": "Einstein",
-                  "email": "albert@einstein.com",
-              },
-              payload={
-                  "comment_id": "string",
-                  "post": {
-                      "text": "string",
-                  },
-              },
-              overrides={
-                "email": {
-                  "bcc": "no-reply@novu.co"
-                }
-              },
+
+      with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+          novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+              workflow_id="weekly-digest",
+              to={"subscriber_id": "usr_123", "email": "alex@example.com"},
+              payload={"activityType": "login"},
           ))
-       
-          # Handle response
-          print(res)
+      ```
+      </Tab>
+      <Tab title="Go">
+      ```go
+      import (
+          "context"
+          "os"
+
+          novugo "github.com/novuhq/novu-go"
+          "github.com/novuhq/novu-go/models/components"
+      )
+
+      s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+      _, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+          WorkflowID: "weekly-digest",
+          To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+              SubscriberID: "usr_123",
+              Email:        "alex@example.com",
+          }),
+          Payload: map[string]any{"activityType": "login"},
+      }, nil)
+      ```
+      </Tab>
+      <Tab title="PHP">
+      ```php
+      use novu;
+      use novu\Models\Components;
+
+      $sdk = novu\Novu::builder()
+          ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+          ->build();
+
+      $sdk->trigger(
+          triggerEventRequestDto: new Components\TriggerEventRequestDto(
+              workflowId: 'weekly-digest',
+              to: new Components\SubscriberPayloadDto(
+                  subscriberId: 'usr_123',
+                  email: 'alex@example.com',
+              ),
+              payload: ['activityType' => 'login'],
+          ),
+      );
+      ```
+      </Tab>
+      <Tab title=".NET">
+      ```csharp
+      using Novu;
+      using Novu.Models.Components;
+      using System.Collections.Generic;
+
+      var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+      await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+          WorkflowId = "weekly-digest",
+          To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+              SubscriberId = "usr_123",
+              Email = "alex@example.com",
+          }),
+          Payload = new Dictionary<string, object>() {
+              { "activityType", "login" },
+          },
+      });
+      ```
+      </Tab>
+      <Tab title="Java">
+      ```java
+      import co.novu.Novu;
+      import co.novu.models.components.*;
+      import java.util.Map;
+
+      Novu novu = Novu.builder()
+          .secretKey("<YOUR_SECRET_KEY_HERE>")
+          .build();
+
+      novu.trigger()
+          .body(TriggerEventRequestDto.builder()
+              .workflowId("weekly-digest")
+              .to(To2.of(SubscriberPayloadDto.builder()
+                  .subscriberId("usr_123")
+                  .email("alex@example.com")
+                  .build()))
+              .payload(Map.of("activityType", "login"))
+              .build())
+          .call();
       ```
       </Tab>
       <Tab title="cURL">
       ```bash
-      curl -X POST https://api.novu.co/v1/events/trigger \
-        -H "Authorization: ApiKey YOUR_API_KEY" \
-        -H "Content-Type: application/json" \
-        -d '{
-          "name": "weekly-digest",
-          "to": { "subscriberId": "usr_123" },
-          "payload": {
-            "activityType": "login"
-          }
-        }'
+      curl -X POST 'https://api.novu.co/v1/events/trigger' \
+      -H 'Content-Type: application/json' \
+      -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+      -d '{
+        "name": "weekly-digest",
+        "to": { "subscriberId": "usr_123", "email": "alex@example.com" },
+        "payload": { "activityType": "login" }
+      }'
       ```
       </Tab>
     </Tabs>

--- a/docs/guides/recipes/managing-workflows.mdx
+++ b/docs/guides/recipes/managing-workflows.mdx
@@ -45,14 +45,39 @@ flowchart TB
 Install the SDK for your stack and set your secret key from the [Novu Dashboard](https://dashboard.novu.co):
 
 <Tabs>
-  <Tab title="Node.js (@novu/api)">
+  <Tab title="Node.js">
     ```bash
     npm install @novu/api zod
     ```
   </Tab>
-  <Tab title="Python (novu-py)">
+  <Tab title="Python">
     ```bash
     pip install novu-py
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```bash
+    go get github.com/novuhq/novu-go
+    ```
+  </Tab>
+  <Tab title="PHP">
+    ```bash
+    composer require novuhq/novu
+    ```
+  </Tab>
+  <Tab title=".NET">
+    ```bash
+    dotnet add package Novu
+    ```
+  </Tab>
+  <Tab title="Java">
+    Maven:
+    ```xml
+    <dependency>
+      <groupId>co.novu</groupId>
+      <artifactId>novu-java</artifactId>
+      <version>LATEST</version>
+    </dependency>
     ```
   </Tab>
 </Tabs>
@@ -71,6 +96,7 @@ Keep a list of every `workflowId` you manage as code (a constant array, a regist
 <Tabs>
   <Tab title="Node.js">
     ```typescript
+    import { Novu } from '@novu/api';
 
     const novu = new Novu({
       secretKey: process.env.NOVU_SECRET_KEY!,
@@ -85,7 +111,6 @@ Keep a list of every `workflowId` you manage as code (a constant array, a regist
 
     /** Build the definition for one workflowId from your in-repo registry. */
     function buildWorkflowDefinition(workflowId: string) {
-      // Example: return workflowDefinitions[workflowId];
       return {
         name: "Payout Initiated",
         description: "This workflow is used to initiate a payout",
@@ -129,33 +154,7 @@ Keep a list of every `workflowId` you manage as code (a constant array, a regist
   </Tab>
   <Tab title="Python">
     ```python
-
-    const novu = new Novu({
-      secretKey: process.env.NOVU_SECRET_KEY!,
-    });
-
-    const MANAGED_WORKFLOW_IDS = [
-      "payout-initiated",
-      "weekly-digest",
-      "order-shipped",
-    ];
-
-    async function publishAllWorkflows() {
-      for (const workflowId of MANAGED_WORKFLOW_IDS) {
-        await novu.workflows.sync(
-          { targetEnvironmentId: process.env.NOVU_TARGET_ENVIRONMENT_ID! },
-          workflowId
-        );
-      }
-    }
-
-    await publishAllWorkflows();
-    ```
-  </Tab>
-  <Tab title="Python">
-    ```python
     import os
-
     from novu_py import Novu
 
     MANAGED_WORKFLOW_IDS = (
@@ -164,14 +163,130 @@ Keep a list of every `workflowId` you manage as code (a constant array, a regist
         "order-shipped",
     )
 
-    with Novu(secret_key=os.environ["NOVU_SECRET_KEY"]) as novu:
+    def build_workflow_definition(workflow_id: str) -> dict:
+        return {
+            "name": "Payout Initiated",
+            "description": "This workflow is used to initiate a payout",
+            "tags": ["payout"],
+            "origin": "external",
+            "validate_payload": False,
+            "steps": [],
+        }
+
+    def create_or_update_workflow_in_development(workflow_id: str):
+        definition = build_workflow_definition(workflow_id)
+        with Novu(secret_key=os.environ["NOVU_SECRET_KEY"]) as novu:
+            try:
+                return novu.workflows.update(workflow_id=workflow_id, update_workflow_dto=definition)
+            except Exception as error:
+                if getattr(error, "status_code", None) == 404:
+                    return novu.workflows.create(create_workflow_dto={**definition, "workflow_id": workflow_id})
+                raise
+
+    def create_or_update_all_workflows_in_development():
         for workflow_id in MANAGED_WORKFLOW_IDS:
-            novu.workflows.sync(
-                workflow_id=workflow_id,
-                sync_workflow_dto={
-                    "target_environment_id": os.environ["NOVU_TARGET_ENVIRONMENT_ID"],
-                },
-            )
+            create_or_update_workflow_in_development(workflow_id)
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```go
+    import (
+        "context"
+        "os"
+
+        novugo "github.com/novuhq/novu-go"
+    )
+
+    var managedWorkflowIDs = []string{
+        "payout-initiated",
+        "weekly-digest",
+        "order-shipped",
+    }
+
+    func createOrUpdateAllWorkflowsInDevelopment(ctx context.Context) error {
+        s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+        for _, workflowID := range managedWorkflowIDs {
+            if err := createOrUpdateWorkflowInDevelopment(ctx, s, workflowID); err != nil {
+                return err
+            }
+        }
+        return nil
+    }
+    ```
+  </Tab>
+  <Tab title="PHP">
+    ```php
+    use novu;
+
+    $managedWorkflowIds = [
+        'payout-initiated',
+        'weekly-digest',
+        'order-shipped',
+    ];
+
+    $sdk = novu\Novu::builder()
+        ->setSecurity(getenv('NOVU_SECRET_KEY'))
+        ->build();
+
+    foreach ($managedWorkflowIds as $workflowId) {
+        try {
+            $sdk->workflows->update($workflowId, buildWorkflowDefinition($workflowId));
+        } catch (\Exception $e) {
+            if ($e->getCode() === 404) {
+                $sdk->workflows->create([...buildWorkflowDefinition($workflowId), 'workflowId' => $workflowId]);
+            } else {
+                throw $e;
+            }
+        }
+    }
+    ```
+  </Tab>
+  <Tab title=".NET">
+    ```csharp
+    using Novu;
+
+    var managedWorkflowIds = new[] { "payout-initiated", "weekly-digest", "order-shipped" };
+    var sdk = new NovuSDK(secretKey: Environment.GetEnvironmentVariable("NOVU_SECRET_KEY")!);
+
+    foreach (var workflowId in managedWorkflowIds)
+    {
+        try
+        {
+            await sdk.Workflows.UpdateAsync(workflowId, BuildWorkflowDefinition(workflowId));
+        }
+        catch (Exception ex) when (ex.Message.Contains("404"))
+        {
+            await sdk.Workflows.CreateAsync(BuildWorkflowDefinition(workflowId, workflowId));
+        }
+    }
+    ```
+  </Tab>
+  <Tab title="Java">
+    ```java
+    import co.novu.Novu;
+    import java.util.List;
+
+    List<String> managedWorkflowIds = List.of(
+        "payout-initiated",
+        "weekly-digest",
+        "order-shipped"
+    );
+
+    Novu novu = Novu.builder()
+        .secretKey(System.getenv("NOVU_SECRET_KEY"))
+        .build();
+
+    for (String workflowId : managedWorkflowIds) {
+        try {
+            novu.workflows().update(workflowId).body(buildWorkflowDefinition(workflowId)).call();
+        } catch (Exception e) {
+            if (e.getMessage().contains("404")) {
+                novu.workflows().create().body(buildWorkflowDefinition(workflowId)).call();
+            } else {
+                throw e;
+            }
+        }
+    }
     ```
   </Tab>
 </Tabs>

--- a/docs/guides/recipes/supabase-auth-notifications.mdx
+++ b/docs/guides/recipes/supabase-auth-notifications.mdx
@@ -24,8 +24,9 @@ Send auth notifications from Supabase by listening to Supabase Auth events in yo
   <Step title="Listen for Supabase auth events">
     Use a Supabase Edge Function or your application backend to handle auth events:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
-import { createClient } from '@supabase/supabase-js';
 import { Novu } from '@novu/api';
 
 const novu = new Novu({ secretKey: Deno.env.get('NOVU_SECRET_KEY')! });
@@ -44,6 +45,145 @@ Deno.serve(async (req) => {
   return new Response('ok');
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+def handle_supabase_auth_event(event_type, record):
+    if event_type == "INSERT" and record.get("email"):
+        with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+            novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+                workflow_id="welcome",
+                to={"subscriber_id": record["id"], "email": record["email"]},
+                payload={"email": record["email"]},
+            ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+func handleSupabaseAuthEvent(eventType string, record map[string]any) error {
+    email, _ := record["email"].(string)
+    id, _ := record["id"].(string)
+    if eventType != "INSERT" || email == "" {
+        return nil
+    }
+
+    s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+    _, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+        WorkflowID: "welcome",
+        To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+            SubscriberID: id,
+            Email:        email,
+        }),
+        Payload: map[string]any{"email": email},
+    }, nil)
+    return err
+}
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+function handleSupabaseAuthEvent(string $type, array $record): void
+{
+    if ($type !== 'INSERT' || empty($record['email'])) {
+        return;
+    }
+
+    $sdk = novu\Novu::builder()
+        ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+        ->build();
+
+    $sdk->trigger(
+        triggerEventRequestDto: new Components\TriggerEventRequestDto(
+            workflowId: 'welcome',
+            to: new Components\SubscriberPayloadDto(
+                subscriberId: $record['id'],
+                email: $record['email'],
+            ),
+            payload: ['email' => $record['email']],
+        ),
+    );
+}
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+async Task HandleSupabaseAuthEvent(string type, Dictionary<string, object> record)
+{
+    if (type != "INSERT" || !record.ContainsKey("email")) return;
+
+    var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+    await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+        WorkflowId = "welcome",
+        To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+            SubscriberId = record["id"].ToString(),
+            Email = record["email"].ToString(),
+        }),
+        Payload = new Dictionary<string, object>() {
+            { "email", record["email"] },
+        },
+    });
+}
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+void handleSupabaseAuthEvent(String type, Map<String, Object> record) {
+    if (!"INSERT".equals(type) || record.get("email") == null) return;
+
+    Novu novu = Novu.builder()
+        .secretKey("<YOUR_SECRET_KEY_HERE>")
+        .build();
+
+    novu.trigger()
+        .body(TriggerEventRequestDto.builder()
+            .workflowId("welcome")
+            .to(To2.of(SubscriberPayloadDto.builder()
+                .subscriberId(record.get("id").toString())
+                .email(record.get("email").toString())
+                .build()))
+            .payload(Map.of("email", record.get("email")))
+            .build())
+        .call();
+}
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "welcome",
+  "to": { "subscriberId": "supabase-user-uuid", "email": "user@example.com" },
+  "payload": { "email": "user@example.com" }
+}'
+```
+  </Tab>
+</Tabs>
   </Step>
 
   <Step title="Handle password reset emails">

--- a/docs/guides/triggerdotdev.mdx
+++ b/docs/guides/triggerdotdev.mdx
@@ -35,13 +35,44 @@ In this guide, you'll learn how to:
 
   <Step>
     Import Novu's SDK and provide the credentials to initialize the Novu instance:
-    ```typescript
 
-    
-    const novu = new Novu({ 
-      secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
-    });
+    <Tabs>
+      <Tab title="Node.js">
+    ```typescript
+    import { Novu } from '@novu/api';
+
+    const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
     ```
+      </Tab>
+      <Tab title="Python">
+    ```python
+    import os
+    from novu_py import Novu
+
+    novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
+    ```
+      </Tab>
+      <Tab title="Go">
+    ```go
+    s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+    ```
+      </Tab>
+      <Tab title="PHP">
+    ```php
+    $novu = novu\Novu::builder()->setSecurity(getenv('NOVU_SECRET_KEY'))->build();
+    ```
+      </Tab>
+      <Tab title=".NET">
+    ```csharp
+    var novu = new NovuSDK(secretKey: Environment.GetEnvironmentVariable("NOVU_SECRET_KEY")!);
+    ```
+      </Tab>
+      <Tab title="Java">
+    ```java
+    Novu novu = Novu.builder().secretKey(System.getenv("NOVU_SECRET_KEY")).build();
+    ```
+      </Tab>
+    </Tabs>
   </Step>
 </Steps>
 
@@ -77,70 +108,95 @@ When calling Novu's `trigger` method, you must provide the following information
 
 ### Basic Trigger Example
 
-Here's a simple Trigger.dev task that triggers a Novu workflow when the task runs. 
+Here's a simple Trigger.dev task that triggers a Novu workflow when the task runs.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { task, retry } from "@trigger.dev/sdk/v3";
 import { Novu } from "@novu/api";
 
-// Initialize the Novu client with your API key
-// It's recommended to store your secret key securely, e.g., in environment variables.
-const novu = new Novu({ 
-  secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
-}); // Add '!' if you're sure it's defined, or handle potential undefined case
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
 export const notifyUserTask = task({
   id: "notify-user-task",
-  run: async (
-    payload: { // Payload received by the Trigger.dev task
-      userId: string;
-      email: string;
-    },
-    { ctx } // Access context if needed, e.g., for logging
-  ) => {
+  run: async (payload: { userId: string; email: string }) => {
     const { userId, email } = payload;
 
-    console.log(`Attempting to trigger Novu workflow for subscriber: ${userId}`);
-
-    // Use retry logic for resilience against transient network issues or brief API unavailability
-    await retry.onThrow(
-      async () => {
-        try {
-          const triggerResult = await novu.trigger({
-            // 1. Specify the workflow to trigger
-            workflowId: "your-workflow-id", // Replace with your actual workflow ID
-
-            // 2. Specify the recipient
-            to: {
-              subscriberId: userId,
-              email: email, // Include other identifiers if needed by your workflow
-            },
-
-            // 3. Payload (optional) - see next section
-            payload: {}, // Empty payload for this basic example
-          });
-
-          console.log("Novu workflow triggered successfully:", triggerResult.data);
-          return triggerResult.data; // Return data if needed elsewhere
-
-        } catch (error: unknown) {
-          // Log the specific error for better debugging
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error triggering Novu';
-          console.error("Failed to trigger Novu workflow:", errorMessage, error);
-          // Throw a new error to ensure retry logic catches it
-          throw new Error(`Novu trigger failed: ${errorMessage}`);
-        }
-      },
-      {
-        maxAttempts: 3, // Configure retry attempts
-        factor: 2,      // Configure backoff strategy
-        minTimeoutInMs: 1000, // Wait at least 1 second before first retry
-        // Add more retry options as needed
-      }
-    );
+    await retry.onThrow(async () => {
+      await novu.trigger({
+        workflowId: "your-workflow-id",
+        to: { subscriberId: userId, email: email },
+        payload: {},
+      });
+    }, { maxAttempts: 3 });
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="your-workflow-id",
+        to={"subscriber_id": user_id, "email": email},
+        payload={},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "your-workflow-id",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: userID, Email: email,
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(triggerEventRequestDto: new Components\TriggerEventRequestDto(
+    workflowId: 'your-workflow-id',
+    to: new Components\SubscriberPayloadDto(subscriberId: $userId, email: $email),
+    payload: [],
+));
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "your-workflow-id",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto { SubscriberId = userId, Email = email }),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("your-workflow-id")
+    .to(To2.of(SubscriberPayloadDto.builder().subscriberId(userId).email(email).build()))
+    .build()).call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "your-workflow-id",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Working with Dynamic Content
 
@@ -169,61 +225,102 @@ To achieve this, you would pass the `userName` and `jobName` in the `payload` ob
 
 ### Advanced Trigger Example
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { task, retry } from "@trigger.dev/sdk/v3";
 import { Novu } from "@novu/api";
 
-const novu = new Novu({ 
-  secretKey: 'ApiKey ' + process.env['NOVU_SECRET_KEY']
-});
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
 export const notifyOnJobCompletion = task({
   id: "notify-on-job-completion",
-  run: async (
-    payload: {
-      userId: string;
-      email: string;
-      name: string;
-      jobId: string;
-    }
-  ) => {
+  run: async (payload: { userId: string; email: string; name: string; jobId: string }) => {
     const { userId, email, name, jobId } = payload;
 
-    await retry.onThrow(
-      async () => {
-        try {
-          // Construct the payload specifically for Novu
-          // This often uses data from the task's payload, but can include other computed values
-          const novuPayload = {
-            userName: name,   // Map 'name' from task payload to 'userName' for the template
-            jobName: `Data Processing Job #${jobId}`, // Can include static text or transform data
-          };
+    await retry.onThrow(async () => {
+      const novuPayload = {
+        userName: name,
+        jobName: `Data Processing Job #${jobId}`,
+      };
 
-          await novu.trigger({
-            workflowId: "inbox-test", // Use the appropriate workflow ID
-            to: {
-              subscriberId: userId,
-              email: email,
-            },
-            payload: { // Pass the constructed payload to Novu
-              ...novuPayload,
-            },
-          });
-          
-          console.log("Novu workflow triggered successfully with payload:", novuPayload);
-          return novuPayload;
+      await novu.trigger({
+        workflowId: "inbox-test",
+        to: { subscriberId: userId, email: email },
+        payload: { ...novuPayload },
+      });
 
-        } catch (error: unknown) {
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error triggering Novu';
-          console.error("Failed to trigger Novu workflow with payload:", errorMessage, error);
-          throw new Error(`Novu trigger failed: ${errorMessage}`);
-        }
-      },
-      { maxAttempts: 2 } // Retry the task up to 2 times
-    );
+      return novuPayload;
+    }, { maxAttempts: 2 });
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="inbox-test",
+        to={"subscriber_id": user_id, "email": email},
+        payload={"userName": name, "jobName": f"Data Processing Job #{job_id}"},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "inbox-test",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: userID, Email: email,
+    }),
+    Payload: map[string]any{
+        "userName": name, "jobName": fmt.Sprintf("Data Processing Job #%s", jobID),
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(triggerEventRequestDto: new Components\TriggerEventRequestDto(
+    workflowId: 'inbox-test',
+    to: new Components\SubscriberPayloadDto(subscriberId: $userId, email: $email),
+    payload: ['userName' => $name, 'jobName' => "Data Processing Job #{$jobId}"],
+));
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "inbox-test",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto { SubscriberId = userId, Email = email }),
+    Payload = new Dictionary<string, object>() {
+        { "userName", name }, { "jobName", $"Data Processing Job #{jobId}" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("inbox-test")
+    .to(To2.of(SubscriberPayloadDto.builder().subscriberId(userId).email(email).build()))
+    .payload(Map.of("userName", name, "jobName", "Data Processing Job #" + jobId))
+    .build()).call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "inbox-test",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": { "userName": "Jane", "jobName": "Data Processing Job #123" }
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Key Points about Payloads
 
@@ -613,6 +710,112 @@ Workflow `payload` variables: `{{userName}}`, `{{theme}}`, `{{errorMessage}}`, `
 
 </Accordion>
 </AccordionGroup>
+
+Novu trigger calls in the AI tasks example:
+
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+await novu.trigger({
+  workflowId: "ai-generation-completed",
+  to: { subscriberId: userId, email: email },
+  payload: {
+    userName: email.split('@')[0],
+    theme: theme,
+    contentId: contentId,
+    contentPreview: contentPreview,
+    imageUrl: imageUrl,
+    viewUrl: `https://yourapp.com/content/${contentId}`,
+  },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+    workflow_id="ai-generation-completed",
+    to={"subscriber_id": user_id, "email": email},
+    payload={
+        "userName": email.split("@")[0],
+        "theme": theme,
+        "contentId": content_id,
+        "contentPreview": content_preview,
+        "imageUrl": image_url,
+        "viewUrl": f"https://yourapp.com/content/{content_id}",
+    },
+))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "ai-generation-completed",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: userID, Email: email,
+    }),
+    Payload: map[string]any{
+        "userName": strings.Split(email, "@")[0],
+        "theme": theme, "contentId": contentID,
+        "contentPreview": contentPreview, "imageUrl": imageURL,
+        "viewUrl": fmt.Sprintf("https://yourapp.com/content/%s", contentID),
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(triggerEventRequestDto: new Components\TriggerEventRequestDto(
+    workflowId: 'ai-generation-completed',
+    to: new Components\SubscriberPayloadDto(subscriberId: $userId, email: $email),
+    payload: [
+        'userName' => explode('@', $email)[0],
+        'theme' => $theme,
+        'contentId' => $contentId,
+        'contentPreview' => $contentPreview,
+        'imageUrl' => $imageUrl,
+        'viewUrl' => "https://yourapp.com/content/{$contentId}",
+    ],
+));
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "ai-generation-completed",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto { SubscriberId = userId, Email = email }),
+    Payload = new Dictionary<string, object>() {
+        { "userName", email.Split('@')[0] }, { "theme", theme },
+        { "contentId", contentId }, { "contentPreview", contentPreview },
+        { "imageUrl", imageUrl }, { "viewUrl", $"https://yourapp.com/content/{contentId}" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("ai-generation-completed")
+    .to(To2.of(SubscriberPayloadDto.builder().subscriberId(userId).email(email).build()))
+    .payload(Map.of(
+        "userName", email.split("@")[0], "theme", theme,
+        "contentId", contentId, "contentPreview", contentPreview,
+        "imageUrl", imageUrl, "viewUrl", "https://yourapp.com/content/" + contentId))
+    .build()).call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "ai-generation-completed",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": { "userName": "user", "theme": "Marketing", "contentId": "content-123" }
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Video processing
 
@@ -1072,6 +1275,112 @@ This workflow provides a complete solution for transcribing videos and keeping u
 </Accordion>
 </AccordionGroup>
 
+Novu trigger calls in the video processing example:
+
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+await novu.trigger({
+  workflowId: "transcription-completed",
+  to: { subscriberId: userId, email: email },
+  payload: {
+    userName: email.split('@')[0],
+    videoName: videoName,
+    transcriptionId: transcriptionId,
+    wordCount: wordCount,
+    duration: duration,
+    viewUrl: `https://yourapp.com/transcriptions/${transcriptionId}`,
+  },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+    workflow_id="transcription-completed",
+    to={"subscriber_id": user_id, "email": email},
+    payload={
+        "userName": email.split("@")[0],
+        "videoName": video_name,
+        "transcriptionId": transcription_id,
+        "wordCount": word_count,
+        "duration": duration,
+        "viewUrl": f"https://yourapp.com/transcriptions/{transcription_id}",
+    },
+))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "transcription-completed",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: userID, Email: email,
+    }),
+    Payload: map[string]any{
+        "userName": strings.Split(email, "@")[0],
+        "videoName": videoName, "transcriptionId": transcriptionID,
+        "wordCount": wordCount, "duration": duration,
+        "viewUrl": fmt.Sprintf("https://yourapp.com/transcriptions/%s", transcriptionID),
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(triggerEventRequestDto: new Components\TriggerEventRequestDto(
+    workflowId: 'transcription-completed',
+    to: new Components\SubscriberPayloadDto(subscriberId: $userId, email: $email),
+    payload: [
+        'userName' => explode('@', $email)[0],
+        'videoName' => $videoName,
+        'transcriptionId' => $transcriptionId,
+        'wordCount' => $wordCount,
+        'duration' => $duration,
+        'viewUrl' => "https://yourapp.com/transcriptions/{$transcriptionId}",
+    ],
+));
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "transcription-completed",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto { SubscriberId = userId, Email = email }),
+    Payload = new Dictionary<string, object>() {
+        { "userName", email.Split('@')[0] }, { "videoName", videoName },
+        { "transcriptionId", transcriptionId }, { "wordCount", wordCount },
+        { "duration", duration }, { "viewUrl", $"https://yourapp.com/transcriptions/{transcriptionId}" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("transcription-completed")
+    .to(To2.of(SubscriberPayloadDto.builder().subscriberId(userId).email(email).build()))
+    .payload(Map.of(
+        "userName", email.split("@")[0], "videoName", videoName,
+        "transcriptionId", transcriptionId, "wordCount", wordCount,
+        "duration", duration, "viewUrl", "https://yourapp.com/transcriptions/" + transcriptionId))
+    .build()).call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "transcription-completed",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": { "videoName": "Weekly Team Meeting", "wordCount": 4320, "duration": "32:15" }
+}'
+```
+  </Tab>
+</Tabs>
+
 ## Managing Subscribers
 
 Before triggering notifications, Novu needs to know *who* to notify. That's where subscribers come in. A **subscriber** in Novu represents a user (or entity) that can receive notifications through one or more channels (in-app, email, SMS, etc.).
@@ -1104,59 +1413,128 @@ Create or update a subscriber in Novu when:
 
 ### Subscriber Creation Example
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { task, retry } from "@trigger.dev/sdk/v3";
 import { Novu } from "@novu/api";
 
-const novu = new Novu({
-  secretKey: 'ApiKey ' + process.env["NOVU_SECRET_KEY"]
-});
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
 export const createSubscriberTask = task({
   id: "create-subscriber-task",
   run: async (payload: {
     userId: string;
     email?: string;
-    firtName?: string;
-    lastName?: string;
+    name?: string;
     phone?: string;
     locale?: string;
     avatar?: string;
     data?: object;
   }) => {
-    const { userId, email, name, phone, avatar } = payload;
+    const { userId, email, name, phone, locale, avatar, data } = payload;
+    const [firstName, lastName = ""] = (name ?? "").split(" ");
 
-    // Split full name into first and last (fallback to empty string)
-    const [firstName, lastName = ""] = name.split(" ");
+    const subscriber = { subscriberId: userId, email, firstName, lastName, phone, locale, avatar, data };
 
-    // Create subscriber object for Novu
-    const subscriber = {
-      subscriberId: userId,
-      email,
-      firstName,
-      lastName,
-      phone,
-      locale,
-      avatar,
-      data,
-    };
-
-    await retry.onThrow(
-      async () => {
-        console.log("Creating Novu subscriber:", subscriber);
-
-        const result = await novu.subscribers.create(subscriber);
-
-        console.log("Subscriber created successfully:", result);
-        return result;
-      },
-      {
-        maxAttempts: 2,
-      }
-    );
+    await retry.onThrow(async () => {
+      return await novu.subscribers.create(subscriber);
+    }, { maxAttempts: 2 });
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.create(
+        create_subscriber_request_dto=novu_py.CreateSubscriberRequestDto(
+            subscriber_id=user_id,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            phone=phone,
+            locale=locale,
+            avatar=avatar,
+            data=custom_data,
+        )
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Subscribers.Create(ctx, components.CreateSubscriberRequestDto{
+    SubscriberID: userID,
+    Email: email,
+    FirstName: firstName,
+    LastName: lastName,
+    Phone: phone,
+    Locale: locale,
+    Avatar: avatar,
+    Data: customData,
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->subscribers->create(
+    createSubscriberRequestDto: new Components\CreateSubscriberRequestDto(
+        subscriberId: $userId,
+        email: $email,
+        firstName: $firstName,
+        lastName: $lastName,
+        phone: $phone,
+        locale: $locale,
+        avatar: $avatar,
+        data: $customData,
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.Subscribers.CreateAsync(new CreateSubscriberRequestDto {
+    SubscriberId = userId,
+    Email = email,
+    FirstName = firstName,
+    LastName = lastName,
+    Phone = phone,
+    Locale = locale,
+    Avatar = avatar,
+    Data = customData,
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.subscribers().create()
+    .body(CreateSubscriberRequestDto.builder()
+        .subscriberId(userId)
+        .email(email)
+        .firstName(firstName)
+        .lastName(lastName)
+        .phone(phone)
+        .locale(locale)
+        .avatar(avatar)
+        .data(customData)
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v2/subscribers' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "subscriberId": "user_id",
+  "email": "user@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe"
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Using Subscriber Data in Templates
 
@@ -1204,17 +1582,73 @@ Once you've added custom fields to a subscriber, you can use them in Novu templa
     ```typescript
     // Example of proactive update
     async function updateUserProfile(userId: string, newData: UserUpdateData) {
-      // Update your database
       await db.users.update(userId, newData);
-      
-      // Sync with Novu
-      await novu.subscribers.update(userId, {
-        email: newData.email,
-        phone: newData.phone,
-        data: { lastUpdated: new Date() }
-      });
+      await novu.subscribers.patch(
+        { email: newData.email, phone: newData.phone, data: { lastUpdated: new Date() } },
+        userId
+      );
     }
     ```
+
+    <Tabs>
+      <Tab title="Node.js">
+    ```typescript
+    await novu.subscribers.patch(
+      { email: newData.email, phone: newData.phone, data: { lastUpdated: new Date() } },
+      userId
+    );
+    ```
+      </Tab>
+      <Tab title="Python">
+    ```python
+    novu.subscribers.patch(subscriber_id=user_id, patch_subscriber_request_dto={
+        "email": new_data.email,
+        "phone": new_data.phone,
+        "data": {"lastUpdated": datetime.now().isoformat()},
+    })
+    ```
+      </Tab>
+      <Tab title="Go">
+    ```go
+    s.Subscribers.Patch(ctx, userID, components.PatchSubscriberRequestDto{
+        Email: &email, Phone: &phone,
+        Data: map[string]any{"lastUpdated": time.Now()},
+    }, nil)
+    ```
+      </Tab>
+      <Tab title="PHP">
+    ```php
+    $sdk->subscribers->patch($userId, new Components\PatchSubscriberRequestDto(
+        email: $newData->email,
+        phone: $newData->phone,
+        data: ['lastUpdated' => date('c')],
+    ));
+    ```
+      </Tab>
+      <Tab title=".NET">
+    ```csharp
+    await sdk.Subscribers.PatchAsync(userId, new PatchSubscriberRequestDto {
+        Email = newData.Email, Phone = newData.Phone,
+        Data = new Dictionary<string, object>() { { "lastUpdated", DateTime.UtcNow } },
+    });
+    ```
+      </Tab>
+      <Tab title="Java">
+    ```java
+    novu.subscribers().patch(userId).body(PatchSubscriberRequestDto.builder()
+        .email(newData.getEmail()).phone(newData.getPhone())
+        .data(Map.of("lastUpdated", Instant.now().toString())).build()).call();
+    ```
+      </Tab>
+      <Tab title="cURL">
+    ```bash
+    curl -X PATCH 'https://api.novu.co/v2/subscribers/user_id' \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+    -d '{ "email": "user@example.com", "phone": "+15551234567" }'
+    ```
+      </Tab>
+    </Tabs>
   </Accordion>
 
   <Accordion title="Enriching Subscriber Data">
@@ -1224,14 +1658,87 @@ Once you've added custom fields to a subscriber, you can use them in Novu templa
     - Add metadata for analytics and tracking
     
     ```typescript
-    // Example of rich subscriber data
-    await novu.subscribers.update(userId, {
-      data: {
-        role: 'admin',
-        subscriptionTier: 'premium',
-        features: ['advanced-analytics', 'priority-support']
-      }
+    await novu.subscribers.patch(
+      {
+        data: {
+          role: 'admin',
+          subscriptionTier: 'premium',
+          features: ['advanced-analytics', 'priority-support'],
+        },
+      },
+      userId
+    );
+    ```
+
+    <Tabs>
+      <Tab title="Node.js">
+    ```typescript
+    await novu.subscribers.patch(
+      { data: { role: 'admin', subscriptionTier: 'premium', features: ['advanced-analytics', 'priority-support'] } },
+      userId
+    );
+    ```
+      </Tab>
+      <Tab title="Python">
+    ```python
+    novu.subscribers.patch(subscriber_id=user_id, patch_subscriber_request_dto={
+        "data": {
+            "role": "admin",
+            "subscriptionTier": "premium",
+            "features": ["advanced-analytics", "priority-support"],
+        },
+    })
+    ```
+      </Tab>
+      <Tab title="Go">
+    ```go
+    s.Subscribers.Patch(ctx, userID, components.PatchSubscriberRequestDto{
+        Data: map[string]any{
+            "role": "admin", "subscriptionTier": "premium",
+            "features": []string{"advanced-analytics", "priority-support"},
+        },
+    }, nil)
+    ```
+      </Tab>
+      <Tab title="PHP">
+    ```php
+    $sdk->subscribers->patch($userId, new Components\PatchSubscriberRequestDto(
+        data: [
+            'role' => 'admin',
+            'subscriptionTier' => 'premium',
+            'features' => ['advanced-analytics', 'priority-support'],
+        ],
+    ));
+    ```
+      </Tab>
+      <Tab title=".NET">
+    ```csharp
+    await sdk.Subscribers.PatchAsync(userId, new PatchSubscriberRequestDto {
+        Data = new Dictionary<string, object>() {
+            { "role", "admin" }, { "subscriptionTier", "premium" },
+            { "features", new[] { "advanced-analytics", "priority-support" } },
+        },
     });
     ```
+      </Tab>
+      <Tab title="Java">
+    ```java
+    novu.subscribers().patch(userId).body(PatchSubscriberRequestDto.builder()
+        .data(Map.of(
+            "role", "admin",
+            "subscriptionTier", "premium",
+            "features", List.of("advanced-analytics", "priority-support")))
+        .build()).call();
+    ```
+      </Tab>
+      <Tab title="cURL">
+    ```bash
+    curl -X PATCH 'https://api.novu.co/v2/subscribers/user_id' \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+    -d '{ "data": { "role": "admin", "subscriptionTier": "premium" } }'
+    ```
+      </Tab>
+    </Tabs>
   </Accordion>
 </AccordionGroup>

--- a/docs/guides/use-cases/digest-notifications.mdx
+++ b/docs/guides/use-cases/digest-notifications.mdx
@@ -29,16 +29,135 @@ Typical digest settings:
 
 Trigger the same workflow for each individual event. Novu handles batching automatically based on the digest step configuration and digest key.
 
-```bash
-curl -X POST https://api.novu.co/v1/events/trigger \
-  -H "Authorization: ApiKey <NOVU_SECRET_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "post-liked",
-    "to": { "subscriberId": "user_123" },
-    "payload": { "postId": "post_456", "likerName": "Alex" }
-  }'
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
+
+await novu.trigger({
+  workflowId: 'post-liked',
+  to: { subscriberId: 'user_123' },
+  payload: { postId: 'post_456', likerName: 'Alex' },
+});
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="post-liked",
+        to={"subscriber_id": "user_123"},
+        payload={"postId": "post_456", "likerName": "Alex"},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "post-liked",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user_123",
+    }),
+    Payload: map[string]any{
+        "postId":    "post_456",
+        "likerName": "Alex",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'post-liked',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user_123'),
+        payload: [
+            'postId' => 'post_456',
+            'likerName' => 'Alex',
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "post-liked",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "user_123",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "postId", "post_456" },
+        { "likerName", "Alex" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("post-liked")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("user_123")
+            .build()))
+        .payload(Map.ofEntries(
+            Map.entry("postId", "post_456"),
+            Map.entry("likerName", "Alex")))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "post-liked",
+  "to": { "subscriberId": "user_123" },
+  "payload": { "postId": "post_456", "likerName": "Alex" }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Related guides
 

--- a/docs/guides/use-cases/password-reset-notifications.mdx
+++ b/docs/guides/use-cases/password-reset-notifications.mdx
@@ -12,6 +12,8 @@ Send password reset and authentication alert notifications through Novu by trigg
 1. Create a workflow (for example, `password-reset`) with an email step containing the reset link: `{{payload.resetUrl}}`.
 2. When your auth system generates a reset token, [trigger the workflow](/api-reference/events/trigger-event) with the subscriber's ID and payload.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
@@ -27,6 +29,141 @@ await novu.trigger({
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="password-reset",
+        to={"subscriber_id": user.id, "email": user.email},
+        payload={
+            "firstName": user.first_name,
+            "resetUrl": f"https://app.example.com/reset?token={token}",
+            "expiresInMinutes": 30,
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "fmt"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "password-reset",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: user.ID,
+        Email:        user.Email,
+    }),
+    Payload: map[string]any{
+        "firstName":        user.FirstName,
+        "resetUrl":         fmt.Sprintf("https://app.example.com/reset?token=%s", token),
+        "expiresInMinutes": 30,
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'password-reset',
+        to: new Components\SubscriberPayloadDto(
+            subscriberId: $user->id,
+            email: $user->email,
+        ),
+        payload: [
+            'firstName' => $user->firstName,
+            'resetUrl' => "https://app.example.com/reset?token={$token}",
+            'expiresInMinutes' => 30,
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "password-reset",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = user.Id,
+        Email = user.Email,
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "firstName", user.FirstName },
+        { "resetUrl", $"https://app.example.com/reset?token={token}" },
+        { "expiresInMinutes", 30 },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("password-reset")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId(user.getId())
+            .email(user.getEmail())
+            .build()))
+        .payload(Map.ofEntries(
+            Map.entry("firstName", user.getFirstName()),
+            Map.entry("resetUrl", "https://app.example.com/reset?token=" + token),
+            Map.entry("expiresInMinutes", 30)))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "password-reset",
+  "to": { "subscriberId": "user_id", "email": "user@example.com" },
+  "payload": {
+    "firstName": "Jane",
+    "resetUrl": "https://app.example.com/reset?token=TOKEN",
+    "expiresInMinutes": 30
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 3. Optionally add an in-app step to notify the user that a reset email was sent.
 

--- a/docs/guides/use-cases/transactional-notifications.mdx
+++ b/docs/guides/use-cases/transactional-notifications.mdx
@@ -15,16 +15,144 @@ Common transactional events include order confirmations, shipping updates, payme
 2. Register or upsert a [subscriber](/platform/concepts/subscribers) with the recipient's `subscriberId`, email, and phone.
 3. [Trigger the workflow](/api-reference/events/trigger-event) from your backend with the workflow identifier, `subscriberId`, and event payload.
 
-```bash
-curl -X POST https://api.novu.co/v1/events/trigger \
-  -H "Authorization: ApiKey <NOVU_SECRET_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "order-shipped",
-    "to": { "subscriberId": "user_123" },
-    "payload": { "orderId": "ORD-456", "trackingUrl": "https://example.com/track/456" }
-  }'
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
+
+await novu.trigger({
+  workflowId: 'order-shipped',
+  to: { subscriberId: 'user_123' },
+  payload: {
+    orderId: 'ORD-456',
+    trackingUrl: 'https://example.com/track/456',
+  },
+});
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="order-shipped",
+        to={"subscriber_id": "user_123"},
+        payload={
+            "orderId": "ORD-456",
+            "trackingUrl": "https://example.com/track/456",
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "order-shipped",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user_123",
+    }),
+    Payload: map[string]any{
+        "orderId":     "ORD-456",
+        "trackingUrl": "https://example.com/track/456",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'order-shipped',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user_123'),
+        payload: [
+            'orderId' => 'ORD-456',
+            'trackingUrl' => 'https://example.com/track/456',
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "order-shipped",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "user_123",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "orderId", "ORD-456" },
+        { "trackingUrl", "https://example.com/track/456" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("order-shipped")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("user_123")
+            .build()))
+        .payload(Map.ofEntries(
+            Map.entry("orderId", "ORD-456"),
+            Map.entry("trackingUrl", "https://example.com/track/456")))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "order-shipped",
+  "to": { "subscriberId": "user_123" },
+  "payload": {
+    "orderId": "ORD-456",
+    "trackingUrl": "https://example.com/track/456"
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## What channels should I use for transactional messages?
 

--- a/docs/guides/webhooks/auth0.mdx
+++ b/docs/guides/webhooks/auth0.mdx
@@ -34,6 +34,8 @@ Trigger Novu notification workflows when Auth0 events occur by receiving Auth0 l
   <Step title="Handle the webhook and trigger Novu">
     Verify the Auth0 event, then trigger the matching Novu workflow:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
@@ -49,6 +51,148 @@ export async function handleAuth0Event(event: Auth0LogEvent) {
   }
 }
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
+
+def handle_auth0_event(event):
+    if event["type"] == "s" and event["description"] == "Success Signup":
+        with novu:
+            novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+                workflow_id="welcome-email",
+                to={"subscriber_id": event["user_id"], "email": event["user_name"]},
+                payload={"firstName": event.get("details", {}).get("body", {}).get("firstName")},
+            ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+func handleAuth0Event(event Auth0LogEvent) error {
+    if event.Type == "s" && event.Description == "Success Signup" {
+        s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+        _, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+            WorkflowID: "welcome-email",
+            To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+                SubscriberID: event.UserID,
+                Email:        event.UserName,
+            }),
+            Payload: map[string]any{
+                "firstName": event.Details.Body.FirstName,
+            },
+        }, nil)
+        return err
+    }
+    return nil
+}
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+function handleAuth0Event(array $event): void
+{
+    if ($event['type'] === 's' && $event['description'] === 'Success Signup') {
+        $sdk = novu\Novu::builder()
+            ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+            ->build();
+
+        $sdk->trigger(
+            triggerEventRequestDto: new Components\TriggerEventRequestDto(
+                workflowId: 'welcome-email',
+                to: new Components\SubscriberPayloadDto(
+                    subscriberId: $event['user_id'],
+                    email: $event['user_name'],
+                ),
+                payload: [
+                    'firstName' => $event['details']['body']['firstName'] ?? null,
+                ],
+            ),
+        );
+    }
+}
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+async Task HandleAuth0Event(Auth0LogEvent auth0Event)
+{
+    if (auth0Event.Type == "s" && auth0Event.Description == "Success Signup")
+    {
+        var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+        await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+            WorkflowId = "welcome-email",
+            To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+                SubscriberId = auth0Event.UserId,
+                Email = auth0Event.UserName,
+            }),
+            Payload = new Dictionary<string, object>() {
+                { "firstName", auth0Event.Details?.Body?.FirstName },
+            },
+        });
+    }
+}
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+void handleAuth0Event(Auth0LogEvent event) {
+    if ("s".equals(event.getType()) && "Success Signup".equals(event.getDescription())) {
+        Novu novu = Novu.builder()
+            .secretKey("<YOUR_SECRET_KEY_HERE>")
+            .build();
+
+        novu.trigger()
+            .body(TriggerEventRequestDto.builder()
+                .workflowId("welcome-email")
+                .to(To2.of(SubscriberPayloadDto.builder()
+                    .subscriberId(event.getUserId())
+                    .email(event.getUserName())
+                    .build()))
+                .payload(Map.ofEntries(
+                    Map.entry("firstName", event.getDetails().getBody().getFirstName())))
+                .build())
+            .call();
+    }
+}
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "welcome-email",
+  "to": { "subscriberId": "auth0|user_id", "email": "user@example.com" },
+  "payload": { "firstName": "Jane" }
+}'
+```
+  </Tab>
+</Tabs>
   </Step>
 </Steps>
 

--- a/docs/guides/webhooks/auth0.mdx
+++ b/docs/guides/webhooks/auth0.mdx
@@ -58,11 +58,9 @@ import os
 import novu_py
 from novu_py import Novu
 
-novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
-
 def handle_auth0_event(event):
     if event["type"] == "s" and event["description"] == "Success Signup":
-        with novu:
+        with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
             novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
                 workflow_id="welcome-email",
                 to={"subscriber_id": event["user_id"], "email": event["user_name"]},

--- a/docs/guides/webhooks/clerk.mdx
+++ b/docs/guides/webhooks/clerk.mdx
@@ -605,10 +605,8 @@ import os
 import novu_py
 from novu_py import Novu
 
-novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
-
 def trigger_workflow(workflow_id: str, subscriber: dict, payload: dict):
-    with novu:
+    with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
         novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
             workflow_id=workflow_id,
             to=subscriber,

--- a/docs/guides/webhooks/clerk.mdx
+++ b/docs/guides/webhooks/clerk.mdx
@@ -580,28 +580,145 @@ Create `app/utils/novu.ts` :
   </Tree.Folder>
 </Tree>
 
-```jsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
-import { SubscriberPayloadDto } from '@novu/api/models/components/subscriberpayloaddto';
 
 const novu = new Novu({
-    secretKey: process.env['NOVU_SECRET_KEY']
+  secretKey: process.env['NOVU_SECRET_KEY']!,
 });
 
-export async function triggerWorkflow(workflowId: string, subscriber: SubscriberPayloadDto, payload: object) {
-    try {
-        console.log("Payload:", payload ,"Triggering workflow:", workflowId, "Subscriber:", subscriber)
-        await novu.trigger({
-            workflowId,
-            to: subscriber,
-            payload
-        });
-        return new Response('Notification triggered', { status: 200 });
-    } catch (error) {
-        return new Response('Error triggering notification', { status: 500 });
-    }
+export async function triggerWorkflow(workflowId: string, subscriber: object, payload: object) {
+  try {
+    await novu.trigger({ workflowId, to: subscriber, payload });
+    return new Response('Notification triggered', { status: 200 });
+  } catch (error) {
+    return new Response('Error triggering notification', { status: 500 });
+  }
 }
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
+
+def trigger_workflow(workflow_id: str, subscriber: dict, payload: dict):
+    with novu:
+        novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+            workflow_id=workflow_id,
+            to=subscriber,
+            payload=payload,
+        ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+func triggerWorkflow(workflowID string, subscriber components.SubscriberPayloadDto, payload map[string]any) error {
+    s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+    _, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+        WorkflowID: workflowID,
+        To:         components.CreateToSubscriberPayloadDto(subscriber),
+        Payload:    payload,
+    }, nil)
+    return err
+}
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+function triggerWorkflow(string $workflowId, array $subscriber, array $payload): void
+{
+    $sdk = novu\Novu::builder()
+        ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+        ->build();
+
+    $sdk->trigger(
+        triggerEventRequestDto: new Components\TriggerEventRequestDto(
+            workflowId: $workflowId,
+            to: new Components\SubscriberPayloadDto(
+                subscriberId: $subscriber['subscriberId'],
+                email: $subscriber['email'] ?? null,
+                firstName: $subscriber['firstName'] ?? null,
+                lastName: $subscriber['lastName'] ?? null,
+            ),
+            payload: $payload,
+        ),
+    );
+}
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var novu = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+async Task TriggerWorkflow(string workflowId, SubscriberPayloadDto subscriber, Dictionary<string, object> payload)
+{
+    await novu.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+        WorkflowId = workflowId,
+        To = To.CreateSubscriberPayloadDto(subscriber),
+        Payload = payload,
+    });
+}
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+void triggerWorkflow(String workflowId, SubscriberPayloadDto subscriber, Map<String, Object> payload) {
+    novu.trigger()
+        .body(TriggerEventRequestDto.builder()
+            .workflowId(workflowId)
+            .to(To2.of(subscriber))
+            .payload(payload)
+            .build())
+        .call();
+}
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "user-created",
+  "to": {
+    "subscriberId": "user_123",
+    "email": "user@example.com",
+    "firstName": "Jane"
+  },
+  "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 
 </Step>
 

--- a/docs/guides/webhooks/stripe.mdx
+++ b/docs/guides/webhooks/stripe.mdx
@@ -299,10 +299,8 @@ import os
 import novu_py
 from novu_py import Novu
 
-novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
-
 def trigger_workflow(workflow_id: str, subscriber: dict, payload: dict):
-    with novu:
+    with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
         novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
             workflow_id=workflow_id,
             to=subscriber,

--- a/docs/guides/webhooks/stripe.mdx
+++ b/docs/guides/webhooks/stripe.mdx
@@ -274,28 +274,145 @@ Create `app/utils/novu.ts` :
   </Tree.Folder>
 </Tree>
 
-```jsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
-import { SubscriberPayloadDto } from '@novu/api/models/components/subscriberpayloaddto';
 
 const novu = new Novu({
-    secretKey: process.env['NOVU_SECRET_KEY']
+  secretKey: process.env['NOVU_SECRET_KEY']!,
 });
 
-export async function triggerWorkflow(workflowId: string, subscriber: SubscriberPayloadDto, payload: object) {
-    try {
-        console.log("Payload:", payload ,"Triggering workflow:", workflowId, "Subscriber:", subscriber)
-        await novu.trigger({
-            workflowId,
-            to: subscriber,
-            payload
-        });
-        return new Response('Notification triggered', { status: 200 });
-    } catch (error) {
-        return new Response('Error triggering notification', { status: 500 });
-    }
+export async function triggerWorkflow(workflowId: string, subscriber: object, payload: object) {
+  try {
+    await novu.trigger({ workflowId, to: subscriber, payload });
+    return new Response('Notification triggered', { status: 200 });
+  } catch (error) {
+    return new Response('Error triggering notification', { status: 500 });
+  }
 }
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+novu = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
+
+def trigger_workflow(workflow_id: str, subscriber: dict, payload: dict):
+    with novu:
+        novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+            workflow_id=workflow_id,
+            to=subscriber,
+            payload=payload,
+        ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+func triggerWorkflow(workflowID string, subscriber components.SubscriberPayloadDto, payload map[string]any) error {
+    s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+    _, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+        WorkflowID: workflowID,
+        To:         components.CreateToSubscriberPayloadDto(subscriber),
+        Payload:    payload,
+    }, nil)
+    return err
+}
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+function triggerWorkflow(string $workflowId, array $subscriber, array $payload): void
+{
+    $sdk = novu\Novu::builder()
+        ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+        ->build();
+
+    $sdk->trigger(
+        triggerEventRequestDto: new Components\TriggerEventRequestDto(
+            workflowId: $workflowId,
+            to: new Components\SubscriberPayloadDto(
+                subscriberId: $subscriber['subscriberId'],
+                email: $subscriber['email'] ?? null,
+                firstName: $subscriber['firstName'] ?? null,
+                lastName: $subscriber['lastName'] ?? null,
+            ),
+            payload: $payload,
+        ),
+    );
+}
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var novu = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+async Task TriggerWorkflow(string workflowId, SubscriberPayloadDto subscriber, Dictionary<string, object> payload)
+{
+    await novu.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+        WorkflowId = workflowId,
+        To = To.CreateSubscriberPayloadDto(subscriber),
+        Payload = payload,
+    });
+}
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+void triggerWorkflow(String workflowId, SubscriberPayloadDto subscriber, Map<String, Object> payload) {
+    novu.trigger()
+        .body(TriggerEventRequestDto.builder()
+            .workflowId(workflowId)
+            .to(To2.of(subscriber))
+            .payload(payload)
+            .build())
+        .call();
+}
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "customer-subscription-created",
+  "to": {
+    "subscriberId": "cus_123",
+    "email": "customer@example.com",
+    "firstName": "Jane"
+  },
+  "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 
 </Step>
 

--- a/docs/platform/build-with-ai/skills.mdx
+++ b/docs/platform/build-with-ai/skills.mdx
@@ -130,9 +130,10 @@ Follow the novu-dashboard-workflows skill. Use Liquid variables for personalizat
 
 Send notifications by triggering Novu workflows. Supports single, bulk, broadcast, and topic-based delivery.
 
-<Tabs>
-<Tab title="Single">
+#### Single trigger
 
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 import { Novu } from "@novu/api";
 
@@ -147,12 +148,129 @@ await novu.trigger({
   },
 });
 ```
-
 </Tab>
-<Tab title="Bulk">
+<Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="welcome-email",
+        to="subscriber-123",
+        payload={
+            "userName": "Jane",
+            "activationLink": "https://app.example.com/activate",
+        },
+    ))
+```
+</Tab>
+<Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "welcome-email",
+    To:         components.CreateToStr("subscriber-123"),
+    Payload: map[string]any{
+        "userName":       "Jane",
+        "activationLink": "https://app.example.com/activate",
+    },
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'welcome-email',
+        to: 'subscriber-123',
+        payload: [
+            'userName' => 'Jane',
+            'activationLink' => 'https://app.example.com/activate',
+        ],
+    ),
+);
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "welcome-email",
+    To = To.CreateStr("subscriber-123"),
+    Payload = new Dictionary<string, object>() {
+        { "userName", "Jane" },
+        { "activationLink", "https://app.example.com/activate" },
+    },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("welcome-email")
+        .to(To2.of("subscriber-123"))
+        .payload(Map.ofEntries(
+            Map.entry("userName", "Jane"),
+            Map.entry("activationLink", "https://app.example.com/activate")))
+        .build())
+    .call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "welcome-email",
+  "to": "subscriber-123",
+  "payload": {
+    "userName": "Jane",
+    "activationLink": "https://app.example.com/activate"
+  }
+}'
+```
+</Tab>
+</Tabs>
+
+#### Bulk trigger
 
 Send up to **100 events** in a single request:
 
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.triggerBulk({
   events: [
@@ -161,24 +279,143 @@ await novu.triggerBulk({
   ],
 });
 ```
-
 </Tab>
-<Tab title="Broadcast">
+<Tab title="Python">
+```python
+novu.trigger_bulk(trigger_bulk_request_dto=novu_py.TriggerBulkRequestDto(
+    events=[
+        {"workflow_id": "welcome-email", "to": "subscriber-1", "payload": {"userName": "Alice"}},
+        {"workflow_id": "welcome-email", "to": "subscriber-2", "payload": {"userName": "Bob"}},
+    ],
+))
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.TriggerBulk(ctx, components.TriggerBulkRequestDto{
+    Events: []components.TriggerEventRequestDto{
+        {WorkflowID: "welcome-email", To: components.CreateToStr("subscriber-1"), Payload: map[string]any{"userName": "Alice"}},
+        {WorkflowID: "welcome-email", To: components.CreateToStr("subscriber-2"), Payload: map[string]any{"userName": "Bob"}},
+    },
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->triggerBulk(triggerBulkRequestDto: new Components\TriggerBulkRequestDto(
+    events: [
+        new Components\TriggerEventRequestDto(workflowId: 'welcome-email', to: 'subscriber-1', payload: ['userName' => 'Alice']),
+        new Components\TriggerEventRequestDto(workflowId: 'welcome-email', to: 'subscriber-2', payload: ['userName' => 'Bob']),
+    ],
+));
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.TriggerBulkAsync(new TriggerBulkRequestDto {
+    Events = new List<TriggerEventRequestDto> {
+        new() { WorkflowId = "welcome-email", To = To.CreateStr("subscriber-1"), Payload = new Dictionary<string, object>() { { "userName", "Alice" } } },
+        new() { WorkflowId = "welcome-email", To = To.CreateStr("subscriber-2"), Payload = new Dictionary<string, object>() { { "userName", "Bob" } } },
+    },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.triggerBulk().body(TriggerBulkRequestDto.builder()
+    .events(List.of(
+        TriggerEventRequestDto.builder().workflowId("welcome-email").to(To2.of("subscriber-1")).payload(Map.of("userName", "Alice")).build(),
+        TriggerEventRequestDto.builder().workflowId("welcome-email").to(To2.of("subscriber-2")).payload(Map.of("userName", "Bob")).build()))
+    .build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger/bulk' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "events": [
+    { "name": "welcome-email", "to": "subscriber-1", "payload": { "userName": "Alice" } },
+    { "name": "welcome-email", "to": "subscriber-2", "payload": { "userName": "Bob" } }
+  ]
+}'
+```
+</Tab>
+</Tabs>
+
+#### Broadcast trigger
 
 Send to **all subscribers** in the environment:
 
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.triggerBroadcast({
   name: "system-announcement",
   payload: { message: "Scheduled maintenance at 2am UTC" },
 });
 ```
-
 </Tab>
-<Tab title="Topic">
+<Tab title="Python">
+```python
+novu.trigger_broadcast(trigger_broadcast_request_dto=novu_py.TriggerBroadcastRequestDto(
+    name="system-announcement",
+    payload={"message": "Scheduled maintenance at 2am UTC"},
+))
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.TriggerBroadcast(ctx, components.TriggerBroadcastRequestDto{
+    Name:    "system-announcement",
+    Payload: map[string]any{"message": "Scheduled maintenance at 2am UTC"},
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->triggerBroadcast(triggerBroadcastRequestDto: new Components\TriggerBroadcastRequestDto(
+    name: 'system-announcement',
+    payload: ['message' => 'Scheduled maintenance at 2am UTC'],
+));
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.TriggerBroadcastAsync(new TriggerBroadcastRequestDto {
+    Name = "system-announcement",
+    Payload = new Dictionary<string, object>() { { "message", "Scheduled maintenance at 2am UTC" } },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.triggerBroadcast().body(TriggerBroadcastRequestDto.builder()
+    .name("system-announcement")
+    .payload(Map.of("message", "Scheduled maintenance at 2am UTC"))
+    .build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger/broadcast' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "system-announcement",
+  "payload": { "message": "Scheduled maintenance at 2am UTC" }
+}'
+```
+</Tab>
+</Tabs>
+
+#### Topic trigger
 
 Send to all subscribers in a topic:
 
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.trigger({
   workflowId: "project-update",
@@ -186,7 +423,78 @@ await novu.trigger({
   payload: { update: "New release deployed" },
 });
 ```
-
+</Tab>
+<Tab title="Python">
+```python
+novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+    workflow_id="project-update",
+    to=[{"type": "Topic", "topic_key": "project-alpha-watchers"}],
+    payload={"update": "New release deployed"},
+))
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Trigger(ctx, components.TriggerEventRequestDto{
+    WorkflowID: "project-update",
+    To: components.CreateToArrayOfTo1([]components.To1{
+        components.CreateTo1TopicPayloadDto(components.TopicPayloadDto{
+            Type: components.TriggerRecipientsTypeEnumTopic, TopicKey: "project-alpha-watchers",
+        }),
+    }),
+    Payload: map[string]any{"update": "New release deployed"},
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->trigger(triggerEventRequestDto: new Components\TriggerEventRequestDto(
+    workflowId: 'project-update',
+    to: [new Components\TopicPayloadDto(
+        topicKey: 'project-alpha-watchers',
+        type: Components\TriggerRecipientsTypeEnum::Topic,
+    )],
+    payload: ['update' => 'New release deployed'],
+));
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(new TriggerEventRequestDto {
+    WorkflowId = "project-update",
+    To = To.CreateArrayOfTo1(new List<To1> {
+        To1.CreateTopicPayloadDto(new TopicPayloadDto {
+            Type = TriggerRecipientsTypeEnum.Topic,
+            TopicKey = "project-alpha-watchers",
+        }),
+    }),
+    Payload = new Dictionary<string, object>() { { "update", "New release deployed" } },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.trigger().body(TriggerEventRequestDto.builder()
+    .workflowId("project-update")
+    .to(To2.of(List.of(To1.of(TopicPayloadDto.builder()
+        .type(TriggerRecipientsTypeEnum.TOPIC)
+        .topicKey("project-alpha-watchers")
+        .build()))))
+    .payload(Map.of("update", "New release deployed"))
+    .build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "name": "project-update",
+  "to": [{ "type": "Topic", "topicKey": "project-alpha-watchers" }],
+  "payload": { "update": "New release deployed" }
+}'
+```
 </Tab>
 </Tabs>
 
@@ -208,49 +516,253 @@ await novu.trigger({
 
 Subscribers are the recipients of your notifications. Each subscriber has a unique `subscriberId` — typically your application's user ID.
 
-<Tabs>
-<Tab title="Create">
+#### Create
 
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.subscribers.create({
-  subscriberId: "user-123",         // required
+  subscriberId: "user-123",
   email: "jane@example.com",
   firstName: "Jane",
   lastName: "Doe",
   phone: "+15551234567",
-  data: { plan: "pro" },            // custom key-value data
+  data: { plan: "pro" },
 });
 ```
-
 </Tab>
-<Tab title="Retrieve">
+<Tab title="Python">
+```python
+novu.subscribers.create(
+    create_subscriber_request_dto=novu_py.CreateSubscriberRequestDto(
+        subscriber_id="user-123",
+        email="jane@example.com",
+        first_name="Jane",
+        last_name="Doe",
+        phone="+15551234567",
+        data={"plan": "pro"},
+    )
+)
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Subscribers.Create(ctx, components.CreateSubscriberRequestDto{
+    SubscriberID: "user-123",
+    Email:        "jane@example.com",
+    FirstName:    "Jane",
+    LastName:     "Doe",
+    Phone:        "+15551234567",
+    Data:         map[string]any{"plan": "pro"},
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->subscribers->create(
+    createSubscriberRequestDto: new Components\CreateSubscriberRequestDto(
+        subscriberId: 'user-123',
+        email: 'jane@example.com',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        phone: '+15551234567',
+        data: ['plan' => 'pro'],
+    ),
+);
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.Subscribers.CreateAsync(new CreateSubscriberRequestDto {
+    SubscriberId = "user-123",
+    Email = "jane@example.com",
+    FirstName = "Jane",
+    LastName = "Doe",
+    Phone = "+15551234567",
+    Data = new Dictionary<string, object>() { { "plan", "pro" } },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.subscribers().create()
+    .body(CreateSubscriberRequestDto.builder()
+        .subscriberId("user-123")
+        .email("jane@example.com")
+        .firstName("Jane")
+        .lastName("Doe")
+        .phone("+15551234567")
+        .data(Map.of("plan", "pro"))
+        .build())
+    .call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v2/subscribers' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "subscriberId": "user-123",
+  "email": "jane@example.com",
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "phone": "+15551234567",
+  "data": { "plan": "pro" }
+}'
+```
+</Tab>
+</Tabs>
 
+#### Retrieve
+
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 const subscriber = await novu.subscribers.retrieve("user-123");
 ```
-
 </Tab>
-<Tab title="Update">
+<Tab title="Python">
+```python
+subscriber = novu.subscribers.retrieve(subscriber_id="user-123")
+```
+</Tab>
+<Tab title="Go">
+```go
+res, err := s.Subscribers.Get(ctx, "user-123", nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$response = $sdk->subscribers->get(subscriberId: 'user-123');
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+var subscriber = await sdk.Subscribers.GetAsync("user-123");
+```
+</Tab>
+<Tab title="Java">
+```java
+var subscriber = novu.subscribers().get("user-123").call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl 'https://api.novu.co/v2/subscribers/user-123' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+```
+</Tab>
+</Tabs>
 
+#### Update
+
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.subscribers.patch(
   { firstName: "Jane", data: { plan: "enterprise" } },
   "user-123"
 );
 ```
-
 </Tab>
-<Tab title="Delete">
+<Tab title="Python">
+```python
+novu.subscribers.patch(
+    subscriber_id="user-123",
+    patch_subscriber_request_dto={"first_name": "Jane", "data": {"plan": "enterprise"}},
+)
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Subscribers.Patch(ctx, "user-123", components.PatchSubscriberRequestDto{
+    FirstName: novu.String("Jane"),
+    Data:      map[string]any{"plan": "enterprise"},
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->subscribers->patch('user-123', new Components\PatchSubscriberRequestDto(
+    firstName: 'Jane',
+    data: ['plan' => 'enterprise'],
+));
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.Subscribers.PatchAsync("user-123", new PatchSubscriberRequestDto {
+    FirstName = "Jane",
+    Data = new Dictionary<string, object>() { { "plan", "enterprise" } },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.subscribers().patch("user-123").body(PatchSubscriberRequestDto.builder()
+    .firstName("Jane")
+    .data(Map.of("plan", "enterprise"))
+    .build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X PATCH 'https://api.novu.co/v2/subscribers/user-123' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{ "firstName": "Jane", "data": { "plan": "enterprise" } }'
+```
+</Tab>
+</Tabs>
 
+#### Delete
+
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.subscribers.delete("user-123");
 ```
-
 </Tab>
-<Tab title="Bulk Create">
+<Tab title="Python">
+```python
+novu.subscribers.delete(subscriber_id="user-123")
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Subscribers.Delete(ctx, "user-123", nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->subscribers->delete(subscriberId: 'user-123');
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.Subscribers.DeleteAsync("user-123");
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.subscribers().delete("user-123").call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X DELETE 'https://api.novu.co/v2/subscribers/user-123' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+```
+</Tab>
+</Tabs>
+
+#### Bulk create
 
 Create up to **500 subscribers** in one request:
 
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.subscribers.createBulk({
   subscribers: [
@@ -259,22 +771,157 @@ await novu.subscribers.createBulk({
   ],
 });
 ```
-
+</Tab>
+<Tab title="Python">
+```python
+novu.subscribers.create_bulk(
+    bulk_subscriber_create_dto=novu_py.BulkSubscriberCreateDto(
+        subscribers=[
+            {"subscriber_id": "user-1", "email": "alice@example.com", "first_name": "Alice"},
+            {"subscriber_id": "user-2", "email": "bob@example.com", "first_name": "Bob"},
+        ],
+    )
+)
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Subscribers.CreateBulk(ctx, components.BulkSubscriberCreateDto{
+    Subscribers: []components.CreateSubscriberRequestDto{
+        {SubscriberID: "user-1", Email: "alice@example.com", FirstName: "Alice"},
+        {SubscriberID: "user-2", Email: "bob@example.com", FirstName: "Bob"},
+    },
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->subscribers->createBulk(bulkSubscriberCreateDto: new Components\BulkSubscriberCreateDto(
+    subscribers: [
+        new Components\CreateSubscriberRequestDto(subscriberId: 'user-1', email: 'alice@example.com', firstName: 'Alice'),
+        new Components\CreateSubscriberRequestDto(subscriberId: 'user-2', email: 'bob@example.com', firstName: 'Bob'),
+    ],
+));
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.Subscribers.CreateBulkAsync(new BulkSubscriberCreateDto {
+    Subscribers = new List<CreateSubscriberRequestDto> {
+        new() { SubscriberId = "user-1", Email = "alice@example.com", FirstName = "Alice" },
+        new() { SubscriberId = "user-2", Email = "bob@example.com", FirstName = "Bob" },
+    },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.subscribers().createBulk().body(BulkSubscriberCreateDto.builder()
+    .subscribers(List.of(
+        CreateSubscriberRequestDto.builder().subscriberId("user-1").email("alice@example.com").firstName("Alice").build(),
+        CreateSubscriberRequestDto.builder().subscriberId("user-2").email("bob@example.com").firstName("Bob").build()))
+    .build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v2/subscribers/bulk' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "subscribers": [
+    { "subscriberId": "user-1", "email": "alice@example.com", "firstName": "Alice" },
+    { "subscriberId": "user-2", "email": "bob@example.com", "firstName": "Bob" }
+  ]
+}'
+```
 </Tab>
 </Tabs>
 
 **Topics** are named groups of subscribers for group-based notification targeting:
 
+<Tabs>
+<Tab title="Node.js">
 ```typescript
-// Create a topic
 await novu.topics.create({ key: "engineering-team", name: "Engineering Team" });
 
-// Add subscribers
 await novu.topics.subscriptions.create(
   { subscriptions: ["user-1", "user-2", "user-3"] },
   "engineering-team"
 );
 ```
+</Tab>
+<Tab title="Python">
+```python
+novu.topics.create(create_topic_request_dto={"key": "engineering-team", "name": "Engineering Team"})
+
+novu.topics.subscriptions.create(
+    topic_key="engineering-team",
+    create_topic_subscriptions_request_dto={"subscriptions": ["user-1", "user-2", "user-3"]},
+)
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Topics.Create(ctx, components.CreateTopicRequestDto{
+    Key: "engineering-team", Name: "Engineering Team",
+}, nil)
+
+_, err = s.Topics.Subscriptions.Create(ctx, "engineering-team", components.CreateTopicSubscriptionsRequestDto{
+    Subscriptions: []string{"user-1", "user-2", "user-3"},
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->topics->create(createTopicRequestDto: new Components\CreateTopicRequestDto(
+    key: 'engineering-team',
+    name: 'Engineering Team',
+));
+
+$sdk->topics->subscriptions->create(
+    topicKey: 'engineering-team',
+    createTopicSubscriptionsRequestDto: new Components\CreateTopicSubscriptionsRequestDto(
+        subscriptions: ['user-1', 'user-2', 'user-3'],
+    ),
+);
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.Topics.CreateAsync(new CreateTopicRequestDto {
+    Key = "engineering-team", Name = "Engineering Team",
+});
+
+await sdk.Topics.Subscriptions.CreateAsync("engineering-team", new CreateTopicSubscriptionsRequestDto {
+    Subscriptions = new List<string> { "user-1", "user-2", "user-3" },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.topics().create().body(CreateTopicRequestDto.builder()
+    .key("engineering-team").name("Engineering Team").build()).call();
+
+novu.topics().subscriptions().create("engineering-team")
+    .body(CreateTopicSubscriptionsRequestDto.builder()
+        .subscriptions(List.of("user-1", "user-2", "user-3")).build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v2/topics' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{ "key": "engineering-team", "name": "Engineering Team" }'
+
+curl -X POST 'https://api.novu.co/v2/topics/engineering-team/subscriptions' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{ "subscriptions": ["user-1", "user-2", "user-3"] }'
+```
+</Tab>
+</Tabs>
 
 ---
 
@@ -366,8 +1013,10 @@ Novu uses a two-level preference system: **workflow defaults** and **subscriber 
 
 **Subscriber-level overrides**:
 
+#### Workflow-level preferences
+
 <Tabs>
-<Tab title="Workflow level">
+<Tab title="Node.js">
 ```typescript
 await novu.subscribers.preferences.update(
   {
@@ -378,7 +1027,70 @@ await novu.subscribers.preferences.update(
 );
 ```
 </Tab>
-<Tab title="Global level">
+<Tab title="Python">
+```python
+novu.subscribers.preferences.update(
+    subscriber_id="subscriber-123",
+    patch_subscriber_preferences_dto={
+        "workflow_id": "weekly-newsletter",
+        "channels": {"email": False, "in_app": True},
+    },
+)
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Subscribers.Preferences.Update(ctx, "subscriber-123", components.PatchSubscriberPreferencesDto{
+    WorkflowID: novu.String("weekly-newsletter"),
+    Channels:   &components.Channels{Email: novu.Bool(false), InApp: novu.Bool(true)},
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->subscribers->preferences->update(
+    subscriberId: 'subscriber-123',
+    patchSubscriberPreferencesDto: new Components\PatchSubscriberPreferencesDto(
+        workflowId: 'weekly-newsletter',
+        channels: new Components\Channels(email: false, inApp: true),
+    ),
+);
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.Subscribers.Preferences.UpdateAsync("subscriber-123", new PatchSubscriberPreferencesDto {
+    WorkflowId = "weekly-newsletter",
+    Channels = new Channels { Email = false, InApp = true },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.subscribers().preferences().update("subscriber-123")
+    .body(PatchSubscriberPreferencesDto.builder()
+        .workflowId("weekly-newsletter")
+        .channels(Channels.builder().email(false).inApp(true).build())
+        .build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X PATCH 'https://api.novu.co/v2/subscribers/subscriber-123/preferences' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "workflowId": "weekly-newsletter",
+  "channels": { "email": false, "inApp": true }
+}'
+```
+</Tab>
+</Tabs>
+
+#### Global preferences
+
+<Tabs>
+<Tab title="Node.js">
 ```typescript
 await novu.subscribers.preferences.update(
   {
@@ -386,6 +1098,56 @@ await novu.subscribers.preferences.update(
   },
   "subscriber-123"
 );
+```
+</Tab>
+<Tab title="Python">
+```python
+novu.subscribers.preferences.update(
+    subscriber_id="subscriber-123",
+    patch_subscriber_preferences_dto={
+        "channels": {"email": False, "in_app": True},
+    },
+)
+```
+</Tab>
+<Tab title="Go">
+```go
+_, err := s.Subscribers.Preferences.Update(ctx, "subscriber-123", components.PatchSubscriberPreferencesDto{
+    Channels: &components.Channels{Email: novu.Bool(false), InApp: novu.Bool(true)},
+}, nil)
+```
+</Tab>
+<Tab title="PHP">
+```php
+$sdk->subscribers->preferences->update(
+    subscriberId: 'subscriber-123',
+    patchSubscriberPreferencesDto: new Components\PatchSubscriberPreferencesDto(
+        channels: new Components\Channels(email: false, inApp: true),
+    ),
+);
+```
+</Tab>
+<Tab title=".NET">
+```csharp
+await sdk.Subscribers.Preferences.UpdateAsync("subscriber-123", new PatchSubscriberPreferencesDto {
+    Channels = new Channels { Email = false, InApp = true },
+});
+```
+</Tab>
+<Tab title="Java">
+```java
+novu.subscribers().preferences().update("subscriber-123")
+    .body(PatchSubscriberPreferencesDto.builder()
+        .channels(Channels.builder().email(false).inApp(true).build())
+        .build()).call();
+```
+</Tab>
+<Tab title="cURL">
+```bash
+curl -X PATCH 'https://api.novu.co/v2/subscribers/subscriber-123/preferences' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{ "channels": { "email": false, "inApp": true } }'
 ```
 </Tab>
 </Tabs>

--- a/docs/platform/concepts/subscribers.mdx
+++ b/docs/platform/concepts/subscribers.mdx
@@ -59,11 +59,13 @@ This approach is useful when:
 - Notifications are sent during real-time events like sign-ups or transactions.
 - You want to keep the creation and delivery logic tightly coupled.
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
 import { Novu } from "@novu/api";
- 
-const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>", });
- 
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
 await novu.trigger({
   to: {
     subscriberId: "subscriber_unique_identifier",
@@ -75,16 +77,146 @@ await novu.trigger({
   workflowId: "workflow_identifier",
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflow_identifier",
+        to={
+            "subscriber_id": "subscriber_unique_identifier",
+            "first_name": "Albert",
+            "last_name": "Einstein",
+            "email": "albert@einstein.com",
+            "phone": "+1234567890",
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflow_identifier",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriber_unique_identifier",
+        FirstName:    "Albert",
+        LastName:     "Einstein",
+        Email:        "albert@einstein.com",
+        Phone:        "+1234567890",
+    }),
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflow_identifier',
+        to: new Components\SubscriberPayloadDto(
+            subscriberId: 'subscriber_unique_identifier',
+            firstName: 'Albert',
+            lastName: 'Einstein',
+            email: 'albert@einstein.com',
+            phone: '+1234567890',
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflow_identifier",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriber_unique_identifier",
+        FirstName = "Albert",
+        LastName = "Einstein",
+        Email = "albert@einstein.com",
+        Phone = "+1234567890",
+    }),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflow_identifier")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriber_unique_identifier")
+            .firstName("Albert")
+            .lastName("Einstein")
+            .email("albert@einstein.com")
+            .phone("+1234567890")
+            .build()))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflow_identifier",
+    "to": {
+        "subscriberId": "subscriber_unique_identifier",
+        "firstName": "Albert",
+        "lastName": "Einstein",
+        "email": "albert@einstein.com",
+        "phone": "+1234567890"
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Ahead of trigger
 
 Alternatively, you can create and store subscriber profiles ahead of time — typically during onboarding, registration, or data sync events. This approach allows you to manage subscriber preferences, enrich profiles, and inspect delivery readiness before any notification is triggered.
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
 import { Novu } from "@novu/api";
- 
-const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>", });
- 
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
 await novu.subscribers.create({
   subscriberId: "subscriber_unique_identifier",
   firstName: "Albert",
@@ -98,6 +230,147 @@ await novu.subscribers.create({
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.create(create_subscriber_request_dto={
+        "subscriber_id": "subscriber_unique_identifier",
+        "first_name": "Albert",
+        "last_name": "Einstein",
+        "email": "albert@einstein.com",
+        "phone": "+1234567890",
+        "data": {
+            "address": "123 Main St, Anytown, USA",
+            "membershipLevel": "Gold",
+            "preferredTopics": ["News", "Sports"],
+        },
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Create(context.Background(), components.CreateSubscriberRequestDto{
+    SubscriberID: "subscriber_unique_identifier",
+    FirstName:    "Albert",
+    LastName:     "Einstein",
+    Email:        "albert@einstein.com",
+    Phone:        "+1234567890",
+    Data: map[string]any{
+        "address":         "123 Main St, Anytown, USA",
+        "membershipLevel": "Gold",
+        "preferredTopics": []string{"News", "Sports"},
+    },
+}, nil, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->subscribers->create(
+    createSubscriberRequestDto: new Components\CreateSubscriberRequestDto(
+        subscriberId: 'subscriber_unique_identifier',
+        firstName: 'Albert',
+        lastName: 'Einstein',
+        email: 'albert@einstein.com',
+        phone: '+1234567890',
+        data: [
+            'address' => '123 Main St, Anytown, USA',
+            'membershipLevel' => 'Gold',
+            'preferredTopics' => ['News', 'Sports'],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.Subscribers.CreateAsync(createSubscriberRequestDto: new CreateSubscriberRequestDto() {
+    SubscriberId = "subscriber_unique_identifier",
+    FirstName = "Albert",
+    LastName = "Einstein",
+    Email = "albert@einstein.com",
+    Phone = "+1234567890",
+    Data = new Dictionary<string, object>() {
+        { "address", "123 Main St, Anytown, USA" },
+        { "membershipLevel", "Gold" },
+        { "preferredTopics", new List<string> { "News", "Sports" } },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.CreateSubscriberRequestDto;
+import java.util.List;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.subscribers().create()
+    .body(CreateSubscriberRequestDto.builder()
+        .subscriberId("subscriber_unique_identifier")
+        .firstName("Albert")
+        .lastName("Einstein")
+        .email("albert@einstein.com")
+        .phone("+1234567890")
+        .data(Map.ofEntries(
+            Map.entry("address", "123 Main St, Anytown, USA"),
+            Map.entry("membershipLevel", "Gold"),
+            Map.entry("preferredTopics", List.of("News", "Sports"))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v2/subscribers' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "subscriberId": "subscriber_unique_identifier",
+    "firstName": "Albert",
+    "lastName": "Einstein",
+    "email": "albert@einstein.com",
+    "phone": "+1234567890",
+    "data": {
+        "address": "123 Main St, Anytown, USA",
+        "membershipLevel": "Gold",
+        "preferredTopics": ["News", "Sports"]
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 This is recommended when:
 - You want to decouple user creation from notification logic.
@@ -108,11 +381,13 @@ This is recommended when:
 
 For scenarios like data migration, syncing large lists, or preloading subscribers, Novu supports bulk creation. This is especially useful when integrating with existing systems or importing subscriber data from external sources. Bulk create method supports creating up to 500 subscribers at once.
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
 import { Novu } from "@novu/api";
- 
-const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>", });
- 
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
 await novu.subscribers.createBulk({
   subscribers: [
     {
@@ -132,6 +407,183 @@ await novu.subscribers.createBulk({
   ],
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.create_bulk(bulk_subscriber_create_dto={
+        "subscribers": [
+            {
+                "subscriber_id": "subscriber_unique_identifier_1",
+                "first_name": "Albert",
+                "last_name": "Einstein",
+                "email": "albert@einstein.com",
+                "phone": "+1234567890",
+            },
+            {
+                "subscriber_id": "subscriber_unique_identifier_2",
+                "first_name": "Isaac",
+                "last_name": "Newton",
+                "email": "isaac@newton.com",
+                "phone": "+1234567891",
+            },
+        ],
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.CreateBulk(context.Background(), components.BulkSubscriberCreateDto{
+    Subscribers: []components.CreateSubscriberRequestDto{
+        {
+            SubscriberID: "subscriber_unique_identifier_1",
+            FirstName:    "Albert",
+            LastName:     "Einstein",
+            Email:        "albert@einstein.com",
+            Phone:        "+1234567890",
+        },
+        {
+            SubscriberID: "subscriber_unique_identifier_2",
+            FirstName:    "Isaac",
+            LastName:     "Newton",
+            Email:        "isaac@newton.com",
+            Phone:        "+1234567891",
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->subscribers->createBulk(
+    bulkSubscriberCreateDto: new Components\BulkSubscriberCreateDto(
+        subscribers: [
+            new Components\CreateSubscriberRequestDto(
+                subscriberId: 'subscriber_unique_identifier_1',
+                firstName: 'Albert',
+                lastName: 'Einstein',
+                email: 'albert@einstein.com',
+                phone: '+1234567890',
+            ),
+            new Components\CreateSubscriberRequestDto(
+                subscriberId: 'subscriber_unique_identifier_2',
+                firstName: 'Isaac',
+                lastName: 'Newton',
+                email: 'isaac@newton.com',
+                phone: '+1234567891',
+            ),
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.Subscribers.CreateBulkAsync(bulkSubscriberCreateDto: new BulkSubscriberCreateDto() {
+    Subscribers = new List<CreateSubscriberRequestDto> {
+        new CreateSubscriberRequestDto() {
+            SubscriberId = "subscriber_unique_identifier_1",
+            FirstName = "Albert",
+            LastName = "Einstein",
+            Email = "albert@einstein.com",
+            Phone = "+1234567890",
+        },
+        new CreateSubscriberRequestDto() {
+            SubscriberId = "subscriber_unique_identifier_2",
+            FirstName = "Isaac",
+            LastName = "Newton",
+            Email = "isaac@newton.com",
+            Phone = "+1234567891",
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.BulkSubscriberCreateDto;
+import co.novu.models.components.CreateSubscriberRequestDto;
+import java.util.List;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.subscribers().createBulk()
+    .body(BulkSubscriberCreateDto.builder()
+        .subscribers(List.of(
+            CreateSubscriberRequestDto.builder()
+                .subscriberId("subscriber_unique_identifier_1")
+                .firstName("Albert")
+                .lastName("Einstein")
+                .email("albert@einstein.com")
+                .phone("+1234567890")
+                .build(),
+            CreateSubscriberRequestDto.builder()
+                .subscriberId("subscriber_unique_identifier_2")
+                .firstName("Isaac")
+                .lastName("Newton")
+                .email("isaac@newton.com")
+                .phone("+1234567891")
+                .build()))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/subscribers/bulk' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "subscribers": [
+        {
+            "subscriberId": "subscriber_unique_identifier_1",
+            "firstName": "Albert",
+            "lastName": "Einstein",
+            "email": "albert@einstein.com",
+            "phone": "+1234567890"
+        },
+        {
+            "subscriberId": "subscriber_unique_identifier_2",
+            "firstName": "Isaac",
+            "lastName": "Newton",
+            "email": "isaac@newton.com",
+            "phone": "+1234567891"
+        }
+    ]
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Where to manage subscriber data
 

--- a/docs/platform/concepts/tenants.mdx
+++ b/docs/platform/concepts/tenants.mdx
@@ -17,19 +17,142 @@ Some of the common multi-tenancy use cases are:
 
 Novu supports multi-tenancy out of the box, the most simple way to implement tenant separation is by prefixing the subscriber identifier with the <Tooltip tip="The tenant identifier is a unique identifier for the tenant in your application. Usually the tenant id in your database.">tenant identifier</Tooltip>
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api";
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
 const subscriberId = `${tenantId}:${userId}`;
 
 await novu.trigger({
-  workflowId,
-  to: {
-    subscriberId,
-  },
-  payload: {
-    tenantId,
-  },
+  workflowId: "workflow_identifier",
+  to: { subscriberId },
+  payload: { tenantId },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+subscriber_id = f"{tenant_id}:{user_id}"
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflow_identifier",
+        to={"subscriber_id": subscriber_id},
+        payload={"tenantId": tenant_id},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "fmt"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+subscriberID := fmt.Sprintf("%s:%s", tenantID, userID)
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflow_identifier",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: subscriberID,
+    }),
+    Payload: map[string]any{
+        "tenantId": tenantID,
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$subscriberId = "{$tenantId}:{$userId}";
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflow_identifier',
+        to: new Components\SubscriberPayloadDto(subscriberId: $subscriberId),
+        payload: ['tenantId' => $tenantId],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+var subscriberId = $"{tenantId}:{userId}";
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflow_identifier",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = subscriberId,
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "tenantId", tenantId },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+String subscriberId = tenantId + ":" + userId;
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflow_identifier")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId(subscriberId)
+            .build()))
+        .payload(Map.of("tenantId", tenantId))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflow_identifier",
+    "to": { "subscriberId": "TENANT_ID:USER_ID" },
+    "payload": { "tenantId": "TENANT_ID" }
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Tenant in Inbox
 
@@ -49,24 +172,184 @@ Each subscriber in a tenant will have it's own unique inbox feed, including a se
 
 When triggering a notification, you can pass a custom tenant object or identifier and use it to manipulate workflows or content.
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api";
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
 const subscriberId = `${tenantId}:${userId}`;
 
 await novu.trigger({
-  workflowId,
-  to: {
-    subscriberId,
-  },
+  workflowId: "workflow_identifier",
+  to: { subscriberId },
   payload: {
     tenant: {
       id: tenantId,
       name: "Airbnb",
       logo: "https://airbnb.com/logo.png",
       primaryColor: "red",
-    }
+    },
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+subscriber_id = f"{tenant_id}:{user_id}"
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflow_identifier",
+        to={"subscriber_id": subscriber_id},
+        payload={
+            "tenant": {
+                "id": tenant_id,
+                "name": "Airbnb",
+                "logo": "https://airbnb.com/logo.png",
+                "primaryColor": "red",
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "fmt"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+subscriberID := fmt.Sprintf("%s:%s", tenantID, userID)
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflow_identifier",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: subscriberID,
+    }),
+    Payload: map[string]any{
+        "tenant": map[string]any{
+            "id":           tenantID,
+            "name":         "Airbnb",
+            "logo":         "https://airbnb.com/logo.png",
+            "primaryColor": "red",
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$subscriberId = "{$tenantId}:{$userId}";
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflow_identifier',
+        to: new Components\SubscriberPayloadDto(subscriberId: $subscriberId),
+        payload: [
+            'tenant' => [
+                'id' => $tenantId,
+                'name' => 'Airbnb',
+                'logo' => 'https://airbnb.com/logo.png',
+                'primaryColor' => 'red',
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+var subscriberId = $"{tenantId}:{userId}";
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflow_identifier",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = subscriberId,
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "tenant", new Dictionary<string, object>() {
+            { "id", tenantId },
+            { "name", "Airbnb" },
+            { "logo", "https://airbnb.com/logo.png" },
+            { "primaryColor", "red" },
+        } },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+String subscriberId = tenantId + ":" + userId;
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflow_identifier")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId(subscriberId)
+            .build()))
+        .payload(Map.of("tenant", Map.ofEntries(
+            Map.entry("id", tenantId),
+            Map.entry("name", "Airbnb"),
+            Map.entry("logo", "https://airbnb.com/logo.png"),
+            Map.entry("primaryColor", "red"))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflow_identifier",
+    "to": { "subscriberId": "TENANT_ID:USER_ID" },
+    "payload": {
+        "tenant": {
+            "id": "TENANT_ID",
+            "name": "Airbnb",
+            "logo": "https://airbnb.com/logo.png",
+            "primaryColor": "red"
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 The tenant object will be available to use in the workflow editor as a variable for the following areas:
 

--- a/docs/platform/inbox/advanced-features/multi-tenancy.mdx
+++ b/docs/platform/inbox/advanced-features/multi-tenancy.mdx
@@ -59,29 +59,204 @@ Once you’ve defined your tenant context, you can use it when triggering workfl
 
 If not, Novu automatically creates it — but if it does exist, Novu reuses the existing record instead of updating it, to prevent accidental overwrites.
 
-```tsx
-import { novu } from './client';
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: 'user-123',
-  },
+  to: { subscriberId: "user-123" },
   payload: {
-    amount: '$250',
-    plan: 'Pro',
+    amount: "$250",
+    plan: "Pro",
   },
   context: {
     tenant: {
-      id: 'acme-corp',
+      id: "acme-corp",
       data: {
-        name: 'Acme Corporation',
-        plan: 'enterprise',
+        name: "Acme Corporation",
+        plan: "enterprise",
       },
     },
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "user-123"},
+        payload={"amount": "$250", "plan": "Pro"},
+        context={
+            "tenant": {
+                "id": "acme-corp",
+                "data": {
+                    "name": "Acme Corporation",
+                    "plan": "enterprise",
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user-123",
+    }),
+    Payload: map[string]any{
+        "amount": "$250",
+        "plan":   "Pro",
+    },
+    Context: map[string]any{
+        "tenant": map[string]any{
+            "id": "acme-corp",
+            "data": map[string]any{
+                "name": "Acme Corporation",
+                "plan": "enterprise",
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: [
+            'amount' => '$250',
+            'plan' => 'Pro',
+        ],
+        context: [
+            'tenant' => [
+                'id' => 'acme-corp',
+                'data' => [
+                    'name' => 'Acme Corporation',
+                    'plan' => 'enterprise',
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "user-123",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "amount", "$250" },
+        { "plan", "Pro" },
+    },
+    Context = new Dictionary<string, object>() {
+        { "tenant", new Dictionary<string, object>() {
+            { "id", "acme-corp" },
+            { "data", new Dictionary<string, object>() {
+                { "name", "Acme Corporation" },
+                { "plan", "enterprise" },
+            } },
+        } },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("user-123")
+            .build()))
+        .payload(Map.ofEntries(
+            Map.entry("amount", "$250"),
+            Map.entry("plan", "Pro")))
+        .context(Map.ofEntries(
+            Map.entry("tenant", TriggerEventRequestDtoContextUnion.of(
+                TriggerEventRequestDtoContext2.builder()
+                    .id("acme-corp")
+                    .data(Map.ofEntries(
+                        Map.entry("name", "Acme Corporation"),
+                        Map.entry("plan", "enterprise")))
+                    .build()))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": { "subscriberId": "user-123" },
+    "payload": {
+        "amount": "$250",
+        "plan": "Pro"
+    },
+    "context": {
+        "tenant": {
+            "id": "acme-corp",
+            "data": {
+                "name": "Acme Corporation",
+                "plan": "enterprise"
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 In this example:
 - The tenant context identifies the organization (“Acme Corporation”).

--- a/docs/platform/integrations/chat.mdx
+++ b/docs/platform/integrations/chat.mdx
@@ -97,7 +97,7 @@ Use the `subscribers.credentials.update` method to store the `webhookUrl` for a 
 Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
@@ -119,8 +119,112 @@ await novu.subscribers.credentials.update(
   "subscriberId"
 );
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.DISCORD,
+            "credentials": {
+                "webhook_url": "<WEBHOOK_URL>",
+            },
+            "integration_identifier": "discord-MnGLxp8uy",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+integrationIdentifier := "discord-MnGLxp8uy"
+webhookURL := "<WEBHOOK_URL>"
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumDiscord,
+    IntegrationIdentifier: &integrationIdentifier,
+    Credentials: components.ChannelCredentials{
+        WebhookURL: &webhookURL,
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->subscribers->updateCredentials(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Discord,
+        credentials: new Components\ChannelCredentials(
+            webhookUrl: '<WEBHOOK_URL>',
+        ),
+        integrationIdentifier: 'discord-MnGLxp8uy',
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.UpdateCredentialsAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Discord,
+        IntegrationIdentifier = "discord-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            WebhookUrl = "<WEBHOOK_URL>",
+        },
+    }
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.subscribers().updateCredentials()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.DISCORD)
+        .integrationIdentifier("discord-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .webhookUrl("<WEBHOOK_URL>")
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
@@ -134,7 +238,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
   "integrationIdentifier": "slack-MnGLxp8uy"
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 ## Supported providers

--- a/docs/platform/integrations/chat/discord.mdx
+++ b/docs/platform/integrations/chat/discord.mdx
@@ -22,44 +22,133 @@ To get started with using Novu's Discord Webhook integration, you need a 'webhoo
 5. After obtaining the webhook URL in the previous step, you need to store it within the subscriber entity. Doing this ensures that Novu knows where (in which discord channel) to send the notification to. Here's how to do it:
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.Discord,
-    credentials: {
-      webhookUrl: "<WEBHOOK_URL>",
-    },
     integrationIdentifier: "discord-MnGLxp8uy",
+    credentials: { webhookUrl: "<WEBHOOK_URL>", },
   },
   "subscriberId"
 );
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.DISCORD,
+            "credentials": {"webhookUrl": "<WEBHOOK_URL>"},
+            "integration_identifier": "discord-MnGLxp8uy",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumDiscord,
+        IntegrationIdentifier: novugo.String("discord-MnGLxp8uy"),
+    Credentials: components.ChannelCredentials{
+        WebhookURL: novugo.String("<WEBHOOK_URL>"),
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Discord,
+        integrationIdentifier: 'discord-MnGLxp8uy',
+        credentials: new Components\ChannelCredentials(
+            webhookUrl: '<WEBHOOK_URL>',
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Discord,
+        IntegrationIdentifier = "discord-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            WebhookUrl = "<WEBHOOK_URL>",
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.DISCORD)
+            .integrationIdentifier("discord-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .webhookUrl("<WEBHOOK_URL>")
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
--H 'Accept: application/json' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "discord",
   "credentials": {
-      "webhookUrl": "<WEBHOOK_URL>"
+    "webhookUrl": "<WEBHOOK_URL>"
   },
   "integrationIdentifier": "discord-MnGLxp8uy"
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.

--- a/docs/platform/integrations/chat/mattermost.mdx
+++ b/docs/platform/integrations/chat/mattermost.mdx
@@ -19,40 +19,261 @@ To integrate Mattermost with your application using the Mattermost Webhook integ
 
 Once you have the webhook URL, you can store it in the subscriber entity in your application. This will allow you to send notifications to Mattermost using the following code:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.Mattermost,
-    credentials: {
-      webhookUrl: "<WEBHOOK_URL>",
-    },
     integrationIdentifier: "mattermost-MnGLxp8uy",
+    credentials: { webhookUrl: "<WEBHOOK_URL>", },
   },
   "subscriberId"
 );
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.MATTERMOST,
+            "credentials": {"webhookUrl": "<WEBHOOK_URL>"},
+            "integration_identifier": "mattermost-MnGLxp8uy",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumMattermost,
+        IntegrationIdentifier: novugo.String("mattermost-MnGLxp8uy"),
+    Credentials: components.ChannelCredentials{
+        WebhookURL: novugo.String("<WEBHOOK_URL>"),
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Mattermost,
+        integrationIdentifier: 'mattermost-MnGLxp8uy',
+        credentials: new Components\ChannelCredentials(
+            webhookUrl: '<WEBHOOK_URL>',
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Mattermost,
+        IntegrationIdentifier = "mattermost-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            WebhookUrl = "<WEBHOOK_URL>",
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.MATTERMOST)
+            .integrationIdentifier("mattermost-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .webhookUrl("<WEBHOOK_URL>")
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "providerId": "mattermost",
+  "credentials": {
+    "webhookUrl": "<WEBHOOK_URL>"
+  },
+  "integrationIdentifier": "mattermost-MnGLxp8uy"
+}'
+```
+  </Tab>
+</Tabs>
 
 ## SDK trigger example
 
 Send a notification to mattermost using the subscriber ID and workflow ID via `@novu/api` sdk
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
+
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: 'subscriberId',
-  },
+  to: { subscriberId: "subscriberId", },
   payload: {
-    message: 'This is a notification from my application!',
-  },
+    "message": "This is a notification from my application!"
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={
+        "message": "This is a notification from my application!"
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+    "message": "This is a notification from my application!"
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: {
+        "message": "This is a notification from my application!"
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+    Payload = {
+    "message": "This is a notification from my application!"
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .payload({
+        "message": "This is a notification from my application!"
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {
+        "message": "This is a notification from my application!"
+    }
+}'
+```
+  </Tab>
+</Tabs>

--- a/docs/platform/integrations/chat/ms-teams.mdx
+++ b/docs/platform/integrations/chat/ms-teams.mdx
@@ -418,19 +418,123 @@ Call this from **your backend** when someone starts the connect flow in your pro
   The generated OAuth URL is valid for only <strong>5 minutes</strong>. Do not cache it — generate a new URL each time someone starts connect.
 </Warning>
 
-```tsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>", });
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 const response = await novu.integrations.generateConnectOAuthUrl({
   integrationIdentifier: 'ms-teams-bot',
-  context: { tenant: 'acme-corp' }, // or subscriberId — at least one is required
-  autoLinkUser: false, // required for tenant-only admin consent (see note below)
+  context: {
+    "tenant": "acme-corp"
+},
+  autoLinkUser: false,
 });
-
-// response.url is the Microsoft admin consent URL
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    response = novu.integrations.generate_connect_o_auth_url(generate_connect_oauth_url_request_dto={
+        "integration_identifier": "ms-teams-bot",
+        "context": {
+        "tenant": "acme-corp"
+},
+        "auto_link_user": False,
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Integrations.GenerateConnectOAuthURL(context.Background(), components.GenerateConnectOauthURLRequestDto{
+    IntegrationIdentifier: "ms-teams-bot",
+    Context: map[string]components.GenerateConnectOauthURLRequestDtoContext{
+        "tenant": components.CreateGenerateConnectOauthURLRequestDtoContextStr("acme-corp"),
+    },
+    AutoLinkUser: novugo.Bool(false),
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+$response = $sdk->integrations->generateConnectOAuthUrl(
+    generateConnectOauthUrlRequestDto: new Components\GenerateConnectOauthUrlRequestDto(
+        integrationIdentifier: 'ms-teams-bot',
+        context: {
+        "tenant": "acme-corp"
+},
+        autoLinkUser: false,
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+var response = await sdk.Integrations.GenerateConnectOAuthUrlAsync(
+    generateConnectOauthUrlRequestDto: new GenerateConnectOauthUrlRequestDto() {
+        IntegrationIdentifier = "ms-teams-bot",
+        Context = {
+    "tenant": "acme-corp"
+},
+        AutoLinkUser = false,
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+var response = novu.integrations().generateConnectOAuthUrl()
+    .body(GenerateConnectOauthUrlRequestDto.builder()
+        .integrationIdentifier("ms-teams-bot")
+        .context({
+        "tenant": "acme-corp"
+})
+        .autoLinkUser(false)
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/integrations/channel-connections/oauth' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "integrationIdentifier": "ms-teams-bot",
+  "context": {
+    "tenant": "acme-corp"
+  },
+  "autoLinkUser": false
+}'
+```
+  </Tab>
+</Tabs>
 
 Call `POST /v1/integrations/channel-connections/oauth` with the same body if you are not using the TypeScript SDK. Authenticate with your Novu **secret key**.
 
@@ -600,13 +704,109 @@ Prerequisites:
 
 Run a **separate** OAuth flow — do not set `autoLinkUser: true` on `generateConnectOAuthUrl`. Use `generateLinkUserOAuthUrl` instead:
 
-```tsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
+
 const response = await novu.integrations.generateLinkUserOAuthUrl({
   integrationIdentifier: 'ms-teams-bot',
-  subscriberId: 'user_123', // must already exist in Novu
-  connectionIdentifier: 'msteams-tenant-acme', // recommended — the connection created by admin consent
+  subscriberId: 'user_123',
+  connectionIdentifier: 'msteams-tenant-acme',
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    response = novu.integrations.generate_link_user_o_auth_url(generate_link_user_oauth_url_request_dto={
+        "integration_identifier": "ms-teams-bot",
+        "subscriber_id": "user_123",
+        "connection_identifier": "msteams-tenant-acme",
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Integrations.GenerateLinkUserOAuthURL(context.Background(), components.GenerateLinkUserOauthURLRequestDto{
+    IntegrationIdentifier: "ms-teams-bot",
+    SubscriberID: "user_123",
+    ConnectionIdentifier: novugo.String("msteams-tenant-acme"),
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+$response = $sdk->integrations->generateLinkUserOAuthUrl(
+    generateLinkUserOauthUrlRequestDto: new Components\GenerateLinkUserOauthUrlRequestDto(
+        integrationIdentifier: 'ms-teams-bot',
+        subscriberId: 'user_123',
+        connectionIdentifier: 'msteams-tenant-acme',
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+var response = await sdk.Integrations.GenerateLinkUserOAuthUrlAsync(
+    generateLinkUserOauthUrlRequestDto: new GenerateLinkUserOauthUrlRequestDto() {
+        IntegrationIdentifier = "ms-teams-bot",
+        SubscriberId = "user_123",
+        ConnectionIdentifier = "msteams-tenant-acme",
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+var response = novu.integrations().generateLinkUserOAuthUrl()
+    .body(GenerateLinkUserOauthUrlRequestDto.builder()
+        .integrationIdentifier("ms-teams-bot")
+        .subscriberId("user_123")
+        .connectionIdentifier("msteams-tenant-acme")
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/integrations/channel-endpoints/oauth' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "integrationIdentifier": "ms-teams-bot",
+  "subscriberId": "user_123",
+  "connectionIdentifier": "msteams-tenant-acme"
+}'
+```
+  </Tab>
+</Tabs>
 
 Call `POST /v1/integrations/channel-endpoints/oauth` with the same body when using the REST API.
 
@@ -721,18 +921,134 @@ The setup begins inside the Microsoft Teams app. Instruct your users to follow t
 
 Unlike the Bot integration, you don't use `ms_teams_channel` here. Instead, you treat this as a generic webhook endpoint. Your app should provide a form where the user can paste the URL they generated in the previous step.
 
-```bash
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
+
 await novu.channelEndpoints.create({
   type: 'webhook',
   identifier: 'teams-workflow-alerts',
   integrationIdentifier: 'ms-teams-workflow',
   subscriberId: 'customer-account-id',
   context: { tenant: 'acme' },
-  endpoint: {
-    url: 'https://prod-00.westeurope.logic.azure.com:443/workflows/...' // workflow URL
-  },
+  endpoint: { url: 'https://prod-00.westeurope.logic.azure.com:443/workflows/...' },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.channel_endpoints.create(request_body={
+        "type": "webhook",
+        "identifier": "teams-workflow-alerts",
+        "integration_identifier": "ms-teams-workflow",
+        "subscriber_id": "customer-account-id",
+        "context": {"tenant": "acme"},
+        "endpoint": {"url": "https://prod-00.westeurope.logic.azure.com:443/workflows/..."},
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+    "github.com/novuhq/novu-go/models/operations"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.ChannelEndpoints.Create(context.Background(), operations.CreateChannelEndpointsControllerCreateChannelEndpointRequestBodyWebhook(
+    components.CreateWebhookEndpointDto{
+        Identifier: novugo.String("teams-workflow-alerts"),
+        IntegrationIdentifier: "ms-teams-workflow",
+        SubscriberID: "customer-account-id",
+        Type: components.CreateWebhookEndpointDtoTypeWebhook,
+        Endpoint: components.WebhookEndpointDto{URL: "https://prod-00.westeurope.logic.azure.com:443/workflows/..."},
+    },
+), nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+$sdk->channelEndpoints->create(
+    requestBody: new Components\CreateWebhookEndpointDto(
+        identifier: 'teams-workflow-alerts',
+        integrationIdentifier: 'ms-teams-workflow',
+        subscriberId: 'customer-account-id',
+        type: Components\CreateWebhookEndpointDtoType::Webhook,
+        endpoint: new Components\WebhookEndpointDto(url: 'https://prod-00.westeurope.logic.azure.com:443/workflows/...'),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+await sdk.ChannelEndpoints.CreateAsync(
+    requestBody: CreateWebhookEndpointDto.CreateWebhook(
+        new CreateWebhookEndpointDto() {
+            Identifier = "teams-workflow-alerts",
+            IntegrationIdentifier = "ms-teams-workflow",
+            SubscriberId = "customer-account-id",
+            Type = CreateWebhookEndpointDtoType.Webhook,
+            Endpoint = new WebhookEndpointDto() { Url = "https://prod-00.westeurope.logic.azure.com:443/workflows/..." },
+        }));
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+novu.channelEndpoints().create()
+    .requestBody(CreateWebhookEndpointDto.builder()
+        .identifier("teams-workflow-alerts")
+        .integrationIdentifier("ms-teams-workflow")
+        .subscriberId("customer-account-id")
+        .type(CreateWebhookEndpointDtoType.WEBHOOK)
+        .endpoint(WebhookEndpointDto.builder().url("https://prod-00.westeurope.logic.azure.com:443/workflows/...").build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/channel-endpoints' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "type": "webhook",
+  "identifier": "teams-workflow-alerts",
+  "integrationIdentifier": "ms-teams-workflow",
+  "subscriberId": "customer-account-id",
+  "context": {
+    "tenant": "acme"
+  },
+  "endpoint": {
+    "url": "https://prod-00.westeurope.logic.azure.com:443/workflows/..."
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Sending the notification
 

--- a/docs/platform/integrations/chat/slack.mdx
+++ b/docs/platform/integrations/chat/slack.mdx
@@ -173,23 +173,111 @@ This URL is specific to the Subscriber or the Context (Tenant) it will be genera
   The generated OAuth URL is valid for only <strong>5 minutes</strong>. Do not cache this URL; generate it dynamically when the user initiates the flow.
 </Warning>
 
-```tsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>", });
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
-// This function should be called by your API when the user requests to connect
-async function getSlackUrl(user, orgId) {
-  
-  const oauthUrl = await novu.integrations.generateChatOAuthUrl({
-    integrationIdentifier: 'slack',
-    subscriberId: user.id,           // The ID of the user performing the action
-    context: { tenant: orgId },      // The tenant/workspace context
-  });
-
-return oauthUrl;
-}
+const response = await novu.integrations.generateChatOAuthUrl({
+  integrationIdentifier: 'slack',
+  subscriberId: 'subscriberId',
+  context: {
+    "tenant": "orgId"
+},
+});
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    response = novu.integrations.generate_chat_o_auth_url(generate_chat_oauth_url_request_dto={
+        "integration_identifier": "slack",
+        "subscriber_id": "subscriberId",
+        context={
+        "tenant": "orgId"
+},
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Integrations.GenerateChatOAuthURL(context.Background(), components.GenerateChatOauthURLRequestDto{
+    IntegrationIdentifier: "slack",
+    SubscriberID: novugo.String("subscriberId"),
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+$response = $sdk->integrations->generateChatOAuthUrl(
+    generateChatOauthUrlRequestDto: new Components\GenerateChatOauthUrlRequestDto(
+        integrationIdentifier: 'slack',
+        subscriberId: 'subscriberId',
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+var response = await sdk.Integrations.GenerateChatOAuthUrlAsync(
+    generateChatOauthUrlRequestDto: new GenerateChatOauthUrlRequestDto() {
+        IntegrationIdentifier = "slack",
+        SubscriberId = "subscriberId",
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+var response = novu.integrations().generateChatOAuthUrl()
+    .body(GenerateChatOauthUrlRequestDto.builder()
+        .integrationIdentifier("slack")
+        .subscriberId("subscriberId")
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/integrations/chat/oauth' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "integrationIdentifier": "slack",
+  "subscriberId": "subscriberId",
+  "context": {
+    "tenant": "orgId"
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 Your application can support multiple Slack workspace connections per user or per tenant by triggering separate OAuth flows.
 
@@ -255,18 +343,134 @@ To learn more about using [Slack conversations API](https://docs.slack.dev/apis/
 <Step title="Create the endpoint">
     **Create the endpoint**: Once the user selects a channel, save it as an endpoint in Novu.
 
-```tsx
-    await novu.channelEndpoints.create({
-      subscriberId: 'user-123',
-      integrationIdentifier: 'slack',
-      connectionIdentifier: 'conn_slack_acme', // The identifier of the connection created in Step 2
-      context: { tenant: 'acme' },
-      type: 'slack_channel',                   // TYPE: Channel
-      endpoint: {
-        channelId: 'C012345'                   // Slack channel ID of the channel selected by the user
-      }
-    });
-    ```
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
+
+await novu.channelEndpoints.create({
+  subscriberId: 'user-123',
+  integrationIdentifier: 'slack',
+  connectionIdentifier: 'conn_slack_acme',
+  context: { tenant: 'acme' },
+  type: 'slack_channel',
+  endpoint: { channelId: 'C012345' },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.channel_endpoints.create(request_body={
+        "subscriber_id": "user-123",
+        "integration_identifier": "slack",
+        "connection_identifier": "conn_slack_acme",
+        "context": {"tenant": "acme"},
+        "type": "slack_channel",
+        "endpoint": {"channel_id": "C012345"},
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+    "github.com/novuhq/novu-go/models/operations"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.ChannelEndpoints.Create(context.Background(), operations.CreateChannelEndpointsControllerCreateChannelEndpointRequestBodySlackChannel(
+    components.CreateSlackChannelEndpointDto{
+        SubscriberID: "user-123",
+        IntegrationIdentifier: "slack",
+        ConnectionIdentifier: novugo.String("conn_slack_acme"),
+        Type: components.CreateSlackChannelEndpointDtoTypeSlackChannel,
+        Endpoint: components.SlackChannelEndpointDto{ChannelID: "C012345"},
+    },
+), nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+$sdk->channelEndpoints->create(
+    requestBody: new Components\CreateSlackChannelEndpointDto(
+        subscriberId: 'user-123',
+        integrationIdentifier: 'slack',
+        connectionIdentifier: 'conn_slack_acme',
+        type: Components\CreateSlackChannelEndpointDtoType::SlackChannel,
+        endpoint: new Components\SlackChannelEndpointDto(channelId: 'C012345'),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+await sdk.ChannelEndpoints.CreateAsync(
+    requestBody: CreateSlackChannelEndpointDto.CreateSlackChannel(
+        new CreateSlackChannelEndpointDto() {
+            SubscriberId = "user-123",
+            IntegrationIdentifier = "slack",
+            ConnectionIdentifier = "conn_slack_acme",
+            Type = CreateSlackChannelEndpointDtoType.SlackChannel,
+            Endpoint = new SlackChannelEndpointDto() { ChannelId = "C012345" },
+        }));
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+novu.channelEndpoints().create()
+    .requestBody(CreateSlackChannelEndpointDto.builder()
+        .subscriberId("user-123")
+        .integrationIdentifier("slack")
+        .connectionIdentifier("conn_slack_acme")
+        .type(CreateSlackChannelEndpointDtoType.SLACK_CHANNEL)
+        .endpoint(SlackChannelEndpointDto.builder().channelId("C012345").build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/channel-endpoints' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "subscriberId": "user-123",
+  "integrationIdentifier": "slack",
+  "connectionIdentifier": "conn_slack_acme",
+  "context": {
+    "tenant": "acme"
+  },
+  "type": "slack_channel",
+  "endpoint": {
+    "channelId": "C012345"
+  }
+}'
+```
+  </Tab>
+</Tabs>
   </Step>
 </Steps>
 
@@ -292,18 +496,134 @@ To learn more about using [Slack `users.list` method](https://docs.slack.dev/ref
 <Step title="Create the endpoint">
     Create the endpoint: Save the returned User ID as the endpoint.
 
-```tsx
-    await novu.channelEndpoints.create({
-      type: 'slack_user',
-      subscriberId: 'user-123',
-      integrationIdentifier: 'slack',
-      connectionIdentifier: 'conn_slack_acme',
-      context: { tenant: 'acme' },
-      endpoint: {
-        userId: 'U01234567',                  // Slack user ID
-      },
-    });
-    ```
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
+
+await novu.channelEndpoints.create({
+  type: 'slack_user',
+  subscriberId: 'user-123',
+  integrationIdentifier: 'slack',
+  connectionIdentifier: 'conn_slack_acme',
+  context: { tenant: 'acme' },
+  endpoint: { userId: 'U01234567' },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.channel_endpoints.create(request_body={
+        "type": "slack_user",
+        "subscriber_id": "user-123",
+        "integration_identifier": "slack",
+        "connection_identifier": "conn_slack_acme",
+        "context": {"tenant": "acme"},
+        "endpoint": {"user_id": "U01234567"},
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+    "github.com/novuhq/novu-go/models/operations"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.ChannelEndpoints.Create(context.Background(), operations.CreateChannelEndpointsControllerCreateChannelEndpointRequestBodySlackUser(
+    components.CreateSlackUserEndpointDto{
+        SubscriberID: "user-123",
+        IntegrationIdentifier: "slack",
+        ConnectionIdentifier: novugo.String("conn_slack_acme"),
+        Type: components.CreateSlackUserEndpointDtoTypeSlackUser,
+        Endpoint: components.SlackUserEndpointDto{UserID: "U01234567"},
+    },
+), nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+$sdk->channelEndpoints->create(
+    requestBody: new Components\CreateSlackUserEndpointDto(
+        subscriberId: 'user-123',
+        integrationIdentifier: 'slack',
+        connectionIdentifier: 'conn_slack_acme',
+        type: Components\CreateSlackUserEndpointDtoType::SlackUser,
+        endpoint: new Components\SlackUserEndpointDto(userId: 'U01234567'),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+await sdk.ChannelEndpoints.CreateAsync(
+    requestBody: CreateSlackUserEndpointDto.CreateSlackUser(
+        new CreateSlackUserEndpointDto() {
+            SubscriberId = "user-123",
+            IntegrationIdentifier = "slack",
+            ConnectionIdentifier = "conn_slack_acme",
+            Type = CreateSlackUserEndpointDtoType.SlackUser,
+            Endpoint = new SlackUserEndpointDto() { UserId = "U01234567" },
+        }));
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+novu.channelEndpoints().create()
+    .requestBody(CreateSlackUserEndpointDto.builder()
+        .subscriberId("user-123")
+        .integrationIdentifier("slack")
+        .connectionIdentifier("conn_slack_acme")
+        .type(CreateSlackUserEndpointDtoType.SLACK_USER)
+        .endpoint(SlackUserEndpointDto.builder().userId("U01234567").build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/channel-endpoints' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "type": "slack_user",
+  "subscriberId": "user-123",
+  "integrationIdentifier": "slack",
+  "connectionIdentifier": "conn_slack_acme",
+  "context": {
+    "tenant": "acme"
+  },
+  "endpoint": {
+    "userId": "U01234567"
+  }
+}'
+```
+  </Tab>
+</Tabs>
   </Step>
 </Steps>
 
@@ -335,23 +655,158 @@ You don’t need to collect `channelId` yourself in this mode, Slack’s native 
 
 Once you have at least one Slack connection, and one or more Slack endpoints. You can trigger the workflow:
 
-```jsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>", });
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
-  name: 'order-shipped',
-  to: {
-    subscriberId: 'user-123',
-  },
-  context: { tenant: 'acme' },       // optional routing context
+  workflowId: "order-shipped",
+  to: { subscriberId: "user-123", },
   payload: {
-    orderNumber: 'ORD-12345',
-    trackingUrl: 'https://acme.com/track/123',
-  },
+    "orderNumber": "ORD-12345",
+    "trackingUrl": "https://acme.com/track/123"
+},
+  context: {
+    "tenant": "acme"
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="order-shipped",
+        to={"subscriber_id": "user-123"},
+        payload={
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+},
+        context={
+        "tenant": "acme"
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "order-shipped",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user-123",
+    }),
+    Payload: map[string]any{
+    "orderNumber": "ORD-12345",
+    "trackingUrl": "https://acme.com/track/123"
+},
+    Context: map[string]any{
+    "tenant": "acme"
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'order-shipped',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: {
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+},
+        context: {
+        "tenant": "acme"
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "order-shipped",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "user-123" }),
+    Payload = {
+    "orderNumber": "ORD-12345",
+    "trackingUrl": "https://acme.com/track/123"
+},
+    Context = {
+    "tenant": "acme"
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("order-shipped")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("user-123").build()))
+        .payload({
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+})
+        .context({
+        "tenant": "acme"
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "order-shipped",
+    "to": [
+        "user-123"
+    ],
+    "payload": {
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+    },
+    "context": {
+        "tenant": "acme"
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 When the workflow is triggered, Novu will:
 

--- a/docs/platform/integrations/chat/telegram.mdx
+++ b/docs/platform/integrations/chat/telegram.mdx
@@ -84,7 +84,90 @@ Novu gives you a link that opens your bot in Telegram. When the subscriber taps 
 Request a connection URL from your server when the subscriber chooses to connect Telegram:
 
 <Tabs>
-<Tab title="cURL">
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: '<NOVU_SECRET_KEY>' });
+
+const response = await novu.integrations.linkChannelEndpoint({
+  integrationIdentifier: 'telegram',
+  subscriberId: '<SUBSCRIBER_ID>',
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    response = novu.integrations.link_channel_endpoint(link_channel_endpoint_request_dto={
+        "integration_identifier": "telegram",
+        "subscriber_id": "<SUBSCRIBER_ID>",
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Integrations.LinkChannelEndpoint(context.Background(), components.LinkChannelEndpointRequestDto{
+    IntegrationIdentifier: "telegram",
+    SubscriberID: "<SUBSCRIBER_ID>",
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+$response = $sdk->integrations->linkChannelEndpoint(
+    linkChannelEndpointRequestDto: new Components\LinkChannelEndpointRequestDto(
+        integrationIdentifier: 'telegram',
+        subscriberId: '<SUBSCRIBER_ID>',
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+var response = await sdk.Integrations.LinkChannelEndpointAsync(
+    linkChannelEndpointRequestDto: new LinkChannelEndpointRequestDto() {
+        IntegrationIdentifier = "telegram",
+        SubscriberId = "<SUBSCRIBER_ID>",
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+var response = novu.integrations().linkChannelEndpoint()
+    .body(LinkChannelEndpointRequestDto.builder()
+        .integrationIdentifier("telegram")
+        .subscriberId("<SUBSCRIBER_ID>")
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X POST 'https://api.novu.co/v1/integrations/channel-endpoints/link' \
 -H 'Content-Type: application/json' \
@@ -94,7 +177,7 @@ curl -L -X POST 'https://api.novu.co/v1/integrations/channel-endpoints/link' \
   "subscriberId": "<SUBSCRIBER_ID>"
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 Open the returned `url` in a new tab or show it as a button in your UI. Generate a fresh link each time the subscriber starts the flow — links expire after a short time.
@@ -142,20 +225,137 @@ Once subscribers have connected Telegram, add a **Chat** step to a workflow and 
   </Step>
 </Steps>
 
-```tsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({ secretKey: '<YOUR_SECRET_KEY_HERE>' });
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
-  workflowId: 'order-shipped',
-  to: { subscriberId: 'user-123' },
+  workflowId: "order-shipped",
+  to: { subscriberId: "user-123", },
   payload: {
-    orderNumber: 'ORD-12345',
-    trackingUrl: 'https://acme.com/track/123',
-  },
+    "orderNumber": "ORD-12345",
+    "trackingUrl": "https://acme.com/track/123"
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="order-shipped",
+        to={"subscriber_id": "user-123"},
+        payload={
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "order-shipped",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user-123",
+    }),
+    Payload: map[string]any{
+    "orderNumber": "ORD-12345",
+    "trackingUrl": "https://acme.com/track/123"
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'order-shipped',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: {
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "order-shipped",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "user-123" }),
+    Payload = {
+    "orderNumber": "ORD-12345",
+    "trackingUrl": "https://acme.com/track/123"
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("order-shipped")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("user-123").build()))
+        .payload({
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "order-shipped",
+    "to": [
+        "user-123"
+    ],
+    "payload": {
+        "orderNumber": "ORD-12345",
+        "trackingUrl": "https://acme.com/track/123"
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 Novu finds the subscriber's linked Telegram chat, renders the message, and sends it through your bot. Verify delivery in **Activity** or in Telegram.
 

--- a/docs/platform/integrations/chat/whats-app.mdx
+++ b/docs/platform/integrations/chat/whats-app.mdx
@@ -96,33 +96,188 @@ After your template is approved, you can use the `template_name` to send notific
 
 To send a notification with a template, you will need to add the following to the `overrides` field:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-    phone: '+11111111111',
-  },
+  to: { subscriberId: "subscriberId",
+    phone: "+11111111111", },
   payload: {},
   overrides: {
-    chat: {
-      template: {
-        name: 'template_name',
-        language: {
-          code: 'en_US',
-        },
-      },
-    },
-  },
+    "chat": {
+        "template": {
+            "name": "template_name",
+            "language": {
+                "code": "en_US"
+            }
+        }
+    }
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId", "phone": "+11111111111"},
+        payload={},
+        overrides={
+        "chat": {
+                "template": {
+                        "name": "template_name",
+                        "language": {
+                                "code": "en_US"
+                        }
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+            Phone: novugo.String("+11111111111"),
+    }),
+    Payload: map[string]any{},
+    Overrides: map[string]any{
+    "chat": {
+        "template": {
+            "name": "template_name",
+            "language": {
+                "code": "en_US"
+            }
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId', phone: '+11111111111'),
+        payload: {},
+        overrides: {
+        "chat": {
+                "template": {
+                        "name": "template_name",
+                        "language": {
+                                "code": "en_US"
+                        }
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId", Phone = "+11111111111" }),
+    Payload = {},
+    Overrides = {
+    "chat": {
+        "template": {
+            "name": "template_name",
+            "language": {
+                "code": "en_US"
+            }
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").phone("+11111111111").build()))
+        .payload({})
+        .overrides({
+        "chat": {
+                "template": {
+                        "name": "template_name",
+                        "language": {
+                                "code": "en_US"
+                        }
+                }
+        }
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId",
+        "phone": "+11111111111"
+    },
+    "payload": {},
+    "overrides": {
+        "chat": {
+            "template": {
+                "name": "template_name",
+                "language": {
+                    "code": "en_US"
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 </Step>
 </Steps>

--- a/docs/platform/integrations/chat/zulip.mdx
+++ b/docs/platform/integrations/chat/zulip.mdx
@@ -39,45 +39,133 @@ The URL generated above will be the target channel of a subscriber that you want
 ## Update credential webhookUrl
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.Zulip,
-    credentials: {
-      webhookUrl: "<WEBHOOK_URL>",
-    },
     integrationIdentifier: "zulip-MnGLxp8uy",
+    credentials: { webhookUrl: "<WEBHOOK_URL>", },
   },
   "subscriberId"
 );
-
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.ZULIP,
+            "credentials": {"webhookUrl": "<WEBHOOK_URL>"},
+            "integration_identifier": "zulip-MnGLxp8uy",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumZulip,
+        IntegrationIdentifier: novugo.String("zulip-MnGLxp8uy"),
+    Credentials: components.ChannelCredentials{
+        WebhookURL: novugo.String("<WEBHOOK_URL>"),
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Zulip,
+        integrationIdentifier: 'zulip-MnGLxp8uy',
+        credentials: new Components\ChannelCredentials(
+            webhookUrl: '<WEBHOOK_URL>',
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Zulip,
+        IntegrationIdentifier = "zulip-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            WebhookUrl = "<WEBHOOK_URL>",
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.ZULIP)
+            .integrationIdentifier("zulip-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .webhookUrl("<WEBHOOK_URL>")
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
--H 'Accept: application/json' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "zulip",
   "credentials": {
-      "webhookUrl": "<WEBHOOK_URL>"
+    "webhookUrl": "<WEBHOOK_URL>"
   },
   "integrationIdentifier": "zulip-MnGLxp8uy"
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 - `subscriberId` is a custom identifier used when identifying your users within the Novu platform.

--- a/docs/platform/integrations/email.mdx
+++ b/docs/platform/integrations/email.mdx
@@ -94,9 +94,9 @@ You can send attachments by passing an `attachments` array in the `payload` of y
 There is a total limit of 20MB for all attachments included in an email.
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```javascript
-import { Novu } from '@novu/api';  
+import { Novu } from '@novu/api';
 
 const novu = new Novu({
   secretKey: "<NOVU_SECRET_KEY>",
@@ -127,9 +127,161 @@ await novu.trigger({
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
 
-</Tab>
-<Tab title="cURL">
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={
+            "attachments": [
+                {
+                    "file": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNkYPhfz0AEYBxVSF+FAP5FDvcfRYWgAAAAAElFTkSuQmCC",
+                    "name": "blue.png",
+                    "mime": "image/png",
+                },
+                {
+                    "file": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII",
+                    "name": "transparent.png",
+                    "mime": "image/png",
+                },
+            ],
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+        "attachments": []map[string]any{
+            {
+                "file": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNkYPhfz0AEYBxVSF+FAP5FDvcfRYWgAAAAAElFTkSuQmCC",
+                "name": "blue.png",
+                "mime": "image/png",
+            },
+            {
+                "file": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII",
+                "name": "transparent.png",
+                "mime": "image/png",
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: [
+            'attachments' => [
+                [
+                    'file' => 'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNkYPhfz0AEYBxVSF+FAP5FDvcfRYWgAAAAAElFTkSuQmCC',
+                    'name' => 'blue.png',
+                    'mime' => 'image/png',
+                ],
+                [
+                    'file' => 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII',
+                    'name' => 'transparent.png',
+                    'mime' => 'image/png',
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "attachments", new List<Dictionary<string, object>>() {
+            new Dictionary<string, object>() {
+                { "file", "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNkYPhfz0AEYBxVSF+FAP5FDvcfRYWgAAAAAElFTkSuQmCC" },
+                { "name", "blue.png" },
+                { "mime", "image/png" },
+            },
+            new Dictionary<string, object>() {
+                { "file", "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII" },
+                { "name", "transparent.png" },
+                { "mime", "image/png" },
+            },
+        } },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .build()))
+        .payload(Map.of(
+            "attachments", List.of(
+                Map.of(
+                    "file", "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNkYPhfz0AEYBxVSF+FAP5FDvcfRYWgAAAAAElFTkSuQmCC",
+                    "name", "blue.png",
+                    "mime", "image/png"),
+                Map.of(
+                    "file", "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII",
+                    "name", "transparent.png",
+                    "mime", "image/png"))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 Use https://eu.api.novu.co/v1/events/trigger api endpoint for the EU region.
 ```bash
 curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
@@ -160,7 +312,7 @@ curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
     }
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 ### Sending email overrides
@@ -176,7 +328,7 @@ You can override the email settings for a single trigger by passing an `override
 - `to` address
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```javascript
 import { Novu } from '@novu/api';
 
@@ -204,7 +356,173 @@ await novu.trigger({
   },
 });
 ```
-</Tab>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        overrides={
+            "email": {
+                "to": ["to@novu.co"],
+                "from": "from@novu.co",
+                "senderName": "Novu Team",
+                "text": "text version of email using overrides",
+                "replyTo": "no-reply@novu.co",
+                "cc": ["1@novu.co"],
+                "bcc": ["2@novu.co"],
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Overrides: map[string]map[string]any{
+        "email": {
+            "to":         []string{"to@novu.co"},
+            "from":       "from@novu.co",
+            "senderName": "Novu Team",
+            "text":       "text version of email using overrides",
+            "replyTo":    "no-reply@novu.co",
+            "cc":         []string{"1@novu.co"},
+            "bcc":        []string{"2@novu.co"},
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        overrides: [
+            'email' => [
+                'to' => ['to@novu.co'],
+                'from' => 'from@novu.co',
+                'senderName' => 'Novu Team',
+                'text' => 'text version of email using overrides',
+                'replyTo' => 'no-reply@novu.co',
+                'cc' => ['1@novu.co'],
+                'bcc' => ['2@novu.co'],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+    }),
+    Overrides = new Overrides() {
+        Email = new Dictionary<string, object>() {
+            { "to", new List<string>() { "to@novu.co" } },
+            { "from", "from@novu.co" },
+            { "senderName", "Novu Team" },
+            { "text", "text version of email using overrides" },
+            { "replyTo", "no-reply@novu.co" },
+            { "cc", new List<string>() { "1@novu.co" } },
+            { "bcc", new List<string>() { "2@novu.co" } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .build()))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .email(Map.of(
+                "to", List.of("to@novu.co"),
+                "from", "from@novu.co",
+                "senderName", "Novu Team",
+                "text", "text version of email using overrides",
+                "replyTo", "no-reply@novu.co",
+                "cc", List.of("1@novu.co"),
+                "bcc", List.of("2@novu.co")))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId"
+    },
+    "overrides": {
+        "email": {
+            "to": ["to@novu.co"],
+            "from": "from@novu.co",
+            "senderName": "Novu Team",
+            "text": "text version of email using overrides",
+            "replyTo": "no-reply@novu.co",
+            "cc": ["1@novu.co"],
+            "bcc": ["2@novu.co"]
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 <Note>
@@ -228,7 +546,7 @@ By default, Novu uses your primary email provider. However, if you want to bypas
 This is useful if you have multiple active integrations for different purposes. For example, you might have one integration for transactional emails and one for marketing emails. You can find the `integrationIdentifier` for each provider in provider page in the **Integration Store**.
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```javascript
 import { Novu } from '@novu/api';
 
@@ -250,7 +568,135 @@ await novu.trigger({
   },
 });
 ```
-</Tab>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        overrides={
+            "email": {
+                "integrationIdentifier": "brevo-abcdef",
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Overrides: map[string]map[string]any{
+        "email": {
+            "integrationIdentifier": "brevo-abcdef",
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        overrides: [
+            'email' => [
+                'integrationIdentifier' => 'brevo-abcdef',
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+    }),
+    Overrides = new Overrides() {
+        Email = new Dictionary<string, object>() {
+            { "integrationIdentifier", "brevo-abcdef" },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .build()))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .email(Map.of("integrationIdentifier", "brevo-abcdef"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId"
+    },
+    "overrides": {
+        "email": {
+            "integrationIdentifier": "brevo-abcdef"
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 ### Overriding email layout 
@@ -274,7 +720,7 @@ Each Novu environment can have multiple layouts. Each email step in the workflow
 4. **Environment default layout** - **Lowest priority**
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
@@ -314,7 +760,204 @@ await novu.trigger({
   }
 });
 ```
-</Tab>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={},
+        overrides={
+            "channels": {
+                "email": {
+                    "layoutId": "black-friday-layout",
+                },
+            },
+            "steps": {
+                "welcome-email": {
+                    "layoutId": "welcome-v2",
+                },
+                "promotional-email": {},
+                "transactional-receipt": {
+                    "layoutId": None,
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{},
+    Overrides: map[string]map[string]any{
+        "channels": {
+            "email": map[string]any{
+                "layoutId": "black-friday-layout",
+            },
+        },
+        "steps": map[string]any{
+            "welcome-email": map[string]any{
+                "layoutId": "welcome-v2",
+            },
+            "promotional-email": map[string]any{},
+            "transactional-receipt": map[string]any{
+                "layoutId": nil,
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: [],
+        overrides: [
+            'channels' => [
+                'email' => [
+                    'layoutId' => 'black-friday-layout',
+                ],
+            ],
+            'steps' => [
+                'welcome-email' => [
+                    'layoutId' => 'welcome-v2',
+                ],
+                'promotional-email' => [],
+                'transactional-receipt' => [
+                    'layoutId' => null,
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+    }),
+    Payload = new Dictionary<string, object>(),
+    Overrides = new Overrides() {
+        Channels = new Channels() {
+            Email = new EmailChannelOverrides() {
+                LayoutId = "black-friday-layout",
+            },
+        },
+        Steps = new Dictionary<string, StepsOverrides>() {
+            { "welcome-email", new StepsOverrides() { LayoutId = "welcome-v2" } },
+            { "promotional-email", new StepsOverrides() },
+            { "transactional-receipt", new StepsOverrides() { LayoutId = null } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .build()))
+        .payload(Map.of())
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .channels(Channels.builder()
+                .email(EmailChannelOverrides.builder()
+                    .layoutId("black-friday-layout")
+                    .build())
+                .build())
+            .steps(Map.of(
+                "welcome-email", StepsOverrides.builder()
+                    .layoutId("welcome-v2")
+                    .build(),
+                "promotional-email", StepsOverrides.builder().build(),
+                "transactional-receipt", StepsOverrides.builder()
+                    .layoutId(null)
+                    .build()))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId"
+    },
+    "payload": {},
+    "overrides": {
+        "channels": {
+            "email": {
+                "layoutId": "black-friday-layout"
+            }
+        },
+        "steps": {
+            "welcome-email": {
+                "layoutId": "welcome-v2"
+            },
+            "promotional-email": {},
+            "transactional-receipt": {
+                "layoutId": null
+            }
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 ### Sending provider specific extra fields
@@ -322,7 +965,7 @@ await novu.trigger({
 You can send provider specific extra fields by passing a `_passthrough` object in the `overrides` object. This lets you send extra fields to the provider SDK. Novu internally uses provider's official SDK to send the email. Each provider has its own supported extra fields. Those extra fields are not validated by Novu and are passed directly to the provider SDK. There are three type of fields that you can send: `body`, `headers`, and `query`. Below is an example of sending `tags` supported by [Resend provider](/platform/integrations/email/resend).
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
@@ -362,7 +1005,238 @@ await novu.trigger({
   }
 });
 ```
-</Tab>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={},
+        overrides={
+            "providers": {
+                "resend": {
+                    "_passthrough": {
+                        "body": {
+                            "tags": [
+                                {
+                                    "name": "category",
+                                    "value": "confirm_email",
+                                },
+                            ],
+                        },
+                        "headers": {
+                            "X-Custom-Header": "custom-header-value",
+                        },
+                        "query": {
+                            "queryParam": "queryValue",
+                        },
+                    },
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{},
+    Overrides: map[string]map[string]any{
+        "providers": {
+            "resend": map[string]any{
+                "_passthrough": map[string]any{
+                    "body": map[string]any{
+                        "tags": []map[string]any{
+                            {
+                                "name":  "category",
+                                "value": "confirm_email",
+                            },
+                        },
+                    },
+                    "headers": map[string]any{
+                        "X-Custom-Header": "custom-header-value",
+                    },
+                    "query": map[string]any{
+                        "queryParam": "queryValue",
+                    },
+                },
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: [],
+        overrides: [
+            'providers' => [
+                'resend' => [
+                    '_passthrough' => [
+                        'body' => [
+                            'tags' => [
+                                [
+                                    'name' => 'category',
+                                    'value' => 'confirm_email',
+                                ],
+                            ],
+                        ],
+                        'headers' => [
+                            'X-Custom-Header' => 'custom-header-value',
+                        ],
+                        'query' => [
+                            'queryParam' => 'queryValue',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+    }),
+    Payload = new Dictionary<string, object>(),
+    Overrides = new Overrides() {
+        Providers = new Dictionary<string, Dictionary<string, object>>() {
+            { "resend", new Dictionary<string, object>() {
+                { "_passthrough", new Dictionary<string, object>() {
+                    { "body", new Dictionary<string, object>() {
+                        { "tags", new List<Dictionary<string, object>>() {
+                            new Dictionary<string, object>() {
+                                { "name", "category" },
+                                { "value", "confirm_email" },
+                            },
+                        } },
+                    } },
+                    { "headers", new Dictionary<string, object>() {
+                        { "X-Custom-Header", "custom-header-value" },
+                    } },
+                    { "query", new Dictionary<string, object>() {
+                        { "queryParam", "queryValue" },
+                    } },
+                } },
+            } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .build()))
+        .payload(Map.of())
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .providers(Map.of(
+                "resend", Map.of(
+                    "_passthrough", Map.of(
+                        "body", Map.of(
+                            "tags", List.of(
+                                Map.of(
+                                    "name", "category",
+                                    "value", "confirm_email"))),
+                        "headers", Map.of(
+                            "X-Custom-Header", "custom-header-value"),
+                        "query", Map.of(
+                            "queryParam", "queryValue")))))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId"
+    },
+    "payload": {},
+    "overrides": {
+        "providers": {
+            "resend": {
+                "_passthrough": {
+                    "body": {
+                        "tags": [
+                            {
+                                "name": "category",
+                                "value": "confirm_email"
+                            }
+                        ]
+                    },
+                    "headers": {
+                        "X-Custom-Header": "custom-header-value"
+                    },
+                    "query": {
+                        "queryParam": "queryValue"
+                    }
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 ## Unsubscribe email 

--- a/docs/platform/integrations/email/mailersend.mdx
+++ b/docs/platform/integrations/email/mailersend.mdx
@@ -31,110 +31,247 @@ Novu has its own email editor for writing email template. If you want to use pre
 </Note>
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: "subscriberId",
+  to: { subscriberId: "subscriberId", },
   payload: {},
   overrides: {
-    email: {
-      customData: {
-        // mailersend template templateId 
-        templateId: "mailersend-template-id",
-        // mailersend template variables 
-        personalization: [{
-          email: 'recipient@email.com',
-          data: {
-            items: {
-              price: '',
-              product: '',
-              quantity: '',
-            },
-            order: {
-              date: '',
-              order_number: '',
-              billing_address: '',
-              customer_message: '',
-            },
-            store: {
-              name: '',
-            },
-            invoice: {
-              total: '',
-              subtotal: '',
-              pay_method: '',
-            },
-            customer: {
-              name: '',
-              email: '',
-              phone: '',
-            },
-          },
-        }, ],
-      },
-    }
-  },
-});
-```
-</Tab>
-<Tab title="cURL">
-```bash
-curl --location 'https://api.novu.co/v1/events/trigger' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
---data '{
-    "name": "workflowIdentifier",
-    "to":  ["subscriberId"],
-    "payload": {},
-    "overrides": {
-        "email": {
-            "customData": {
-                "templateId": "mailersend-template-id",
-                "personalization": [{
+    "email": {
+        "customData": {
+            "templateId": "mailersend-template-id",
+            "personalization": [
+                {
                     "email": "recipient@email.com",
                     "data": {
                         "items": {
                             "price": "",
                             "product": "",
                             "quantity": ""
-                        },
-                        "order": {
-                            "date": "",
-                            "order_number": "",
-                            "billing_address": "",
-                            "customer_message": ""
-                        },
-                        "store": {
-                            "name": ""
-                        },
-                        "invoice": {
-                            "total": "",
-                            "subtotal": "",
-                            "pay_method": ""
-                        },
-                        "customer": {
-                            "name": "",
-                            "email": "",
-                            "phone": ""
                         }
                     }
-                }]
+                }
+            ]
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={},
+        overrides={
+        "email": {
+                "customData": {
+                        "templateId": "mailersend-template-id",
+                        "personalization": [
+                                {
+                                        "email": "recipient@email.com",
+                                        "data": {
+                                                "items": {
+                                                        "price": "",
+                                                        "product": "",
+                                                        "quantity": ""
+                                                }
+                                        }
+                                }
+                        ]
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{},
+    Overrides: map[string]any{
+    "email": {
+        "customData": {
+            "templateId": "mailersend-template-id",
+            "personalization": [
+                {
+                    "email": "recipient@email.com",
+                    "data": {
+                        "items": {
+                            "price": "",
+                            "product": "",
+                            "quantity": ""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: {},
+        overrides: {
+        "email": {
+                "customData": {
+                        "templateId": "mailersend-template-id",
+                        "personalization": [
+                                {
+                                        "email": "recipient@email.com",
+                                        "data": {
+                                                "items": {
+                                                        "price": "",
+                                                        "product": "",
+                                                        "quantity": ""
+                                                }
+                                        }
+                                }
+                        ]
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+    Payload = {},
+    Overrides = {
+    "email": {
+        "customData": {
+            "templateId": "mailersend-template-id",
+            "personalization": [
+                {
+                    "email": "recipient@email.com",
+                    "data": {
+                        "items": {
+                            "price": "",
+                            "product": "",
+                            "quantity": ""
+                        }
+                    }
+                }
+            ]
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .payload({})
+        .overrides({
+        "email": {
+                "customData": {
+                        "templateId": "mailersend-template-id",
+                        "personalization": [
+                                {
+                                        "email": "recipient@email.com",
+                                        "data": {
+                                                "items": {
+                                                        "price": "",
+                                                        "product": "",
+                                                        "quantity": ""
+                                                }
+                                        }
+                                }
+                        ]
+                }
+        }
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {},
+    "overrides": {
+        "email": {
+            "customData": {
+                "templateId": "mailersend-template-id",
+                "personalization": [
+                    {
+                        "email": "recipient@email.com",
+                        "data": {
+                            "items": {
+                                "price": "",
+                                "product": "",
+                                "quantity": ""
+                            }
+                        }
+                    }
+                ]
             }
         }
     }
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 ## Next Steps

--- a/docs/platform/integrations/email/sendgrid.mdx
+++ b/docs/platform/integrations/email/sendgrid.mdx
@@ -64,62 +64,212 @@ Novu has its own email editor for writing email template. To send pre-made templ
 </Note>
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
-import {
-  Novu
-} from "@novu/api";
+import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-  },
+  to: { subscriberId: "subscriberId", },
   payload: {},
   overrides: {
-    providers: {
-      sendgrid: {
-        templateId: "d-d965b02b1b5d4856bf332a5e98c7470c",
-        dynamicTemplateData: {
-          total: "$ 239.85",
-          items: [{
-            text: "New Line Sneakers",
-            image: "https://marketing-image-production.s3.amazonaws.com/uploads/8dda1131320a6d978b515cc04ed479df259a458d5d45d58b6b381cae0bf9588113e80ef912f69e8c4cc1ef1a0297e8eefdb7b270064cc046b79a44e21b811802.png",
-            price: "$ 79.95",
-          }, {
-            text: "Old Line Sneakers rlfjrjrh4hr4rh4",
-            image: "https://marketing-image-production.s3.amazonaws.com/uploads/3629f54390ead663d4eb7c53702e492de63299d7c5f7239efdc693b09b9b28c82c924225dcd8dcb65732d5ca7b7b753c5f17e056405bbd4596e4e63a96ae5018.png",
-            price: "$ 79.95",
-          }, ],
-          receipt: true,
-          name: "Sample Name",
-          address01: "1234 Fake St.",
-          address02: "Apt. 123",
-          city: "Place",
-          state: "CO",
-          zip: "80202",
-        },
-      },
-    },
-  },
+    "providers": {
+        "sendgrid": {
+            "templateId": "d-d965b02b1b5d4856bf332a5e98c7470c",
+            "dynamicTemplateData": {
+                "total": "$ 239.85",
+                "receipt": true,
+                "name": "Sample Name",
+                "address01": "1234 Fake St.",
+                "address02": "Apt. 123",
+                "city": "Place",
+                "state": "CO",
+                "zip": "80202"
+            }
+        }
+    }
+},
 });
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={},
+        overrides={
+        "providers": {
+                "sendgrid": {
+                        "templateId": "d-d965b02b1b5d4856bf332a5e98c7470c",
+                        "dynamicTemplateData": {
+                                "total": "$ 239.85",
+                                "receipt": true,
+                                "name": "Sample Name",
+                                "address01": "1234 Fake St.",
+                                "address02": "Apt. 123",
+                                "city": "Place",
+                                "state": "CO",
+                                "zip": "80202"
+                        }
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{},
+    Overrides: map[string]any{
+    "providers": {
+        "sendgrid": {
+            "templateId": "d-d965b02b1b5d4856bf332a5e98c7470c",
+            "dynamicTemplateData": {
+                "total": "$ 239.85",
+                "receipt": true,
+                "name": "Sample Name",
+                "address01": "1234 Fake St.",
+                "address02": "Apt. 123",
+                "city": "Place",
+                "state": "CO",
+                "zip": "80202"
+            }
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: {},
+        overrides: {
+        "providers": {
+                "sendgrid": {
+                        "templateId": "d-d965b02b1b5d4856bf332a5e98c7470c",
+                        "dynamicTemplateData": {
+                                "total": "$ 239.85",
+                                "receipt": true,
+                                "name": "Sample Name",
+                                "address01": "1234 Fake St.",
+                                "address02": "Apt. 123",
+                                "city": "Place",
+                                "state": "CO",
+                                "zip": "80202"
+                        }
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+    Payload = {},
+    Overrides = {
+    "providers": {
+        "sendgrid": {
+            "templateId": "d-d965b02b1b5d4856bf332a5e98c7470c",
+            "dynamicTemplateData": {
+                "total": "$ 239.85",
+                "receipt": true,
+                "name": "Sample Name",
+                "address01": "1234 Fake St.",
+                "address02": "Apt. 123",
+                "city": "Place",
+                "state": "CO",
+                "zip": "80202"
+            }
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .payload({})
+        .overrides({
+        "providers": {
+                "sendgrid": {
+                        "templateId": "d-d965b02b1b5d4856bf332a5e98c7470c",
+                        "dynamicTemplateData": {
+                                "total": "$ 239.85",
+                                "receipt": true,
+                                "name": "Sample Name",
+                                "address01": "1234 Fake St.",
+                                "address02": "Apt. 123",
+                                "city": "Place",
+                                "state": "CO",
+                                "zip": "80202"
+                        }
+                }
+        }
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl --location 'https://api.novu.co/v1/events/trigger' \
 --header 'Content-Type: application/json' \
---header 'Accept: application/json' \
 --header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
---data '{
-    "name": "workflowIdentifier",
-    "to":  ["subscriberId"],
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
     "payload": {},
     "overrides": {
         "providers": {
@@ -127,18 +277,6 @@ curl --location 'https://api.novu.co/v1/events/trigger' \
                 "templateId": "d-d965b02b1b5d4856bf332a5e98c7470c",
                 "dynamicTemplateData": {
                     "total": "$ 239.85",
-                    "items": [
-                        {
-                            "text": "New Line Sneakers",
-                            "image": "https://marketing-image-production.s3.amazonaws.com/uploads/8dda1131320a6d978b515cc04ed479df259a458d5d45d58b6b381cae0bf9588113e80ef912f69e8c4cc1ef1a0297e8eefdb7b270064cc046b79a44e21b811802.png",
-                            "price": "$ 79.95"
-                        },
-                        {
-                            "text": "Old Line Sneakers rlfjrjrh4hr4rh4",
-                            "image": "https://marketing-image-production.s3.amazonaws.com/uploads/3629f54390ead663d4eb7c53702e492de63299d7c5f7239efdc693b09b9b28c82c924225dcd8dcb65732d5ca7b7b753c5f17e056405bbd4596e4e63a96ae5018.png",
-                            "price": "$ 79.95"
-                        }
-                    ],
                     "receipt": true,
                     "name": "Sample Name",
                     "address01": "1234 Fake St.",
@@ -152,8 +290,8 @@ curl --location 'https://api.novu.co/v1/events/trigger' \
     }
 }'
 ```
-</Tab>
-<Tab title="Novu Framework">
+  </Tab>
+  <Tab title="Novu Framework">
 ```typescript
 import { workflow } from "@novu/framework";
 import { z } from "zod";
@@ -217,7 +355,7 @@ export const sendgridOverridesEmailExample = workflow(
   }
 );
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 ## Next Steps

--- a/docs/platform/integrations/push.mdx
+++ b/docs/platform/integrations/push.mdx
@@ -75,6 +75,8 @@ Novu offers two ways of adding device tokens to a subscriber's profile:
 
 You can pass the device tokens in the `channels` array of the subscriber field when triggering a workflow. Novu automatically updates the subscriber's profile with these tokens before sending the message. Here is an example with FCM:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
@@ -101,6 +103,166 @@ await novu.trigger({
   payload: {},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={
+            "subscriber_id": "subscriberId",
+            "channels": [
+                {
+                    "provider_id": novu_py.ChatOrPushProviderEnum.FCM,
+                    "credentials": {
+                        "device_tokens": ["token-1", "token-2"],
+                    },
+                },
+            ],
+        },
+        payload={},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+        Channels: []components.SubscriberChannelDto{
+            {
+                ProviderID: components.SubscriberChannelDtoProviderIdFcm,
+                Credentials: components.ChannelCredentialsDto{
+                    DeviceTokens: []string{"token-1", "token-2"},
+                },
+            },
+        },
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(
+            subscriberId: 'subscriberId',
+            channels: [
+                new Components\SubscriberChannelDto(
+                    providerId: Components\SubscriberChannelDtoProviderId::Fcm,
+                    credentials: new Components\ChannelCredentialsDto(
+                        deviceTokens: ['token-1', 'token-2'],
+                    ),
+                ),
+            ],
+        ),
+        payload: [],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+        Channels = new List<SubscriberChannelDto>() {
+            new SubscriberChannelDto() {
+                ProviderId = SubscriberChannelDtoProviderId.Fcm,
+                Credentials = new ChannelCredentialsDto() {
+                    DeviceTokens = new List<string>() { "token-1", "token-2" },
+                },
+            },
+        },
+    }),
+    Payload = new Dictionary<string, object>(),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .channels(List.of(
+                SubscriberChannelDto.builder()
+                    .providerId(SubscriberChannelDtoProviderId.FCM)
+                    .credentials(ChannelCredentialsDto.builder()
+                        .deviceTokens(List.of("token-1", "token-2"))
+                        .build())
+                    .build()))
+            .build()))
+        .payload(Map.of())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId",
+        "channels": [
+            {
+                "providerId": "fcm",
+                "credentials": {
+                    "deviceTokens": ["token-1", "token-2"]
+                }
+            }
+        ]
+    },
+    "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 
 #### Ahead of trigger
 
@@ -110,41 +272,137 @@ This method is useful when you manage device registration outside of your workfl
 
 <Tabs>
   <Tab title="Node.js">
-  ```typescript
+```typescript
+import { Novu } from '@novu/api';
+import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
- 
-  const novu = new Novu({ secretKey: "YOUR_SECRET_KEY_HERE",});
-  
-  async function run() {
-    const result = await novu.subscribers.credentials.update({
-      providerId: ChatOrPushProviderEnum.Fcm,
-      credentials: {
-        deviceTokens: [
-          "token1",
-          "token2",
-        ],
-      },
-    }, "subscriberId");
-  }
-  run();
-  ```
+const novu = new Novu({ secretKey: "YOUR_SECRET_KEY_HERE" });
+
+const result = await novu.subscribers.credentials.update({
+  providerId: ChatOrPushProviderEnum.Fcm,
+  credentials: {
+    deviceTokens: [
+      "token1",
+      "token2",
+    ],
+  },
+}, "subscriberId");
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.FCM,
+            "credentials": {
+                "device_tokens": ["token1", "token2"],
+            },
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumFcm,
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->subscribers->updateCredentials(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Fcm,
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.UpdateCredentialsAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Fcm,
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string>() { "token1", "token2" },
+        },
+    }
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.subscribers().updateCredentials()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.FCM)
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2"))
+            .build())
+        .build())
+    .call();
+```
   </Tab>
   <Tab title="cURL">
-  ```bash
-  curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
-  -d '{
-    "providerId": "fcm",
-    "credentials": {
-      "deviceTokens" : [
-        "token1",
-        "token2"
-      ]
-    }
-  }'
-  ```
+```bash
+curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "providerId": "fcm",
+  "credentials": {
+    "deviceTokens" : [
+      "token1",
+      "token2"
+    ]
+  }
+}'
+```
   </Tab>
 </Tabs>
 
@@ -158,44 +416,147 @@ By default, device tokens are stored for the most recently created integration. 
 
 <Tabs>
   <Tab title="Node.js">
-  ```typescript
+```typescript
+import { Novu } from '@novu/api';
+import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
- 
-  const novu = new Novu({ secretKey: "YOUR_SECRET_KEY_HERE",});
-  
-  async function run() {
-    const result = await novu.subscribers.credentials.update({
-      providerId: ChatOrPushProviderEnum.Fcm,
-      // Use integrationIdentifier to store device tokens for a specific integration
-      integrationIdentifier: "fcm-MnGLxp8uy",
-      credentials: {
-        deviceTokens: [
-          "token1",
-          "token2",
-        ],
-      },
-    }, "subscriberId");
-  }
-  run();
-  ```
+const novu = new Novu({ secretKey: "YOUR_SECRET_KEY_HERE" });
+
+const result = await novu.subscribers.credentials.update({
+  providerId: ChatOrPushProviderEnum.Fcm,
+  // Use integrationIdentifier to store device tokens for a specific integration
+  integrationIdentifier: "fcm-MnGLxp8uy",
+  credentials: {
+    deviceTokens: [
+      "token1",
+      "token2",
+    ],
+  },
+}, "subscriberId");
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.FCM,
+            "integration_identifier": "fcm-MnGLxp8uy",
+            "credentials": {
+                "device_tokens": ["token1", "token2"],
+            },
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+integrationIdentifier := "fcm-MnGLxp8uy"
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumFcm,
+    IntegrationIdentifier: &integrationIdentifier,
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->subscribers->updateCredentials(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Fcm,
+        integrationIdentifier: 'fcm-MnGLxp8uy',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.UpdateCredentialsAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Fcm,
+        IntegrationIdentifier = "fcm-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string>() { "token1", "token2" },
+        },
+    }
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.subscribers().updateCredentials()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.FCM)
+        .integrationIdentifier("fcm-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2"))
+            .build())
+        .build())
+    .call();
+```
   </Tab>
   <Tab title="cURL">
-  ```bash
-  curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
-  -d '{
-    "providerId": "fcm",
-    "credentials": {
-      "deviceTokens" : [
-        "token1",
-        "token2"
-      ]
-    },
-    "integrationIdentifier": "fcm-MnGLxp8uy"
-  }'
-  ```
+```bash
+curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "providerId": "fcm",
+  "credentials": {
+    "deviceTokens" : [
+      "token1",
+      "token2"
+    ]
+  },
+  "integrationIdentifier": "fcm-MnGLxp8uy"
+}'
+```
   </Tab>
 </Tabs>
 
@@ -222,6 +583,8 @@ To remove device tokens from subscriber credentials, follow this process:
 2. Filter out the token you want to remove.
 3. Update the subscriber with the new, filtered list.
 
+<Tabs>
+  <Tab title="Node.js">
 ```ts
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
@@ -251,11 +614,213 @@ await novu.subscribers.credentials.update(
   subscriberId
 );
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+subscriber_id = "subscriberId"
+provider_id = novu_py.ChatOrPushProviderEnum.FCM
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    # 1. Fetch current credentials
+    subscriber = novu.subscribers.retrieve(subscriber_id=subscriber_id)
+    current_tokens = subscriber.subscriber_response_dto.credentials.get("fcm", {}).get("device_tokens", [])
+
+    # 2. Remove the specific token
+    filtered_tokens = [token for token in current_tokens if token != "token_to_remove"]
+
+    # 3. Update subscriber
+    novu.subscribers.credentials.update(
+        subscriber_id=subscriber_id,
+        update_subscriber_channel_request_dto={
+            "provider_id": provider_id,
+            "credentials": {
+                "device_tokens": filtered_tokens,
+            },
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+subscriberID := "subscriberId"
+providerID := components.ChatOrPushProviderEnumFcm
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+// 1. Fetch current credentials
+res, err := s.Subscribers.Retrieve(context.Background(), subscriberID, nil)
+if err != nil {
+    panic(err)
+}
+
+currentTokens := []string{}
+if credentials, ok := res.SubscriberResponseDto.Credentials["fcm"]; ok {
+    currentTokens = credentials.DeviceTokens
+}
+
+// 2. Remove the specific token
+filteredTokens := []string{}
+for _, token := range currentTokens {
+    if token != "token_to_remove" {
+        filteredTokens = append(filteredTokens, token)
+    }
+}
+
+// 3. Update subscriber
+_, err = s.Subscribers.Credentials.Update(context.Background(), subscriberID, components.UpdateSubscriberChannelRequestDto{
+    ProviderID: providerID,
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: filteredTokens,
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$subscriberId = 'subscriberId';
+$providerId = Components\ChatOrPushProviderEnum::Fcm;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+// 1. Fetch current credentials
+$response = $sdk->subscribers->get(subscriberId: $subscriberId);
+$currentTokens = $response->subscriberResponseDto->credentials['fcm']['deviceTokens'] ?? [];
+
+// 2. Remove the specific token
+$filteredTokens = array_values(array_filter(
+    $currentTokens,
+    fn (string $token): bool => $token !== 'token_to_remove',
+));
+
+// 3. Update subscriber
+$sdk->subscribers->updateCredentials(
+    subscriberId: $subscriberId,
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: $providerId,
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: $filteredTokens,
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+using System.Linq;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+var subscriberId = "subscriberId";
+var providerId = ChatOrPushProviderEnum.Fcm;
+
+// 1. Fetch current credentials
+var subscriber = await sdk.Subscribers.RetrieveAsync(subscriberId: subscriberId);
+var currentTokens = subscriber.SubscriberResponseDto.Credentials["fcm"].DeviceTokens;
+
+// 2. Remove the specific token
+var filteredTokens = currentTokens
+    .Where(token => token != "token_to_remove")
+    .ToList();
+
+// 3. Update subscriber
+await sdk.Subscribers.UpdateCredentialsAsync(
+    subscriberId: subscriberId,
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = providerId,
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = filteredTokens,
+        },
+    }
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+String subscriberId = "subscriberId";
+
+// 1. Fetch current credentials
+var subscriber = novu.subscribers().get()
+    .subscriberId(subscriberId)
+    .call()
+    .subscriberResponseDto()
+    .orElseThrow();
+
+List<String> currentTokens = subscriber.credentials().get("fcm").deviceTokens();
+
+// 2. Remove the specific token
+List<String> filteredTokens = currentTokens.stream()
+    .filter(token -> !token.equals("token_to_remove"))
+    .collect(Collectors.toList());
+
+// 3. Update subscriber
+novu.subscribers().updateCredentials()
+    .subscriberId(subscriberId)
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.FCM)
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(filteredTokens)
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+# 1. Fetch current credentials
+curl -L -X GET 'https://api.novu.co/v2/subscribers/subscriberId' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+
+# 2. Remove the specific token from the response, then update credentials
+curl -L -X PUT 'https://api.novu.co/v1/subscribers/subscriberId/credentials' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "providerId": "fcm",
+  "credentials": {
+    "deviceTokens": ["remaining-token-1", "remaining-token-2"]
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 #### Remove all tokens
 
 To remove all device tokens for a provider, or for a specific integration, update the credentials with an empty array.
 
+<Tabs>
+  <Tab title="Node.js">
 ```tsx
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
@@ -274,6 +839,120 @@ await novu.subscribers.credentials.update(
   "subscriberId"
 );
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.FCM,
+            "credentials": {
+                "device_tokens": [],
+            },
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumFcm,
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->subscribers->updateCredentials(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Fcm,
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: [],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.UpdateCredentialsAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Fcm,
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string>(),
+        },
+    }
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.subscribers().updateCredentials()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.FCM)
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of())
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X PUT 'https://api.novu.co/v1/subscribers/subscriberId/credentials' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "providerId": "fcm",
+  "credentials": {
+    "deviceTokens": []
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Supported providers
 

--- a/docs/platform/integrations/push/apns.mdx
+++ b/docs/platform/integrations/push/apns.mdx
@@ -135,6 +135,7 @@ $sdk->subscribersCredentials->update(
 using Novu;
 using Novu.Models.Components;
 using System.Collections.Generic;
+using System.Collections.Generic;
 
 var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 
@@ -253,7 +254,7 @@ $sdk->trigger(
     triggerEventRequestDto: new Components\TriggerEventRequestDto(
         workflowId: 'workflowId',
         to: new Components\SubscriberPayloadDto(subscriberId: 'SUBSCRIBER_ID'),
-        payload: {},
+        payload: [],
     ),
 );
 ```
@@ -262,13 +263,14 @@ $sdk->trigger(
 ```csharp
 using Novu;
 using Novu.Models.Components;
+using System.Collections.Generic;
 
 var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 
 await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
     WorkflowId = "workflowId",
     To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "SUBSCRIBER_ID" }),
-    Payload = {},
+    Payload = new Dictionary<string, object>(),
 });
 ```
   </Tab>
@@ -283,7 +285,7 @@ novu.trigger()
     .body(TriggerEventRequestDto.builder()
         .workflowId("workflowId")
         .to(To2.of(SubscriberPayloadDto.builder().subscriberId("SUBSCRIBER_ID").build()))
-        .payload({})
+        .payload(Map.of())
         .build())
     .call();
 ```
@@ -389,23 +391,23 @@ res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
         SubscriberID: "subscriberId",
     }),
     Payload: map[string]any{
-    "abc": "def"
-},
+        "abc": "def",
+    },
     Overrides: map[string]any{
-    "apns": {
-        "payload": {
-            "aps": {
-                "notification": {
-                    "title": "Test",
-                    "body": "Test push"
+        "apns": map[string]any{
+            "payload": map[string]any{
+                "aps": map[string]any{
+                    "notification": map[string]any{
+                        "title": "Test",
+                        "body":  "Test push",
+                    },
+                    "data": map[string]any{
+                        "key": "value",
+                    },
                 },
-                "data": {
-                    "key": "value"
-                }
-            }
-        }
-    }
-},
+            },
+        },
+    },
 }, nil)
 ```
   </Tab>
@@ -420,24 +422,22 @@ $sdk->trigger(
     triggerEventRequestDto: new Components\TriggerEventRequestDto(
         workflowId: 'workflowId',
         to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
-        payload: {
-        "abc": "def"
-},
-        overrides: {
-        "apns": {
-                "payload": {
-                        "aps": {
-                                "notification": {
-                                        "title": "Test",
-                                        "body": "Test push"
-                                },
-                                "data": {
-                                        "key": "value"
-                                }
-                        }
-                }
-        }
-},
+        payload: ['abc' => 'def'],
+        overrides: [
+            'apns' => [
+                'payload' => [
+                    'aps' => [
+                        'notification' => [
+                            'title' => 'Test',
+                            'body' => 'Test push',
+                        ],
+                        'data' => [
+                            'key' => 'value',
+                        ],
+                    ],
+                ],
+            ],
+        ],
     ),
 );
 ```
@@ -446,30 +446,31 @@ $sdk->trigger(
 ```csharp
 using Novu;
 using Novu.Models.Components;
+using System.Collections.Generic;
 
 var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 
 await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
     WorkflowId = "workflowId",
     To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
-    Payload = {
-    "abc": "def"
-},
-    Overrides = {
-    "apns": {
-        "payload": {
-            "aps": {
-                "notification": {
-                    "title": "Test",
-                    "body": "Test push"
-                },
-                "data": {
-                    "key": "value"
-                }
-            }
-        }
-    }
-},
+    Payload = new Dictionary<string, object>() {
+        { "abc", "def" },
+    },
+    Overrides = new Overrides() {
+        Push = new Dictionary<string, object>() {
+            { "payload", new Dictionary<string, object>() {
+                { "aps", new Dictionary<string, object>() {
+                    { "notification", new Dictionary<string, object>() {
+                        { "title", "Test" },
+                        { "body", "Test push" },
+                    } },
+                    { "data", new Dictionary<string, object>() {
+                        { "key", "value" },
+                    } },
+                } },
+            } },
+        },
+    },
 });
 ```
   </Tab>
@@ -477,6 +478,7 @@ await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
 ```java
 import co.novu.Novu;
 import co.novu.models.components.*;
+import java.util.Map;
 
 Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 
@@ -484,24 +486,14 @@ novu.trigger()
     .body(TriggerEventRequestDto.builder()
         .workflowId("workflowId")
         .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
-        .payload({
-        "abc": "def"
-})
-        .overrides({
-        "apns": {
-                "payload": {
-                        "aps": {
-                                "notification": {
-                                        "title": "Test",
-                                        "body": "Test push"
-                                },
-                                "data": {
-                                        "key": "value"
-                                }
-                        }
-                }
-        }
-})
+        .payload(Map.of("abc", "def"))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of("apns", Map.of(
+                "payload", Map.of(
+                    "aps", Map.of(
+                        "notification", Map.of("title", "Test", "body", "Test push"),
+                        "data", Map.of("key", "value"))))))
+            .build())
         .build())
     .call();
 ```

--- a/docs/platform/integrations/push/apns.mdx
+++ b/docs/platform/integrations/push/apns.mdx
@@ -56,104 +56,485 @@ After configuration, APNS can be used in any Novu workflow that includes a Push 
 Each subscriber (user) must have one or more device tokens registered to receive push notifications. Tokens can be added or updated through Novu’s API using the [Update Subscriber Credentials](/api-reference/subscribers/update-provider-credentials) endpoint.
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "[https://eu.api.novu.co](https://eu.api.novu.co)",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.Apns,
-    // Use integrationIdentifier to store device tokens for a specific integration
     integrationIdentifier: "string",
-    credentials: {
-      deviceTokens: ["token1", "token2", "token3"],
-    },
+    credentials: { deviceTokens: ["token1", "token2", "token3"] },
   },
   "subscriberId"
 );
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.APNS,
+            "credentials": {"deviceTokens": ["token1", "token2", "token3"]},
+            "integration_identifier": "string",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumApns,
+        IntegrationIdentifier: novugo.String("string"),
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2", "token3"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Apns,
+        integrationIdentifier: 'string',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2', 'token3'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Apns,
+        IntegrationIdentifier = "string",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string> { "token1", "token2", "token3" },
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.APNS)
+            .integrationIdentifier("string")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2", "token3"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
--H 'Accept: application/json' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "apns",
-  "deviceTokens": ["token1", "token2"],
+  "credentials": {
+    "deviceTokens": [
+      "token1",
+      "token2",
+      "token3"
+    ]
+  },
   "integrationIdentifier": "string"
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 ### Triggering workflows
 
 Once subscribers’ devices are registered, push notifications are delivered through [workflows that include a Push step](/platform/workflow/create-a-workflow). A workflow can be triggered using the Novu [SDK](/platform/sdks) or [API](/api-reference/events/trigger-event).
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: 'SUBSCRIBER_ID',
-  },
-  payload: {
-    // Your payload data
-  },
+  to: { subscriberId: "SUBSCRIBER_ID", },
+  payload: {},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
 
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "SUBSCRIBER_ID"},
+        payload={},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "SUBSCRIBER_ID",
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'SUBSCRIBER_ID'),
+        payload: {},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "SUBSCRIBER_ID" }),
+    Payload = {},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("SUBSCRIBER_ID").build()))
+        .payload({})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "SUBSCRIBER_ID"
+    ],
+    "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 ## Customizing notifications with overrides
 
-Novu supports an `overrides` field that lets you attach APNS-specific payload parameters when triggering a workflow. This feature is useful for customizing the behavior or presentation of notifications, such as setting titles, bodies, or custom data fields.
+Novu supports an `overrides` field that lets you attach APNS-specific payload parameters when triggering a workflow.
 
-The `overrides` field supports all [APNS Notification payload](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification?language=objc) values. Here is an example:
+The `overrides` field supports all [APNS Notification payload](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification?language=objc) values. Here is an example:
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-  },
+  to: { subscriberId: "subscriberId", },
   payload: {
-    abc: 'def', // If the notification is a data notification, then the payload is sent as the data
-  },
+    "abc": "def"
+},
   overrides: {
-    apns: {
-      payload: {
-        aps: {
-          notification: {
-            title: 'Test',
-            body: 'Test push',
-          },
-          data: {
-            key: 'value',
-          },
-        },
-      },
-    },
-  },
+    "apns": {
+        "payload": {
+            "aps": {
+                "notification": {
+                    "title": "Test",
+                    "body": "Test push"
+                },
+                "data": {
+                    "key": "value"
+                }
+            }
+        }
+    }
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={
+        "abc": "def"
+},
+        overrides={
+        "apns": {
+                "payload": {
+                        "aps": {
+                                "notification": {
+                                        "title": "Test",
+                                        "body": "Test push"
+                                },
+                                "data": {
+                                        "key": "value"
+                                }
+                        }
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+    "abc": "def"
+},
+    Overrides: map[string]any{
+    "apns": {
+        "payload": {
+            "aps": {
+                "notification": {
+                    "title": "Test",
+                    "body": "Test push"
+                },
+                "data": {
+                    "key": "value"
+                }
+            }
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: {
+        "abc": "def"
+},
+        overrides: {
+        "apns": {
+                "payload": {
+                        "aps": {
+                                "notification": {
+                                        "title": "Test",
+                                        "body": "Test push"
+                                },
+                                "data": {
+                                        "key": "value"
+                                }
+                        }
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+    Payload = {
+    "abc": "def"
+},
+    Overrides = {
+    "apns": {
+        "payload": {
+            "aps": {
+                "notification": {
+                    "title": "Test",
+                    "body": "Test push"
+                },
+                "data": {
+                    "key": "value"
+                }
+            }
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .payload({
+        "abc": "def"
+})
+        .overrides({
+        "apns": {
+                "payload": {
+                        "aps": {
+                                "notification": {
+                                        "title": "Test",
+                                        "body": "Test push"
+                                },
+                                "data": {
+                                        "key": "value"
+                                }
+                        }
+                }
+        }
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {
+        "abc": "def"
+    },
+    "overrides": {
+        "apns": {
+            "payload": {
+                "aps": {
+                    "notification": {
+                        "title": "Test",
+                        "body": "Test push"
+                    },
+                    "data": {
+                        "key": "value"
+                    }
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>

--- a/docs/platform/integrations/push/apns.mdx
+++ b/docs/platform/integrations/push/apns.mdx
@@ -278,6 +278,7 @@ await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
 ```java
 import co.novu.Novu;
 import co.novu.models.components.*;
+import java.util.Map;
 
 Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 

--- a/docs/platform/integrations/push/expo-push.mdx
+++ b/docs/platform/integrations/push/expo-push.mdx
@@ -82,46 +82,136 @@ Before Novu can send a push notification to a subscriber (user), you must associ
 You can do this by making an API call to [update the subscriber's credentials](/api-reference/subscribers/update-provider-credentials).
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.Expo,
-    // Use integrationIdentifier to store device tokens for a specific integration
     integrationIdentifier: "string",
-    credentials: {
-      deviceTokens: [
-        "token1",
-        "token2"
-      ]
-    },
+    credentials: { deviceTokens: ["token1", "token2"] },
   },
   "subscriberId"
 );
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.EXPO,
+            "credentials": {"deviceTokens": ["token1", "token2"]},
+            "integration_identifier": "string",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumExpo,
+        IntegrationIdentifier: novugo.String("string"),
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Expo,
+        integrationIdentifier: 'string',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Expo,
+        IntegrationIdentifier = "string",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string> { "token1", "token2" },
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.EXPO)
+            .integrationIdentifier("string")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
--H 'Accept: application/json' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "expo",
-  "deviceTokens": ["token1", "token2"],
+  "credentials": {
+    "deviceTokens": [
+      "token1",
+      "token2"
+    ]
+  },
   "integrationIdentifier": "string"
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 <Note>
@@ -130,63 +220,346 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 
 ### Step 2: Send a notification
 
-Now you're ready to send a push notification. [Create a workflow with a Push step](/platform/workflow/create-a-workflow) and trigger it. Novu sends the notification to all devices associated with the subscriber.
+Now you're ready to send a push notification.
 
-The example below demonstrates a simple trigger using Novu’s SDK.
-
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: 'SUBSCRIBER_ID',
-  },
-  payload: {
-    // Your payload data
-  },
+  to: { subscriberId: "SUBSCRIBER_ID", },
+  payload: {},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
 
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "SUBSCRIBER_ID"},
+        payload={},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "SUBSCRIBER_ID",
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'SUBSCRIBER_ID'),
+        payload: {},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "SUBSCRIBER_ID" }),
+    Payload = {},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("SUBSCRIBER_ID").build()))
+        .payload({})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "SUBSCRIBER_ID"
+    ],
+    "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 ## Using overrides to customize notifications
 
-Novu provides an overrides field that let you send additional Expo-specific message fields. You can use this to control how messages are displayed or to attach custom payloads.
-
-The overrides field supports all [Expo Message Request](https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format) values. Here is an example:
-
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: { subscriberId: "subscriber-id-123" },
+  to: { subscriberId: "subscriber-id-123", },
   payload: {
-    orderId: "12345",
-  },
+    "orderId": "12345"
+},
   overrides: {
-    providers: {
-      expo: {
-        title: "Order Update",
-        body: "Your order #12345 has been shipped!",
-        data: {
-          deepLink: "myapp://orders/12345",
-          orderId: "12345",
-        },
-        sound: "default",
-        priority: "high",
-        ttl: 3600,
-      },
-    },
-  },
+    "providers": {
+        "expo": {
+            "title": "Order Update",
+            "body": "Your order #12345 has been shipped!",
+            "data": {
+                "deepLink": "myapp://orders/12345",
+                "orderId": "12345"
+            },
+            "sound": "default",
+            "priority": "high",
+            "ttl": 3600
+        }
+    }
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriber-id-123"},
+        payload={
+        "orderId": "12345"
+},
+        overrides={
+        "providers": {
+                "expo": {
+                        "title": "Order Update",
+                        "body": "Your order #12345 has been shipped!",
+                        "data": {
+                                "deepLink": "myapp://orders/12345",
+                                "orderId": "12345"
+                        },
+                        "sound": "default",
+                        "priority": "high",
+                        "ttl": 3600
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriber-id-123",
+    }),
+    Payload: map[string]any{
+    "orderId": "12345"
+},
+    Overrides: map[string]any{
+    "providers": {
+        "expo": {
+            "title": "Order Update",
+            "body": "Your order #12345 has been shipped!",
+            "data": {
+                "deepLink": "myapp://orders/12345",
+                "orderId": "12345"
+            },
+            "sound": "default",
+            "priority": "high",
+            "ttl": 3600
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriber-id-123'),
+        payload: {
+        "orderId": "12345"
+},
+        overrides: {
+        "providers": {
+                "expo": {
+                        "title": "Order Update",
+                        "body": "Your order #12345 has been shipped!",
+                        "data": {
+                                "deepLink": "myapp://orders/12345",
+                                "orderId": "12345"
+                        },
+                        "sound": "default",
+                        "priority": "high",
+                        "ttl": 3600
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriber-id-123" }),
+    Payload = {
+    "orderId": "12345"
+},
+    Overrides = {
+    "providers": {
+        "expo": {
+            "title": "Order Update",
+            "body": "Your order #12345 has been shipped!",
+            "data": {
+                "deepLink": "myapp://orders/12345",
+                "orderId": "12345"
+            },
+            "sound": "default",
+            "priority": "high",
+            "ttl": 3600
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriber-id-123").build()))
+        .payload({
+        "orderId": "12345"
+})
+        .overrides({
+        "providers": {
+                "expo": {
+                        "title": "Order Update",
+                        "body": "Your order #12345 has been shipped!",
+                        "data": {
+                                "deepLink": "myapp://orders/12345",
+                                "orderId": "12345"
+                        },
+                        "sound": "default",
+                        "priority": "high",
+                        "ttl": 3600
+                }
+        }
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriber-id-123"
+    ],
+    "payload": {
+        "orderId": "12345"
+    },
+    "overrides": {
+        "providers": {
+            "expo": {
+                "title": "Order Update",
+                "body": "Your order #12345 has been shipped!",
+                "data": {
+                    "deepLink": "myapp://orders/12345",
+                    "orderId": "12345"
+                },
+                "sound": "default",
+                "priority": "high",
+                "ttl": 3600
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>

--- a/docs/platform/integrations/push/fcm.mdx
+++ b/docs/platform/integrations/push/fcm.mdx
@@ -265,15 +265,15 @@ res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
         SubscriberID: "subscriberId",
     }),
     Payload: map[string]any{
-    "key": "value"
-},
+        "key": "value",
+    },
     Overrides: map[string]any{
-    "providers": {
-        "fcm": {
-            "topic": "topic-123"
-        }
-    }
-},
+        "providers": map[string]any{
+            "fcm": map[string]any{
+                "topic": "topic-123",
+            },
+        },
+    },
 }, nil)
 ```
   </Tab>
@@ -288,16 +288,14 @@ $sdk->trigger(
     triggerEventRequestDto: new Components\TriggerEventRequestDto(
         workflowId: 'workflowId',
         to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
-        payload: {
-        "key": "value"
-},
-        overrides: {
-        "providers": {
-                "fcm": {
-                        "topic": "topic-123"
-                }
-        }
-},
+        payload: ['key' => 'value'],
+        overrides: [
+            'providers' => [
+                'fcm' => [
+                    'topic' => 'topic-123',
+                ],
+            ],
+        ],
     ),
 );
 ```
@@ -306,22 +304,23 @@ $sdk->trigger(
 ```csharp
 using Novu;
 using Novu.Models.Components;
+using System.Collections.Generic;
 
 var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 
 await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
     WorkflowId = "workflowId",
     To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
-    Payload = {
-    "key": "value"
-},
-    Overrides = {
-    "providers": {
-        "fcm": {
-            "topic": "topic-123"
-        }
-    }
-},
+    Payload = new Dictionary<string, object>() {
+        { "key", "value" },
+    },
+    Overrides = new Overrides() {
+        Providers = new Dictionary<string, Dictionary<string, object>>() {
+            { "fcm", new Dictionary<string, object>() {
+                { "topic", "topic-123" },
+            } },
+        },
+    },
 });
 ```
   </Tab>
@@ -329,6 +328,7 @@ await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
 ```java
 import co.novu.Novu;
 import co.novu.models.components.*;
+import java.util.Map;
 
 Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 
@@ -336,16 +336,10 @@ novu.trigger()
     .body(TriggerEventRequestDto.builder()
         .workflowId("workflowId")
         .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
-        .payload({
-        "key": "value"
-})
-        .overrides({
-        "providers": {
-                "fcm": {
-                        "topic": "topic-123"
-                }
-        }
-})
+        .payload(Map.of("key", "value"))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of("providers", Map.of("fcm", Map.of("topic", "topic-123"))))
+            .build())
         .build())
     .call();
 ```
@@ -453,19 +447,19 @@ res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
         SubscriberID: "subscriberId",
     }),
     Payload: map[string]any{
-    "key": "value"
-},
+        "key": "value",
+    },
     Overrides: map[string]any{
-    "providers": {
-        "fcm": {
-            "webPush": {
-                "fcmOptions": {
-                    "link": "/foo"
-                }
-            }
-        }
-    }
-},
+        "providers": map[string]any{
+            "fcm": map[string]any{
+                "webPush": map[string]any{
+                    "fcmOptions": map[string]any{
+                        "link": "/foo",
+                    },
+                },
+            },
+        },
+    },
 }, nil)
 ```
   </Tab>
@@ -480,20 +474,18 @@ $sdk->trigger(
     triggerEventRequestDto: new Components\TriggerEventRequestDto(
         workflowId: 'workflowId',
         to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
-        payload: {
-        "key": "value"
-},
-        overrides: {
-        "providers": {
-                "fcm": {
-                        "webPush": {
-                                "fcmOptions": {
-                                        "link": "/foo"
-                                }
-                        }
-                }
-        }
-},
+        payload: ['key' => 'value'],
+        overrides: [
+            'providers' => [
+                'fcm' => [
+                    'webPush' => [
+                        'fcmOptions' => [
+                            'link' => '/foo',
+                        ],
+                    ],
+                ],
+            ],
+        ],
     ),
 );
 ```
@@ -502,26 +494,27 @@ $sdk->trigger(
 ```csharp
 using Novu;
 using Novu.Models.Components;
+using System.Collections.Generic;
 
 var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 
 await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
     WorkflowId = "workflowId",
     To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
-    Payload = {
-    "key": "value"
-},
-    Overrides = {
-    "providers": {
-        "fcm": {
-            "webPush": {
-                "fcmOptions": {
-                    "link": "/foo"
-                }
-            }
-        }
-    }
-},
+    Payload = new Dictionary<string, object>() {
+        { "key", "value" },
+    },
+    Overrides = new Overrides() {
+        Providers = new Dictionary<string, Dictionary<string, object>>() {
+            { "fcm", new Dictionary<string, object>() {
+                { "webPush", new Dictionary<string, object>() {
+                    { "fcmOptions", new Dictionary<string, object>() {
+                        { "link", "/foo" },
+                    } },
+                } },
+            } },
+        },
+    },
 });
 ```
   </Tab>
@@ -529,6 +522,7 @@ await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
 ```java
 import co.novu.Novu;
 import co.novu.models.components.*;
+import java.util.Map;
 
 Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 
@@ -536,20 +530,11 @@ novu.trigger()
     .body(TriggerEventRequestDto.builder()
         .workflowId("workflowId")
         .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
-        .payload({
-        "key": "value"
-})
-        .overrides({
-        "providers": {
-                "fcm": {
-                        "webPush": {
-                                "fcmOptions": {
-                                        "link": "/foo"
-                                }
-                        }
-                }
-        }
-})
+        .payload(Map.of("key", "value"))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of("providers", Map.of("fcm", Map.of(
+                "webPush", Map.of("fcmOptions", Map.of("link", "/foo"))))))
+            .build())
         .build())
     .call();
 ```

--- a/docs/platform/integrations/push/fcm.mdx
+++ b/docs/platform/integrations/push/fcm.mdx
@@ -62,41 +62,134 @@ You can do this by making an API call to [update the subscriber's credentials](/
 
 <Tabs>
   <Tab title="Node.js">
-  ```typescript
+```typescript
+import { Novu } from '@novu/api';
+import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({ secretKey: "YOUR_SECRET_KEY_HERE",});
-  
-  async function run() {
-    const result = await novu.subscribers.credentials.update({
-      providerId: ChatOrPushProviderEnum.Fcm,
-      credentials: {
-        deviceTokens: [
-          "token1",
-          "token2",
-        ],
-      },
-    }, "subscriberId");
-  }
-  run();
-  ```
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
+
+await novu.subscribers.credentials.update(
+  {
+    providerId: ChatOrPushProviderEnum.Fcm,
+    integrationIdentifier: "string",
+    credentials: { deviceTokens: ["token1", "token2"] },
+  },
+  "subscriberId"
+);
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.FCM,
+            "credentials": {"deviceTokens": ["token1", "token2"]},
+            "integration_identifier": "string",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumFcm,
+        IntegrationIdentifier: novugo.String("string"),
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::Fcm,
+        integrationIdentifier: 'string',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.Fcm,
+        IntegrationIdentifier = "string",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string> { "token1", "token2" },
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.FCM)
+            .integrationIdentifier("string")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2"))
+            .build())
+        .build())
+    .call();
+```
   </Tab>
   <Tab title="cURL">
-  ```bash
-  curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
-  -d '{
-    "providerId": "fcm",
-    "credentials": {
-      "deviceTokens" : [
-        "token1",
-        "token2"
-      ]
-    },
-    "integrationIdentifier": "string"
-  }'
-  ```
+```bash
+curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "providerId": "fcm",
+  "credentials": {
+    "deviceTokens": [
+      "token1",
+      "token2"
+    ]
+  },
+  "integrationIdentifier": "string"
+}'
+```
   </Tab>
 </Tabs>
 
@@ -108,190 +201,179 @@ const novu = new Novu({ secretKey: "YOUR_SECRET_KEY_HERE",});
 
 Now you're ready to send a push notification. You can trigger a notification to a subscriber who has a registered device token.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: 'SUBSCRIBER_ID',
-  },
+  to: { subscriberId: "subscriberId", },
   payload: {
-    // Your payload data
-  },
+    "key": "value"
+},
+  overrides: {
+    "providers": {
+        "fcm": {
+            "topic": "topic-123"
+        }
+    }
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
 
-## Using multiple FCM integrations
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={
+        "key": "value"
+},
+        overrides={
+        "providers": {
+                "fcm": {
+                        "topic": "topic-123"
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
 
-If you have multiple active FCM integrations, then you can specify which integration to associate the tokens with by providing the `integrationIdentifier`.
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
 
-You can find this identifier in your Novu dashboard on the integration's settings page.
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
 
-![Integration identifier](/images/channels-and-providers/push/integrationidentifier.png)
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+    "key": "value"
+},
+    Overrides: map[string]any{
+    "providers": {
+        "fcm": {
+            "topic": "topic-123"
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
 
-```typescript
-import { Novu } from '@novu/api';
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-});
-
-await novu.subscribers.credentials.update(
-  {
-    providerId: "fcm",
-    // Use integrationIdentifier to store device tokens for a specific integration
-    integrationIdentifier: "string",
-    credentials: {
-      deviceTokens: [
-        "token1",
-        "token2"
-      ]
-    },
-  },
-  "subscriberId"
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: {
+        "key": "value"
+},
+        overrides: {
+        "providers": {
+                "fcm": {
+                        "topic": "topic-123"
+                }
+        }
+},
+    ),
 );
 ```
-## Using overrides to customize notifications
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
 
-Novu lets you customize the behavior of push notifications by using the overrides field when triggering workflows. Overrides give you full control over message content and delivery parameters that aren’t configurable from the Novu workflow editor.
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 
-To learn more about how overrides work across all channels, see the [Trigger Overrides](/platform/integrations/trigger-overrides) documentation.
-
-### Override FCM field
-
-Overrides let you send platform-specific data that is not available in the workflow editor. The overrides field supports:
-- `apns` overrides
-- `android` overrides
-- `webpush` overrides
-- `fcmOptions` overrides
-
-| Override field | Type / Interface | Link                                                                                         |
-| -------------- | ---------------- | -------------------------------------------------------------------------------------------- |
-| android        | AndroidConfig    | https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.androidconfig |
-| apns           | ApnsConfig       | https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.apnsconfig    |
-| webPush        | WebpushConfig    | https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.webpushconfig |
-| fcmOptions     | FcmOptions       | https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.fcmoptions    |
-
-You can use these fields to customize how notifications are sent to Android, iOS via APNS, or web clients.
-
-```typescript
-await novu.trigger({
-  workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-  },
-  payload: {
-    key: "value",
-  },
-  overrides: {
-    fcm: {
-      // For a data-only notification (silent push)
-      type: 'data',
-      data: {
-        custom_key: 'custom_value',
-      },
-      // Platform-specific overrides
-      android: {
-        // See FCM AndroidConfig options
-      },
-      apns: {
-        // See FCM ApnsConfig options
-      },
-      webPush: {
-        // See FCM WebpushConfig options
-      },
-      fcmOptions: {
-        // See FCM FcmOptions
-      }
-    },
-  },
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+    Payload = {
+    "key": "value"
+},
+    Overrides = {
+    "providers": {
+        "fcm": {
+            "topic": "topic-123"
+        }
+    }
+},
 });
 ```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
 
-### Override FCM notification content
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 
-By default, Novu sends the FCM notification content written in the step editor workflow. However, you can override the notification content by using the `overrides` field.
-
-```typescript
-import { Novu } from '@novu/api';
-
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
-
-await novu.trigger({
-  workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-  },
-  payload: {
-    key: "value",
-  },
-  overrides: {
-    providers: {
-      fcm: {
-        type: "data",
-
-// URL of an image to be displayed in the notification.
-        imageUrl: "https://domain.com/image.png",
-
-// If type is not set, you can use the "data" override to send notification messages with optional data payload
-        data: {
-          key: "value",
-        },
-
-// Check FCM Overrides section above for these types
-        android: {},
-        apns: {},
-        webPush: {},
-        fcmOptions: {},
-      },
-    },
-  },
-});
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .payload({
+        "key": "value"
+})
+        .overrides({
+        "providers": {
+                "fcm": {
+                        "topic": "topic-123"
+                }
+        }
+})
+        .build())
+    .call();
 ```
-
-<Note>
-  Overrides can be applied at runtime to customize or enrich notifications based on user context, device type, or workflow logic.
-</Note>
-
-## Sending notifications to FCM topics
-
-[FCM topics](https://firebase.google.com/docs/cloud-messaging/android/topic-messaging) are used to send notifications to multiple devices at once. In the `overrides`, you need to specify the [topic](/platform/concepts/topics) you want to send the notification to.
-
-```typescript
-import { Novu } from '@novu/api';
-
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
-
-await novu.trigger({
-  workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-  },
-  payload: {
-    key: "value",
-  },
-  overrides: {
-    providers: {
-      fcm: {
-        topic: "topic-123",
-      },
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {
+        "key": "value"
     },
-  },
-});
+    "overrides": {
+        "providers": {
+            "fcm": {
+                "topic": "topic-123"
+            }
+        }
+    }
+}'
 ```
+  </Tab>
+</Tabs>
 
 ## Web push with relative links
 
@@ -300,61 +382,205 @@ Suppose you're using the Firebase (FCM) provider to send push notifications to w
 In that case, you must use the `link` property with a relative URL.
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-  },
+  to: { subscriberId: "subscriberId", },
   payload: {
-    key: "value",
-  },
+    "key": "value"
+},
   overrides: {
-    providers: {
-      fcm: {
-        webPush: {
-          fcmOptions: {
-            link: "/foo",
-          },
-        },
-      },
-    },
-  },
+    "providers": {
+        "fcm": {
+            "webPush": {
+                "fcmOptions": {
+                    "link": "/foo"
+                }
+            }
+        }
+    }
+},
 });
 ```
-</Tab>
-<Tab title="Curl">
-```bash
-curl --location --request POST 'https://url.to.our.selfhosted.novu' \
-    --header 'Authorization: ApiKey KEY' \
-    --header 'Content-Type: application/json' \
-    --data-raw '{
-        "name": "workflow-name",
-        "to": {
-            "subscriberId": "subscriberId"
-        },
-        "overrides": {
-          "fcm": {
-            "webPush": {
-              "fcm_options": {
-                "link": "/foo"
-              }
-            }
-          }
-        }
-      }'
-```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
 
-</Tab>
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={
+        "key": "value"
+},
+        overrides={
+        "providers": {
+                "fcm": {
+                        "webPush": {
+                                "fcmOptions": {
+                                        "link": "/foo"
+                                }
+                        }
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+    "key": "value"
+},
+    Overrides: map[string]any{
+    "providers": {
+        "fcm": {
+            "webPush": {
+                "fcmOptions": {
+                    "link": "/foo"
+                }
+            }
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: {
+        "key": "value"
+},
+        overrides: {
+        "providers": {
+                "fcm": {
+                        "webPush": {
+                                "fcmOptions": {
+                                        "link": "/foo"
+                                }
+                        }
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+    Payload = {
+    "key": "value"
+},
+    Overrides = {
+    "providers": {
+        "fcm": {
+            "webPush": {
+                "fcmOptions": {
+                    "link": "/foo"
+                }
+            }
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .payload({
+        "key": "value"
+})
+        .overrides({
+        "providers": {
+                "fcm": {
+                        "webPush": {
+                                "fcmOptions": {
+                                        "link": "/foo"
+                                }
+                        }
+                }
+        }
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {
+        "key": "value"
+    },
+    "overrides": {
+        "providers": {
+            "fcm": {
+                "webPush": {
+                    "fcmOptions": {
+                        "link": "/foo"
+                    }
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 ## Frequently asked questions

--- a/docs/platform/integrations/push/onesignal.mdx
+++ b/docs/platform/integrations/push/onesignal.mdx
@@ -69,111 +69,433 @@ To target a OneSignal user from Novu, you must register their `player_id` as the
 You can do this by making an API call to [update the subscriber's credentials](/api-reference/subscribers/update-provider-credentials).
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.OneSignal,
-    // Use integrationIdentifier to store device tokens for a specific integration
     integrationIdentifier: "string",
-    credentials: {
-      deviceTokens: [
-        "token1",
-        "token2",
-        "token3"
-      ],
-    },
+    credentials: { deviceTokens: ["token1", "token2", "token3"] },
   },
   "subscriberId"
 );
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.ONESIGNAL,
+            "credentials": {"deviceTokens": ["token1", "token2", "token3"]},
+            "integration_identifier": "string",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumOneSignal,
+        IntegrationIdentifier: novugo.String("string"),
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2", "token3"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::OneSignal,
+        integrationIdentifier: 'string',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2', 'token3'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.OneSignal,
+        IntegrationIdentifier = "string",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string> { "token1", "token2", "token3" },
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.ONESIGNAL)
+            .integrationIdentifier("string")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2", "token3"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
--H 'Accept: application/json' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "one-signal",
-  "deviceTokens": ["token1", "token2", "token3"],
+  "credentials": {
+    "deviceTokens": [
+      "token1",
+      "token2",
+      "token3"
+    ]
+  },
   "integrationIdentifier": "string"
 }'
 ```
-</Tab>
+  </Tab>
 </Tabs>
 
 ### Step 2: Send a notification
 
-Now you're ready to send a push notification. [Create a workflow with a Push step](/platform/workflow/create-a-workflow) and trigger it. Novu sends the notification to all devices (player IDs) associated with the subscriber.
-
-The example below demonstrates, how to [trigger a workflow](/platform/sdks/server/typescript) using Novu’s SDK.
-
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: 'SUBSCRIBER_ID',
-  },
-  payload: {
-    // Your payload data
-  },
+  to: { subscriberId: "SUBSCRIBER_ID", },
+  payload: {},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
 
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "SUBSCRIBER_ID"},
+        payload={},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "SUBSCRIBER_ID",
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'SUBSCRIBER_ID'),
+        payload: {},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "SUBSCRIBER_ID" }),
+    Payload = {},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("SUBSCRIBER_ID").build()))
+        .payload({})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "SUBSCRIBER_ID"
+    ],
+    "payload": {}
+}'
+```
+  </Tab>
+</Tabs>
 ## Using overrides to customize notifications
 
-Novu provides an `overrides` field that lets you send additional OneSignal-specific message fields. You can use this to control how messages are displayed or to attach custom payloads.
-
-The overrides field supports all OneSignal Create Notification parameters. Here is an example:
-
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-  },
+  to: { subscriberId: "subscriberId", },
   payload: {
-    abc: 'def', // If the notification is a data notification, the payload will be sent as the data
-  },
+    "abc": "def"
+},
   overrides: {
-    subtitle: 'This is subtitle value',
-    mutableContent: 'Mutable content value',
-    // for android notification categories
-    channelId: 'category_id',
-    // for ios notification categories
-    categoryId: 'Category id',
-    // same value is used for all sizes and browsers
-    icon: 'https://image.com/icon.png',
-    // used for both android and ios
-    sound: 'sound file url',
-  },
+    "subtitle": "This is subtitle value",
+    "mutableContent": "Mutable content value",
+    "channelId": "category_id",
+    "categoryId": "Category id",
+    "icon": "https://image.com/icon.png",
+    "sound": "sound file url"
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
 
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={
+        "abc": "def"
+},
+        overrides={
+        "subtitle": "This is subtitle value",
+        "mutableContent": "Mutable content value",
+        "channelId": "category_id",
+        "categoryId": "Category id",
+        "icon": "https://image.com/icon.png",
+        "sound": "sound file url"
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+    "abc": "def"
+},
+    Overrides: map[string]any{
+    "subtitle": "This is subtitle value",
+    "mutableContent": "Mutable content value",
+    "channelId": "category_id",
+    "categoryId": "Category id",
+    "icon": "https://image.com/icon.png",
+    "sound": "sound file url"
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: {
+        "abc": "def"
+},
+        overrides: {
+        "subtitle": "This is subtitle value",
+        "mutableContent": "Mutable content value",
+        "channelId": "category_id",
+        "categoryId": "Category id",
+        "icon": "https://image.com/icon.png",
+        "sound": "sound file url"
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+    Payload = {
+    "abc": "def"
+},
+    Overrides = {
+    "subtitle": "This is subtitle value",
+    "mutableContent": "Mutable content value",
+    "channelId": "category_id",
+    "categoryId": "Category id",
+    "icon": "https://image.com/icon.png",
+    "sound": "sound file url"
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .payload({
+        "abc": "def"
+})
+        .overrides({
+        "subtitle": "This is subtitle value",
+        "mutableContent": "Mutable content value",
+        "channelId": "category_id",
+        "categoryId": "Category id",
+        "icon": "https://image.com/icon.png",
+        "sound": "sound file url"
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {
+        "abc": "def"
+    },
+    "overrides": {
+        "subtitle": "This is subtitle value",
+        "mutableContent": "Mutable content value",
+        "channelId": "category_id",
+        "categoryId": "Category id",
+        "icon": "https://image.com/icon.png",
+        "sound": "sound file url"
+    }
+}'
+```
+  </Tab>
+</Tabs>
 ## Using external user ID
 
 By default, Novu uses `player_id` to send notifications, but you can select the `External ID` option in the OneSignal integration settings in Novu. If `External ID` option is selected, then `deviceTokens` stored in subscriber credentials for the OneSignal provider, are used as external user IDs.

--- a/docs/platform/integrations/push/push-activity-tracking.mdx
+++ b/docs/platform/integrations/push/push-activity-tracking.mdx
@@ -137,16 +137,14 @@ messaging()
 
 Create an endpoint on your backend that receives the event data from your application and uses the Novu SDK to forward it to Novu.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
-const novuClient = new Novu({
-  apiKey: process.env.NOVU_API_KEY,
-});
+const novuClient = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
 
-// Your backend API endpoint that receives events from your mobile application
 app.post('/api/notifications/events', async (req, res) => {
-  // Forward the event data to Novu
   const response = await novuClient.activity.track({
     environmentId: process.env.NOVU_ENVIRONMENT_ID,
     integrationId: process.env.NOVU_INTEGRATION_ID,
@@ -156,6 +154,104 @@ app.post('/api/notifications/events', async (req, res) => {
   res.status(200).json({ success: true, data: response });
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+novu_client = Novu(secret_key=os.getenv("NOVU_SECRET_KEY", ""))
+
+@app.post("/api/notifications/events")
+async def track_push_event(req_body: dict):
+    with novu_client as novu:
+        response = novu.activity.track(
+            environment_id=os.getenv("NOVU_ENVIRONMENT_ID", ""),
+            integration_id=os.getenv("NOVU_INTEGRATION_ID", ""),
+            request_body=req_body,
+        )
+    return {"success": True, "data": response}
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Activity.Track(context.Background(), components.ActivityTrackRequestDto{
+    EnvironmentID: os.Getenv("NOVU_ENVIRONMENT_ID"),
+    IntegrationID: os.Getenv("NOVU_INTEGRATION_ID"),
+    RequestBody:   eventData,
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity(getenv('NOVU_SECRET_KEY'))->build();
+$response = $sdk->activity->track(
+    activityTrackRequestDto: new Components\ActivityTrackRequestDto(
+        environmentId: getenv('NOVU_ENVIRONMENT_ID'),
+        integrationId: getenv('NOVU_INTEGRATION_ID'),
+        requestBody: $reqBody,
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: Environment.GetEnvironmentVariable("NOVU_SECRET_KEY"));
+var response = await sdk.Activity.TrackAsync(
+    activityTrackRequestDto: new ActivityTrackRequestDto() {
+        EnvironmentId = Environment.GetEnvironmentVariable("NOVU_ENVIRONMENT_ID"),
+        IntegrationId = Environment.GetEnvironmentVariable("NOVU_INTEGRATION_ID"),
+        RequestBody = reqBody,
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey(System.getenv("NOVU_SECRET_KEY")).build();
+var response = novu.activity().track()
+    .body(ActivityTrackRequestDto.builder()
+        .environmentId(System.getenv("NOVU_ENVIRONMENT_ID"))
+        .integrationId(System.getenv("NOVU_INTEGRATION_ID"))
+        .requestBody(reqBody)
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/activity/track' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+  "environmentId": "<NOVU_ENVIRONMENT_ID>",
+  "integrationId": "<NOVU_INTEGRATION_ID>",
+  "requestBody": {
+    "eventType": "opened",
+    "eventId": "<__nvMessageId>"
+  }
+}'
+```
+  </Tab>
+</Tabs>
 
 <Note>
   Both `Integration ID` and `Environment ID` can be found in the push provider integration page after enabling Push Activity Tracking.

--- a/docs/platform/integrations/push/push-webhook.mdx
+++ b/docs/platform/integrations/push/push-webhook.mdx
@@ -72,34 +72,128 @@ Any random string can be used as a device token. This token is included in the w
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.PushWebhook,
-    // Use integrationIdentifier to store device tokens for a specific integration
     integrationIdentifier: "push-webhook-MnGLxp8uy",
-    credentials: {
-      deviceTokens: ["token1", "token2", "token3"],
-    },
+    credentials: { deviceTokens: ["token1", "token2", "token3"] },
   },
   "subscriberId"
 );
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.PUSHWEBHOOK,
+            "credentials": {"deviceTokens": ["token1", "token2", "token3"]},
+            "integration_identifier": "push-webhook-MnGLxp8uy",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumPushWebhook,
+        IntegrationIdentifier: novugo.String("push-webhook-MnGLxp8uy"),
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2", "token3"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::PushWebhook,
+        integrationIdentifier: 'push-webhook-MnGLxp8uy',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2', 'token3'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.PushWebhook,
+        IntegrationIdentifier = "push-webhook-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string> { "token1", "token2", "token3" },
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.PUSHWEBHOOK)
+            .integrationIdentifier("push-webhook-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2", "token3"))
+            .build())
+        .build())
+    .call();
 ```
   </Tab>
   <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
--H 'Accept: application/json' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "push-webhook",
-  "deviceTokens": ['ANY_RANDOM_STRING'],
+  "credentials": {
+    "deviceTokens": [
+      "token1",
+      "token2",
+      "token3"
+    ]
+  },
   "integrationIdentifier": "push-webhook-MnGLxp8uy"
 }'
 ```
@@ -112,25 +206,130 @@ Now you're ready to send a push notification. [Create a workflow with a Push ste
 
 The example below demonstrates a simple trigger using Novu’s SDK.
 
-```jsx
+<Tabs>
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({
-  secretKey: "<NOVU_SECRET_KEY>",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: 'SUBSCRIBER_ID',
-  },
-  payload: {
-    // This payload data will be included
-    // in the webhook request
-    custom_message: "This is custom message from payload.",
-  },  
+  to: { subscriberId: "SUBSCRIBER_ID", },
+  payload: {
+    "custom_message": "This is custom message from payload."
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "SUBSCRIBER_ID"},
+        payload={
+        "custom_message": "This is custom message from payload."
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "SUBSCRIBER_ID",
+    }),
+    Payload: map[string]any{
+    "custom_message": "This is custom message from payload."
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'SUBSCRIBER_ID'),
+        payload: {
+        "custom_message": "This is custom message from payload."
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "SUBSCRIBER_ID" }),
+    Payload = {
+    "custom_message": "This is custom message from payload."
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("SUBSCRIBER_ID").build()))
+        .payload({
+        "custom_message": "This is custom message from payload."
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "SUBSCRIBER_ID"
+    ],
+    "payload": {
+        "custom_message": "This is custom message from payload."
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Payload sent by Novu to webhook URL
 

--- a/docs/platform/integrations/push/pusher-beams.mdx
+++ b/docs/platform/integrations/push/pusher-beams.mdx
@@ -80,7 +80,7 @@ To target a Pusher Beams user from Novu, you must register this `userId` as the 
 You can do this by making an API call to [update the subscriber's credentials](/api-reference/subscribers/update-provider-credentials).
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
@@ -94,17 +94,110 @@ const novu = new Novu({
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.PusherBeams,
-    // Use integrationIdentifier to store device tokens for a specific integration
     integrationIdentifier: "pusher-beams-MnGLxp8uy",
-    credentials: {
-      deviceTokens: ["token1", "token2", "token3"],
-    },
+    credentials: { deviceTokens: ["token1", "token2", "token3"] },
   },
   "subscriberId"
 );
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.PUSHERBEAMS,
+            "credentials": {"deviceTokens": ["token1", "token2", "token3"]},
+            "integration_identifier": "pusher-beams-MnGLxp8uy",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumPusherBeams,
+    IntegrationIdentifier: novugo.String("pusher-beams-MnGLxp8uy"),
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2", "token3"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::PusherBeams,
+        integrationIdentifier: 'pusher-beams-MnGLxp8uy',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2', 'token3'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.PusherBeams,
+        IntegrationIdentifier = "pusher-beams-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string> { "token1", "token2", "token3" },
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.PUSHERBEAMS)
+        .integrationIdentifier("pusher-beams-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2", "token3"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
@@ -112,12 +205,17 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "pusher-beams",
-  "deviceTokens": ['userId-from-pusher-beams'],
+  "credentials": {
+    "deviceTokens": [
+      "token1",
+      "token2",
+      "token3"
+    ]
+  },
   "integrationIdentifier": "pusher-beams-MnGLxp8uy"
 }'
 ```
-
-</Tab>
+  </Tab>
 </Tabs>
 
 ### Step 2: Send a notification
@@ -126,6 +224,8 @@ Now you're ready to send a push notification. [Create a workflow with a Push ste
 
 The example below demonstrates a simple trigger using Novu’s SDK.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
@@ -141,7 +241,108 @@ await novu.trigger({
     subscriberId: "subscriberId",
   },
   payload: {
-    custom_data: 'custom_data', // the payload will be sent as notification data object. Cannot contain the key "pusher"
-  },
+    "custom_data": "custom_data"
+},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={
+        "custom_data": "custom_data"
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{
+        "custom_data": "custom_data",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: [],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {
+        "custom_data": "custom_data"
+    }
+}'
+```
+  </Tab>
+</Tabs>

--- a/docs/platform/integrations/push/pushpad.mdx
+++ b/docs/platform/integrations/push/pushpad.mdx
@@ -101,7 +101,7 @@ This `uid` is the identifier Novu uses to target a specific browser. For example
 You can do this by making an API call to [update the subscriber's credentials](/api-reference/subscribers/update-provider-credentials).
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 import { ChatOrPushProviderEnum } from "@novu/api/models/components";
@@ -115,17 +115,110 @@ const novu = new Novu({
 await novu.subscribers.credentials.update(
   {
     providerId: ChatOrPushProviderEnum.PushPad,
-    // Use integrationIdentifier to store device tokens for a specific integration
     integrationIdentifier: "pushpad-MnGLxp8uy",
-    credentials: {
-      deviceTokens: ["token1", "token2", "token3"],
-    },
+    credentials: { deviceTokens: ["token1", "token2", "token3"] },
   },
   "subscriberId"
 );
 ```
-</Tab>
-<Tab title="cURL">
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.subscribers.credentials.update(
+        subscriber_id="subscriberId",
+        update_subscriber_channel_request_dto={
+            "provider_id": novu_py.ChatOrPushProviderEnum.PUSHPAD,
+            "credentials": {"deviceTokens": ["token1", "token2", "token3"]},
+            "integration_identifier": "pushpad-MnGLxp8uy",
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Subscribers.Credentials.Update(context.Background(), "subscriberId", components.UpdateSubscriberChannelRequestDto{
+    ProviderID: components.ChatOrPushProviderEnumPushPad,
+    IntegrationIdentifier: novugo.String("pushpad-MnGLxp8uy"),
+    Credentials: components.ChannelCredentials{
+        DeviceTokens: []string{"token1", "token2", "token3"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->subscribersCredentials->update(
+    subscriberId: 'subscriberId',
+    updateSubscriberChannelRequestDto: new Components\UpdateSubscriberChannelRequestDto(
+        providerId: Components\ChatOrPushProviderEnum::PushPad,
+        integrationIdentifier: 'pushpad-MnGLxp8uy',
+        credentials: new Components\ChannelCredentials(
+            deviceTokens: ['token1', 'token2', 'token3'],
+        ),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.Subscribers.Credentials.UpdateAsync(
+    subscriberId: "subscriberId",
+    updateSubscriberChannelRequestDto: new UpdateSubscriberChannelRequestDto() {
+        ProviderId = ChatOrPushProviderEnum.PushPad,
+        IntegrationIdentifier = "pushpad-MnGLxp8uy",
+        Credentials = new ChannelCredentials() {
+            DeviceTokens = new List<string> { "token1", "token2", "token3" },
+        },
+    });
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.subscribers().credentials().update()
+    .subscriberId("subscriberId")
+    .body(UpdateSubscriberChannelRequestDto.builder()
+        .providerId(ChatOrPushProviderEnum.PUSHPAD)
+        .integrationIdentifier("pushpad-MnGLxp8uy")
+        .credentials(ChannelCredentials.builder()
+            .deviceTokens(List.of("token1", "token2", "token3"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
 ```bash
 curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' \
 -H 'Content-Type: application/json' \
@@ -133,12 +226,17 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "providerId": "pushpad",
-  "deviceTokens": ['user123'],
+  "credentials": {
+    "deviceTokens": [
+      "token1",
+      "token2",
+      "token3"
+    ]
+  },
   "integrationIdentifier": "pushpad-MnGLxp8uy"
 }'
 ```
-
-</Tab>
+  </Tab>
 </Tabs>
 
 ### Step 2: Send a notification
@@ -147,6 +245,8 @@ Now you're ready to send a push notification. [Create a workflow with a Push ste
 
 The example below demonstrates a simple trigger using Novu’s SDK.
 
+<Tabs>
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from '@novu/api';
 
@@ -164,3 +264,98 @@ await novu.trigger({
   payload: {},
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        payload={},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Payload: map[string]any{},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        payload: [],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId" }),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").build()))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": [
+        "subscriberId"
+    ],
+    "payload": {}
+}'
+```
+  </Tab>
+</Tabs>

--- a/docs/platform/integrations/sms.mdx
+++ b/docs/platform/integrations/sms.mdx
@@ -78,6 +78,8 @@ Each provider has different requirements.
 
 You can override the SMS settings when triggerring a notification by passing the `overrides` object. The overrides object field supports an `sms` property and `from`, `to`, and `content` field overrides. This lets you send a message to a different recipient, from a different sender, or with a different content.
 
+<Tabs>
+  <Tab title="Node.js">
 ```javascript
 import { Novu } from '@novu/api';  
 
@@ -101,6 +103,149 @@ await novu.trigger({
   },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        overrides={
+            "sms": {
+                "to": "+123012345678",
+                "from": "Novu Team",
+                "content": "This SMS message is from overrides",
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Overrides: map[string]map[string]any{
+        "sms": {
+            "to":      "+123012345678",
+            "from":    "Novu Team",
+            "content": "This SMS message is from overrides",
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        overrides: [
+            'sms' => [
+                'to' => '+123012345678',
+                'from' => 'Novu Team',
+                'content' => 'This SMS message is from overrides',
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+    }),
+    Overrides = new Overrides() {
+        Sms = new Dictionary<string, object>() {
+            { "to", "+123012345678" },
+            { "from", "Novu Team" },
+            { "content", "This SMS message is from overrides" },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .build()))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .sms(Map.of(
+                "to", "+123012345678",
+                "from", "Novu Team",
+                "content", "This SMS message is from overrides"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId"
+    },
+    "overrides": {
+        "sms": {
+            "to": "+123012345678",
+            "from": "Novu Team",
+            "content": "This SMS message is from overrides"
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Target a specific provider
 
@@ -109,7 +254,7 @@ By default, Novu uses your primary SMS provider. If you want to bypass this and 
 This is useful if you have multiple active integrations for different purposes. For example, you might have one integration for transactional SMS and one for security SMS. You can find the `integrationIdentifier` in the **Integration Store** of the Novu dashboard.
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```javascript
 import { Novu } from '@novu/api';  
 
@@ -128,9 +273,136 @@ await novu.trigger({
     sms: { integrationIdentifier: 'infobip-abcdef', },
   },
 });
-
 ```
-</Tab>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId"},
+        overrides={
+            "sms": {
+                "integrationIdentifier": "infobip-abcdef",
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+    }),
+    Overrides: map[string]map[string]any{
+        "sms": {
+            "integrationIdentifier": "infobip-abcdef",
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<NOVU_SECRET_KEY>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId'),
+        overrides: [
+            'sms' => [
+                'integrationIdentifier' => 'infobip-abcdef',
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriberId",
+    }),
+    Overrides = new Overrides() {
+        Sms = new Dictionary<string, object>() {
+            { "integrationIdentifier", "infobip-abcdef" },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<NOVU_SECRET_KEY>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriberId")
+            .build()))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .sms(Map.of("integrationIdentifier", "infobip-abcdef"))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId"
+    },
+    "overrides": {
+        "sms": {
+            "integrationIdentifier": "infobip-abcdef"
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 ## Supported providers

--- a/docs/platform/integrations/sms/gupshup.mdx
+++ b/docs/platform/integrations/sms/gupshup.mdx
@@ -45,44 +45,178 @@ Novu has its own SMS editor for writing SMS template. To use premade Gupshup tem
 </Note>
 
 <Tabs>
-  <Tab title="Node.Js">
-```typescript 
+  <Tab title="Node.js">
+```typescript
 import { Novu } from '@novu/api';
 
-const novu = new Novu({ secretKey: "NOVU_SECRET_KEY" });
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "WORKFLOW_ID",
-  to: "SUBSCRIBER_ID",
+  to: { subscriberId: "SUBSCRIBER_ID", },
   payload: {
-    key: "value",
-  },
+    "key": "value"
+},
   overrides: {
-    providers: {
-      gupshup: {
-        principalEntityId: "principal-entity-id",
-        dltTemplateId: "dlt-template-id",
-      },
-    },
-  },
+    "providers": {
+        "gupshup": {
+            "principalEntityId": "principal-entity-id",
+            "dltTemplateId": "dlt-template-id"
+        }
+    }
+},
 });
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="WORKFLOW_ID",
+        to={"subscriber_id": "SUBSCRIBER_ID"},
+        payload={
+        "key": "value"
+},
+        overrides={
+        "providers": {
+                "gupshup": {
+                        "principalEntityId": "principal-entity-id",
+                        "dltTemplateId": "dlt-template-id"
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "WORKFLOW_ID",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "SUBSCRIBER_ID",
+    }),
+    Payload: map[string]any{
+    "key": "value"
+},
+    Overrides: map[string]any{
+    "providers": {
+        "gupshup": {
+            "principalEntityId": "principal-entity-id",
+            "dltTemplateId": "dlt-template-id"
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'WORKFLOW_ID',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'SUBSCRIBER_ID'),
+        payload: {
+        "key": "value"
+},
+        overrides: {
+        "providers": {
+                "gupshup": {
+                        "principalEntityId": "principal-entity-id",
+                        "dltTemplateId": "dlt-template-id"
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "WORKFLOW_ID",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "SUBSCRIBER_ID" }),
+    Payload = {
+    "key": "value"
+},
+    Overrides = {
+    "providers": {
+        "gupshup": {
+            "principalEntityId": "principal-entity-id",
+            "dltTemplateId": "dlt-template-id"
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("WORKFLOW_ID")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("SUBSCRIBER_ID").build()))
+        .payload({
+        "key": "value"
+})
+        .overrides({
+        "providers": {
+                "gupshup": {
+                        "principalEntityId": "principal-entity-id",
+                        "dltTemplateId": "dlt-template-id"
+                }
+        }
+})
+        .build())
+    .call();
 ```
   </Tab>
   <Tab title="cURL">
 ```bash
 curl --location 'https://api.novu.co/v1/events/trigger' \
 --header 'Content-Type: application/json' \
---header 'Accept: application/json' \
 --header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
---data '{
-    "name": "workflowIdentifier",
-    "to":  ["subscriberId"],
-    "payload": {},
+-d '{
+    "name": "WORKFLOW_ID",
+    "to": [
+        "SUBSCRIBER_ID"
+    ],
+    "payload": {
+        "key": "value"
+    },
     "overrides": {
         "providers": {
             "gupshup": {
-              "principalEntityId": "principal-entity-id",
-              "dltTemplateId": "dlt-template-id"
+                "principalEntityId": "principal-entity-id",
+                "dltTemplateId": "dlt-template-id"
             }
         }
     }

--- a/docs/platform/integrations/sms/twilio.mdx
+++ b/docs/platform/integrations/sms/twilio.mdx
@@ -67,26 +67,201 @@ For more detailed instructions, follow one of their many [Tutorials](https://www
 To send WhatsApp messages with Twilio integration, prefix the phone number of the subscriber with `whatsapp:` as shown below:
 
 <Tabs>
-<Tab title="Node.js">
-```ts
-import { Novu } from "@novu/api";
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
 
-const novu = new Novu({ 
-  secretKey: "<NOVU_SECRET_KEY>",
-  // Required if using EU region
-  // serverURL: "https://eu.api.novu.co",
-});
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 await novu.trigger({
   workflowId: "workflowId",
-  to: {
-    subscriberId: "subscriberId",
-    phone: "whatsapp:+14155238886",
-  },
+  to: { subscriberId: "subscriberId",
+    phone: "whatsapp:+14155238886", },
   payload: {},
+  overrides: {
+    "providers": {
+        "twilio": {
+            "_passthrough": {
+                "body": {
+                    "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                    "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                }
+            }
+        }
+    }
+},
 });
 ```
-</Tab>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId", "phone": "whatsapp:+14155238886"},
+        payload={},
+        overrides={
+        "providers": {
+                "twilio": {
+                        "_passthrough": {
+                                "body": {
+                                        "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                                        "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                                }
+                        }
+                }
+        }
+},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+            Phone: novugo.String("whatsapp:+14155238886"),
+    }),
+    Payload: map[string]any{},
+    Overrides: map[string]any{
+    "providers": {
+        "twilio": {
+            "_passthrough": {
+                "body": {
+                    "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                    "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                }
+            }
+        }
+    }
+},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId', phone: 'whatsapp:+14155238886'),
+        payload: {},
+        overrides: {
+        "providers": {
+                "twilio": {
+                        "_passthrough": {
+                                "body": {
+                                        "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                                        "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                                }
+                        }
+                }
+        }
+},
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId", Phone = "whatsapp:+14155238886" }),
+    Payload = {},
+    Overrides = {
+    "providers": {
+        "twilio": {
+            "_passthrough": {
+                "body": {
+                    "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                    "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                }
+            }
+        }
+    }
+},
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").phone("whatsapp:+14155238886").build()))
+        .payload({})
+        .overrides({
+        "providers": {
+                "twilio": {
+                        "_passthrough": {
+                                "body": {
+                                        "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                                        "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                                }
+                        }
+                }
+        }
+})
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId",
+        "phone": "whatsapp:+14155238886"
+    },
+    "payload": {},
+    "overrides": {
+        "providers": {
+            "twilio": {
+                "_passthrough": {
+                    "body": {
+                        "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                        "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                    }
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 ### Sending WhatsApp template message
@@ -94,7 +269,7 @@ await novu.trigger({
 To send WhatsApp template messages with Twilio integration, you can use the `template` field in the `overrides` object.
 
 <Tabs>
-<Tab title="Node.js">
+  <Tab title="Node.js">
 ```typescript
 import { Novu } from "@novu/api";
 
@@ -116,9 +291,7 @@ await novu.trigger({
       twilio: {
         "_passthrough": {
           "body": {
-            // example contentSid
             "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
-            // example contentVariables
             "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
           }
         }
@@ -127,7 +300,173 @@ await novu.trigger({
   }
 });
 ```
-</Tab>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "subscriberId", "phone": "whatsapp:+14155238886"},
+        payload={},
+        overrides={
+            "providers": {
+                "twilio": {
+                    "_passthrough": {
+                        "body": {
+                            "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                            "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                        }
+                    }
+                }
+            }
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriberId",
+        Phone: novugo.String("whatsapp:+14155238886"),
+    }),
+    Payload: map[string]any{},
+    Overrides: map[string]any{
+        "providers": map[string]any{
+            "twilio": map[string]any{
+                "_passthrough": map[string]any{
+                    "body": map[string]any{
+                        "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                        "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}",
+                    },
+                },
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriberId', phone: 'whatsapp:+14155238886'),
+        payload: [],
+        overrides: [
+            'providers' => [
+                'twilio' => [
+                    '_passthrough' => [
+                        'body' => [
+                            'contentSid' => 'HXb5b62575e6e4ff6129ad7c8efe1f983e',
+                            'contentVariables' => '{"1":"12/1","2":"3pm"}',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "subscriberId", Phone = "whatsapp:+14155238886" }),
+    Payload = new Dictionary<string, object>(),
+    Overrides = new Overrides() {
+        Providers = new Dictionary<string, Dictionary<string, object>>() {
+            { "twilio", new Dictionary<string, object>() {
+                { "_passthrough", new Dictionary<string, object>() {
+                    { "body", new Dictionary<string, object>() {
+                        { "contentSid", "HXb5b62575e6e4ff6129ad7c8efe1f983e" },
+                        { "contentVariables", "{\"1\":\"12/1\",\"2\":\"3pm\"}" },
+                    } },
+                } },
+            } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("subscriberId").phone("whatsapp:+14155238886").build()))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of("providers", Map.of("twilio", Map.of(
+                "_passthrough", Map.of("body", Map.of(
+                    "contentSid", "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                    "contentVariables", "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                ))
+            ))))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl --location 'https://api.novu.co/v1/events/trigger' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": {
+        "subscriberId": "subscriberId",
+        "phone": "whatsapp:+14155238886"
+    },
+    "payload": {},
+    "overrides": {
+        "providers": {
+            "twilio": {
+                "_passthrough": {
+                    "body": {
+                        "contentSid": "HXb5b62575e6e4ff6129ad7c8efe1f983e",
+                        "contentVariables": "{\"1\":\"12/1\",\"2\":\"3pm\"}"
+                    }
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
 </Tabs>
 
 <Note>

--- a/docs/platform/integrations/trigger-overrides.mdx
+++ b/docs/platform/integrations/trigger-overrides.mdx
@@ -58,46 +58,266 @@ Use workflow-level overrides when:
 - You need to define common metadata like headers, personalization, or layout settings.
 - You want consistent behavior across all steps for a given provider.
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
 import { Novu } from "@novu/api";
 
-const novu = new Novu("<YOUR_SECRET_KEY_HERE>");
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
 
-async function run() {
-  const result = await novu.trigger({
-    to: {
-      subscriberId: "subscriber_unique_identifier",
-      firstName: "Albert",
-      lastName: "Einstein",
-      email: "albert@einstein.com",
-      phone: "+1234567890",
-    },
-    workflowId: "workflow_identifier",
-    payload: {
-      comment_id: "string",
-      post: {
-        text: "string",
-      },
-    },
-    overrides: {
-      providers: {
-        sendgrid: {
-          template_id: "xxxxxxxx", // Make sure this is a string
-          trackingSettings: {
-            clickTracking: {
-              enable: true,
-              enableText: false,
-            },
+await novu.trigger({
+  to: {
+    subscriberId: "subscriber_unique_identifier",
+    firstName: "Albert",
+    lastName: "Einstein",
+    email: "albert@einstein.com",
+    phone: "+1234567890",
+  },
+  workflowId: "workflow_identifier",
+  payload: {
+    comment_id: "string",
+    post: { text: "string" },
+  },
+  overrides: {
+    providers: {
+      sendgrid: {
+        template_id: "xxxxxxxx",
+        trackingSettings: {
+          clickTracking: {
+            enable: true,
+            enableText: false,
           },
         },
       },
     },
-  });
-}
-
-run();
-
+  },
+});
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflow_identifier",
+        to={
+            "subscriber_id": "subscriber_unique_identifier",
+            "first_name": "Albert",
+            "last_name": "Einstein",
+            "email": "albert@einstein.com",
+            "phone": "+1234567890",
+        },
+        payload={
+            "comment_id": "string",
+            "post": {"text": "string"},
+        },
+        overrides={
+            "providers": {
+                "sendgrid": {
+                    "template_id": "xxxxxxxx",
+                    "trackingSettings": {
+                        "clickTracking": {
+                            "enable": True,
+                            "enableText": False,
+                        },
+                    },
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflow_identifier",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriber_unique_identifier",
+        FirstName:    "Albert",
+        LastName:     "Einstein",
+        Email:        "albert@einstein.com",
+        Phone:        "+1234567890",
+    }),
+    Payload: map[string]any{
+        "comment_id": "string",
+        "post":       map[string]any{"text": "string"},
+    },
+    Overrides: map[string]map[string]any{
+        "providers": {
+            "sendgrid": map[string]any{
+                "template_id": "xxxxxxxx",
+                "trackingSettings": map[string]any{
+                    "clickTracking": map[string]any{
+                        "enable":     true,
+                        "enableText": false,
+                    },
+                },
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflow_identifier',
+        to: new Components\SubscriberPayloadDto(
+            subscriberId: 'subscriber_unique_identifier',
+            firstName: 'Albert',
+            lastName: 'Einstein',
+            email: 'albert@einstein.com',
+            phone: '+1234567890',
+        ),
+        payload: [
+            'comment_id' => 'string',
+            'post' => ['text' => 'string'],
+        ],
+        overrides: [
+            'providers' => [
+                'sendgrid' => [
+                    'template_id' => 'xxxxxxxx',
+                    'trackingSettings' => [
+                        'clickTracking' => [
+                            'enable' => true,
+                            'enableText' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflow_identifier",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriber_unique_identifier",
+        FirstName = "Albert",
+        LastName = "Einstein",
+        Email = "albert@einstein.com",
+        Phone = "+1234567890",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "comment_id", "string" },
+        { "post", new Dictionary<string, object>() { { "text", "string" } } },
+    },
+    Overrides = new Overrides() {
+        Providers = new Dictionary<string, Dictionary<string, object>>() {
+            { "sendgrid", new Dictionary<string, object>() {
+                { "template_id", "xxxxxxxx" },
+                { "trackingSettings", new Dictionary<string, object>() {
+                    { "clickTracking", new Dictionary<string, object>() {
+                        { "enable", true },
+                        { "enableText", false },
+                    } },
+                } },
+            } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflow_identifier")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriber_unique_identifier")
+            .firstName("Albert")
+            .lastName("Einstein")
+            .email("albert@einstein.com")
+            .phone("+1234567890")
+            .build()))
+        .payload(Map.ofEntries(
+            Map.entry("comment_id", "string"),
+            Map.entry("post", Map.of("text", "string"))))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of("providers", Map.of("sendgrid", Map.ofEntries(
+                Map.entry("template_id", "xxxxxxxx"),
+                Map.entry("trackingSettings", Map.of("clickTracking", Map.ofEntries(
+                    Map.entry("enable", true),
+                    Map.entry("enableText", false))))))))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflow_identifier",
+    "to": {
+        "subscriberId": "subscriber_unique_identifier",
+        "firstName": "Albert",
+        "lastName": "Einstein",
+        "email": "albert@einstein.com",
+        "phone": "+1234567890"
+    },
+    "payload": {
+        "comment_id": "string",
+        "post": { "text": "string" }
+    },
+    "overrides": {
+        "providers": {
+            "sendgrid": {
+                "template_id": "xxxxxxxx",
+                "trackingSettings": {
+                    "clickTracking": {
+                        "enable": true,
+                        "enableText": false
+                    }
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 This configuration affects every step in the workflow that uses SendGrid, unless a step-level override provides a more specific value.
 
@@ -127,59 +347,352 @@ Use step-level overrides when:
 - You want to send push notifications through the same provider, but with different settings for each step. For example, two steps use FCM, but each sends a different sound or title.
 - You need to customize the payload for a specific push step, such as platform-specific settings for Android and iOS, without affecting other steps.
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
 import { Novu } from "@novu/api";
 
 const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
 
-async function run() {
-  const result = await novu.trigger({
-    to: {
-      subscriberId: "subscriber_unique_identifier",
-      firstName: "Albert",
-      lastName: "Einstein",
-      email: "albert@einstein.com",
-      phone: "+1234567890",
-    },
-    workflowId: "workflow_identifier",
-    payload: {
-      comment_id: "string",
-      post: {
-        text: "string",
+await novu.trigger({
+  to: {
+    subscriberId: "subscriber_unique_identifier",
+    firstName: "Albert",
+    lastName: "Einstein",
+    email: "albert@einstein.com",
+    phone: "+1234567890",
+  },
+  workflowId: "workflow_identifier",
+  payload: {
+    comment_id: "string",
+    post: { text: "string" },
+  },
+  overrides: {
+    steps: {
+      "push-step": {
+        providers: {
+          fcm: {
+            notification: {
+              title: "New Comment",
+              body: "Someone replied to your post!",
+              sound: "default",
+            },
+            android: {
+              notification: {
+                sound: "sound_bell",
+              },
+            },
+            apns: {
+              payload: {
+                aps: {
+                  sound: "notification_bell.caf",
+                },
+              },
+            },
+          },
+        },
       },
     },
-    overrides: {
-      steps: {
-        'push-step': {
-          providers: {
-            fcm: {
-              notification: {
-                title: 'New Comment',
-                body: 'Someone replied to your post!',
-                sound: 'default', // Play default system sound
-              },
-              android: {
-                notification: {
-                  sound: 'sound_bell' // matches res/raw/sound_bell.mp3
-                }
-              },
-              apns: {
-                payload: {
-                  aps: {
-                    sound: 'notification_bell.caf' // For iOS
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  });
-}
-
-run();
+  },
+});
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflow_identifier",
+        to={
+            "subscriber_id": "subscriber_unique_identifier",
+            "first_name": "Albert",
+            "last_name": "Einstein",
+            "email": "albert@einstein.com",
+            "phone": "+1234567890",
+        },
+        payload={
+            "comment_id": "string",
+            "post": {"text": "string"},
+        },
+        overrides={
+            "steps": {
+                "push-step": {
+                    "providers": {
+                        "fcm": {
+                            "notification": {
+                                "title": "New Comment",
+                                "body": "Someone replied to your post!",
+                                "sound": "default",
+                            },
+                            "android": {
+                                "notification": {
+                                    "sound": "sound_bell",
+                                },
+                            },
+                            "apns": {
+                                "payload": {
+                                    "aps": {
+                                        "sound": "notification_bell.caf",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflow_identifier",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriber_unique_identifier",
+        FirstName:    "Albert",
+        LastName:     "Einstein",
+        Email:        "albert@einstein.com",
+        Phone:        "+1234567890",
+    }),
+    Payload: map[string]any{
+        "comment_id": "string",
+        "post":       map[string]any{"text": "string"},
+    },
+    Overrides: map[string]map[string]any{
+        "steps": {
+            "push-step": map[string]any{
+                "providers": map[string]any{
+                    "fcm": map[string]any{
+                        "notification": map[string]any{
+                            "title": "New Comment",
+                            "body":  "Someone replied to your post!",
+                            "sound": "default",
+                        },
+                        "android": map[string]any{
+                            "notification": map[string]any{
+                                "sound": "sound_bell",
+                            },
+                        },
+                        "apns": map[string]any{
+                            "payload": map[string]any{
+                                "aps": map[string]any{
+                                    "sound": "notification_bell.caf",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflow_identifier',
+        to: new Components\SubscriberPayloadDto(
+            subscriberId: 'subscriber_unique_identifier',
+            firstName: 'Albert',
+            lastName: 'Einstein',
+            email: 'albert@einstein.com',
+            phone: '+1234567890',
+        ),
+        payload: [
+            'comment_id' => 'string',
+            'post' => ['text' => 'string'],
+        ],
+        overrides: [
+            'steps' => [
+                'push-step' => [
+                    'providers' => [
+                        'fcm' => [
+                            'notification' => [
+                                'title' => 'New Comment',
+                                'body' => 'Someone replied to your post!',
+                                'sound' => 'default',
+                            ],
+                            'android' => [
+                                'notification' => [
+                                    'sound' => 'sound_bell',
+                                ],
+                            ],
+                            'apns' => [
+                                'payload' => [
+                                    'aps' => [
+                                        'sound' => 'notification_bell.caf',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflow_identifier",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriber_unique_identifier",
+        FirstName = "Albert",
+        LastName = "Einstein",
+        Email = "albert@einstein.com",
+        Phone = "+1234567890",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "comment_id", "string" },
+        { "post", new Dictionary<string, object>() { { "text", "string" } } },
+    },
+    Overrides = new Overrides() {
+        Steps = new Dictionary<string, Dictionary<string, Dictionary<string, object>>>() {
+            { "push-step", new Dictionary<string, Dictionary<string, object>>() {
+                { "providers", new Dictionary<string, object>() {
+                    { "fcm", new Dictionary<string, object>() {
+                        { "notification", new Dictionary<string, object>() {
+                            { "title", "New Comment" },
+                            { "body", "Someone replied to your post!" },
+                            { "sound", "default" },
+                        } },
+                        { "android", new Dictionary<string, object>() {
+                            { "notification", new Dictionary<string, object>() {
+                                { "sound", "sound_bell" },
+                            } },
+                        } },
+                        { "apns", new Dictionary<string, object>() {
+                            { "payload", new Dictionary<string, object>() {
+                                { "aps", new Dictionary<string, object>() {
+                                    { "sound", "notification_bell.caf" },
+                                } },
+                            } },
+                        } },
+                    } },
+                } },
+            } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflow_identifier")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriber_unique_identifier")
+            .firstName("Albert")
+            .lastName("Einstein")
+            .email("albert@einstein.com")
+            .phone("+1234567890")
+            .build()))
+        .payload(Map.ofEntries(
+            Map.entry("comment_id", "string"),
+            Map.entry("post", Map.of("text", "string"))))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of("steps", Map.of("push-step", Map.of("providers", Map.of("fcm", Map.ofEntries(
+                Map.entry("notification", Map.ofEntries(
+                    Map.entry("title", "New Comment"),
+                    Map.entry("body", "Someone replied to your post!"),
+                    Map.entry("sound", "default"))),
+                Map.entry("android", Map.of("notification", Map.of("sound", "sound_bell"))),
+                Map.entry("apns", Map.of("payload", Map.of("aps", Map.of("sound", "notification_bell.caf"))))))))))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflow_identifier",
+    "to": {
+        "subscriberId": "subscriber_unique_identifier",
+        "firstName": "Albert",
+        "lastName": "Einstein",
+        "email": "albert@einstein.com",
+        "phone": "+1234567890"
+    },
+    "payload": {
+        "comment_id": "string",
+        "post": { "text": "string" }
+    },
+    "overrides": {
+        "steps": {
+            "push-step": {
+                "providers": {
+                    "fcm": {
+                        "notification": {
+                            "title": "New Comment",
+                            "body": "Someone replied to your post!",
+                            "sound": "default"
+                        },
+                        "android": {
+                            "notification": {
+                                "sound": "sound_bell"
+                            }
+                        },
+                        "apns": {
+                            "payload": {
+                                "aps": {
+                                    "sound": "notification_bell.caf"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 <Note>
   The `push-step` refers to the step identifier, which you can copy directly from your workflow in the Novu dashboard. Use this identifier to target the specific step you want to override. 

--- a/docs/platform/workflow/advanced-features/contexts.mdx
+++ b/docs/platform/workflow/advanced-features/contexts.mdx
@@ -19,54 +19,439 @@ Without context, you might have to create two different subscribers or use worka
 
 However, with context, you can provide this metadata directly in the trigger. This allows you to use a single workflow and subscriber entity, while dynamically changing content or logic based on the context.
 
-<CodeGroup>
-```javascript title="Without context"
-// Problem: How does Novu know which app is sending the notification?
+### Without context
+
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
 
 // Notion Email notification
 await novu.trigger({
   workflowId: "workflowId",
-  to: { subscriberId: 'john@acme.com' },
-  payload: { title: 'You have 1 new email' }
+  to: { subscriberId: "john@acme.com" },
+  payload: { title: "You have 1 new email" },
 });
 
-// Notion Calendar notification  
-await novu.trigger({  
+// Notion Calendar notification
+await novu.trigger({
   workflowId: "workflowId",
-  to: 'john@acme.com',
-  payload: { title: 'You have a new meeting invite' }
+  to: { subscriberId: "john@acme.com" },
+  payload: { title: "You have a new meeting invite" },
 });
 ```
-```javascript title="With context"
-// Solution: Pass an 'app' context to differentiate triggers.
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "john@acme.com"},
+        payload={"title": "You have 1 new email"},
+    ))
+
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "john@acme.com"},
+        payload={"title": "You have a new meeting invite"},
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "john@acme.com",
+    }),
+    Payload: map[string]any{"title": "You have 1 new email"},
+}, nil)
+
+s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "john@acme.com",
+    }),
+    Payload: map[string]any{"title": "You have a new meeting invite"},
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'john@acme.com'),
+        payload: ['title' => 'You have 1 new email'],
+    ),
+);
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'john@acme.com'),
+        payload: ['title' => 'You have a new meeting invite'],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "john@acme.com",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "title", "You have 1 new email" },
+    },
+});
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "john@acme.com",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "title", "You have a new meeting invite" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("john@acme.com")
+            .build()))
+        .payload(Map.of("title", "You have 1 new email"))
+        .build())
+    .call();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("john@acme.com")
+            .build()))
+        .payload(Map.of("title", "You have a new meeting invite"))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": { "subscriberId": "john@acme.com" },
+    "payload": { "title": "You have 1 new email" }
+}'
+
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": { "subscriberId": "john@acme.com" },
+    "payload": { "title": "You have a new meeting invite" }
+}'
+```
+  </Tab>
+</Tabs>
+
+### With context
+
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
 
 // Notion Email notification
 await novu.trigger({
   workflowId: "workflowId",
-  to: { subscriberId: 'john@acme.com' },
-  payload: { title: 'You have 1 new email' },
+  to: { subscriberId: "john@acme.com" },
+  payload: { title: "You have 1 new email" },
   context: {
-    app: 'notion-email',
-    branding: {
-      logo: "url_for_email_logo.png"
-    }
-  }
+    app: "notion-email",
+    branding: { logo: "url_for_email_logo.png" },
+  },
 });
 
-// Notion Calendar notification  
+// Notion Calendar notification
 await novu.trigger({
   workflowId: "workflowId",
-  to: { subscriberId: 'john@acme.com' },
-  payload: { title: 'You have a new meeting invite' },
+  to: { subscriberId: "john@acme.com" },
+  payload: { title: "You have a new meeting invite" },
   context: {
-    app: 'notion-calendar',
-    branding: {
-      logo: "url_for_calendar_logo.png"
-    }
-  }
+    app: "notion-calendar",
+    branding: { logo: "url_for_calendar_logo.png" },
+  },
 });
 ```
-</CodeGroup>
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "john@acme.com"},
+        payload={"title": "You have 1 new email"},
+        context={
+            "app": "notion-email",
+            "branding": {"logo": "url_for_email_logo.png"},
+        },
+    ))
+
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "john@acme.com"},
+        payload={"title": "You have a new meeting invite"},
+        context={
+            "app": "notion-calendar",
+            "branding": {"logo": "url_for_calendar_logo.png"},
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "john@acme.com",
+    }),
+    Payload: map[string]any{"title": "You have 1 new email"},
+    Context: map[string]any{
+        "app":      "notion-email",
+        "branding": map[string]any{"logo": "url_for_email_logo.png"},
+    },
+}, nil)
+
+s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "john@acme.com",
+    }),
+    Payload: map[string]any{"title": "You have a new meeting invite"},
+    Context: map[string]any{
+        "app":      "notion-calendar",
+        "branding": map[string]any{"logo": "url_for_calendar_logo.png"},
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'john@acme.com'),
+        payload: ['title' => 'You have 1 new email'],
+        context: [
+            'app' => 'notion-email',
+            'branding' => ['logo' => 'url_for_email_logo.png'],
+        ],
+    ),
+);
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'john@acme.com'),
+        payload: ['title' => 'You have a new meeting invite'],
+        context: [
+            'app' => 'notion-calendar',
+            'branding' => ['logo' => 'url_for_calendar_logo.png'],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "john@acme.com",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "title", "You have 1 new email" },
+    },
+    Context = new Dictionary<string, object>() {
+        { "app", "notion-email" },
+        { "branding", new Dictionary<string, object>() {
+            { "logo", "url_for_email_logo.png" },
+        } },
+    },
+});
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "john@acme.com",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "title", "You have a new meeting invite" },
+    },
+    Context = new Dictionary<string, object>() {
+        { "app", "notion-calendar" },
+        { "branding", new Dictionary<string, object>() {
+            { "logo", "url_for_calendar_logo.png" },
+        } },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("john@acme.com")
+            .build()))
+        .payload(Map.of("title", "You have 1 new email"))
+        .context(Map.ofEntries(
+            Map.entry("app", TriggerEventRequestDtoContextUnion.of("notion-email")),
+            Map.entry("branding", TriggerEventRequestDtoContextUnion.of(
+                TriggerEventRequestDtoContext2.builder()
+                    .id("branding")
+                    .data(Map.of("logo", "url_for_email_logo.png"))
+                    .build()))))
+        .build())
+    .call();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("john@acme.com")
+            .build()))
+        .payload(Map.of("title", "You have a new meeting invite"))
+        .context(Map.ofEntries(
+            Map.entry("app", TriggerEventRequestDtoContextUnion.of("notion-calendar")),
+            Map.entry("branding", TriggerEventRequestDtoContextUnion.of(
+                TriggerEventRequestDtoContext2.builder()
+                    .id("branding")
+                    .data(Map.of("logo", "url_for_calendar_logo.png"))
+                    .build()))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": { "subscriberId": "john@acme.com" },
+    "payload": { "title": "You have 1 new email" },
+    "context": {
+        "app": "notion-email",
+        "branding": { "logo": "url_for_email_logo.png" }
+    }
+}'
+
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": { "subscriberId": "john@acme.com" },
+    "payload": { "title": "You have a new meeting invite" },
+    "context": {
+        "app": "notion-calendar",
+        "branding": { "logo": "url_for_calendar_logo.png" }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 Here are some ways that you can use contexts:
 

--- a/docs/platform/workflow/advanced-features/contexts/manage-contexts.mdx
+++ b/docs/platform/workflow/advanced-features/contexts/manage-contexts.mdx
@@ -20,30 +20,222 @@ Each context consists of:
 
 Supported data formats include:
 
-```typescript
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
 await novu.trigger({
   workflowId: "workflowId",
-  to: { subscriberId: 'user123' },
-  payload: { userName: 'John' },
+  to: { subscriberId: "user123" },
+  payload: { userName: "John" },
   context: {
     // Simple string format
-    tenant: 'acme-corp', 
-    
+    tenant: "acme-corp",
     // Rich object format (ID only)
-    app: { id: 'jira' },                    
-    
+    app: { id: "jira" },
     // Rich object format (ID + data)
-    region: {                               
-      id: 'us-east',
+    region: {
+      id: "us-east",
       data: {
-        name: 'US East',
-        timezone: 'America/New_York',
-        currency: 'USD'
-      }
-    }
-  }
+        name: "US East",
+        timezone: "America/New_York",
+        currency: "USD",
+      },
+    },
+  },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "user123"},
+        payload={"userName": "John"},
+        context={
+            "tenant": "acme-corp",
+            "app": {"id": "jira"},
+            "region": {
+                "id": "us-east",
+                "data": {
+                    "name": "US East",
+                    "timezone": "America/New_York",
+                    "currency": "USD",
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user123",
+    }),
+    Payload: map[string]any{
+        "userName": "John",
+    },
+    Context: map[string]any{
+        "tenant": "acme-corp",
+        "app": map[string]any{
+            "id": "jira",
+        },
+        "region": map[string]any{
+            "id": "us-east",
+            "data": map[string]any{
+                "name":     "US East",
+                "timezone": "America/New_York",
+                "currency": "USD",
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user123'),
+        payload: [
+            'userName' => 'John',
+        ],
+        context: [
+            'tenant' => 'acme-corp',
+            'app' => ['id' => 'jira'],
+            'region' => [
+                'id' => 'us-east',
+                'data' => [
+                    'name' => 'US East',
+                    'timezone' => 'America/New_York',
+                    'currency' => 'USD',
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "user123",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "userName", "John" },
+    },
+    Context = new Dictionary<string, object>() {
+        { "tenant", "acme-corp" },
+        { "app", new Dictionary<string, object>() { { "id", "jira" } } },
+        { "region", new Dictionary<string, object>() {
+            { "id", "us-east" },
+            { "data", new Dictionary<string, object>() {
+                { "name", "US East" },
+                { "timezone", "America/New_York" },
+                { "currency", "USD" },
+            } },
+        } },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("user123")
+            .build()))
+        .payload(Map.of("userName", "John"))
+        .context(Map.ofEntries(
+            Map.entry("tenant", TriggerEventRequestDtoContextUnion.of("acme-corp")),
+            Map.entry("app", TriggerEventRequestDtoContextUnion.of(
+                TriggerEventRequestDtoContext2.builder()
+                    .id("jira")
+                    .build())),
+            Map.entry("region", TriggerEventRequestDtoContextUnion.of(
+                TriggerEventRequestDtoContext2.builder()
+                    .id("us-east")
+                    .data(Map.ofEntries(
+                        Map.entry("name", "US East"),
+                        Map.entry("timezone", "America/New_York"),
+                        Map.entry("currency", "USD")))
+                    .build()))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": { "subscriberId": "user123" },
+    "payload": { "userName": "John" },
+    "context": {
+        "tenant": "acme-corp",
+        "app": { "id": "jira" },
+        "region": {
+            "id": "us-east",
+            "data": {
+                "name": "US East",
+                "timezone": "America/New_York",
+                "currency": "USD"
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Create a Context
 
@@ -84,39 +276,299 @@ Use the dashboard to manually define contexts that represent key business entiti
 
 Novu provides an API to create a context. If a context with the same `type:id` combination already exists, then the request will fail.
 
-```bash
-POST /v2/contexts
-{
-  "type": "tenant",
-  "id": "acme-corp",
-  "data": {
-    "name": "Acme Corporation",
-    "plan": "enterprise"
-  }
-}
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
+await novu.contexts.create({
+  type: "tenant",
+  id: "acme-corp",
+  data: {
+    name: "Acme Corporation",
+    plan: "enterprise",
+  },
+});
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.contexts.create(create_context_request_dto={
+        "type": "tenant",
+        "id": "acme-corp",
+        "data": {
+            "name": "Acme Corporation",
+            "plan": "enterprise",
+        },
+    })
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Contexts.Create(context.Background(), components.CreateContextRequestDto{
+    Type: "tenant",
+    ID:   "acme-corp",
+    Data: map[string]any{
+        "name": "Acme Corporation",
+        "plan": "enterprise",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->contexts->create(
+    createContextRequestDto: new Components\CreateContextRequestDto(
+        type: 'tenant',
+        id: 'acme-corp',
+        data: [
+            'name' => 'Acme Corporation',
+            'plan' => 'enterprise',
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.Contexts.CreateAsync(createContextRequestDto: new CreateContextRequestDto() {
+    Type = "tenant",
+    Id = "acme-corp",
+    Data = new Dictionary<string, object>() {
+        { "name", "Acme Corporation" },
+        { "plan", "enterprise" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.CreateContextRequestDto;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.contexts().create()
+    .body(CreateContextRequestDto.builder()
+        .type("tenant")
+        .id("acme-corp")
+        .data(Map.ofEntries(
+            Map.entry("name", "Acme Corporation"),
+            Map.entry("plan", "enterprise")))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v2/contexts' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "type": "tenant",
+    "id": "acme-corp",
+    "data": {
+        "name": "Acme Corporation",
+        "plan": "enterprise"
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 ### Create a context via API (Just-in-time)
 
-Contexts can also be created automatically when you trigger a workflow that includes a new context object. If the specified `type:id` doesn’t exist, then Novu automatically creates it before running the workflow.
+Contexts can also be created automatically when you trigger a workflow that includes a new context object. If the specified `type:id` doesn't exist, then Novu automatically creates it before running the workflow.
 
-```jsx
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
 await novu.trigger({
   workflowId: "workflowId",
-  to: { subscriberId: 'user@example.com' },
-  payload: { userName: 'John' },
+  to: { subscriberId: "user@example.com" },
+  payload: { userName: "John" },
   context: {
-    tenant: 'acme-corp',   // Created automatically if it doesn’t exist
-    app: 'jira'
-  }
+    tenant: "acme-corp", // Created automatically if it doesn't exist
+    app: "jira",
+  },
 });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflowId",
+        to={"subscriber_id": "user@example.com"},
+        payload={"userName": "John"},
+        context={
+            "tenant": "acme-corp",
+            "app": "jira",
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflowId",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user@example.com",
+    }),
+    Payload: map[string]any{
+        "userName": "John",
+    },
+    Context: map[string]any{
+        "tenant": "acme-corp",
+        "app":    "jira",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflowId',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user@example.com'),
+        payload: ['userName' => 'John'],
+        context: [
+            'tenant' => 'acme-corp',
+            'app' => 'jira',
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflowId",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "user@example.com",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "userName", "John" },
+    },
+    Context = new Dictionary<string, object>() {
+        { "tenant", "acme-corp" },
+        { "app", "jira" },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflowId")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("user@example.com")
+            .build()))
+        .payload(Map.of("userName", "John"))
+        .context(Map.ofEntries(
+            Map.entry("tenant", TriggerEventRequestDtoContextUnion.of("acme-corp")),
+            Map.entry("app", TriggerEventRequestDtoContextUnion.of("jira"))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "workflowId",
+    "to": { "subscriberId": "user@example.com" },
+    "payload": { "userName": "John" },
+    "context": {
+        "tenant": "acme-corp",
+        "app": "jira"
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 If a matching context already exists, Novu reuses it as-is without modifying any stored data. This behavior ensures consistency and avoids accidental changes to shared metadata.
 
 ## Update a context
 
-You can update a context’s data payload at any time. The context `type` and `id` remain immutable. However, to change an existing context’s data, you must explicitly update it through the dashboard or API.
+You can update a context's data payload at any time. The context `type` and `id` remain immutable. However, to change an existing context's data, you must explicitly update it through the dashboard or API.
 
 #### Update a context via dashboard
 
@@ -146,15 +598,140 @@ You can update a context’s data payload at any time. The context `type` and `i
 
 Novu provides an API to update an existing context. The `data` object is replaced entirely during updates (not merged). Include all fields you want to retain.
 
-```bash
-PATCH /v2/contexts/tenant/acme-corp
-{
-  "data": {
-    "plan": "premium",
-    "region": "us-east"
-  }
-}
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
+await novu.contexts.update({
+  type: "tenant",
+  id: "acme-corp",
+  updateContextRequestDto: {
+    data: {
+      plan: "premium",
+      region: "us-east",
+    },
+  },
+});
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.contexts.update(
+        type_="tenant",
+        id="acme-corp",
+        update_context_request_dto={
+            "data": {
+                "plan": "premium",
+                "region": "us-east",
+            },
+        },
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Contexts.Update(context.Background(), "acme-corp", "tenant", components.UpdateContextRequestDto{
+    Data: map[string]any{
+        "plan":   "premium",
+        "region": "us-east",
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->contexts->update(
+    id: 'acme-corp',
+    type: 'tenant',
+    updateContextRequestDto: new Components\UpdateContextRequestDto(
+        data: [
+            'plan' => 'premium',
+            'region' => 'us-east',
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.Contexts.UpdateAsync(
+    id: "acme-corp",
+    type: "tenant",
+    updateContextRequestDto: new UpdateContextRequestDto() {
+        Data = new Dictionary<string, object>() {
+            { "plan", "premium" },
+            { "region", "us-east" },
+        },
+    }
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.UpdateContextRequestDto;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.contexts().update()
+    .id("acme-corp")
+    .type("tenant")
+    .body(UpdateContextRequestDto.builder()
+        .data(Map.ofEntries(
+            Map.entry("plan", "premium"),
+            Map.entry("region", "us-east")))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X PATCH 'https://api.novu.co/v2/contexts/tenant/acme-corp' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "data": {
+        "plan": "premium",
+        "region": "us-east"
+    }
+}'
+```
+  </Tab>
+</Tabs>
 
 ## Retrieve a single context
 
@@ -180,14 +757,87 @@ You can retrieve a context to verify its data, confirm its creation, or inspect 
 
 Novu provides an API to retrieve a single, specific context by providing its `type` and `id` in the URL.
 
-```bash
-GET /v2/contexts/:type/:id
-```
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
 
-Here is an example:
-```bash
-GET /v2/contexts/tenant/acme-corp
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
+await novu.contexts.retrieve("tenant", "acme-corp");
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.contexts.retrieve(type_="tenant", id="acme-corp")
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Contexts.Retrieve(context.Background(), "acme-corp", "tenant", nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->contexts->retrieve(
+    id: 'acme-corp',
+    type: 'tenant',
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.Contexts.RetrieveAsync(
+    id: "acme-corp",
+    type: "tenant"
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.contexts().get()
+    .id("acme-corp")
+    .type("tenant")
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X GET 'https://api.novu.co/v2/contexts/tenant/acme-corp' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+```
+  </Tab>
+</Tabs>
 
 ## List or search for contexts
 
@@ -213,14 +863,99 @@ You can list all contexts in your environment or search for specific ones by con
 
 Novu provides an API that lists or searches available contexts. Use pagination and search parameters to retrieve subsets efficiently.
 
-```bash
-GET /v2/contexts
-GET /v2/contexts?search=acme
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
+await novu.contexts.list({ search: "acme" });
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.contexts.list(request={"search": "acme"})
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/operations"
+)
+
+search := "acme"
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Contexts.List(context.Background(), operations.ContextsControllerListContextsRequest{
+    Search: &search,
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Operations;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->contexts->list(
+    request: new Operations\ContextsControllerListContextsRequest(
+        search: 'acme',
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Requests;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.Contexts.ListAsync(new ContextsControllerListContextsRequest() {
+    Search = "acme",
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.operations.ContextsControllerListContextsRequest;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.contexts().list()
+    .request(ContextsControllerListContextsRequest.builder()
+        .search("acme")
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X GET 'https://api.novu.co/v2/contexts?search=acme' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+```
+  </Tab>
+</Tabs>
 
 ## Delete a context
 
-Delete a context if it’s no longer needed. This action permanently removes the context from your Novu environment. 
+Delete a context if it's no longer needed. This action permanently removes the context from your Novu environment. 
 
 <Warning>
   Deleting a context cannot be undone. Ensure the context is no longer required by any active or historical workflows you might need to analyze. 
@@ -256,12 +991,84 @@ Delete a context if it’s no longer needed. This action permanently removes the
 
 Novu provides an API that you can use to delete a context. Once deleted, the context will no longer be available for use in new workflow executions.
 
-```bash
-DELETE /v2/contexts/:type/:id
-```
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api"
 
-Here is an example:
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
 
-```bash
-DELETE /v2/contexts/tenant/acme-corp
+await novu.contexts.delete("tenant", "acme-corp");
 ```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.contexts.delete(type_="tenant", id="acme-corp")
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+res, err := s.Contexts.Delete(context.Background(), "acme-corp", "tenant", nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->contexts->delete(
+    id: 'acme-corp',
+    type: 'tenant',
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.Contexts.DeleteAsync(
+    id: "acme-corp",
+    type: "tenant"
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.contexts().delete()
+    .id("acme-corp")
+    .type("tenant")
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X DELETE 'https://api.novu.co/v2/contexts/tenant/acme-corp' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>'
+```
+  </Tab>
+</Tabs>

--- a/docs/platform/workflow/trigger-workflow.mdx
+++ b/docs/platform/workflow/trigger-workflow.mdx
@@ -52,24 +52,9 @@ Replace `YOUR_WORKFLOW_ID`, `YOUR_SUBSCRIBER_ID`, and payload fields with values
 
 Novu provides official server-side SDKs for TypeScript/Node.js (`@novu/api`), Python (`novu-py`), Go (`novu-go`), PHP (`novuhq/novu`), .NET (`Novu`), and Java (`co.novu:novu-java`). Use the SDK that matches the project's language. Fall back to the REST API only when no SDK fits the stack.
 
-Example with the Node.js SDK:
+Example with the Node.js SDK — see the **Trigger Event API** section below for the same `welcome-email` trigger in Python, Go, PHP, .NET, Java, and cURL.
 
-```typescript
-import { Novu } from "@novu/api";
-
-const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
-
-await novu.trigger({
-  workflowId: "welcome-email",
-  to: { subscriberId: "YOUR_SUBSCRIBER_ID" },
-  payload: {
-    userName: "Jane",
-    activationLink: "https://app.example.com/activate",
-  },
-});
-```
-
-See https://docs.novu.co/platform/sdks/server/typescript for other SDK installation and usage examples.
+See https://docs.novu.co/platform/sdks/server/typescript for SDK installation and usage details.
 
 ## Always Do
 

--- a/docs/platform/workflow/trigger-workflow.mdx
+++ b/docs/platform/workflow/trigger-workflow.mdx
@@ -52,7 +52,7 @@ Replace `YOUR_WORKFLOW_ID`, `YOUR_SUBSCRIBER_ID`, and payload fields with values
 
 Novu provides official server-side SDKs for TypeScript/Node.js (`@novu/api`), Python (`novu-py`), Go (`novu-go`), PHP (`novuhq/novu`), .NET (`Novu`), and Java (`co.novu:novu-java`). Use the SDK that matches the project's language. Fall back to the REST API only when no SDK fits the stack.
 
-Example with the Node.js SDK — see the **Trigger Event API** section below for the same `welcome-email` trigger in Python, Go, PHP, .NET, Java, and cURL.
+Example with the Node.js SDK — see the **Trigger Event API** section below for the same trigger pattern in Python, Go, PHP, .NET, Java, and cURL (replace `workflow_identifier` with your workflow ID, such as `welcome-email`).
 
 See https://docs.novu.co/platform/sdks/server/typescript for SDK installation and usage details.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds full 7-tab server-side SDK examples (Node.js, Python, Go, PHP, .NET, Java, cURL) to every in-scope documentation page that previously showed TypeScript-only or partial SDK snippets.

**43 files updated** across platform, guides, and community docs (~133 code blocks expanded).

## Review fixes (Greptile)

- **fcm.mdx** — Fixed invalid Go (`map[string]any` nested literals), PHP (array syntax), .NET (`Dictionary`/`Overrides`), and Java (`Map.of` / `additionalProperties`) in topic and web-push override tabs
- **apns.mdx** — Same syntax fixes for APNS override tabs; empty payload examples use valid PHP `[]`, C# `Dictionary`, and Java `Map.of()`; added missing `import java.util.Map;` to the "Send a notification" Java tab
- **clerk.mdx, auth0.mdx, stripe.mdx** — Python tabs now instantiate `Novu` inside the `with` block instead of reusing a module-level client
- **trigger-workflow.mdx** — Cross-reference text clarified (`workflow_identifier` vs `welcome-email`)

## What changed

### Tier 1 — Core platform
- Contexts: `manage-contexts.mdx`, `contexts.mdx`, `multi-tenancy.mdx`
- Concepts: `subscribers.mdx`, `tenants.mdx`
- Workflow: `trigger-workflow.mdx`, `trigger-overrides.mdx`

### Tier 2 — Integrations
- Channel overviews: email, sms, push, chat
- 19 provider pages: SendGrid, FCM, Slack, Twilio, etc.

### Tier 3 — Guides & AI
- 11 guide pages (webhooks, inngest, triggerdotdev, use-cases, migration, managing-workflows)
- `build-with-ai/skills.mdx`

### Tier 4 — Community
- `deploy-with-docker.mdx` — self-hosted examples with `serverURL` on all SDK tabs

## Excluded (intentionally unchanged)

- `docs/api-reference/**` — auto-generated from OpenAPI
- `docs/.mintlify/skills/**` — synced from external repo
- Client-side SDK pages (`@novu/react`, Inbox quickstarts)
- Framework docs (TypeScript-only by design)
- `guides/webhooks/segment.mdx` — raw fetch in Segment runtime

## Test plan

- [x] Verified all 43 in-scope files include `<Tab title="Java">` tabs
- [x] Fixed Greptile-flagged invalid syntax in FCM, APNS, webhook, and trigger-workflow pages
- [x] TesterArmy exploration passed on SDK tab pages
- [ ] Mintlify preview — confirm tab rendering on updated pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dc78396-f2c9-4208-9ffa-eae0c08de2fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dc78396-f2c9-4208-9ffa-eae0c08de2fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands documentation across 43 files by adding full 7-tab server-side SDK examples (Node.js, Python, Go, PHP, .NET, Java, cURL) to every in-scope platform, guide, and community page that previously showed only TypeScript or partial snippets. It also applies targeted fixes to previously reviewed syntax errors in FCM, APNS, and webhook pages.

- **~133 code blocks expanded** across push, email, SMS, chat, subscriber, tenant, workflow, and guide docs with correct language-specific idioms (typed Go map literals, PHP array syntax, C# `Dictionary` initializers, Java `Map.of`/`Map.ofEntries` with proper imports).
- **Previously flagged issues resolved**: invalid Go/PHP/.NET/Java syntax in `fcm.mdx` and `apns.mdx` override tabs, Python context-manager reuse in `clerk.mdx`, `auth0.mdx`, and `stripe.mdx`, missing `import java.util.Map` in the APNS Java tab, and the `trigger-workflow.mdx` cross-reference identifier mismatch.
- **One remaining nit**: `apns.mdx` has a duplicate `using System.Collections.Generic;` in its first .NET tab — a copy-paste artifact that should be removed.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime code; all previously flagged syntax errors have been corrected and the one remaining nit (duplicate using directive in a C# example) has no functional impact.

Every previously reported syntax error across FCM, APNS, the webhook guides, and trigger-workflow.mdx has been addressed in this revision. The only new issue is a duplicate `using System.Collections.Generic;` in one .NET code snippet in apns.mdx — a cosmetic copy-paste artifact that doesn't affect readers' ability to use the example.

docs/platform/integrations/push/apns.mdx — duplicate using directive in its first .NET tab.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/integrations/push/apns.mdx | Adds 6 new SDK language tabs for device-token registration and notification triggering; duplicate `using System.Collections.Generic;` in the first .NET tab is the only issue. |
| docs/platform/integrations/push/fcm.mdx | All previously flagged Go, PHP, .NET, and Java syntax errors in override tabs are now fixed with correct typed map literals and Dictionary initializers. |
| docs/guides/webhooks/clerk.mdx | Python tab now correctly instantiates `Novu` inside the `with` block, fixing the previously flagged context-manager reuse issue. |
| docs/guides/webhooks/auth0.mdx | Python context-manager fix applied; all 7 SDK tabs are correctly structured. |
| docs/guides/webhooks/stripe.mdx | Python context-manager fix applied; all 7 SDK tabs are correctly structured. |
| docs/platform/workflow/trigger-workflow.mdx | Cross-reference text updated to say "replace `workflow_identifier` with your workflow ID, such as `welcome-email`", resolving the previous identifier mismatch. |
| docs/platform/integrations/trigger-overrides.mdx | Adds complete 7-tab SDK examples for channel overrides; Java uses `Map.ofEntries`/`Map.entry` correctly with proper imports. |
| docs/platform/workflow/advanced-features/contexts/manage-contexts.mdx | Largest file in the PR (~900-line diff); adds 7-language context/tenancy examples with correct imports across all tabs. |
| docs/guides/triggerdotdev.mdx | Adds multi-SDK examples for Trigger.dev integration; Java snippets are partial (no class wrapper/imports) which is intentional for guide-style docs. |
| docs/guides/inngest.mdx | Adds 7-tab SDK examples throughout the Inngest integration guide; code snippets are intentionally partial (guide style). |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Multi-SDK Docs Expansion] --> B[43 Files Updated]
    B --> C[Platform Docs]
    B --> D[Guide Docs]
    B --> E[Community Docs]
    C --> C1[Push: FCM, APNS, Expo, OneSignal...]
    C --> C2[Email: SendGrid, Mailersend...]
    C --> C3[SMS: Twilio, Gupshup]
    C --> C4[Chat: Slack, Discord, Teams...]
    C --> C5[Concepts: Subscribers, Tenants]
    C --> C6[Workflow: Trigger, Overrides, Contexts]
    D --> D1[Webhooks: Clerk, Auth0, Stripe]
    D --> D2[Integrations: Inngest, Trigger.dev]
    D --> D3[Use Cases & Recipes]
    E --> E1[Deploy with Docker]
    C1 & C2 & C3 & C4 & C5 & C6 & D1 & D2 & D3 & E1 --> F[7-Tab SDK Examples Added]
    F --> G[Node.js]
    F --> H[Python]
    F --> I[Go]
    F --> J[PHP]
    F --> K[.NET]
    F --> L[Java]
    F --> M[cURL]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR: Multi-SDK Docs Expansion] --> B[43 Files Updated]
    B --> C[Platform Docs]
    B --> D[Guide Docs]
    B --> E[Community Docs]
    C --> C1[Push: FCM, APNS, Expo, OneSignal...]
    C --> C2[Email: SendGrid, Mailersend...]
    C --> C3[SMS: Twilio, Gupshup]
    C --> C4[Chat: Slack, Discord, Teams...]
    C --> C5[Concepts: Subscribers, Tenants]
    C --> C6[Workflow: Trigger, Overrides, Contexts]
    D --> D1[Webhooks: Clerk, Auth0, Stripe]
    D --> D2[Integrations: Inngest, Trigger.dev]
    D --> D3[Use Cases & Recipes]
    E --> E1[Deploy with Docker]
    C1 & C2 & C3 & C4 & C5 & C6 & D1 & D2 & D3 & E1 --> F[7-Tab SDK Examples Added]
    F --> G[Node.js]
    F --> H[Python]
    F --> I[Go]
    F --> J[PHP]
    F --> K[.NET]
    F --> L[Java]
    F --> M[cURL]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["docs(docs): add missing Map import in AP..."](https://github.com/novuhq/novu/commit/b4ed1c9f4180e961943070ba2a5d18367c33872f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40893029)</sub>

<!-- /greptile_comment -->