### PR TITLE
fix(api-service): return v0 notification payload as data in inbox API fixes NV-8155

### DIFF
--- a/apps/api/src/app/inbox/utils/notification-mapper.spec.ts
+++ b/apps/api/src/app/inbox/utils/notification-mapper.spec.ts
@@ -1,0 +1,89 @@
+import { ChannelTypeEnum } from '@novu/dal';
+import { ChannelCTATypeEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+
+import { mapToDto } from './notification-mapper';
+
+const baseMessage = {
+  _id: 'message-id',
+  transactionId: 'transaction-id',
+  content: 'Hello',
+  read: false,
+  seen: false,
+  archived: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  channel: ChannelTypeEnum.IN_APP,
+  subscriber: {
+    _id: 'subscriber-id',
+    subscriberId: 'subscriber-id',
+  },
+  cta: {
+    type: ChannelCTATypeEnum.REDIRECT,
+    data: {},
+  },
+};
+
+describe('notification-mapper', () => {
+  it('returns v2 data when message.data is set', () => {
+    const result = mapToDto({
+      ...baseMessage,
+      data: { orderId: '123' },
+      payload: { orderId: '123', secret: 'hidden' },
+      template: {
+        _id: 'template-id',
+        name: 'v2 workflow',
+        type: ResourceTypeEnum.BRIDGE,
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+      },
+    } as any);
+
+    expect(result.data).to.deep.equal({ orderId: '123' });
+  });
+
+  it('returns payload as data for v0 workflow notifications without data', () => {
+    const payload = { orderId: '456', customerName: 'Jane' };
+
+    const result = mapToDto({
+      ...baseMessage,
+      payload,
+      template: {
+        _id: 'template-id',
+        name: 'v0 workflow',
+        type: ResourceTypeEnum.REGULAR,
+        origin: ResourceOriginEnum.NOVU_CLOUD_V1,
+      },
+    } as any);
+
+    expect(result.data).to.deep.equal(payload);
+  });
+
+  it('returns payload as data for legacy v0 workflows without origin or type', () => {
+    const payload = { foo: 'bar' };
+
+    const result = mapToDto({
+      ...baseMessage,
+      payload,
+      template: {
+        _id: 'template-id',
+        name: 'legacy workflow',
+      },
+    } as any);
+
+    expect(result.data).to.deep.equal(payload);
+  });
+
+  it('does not return payload as data for v2 workflows without data', () => {
+    const result = mapToDto({
+      ...baseMessage,
+      payload: { orderId: '789' },
+      template: {
+        _id: 'template-id',
+        name: 'v2 workflow',
+        type: ResourceTypeEnum.BRIDGE,
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+      },
+    } as any);
+
+    expect(result.data).to.be.undefined;
+  });
+});

--- a/apps/api/src/app/inbox/utils/notification-mapper.ts
+++ b/apps/api/src/app/inbox/utils/notification-mapper.ts
@@ -1,31 +1,61 @@
 import type { MessageEntity } from '@novu/dal';
-import { ButtonTypeEnum, MessageActionStatusEnum, sanitizeInAppRedirect, SeverityLevelEnum } from '@novu/shared';
+import {
+  ButtonTypeEnum,
+  MessageActionStatusEnum,
+  ResourceOriginEnum,
+  ResourceTypeEnum,
+  sanitizeInAppRedirect,
+  SeverityLevelEnum,
+} from '@novu/shared';
 
 import { InboxNotificationDto, InboxSubscriberResponseDto } from '../dtos/inbox-notification.dto';
 
-const mapSingleItem = ({
-  _id,
-  content,
-  read,
-  seen,
-  archived,
-  snoozedUntil,
-  deliveredAt,
-  createdAt,
-  lastReadDate,
-  firstSeenDate,
-  archivedAt,
-  channel,
-  subscriber,
-  subject,
-  avatar,
-  cta,
-  tags,
-  severity,
-  data,
-  template,
-  transactionId,
-}: MessageEntity): InboxNotificationDto => {
+function isV0WorkflowTemplate(template: NonNullable<MessageEntity['template']>): boolean {
+  if (template.type === ResourceTypeEnum.REGULAR || template.origin === ResourceOriginEnum.NOVU_CLOUD_V1) {
+    return true;
+  }
+
+  return template.type === undefined && template.origin === undefined;
+}
+
+function resolveNotificationData(message: MessageEntity): Record<string, unknown> | undefined {
+  if (message.data != null) {
+    return message.data;
+  }
+
+  const template = message.template;
+
+  if (template && isV0WorkflowTemplate(template) && message.payload) {
+    return message.payload;
+  }
+
+  return undefined;
+}
+
+const mapSingleItem = (message: MessageEntity): InboxNotificationDto => {
+  const {
+    _id,
+    content,
+    read,
+    seen,
+    archived,
+    snoozedUntil,
+    deliveredAt,
+    createdAt,
+    lastReadDate,
+    firstSeenDate,
+    archivedAt,
+    channel,
+    subscriber,
+    subject,
+    avatar,
+    cta,
+    tags,
+    severity,
+    template,
+    transactionId,
+  } = message;
+  const data = resolveNotificationData(message);
   const to: InboxSubscriberResponseDto = {
     id: subscriber?._id ?? '',
     firstName: subscriber?.firstName,

--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -426,7 +426,7 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
           .populate('actorSubscriber', '_id firstName lastName avatar subscriberId')
           .populate({
             path: 'template',
-            select: '_id name tags data critical triggers severity',
+            select: '_id name tags data critical triggers severity origin type',
             options: {
               withDeleted: true,
             },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Customers migrating from `@novu/headless` to `@novu/js` need v0 workflow notifications to expose trigger payload via the `data` field in `notifications.list`, matching v2 data object behavior.

This change maps `message.payload` → `notification.data` for v0 workflows (`REGULAR` type or `novu-cloud-v1` origin) when `message.data` is absent. V2 notifications continue to return only the configured data object.

```mermaid
flowchart LR
  A[MessageEntity] --> B{message.data set?}
  B -->|yes| C[Return message.data]
  B -->|no| D{v0 template?}
  D -->|yes| E[Return message.payload]
  D -->|no| F[Return undefined]
```

**Changes:**
- `apps/api/src/app/inbox/utils/notification-mapper.ts` — resolve `data` from payload for v0 workflows
- `libs/dal/src/repositories/message/message.repository.ts` — populate `origin` and `type` on template lookup
- `apps/api/src/app/inbox/utils/notification-mapper.spec.ts` — unit tests for v0/v2/legacy cases

**Note:** This is a read-time mapping only. Server-side `data` query filters still operate on `message.data` in MongoDB and won't match v0 payload fields unless separately addressed.

### Test plan

- [x] Unit tests: `pnpm --filter @novu/api-service test -- --grep notification-mapper` (4 passing)
- [x] Build: `pnpm --filter @novu/api-service build`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1782882629886339?thread_ts=1782882629.886339&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-cb39f7d2-91da-501b-a417-3daf5957781b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb39f7d2-91da-501b-a417-3daf5957781b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR maps inbox notification data for v0 workflow messages. The main changes are:

- Falls back from `message.data` to `message.payload` for v0 and legacy workflow notifications.
- Keeps v2 notifications using only the configured `message.data` object.
- Adds `origin` and `type` to paginated template population for inbox list responses.
- Adds unit tests for v0, v2, and legacy mapper behavior.

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped, but the single-message inbox mutation path needs attention to keep response mapping consistent with list responses.

The updated mapper behavior is covered for the main list-style cases, and the repository change is small. The remaining concern is localized to a related repository read path used by mutation responses.

libs/dal/src/repositories/message/message.repository.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a focused mapper-level projection harness that simulates a list-style v0 template and a findOneForInbox-style projection, and observed that the mapper returned payload as data in both cases, while the environment blocked API-level mutation reproduction due to an inability to load the built main entry for @novu/application-generic.
- Reviewed payload behavior across v0 and v2 variants, noting that v0 payload-only responses omit data in the base path but the head response includes orderId and customerName, that data precedence makes both base and head return message.data with orderId set to data-wins instead of the payload, and that v2 payload-only paths omit payload from data.

<a href="https://app.greptile.com/trex/runs/12878555/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/dal/src/repositories/message/message.repository.ts`, line 146 ([link](https://github.com/novuhq/novu/blob/9b9ff409b7f9125652e727f18e8eae0c1a9debf0/libs/dal/src/repositories/message/message.repository.ts#L146)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Include template version fields**
   `findOneForInbox` still populates `template` without `origin` and `type`, but `mark-notification-as` and `update-notification-action` both re-read a single message through this method before calling `mapToDto`. For v0 templates that have either field set in Mongo, `isV0WorkflowTemplate` receives neither field and the updated notification response omits `payload` from `data`, while the list endpoint now includes it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: libs/dal/src/repositories/message/message.repository.ts
   Line: 146

   Comment:
   **Include template version fields**
   `findOneForInbox` still populates `template` without `origin` and `type`, but `mark-notification-as` and `update-notification-action` both re-read a single message through this method before calling `mapToDto`. For v0 templates that have either field set in Mongo, `isV0WorkflowTemplate` receives neither field and the updated notification response omits `payload` from `data`, while the list endpoint now includes it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Fdal%2Fsrc%2Frepositories%2Fmessage%2Fmessage.repository.ts%0ALine%3A%20146%0A%0AComment%3A%0A**Include%20template%20version%20fields**%0A%60findOneForInbox%60%20still%20populates%20%60template%60%20without%20%60origin%60%20and%20%60type%60%2C%20but%20%60mark-notification-as%60%20and%20%60update-notification-action%60%20both%20re-read%20a%20single%20message%20through%20this%20method%20before%20calling%20%60mapToDto%60.%20For%20v0%20templates%20that%20have%20either%20field%20set%20in%20Mongo%2C%20%60isV0WorkflowTemplate%60%20receives%20neither%20field%20and%20the%20updated%20notification%20response%20omits%20%60payload%60%20from%20%60data%60%2C%20while%20the%20list%20endpoint%20now%20includes%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Fdal%2Fsrc%2Frepositories%2Fmessage%2Fmessage.repository.ts%3A146%0A**Include%20template%20version%20fields**%0A%60findOneForInbox%60%20still%20populates%20%60template%60%20without%20%60origin%60%20and%20%60type%60%2C%20but%20%60mark-notification-as%60%20and%20%60update-notification-action%60%20both%20re-read%20a%20single%20message%20through%20this%20method%20before%20calling%20%60mapToDto%60.%20For%20v0%20templates%20that%20have%20either%20field%20set%20in%20Mongo%2C%20%60isV0WorkflowTemplate%60%20receives%20neither%20field%20and%20the%20updated%20notification%20response%20omits%20%60payload%60%20from%20%60data%60%2C%20while%20the%20list%20endpoint%20now%20includes%20it.%0A%0A&pr=11750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
libs/dal/src/repositories/message/message.repository.ts:146
**Include template version fields**
`findOneForInbox` still populates `template` without `origin` and `type`, but `mark-notification-as` and `update-notification-action` both re-read a single message through this method before calling `mapToDto`. For v0 templates that have either field set in Mongo, `isV0WorkflowTemplate` receives neither field and the updated notification response omits `payload` from `data`, while the list endpoint now includes it.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): return v0 notification..."](https://github.com/novuhq/novu/commit/9b9ff409b7f9125652e727f18e8eae0c1a9debf0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41021667)</sub>

<!-- /greptile_comment -->