### PR TITLE
docs(api): Document idempotency and transactionId billing on trigger API fixes DOC-399

### DIFF
--- a/docs/api-reference/events/trigger-event.mdx
+++ b/docs/api-reference/events/trigger-event.mdx
@@ -12,10 +12,10 @@ If you retry a trigger request, use an [idempotency key](/api-reference/idempote
 
 | Mechanism | Where it applies | Effect on billing |
 | --- | --- | --- |
-| `Idempotency-Key` header | API layer, before the request is queued | Repeated requests with the same key return the cached response and count as **one** workflow run |
+| `Idempotency-Key` header | API layer, before the request is queued | After the first request completes, duplicates return the cached response and count as **one** workflow run |
 | `transactionId` in the request body | During trigger processing | Does **not** provide the same API-level protection as an idempotency key |
 
-When you send the same `Idempotency-Key` on multiple `POST /v1/events/trigger` requests, Novu halts duplicates at the API layer. The request never reaches the worker queue again, so only the first successful trigger counts toward billing.
+When you send the same `Idempotency-Key` on multiple `POST /v1/events/trigger` requests, Novu halts duplicates at the API layer. Once the first request completes, later requests return the cached response and never reach the worker queue, so only one trigger counts toward billing. While the first request is still processing, duplicates receive a `409 Conflict` response.
 
 The optional `transactionId` field is useful for tracing and [cancellation](/api-reference/events/cancel-triggered-event), but it is not a substitute for idempotency. Novu checks `transactionId` uniqueness during processing rather than at the API boundary, so concurrent or retried requests with the same `transactionId` are not deduplicated the same way. For safe retries and atomic deduplication, send an `Idempotency-Key` header on every trigger request.
 

--- a/docs/api-reference/events/trigger-event.mdx
+++ b/docs/api-reference/events/trigger-event.mdx
@@ -3,3 +3,22 @@ title: "Trigger event"
 description: "Trigger a Novu workflow by sending an event with workflowId, subscriberId, and payload. Returns a transactionId for tracking."
 openapi: "POST /v1/events/trigger"
 ---
+
+Trigger a workflow by sending a `POST` request with the workflow identifier, target subscriber(s), and optional payload. The response includes a `transactionId` you can use to trace the run in the Activity Feed, cancel the event, or look up related messages.
+
+## Idempotency and billing
+
+If you retry a trigger request, use an [idempotency key](/api-reference/idempotency) to avoid duplicate workflow runs and duplicate billing.
+
+| Mechanism | Where it applies | Effect on billing |
+| --- | --- | --- |
+| `Idempotency-Key` header | API layer, before the request is queued | Repeated requests with the same key return the cached response and count as **one** workflow run |
+| `transactionId` in the request body | During trigger processing | Does **not** provide the same API-level protection as an idempotency key |
+
+When you send the same `Idempotency-Key` on multiple `POST /v1/events/trigger` requests, Novu halts duplicates at the API layer. The request never reaches the worker queue again, so only the first successful trigger counts toward billing.
+
+The optional `transactionId` field is useful for tracing and [cancellation](/api-reference/events/cancel-triggered-event), but it is not a substitute for idempotency. Novu checks `transactionId` uniqueness during processing rather than at the API boundary, so concurrent or retried requests with the same `transactionId` are not deduplicated the same way. For safe retries and atomic deduplication, send an `Idempotency-Key` header on every trigger request.
+
+<Note>
+  Idempotency is not enabled for all organizations. Contact [support](mailto:support@novu.co) to enable it for your organization.
+</Note>

--- a/docs/api-reference/idempotency.mdx
+++ b/docs/api-reference/idempotency.mdx
@@ -29,20 +29,135 @@ This differs from the optional `transactionId` request field, which is checked f
 
 ## Using Idempotency Keys
 
-To make an idempotent request, include the `Idempotency-Key` header with a unique identifier:
+To make an idempotent trigger request, pass a unique idempotency key with your request:
 
-<CodeGroup>
-```bash title="Trigger event"
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
+
+await novu.trigger(
+  {
+    workflowId: "workflow-id",
+    to: "unique_subscriber_identifier",
+    payload: {
+      postId: "123",
+    },
+  },
+  // Idempotency key
+  "unique-request-id-12345"
+);
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(
+        trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+            workflow_id="workflow-id",
+            to="unique_subscriber_identifier",
+            payload={
+                "postId": "123",
+            },
+        ),
+        idempotency_key="unique-request-id-12345",
+    )
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+idempotencyKey := "unique-request-id-12345"
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflow-id",
+    To: components.CreateToStr("unique_subscriber_identifier"),
+    Payload: map[string]any{
+        "postId": "123",
+    },
+}, &idempotencyKey)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflow-id',
+        to: 'unique_subscriber_identifier',
+        payload: ['postId' => '123'],
+    ),
+    idempotencyKey: 'unique-request-id-12345',
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(
+    triggerEventRequestDto: new TriggerEventRequestDto() {
+        WorkflowId = "workflow-id",
+        To = To.CreateStr("unique_subscriber_identifier"),
+        Payload = new Dictionary<string, object>() {
+            { "postId", "123" },
+        },
+    },
+    idempotencyKey: "unique-request-id-12345"
+);
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .idempotencyKey("unique-request-id-12345")
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflow-id")
+        .to(To2.of("unique_subscriber_identifier"))
+        .payload(Map.of("postId", "123"))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
 curl -X POST https://api.novu.co/v1/events/trigger \
   --header 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
   --header 'Idempotency-Key: unique-request-id-12345' \
   --header 'Content-Type: application/json' \
-  --data '{"name": "workflow-id", "to": {"subscriberId": "subscriber-123"}}'
+  --data '{"name": "workflow-id", "to": "unique_subscriber_identifier", "payload": {"postId": "123"}}'
 ```
-```bash title="Authorization header"
---header 'Authorization: ApiKey <NOVU_SECRET_KEY>'
-```
-</CodeGroup>
+  </Tab>
+</Tabs>
 
 ### Key Requirements
 
@@ -72,7 +187,7 @@ Idempotency is supported for the following HTTP methods:
 
 ## Authentication Requirements
 
-Idempotency is only available when authenticating with an API Key. Include the `Authorization: ApiKey` header shown in the **Authorization header** tab above.
+Idempotency is only available when authenticating with an API Key. Include the `Authorization: ApiKey <NOVU_SECRET_KEY>` header, as shown in the **cURL** tab above.
 
 Requests using other authentication methods will be processed normally without idempotency support.
 

--- a/docs/api-reference/idempotency.mdx
+++ b/docs/api-reference/idempotency.mdx
@@ -23,7 +23,7 @@ This mechanism protects against network issues, timeouts, and other scenarios wh
 
 ## Trigger events and billing
 
-On `POST /v1/events/trigger`, idempotency keys are enforced at the API layer before the request is queued. If you send 100 requests with the same `Idempotency-Key`, only the first is processed; the rest receive the cached response and count as **one** workflow run toward billing.
+On `POST /v1/events/trigger`, idempotency keys are enforced at the API layer before the request is queued. If you send 100 requests with the same `Idempotency-Key`, only the first is processed. Once that request completes, subsequent requests receive the cached response and count as **one** workflow run toward billing. While the first request is still in progress, duplicates receive a `409 Conflict` response and are not queued.
 
 This differs from the optional `transactionId` request field, which is checked for uniqueness during trigger processing rather than at the API boundary. `transactionId` is useful for tracing and cancellation, but it does not provide the same deduplication or billing protection as an idempotency key. For safe retries, always prefer `Idempotency-Key`. See the [Trigger event](/api-reference/events/trigger-event) API reference and [Trigger](/platform/concepts/trigger) concepts page for details.
 

--- a/docs/api-reference/idempotency.mdx
+++ b/docs/api-reference/idempotency.mdx
@@ -21,6 +21,12 @@ When you send a request with an idempotency key:
 
 This mechanism protects against network issues, timeouts, and other scenarios where a request might be retried.
 
+## Trigger events and billing
+
+On `POST /v1/events/trigger`, idempotency keys are enforced at the API layer before the request is queued. If you send 100 requests with the same `Idempotency-Key`, only the first is processed; the rest receive the cached response and count as **one** workflow run toward billing.
+
+This differs from the optional `transactionId` request field, which is checked for uniqueness during trigger processing rather than at the API boundary. `transactionId` is useful for tracing and cancellation, but it does not provide the same deduplication or billing protection as an idempotency key. For safe retries, always prefer `Idempotency-Key`. See the [Trigger event](/api-reference/events/trigger-event) API reference and [Trigger](/platform/concepts/trigger) concepts page for details.
+
 ## Using Idempotency Keys
 
 To make an idempotent request, include the `Idempotency-Key` header with a unique identifier:

--- a/docs/platform/concepts/trigger.mdx
+++ b/docs/platform/concepts/trigger.mdx
@@ -63,4 +63,12 @@ Jobs play a crucial role in the trigger event lifecycle. They are created based 
   <Accordion title="How events are billed for digested events?">
     As a workflow triggered to one subscriber is billed as 1 event. if events are digested 15 times and a single digested notification is sent, then 15 events will be billed.
   </Accordion>
+
+  <Accordion title="How are duplicate trigger requests with the same idempotency key billed?">
+    Repeated `POST /v1/events/trigger` requests that include the same `Idempotency-Key` header are halted at the API layer. Novu returns the cached response from the first request and does not queue the trigger again, so the duplicate requests count as **one** workflow run for billing. See [Idempotency](/api-reference/idempotency) for header requirements and retry behavior.
+  </Accordion>
+
+  <Accordion title="Does transactionId deduplicate triggers the same way as an idempotency key?">
+    No. The optional `transactionId` field is returned for tracing and can be used to [cancel a triggered event](/api-reference/events/cancel-triggered-event), but duplicate `transactionId` values are **not** deduplicated at the API layer the way `Idempotency-Key` is. Uniqueness is enforced during trigger processing, so retried or concurrent requests with the same `transactionId` do not get the same billing protection as an idempotency key. For safe retries and atomic deduplication, use an `Idempotency-Key` header on every trigger request.
+  </Accordion>
 </AccordionGroup>

--- a/docs/platform/concepts/trigger.mdx
+++ b/docs/platform/concepts/trigger.mdx
@@ -65,7 +65,7 @@ Jobs play a crucial role in the trigger event lifecycle. They are created based 
   </Accordion>
 
   <Accordion title="How are duplicate trigger requests with the same idempotency key billed?">
-    Repeated `POST /v1/events/trigger` requests that include the same `Idempotency-Key` header are halted at the API layer. Novu returns the cached response from the first request and does not queue the trigger again, so the duplicate requests count as **one** workflow run for billing. See [Idempotency](/api-reference/idempotency) for header requirements and retry behavior.
+    Repeated `POST /v1/events/trigger` requests that include the same `Idempotency-Key` header are halted at the API layer. Once the first request completes, duplicates return the cached response and do not queue the trigger again, so they count as **one** workflow run for billing. While the first request is still processing, duplicates receive a `409 Conflict` response. See [Idempotency](/api-reference/idempotency) for header requirements and retry behavior.
   </Accordion>
 
   <Accordion title="Does transactionId deduplicate triggers the same way as an idempotency key?">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents how idempotency keys and `transactionId` affect trigger deduplication and billing, per customer feedback in DOC-399.

## Changes

- **`docs/api-reference/events/trigger-event.mdx`** — Added intro and an "Idempotency and billing" section with a comparison table explaining that `Idempotency-Key` halts duplicates at the API layer (one workflow run), while `transactionId` does not provide the same protection.
- **`docs/platform/concepts/trigger.mdx`** — Added two FAQ entries covering idempotency-key billing and how `transactionId` differs from idempotency.
- **`docs/api-reference/idempotency.mdx`** — Added a "Trigger events and billing" section cross-referencing the trigger API and concepts pages.

## Key points documented

| Mechanism | Behavior |
| --- | --- |
| `Idempotency-Key` header | Halted at API layer; after the first request completes, duplicates return the cached response and count as **one** workflow run. While the first request is in progress, duplicates receive `409 Conflict`. |
| `transactionId` body field | Uniqueness checked during processing; useful for tracing/cancellation but **not** equivalent to idempotency for billing or deduplication |

Recommended approach: use `Idempotency-Key` for safe retries and atomic deduplication.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-399](https://linear.app/novu/issue/DOC-399/document-idempotency-and-transactionid-billing-on-trigger-api-docs)

<div><a href="https://cursor.com/agents/bc-0f40f9f6-7843-4c05-aa76-cbf64a022d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f40f9f6-7843-4c05-aa76-cbf64a022d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clarifies idempotency behavior for trigger requests. The main changes are:

- Adds trigger API guidance for `Idempotency-Key` deduplication and billing.
- Explains that `transactionId` is for tracing and cancellation, not API-layer deduplication.
- Expands idempotency examples across official server-side SDKs and cURL.
- Adds trigger concept FAQ entries for duplicate request billing and `transactionId` behavior.

<h3>Confidence Score: 5/5</h3>

Documentation-only changes are safe to merge.

The modified files add explanatory API and concept guidance without changing runtime behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the base and head logs to confirm that the head log includes trigger-event additions and trigger concept FAQ entries.
- Verified that the idempotency page now includes the billing section, cross-references, and SDK examples.
- Checked the excerpted cURL header and noted that the Idempotency-Key header uses single quotes, and the exact-string check is marked absent.
- Ran git diff --check and confirmed it passed for the changed docs files.

<a href="https://app.greptile.com/trex/runs/13025905/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;next&#39; into fix/document-id..."](https://github.com/novuhq/novu/commit/a8d86020b12f36c31adc40e3a8e248439a078b06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41022773)</sub>

<!-- /greptile_comment -->