### PR TITLE
fix(react): set preferences/schedule data directly on fetch to prevent undefined state on re-mount

### DIFF
--- a/packages/react/src/hooks/usePreferences.ts
+++ b/packages/react/src/hooks/usePreferences.ts
@@ -55,8 +55,9 @@ export const usePreferences = (props?: UsePreferencesProps): UsePreferencesResul
     if (response.error) {
       setError(response.error);
       onError?.(response.error);
-    } else {
-      onSuccess?.(response.data!);
+    } else if (response.data) {
+      setData(response.data);
+      onSuccess?.(response.data);
     }
     setIsLoading(false);
     setIsFetching(false);

--- a/packages/react/src/hooks/useSchedule.ts
+++ b/packages/react/src/hooks/useSchedule.ts
@@ -50,8 +50,9 @@ export const useSchedule = (props?: UseScheduleProps): UseScheduleResult => {
     if (response.error) {
       setError(response.error);
       onError?.(response.error);
-    } else {
-      onSuccess?.(response.data!);
+    } else if (response.data) {
+      setData(response.data);
+      onSuccess?.(response.data);
     }
     setIsLoading(false);
     setIsFetching(false);


### PR DESCRIPTION
## Summary

Fixes #10057

`usePreferences` (and the sibling `useSchedule`) can get permanently stuck in a broken state after a component that uses them unmounts and re-mounts:

| State | Expected on re-mount | Actual on re-mount |
| -- | -- | -- |
| `isLoading` | `true` → `false` | `true` → `false` |
| `error` | `undefined` | `undefined` |
| `preferences` | valid array | `undefined` (never resolves) |

## Root Cause

Both hooks populate their `data` state **only** via event listeners (`preferences.list.pending` / `preferences.list.resolved`, and the equivalent `preference.schedule.get.*` events). The `useEffect` starts the async fetch **before** it registers those listeners:

```ts
useEffect(() => {
  fetchPreferences();                              // fetch started first
  const c1 = on('preferences.list.pending', sync); // listeners registered after
  const c2 = on('preferences.list.resolved', sync);
  // ...
}, []);
```

The `@novu/js` event emitter is built on `mitt`, which dispatches **synchronously**. When the in-memory cache is already warm, `preferences.list()` emits `pending` and `resolved` synchronously, without awaiting any network request:

```ts
let data = this.#useCache ? this.cache.getAll(args) : undefined;
this._emitter.emit('preferences.list.pending', { args, data });
if (!data) { /* network fetch */ }
this._emitter.emit('preferences.list.resolved', { args, data });
```

- **First mount:** the session isn't initialized yet, so `callWithSession` queues the call and resolves it later. That async gap lets the hook register its listeners first, so the events are captured and `sync()` sets the data. Works.
- **Any subsequent re-mount:** the session is initialized *and* the cache is warm, so `list()` runs fully synchronously inside `fetchPreferences()` — the `pending`/`resolved` events fire **before** the listeners are registered and are lost. Since the success branch only calls `onSuccess?.(response.data!)` and never `setData`, `preferences` stays `undefined` forever.

`useNotifications` — which the issue reporter confirms works correctly — does not have this bug precisely because its success branch calls `setData(responseData.notifications)` directly from the response rather than depending on events.

## Fix

Align `usePreferences` and `useSchedule` with the proven `useNotifications` pattern by setting state directly from the fetch response:

```diff
     if (response.error) {
       setError(response.error);
       onError?.(response.error);
-    } else {
-      onSuccess?.(response.data!);
+    } else if (response.data) {
+      setData(response.data);
+      onSuccess?.(response.data);
     }
```

This also removes the unsafe non-null assertion (`response.data!`) in favor of an explicit `response.data` guard, which additionally prevents clobbering state in the (previously unhandled) edge case where a response carries neither `data` nor `error`.

## Scope

- `packages/react/src/hooks/usePreferences.ts`
- `packages/react/src/hooks/useSchedule.ts`

No public API/type changes, no new dependencies. A previous community PR (#10071) applied the same fix to `usePreferences` and was auto-closed for inactivity rather than rejected on merit; this PR revives that fix and additionally covers `useSchedule`, which has the identical defect.

## Testing

- Verified via code analysis that `mitt` dispatches synchronously and that a warm cache in `Preferences.list()` emits `pending`/`resolved` before the hook's listeners are attached on re-mount.
- Manual repro: mount a component using `usePreferences`, unmount it, then re-mount — `preferences` now resolves to the cached array instead of remaining `undefined`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the React preferences hooks to set fetched data directly. The main changes are:

- `usePreferences` now stores successful `preferences.list()` responses in hook state.
- `useSchedule` now stores successful `preferences.schedule.get()` responses in hook state.
- Both hooks avoid calling `onSuccess` with a non-null assertion when the response has no data.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to two matching hook success paths and follow the existing `useNotifications` pattern.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the use-preferences-remount sequence and captured before and after visuals showing undefined versus cached preferences.
- Captured the Use Schedule Remount visuals to verify the before and after posters reflect the updated state.
- Inspected verbose logs to confirm synchronous warm-cache emissions occurred before second-mount listeners registered.
- Compared onSuccess behavior across hooks, noting the before state had onSuccess invoked once with undefined and the after state showed no onSuccess invocations and no unsafe payload.

<a href="https://app.greptile.com/trex/runs/12951498/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/react/src/hooks/usePreferences.ts | Sets preferences state directly from successful fetch responses so warm-cache remounts no longer rely only on synchronous events. |
| packages/react/src/hooks/useSchedule.ts | Sets schedule state directly from successful fetch responses so warm-cache remounts no longer rely only on synchronous events. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Component
participant Hook as usePreferences/useSchedule
participant Client as @novu/js preferences API
participant Cache

Component->>Hook: fetch preferences/schedule
Client->>Cache: read cached data
Cache-->>Client: cached response
Client-->>Hook: response.data
Hook->>Hook: setData(response.data)
Hook-->>Component: preferences/schedule available
Hook->>Client: register cache event listeners
Client-->>Hook: future updated/pending/resolved events
Hook->>Hook: sync event data
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Component
participant Hook as usePreferences/useSchedule
participant Client as @novu/js preferences API
participant Cache

Component->>Hook: fetch preferences/schedule
Client->>Cache: read cached data
Cache-->>Client: cached response
Client-->>Hook: response.data
Hook->>Hook: setData(response.data)
Hook-->>Component: preferences/schedule available
Hook->>Client: register cache event listeners
Client-->>Hook: future updated/pending/resolved events
Hook->>Hook: sync event data
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(react): set preferences/schedule dat..."](https://github.com/novuhq/novu/commit/a1a0115788363fa8d42022eb340ba313d3162f56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41166107)</sub>

<!-- /greptile_comment -->