### PR TITLE
refactor(api): remove conversation activation service from inbound handler and enhance agent reply handling with system-generated flag

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -159,9 +159,6 @@ describe('AgentInboundHandler', () => {
       maybeBlock: sinon.stub().resolves(false),
       maybeBlockConversation: sinon.stub().resolves(false),
     };
-    const conversationActivation = {
-      registerEngagement: sinon.stub().resolves(false),
-    };
     const handler = new AgentInboundHandler(
       logger as any,
       subscriberResolver as any,
@@ -180,8 +177,7 @@ describe('AgentInboundHandler', () => {
       connectClaimTokenService as any,
       keylessAbuseGuard as any,
       planLimitGate as any,
-      inboundAck as any,
-      conversationActivation as any
+      inboundAck as any
     );
 
     return {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -42,7 +42,6 @@ import {
   BotAuthorSkippedError,
   ConnectOrgSubscriberCapExceededError,
 } from '../conversation/agent-subscriber-resolver.service';
-import { ConversationActivationService } from '../conversation/conversation-activation.service';
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { BridgeReaction } from '../runtime/bridge-executor.service';
 import type { ConversationTurn } from '../runtime/conversation-turn';
@@ -244,8 +243,7 @@ export class AgentInboundHandler implements OnModuleInit {
     private readonly connectClaimTokenService: ConnectClaimTokenService,
     private readonly keylessAbuseGuard: KeylessAbuseGuardService,
     private readonly planLimitGate: PlanLimitGateService,
-    private readonly inboundAck: InboundAckService,
-    private readonly conversationActivation: ConversationActivationService
+    private readonly inboundAck: InboundAckService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -432,8 +430,6 @@ export class AgentInboundHandler implements OnModuleInit {
     };
 
     await runtime.dispatch(turn);
-
-    await this.registerConversationEngagement(agentId, config, conversation, thread.isDM);
   }
 
   /**
@@ -476,37 +472,6 @@ export class AgentInboundHandler implements OnModuleInit {
       captureAgentWarning(err, {
         component: 'agent-inbound-handler',
         operation: 'mark-integration-connected',
-        agentId,
-      });
-    }
-  }
-
-  /**
-   * Counts the active conversation once the agent has actually engaged
-   * (dispatch succeeded). Idempotent per activation — repeated engagements
-   * inside the same window/period only slide the rolling window. Fail-soft:
-   * billing accounting must never crash the inbound webhook.
-   */
-  private async registerConversationEngagement(
-    agentId: string,
-    config: ResolvedAgentConfig,
-    conversation: ConversationEntity,
-    isDirectMessage: boolean
-  ): Promise<void> {
-    try {
-      await this.conversationActivation.registerEngagement({
-        conversation,
-        platform: config.platform,
-        organizationId: config.organizationId,
-        environmentId: config.environmentId,
-        agentId,
-        isDirectMessage,
-      });
-    } catch (err) {
-      this.logger.warn(err, `[agent:${agentId}] Failed to register active-conversation engagement`);
-      captureAgentWarning(err, {
-        component: 'agent-inbound-handler',
-        operation: 'register-conversation-engagement',
         agentId,
       });
     }

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command.ts
@@ -1,7 +1,7 @@
 import type { Signal, ToolResult } from '@novu/framework';
 import type { PlanModel } from 'chat';
 import { Type } from 'class-transformer';
-import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../../shared/commands/project.command';
 import { AddReactionPayloadDto, EditPayloadDto, ReplyContentDto } from '../../../shared/dtos/agent-reply-payload.dto';
 import type { PlanPhase } from '../../egress/plan-phase';
@@ -57,4 +57,14 @@ export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
 
   @IsOptional()
   slackNative?: SlackNativeDelivery;
+
+  /**
+   * Marks a reply as system-generated (e.g. an error notice emitted by the
+   * managed runtime). System replies are still delivered, but they do not
+   * count an active conversation and bypass the free-tier outbound gate so an
+   * error message is never swallowed by a 402.
+   */
+  @IsOptional()
+  @IsBoolean()
+  isSystemGenerated?: boolean;
 }

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { HandleAgentReply } from './handle-agent-reply.usecase';
+
+describe('HandleAgentReply - active-conversation counting', () => {
+  function setup() {
+    const conversation = { _id: 'conv1', _agentId: 'agent1', participants: [] };
+    const channel = { platform: 'whatsapp', platformThreadId: 'thread1', firstPlatformMessageId: 'msg1' };
+
+    const agentRepository = {
+      findOne: sinon.stub().resolves({ _id: 'agent1', name: 'Agent', identifier: 'agent-1' }),
+    };
+    const subscriberRepository = { findBySubscriberId: sinon.stub().resolves(null) };
+    const bridgeExecutor = { execute: sinon.stub().resolves(undefined) };
+    // Managed config so the bridge-only inboundAck path is skipped.
+    const agentConfigResolver = { resolve: sinon.stub().resolves({ isManaged: true, platform: 'whatsapp' }) };
+    const conversationService = {
+      getConversation: sinon.stub().resolves(conversation),
+      getPrimaryChannel: sinon.stub().returns(channel),
+    };
+    const logger = { setContext: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+    const parseEventRequest = { execute: sinon.stub().resolves({ transactionId: 'txn1' }) };
+    const analyticsService = { track: sinon.stub() };
+    const outboundGateway = {
+      deliver: sinon.stub().resolves({ messageId: 'm1', platformThreadId: 'thread1' }),
+    };
+    const inboundAck = { onBridgeReplyDelivered: sinon.stub().resolves(undefined) };
+    const conversationActivation = {
+      assertOutboundWithinLimit: sinon.stub().resolves(undefined),
+      registerEngagement: sinon.stub().resolves(false),
+    };
+
+    const usecase = new HandleAgentReply(
+      agentRepository as any,
+      subscriberRepository as any,
+      bridgeExecutor as any,
+      agentConfigResolver as any,
+      conversationService as any,
+      logger as any,
+      parseEventRequest as any,
+      analyticsService as any,
+      outboundGateway as any,
+      inboundAck as any,
+      conversationActivation as any
+    );
+
+    const baseCommand = {
+      userId: 'user1',
+      environmentId: 'env1',
+      organizationId: 'org1',
+      conversationId: 'conv1',
+      agentIdentifier: 'agent-1',
+      integrationIdentifier: 'wa-main',
+    };
+
+    return { usecase, baseCommand, outboundGateway, conversationActivation };
+  }
+
+  it('counts an active conversation for a normal agent reply', async () => {
+    const { usecase, baseCommand, outboundGateway, conversationActivation } = setup();
+
+    await usecase.execute({ ...baseCommand, reply: { markdown: 'hi' } } as any);
+
+    expect(outboundGateway.deliver.calledOnce).to.equal(true);
+    expect(conversationActivation.assertOutboundWithinLimit.calledOnce).to.equal(true);
+    expect(conversationActivation.registerEngagement.calledOnce).to.equal(true);
+  });
+
+  it('delivers a system-generated reply without counting or gating', async () => {
+    const { usecase, baseCommand, outboundGateway, conversationActivation } = setup();
+
+    await usecase.execute({ ...baseCommand, reply: { markdown: 'session failed' }, isSystemGenerated: true } as any);
+
+    expect(outboundGateway.deliver.calledOnce).to.equal(true);
+    expect(conversationActivation.assertOutboundWithinLimit.called).to.equal(false);
+    expect(conversationActivation.registerEngagement.called).to.equal(false);
+  });
+});

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -106,19 +106,26 @@ export class HandleAgentReply {
 
     let replyInfo: SentMessageInfo | undefined;
     if (command.reply) {
-      // Free-tier short-circuit: an agent-initiated reply that would start a new
-      // active conversation is rejected once the included limit is reached
-      // (covers proactive/outbound-only threads). Replies inside an already-counted
-      // conversation pass through.
-      await this.conversationActivation.assertOutboundWithinLimit({
-        conversation,
-        platform: channel.platform as AgentPlatformEnum,
-        organizationId: command.organizationId,
-      });
+      // System-generated replies (e.g. runtime error notices) are always
+      // delivered but never count an active conversation, and they bypass the
+      // free-tier gate so an error message is never swallowed by a 402.
+      if (!command.isSystemGenerated) {
+        // Free-tier short-circuit: an agent-initiated reply that would start a new
+        // active conversation is rejected once the included limit is reached
+        // (covers proactive/outbound-only threads). Replies inside an already-counted
+        // conversation pass through.
+        await this.conversationActivation.assertOutboundWithinLimit({
+          conversation,
+          platform: channel.platform as AgentPlatformEnum,
+          organizationId: command.organizationId,
+        });
+      }
 
       replyInfo = await this.deliverMessage(command, conversation, channel, command.reply, agentName);
 
-      await this.registerConversationEngagement(command, conversation, channel);
+      if (!command.isSystemGenerated) {
+        await this.registerConversationEngagement(command, conversation, channel);
+      }
 
       if (!config!.isManaged) {
         void this.inboundAck.onBridgeReplyDelivered({

--- a/apps/api/src/app/agents/e2e/active-conversations.e2e.ts
+++ b/apps/api/src/app/agents/e2e/active-conversations.e2e.ts
@@ -9,6 +9,8 @@ import { ConversationActivationService } from '../conversation-runtime/conversat
 import { OutboundGateway } from '../conversation-runtime/egress/outbound.gateway';
 import { ChatInstanceRegistry } from '../conversation-runtime/ingress/chat-instance.registry';
 import { AgentInboundHandler } from '../conversation-runtime/ingress/inbound-turn.handler';
+import { HandleAgentReplyCommand } from '../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command';
+import { HandleAgentReply } from '../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
 import { AgentExecutionParams, BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
 import { RuntimeResolver } from '../conversation-runtime/runtime/runtime-resolver.service';
 import { AgentEventEnum } from '../shared/enums/agent-event.enum';
@@ -61,6 +63,7 @@ describe('Active Conversations metering - inbound flow #novu-v2', () => {
   let inboundHandler: AgentInboundHandler;
   let configResolver: AgentConfigResolver;
   let activationService: ConversationActivationService;
+  let handleAgentReply: HandleAgentReply;
   let bridgeCalls: AgentExecutionParams[];
 
   beforeEach(async () => {
@@ -68,11 +71,37 @@ describe('Active Conversations metering - inbound flow #novu-v2', () => {
     inboundHandler = testServer.getService(AgentInboundHandler);
     configResolver = testServer.getService(AgentConfigResolver);
     activationService = testServer.getService(ConversationActivationService);
+    handleAgentReply = testServer.getService(HandleAgentReply);
+
+    // Active conversations are counted on a delivered agent reply, not on the
+    // raw inbound message. Stub the network delivery and have the (stubbed)
+    // bridge simulate the agent replying back for every dispatched message —
+    // this mirrors production, where the bridge posts a reply via the reply
+    // API, and is what drives activation counting.
+    sinon
+      .stub(testServer.getService(OutboundGateway), 'deliver')
+      .resolves({ messageId: 'sent-e2e', platformThreadId: 'thread-e2e' } as any);
 
     bridgeCalls = [];
     const bridgeExecutor = testServer.getService(BridgeExecutorService);
     sinon.stub(bridgeExecutor, 'execute').callsFake(async (params: AgentExecutionParams) => {
       bridgeCalls.push(params);
+
+      if (params.event !== AgentEventEnum.ON_MESSAGE) {
+        return;
+      }
+
+      await handleAgentReply.execute(
+        HandleAgentReplyCommand.create({
+          userId: ctx.session.user._id,
+          environmentId: params.config.environmentId,
+          organizationId: params.config.organizationId,
+          conversationId: params.conversation._id,
+          agentIdentifier: params.config.agentIdentifier,
+          integrationIdentifier: params.config.integrationIdentifier,
+          reply: { markdown: 'ack' },
+        })
+      );
     });
   });
 

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -279,7 +279,7 @@ export class ManagedAgentEventHandler {
 
     try {
       await this.handleAgentReply.execute(
-        HandleAgentReplyCommand.create({ ...baseCommand, reply: { markdown: message } })
+        HandleAgentReplyCommand.create({ ...baseCommand, reply: { markdown: message }, isSystemGenerated: true })
       );
       await this.inboundAck.onManagedTurnComplete(metadata);
       await this.handlePlanProgress.execute(


### PR DESCRIPTION
### What changed? Why was the change needed?
- Removed the unused ConversationActivationService from AgentInboundHandler.
- Updated HandleAgentReply to include an isSystemGenerated flag for replies, allowing system-generated messages to bypass active conversation counting and free-tier limits.
- Added tests for active conversation counting and system-generated replies in HandleAgentReply use case.
- Adjusted e2e tests to reflect changes in active conversation counting logic.

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors active-conversation activation counting to move from the inbound turn handler to the `HandleAgentReply` use case, ensuring engagements are only recorded when a reply is actually delivered. It also introduces an `isSystemGenerated` flag on `HandleAgentReplyCommand` so managed-runtime error messages can bypass the free-tier 402 gate and activation counting.

- `ConversationActivationService` is removed from `AgentInboundHandler`; the `registerConversationEngagement` call (and its fail-soft wrapper) is relocated to `HandleAgentReply.execute`, guarded by `!command.isSystemGenerated`.
- The managed-runtime error delivery path in `ManagedAgentEventHandler` now passes `isSystemGenerated: true` when sending error notices.
- E2E tests are restructured so the stubbed bridge executor directly calls `handleAgentReply.execute`, mirroring the production flow where activation counting is driven by reply delivery rather than message dispatch.


<h3>Confidence Score: 4/5</h3>

The change is safe to merge. Activation counting is moved to the correct point (reply delivery), and error messages are correctly exempted from billing limits and engagement recording.

The refactor is well-scoped and logically sound. The isSystemGenerated flag cannot be set via the external API controller (it is never forwarded from AgentReplyController), so there is no billing-bypass risk from external callers. The ConversationActivationService's own fallback to conversation.isDirectMessage handles the absence of a live isDM hint on the reply path. One minor asymmetry remains: inboundAck.onBridgeReplyDelivered is not guarded by isSystemGenerated the way the limit gate and engagement registration are, which could produce an unexpected side effect if a non-managed agent ever sends a system-generated reply in a future call site.

handle-agent-reply.usecase.ts — the bridge-ack guard asymmetry noted above; active-conversations.e2e.ts — the restructured test correctly models the production flow, but relies on void fire-and-forget on the real InboundAckService which silently swallows any ack errors in test environments.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts | Core refactor: activation counting and limit gating are now conditional on !isSystemGenerated; the inboundAck call for bridge agents is not guarded by the same flag, leaving a theoretical edge case for future non-managed system-generated replies. |
| apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command.ts | Added optional isSystemGenerated boolean field with proper class-validator decorators; the field is not forwarded from the external API controller, keeping it effectively internal-only. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | ConversationActivationService dependency and registerConversationEngagement call removed cleanly; constructor parameter list and spec updated consistently. |
| apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts | Error delivery path correctly sets isSystemGenerated: true, allowing error notices to bypass free-tier gate and activation counting. |
| apps/api/src/app/agents/e2e/active-conversations.e2e.ts | E2E test restructured to mirror production flow: the bridge executor stub now calls handleAgentReply.execute, which drives activation counting; OutboundGateway.deliver is also stubbed to avoid real network calls. |
| apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.spec.ts | New unit tests directly verify that assertOutboundWithinLimit and registerEngagement are called for normal replies and skipped for system-generated ones. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Slack
    participant InboundHandler as AgentInboundHandler
    participant BridgeExecutor as BridgeExecutorService
    participant ReplyAPI as AgentReplyController
    participant HandleReply as HandleAgentReply
    participant ActivationSvc as ConversationActivationService
    participant OutboundGW as OutboundGateway

    Slack->>InboundHandler: handle(message)
    InboundHandler->>InboundHandler: "resolve conversation & subscriber"
    InboundHandler->>InboundHandler: planLimitGate.maybeBlockConversation()
    InboundHandler->>BridgeExecutor: runtime.dispatch(turn)
    Note over InboundHandler: No engagement counted here anymore

    alt Bridge (non-managed) agent
        BridgeExecutor-->>InboundHandler: returns
        Note over BridgeExecutor: Bridge engine posts reply asynchronously
        BridgeExecutor->>ReplyAPI: POST /agents/:id/reply
        ReplyAPI->>HandleReply: execute(command)
    else Managed agent
        BridgeExecutor-->>InboundHandler: returns
        Note over BridgeExecutor: ManagedAgentEventHandler fires
        BridgeExecutor->>HandleReply: execute(command, isSystemGenerated?)
    end

    alt "isSystemGenerated = false (normal reply)"
        HandleReply->>ActivationSvc: assertOutboundWithinLimit()
        HandleReply->>OutboundGW: deliver(message)
        HandleReply->>ActivationSvc: registerEngagement()
    else "isSystemGenerated = true (error notice)"
        Note over HandleReply: Skip limit gate and engagement count
        HandleReply->>OutboundGW: deliver(error message)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Slack
    participant InboundHandler as AgentInboundHandler
    participant BridgeExecutor as BridgeExecutorService
    participant ReplyAPI as AgentReplyController
    participant HandleReply as HandleAgentReply
    participant ActivationSvc as ConversationActivationService
    participant OutboundGW as OutboundGateway

    Slack->>InboundHandler: handle(message)
    InboundHandler->>InboundHandler: "resolve conversation & subscriber"
    InboundHandler->>InboundHandler: planLimitGate.maybeBlockConversation()
    InboundHandler->>BridgeExecutor: runtime.dispatch(turn)
    Note over InboundHandler: No engagement counted here anymore

    alt Bridge (non-managed) agent
        BridgeExecutor-->>InboundHandler: returns
        Note over BridgeExecutor: Bridge engine posts reply asynchronously
        BridgeExecutor->>ReplyAPI: POST /agents/:id/reply
        ReplyAPI->>HandleReply: execute(command)
    else Managed agent
        BridgeExecutor-->>InboundHandler: returns
        Note over BridgeExecutor: ManagedAgentEventHandler fires
        BridgeExecutor->>HandleReply: execute(command, isSystemGenerated?)
    end

    alt "isSystemGenerated = false (normal reply)"
        HandleReply->>ActivationSvc: assertOutboundWithinLimit()
        HandleReply->>OutboundGW: deliver(message)
        HandleReply->>ActivationSvc: registerEngagement()
    else "isSystemGenerated = true (error notice)"
        Note over HandleReply: Skip limit gate and engagement count
        HandleReply->>OutboundGW: deliver(error message)
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts`, line 130-137 ([link](https://github.com/novuhq/novu/blob/e0c7f0f13057a5e32a882457d3c75e7f346795ff/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts#L130-L137)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `inboundAck.onBridgeReplyDelivered` call is not guarded by `!command.isSystemGenerated`, so a future call site that passes `isSystemGenerated: true` for a bridge (non-managed) agent would still trigger the bridge ack. Currently this path is unreachable because `isSystemGenerated` is only set in the managed-runtime handler (where `config.isManaged === true`), but the asymmetry with the limit-gate and engagement guards above it may be surprising. Consider aligning the guard here for defensive consistency.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
   Line: 130-137

   Comment:
   The `inboundAck.onBridgeReplyDelivered` call is not guarded by `!command.isSystemGenerated`, so a future call site that passes `isSystemGenerated: true` for a bridge (non-managed) agent would still trigger the bridge ack. Currently this path is unreachable because `isSystemGenerated` is only set in the managed-runtime handler (where `config.isManaged === true`), but the asymmetry with the limit-gate and engagement guards above it may be surprising. Consider aligning the guard here for defensive consistency.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Freply%2Fhandle-agent-reply%2Fhandle-agent-reply.usecase.ts%0ALine%3A%20130-137%0A%0AComment%3A%0AThe%20%60inboundAck.onBridgeReplyDelivered%60%20call%20is%20not%20guarded%20by%20%60!command.isSystemGenerated%60%2C%20so%20a%20future%20call%20site%20that%20passes%20%60isSystemGenerated%3A%20true%60%20for%20a%20bridge%20%28non-managed%29%20agent%20would%20still%20trigger%20the%20bridge%20ack.%20Currently%20this%20path%20is%20unreachable%20because%20%60isSystemGenerated%60%20is%20only%20set%20in%20the%20managed-runtime%20handler%20%28where%20%60config.isManaged%20%3D%3D%3D%20true%60%29%2C%20but%20the%20asymmetry%20with%20the%20limit-gate%20and%20engagement%20guards%20above%20it%20may%20be%20surprising.%20Consider%20aligning%20the%20guard%20here%20for%20defensive%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!config!.isManaged%20%26%26%20!command.isSystemGenerated%29%20%7B%0A%20%20%20%20%20%20%20%20void%20this.inboundAck.onBridgeReplyDelivered%28%7B%0A%20%20%20%20%20%20%20%20%20%20agentId%3A%20conversation._agentId%2C%0A%20%20%20%20%20%20%20%20%20%20config%3A%20config!%2C%0A%20%20%20%20%20%20%20%20%20%20platformThreadId%3A%20channel.platformThreadId%2C%0A%20%20%20%20%20%20%20%20%20%20firstPlatformMessageId%3A%20channel.firstPlatformMessageId%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11760&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Freply%2Fhandle-agent-reply%2Fhandle-agent-reply.usecase.ts%3A130-137%0AThe%20%60inboundAck.onBridgeReplyDelivered%60%20call%20is%20not%20guarded%20by%20%60!command.isSystemGenerated%60%2C%20so%20a%20future%20call%20site%20that%20passes%20%60isSystemGenerated%3A%20true%60%20for%20a%20bridge%20%28non-managed%29%20agent%20would%20still%20trigger%20the%20bridge%20ack.%20Currently%20this%20path%20is%20unreachable%20because%20%60isSystemGenerated%60%20is%20only%20set%20in%20the%20managed-runtime%20handler%20%28where%20%60config.isManaged%20%3D%3D%3D%20true%60%29%2C%20but%20the%20asymmetry%20with%20the%20limit-gate%20and%20engagement%20guards%20above%20it%20may%20be%20surprising.%20Consider%20aligning%20the%20guard%20here%20for%20defensive%20consistency.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!config!.isManaged%20%26%26%20!command.isSystemGenerated%29%20%7B%0A%20%20%20%20%20%20%20%20void%20this.inboundAck.onBridgeReplyDelivered%28%7B%0A%20%20%20%20%20%20%20%20%20%20agentId%3A%20conversation._agentId%2C%0A%20%20%20%20%20%20%20%20%20%20config%3A%20config!%2C%0A%20%20%20%20%20%20%20%20%20%20platformThreadId%3A%20channel.platformThreadId%2C%0A%20%20%20%20%20%20%20%20%20%20firstPlatformMessageId%3A%20channel.firstPlatformMessageId%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=11760&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts:130-137
The `inboundAck.onBridgeReplyDelivered` call is not guarded by `!command.isSystemGenerated`, so a future call site that passes `isSystemGenerated: true` for a bridge (non-managed) agent would still trigger the bridge ack. Currently this path is unreachable because `isSystemGenerated` is only set in the managed-runtime handler (where `config.isManaged === true`), but the asymmetry with the limit-gate and engagement guards above it may be surprising. Consider aligning the guard here for defensive consistency.

```suggestion
      if (!config!.isManaged && !command.isSystemGenerated) {
        void this.inboundAck.onBridgeReplyDelivered({
          agentId: conversation._agentId,
          config: config!,
          platformThreadId: channel.platformThreadId,
          firstPlatformMessageId: channel.firstPlatformMessageId,
        });
      }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api): remove conversation activ..."](https://github.com/novuhq/novu/commit/e0c7f0f13057a5e32a882457d3c75e7f346795ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41348440)</sub>

<!-- /greptile_comment -->