### PR TITLE
fix(worker): handle missing array values in IN/NOT_IN step filters fixes NV-8168

### DIFF
--- a/apps/worker/src/app/workflow/services/standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.ts
@@ -229,6 +229,7 @@ export class StandardWorker extends StandardWorkerService {
 
   private async jobHasFailed(job: Job<IStandardDataDto, void, string>, error: Error): Promise<boolean> {
     let jobId;
+    let hasToBackoff = false;
 
     nr.noticeError(error);
 
@@ -236,7 +237,7 @@ export class StandardWorker extends StandardWorkerService {
       const minimalData = this.extractMinimalJobData(job.data);
       jobId = minimalData.jobId;
 
-      const hasToBackoff = this.runJob.shouldBackoff(error);
+      hasToBackoff = this.runJob.shouldBackoff(error);
       const hasReachedMaxAttempts = job.attemptsMade >= this.DEFAULT_ATTEMPTS;
       const shouldHandleLastFailedJob = hasToBackoff && hasReachedMaxAttempts;
 
@@ -280,7 +281,7 @@ export class StandardWorker extends StandardWorkerService {
     } catch (anotherError) {
       Logger.error(anotherError, `Failed to set job ${jobId} as failed`, LOG_CONTEXT);
 
-      return true;
+      return hasToBackoff && job.attemptsMade < this.DEFAULT_ATTEMPTS;
     }
   }
 

--- a/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
@@ -23,6 +23,7 @@ import sinon from 'sinon';
 describe('Message filter matcher', () => {
   const executionLogQueueService = {
     add: sinon.stub(),
+    execute: sinon.stub().resolves(),
   };
   const conditionsFilter = new ConditionsFilter(
     undefined as any,
@@ -370,6 +371,35 @@ describe('Message filter matcher', () => {
     );
 
     expect(matchedMessage.passed).to.equal(false);
+  });
+
+  it('should fail closed when filter evaluation throws', async () => {
+    const processFilterEqualityStub = sinon
+      .stub(ConditionsFilter.prototype as any, 'processFilterEquality')
+      .throws(new TypeError('Cannot read properties of undefined (reading "includes")'));
+
+    const matchedMessage = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('Throws On Eval', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.EQUAL,
+            value: 'true',
+            field: 'varField',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {
+            varField: true,
+          },
+        },
+      })
+    );
+
+    expect(matchedMessage.passed).to.equal(false);
+    expect(matchedMessage.conditions[0]?.passed).to.equal(false);
+
+    processFilterEqualityStub.restore();
   });
 
   it('should check if key is defined or not in subscriber data', async () => {

--- a/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
@@ -310,6 +310,68 @@ describe('Message filter matcher', () => {
     expect(matchedMessage.passed).to.equal(true);
   });
 
+  it('should handle IN operator when payload field is missing', async () => {
+    const matchedMessage = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('Missing Field', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.IN,
+            value: 'premium',
+            field: 'tags',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {},
+        },
+      })
+    );
+
+    expect(matchedMessage.passed).to.equal(false);
+  });
+
+  it('should handle NOT_IN operator when payload field is missing', async () => {
+    const matchedMessage = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('Missing Field', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.NOT_IN,
+            value: 'blocked',
+            field: 'tags',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {},
+        },
+      })
+    );
+
+    expect(matchedMessage.passed).to.equal(true);
+  });
+
+  it('should handle IN operator when payload field is not an array', async () => {
+    const matchedMessage = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('Non Array Field', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.IN,
+            value: 'premium',
+            field: 'tags',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {
+            tags: 'premium',
+          },
+        },
+      })
+    );
+
+    expect(matchedMessage.passed).to.equal(false);
+  });
+
   it('should check if key is defined or not in subscriber data', async () => {
     const matchedMessage = await conditionsFilter.filter(
       mapConditionsFilterCommand({

--- a/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -346,34 +346,90 @@ export class ConditionsFilter extends Filter {
     command: ConditionsFilterCommand,
     filterProcessingDetails: FilterProcessingDetails
   ): Promise<boolean> {
-    let passed = false;
+    try {
+      let passed = false;
 
-    if (child.on === FilterPartTypeEnum.WEBHOOK) {
-      if (process.env.NODE_ENV === 'test') return true;
-      child.value = await this.compileFilter(child.value, variables, command.job);
-      const res = await this.getWebhookResponse(child, variables, command);
-      passed = this.processFilterEquality({ payload: undefined, webhook: res }, child, filterProcessingDetails);
+      if (child.on === FilterPartTypeEnum.WEBHOOK) {
+        if (process.env.NODE_ENV === 'test') return true;
+        child.value = await this.compileFilter(child.value, variables, command.job);
+        const res = await this.getWebhookResponse(child, variables, command);
+        passed = this.processFilterEquality({ payload: undefined, webhook: res }, child, filterProcessingDetails);
+      }
+
+      if (
+        child.on === FilterPartTypeEnum.TENANT ||
+        child.on === FilterPartTypeEnum.PAYLOAD ||
+        child.on === FilterPartTypeEnum.SUBSCRIBER
+      ) {
+        child.value = await this.compileFilter(child.value, variables, command.job);
+
+        passed = this.processFilterEquality(variables, child, filterProcessingDetails);
+      }
+
+      if (child.on === FilterPartTypeEnum.IS_ONLINE || child.on === FilterPartTypeEnum.IS_ONLINE_IN_LAST) {
+        passed = await this.processIsOnline(child, command, filterProcessingDetails);
+      }
+
+      if (child.on === FilterPartTypeEnum.PREVIOUS_STEP) {
+        passed = await this.processPreviousStep(child, command, filterProcessingDetails);
+      }
+
+      return passed;
+    } catch (error) {
+      if (this.isRetryableWebhookFilterError(error)) {
+        throw error;
+      }
+
+      await this.recordFilterEvaluationError(error, child, command, filterProcessingDetails);
+
+      return false;
     }
+  }
 
-    if (
-      child.on === FilterPartTypeEnum.TENANT ||
-      child.on === FilterPartTypeEnum.PAYLOAD ||
-      child.on === FilterPartTypeEnum.SUBSCRIBER
-    ) {
-      child.value = await this.compileFilter(child.value, variables, command.job);
+  private isRetryableWebhookFilterError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
 
-      passed = this.processFilterEquality(variables, child, filterProcessingDetails);
+    return (
+      message.includes('Exception while performing webhook request.') ||
+      message.includes('Webhook URL blocked by SSRF protection.')
+    );
+  }
+
+  private async recordFilterEvaluationError(
+    error: unknown,
+    child: FilterParts,
+    command: ConditionsFilterCommand,
+    filterProcessingDetails: FilterProcessingDetails
+  ): Promise<void> {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const field = 'field' in child ? child.field : '';
+    const operator = 'operator' in child ? child.operator : FieldOperatorEnum.EQUAL;
+    const expected = 'value' in child ? `${child.value ?? ''}` : '';
+
+    filterProcessingDetails.addCondition({
+      filter: FILTER_TO_LABEL[child.on],
+      field,
+      expected,
+      actual: errorMessage,
+      operator,
+      passed: false,
+    });
+
+    try {
+      await this.createExecutionDetails.execute(
+        CreateExecutionDetailsCommand.create({
+          ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
+          detail: DetailEnum.PROCESSING_STEP_FILTER_ERROR,
+          source: ExecutionDetailsSourceEnum.INTERNAL,
+          status: ExecutionDetailsStatusEnum.FAILED,
+          isTest: false,
+          isRetry: false,
+          raw: JSON.stringify({ error: errorMessage, filterOn: child.on, field }),
+        })
+      );
+    } catch {
+      // Execution detail logging is best-effort; the filter still fails closed.
     }
-
-    if (child.on === FilterPartTypeEnum.IS_ONLINE || child.on === FilterPartTypeEnum.IS_ONLINE_IN_LAST) {
-      passed = await this.processIsOnline(child, command, filterProcessingDetails);
-    }
-
-    if (child.on === FilterPartTypeEnum.PREVIOUS_STEP) {
-      passed = await this.processPreviousStep(child, command, filterProcessingDetails);
-    }
-
-    return passed;
   }
   private async handleGroupFilters(
     filter: StepFilter,

--- a/libs/application-generic/src/utils/filter.ts
+++ b/libs/application-generic/src/utils/filter.ts
@@ -39,11 +39,11 @@ export abstract class Filter {
 
         break;
       case FieldOperatorEnum.NOT_IN:
-        result = !(actualValue as any).includes(filterValue);
+        result = Array.isArray(actualValue) ? !actualValue.includes(filterValue) : true;
 
         break;
       case FieldOperatorEnum.IN:
-        result = (actualValue as any).includes(filterValue);
+        result = Array.isArray(actualValue) ? actualValue.includes(filterValue) : false;
 
         break;
       case FieldOperatorEnum.IS_DEFINED:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes worker crashes and retry storms caused by legacy step filter evaluation (`step.filters`).

### 1. Guard `IN` / `NOT_IN` operators
When the filtered field is missing or not an array, return a safe result instead of calling `.includes()` on `undefined`.

### 2. Fail-closed filter evaluation
Wrap `processFilter` in try/catch so any unexpected evaluation error (TypeError, bad comparisons, etc.) is treated as **condition not passed** instead of crashing the worker. The step is skipped rather than failing the job.

- Webhook **HTTP** failures are still re-thrown so existing retry/backoff behavior is preserved.
- A failed condition is recorded in filter processing details; execution detail logging is best-effort.

### 3. Stop infinite retries when marking a job failed fails
When `setJobAsFailed` throws (e.g. `DalException` from `JobRepository.setError`), the worker previously returned `true` from the SQS failed handler, causing **unbounded redelivery**. Now it only retries when the original error was a retryable webhook filter failure and attempts remain.


## Test plan

- [x] `conditions-filter.usecase.spec.ts` — 38 passing
  - Missing/non-array `IN`/`NOT_IN` payload fields
  - Fail-closed when `processFilterEquality` throws
- [x] Rebuilt `@novu/application-generic` before running worker tests

## Follow-ups (not in this PR)

- Idempotent scheduler callback enqueue
- Persisted reprocessing attempt cap on jobs
- Author-time validation for legacy filter operators
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a918a7d-a385-4e42-a2c2-0458c795cfb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a918a7d-a385-4e42-a2c2-0458c795cfb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three distinct defensive improvements to the legacy step filter evaluation path (`step.filters`): safe fallback returns for `IN`/`NOT_IN` operators when the payload field is missing or not an array, a fail-closed wrapper around `processFilter` that swallows unexpected errors instead of crashing the worker, and a fix to the SQS failed handler so it stops unconditionally returning `true` (causing infinite re-delivery) when `setJobAsFailed` itself throws.

- **`IN`/`NOT_IN` guard** (`filter.ts`): when `actualValue` is not an array, `IN` now returns `false` (miss) and `NOT_IN` returns `true` (pass), preventing a crash on `.includes()` of `undefined`.
- **Fail-closed `processFilter`** (`conditions-filter.usecase.ts`): unexpected evaluation errors are caught, recorded via `filterProcessingDetails` and a best-effort execution-detail log, and the condition is treated as not passed; webhook HTTP errors are explicitly re-thrown to preserve retry behaviour.
- **Bounded retry in `jobHasFailed` catch** (`standard.worker.ts`): returns `hasToBackoff && job.attemptsMade < DEFAULT_ATTEMPTS` instead of unconditional `true`, stopping unbounded SQS re-delivery when only the final error-recording step fails.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three changes are well-scoped defensive fixes with direct unit-test coverage and no schema or API surface changes.

The IN/NOT_IN array guards are trivial and verified by new tests. The fail-closed wrapper introduces two minor design points worth a follow-up (fragile string-matching for webhook retries and silent swallowing of PlatformException from buildHmac), but neither represents a regression from pre-PR behaviour. The standard.worker.ts catch fix is logically equivalent to the happy-path return and correctly stops unbounded re-delivery.

conditions-filter.usecase.ts deserves a follow-up to harden the retryable-error detection and ensure PlatformException from environment lookup does not get silently dropped.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/utils/filter.ts | Added Array.isArray guards for IN and NOT_IN operators; straightforward and correct fix preventing crashes on undefined/non-array payload fields. |
| libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts | Wraps processFilter in try/catch with fail-closed semantics; webhook retry detection relies on fragile string matching against serialized JSON error messages. |
| apps/worker/src/app/workflow/services/standard.worker.ts | Fixes unbounded SQS re-delivery when setJobAsFailed throws; the new catch expression is logically equivalent to the happy-path return condition. |
| apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts | Adds well-scoped unit tests for the three new behaviours; also adds a missing execute stub that prevented the test harness from compiling cleanly. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processFilter called] --> B{child.on type?}
    B -->|WEBHOOK| C[getWebhookResponse]
    B -->|PAYLOAD / SUBSCRIBER / TENANT| D[compileFilter → processFilterEquality]
    B -->|IS_ONLINE / IS_ONLINE_IN_LAST| E[processIsOnline]
    B -->|PREVIOUS_STEP| F[processPreviousStep]

    C --> G{HTTP error?}
    G -->|SSRF / request failure| H[throw retryable error]
    G -->|success| D

    D --> I{actualValue array?}
    I -->|IN operator| J{Array.isArray?}
    I -->|NOT_IN operator| K{Array.isArray?}
    J -->|yes| L[actualValue.includes → true/false]
    J -->|no| M[return false]
    K -->|yes| N[!actualValue.includes → true/false]
    K -->|no| O[return true]

    L & M & N & O --> P[passed = result]
    E & F --> P
    P --> Q[return passed]

    H --> R{isRetryableWebhookFilterError?}
    Q --> S[caller]

    subgraph catch [Outer try/catch in processFilter]
        R -->|yes| T[re-throw → worker retries]
        R -->|no| U[recordFilterEvaluationError]
        U --> V[addCondition passed=false]
        V --> W[best-effort ExecutionDetail log]
        W --> X[return false — step skipped]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processFilter called] --> B{child.on type?}
    B -->|WEBHOOK| C[getWebhookResponse]
    B -->|PAYLOAD / SUBSCRIBER / TENANT| D[compileFilter → processFilterEquality]
    B -->|IS_ONLINE / IS_ONLINE_IN_LAST| E[processIsOnline]
    B -->|PREVIOUS_STEP| F[processPreviousStep]

    C --> G{HTTP error?}
    G -->|SSRF / request failure| H[throw retryable error]
    G -->|success| D

    D --> I{actualValue array?}
    I -->|IN operator| J{Array.isArray?}
    I -->|NOT_IN operator| K{Array.isArray?}
    J -->|yes| L[actualValue.includes → true/false]
    J -->|no| M[return false]
    K -->|yes| N[!actualValue.includes → true/false]
    K -->|no| O[return true]

    L & M & N & O --> P[passed = result]
    E & F --> P
    P --> Q[return passed]

    H --> R{isRetryableWebhookFilterError?}
    Q --> S[caller]

    subgraph catch [Outer try/catch in processFilter]
        R -->|yes| T[re-throw → worker retries]
        R -->|no| U[recordFilterEvaluationError]
        U --> V[addCondition passed=false]
        V --> W[best-effort ExecutionDetail log]
        W --> X[return false — step skipped]
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(worker): fail closed on step filter ..."](https://github.com/novuhq/novu/commit/906ef34914a9a49de1808894df8d8d8f580265b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41635399)</sub>

<!-- /greptile_comment -->