### PR TITLE
fix(js): localize de-DE sub-minute inbox timestamps fixes NV-8169

### DIFF
--- a/packages/js/src/ui/context/LocalizationContext.tsx
+++ b/packages/js/src/ui/context/LocalizationContext.tsx
@@ -5,6 +5,8 @@ import {
   defaultSubscriptionLocalization,
   dynamicLocalization,
 } from '../config/defaultLocalization';
+import { normalizeIntlLocale } from '../helpers/normalizeIntlLocale';
+import { useNovu } from './NovuContext';
 
 export type InboxLocalizationKey = keyof typeof defaultInboxLocalization;
 export type SubscriptionLocalizationKey = keyof typeof defaultSubscriptionLocalization;
@@ -59,14 +61,20 @@ const LocalizationContext = createContext<LocalizationContextType | undefined>(u
 type LocalizationProviderProps = ParentProps & { localization?: AllLocalization };
 
 export const LocalizationProvider = (props: LocalizationProviderProps) => {
+  const novu = useNovu();
+
   const localization = createMemo<Record<string, string | Function>>(() => {
-    const { dynamic, ...localizationObject } = props.localization || {};
+    const { dynamic, locale: explicitLocale, ...localizationObject } = props.localization || {};
+    const subscriber = novu().options.subscriber;
+    const subscriberLocale = typeof subscriber === 'object' ? subscriber?.locale : undefined;
+    const resolvedLocale = explicitLocale ?? subscriberLocale ?? defaultLocalization.locale;
 
     return {
       ...defaultLocalization,
       ...dynamicLocalization(),
       ...(dynamic || {}),
       ...localizationObject,
+      locale: resolvedLocale,
     };
   });
 
@@ -79,7 +87,7 @@ export const LocalizationProvider = (props: LocalizationProviderProps) => {
     return value as string;
   };
 
-  const locale = createMemo(() => localization().locale as string);
+  const locale = createMemo(() => normalizeIntlLocale(localization().locale as string));
 
   return (
     <LocalizationContext.Provider

--- a/packages/js/src/ui/context/LocalizationContext.tsx
+++ b/packages/js/src/ui/context/LocalizationContext.tsx
@@ -6,7 +6,6 @@ import {
   dynamicLocalization,
 } from '../config/defaultLocalization';
 import { normalizeIntlLocale } from '../helpers/normalizeIntlLocale';
-import { useNovu } from './NovuContext';
 
 export type InboxLocalizationKey = keyof typeof defaultInboxLocalization;
 export type SubscriptionLocalizationKey = keyof typeof defaultSubscriptionLocalization;
@@ -61,20 +60,14 @@ const LocalizationContext = createContext<LocalizationContextType | undefined>(u
 type LocalizationProviderProps = ParentProps & { localization?: AllLocalization };
 
 export const LocalizationProvider = (props: LocalizationProviderProps) => {
-  const novu = useNovu();
-
   const localization = createMemo<Record<string, string | Function>>(() => {
-    const { dynamic, locale: explicitLocale, ...localizationObject } = props.localization || {};
-    const subscriber = novu().options.subscriber;
-    const subscriberLocale = typeof subscriber === 'object' ? subscriber?.locale : undefined;
-    const resolvedLocale = explicitLocale ?? subscriberLocale ?? defaultLocalization.locale;
+    const { dynamic, ...localizationObject } = props.localization || {};
 
     return {
       ...defaultLocalization,
       ...dynamicLocalization(),
       ...(dynamic || {}),
       ...localizationObject,
-      locale: resolvedLocale,
     };
   });
 

--- a/packages/js/src/ui/helpers/formatToRelativeTime.test.ts
+++ b/packages/js/src/ui/helpers/formatToRelativeTime.test.ts
@@ -18,6 +18,39 @@ describe('formatToRelativeTime', () => {
     expect(result).toMatch(/now/i);
   });
 
+  it('returns German sub-minute text for de-DE locale', () => {
+    const result = formatToRelativeTime({
+      fromDate: dateSecondsAgo(30, now),
+      toDate: now,
+      locale: 'de-DE',
+    });
+
+    expect(result).toMatch(/jetzt/i);
+    expect(result).not.toMatch(/just now/i);
+  });
+
+  it('returns German sub-minute text for de_DE locale', () => {
+    const result = formatToRelativeTime({
+      fromDate: dateSecondsAgo(30, now),
+      toDate: now,
+      locale: 'de_DE',
+    });
+
+    expect(result).toMatch(/jetzt/i);
+    expect(result).not.toMatch(/just now/i);
+  });
+
+  it('returns German hour text for de-DE locale', () => {
+    const result = formatToRelativeTime({
+      fromDate: dateSecondsAgo(17 * SECONDS.inHour, now),
+      toDate: now,
+      locale: 'de-DE',
+    });
+
+    expect(result).toMatch(/17/);
+    expect(result).toMatch(/Std/i);
+  });
+
   it('returns 1 minute for 61 seconds', () => {
     const result = formatToRelativeTime({ fromDate: dateSecondsAgo(61, now), toDate: now });
     expect(result).toMatch(/1/);

--- a/packages/js/src/ui/helpers/formatToRelativeTime.ts
+++ b/packages/js/src/ui/helpers/formatToRelativeTime.ts
@@ -1,3 +1,5 @@
+import { normalizeIntlLocale } from './normalizeIntlLocale';
+
 const DEFAULT_LOCALE = 'en-US';
 
 const SECONDS = {
@@ -17,15 +19,17 @@ export function formatToRelativeTime({
   locale?: string;
   toDate?: Date;
 }) {
+  const intlLocale = normalizeIntlLocale(locale);
+
   // time elapsed in milliseconds between the two dates
   const elapsed = toDate.getTime() - fromDate.getTime();
 
-  const formatter = new Intl.RelativeTimeFormat(locale, { style: 'narrow' });
+  const formatter = new Intl.RelativeTimeFormat(intlLocale, { style: 'narrow' });
 
   const diffInSeconds = Math.floor(elapsed / 1000);
 
   if (Math.abs(diffInSeconds) < SECONDS.inMinute) {
-    const subMinuteFormatter = new Intl.RelativeTimeFormat(locale, { style: 'narrow', numeric: 'auto' });
+    const subMinuteFormatter = new Intl.RelativeTimeFormat(intlLocale, { style: 'narrow', numeric: 'auto' });
 
     return subMinuteFormatter.format(-0, 'second');
   }
@@ -43,7 +47,7 @@ export function formatToRelativeTime({
   }
   // Otherwise, return the date formatted with month and day. i.e Dec 3
   else {
-    return new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(fromDate);
+    return new Intl.DateTimeFormat(intlLocale, { month: 'short', day: 'numeric' }).format(fromDate);
   }
 }
 
@@ -52,6 +56,8 @@ export function formatToRelativeTime({
  * Returns formats that pair well with "Snoozed until" label, like "2 hours" or "Mar 5"
  */
 export function formatSnoozedUntil({ untilDate, locale = DEFAULT_LOCALE }: { untilDate: Date; locale?: string }) {
+  const intlLocale = normalizeIntlLocale(locale);
+
   // time remaining in milliseconds between the two dates
   const remaining = untilDate.getTime() - new Date().getTime();
 
@@ -90,6 +96,6 @@ export function formatSnoozedUntil({ untilDate, locale = DEFAULT_LOCALE }: { unt
   }
   // Otherwise, return the date formatted with month and day
   else {
-    return new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(untilDate);
+    return new Intl.DateTimeFormat(intlLocale, { month: 'short', day: 'numeric' }).format(untilDate);
   }
 }

--- a/packages/js/src/ui/helpers/index.ts
+++ b/packages/js/src/ui/helpers/index.ts
@@ -1,6 +1,7 @@
 export * from './constants';
 export * from './createInfiniteScroll';
 export * from './formatToRelativeTime';
+export * from './normalizeIntlLocale';
 export * from './useNotificationVisibility';
 export * from './useStyle';
 export * from './useTabsDropdown';

--- a/packages/js/src/ui/helpers/normalizeIntlLocale.test.ts
+++ b/packages/js/src/ui/helpers/normalizeIntlLocale.test.ts
@@ -1,0 +1,13 @@
+import { normalizeIntlLocale } from './normalizeIntlLocale';
+
+describe('normalizeIntlLocale', () => {
+  it('converts underscore locale codes to BCP 47 tags', () => {
+    expect(normalizeIntlLocale('de_DE')).toBe('de-DE');
+    expect(normalizeIntlLocale('en_US')).toBe('en-US');
+  });
+
+  it('leaves hyphenated locale codes unchanged', () => {
+    expect(normalizeIntlLocale('de-DE')).toBe('de-DE');
+    expect(normalizeIntlLocale('en-US')).toBe('en-US');
+  });
+});

--- a/packages/js/src/ui/helpers/normalizeIntlLocale.ts
+++ b/packages/js/src/ui/helpers/normalizeIntlLocale.ts
@@ -1,0 +1,6 @@
+/**
+ * Converts Novu locale codes (e.g. de_DE) to BCP 47 tags expected by Intl APIs (e.g. de-DE).
+ */
+export function normalizeIntlLocale(locale: string): string {
+  return locale.replace(/_/g, '-');
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes German (`de-DE`) notification row timestamps showing English **"Just now"** for notifications created within the last minute.

While NV-7345 replaced the hardcoded English string with `Intl.RelativeTimeFormat`, a locale format mismatch remained: Novu stores locales with underscores (`de_DE`), but `Intl` APIs require BCP 47 tags (`de-DE`). Underscore codes can fail or fall back to English for sub-minute formatting.

## Changes

- Added `normalizeIntlLocale()` to convert underscore locale codes to BCP 47 tags before calling `Intl` APIs.
- Applied locale normalization in `formatToRelativeTime`, `formatSnoozedUntil`, and the `LocalizationProvider` locale accessor.
- Added unit tests for `de-DE` and `de_DE` sub-minute and hour formatting.

## Test plan

- [x] `pnpm test -- src/ui/helpers/formatToRelativeTime.test.ts src/ui/helpers/normalizeIntlLocale.test.ts` in `packages/js`
- [x] `pnpm --filter @novu/js build`
- [ ] Verify inbox notification row shows **"jetzt"** (not "Just now") for recent notifications when `localization.locale` is `de-DE` or `de_DE`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d7a46f1-cdde-49c5-b979-94f572710213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d7a46f1-cdde-49c5-b979-94f572710213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes localized relative timestamps for Novu locale codes used with `Intl`. The main changes are:

- Added `normalizeIntlLocale()` to convert underscore locale codes like `de_DE` to BCP 47 tags like `de-DE`.
- Applied locale normalization in `LocalizationProvider`, `formatToRelativeTime`, and date formatting inside `formatSnoozedUntil`.
- Exported the new helper from the UI helpers barrel.
- Added tests for German sub-minute timestamps and locale normalization.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are small and limited to locale normalization before `Intl` formatting. The affected notification timestamp path and helper behavior have focused tests. No correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The helper tests ran and passed under the sandbox Node 24 environment, as shown in the novu-js-helper-tests.log.
- The build started, dist was cleaned, but the tsup/esbuild process was terminated with exit code 137, blocking progress.
- An attempt was made to run the real-package Playwright harness via notification-row-harness.mjs, but it failed after dist artifacts were unavailable.
- Artifacts were collected documenting the helper test results, the build blocker, and the harness attempt.

<a href="https://app.greptile.com/trex/runs/13310739/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/ui/context/LocalizationContext.tsx | Normalizes the localization context locale accessor before downstream `Intl` helpers consume it. |
| packages/js/src/ui/helpers/formatToRelativeTime.ts | Normalizes locale input before constructing `Intl.RelativeTimeFormat` and `Intl.DateTimeFormat`. |
| packages/js/src/ui/helpers/normalizeIntlLocale.ts | Adds a small helper that converts Novu underscore locale codes to `Intl`-compatible hyphenated tags. |
| packages/js/src/ui/helpers/formatToRelativeTime.test.ts | Adds coverage for German sub-minute and hour relative formatting. |
| packages/js/src/ui/helpers/normalizeIntlLocale.test.ts | Adds focused tests for underscore-to-hyphen locale normalization. |
| packages/js/src/ui/helpers/index.ts | Exports the new locale normalization helper from the helpers barrel. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant App as Inbox UI
participant Provider as LocalizationProvider
participant Helper as normalizeIntlLocale
participant Formatter as formatToRelativeTime
participant Intl as Intl APIs

App->>Provider: Read configured localization.locale
Provider->>Helper: normalizeIntlLocale(locale)
Helper-->>Provider: BCP 47 locale tag
App->>Formatter: "formatToRelativeTime({ fromDate, locale })"
Formatter->>Helper: normalizeIntlLocale(locale)
Helper-->>Formatter: BCP 47 locale tag
Formatter->>Intl: RelativeTimeFormat / DateTimeFormat
Intl-->>Formatter: Localized timestamp text
Formatter-->>App: Render notification timestamp
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant App as Inbox UI
participant Provider as LocalizationProvider
participant Helper as normalizeIntlLocale
participant Formatter as formatToRelativeTime
participant Intl as Intl APIs

App->>Provider: Read configured localization.locale
Provider->>Helper: normalizeIntlLocale(locale)
Helper-->>Provider: BCP 47 locale tag
App->>Formatter: "formatToRelativeTime({ fromDate, locale })"
Formatter->>Helper: normalizeIntlLocale(locale)
Helper-->>Formatter: BCP 47 locale tag
Formatter->>Intl: RelativeTimeFormat / DateTimeFormat
Intl-->>Formatter: Localized timestamp text
Formatter-->>App: Render notification timestamp
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(js): drop subscriber locale fallback..."](https://github.com/novuhq/novu/commit/770e827e05b5efc17fab8209a691c3425c43157c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41640010)</sub>

<!-- /greptile_comment -->