### PR TITLE
fix(api-service): scope Vercel partner integration  fixes NV-8171

### DIFF
--- a/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.spec.ts
+++ b/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.spec.ts
@@ -153,7 +153,7 @@ describe('UpdateVercelIntegration', () => {
   it('should update vercel configuration successfully', async () => {
     const command = {
       userId: session.user._id,
-      organizationId: session.organization._id,
+      organizationId: 'org-id',
       environmentId: session.environment._id,
       configurationId: 'test-config-id',
       data: {
@@ -300,7 +300,7 @@ describe('UpdateVercelIntegration', () => {
 
     const command = {
       userId: session.user._id,
-      organizationId: session.organization._id,
+      organizationId: 'org-id',
       environmentId: session.environment._id,
       configurationId: 'test-config-id',
       data: {
@@ -336,7 +336,7 @@ describe('UpdateVercelIntegration', () => {
 
     const command = {
       userId: session.user._id,
-      organizationId: session.organization._id,
+      organizationId: 'org-id',
       environmentId: session.environment._id,
       configurationId: 'test-config-id',
       data: {
@@ -350,13 +350,36 @@ describe('UpdateVercelIntegration', () => {
     assert.notCalled(httpServiceMock.delete);
   });
 
+  it('should reject organizations other than the logged-in organization', async () => {
+    const command = {
+      userId: session.user._id,
+      organizationId: 'org-id',
+      environmentId: session.environment._id,
+      configurationId: 'test-config-id',
+      data: {
+        'foreign-org-id': ['project-1'],
+      },
+    };
+
+    try {
+      await updateVercelIntegration.execute(command);
+      throw new Error('Should not reach here');
+    } catch (error) {
+      expect(error).to.be.instanceOf(BadRequestException);
+      expect(error.message).to.equal('One or more organizations are not accessible.');
+      assert.notCalled(organizationRepositoryMock.bulkUpdatePartnerConfiguration);
+      assert.notCalled(environmentRepositoryMock.find);
+      assert.notCalled(httpServiceMock.get);
+    }
+  });
+
   it('should throw BadRequestException when configuration not found', async () => {
     organizationRepositoryMock.findByPartnerConfigurationId.resolves([]);
 
     try {
       await updateVercelIntegration.execute({
         userId: session.user._id,
-        organizationId: session.organization._id,
+        organizationId: 'org-id',
         environmentId: session.environment._id,
         configurationId: 'test-config-id',
         data: {},
@@ -376,7 +399,7 @@ describe('UpdateVercelIntegration', () => {
     try {
       await updateVercelIntegration.execute({
         userId: session.user._id,
-        organizationId: session.organization._id,
+        organizationId: 'org-id',
         environmentId: session.environment._id,
         configurationId: 'test-config-id',
         data: {
@@ -397,7 +420,7 @@ describe('UpdateVercelIntegration', () => {
     try {
       await updateVercelIntegration.execute({
         userId: session.user._id,
-        organizationId: session.organization._id,
+        organizationId: 'org-id',
         environmentId: session.environment._id,
         configurationId: 'test-config-id',
         data: {
@@ -458,7 +481,7 @@ describe('UpdateVercelIntegration', () => {
 
     const command = {
       userId: session.user._id,
-      organizationId: session.organization._id,
+      organizationId: 'org-id',
       environmentId: session.environment._id,
       configurationId: 'test-config-id',
       data: {

--- a/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts
+++ b/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts
@@ -55,6 +55,8 @@ export class UpdateVercelIntegration {
     try {
       const { userId, organizationId, configurationId, data: orgIdsToProjectIds } = command;
 
+      this.validateOrganizationsAccess(organizationId, Object.keys(orgIdsToProjectIds));
+
       const configuration = await this.getCurrentOrgPartnerConfiguration({
         userId,
         configurationId,
@@ -162,6 +164,16 @@ export class UpdateVercelIntegration {
       });
     } catch (error) {
       this.logger.error({ err: error }, 'Error updating bridge url');
+    }
+  }
+
+  private validateOrganizationsAccess(organizationId: string, requestedOrganizationIds: string[]): void {
+    const hasUnauthorizedOrganization = requestedOrganizationIds.some(
+      (requestedOrganizationId) => requestedOrganizationId !== organizationId
+    );
+
+    if (hasUnauthorizedOrganization) {
+      throw new BadRequestException('One or more organizations are not accessible.');
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds a server-side guard to the Vercel partner integration update use-case so it only operates on the caller's currently logged-in organization. Any organization id supplied in the request payload that does not match the session organization is rejected.

### Changes
- Validate request organization ids against the logged-in organization in `UpdateVercelIntegration`.
- Add unit test covering rejection of non-matching organizations.

### Testing
- `apps/api` unit tests for `UpdateVercelIntegration` pass (8/8).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9930950-ff6a-45bd-b78b-627fe9e4178f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9930950-ff6a-45bd-b78b-627fe9e4178f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds server-side organization scoping for Vercel partner integration updates. The main changes are:

- Reject request payloads that include organization ids other than the logged-in organization.
- Update existing `UpdateVercelIntegration` tests to use the mocked organization id.
- Add a unit test for rejecting mismatched organization ids in the request payload.

<h3>Confidence Score: 4/5</h3>

The changed workflow has one contained authorization scoping issue that should be fixed before merging.

The new guard validates payload organization ids, but the configuration lookup can still use another organization's Vercel configuration for users who belong to multiple organizations. The rest of the change is small and localized.

apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to reproduce the execute() path for an orgA payload using an orgB configuration via a focused Mocha spec; the run was blocked during test bootstrap due to a missing module, and a narrower ts-node harness was started but the step limit was reached before producing output.
- Reviewed blocker evidence across the vercel integration tests; logs show a Cannot find module error blocking the repro, followed by a remediation attempt that emitted bundles but was terminated with exit code 137 before tests could run.

<a href="https://app.greptile.com/trex/runs/13199076/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts | Adds payload organization-id validation, but the partner configuration lookup remains scoped only by user and configuration id. |
| apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.spec.ts | Adds coverage for rejecting mismatched payload organization ids, but not for mismatched configuration ownership. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller
participant UpdateVercelIntegration
participant OrganizationRepository
participant Vercel
participant EnvironmentRepository
participant Sync

Caller->>UpdateVercelIntegration: execute(command with organizationId, configurationId, data)
UpdateVercelIntegration->>UpdateVercelIntegration: validateOrganizationsAccess(organizationId, Object.keys(data))
UpdateVercelIntegration->>OrganizationRepository: findByPartnerConfigurationId(userId, configurationId)
OrganizationRepository-->>UpdateVercelIntegration: first matching partner configuration
UpdateVercelIntegration->>Vercel: remove old env vars using configuration token/team
UpdateVercelIntegration->>OrganizationRepository: bulkUpdatePartnerConfiguration(data, configuration)
UpdateVercelIntegration->>EnvironmentRepository: find environments for payload organization ids
UpdateVercelIntegration->>Vercel: upsert Novu env vars on selected projects
UpdateVercelIntegration->>Sync: update bridge URL per environment
UpdateVercelIntegration-->>Caller: "{ success: true }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller
participant UpdateVercelIntegration
participant OrganizationRepository
participant Vercel
participant EnvironmentRepository
participant Sync

Caller->>UpdateVercelIntegration: execute(command with organizationId, configurationId, data)
UpdateVercelIntegration->>UpdateVercelIntegration: validateOrganizationsAccess(organizationId, Object.keys(data))
UpdateVercelIntegration->>OrganizationRepository: findByPartnerConfigurationId(userId, configurationId)
OrganizationRepository-->>UpdateVercelIntegration: first matching partner configuration
UpdateVercelIntegration->>Vercel: remove old env vars using configuration token/team
UpdateVercelIntegration->>OrganizationRepository: bulkUpdatePartnerConfiguration(data, configuration)
UpdateVercelIntegration->>EnvironmentRepository: find environments for payload organization ids
UpdateVercelIntegration->>Vercel: upsert Novu env vars on selected projects
UpdateVercelIntegration->>Sync: update bridge URL per environment
UpdateVercelIntegration-->>Caller: "{ success: true }"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts`, line 60-63 ([link](https://github.com/novuhq/novu/blob/d16b57857a4d4f1807880307388b8334a249cbf5/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts#L60-L63)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Configuration remains unscoped**
   `validateOrganizationsAccess` only checks the payload keys, but `getCurrentOrgPartnerConfiguration` still looks up `configurationId` across every organization the user belongs to and returns the first match. When a user is logged into `org A` and sends `organizationId: org A`, `data: { orgA: [...] }`, and a `configurationId` from `org B`, this code reuses `org B`'s Vercel token/team and writes that configuration onto `org A`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts
   Line: 60-63

   Comment:
   **Configuration remains unscoped**
   `validateOrganizationsAccess` only checks the payload keys, but `getCurrentOrgPartnerConfiguration` still looks up `configurationId` across every organization the user belongs to and returns the first match. When a user is logged into `org A` and sends `organizationId: org A`, `data: { orgA: [...] }`, and a `configurationId` from `org B`, this code reuses `org B`'s Vercel token/team and writes that configuration onto `org A`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fpartner-integrations%2Fusecases%2Fupdate-vercel-integration%2Fupdate-vercel-integration.usecase.ts%0ALine%3A%2060-63%0A%0AComment%3A%0A**Configuration%20remains%20unscoped**%0A%60validateOrganizationsAccess%60%20only%20checks%20the%20payload%20keys%2C%20but%20%60getCurrentOrgPartnerConfiguration%60%20still%20looks%20up%20%60configurationId%60%20across%20every%20organization%20the%20user%20belongs%20to%20and%20returns%20the%20first%20match.%20When%20a%20user%20is%20logged%20into%20%60org%20A%60%20and%20sends%20%60organizationId%3A%20org%20A%60%2C%20%60data%3A%20%7B%20orgA%3A%20%5B...%5D%20%7D%60%2C%20and%20a%20%60configurationId%60%20from%20%60org%20B%60%2C%20this%20code%20reuses%20%60org%20B%60's%20Vercel%20token%2Fteam%20and%20writes%20that%20configuration%20onto%20%60org%20A%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11767&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fpartner-integrations%2Fusecases%2Fupdate-vercel-integration%2Fupdate-vercel-integration.usecase.ts%3A60-63%0A**Configuration%20remains%20unscoped**%0A%60validateOrganizationsAccess%60%20only%20checks%20the%20payload%20keys%2C%20but%20%60getCurrentOrgPartnerConfiguration%60%20still%20looks%20up%20%60configurationId%60%20across%20every%20organization%20the%20user%20belongs%20to%20and%20returns%20the%20first%20match.%20When%20a%20user%20is%20logged%20into%20%60org%20A%60%20and%20sends%20%60organizationId%3A%20org%20A%60%2C%20%60data%3A%20%7B%20orgA%3A%20%5B...%5D%20%7D%60%2C%20and%20a%20%60configurationId%60%20from%20%60org%20B%60%2C%20this%20code%20reuses%20%60org%20B%60's%20Vercel%20token%2Fteam%20and%20writes%20that%20configuration%20onto%20%60org%20A%60.%0A%0A&pr=11767&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts:60-63
**Configuration remains unscoped**
`validateOrganizationsAccess` only checks the payload keys, but `getCurrentOrgPartnerConfiguration` still looks up `configurationId` across every organization the user belongs to and returns the first match. When a user is logged into `org A` and sends `organizationId: org A`, `data: { orgA: [...] }`, and a `configurationId` from `org B`, this code reuses `org B`'s Vercel token/team and writes that configuration onto `org A`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): restrict vercel partner integr..."](https://github.com/novuhq/novu/commit/d16b57857a4d4f1807880307388b8334a249cbf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41649209)</sub>

<!-- /greptile_comment -->