### PR TITLE
fix(api-service): validate environment ownership for env variable values fixes NV-8172

### DIFF
--- a/apps/api/src/app/environment-variables/usecases/create-environment-variable/create-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/create-environment-variable/create-environment-variable.usecase.ts
@@ -1,15 +1,17 @@
 import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
 import { encryptSecret, ResourceValidatorService } from '@novu/application-generic';
-import { EnvironmentVariableRepository, ErrorCodesEnum } from '@novu/dal';
+import { EnvironmentRepository, EnvironmentVariableRepository, ErrorCodesEnum } from '@novu/dal';
 import { EnvironmentVariableType, SECRET_MASK } from '@novu/shared';
 import { EnvironmentVariableResponseDto } from '../../dtos/environment-variable-response.dto';
 import { toEnvironmentVariableResponseDto } from '../get-environment-variables/get-environment-variables.usecase';
+import { validateEnvironmentVariableValues } from '../validate-environment-variable-values';
 import { CreateEnvironmentVariableCommand } from './create-environment-variable.command';
 
 @Injectable()
 export class CreateEnvironmentVariable {
   constructor(
     private environmentVariableRepository: EnvironmentVariableRepository,
+    private environmentRepository: EnvironmentRepository,
     private resourceValidatorService: ResourceValidatorService
   ) {}
 
@@ -26,6 +28,13 @@ export class CreateEnvironmentVariable {
     }
 
     const incomingValues = command.values ?? [];
+
+    await validateEnvironmentVariableValues(
+      this.environmentRepository,
+      command.organizationId,
+      incomingValues
+    );
+
     const maskedValue = incomingValues.find((v) => v.value === SECRET_MASK);
     if (maskedValue) {
       throw new BadRequestException(

--- a/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
@@ -1,14 +1,18 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { encryptSecret } from '@novu/application-generic';
-import { EnvironmentVariableRepository } from '@novu/dal';
+import { EnvironmentRepository, EnvironmentVariableRepository } from '@novu/dal';
 import { SECRET_MASK } from '@novu/shared';
 import { EnvironmentVariableResponseDto } from '../../dtos/environment-variable-response.dto';
 import { toEnvironmentVariableResponseDto } from '../get-environment-variables/get-environment-variables.usecase';
+import { validateEnvironmentVariableValues } from '../validate-environment-variable-values';
 import { UpdateEnvironmentVariableCommand } from './update-environment-variable.command';
 
 @Injectable()
 export class UpdateEnvironmentVariable {
-  constructor(private environmentVariableRepository: EnvironmentVariableRepository) {}
+  constructor(
+    private environmentVariableRepository: EnvironmentVariableRepository,
+    private environmentRepository: EnvironmentRepository
+  ) {}
 
   async execute(command: UpdateEnvironmentVariableCommand): Promise<EnvironmentVariableResponseDto> {
     const existing = await this.environmentVariableRepository.findOne(
@@ -33,6 +37,12 @@ export class UpdateEnvironmentVariable {
     }
 
     if (command.values !== undefined) {
+      await validateEnvironmentVariableValues(
+        this.environmentRepository,
+        command.organizationId,
+        command.values
+      );
+
       // Defense in depth: never let the public secret mask string be persisted as an
       // actual variable value. The dashboard returns mask strings on reads, so accepting
       // them on writes would silently overwrite real secrets.

--- a/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.spec.ts
+++ b/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.spec.ts
@@ -1,0 +1,62 @@
+import { NotFoundException } from '@nestjs/common';
+import { EnvironmentRepository } from '@novu/dal';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import { validateEnvironmentVariableValues } from './validate-environment-variable-values';
+
+describe('validateEnvironmentVariableValues', () => {
+  const organizationId = 'org-id';
+  let environmentRepositoryMock: { findByIdAndOrganization: ReturnType<typeof stub> };
+
+  beforeEach(() => {
+    environmentRepositoryMock = {
+      findByIdAndOrganization: stub(),
+    };
+  });
+
+  it('should skip validation when values are empty', async () => {
+    await validateEnvironmentVariableValues(
+      environmentRepositoryMock as unknown as EnvironmentRepository,
+      organizationId,
+      []
+    );
+
+    expect(environmentRepositoryMock.findByIdAndOrganization.called).to.equal(false);
+  });
+
+  it('should validate unique environment ids belong to the organization', async () => {
+    environmentRepositoryMock.findByIdAndOrganization
+      .withArgs('env-a', organizationId)
+      .resolves({ _id: 'env-a' })
+      .withArgs('env-b', organizationId)
+      .resolves({ _id: 'env-b' });
+
+    await validateEnvironmentVariableValues(
+      environmentRepositoryMock as unknown as EnvironmentRepository,
+      organizationId,
+      [
+        { _environmentId: 'env-a', value: 'a' },
+        { _environmentId: 'env-b', value: 'b' },
+        { _environmentId: 'env-a', value: 'a-duplicate' },
+      ]
+    );
+
+    expect(environmentRepositoryMock.findByIdAndOrganization.callCount).to.equal(2);
+  });
+
+  it('should reject environment ids that do not belong to the organization', async () => {
+    environmentRepositoryMock.findByIdAndOrganization.withArgs('foreign-env-id', organizationId).resolves(null);
+
+    try {
+      await validateEnvironmentVariableValues(
+        environmentRepositoryMock as unknown as EnvironmentRepository,
+        organizationId,
+        [{ _environmentId: 'foreign-env-id', value: 'value' }]
+      );
+      throw new Error('Should not reach here');
+    } catch (error) {
+      expect(error).to.be.instanceOf(NotFoundException);
+      expect(error.message).to.equal('Environment with id foreign-env-id not found');
+    }
+  });
+});

--- a/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.ts
+++ b/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.ts
@@ -1,0 +1,29 @@
+import { NotFoundException } from '@nestjs/common';
+import { EnvironmentRepository } from '@novu/dal';
+
+type EnvironmentVariableValueInput = {
+  _environmentId: string;
+};
+
+export async function validateEnvironmentVariableValues(
+  environmentRepository: EnvironmentRepository,
+  organizationId: string,
+  values: EnvironmentVariableValueInput[] | undefined
+): Promise<void> {
+  if (!values?.length) {
+    return;
+  }
+
+  const uniqueEnvironmentIds = [...new Set(values.map((value) => value._environmentId))];
+
+  const environments = await Promise.all(
+    uniqueEnvironmentIds.map((environmentId) =>
+      environmentRepository.findByIdAndOrganization(environmentId, organizationId)
+    )
+  );
+
+  const invalidEnvironmentIndex = environments.findIndex((environment) => !environment);
+  if (invalidEnvironmentIndex !== -1) {
+    throw new NotFoundException(`Environment with id ${uniqueEnvironmentIds[invalidEnvironmentIndex]} not found`);
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Validate that `_environmentId` values in environment variable create/update requests belong to the authenticated organization before persisting.

## Changes

- Added shared validation helper using `findByIdAndOrganization`
- Applied validation in create and update use cases
- Added unit tests

## Test plan

- [x] `pnpm test -- --grep validateEnvironmentVariableValues` in `apps/api`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc9be423-ca92-4bed-9ef8-d449578b9f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc9be423-ca92-4bed-9ef8-d449578b9f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds organization ownership checks before saving environment variable values. The main changes are:

- Validate submitted value `_environmentId` entries with `findByIdAndOrganization`.
- Apply the validation in both create and update environment variable flows.
- Add unit tests for empty inputs, duplicate environment IDs, and foreign environment rejection.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is small and scoped to validating submitted environment IDs before persistence. The helper is covered for empty input, de-duplication, and rejection of foreign IDs. Validation runs before values are encrypted or saved.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to run the validateEnvironmentVariableValues spec, but the test plan exited with code 1 during pnpm build:metadata, showing a Node engine warning and TS2307 errors for missing workspace packages such as @novu/application-generic, @novu/framework/nest, @novu/notifications, and @novu/shared; a focused Mocha run also exited before test execution with Cannot find module '/home/user/repo/apps/api/node\_modules/@novu/application-generic/build/main/index.js', and the blocker matches the runtime hint that workspace package build outputs are unavailable, so the spec could not be run.

<a href="https://app.greptile.com/trex/runs/13202671/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/environment-variables/usecases/create-environment-variable/create-environment-variable.usecase.ts | Create flow now validates every submitted value `_environmentId` against the authenticated organization before mask checks and persistence. |
| apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts | Update flow now validates submitted value environments before merging and encrypting patched values. |
| apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.ts | Adds a shared helper that de-duplicates environment IDs and rejects IDs not found for the organization. |
| apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.spec.ts | Adds focused unit coverage for empty inputs, de-duplication, and foreign environment rejection. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Client
  participant UseCase as Create/Update Environment Variable
  participant Validator as validateEnvironmentVariableValues
  participant EnvRepo as EnvironmentRepository
  participant VarRepo as EnvironmentVariableRepository

  Client->>UseCase: Submit environment variable values
  UseCase->>Validator: Validate values with organizationId
  Validator->>Validator: De-duplicate _environmentId values
  loop each unique environment id
    Validator->>EnvRepo: findByIdAndOrganization(environmentId, organizationId)
    EnvRepo-->>Validator: Environment or null
  end
  alt any environment missing for organization
    Validator-->>UseCase: throw NotFoundException
    UseCase-->>Client: reject request
  else all environments owned by organization
    Validator-->>UseCase: validation ok
    UseCase->>UseCase: mask check, encrypt/merge values
    UseCase->>VarRepo: create or update variable
    VarRepo-->>UseCase: persisted variable
    UseCase-->>Client: EnvironmentVariableResponseDto
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Client
  participant UseCase as Create/Update Environment Variable
  participant Validator as validateEnvironmentVariableValues
  participant EnvRepo as EnvironmentRepository
  participant VarRepo as EnvironmentVariableRepository

  Client->>UseCase: Submit environment variable values
  UseCase->>Validator: Validate values with organizationId
  Validator->>Validator: De-duplicate _environmentId values
  loop each unique environment id
    Validator->>EnvRepo: findByIdAndOrganization(environmentId, organizationId)
    EnvRepo-->>Validator: Environment or null
  end
  alt any environment missing for organization
    Validator-->>UseCase: throw NotFoundException
    UseCase-->>Client: reject request
  else all environments owned by organization
    Validator-->>UseCase: validation ok
    UseCase->>UseCase: mask check, encrypt/merge values
    UseCase->>VarRepo: create or update variable
    VarRepo-->>UseCase: persisted variable
    UseCase-->>Client: EnvironmentVariableResponseDto
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): validate environment o..."](https://github.com/novuhq/novu/commit/44c4f60061986cf44ab43458a945c38aa499e424) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41656851)</sub>

<!-- /greptile_comment -->