### PR TITLE
feat(api-service): rolling secret key rotation behind feature flag fixes NV-8173

### DIFF
--- a/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
@@ -1,0 +1,144 @@
+import { NOVU_ENCRYPTION_SUB_MASK } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #novu-v2', () => {
+  let session: UserSession;
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    process.env.IS_MULTIPLE_SECRET_KEYS_ALLOWED = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.IS_MULTIPLE_SECRET_KEYS_ALLOWED;
+  });
+
+  it('should create an additional api key', async () => {
+    const { body, status } = await session.testAgent.post('/v1/environments/api-keys').send();
+
+    expect(status).to.equal(201);
+    expect(body.data.length).to.equal(2);
+    expect(body.data[0].key).to.not.equal(body.data[1].key);
+
+    for (const apiKey of body.data) {
+      expect(apiKey.key).to.not.contains(NOVU_ENCRYPTION_SUB_MASK);
+      expect(apiKey.hash).to.be.a('string');
+      expect(apiKey._userId).to.equal(session.user._id);
+    }
+  });
+
+  it('should keep the original key first and append the new key', async () => {
+    const {
+      body: { data: originalKeys },
+    } = await session.testAgent.get('/v1/environments/api-keys').send();
+
+    const { body } = await session.testAgent.post('/v1/environments/api-keys').send();
+
+    expect(body.data[0].key).to.equal(originalKeys[0].key);
+    expect(body.data[1].key).to.not.equal(originalKeys[0].key);
+  });
+
+  it('should reject creating a third api key', async () => {
+    await session.testAgent.post('/v1/environments/api-keys').send().expect(201);
+
+    const { body, status } = await session.testAgent.post('/v1/environments/api-keys').send();
+
+    expect(status).to.equal(400);
+    expect(body.message).to.contain('maximum');
+  });
+
+  it('should authenticate with both keys during rotation', async () => {
+    const { body } = await session.testAgent.post('/v1/environments/api-keys').send();
+    const [oldKey, newKey] = body.data;
+
+    for (const apiKey of [oldKey, newKey]) {
+      const { status } = await session.testAgent
+        .get('/v1/environments/me')
+        .set('authorization', `ApiKey ${apiKey.key}`)
+        .send();
+
+      expect(status).to.equal(200);
+    }
+  });
+
+  it('should delete a specific api key and invalidate it', async () => {
+    const {
+      body: { data: keysAfterCreate },
+    } = await session.testAgent.post('/v1/environments/api-keys').send();
+    const [oldKey, newKey] = keysAfterCreate;
+
+    const { body, status } = await session.testAgent.delete(`/v1/environments/api-keys/${oldKey.hash}`).send();
+
+    expect(status).to.equal(200);
+    expect(body.data.length).to.equal(1);
+    expect(body.data[0].key).to.equal(newKey.key);
+
+    const { status: deletedKeyAuthStatus } = await session.testAgent
+      .get('/v1/environments/me')
+      .set('authorization', `ApiKey ${oldKey.key}`)
+      .send();
+
+    expect(deletedKeyAuthStatus).to.equal(401);
+
+    const { status: remainingKeyAuthStatus } = await session.testAgent
+      .get('/v1/environments/me')
+      .set('authorization', `ApiKey ${newKey.key}`)
+      .send();
+
+    expect(remainingKeyAuthStatus).to.equal(200);
+  });
+
+  it('should not delete the last remaining api key', async () => {
+    const {
+      body: { data: keys },
+    } = await session.testAgent.get('/v1/environments/api-keys').send();
+
+    const { body, status } = await session.testAgent.delete(`/v1/environments/api-keys/${keys[0].hash}`).send();
+
+    expect(status).to.equal(400);
+    expect(body.message).to.contain('last remaining');
+  });
+
+  it('should return 404 when deleting an unknown api key', async () => {
+    await session.testAgent.post('/v1/environments/api-keys').send().expect(201);
+
+    const unknownHash = 'a'.repeat(64);
+    const { status } = await session.testAgent.delete(`/v1/environments/api-keys/${unknownHash}`).send();
+
+    expect(status).to.equal(404);
+  });
+
+  it('should reject create and delete when the feature flag is disabled', async () => {
+    const {
+      body: { data: keys },
+    } = await session.testAgent.get('/v1/environments/api-keys').send();
+
+    delete process.env.IS_MULTIPLE_SECRET_KEYS_ALLOWED;
+
+    const { status: createStatus } = await session.testAgent.post('/v1/environments/api-keys').send();
+    expect(createStatus).to.equal(403);
+
+    const { status: deleteStatus } = await session.testAgent
+      .delete(`/v1/environments/api-keys/${keys[0].hash}`)
+      .send();
+    expect(deleteStatus).to.equal(403);
+  });
+
+  it('should collapse to a single key on regenerate', async () => {
+    await session.testAgent.post('/v1/environments/api-keys').send().expect(201);
+
+    const { body } = await session.testAgent.post('/v1/environments/api-keys/regenerate').send();
+
+    expect(body.data.length).to.equal(1);
+  });
+
+  it('should return the hash for each api key on list', async () => {
+    const { body } = await session.testAgent.get('/v1/environments/api-keys').send();
+
+    expect(body.data.length).to.equal(1);
+    expect(body.data[0].hash).to.be.a('string');
+    expect(body.data[0].hash).to.have.length(64);
+  });
+});

--- a/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
@@ -2,7 +2,8 @@ import { NOVU_ENCRYPTION_SUB_MASK } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-process.env.LAUNCH_DARKLY_SDK_KEY = ''; // disable Launch Darkly to allow test to define FF state
+const mutableEnv = process.env as Record<string, string | undefined>;
+mutableEnv.LAUNCH_DARKLY_SDK_KEY = ''; // disable Launch Darkly to allow test to define FF state
 
 describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #novu-v2', () => {
   let session: UserSession;
@@ -10,11 +11,11 @@ describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #no
   beforeEach(async () => {
     session = new UserSession();
     await session.initialize();
-    process.env.IS_MULTIPLE_SECRET_KEYS_ALLOWED = 'true';
+    mutableEnv.IS_MULTIPLE_SECRET_KEYS_ALLOWED = 'true';
   });
 
   afterEach(() => {
-    delete process.env.IS_MULTIPLE_SECRET_KEYS_ALLOWED;
+    delete mutableEnv.IS_MULTIPLE_SECRET_KEYS_ALLOWED;
   });
 
   it('should create an additional api key', async () => {
@@ -117,7 +118,7 @@ describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #no
       body: { data: keys },
     } = await session.testAgent.get('/v1/environments/api-keys').send();
 
-    delete process.env.IS_MULTIPLE_SECRET_KEYS_ALLOWED;
+    delete mutableEnv.IS_MULTIPLE_SECRET_KEYS_ALLOWED;
 
     const { status: createStatus } = await session.testAgent.post('/v1/environments/api-keys').send();
     expect(createStatus).to.equal(403);

--- a/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
@@ -74,9 +74,15 @@ describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #no
 
     const { body, status } = await session.testAgent.delete(`/v1/environments/api-keys/${oldKey.hash}`).send();
 
-    expect(status).to.equal(200);
-    expect(body.data.length).to.equal(1);
-    expect(body.data[0].key).to.equal(newKey.key);
+    expect(status).to.equal(204);
+    expect(body).to.deep.equal({});
+
+    const {
+      body: { data: remainingKeys },
+    } = await session.testAgent.get('/v1/environments/api-keys').send();
+
+    expect(remainingKeys.length).to.equal(1);
+    expect(remainingKeys[0].key).to.equal(newKey.key);
 
     const { status: deletedKeyAuthStatus } = await session.testAgent
       .get('/v1/environments/me')
@@ -121,7 +127,7 @@ describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #no
     ]);
 
     const statuses = [first.status, second.status].sort();
-    expect(statuses).to.deep.equal([200, 400]);
+    expect(statuses).to.deep.equal([204, 400]);
 
     const {
       body: { data: remainingKeys },

--- a/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
@@ -93,6 +93,43 @@ describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #no
     expect(remainingKeyAuthStatus).to.equal(200);
   });
 
+  it('should never exceed the key cap under concurrent create requests', async () => {
+    const [first, second] = await Promise.all([
+      session.testAgent.post('/v1/environments/api-keys').send(),
+      session.testAgent.post('/v1/environments/api-keys').send(),
+    ]);
+
+    const statuses = [first.status, second.status].sort();
+    expect(statuses).to.deep.equal([201, 400]);
+
+    const {
+      body: { data: keys },
+    } = await session.testAgent.get('/v1/environments/api-keys').send();
+
+    expect(keys.length).to.equal(2);
+  });
+
+  it('should never delete all keys under concurrent delete requests', async () => {
+    const {
+      body: { data: keysAfterCreate },
+    } = await session.testAgent.post('/v1/environments/api-keys').send();
+    const [firstKey, secondKey] = keysAfterCreate;
+
+    const [first, second] = await Promise.all([
+      session.testAgent.delete(`/v1/environments/api-keys/${firstKey.hash}`).send(),
+      session.testAgent.delete(`/v1/environments/api-keys/${secondKey.hash}`).send(),
+    ]);
+
+    const statuses = [first.status, second.status].sort();
+    expect(statuses).to.deep.equal([200, 400]);
+
+    const {
+      body: { data: remainingKeys },
+    } = await session.testAgent.get('/v1/environments/api-keys').send();
+
+    expect(remainingKeys.length).to.equal(1);
+  });
+
   it('should not delete the last remaining api key', async () => {
     const {
       body: { data: keys },
@@ -123,9 +160,7 @@ describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #no
     const { status: createStatus } = await session.testAgent.post('/v1/environments/api-keys').send();
     expect(createStatus).to.equal(403);
 
-    const { status: deleteStatus } = await session.testAgent
-      .delete(`/v1/environments/api-keys/${keys[0].hash}`)
-      .send();
+    const { status: deleteStatus } = await session.testAgent.delete(`/v1/environments/api-keys/${keys[0].hash}`).send();
     expect(deleteStatus).to.equal(403);
   });
 

--- a/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts
@@ -2,6 +2,8 @@ import { NOVU_ENCRYPTION_SUB_MASK } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
+process.env.LAUNCH_DARKLY_SDK_KEY = ''; // disable Launch Darkly to allow test to define FF state
+
 describe('Manage Environment API Keys - /environments/api-keys (POST/DELETE) #novu-v2', () => {
   let session: UserSession;
 

--- a/apps/api/src/app/environments-v1/environments-v1.controller.ts
+++ b/apps/api/src/app/environments-v1/environments-v1.controller.ts
@@ -4,6 +4,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   Post,
   Put,
@@ -233,15 +235,15 @@ export class EnvironmentsControllerV1 {
   }
 
   @Delete('/api-keys/:hash')
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     summary: 'Delete an api key',
     description: 'Deletes a specific API key of the current environment, identified by its SHA-256 hash.',
   })
   @ApiParam({ name: 'hash', description: 'The SHA-256 hash of the API key to delete', type: String })
-  @ApiResponse(ApiKey, 200, true)
   @ApiExcludeEndpoint()
   @RequirePermissions(PermissionsEnum.API_KEY_WRITE)
-  async deleteOrganizationApiKey(@UserSession() user: UserSessionData, @Param('hash') hash: string): Promise<ApiKey[]> {
+  async deleteOrganizationApiKey(@UserSession() user: UserSessionData, @Param('hash') hash: string): Promise<void> {
     const command = DeleteApiKeyCommand.create({
       userId: user._id,
       organizationId: user.organizationId,
@@ -249,7 +251,7 @@ export class EnvironmentsControllerV1 {
       hash,
     });
 
-    return await this.deleteApiKeyUsecase.execute(command);
+    await this.deleteApiKeyUsecase.execute(command);
   }
 
   @Post('/api-keys/regenerate')

--- a/apps/api/src/app/environments-v1/environments-v1.controller.ts
+++ b/apps/api/src/app/environments-v1/environments-v1.controller.ts
@@ -37,8 +37,11 @@ import { UserSession } from '../shared/framework/user.decorator';
 import { CreateEnvironmentRequestDto } from './dtos/create-environment-request.dto';
 import { EnvironmentResponseDto } from './dtos/environment-response.dto';
 import { UpdateEnvironmentRequestDto } from './dtos/update-environment-request.dto';
+import { CreateApiKey } from './usecases/create-api-key/create-api-key.usecase';
 import { CreateEnvironmentCommand } from './usecases/create-environment/create-environment.command';
 import { CreateEnvironment } from './usecases/create-environment/create-environment.usecase';
+import { DeleteApiKeyCommand } from './usecases/delete-api-key/delete-api-key.command';
+import { DeleteApiKey } from './usecases/delete-api-key/delete-api-key.usecase';
 import { DeleteEnvironmentCommand } from './usecases/delete-environment/delete-environment.command';
 import { DeleteEnvironment } from './usecases/delete-environment/delete-environment.usecase';
 import { GetApiKeysCommand } from './usecases/get-api-keys/get-api-keys.command';
@@ -63,6 +66,8 @@ export class EnvironmentsControllerV1 {
     private createEnvironmentUsecase: CreateEnvironment,
     private updateEnvironmentUsecase: UpdateEnvironment,
     private getApiKeysUsecase: GetApiKeys,
+    private createApiKeyUsecase: CreateApiKey,
+    private deleteApiKeyUsecase: DeleteApiKey,
     private regenerateApiKeysUsecase: RegenerateApiKeys,
     private getEnvironmentUsecase: GetEnvironment,
     private getMyEnvironmentsUsecase: GetMyEnvironments,
@@ -206,6 +211,45 @@ export class EnvironmentsControllerV1 {
     });
 
     return await this.getApiKeysUsecase.execute(command);
+  }
+
+  @Post('/api-keys')
+  @ApiOperation({
+    summary: 'Create an additional api key',
+    description:
+      'Creates an additional API key for the current environment to support rolling key rotation without downtime.',
+  })
+  @ApiResponse(ApiKey, 201, true)
+  @ApiExcludeEndpoint()
+  @RequirePermissions(PermissionsEnum.API_KEY_WRITE)
+  async createOrganizationApiKey(@UserSession() user: UserSessionData): Promise<ApiKey[]> {
+    const command = GetApiKeysCommand.create({
+      userId: user._id,
+      organizationId: user.organizationId,
+      environmentId: user.environmentId,
+    });
+
+    return await this.createApiKeyUsecase.execute(command);
+  }
+
+  @Delete('/api-keys/:hash')
+  @ApiOperation({
+    summary: 'Delete an api key',
+    description: 'Deletes a specific API key of the current environment, identified by its SHA-256 hash.',
+  })
+  @ApiParam({ name: 'hash', description: 'The SHA-256 hash of the API key to delete', type: String })
+  @ApiResponse(ApiKey, 200, true)
+  @ApiExcludeEndpoint()
+  @RequirePermissions(PermissionsEnum.API_KEY_WRITE)
+  async deleteOrganizationApiKey(@UserSession() user: UserSessionData, @Param('hash') hash: string): Promise<ApiKey[]> {
+    const command = DeleteApiKeyCommand.create({
+      userId: user._id,
+      organizationId: user.organizationId,
+      environmentId: user.environmentId,
+      hash,
+    });
+
+    return await this.deleteApiKeyUsecase.execute(command);
   }
 
   @Post('/api-keys/regenerate')

--- a/apps/api/src/app/environments-v1/usecases/create-api-key/create-api-key.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/create-api-key/create-api-key.usecase.ts
@@ -1,0 +1,66 @@
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { decryptApiKey, encryptApiKey, FeatureFlagsService } from '@novu/application-generic';
+import { EnvironmentRepository } from '@novu/dal';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { createHash } from 'crypto';
+import { ApiKeyDto } from '../../dtos/api-key.dto';
+import { GenerateUniqueApiKey } from '../generate-unique-api-key/generate-unique-api-key.usecase';
+import { GetApiKeysCommand } from '../get-api-keys/get-api-keys.command';
+
+export const MAX_API_KEYS_PER_ENVIRONMENT = 2;
+
+@Injectable()
+export class CreateApiKey {
+  constructor(
+    private environmentRepository: EnvironmentRepository,
+    private generateUniqueApiKey: GenerateUniqueApiKey,
+    private featureFlagsService: FeatureFlagsService
+  ) {}
+
+  async execute(command: GetApiKeysCommand): Promise<ApiKeyDto[]> {
+    const isMultipleSecretKeysAllowed = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_MULTIPLE_SECRET_KEYS_ALLOWED,
+      organization: { _id: command.organizationId },
+      user: { _id: command.userId },
+      environment: { _id: command.environmentId },
+      defaultValue: false,
+    });
+
+    if (!isMultipleSecretKeysAllowed) {
+      throw new ForbiddenException('Creating additional API keys is not enabled for your organization');
+    }
+
+    const environment = await this.environmentRepository.findOne({ _id: command.environmentId });
+
+    if (!environment) {
+      throw new NotFoundException(`Environment id: ${command.environmentId} not found`);
+    }
+
+    if (environment.apiKeys.length >= MAX_API_KEYS_PER_ENVIRONMENT) {
+      throw new BadRequestException(
+        `Environment can have a maximum of ${MAX_API_KEYS_PER_ENVIRONMENT} API keys. Delete an existing key before creating a new one.`
+      );
+    }
+
+    const key = await this.generateUniqueApiKey.execute();
+    const encryptedApiKey = encryptApiKey(key);
+    const hashedApiKey = createHash('sha256').update(key).digest('hex');
+
+    const apiKeys = await this.environmentRepository.addApiKey(
+      command.environmentId,
+      encryptedApiKey,
+      command.userId,
+      hashedApiKey
+    );
+
+    return apiKeys.map((item) => {
+      const decryptedKey = decryptApiKey(item.key);
+
+      return {
+        _userId: item._userId,
+        key: decryptedKey,
+        hash: item.hash ?? createHash('sha256').update(decryptedKey).digest('hex'),
+      };
+    });
+  }
+}

--- a/apps/api/src/app/environments-v1/usecases/create-api-key/create-api-key.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/create-api-key/create-api-key.usecase.ts
@@ -36,22 +36,27 @@ export class CreateApiKey {
       throw new NotFoundException(`Environment id: ${command.environmentId} not found`);
     }
 
-    if (environment.apiKeys.length >= MAX_API_KEYS_PER_ENVIRONMENT) {
-      throw new BadRequestException(
-        `Environment can have a maximum of ${MAX_API_KEYS_PER_ENVIRONMENT} API keys. Delete an existing key before creating a new one.`
-      );
-    }
-
     const key = await this.generateUniqueApiKey.execute();
     const encryptedApiKey = encryptApiKey(key);
     const hashedApiKey = createHash('sha256').update(key).digest('hex');
 
+    /*
+     * The cap is enforced atomically in the update predicate so concurrent
+     * requests cannot push the environment above the maximum.
+     */
     const apiKeys = await this.environmentRepository.addApiKey(
       command.environmentId,
       encryptedApiKey,
       command.userId,
-      hashedApiKey
+      hashedApiKey,
+      MAX_API_KEYS_PER_ENVIRONMENT
     );
+
+    if (apiKeys === null) {
+      throw new BadRequestException(
+        `Environment can have a maximum of ${MAX_API_KEYS_PER_ENVIRONMENT} API keys. Delete an existing key before creating a new one.`
+      );
+    }
 
     return apiKeys.map((item) => {
       const decryptedKey = decryptApiKey(item.key);

--- a/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.command.ts
+++ b/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.command.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class DeleteApiKeyCommand extends EnvironmentWithUserCommand {
+  @IsNotEmpty()
+  @IsString()
+  readonly hash: string;
+}

--- a/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.usecase.ts
@@ -8,7 +8,6 @@ import {
 import { EnvironmentRepository, IApiKey } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { createHash } from 'crypto';
-import { ApiKeyDto } from '../../dtos/api-key.dto';
 import { DeleteApiKeyCommand } from './delete-api-key.command';
 
 @Injectable()
@@ -19,7 +18,7 @@ export class DeleteApiKey {
     private inMemoryLRUCacheService: InMemoryLRUCacheService
   ) {}
 
-  async execute(command: DeleteApiKeyCommand): Promise<ApiKeyDto[]> {
+  async execute(command: DeleteApiKeyCommand): Promise<void> {
     const isMultipleSecretKeysAllowed = await this.featureFlagsService.getFlag({
       key: FeatureFlagsKeysEnum.IS_MULTIPLE_SECRET_KEYS_ALLOWED,
       organization: { _id: command.organizationId },
@@ -71,18 +70,6 @@ export class DeleteApiKey {
      * the store's short TTL.
      */
     this.inMemoryLRUCacheService.invalidate(InMemoryLRUCacheStore.API_KEY_USER, command.hash);
-
-    const remainingKeys = await this.environmentRepository.getApiKeys(command.environmentId);
-
-    return remainingKeys.map((item) => {
-      const decryptedKey = decryptApiKey(item.key);
-
-      return {
-        _userId: item._userId,
-        key: decryptedKey,
-        hash: item.hash ?? createHash('sha256').update(decryptedKey).digest('hex'),
-      };
-    });
   }
 
   private getKeyHash(apiKey: IApiKey): string {

--- a/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.usecase.ts
@@ -1,0 +1,81 @@
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  decryptApiKey,
+  FeatureFlagsService,
+  InMemoryLRUCacheService,
+  InMemoryLRUCacheStore,
+} from '@novu/application-generic';
+import { EnvironmentRepository, IApiKey } from '@novu/dal';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { createHash } from 'crypto';
+import { ApiKeyDto } from '../../dtos/api-key.dto';
+import { DeleteApiKeyCommand } from './delete-api-key.command';
+
+@Injectable()
+export class DeleteApiKey {
+  constructor(
+    private environmentRepository: EnvironmentRepository,
+    private featureFlagsService: FeatureFlagsService,
+    private inMemoryLRUCacheService: InMemoryLRUCacheService
+  ) {}
+
+  async execute(command: DeleteApiKeyCommand): Promise<ApiKeyDto[]> {
+    const isMultipleSecretKeysAllowed = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_MULTIPLE_SECRET_KEYS_ALLOWED,
+      organization: { _id: command.organizationId },
+      user: { _id: command.userId },
+      environment: { _id: command.environmentId },
+      defaultValue: false,
+    });
+
+    if (!isMultipleSecretKeysAllowed) {
+      throw new ForbiddenException('Deleting API keys is not enabled for your organization');
+    }
+
+    const apiKeys = await this.environmentRepository.getApiKeys(command.environmentId);
+
+    if (apiKeys.length === 0) {
+      throw new NotFoundException(`Environment id: ${command.environmentId} has no API keys`);
+    }
+
+    const keyToDelete = apiKeys.find((apiKey) => this.getKeyHash(apiKey) === command.hash);
+
+    if (!keyToDelete) {
+      throw new NotFoundException('API key not found');
+    }
+
+    if (apiKeys.length === 1) {
+      throw new BadRequestException('Cannot delete the last remaining API key. Create a new key first.');
+    }
+
+    const remainingKeys = await this.environmentRepository.deleteApiKey(
+      command.environmentId,
+      keyToDelete.hash ? { hash: keyToDelete.hash } : { key: keyToDelete.key }
+    );
+
+    /*
+     * Best-effort invalidation of the local auth cache so the deleted key stops
+     * authenticating immediately on this instance. Other instances converge via
+     * the store's short TTL.
+     */
+    this.inMemoryLRUCacheService.invalidate(InMemoryLRUCacheStore.API_KEY_USER, command.hash);
+
+    return remainingKeys.map((item) => {
+      const decryptedKey = decryptApiKey(item.key);
+
+      return {
+        _userId: item._userId,
+        key: decryptedKey,
+        hash: item.hash ?? createHash('sha256').update(decryptedKey).digest('hex'),
+      };
+    });
+  }
+
+  private getKeyHash(apiKey: IApiKey): string {
+    if (apiKey.hash) {
+      return apiKey.hash;
+    }
+
+    return createHash('sha256').update(decryptApiKey(apiKey.key)).digest('hex');
+  }
+}

--- a/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.usecase.ts
@@ -48,10 +48,22 @@ export class DeleteApiKey {
       throw new BadRequestException('Cannot delete the last remaining API key. Create a new key first.');
     }
 
-    const remainingKeys = await this.environmentRepository.deleteApiKey(
+    /*
+     * The "at least one key must remain" invariant is enforced atomically in
+     * the delete predicate, so concurrent deletes cannot empty the array.
+     */
+    const { matched, modified } = await this.environmentRepository.deleteApiKey(
       command.environmentId,
       keyToDelete.hash ? { hash: keyToDelete.hash } : { key: keyToDelete.key }
     );
+
+    if (matched === 0) {
+      throw new BadRequestException('Cannot delete the last remaining API key. Create a new key first.');
+    }
+
+    if (modified === 0) {
+      throw new NotFoundException('API key not found');
+    }
 
     /*
      * Best-effort invalidation of the local auth cache so the deleted key stops
@@ -59,6 +71,8 @@ export class DeleteApiKey {
      * the store's short TTL.
      */
     this.inMemoryLRUCacheService.invalidate(InMemoryLRUCacheStore.API_KEY_USER, command.hash);
+
+    const remainingKeys = await this.environmentRepository.getApiKeys(command.environmentId);
 
     return remainingKeys.map((item) => {
       const decryptedKey = decryptApiKey(item.key);

--- a/apps/api/src/app/environments-v1/usecases/get-api-keys/get-api-keys.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/get-api-keys/get-api-keys.usecase.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { decryptApiKey } from '@novu/application-generic';
 import { EnvironmentRepository, IApiKey } from '@novu/dal';
+import { createHash } from 'crypto';
 import { ApiKey } from '../../../shared/dtos/api-key';
 import { GetApiKeysCommand } from './get-api-keys.command';
 
@@ -12,9 +13,12 @@ export class GetApiKeys {
     const keys = await this.environmentRepository.getApiKeys(command.environmentId);
 
     return keys.map((apiKey: IApiKey) => {
+      const decryptedKey = decryptApiKey(apiKey.key);
+
       return {
-        key: decryptApiKey(apiKey.key),
+        key: decryptedKey,
         _userId: apiKey._userId,
+        hash: apiKey.hash ?? createHash('sha256').update(decryptedKey).digest('hex'),
       };
     });
   }

--- a/apps/api/src/app/environments-v1/usecases/index.ts
+++ b/apps/api/src/app/environments-v1/usecases/index.ts
@@ -1,5 +1,7 @@
 import { GetMxRecord } from '../../inbound-parse/usecases/get-mx-record/get-mx-record.usecase';
+import { CreateApiKey } from './create-api-key/create-api-key.usecase';
 import { CreateEnvironment } from './create-environment/create-environment.usecase';
+import { DeleteApiKey } from './delete-api-key/delete-api-key.usecase';
 import { DeleteEnvironment } from './delete-environment';
 import { GenerateUniqueApiKey } from './generate-unique-api-key/generate-unique-api-key.usecase';
 import { GetApiKeys } from './get-api-keys/get-api-keys.usecase';
@@ -14,6 +16,8 @@ export const USE_CASES = [
   UpdateEnvironment,
   GenerateUniqueApiKey,
   GetApiKeys,
+  CreateApiKey,
+  DeleteApiKey,
   RegenerateApiKeys,
   GetEnvironment,
   GetMyEnvironments,

--- a/apps/api/src/app/environments-v1/usecases/regenerate-api-keys/regenerate-api-keys.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/regenerate-api-keys/regenerate-api-keys.usecase.ts
@@ -36,6 +36,7 @@ export class RegenerateApiKeys {
       return {
         _userId: item._userId,
         key: decryptApiKey(item.key),
+        hash: item.hash,
       };
     });
   }

--- a/apps/api/src/app/inbox/usecases/session/session.spec.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.spec.ts
@@ -537,7 +537,7 @@ describe('Session', () => {
     expect(
       validateContextHmacEncryptionStub.calledWith(
         sinon.match({
-          apiKey: environment.apiKeys[0].key,
+          apiKeys: [environment.apiKeys[0].key],
           context: command.requestData.context,
           contextHash: command.requestData.contextHash,
         })

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -65,7 +65,7 @@ import { KeylessAbuseGuardService } from '../../../keyless/keyless-abuse-guard.s
 import { GetOrganizationSettingsCommand } from '../../../organization/usecases/get-organization-settings/get-organization-settings.command';
 import { GetOrganizationSettings } from '../../../organization/usecases/get-organization-settings/get-organization-settings.usecase';
 import { ScheduleDto } from '../../../shared/dtos/schedule';
-import { isHmacValid } from '../../../shared/helpers/is-valid-hmac';
+import { isHmacValidForAnyKey } from '../../../shared/helpers/is-valid-hmac';
 import { SubscriberDto, SubscriberSessionRequestDto } from '../../dtos/subscriber-session-request.dto';
 import { SubscriberSessionResponseDto } from '../../dtos/subscriber-session-response.dto';
 import {
@@ -144,16 +144,18 @@ export class Session {
       throw new NotFoundException('The active in-app integration could not be found');
     }
 
+    const environmentApiKeys = environment.apiKeys.map((apiKey) => apiKey.key);
+
     if (inAppIntegration.credentials.hmac) {
       validateHmacEncryption({
-        apiKey: environment.apiKeys[0].key,
+        apiKeys: environmentApiKeys,
         subscriberId: subscriber.subscriberId,
         subscriberHash: command.requestData.subscriberHash,
       });
 
       if (command.requestData.context) {
         validateContextHmacEncryption({
-          apiKey: environment.apiKeys[0].key,
+          apiKeys: environmentApiKeys,
           context: command.requestData.context,
           contextHash: command.requestData.contextHash,
         });
@@ -179,8 +181,8 @@ export class Session {
         locale: subscriber.locale,
         data: subscriber.data as CustomDataType,
         timezone: subscriber.timezone,
-        allowUpdate: isHmacValid(
-          environment.apiKeys[0].key,
+        allowUpdate: isHmacValidForAnyKey(
+          environmentApiKeys,
           subscriber.subscriberId,
           command.requestData.subscriberHash
         ),

--- a/apps/api/src/app/inbox/utils/encryption.ts
+++ b/apps/api/src/app/inbox/utils/encryption.ts
@@ -1,31 +1,31 @@
 import { BadRequestException } from '@nestjs/common';
 import { ContextPayload } from '@novu/shared';
-import { isContextHmacValid, isHmacValid } from '../../shared/helpers/is-valid-hmac';
+import { isContextHmacValidForAnyKey, isHmacValidForAnyKey } from '../../shared/helpers/is-valid-hmac';
 
 export function validateHmacEncryption({
-  apiKey,
+  apiKeys,
   subscriberId,
   subscriberHash,
 }: {
-  apiKey: string;
+  apiKeys: string[];
   subscriberId: string;
   subscriberHash?: string;
 }) {
-  if (!isHmacValid(apiKey, subscriberId, subscriberHash)) {
+  if (!isHmacValidForAnyKey(apiKeys, subscriberId, subscriberHash)) {
     throw new BadRequestException('Please provide a valid HMAC hash');
   }
 }
 
 export function validateContextHmacEncryption({
-  apiKey,
+  apiKeys,
   context,
   contextHash,
 }: {
-  apiKey: string;
+  apiKeys: string[];
   context: ContextPayload;
   contextHash?: string;
 }) {
-  if (!isContextHmacValid(apiKey, context, contextHash)) {
+  if (!isContextHmacValidForAnyKey(apiKeys, context, contextHash)) {
     throw new BadRequestException('Please provide a valid context HMAC hash');
   }
 }

--- a/apps/api/src/app/shared/dtos/api-key.ts
+++ b/apps/api/src/app/shared/dtos/api-key.ts
@@ -1,8 +1,13 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ApiKey {
   @ApiProperty()
   key: string;
   @ApiProperty()
   _userId: string;
+  @ApiPropertyOptional({
+    type: String,
+    description: 'SHA-256 hash of the API key, used to reference a specific key (e.g. for deletion)',
+  })
+  hash?: string;
 }

--- a/apps/api/src/app/shared/helpers/is-valid-hmac.ts
+++ b/apps/api/src/app/shared/helpers/is-valid-hmac.ts
@@ -17,6 +17,14 @@ export function isHmacValid(secretKey: string, subscriberId: string, hmacHash: s
   return areHexDigestsEqual(computedHmacHash, hmacHash);
 }
 
+/**
+ * Validates the HMAC against every active API key of the environment, so that
+ * clients signed with either key keep working during a rolling key rotation.
+ */
+export function isHmacValidForAnyKey(secretKeys: string[], subscriberId: string, hmacHash: string | undefined) {
+  return secretKeys.some((secretKey) => isHmacValid(secretKey, subscriberId, hmacHash));
+}
+
 export function isContextHmacValid(
   secretKey: string,
   context: ContextPayload,
@@ -34,4 +42,16 @@ export function isContextHmacValid(
   }
 
   return areHexDigestsEqual(computedContextHash, contextHash);
+}
+
+/**
+ * Validates the context HMAC against every active API key of the environment,
+ * so that clients signed with either key keep working during a rolling key rotation.
+ */
+export function isContextHmacValidForAnyKey(
+  secretKeys: string[],
+  context: ContextPayload,
+  contextHash: string | undefined
+): boolean {
+  return secretKeys.some((secretKey) => isContextHmacValid(secretKey, context, contextHash));
 }

--- a/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
@@ -3,8 +3,6 @@ import {
   AnalyticsService,
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
-  createHash,
-  decryptApiKey,
   InstrumentUsecase,
   LogDecorator,
   SelectIntegration,
@@ -13,7 +11,7 @@ import {
 import { EnvironmentRepository } from '@novu/dal';
 import { ChannelTypeEnum, InAppProviderIdEnum } from '@novu/shared';
 import { AuthService } from '../../../auth/services/auth.service';
-import { isHmacValid } from '../../../shared/helpers/is-valid-hmac';
+import { isHmacValidForAnyKey } from '../../../shared/helpers/is-valid-hmac';
 
 import { SessionInitializeResponseDto } from '../../dtos/session-initialize-response.dto';
 import { InitializeSessionCommand } from './initialize-session.command';
@@ -64,7 +62,11 @@ export class InitializeSession {
         lastName: command.lastName,
         email: command.email,
         phone: command.phone,
-        allowUpdate: isHmacValid(environment.apiKeys[0].key, command.subscriberId, command.hmacHash),
+        allowUpdate: isHmacValidForAnyKey(
+          environment.apiKeys.map((apiKey) => apiKey.key),
+          command.subscriberId,
+          command.hmacHash
+        ),
       })
     );
 
@@ -87,7 +89,9 @@ export class InitializeSession {
 }
 
 function validateNotificationCenterEncryption(environment, command: InitializeSessionCommand) {
-  if (!isHmacValid(environment.apiKeys[0].key, command.subscriberId, command.hmacHash)) {
+  const apiKeys = environment.apiKeys.map((apiKey) => apiKey.key);
+
+  if (!isHmacValidForAnyKey(apiKeys, command.subscriberId, command.hmacHash)) {
     throw new BadRequestException('Please provide a valid HMAC hash');
   }
 }

--- a/apps/dashboard/src/api/environments.ts
+++ b/apps/dashboard/src/api/environments.ts
@@ -134,6 +134,20 @@ export async function regenerateApiKeys({ environment }: { environment: IEnviron
   return post<{ data: IApiKey[] }>(`/environments/api-keys/regenerate`, { environment });
 }
 
+export async function createApiKey({ environment }: { environment: IEnvironment }): Promise<{ data: IApiKey[] }> {
+  return post<{ data: IApiKey[] }>(`/environments/api-keys`, { environment });
+}
+
+export async function deleteApiKey({
+  environment,
+  hash,
+}: {
+  environment: IEnvironment;
+  hash: string;
+}): Promise<{ data: IApiKey[] }> {
+  return del<{ data: IApiKey[] }>(`/environments/api-keys/${hash}`, { environment });
+}
+
 export async function diffEnvironments({
   sourceEnvironmentId,
   targetEnvironmentId,

--- a/apps/dashboard/src/api/environments.ts
+++ b/apps/dashboard/src/api/environments.ts
@@ -138,14 +138,8 @@ export async function createApiKey({ environment }: { environment: IEnvironment 
   return post<{ data: IApiKey[] }>(`/environments/api-keys`, { environment });
 }
 
-export async function deleteApiKey({
-  environment,
-  hash,
-}: {
-  environment: IEnvironment;
-  hash: string;
-}): Promise<{ data: IApiKey[] }> {
-  return del<{ data: IApiKey[] }>(`/environments/api-keys/${hash}`, { environment });
+export async function deleteApiKey({ environment, hash }: { environment: IEnvironment; hash: string }): Promise<void> {
+  return del<void>(`/environments/api-keys/${hash}`, { environment });
 }
 
 export async function diffEnvironments({

--- a/apps/dashboard/src/hooks/use-fetch-api-keys.ts
+++ b/apps/dashboard/src/hooks/use-fetch-api-keys.ts
@@ -2,7 +2,7 @@ import { IApiKey } from '@novu/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEnvironment } from '@/context/environment/hooks';
 import { QueryKeys } from '@/utils/query-keys';
-import { getApiKeys, regenerateApiKeys } from '../api/environments';
+import { createApiKey, deleteApiKey, getApiKeys, regenerateApiKeys } from '../api/environments';
 
 export const useFetchApiKeys = ({ enabled = true }: { enabled?: boolean } = {}) => {
   const { currentEnvironment } = useEnvironment();
@@ -24,6 +24,34 @@ export const useRegenerateApiKeys = () => {
     mutationFn: () => regenerateApiKeys({ environment: currentEnvironment! }),
     onSuccess: () => {
       // Invalidate the API keys query to refetch the new keys
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.getApiKeys, currentEnvironment?._id],
+      });
+    },
+  });
+};
+
+export const useCreateApiKey = () => {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => createApiKey({ environment: currentEnvironment! }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.getApiKeys, currentEnvironment?._id],
+      });
+    },
+  });
+};
+
+export const useDeleteApiKey = () => {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ hash }: { hash: string }) => deleteApiKey({ environment: currentEnvironment!, hash }),
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.getApiKeys, currentEnvironment?._id],
       });

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -165,13 +165,13 @@ export function ApiKeysPage() {
                     {canRegenerateApiKeys && (
                       <div className="flex items-center justify-between gap-3 border-t border-neutral-100 pt-3">
                         <p className="text-foreground-500 text-xs">
-                          Rotate without downtime: generate a new key, switch your apps to it, then delete the old key.
+                          Key rotation: generate a new key, switch your apps to it, then delete the old key.
                         </p>
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span>
                               <Button
-                                size="sm"
+                                size="xs"
                                 variant="secondary"
                                 mode="outline"
                                 leadingIcon={RiAddLine}

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -159,9 +159,7 @@ export function ApiKeysPage() {
                           isRegenerateLoading={regenerateApiKeysMutation.isPending}
                           showDeleteButton={canRegenerateApiKeys && (apiKeys?.length ?? 0) > 1}
                           onDeleteClick={() => setKeyPendingDeletion(apiKey)}
-                          isDeleteLoading={
-                            deleteApiKeyMutation.isPending && keyPendingDeletion?.hash === apiKey.hash
-                          }
+                          isDeleteLoading={deleteApiKeyMutation.isPending && keyPendingDeletion?.hash === apiKey.hash}
                         />
                       ))}
                     {canRegenerateApiKeys && (

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -1,7 +1,8 @@
-import { PermissionsEnum } from '@novu/shared';
+import { FeatureFlagsKeysEnum, IApiKey, PermissionsEnum } from '@novu/shared';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { RiEyeLine, RiEyeOffLine, RiLoopRightFill } from 'react-icons/ri';
+import { RiAddLine, RiDeleteBin2Line, RiEyeLine, RiEyeOffLine, RiLoopRightFill } from 'react-icons/ri';
+import { ConfirmationModal } from '@/components/confirmation-modal';
 import { PageMeta } from '@/components/page-meta';
 import { Card, CardContent, CardHeader } from '@/components/primitives/card';
 import { CopyButton } from '@/components/primitives/copy-button';
@@ -20,8 +21,11 @@ import { showErrorToast, showSuccessToast } from '../components/primitives/sonne
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/primitives/tooltip';
 import { RegenerateApiKeysDialog } from '../components/regenerate-api-keys-dialog';
 import { IS_SELF_HOSTED } from '../config';
-import { useFetchApiKeys, useRegenerateApiKeys } from '../hooks/use-fetch-api-keys';
+import { useFeatureFlag } from '../hooks/use-feature-flag';
+import { useCreateApiKey, useDeleteApiKey, useFetchApiKeys, useRegenerateApiKeys } from '../hooks/use-fetch-api-keys';
 import { useHasPermission } from '../hooks/use-has-permission';
+
+const MAX_SECRET_KEYS = 2;
 
 // Convert https:// to wss:// for WebSocket URLs
 const getWebSocketUrl = (url: string) => {
@@ -42,9 +46,14 @@ export function ApiKeysPage() {
   const apiKeys = apiKeysQuery.data?.data;
   const isLoading = apiKeysQuery.isLoading;
   const [isRegenerateDialogOpen, setIsRegenerateDialogOpen] = useState(false);
+  const [keyPendingDeletion, setKeyPendingDeletion] = useState<IApiKey | null>(null);
   const regenerateApiKeysMutation = useRegenerateApiKeys();
+  const createApiKeyMutation = useCreateApiKey();
+  const deleteApiKeyMutation = useDeleteApiKey();
   const has = useHasPermission();
   const canRegenerateApiKeys = has({ permission: PermissionsEnum.API_KEY_WRITE });
+  const isMultipleSecretKeysAllowed = useFeatureFlag(FeatureFlagsKeysEnum.IS_MULTIPLE_SECRET_KEYS_ALLOWED);
+  const hasMaxSecretKeys = (apiKeys?.length ?? 0) >= MAX_SECRET_KEYS;
 
   const form = useForm<ApiKeysFormData>({
     values: {
@@ -61,6 +70,29 @@ export function ApiKeysPage() {
       setIsRegenerateDialogOpen(false);
     } catch (e: any) {
       const message = e?.message || 'Failed to regenerate API keys';
+      showErrorToast(message);
+    }
+  };
+
+  const handleCreateKey = async () => {
+    try {
+      await createApiKeyMutation.mutateAsync();
+      showSuccessToast('New secret key generated');
+    } catch (e: any) {
+      const message = e?.message || 'Failed to generate a new secret key';
+      showErrorToast(message);
+    }
+  };
+
+  const handleDeleteKey = async () => {
+    if (!keyPendingDeletion?.hash) return;
+
+    try {
+      await deleteApiKeyMutation.mutateAsync({ hash: keyPendingDeletion.hash });
+      showSuccessToast('Secret key deleted');
+      setKeyPendingDeletion(null);
+    } catch (e: any) {
+      const message = e?.message || 'Failed to delete the secret key';
       showErrorToast(message);
     }
   };
@@ -111,18 +143,71 @@ export function ApiKeysPage() {
               </CardHeader>
 
               <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
-                <div className="space-y-4">
-                  <SettingField
-                    label="Secret Key"
-                    tooltip="Keep it secure and never share it publicly"
-                    value={form.getValues('apiKey')}
-                    secret
-                    isLoading={isLoading}
-                    showRegenerateButton={canRegenerateApiKeys}
-                    onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
-                    isRegenerateLoading={regenerateApiKeysMutation.isPending}
-                  />
-                </div>
+                {isMultipleSecretKeysAllowed ? (
+                  <div className="space-y-4">
+                    {isLoading && <SettingField label="Secret Key" secret isLoading />}
+                    {!isLoading &&
+                      apiKeys?.map((apiKey, index) => (
+                        <SettingField
+                          key={apiKey.hash ?? apiKey.key}
+                          label={index === 0 ? 'Secret Key' : 'Secret Key (new)'}
+                          tooltip="Keep it secure and never share it publicly"
+                          value={apiKey.key}
+                          secret
+                          showRegenerateButton={canRegenerateApiKeys && index === 0}
+                          onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
+                          isRegenerateLoading={regenerateApiKeysMutation.isPending}
+                          showDeleteButton={canRegenerateApiKeys && (apiKeys?.length ?? 0) > 1}
+                          onDeleteClick={() => setKeyPendingDeletion(apiKey)}
+                          isDeleteLoading={
+                            deleteApiKeyMutation.isPending && keyPendingDeletion?.hash === apiKey.hash
+                          }
+                        />
+                      ))}
+                    {canRegenerateApiKeys && (
+                      <div className="flex items-center justify-between gap-3 border-t border-neutral-100 pt-3">
+                        <p className="text-foreground-500 text-xs">
+                          Rotate without downtime: generate a new key, switch your apps to it, then delete the old key.
+                        </p>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span>
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                mode="outline"
+                                leadingIcon={RiAddLine}
+                                onClick={handleCreateKey}
+                                disabled={isLoading || hasMaxSecretKeys}
+                                isLoading={createApiKeyMutation.isPending}
+                              >
+                                Generate new key
+                              </Button>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {hasMaxSecretKeys
+                              ? `You can have up to ${MAX_SECRET_KEYS} secret keys. Delete a key to generate a new one.`
+                              : 'Generate an additional secret key for a rolling rotation'}
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    <SettingField
+                      label="Secret Key"
+                      tooltip="Keep it secure and never share it publicly"
+                      value={form.getValues('apiKey')}
+                      secret
+                      isLoading={isLoading}
+                      showRegenerateButton={canRegenerateApiKeys}
+                      onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
+                      isRegenerateLoading={regenerateApiKeysMutation.isPending}
+                    />
+                  </div>
+                )}
               </CardContent>
             </Card>
             <Card className="w-full overflow-hidden shadow-none">
@@ -168,6 +253,25 @@ export function ApiKeysPage() {
         onConfirm={handleRegenerateKeys}
         isLoading={regenerateApiKeysMutation.isPending}
       />
+      <ConfirmationModal
+        open={!!keyPendingDeletion}
+        onOpenChange={(open) => {
+          if (!open) {
+            setKeyPendingDeletion(null);
+          }
+        }}
+        onConfirm={handleDeleteKey}
+        title="Delete secret key"
+        description={
+          <span>
+            The secret key ending in <span className="font-mono">…{keyPendingDeletion?.key?.slice(-4)}</span> will stop
+            working within about a minute. Make sure none of your applications still use it before deleting.
+          </span>
+        }
+        confirmButtonText="Delete key"
+        confirmButtonVariant="error"
+        isLoading={deleteApiKeyMutation.isPending}
+      />
     </>
   );
 }
@@ -182,6 +286,9 @@ interface SettingFieldProps {
   showRegenerateButton?: boolean;
   onRegenerateClick?: () => void;
   isRegenerateLoading?: boolean;
+  showDeleteButton?: boolean;
+  onDeleteClick?: () => void;
+  isDeleteLoading?: boolean;
 }
 
 function SettingField({
@@ -194,6 +301,9 @@ function SettingField({
   showRegenerateButton = false,
   onRegenerateClick,
   isRegenerateLoading,
+  showDeleteButton = false,
+  onDeleteClick,
+  isDeleteLoading,
 }: SettingFieldProps) {
   const [showSecret, setShowSecret] = useState(false);
 
@@ -217,6 +327,7 @@ function SettingField({
             <Skeleton className="h-[38px] flex-1 rounded-lg" />
             {secret && <Skeleton className="h-[38px] w-[38px] rounded-lg" />}
             {showRegenerateButton && <Skeleton className="h-[38px] w-[38px] rounded-lg" />}
+            {showDeleteButton && <Skeleton className="h-[38px] w-[38px] rounded-lg" />}
           </>
         ) : (
           <>
@@ -252,6 +363,23 @@ function SettingField({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Regenerate API Key</TooltipContent>
+              </Tooltip>
+            )}
+            {showDeleteButton && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="md"
+                    variant="secondary"
+                    mode="outline"
+                    onClick={onDeleteClick}
+                    disabled={isDeleteLoading}
+                    className="h-[38px] min-w-[38px] p-0"
+                  >
+                    <RiDeleteBin2Line className="text-destructive h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Delete API Key</TooltipContent>
               </Tooltip>
             )}
           </>

--- a/libs/dal/src/repositories/environment/environment.repository.ts
+++ b/libs/dal/src/repositories/environment/environment.repository.ts
@@ -45,29 +45,47 @@ export class EnvironmentRepository extends BaseRepository<EnvironmentDBModel, En
     });
   }
 
-  async addApiKey(environmentId: string, key: EncryptedSecret, userId: string, hash?: string) {
-    await this.update(
-      {
-        _id: environmentId,
-      },
-      {
-        $push: {
-          apiKeys: {
-            key,
-            _userId: userId,
-            hash,
-          },
+  /**
+   * Appends an API key. When `maxKeysCount` is provided, the cap is enforced
+   * atomically in the update predicate (no key at index `maxKeysCount - 1`),
+   * so concurrent creates cannot exceed the cap. Returns `null` when the cap
+   * was reached (or the environment does not exist).
+   */
+  async addApiKey(environmentId: string, key: EncryptedSecret, userId: string, hash?: string, maxKeysCount?: number) {
+    const query = {
+      _id: environmentId,
+      ...(maxKeysCount !== undefined && { [`apiKeys.${maxKeysCount - 1}`]: { $exists: false } }),
+    };
+
+    const { matched } = await this.update(query, {
+      $push: {
+        apiKeys: {
+          key,
+          _userId: userId,
+          hash,
         },
-      }
-    );
+      },
+    });
+
+    if (matched === 0) {
+      return null;
+    }
 
     return await this.getApiKeys(environmentId);
   }
 
+  /**
+   * Removes a single API key. The "at least one key must remain" invariant is
+   * enforced atomically in the update predicate (a second key must exist at
+   * pull time), so concurrent deletes cannot empty the array.
+   * `matched === 0` means only one key remained; `modified === 0` means the
+   * key was not found (e.g. already deleted concurrently).
+   */
   async deleteApiKey(environmentId: string, keyQuery: { hash: string } | { key: EncryptedSecret | string }) {
-    await this.update(
+    const { matched, modified } = await this.update(
       {
         _id: environmentId,
+        'apiKeys.1': { $exists: true },
       },
       {
         $pull: {
@@ -76,7 +94,7 @@ export class EnvironmentRepository extends BaseRepository<EnvironmentDBModel, En
       }
     );
 
-    return await this.getApiKeys(environmentId);
+    return { matched, modified };
   }
 
   async findByApiKey({ hash }: { hash: string }) {

--- a/libs/dal/src/repositories/environment/environment.repository.ts
+++ b/libs/dal/src/repositories/environment/environment.repository.ts
@@ -23,8 +23,11 @@ export class EnvironmentRepository extends BaseRepository<EnvironmentDBModel, En
       },
       {
         $set: {
-          'apiKeys.$._userId': newUserId,
+          'apiKeys.$[element]._userId': newUserId,
         },
+      },
+      {
+        arrayFilters: [{ 'element._userId': oldUserId }],
       }
     );
   }
@@ -42,8 +45,8 @@ export class EnvironmentRepository extends BaseRepository<EnvironmentDBModel, En
     });
   }
 
-  async addApiKey(environmentId: string, key: EncryptedSecret, userId: string) {
-    return await this.update(
+  async addApiKey(environmentId: string, key: EncryptedSecret, userId: string, hash?: string) {
+    await this.update(
       {
         _id: environmentId,
       },
@@ -52,10 +55,28 @@ export class EnvironmentRepository extends BaseRepository<EnvironmentDBModel, En
           apiKeys: {
             key,
             _userId: userId,
+            hash,
           },
         },
       }
     );
+
+    return await this.getApiKeys(environmentId);
+  }
+
+  async deleteApiKey(environmentId: string, keyQuery: { hash: string } | { key: EncryptedSecret | string }) {
+    await this.update(
+      {
+        _id: environmentId,
+      },
+      {
+        $pull: {
+          apiKeys: keyQuery,
+        },
+      }
+    );
+
+    return await this.getApiKeys(environmentId);
   }
 
   async findByApiKey({ hash }: { hash: string }) {

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -125,6 +125,15 @@ export enum FeatureFlagsKeysEnum {
    * button is disabled.
    */
   IS_MCP_PROVIDER_MANAGED_ENABLED = 'IS_MCP_PROVIDER_MANAGED_ENABLED',
+  /**
+   * Temporary flag for rolling secret key rotation. When enabled, customers can
+   * create a second API key (`POST /v1/environments/api-keys`) and delete a specific
+   * key (`DELETE /v1/environments/api-keys/:hash`) so they can rotate keys without
+   * downtime. Also gates the multi-key UI on the dashboard API Keys page
+   * (`VITE_IS_MULTIPLE_SECRET_KEYS_ALLOWED` when self-hosted). Enable per
+   * organization for the duration of the rotation, then disable.
+   */
+  IS_MULTIPLE_SECRET_KEYS_ALLOWED = 'IS_MULTIPLE_SECRET_KEYS_ALLOWED',
 
   // String flags
   CF_SCHEDULER_MODE = 'CF_SCHEDULER_MODE', // Values: "off" | "shadow" | "live" | "complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Allows customers to rotate their Novu secret keys in a rolling fashion without downtime: generate a second key, switch their apps to it, then delete the old key. Everything is gated behind a new temporary feature flag `IS_MULTIPLE_SECRET_KEYS_ALLOWED` (LaunchDarkly on cloud, `IS_MULTIPLE_SECRET_KEYS_ALLOWED` / `VITE_IS_MULTIPLE_SECRET_KEYS_ALLOWED` env vars when self-hosted) so it can be enabled per organization for the duration of a rotation and disabled afterwards. With the flag off, API and dashboard behavior is unchanged.

```mermaid
flowchart LR
    createKey["Generate 2nd key (dashboard)"] --> switchApp["Customer switches app to new key"]
    switchApp --> deleteOld["Delete old key (dashboard)"]
    deleteOld --> done["Single key again - flag can be disabled"]
```

**API (`apps/api`)**
- `POST /v1/environments/api-keys` — new `CreateApiKey` use case: `$push`es an additional key (capped at 2), flag-gated (403 when off), requires `API_KEY_WRITE`. The cap is enforced atomically in the update predicate (`apiKeys.<max-1>: { $exists: false }`), so concurrent creates cannot exceed it.
- `DELETE /v1/environments/api-keys/:hash` — new `DeleteApiKey` use case: deletes a specific key by SHA-256 hash and returns a `204 No Content` acknowledgment (no key material in the response). Refuses to delete the last remaining key (enforced atomically via `apiKeys.1: { $exists: true }` in the pull predicate, so concurrent deletes cannot empty the array), flag-gated, best-effort invalidates the local `API_KEY_USER` LRU auth cache entry (cross-instance staleness bounded by the existing 1-minute TTL, same as regenerate today).
- `GET /v1/environments/api-keys` now also returns each key's `hash` (computed from the plaintext key when missing) so the UI can address keys for deletion. Regenerate is unchanged and still collapses to a single key.
- **Multi-key correctness:** Inbox and legacy widget HMAC validation (`session.usecase.ts`, `initialize-session.usecase.ts`) now validate `subscriberHash`/`contextHash` against every active key instead of only `apiKeys[0]`, so HMAC-enabled customers keep working mid-rotation. Other `apiKeys[0]` consumers (bridge signing, OAuth, snippets) intentionally keep using the oldest key, which stays at index 0 until the old key is deleted.

**DAL (`libs/dal`)**
- `addApiKey` now persists the `hash` (previously a pushed key would be unauthenticatable), optionally enforces a max key count in the update predicate, and returns the updated key list (or `null` when the cap was hit).
- New `deleteApiKey` (`$pull` by `hash` or by `key` for legacy entries without a stored hash) that atomically requires a second key to remain, returning `matched`/`modified` so callers can distinguish last-key rejection from key-not-found.
- `updateApiKeyUserId` (member removal) uses `arrayFilters` to update all matching keys instead of only the first positional match.

**Shared (`packages/shared`)**
- New `FeatureFlagsKeysEnum.IS_MULTIPLE_SECRET_KEYS_ALLOWED` with JSDoc marking it as a temporary rotation flag.

**Dashboard (`apps/dashboard`)**
- Flag on: the Secret Keys card lists all keys ("Secret Key" / "Secret Key (new)"), each with mask/reveal/copy; a "Generate new key" button (disabled at 2 keys with an explanatory tooltip) and per-key delete buttons (shown only when 2 keys exist) with a confirmation dialog warning the key stops working within about a minute. After a delete, the list refreshes via query invalidation.
- Flag off: the existing single-key UI is untouched.
- New `createApiKey`/`deleteApiKey` API client functions and `useCreateApiKey`/`useDeleteApiKey` mutation hooks.

### Screenshots

[rolling_secret_key_rotation_demo.mp4](https://cursor.com/agents/bc-445008a4-e83c-43d6-9411-5256df0a7eb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frolling_secret_key_rotation_demo.mp4)

![Two secret keys during rotation](https://cursor.com/artifacts/c/art-b6a0c7c8-4ca1-44a8-9847-6341f44e26de)
![Delete secret key confirmation dialog](https://cursor.com/artifacts/c/art-4ab11c2c-832a-4b25-997c-b118d2245d5e)
![Single key after rotation completes](https://cursor.com/artifacts/c/art-77a0b673-c4b4-4dd9-bb9d-f61fd64a5723)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- E2E coverage in `apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts` (12 tests): create second key, key ordering, 2-key cap, auth with both keys, delete specific key (204 ack) + auth invalidation, concurrent create cap invariant, concurrent delete last-key invariant, last-key protection, 404 on unknown hash, 403 with flag off, regenerate collapse, hash in list response. All pass; pre-existing failures in the surrounding suite are identical on `next`.
- Known limitation (documented, not fixed): customers verifying bridge/webhook signatures with a single stored secret have a brief mismatch window between switching their env var and deleting the old key, since Novu signs with the oldest key.
- If the flag is disabled while an environment still has 2 keys, both keys keep authenticating and the regenerate endpoint remains available as an escape hatch to collapse back to a single key.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-445008a4-e83c-43d6-9411-5256df0a7eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-445008a4-e83c-43d6-9411-5256df0a7eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds feature-flagged rolling secret key rotation. The main changes are:

- New API routes to create a second environment API key and delete a specific key by hash.
- Atomic DAL updates for the two-key cap and the last-key deletion guard.
- API key hashes returned in list and regenerate responses for dashboard deletion flows.
- Inbox and widget HMAC validation updated to accept any active key during rotation.
- Dashboard UI for generating, viewing, copying, and deleting rotation keys behind the feature flag.
- E2E coverage for creation, deletion, auth, feature gating, concurrency invariants, and regenerate collapse.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are feature-gated, include atomic repository predicates for the main rotation invariants, and add E2E coverage for the key creation and deletion flows.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex inspected the changed API keys page and confirmed the UI renders multiple secret-key rows with per-key reveal/copy controls, a first-key regenerate control, delete controls when more than one key exists, the generate-new-key button disabled at the two-key cap, the cap tooltip text, and a delete confirmation modal, and also reviewed the supporting hooks and API functions.
- Runtime validation was not completed: the dashboard was not started, no mocked backend was run, and no browser capture artifacts were generated.
- The mock API was started on 127.0.0.1:4301, but Vite reported unresolved workspace entries for @novu/maily-core and @novu/react during dependency scanning, and no valid API keys page, tooltip, dialog, browser console, or video capture was produced.

<a href="https://app.greptile.com/trex/runs/13312758/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/environments-v1/usecases/create-api-key/create-api-key.usecase.ts | Implements feature-flagged second key creation with atomic cap enforcement and hash persistence. |
| apps/api/src/app/environments-v1/usecases/delete-api-key/delete-api-key.usecase.ts | Implements feature-flagged key deletion with last-key protection and local auth cache invalidation. |
| libs/dal/src/repositories/environment/environment.repository.ts | Persists API key hashes, atomically enforces create/delete invariants, and updates all matching user-owned keys. |
| apps/api/src/app/shared/helpers/is-valid-hmac.ts | Adds any-key HMAC validation helpers while preserving existing single-key validators. |
| apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts | Updates legacy widget HMAC validation and subscriber update authorization to accept either active key. |
| apps/api/src/app/inbox/usecases/session/session.usecase.ts | Validates subscriber and context HMACs against all active environment keys during rotation. |
| apps/dashboard/src/pages/api-keys.tsx | Adds feature-flagged multi-key UI with generation, per-key deletion, confirmation, and cap messaging. |
| apps/api/src/app/environments-v1/e2e/manage-api-keys.e2e.ts | Adds E2E coverage for multi-key creation, deletion, feature gating, concurrency invariants, auth, regenerate collapse, and hash listing. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Dashboard
participant API as Environments API
participant FF as FeatureFlagsService
participant DAL as EnvironmentRepository
participant Auth as API Key Auth Cache

Dashboard->>API: POST /v1/environments/api-keys
API->>FF: Check IS_MULTIPLE_SECRET_KEYS_ALLOWED
FF-->>API: enabled
API->>DAL: "addApiKey(maxKeys=2, hash)"
DAL-->>API: updated apiKeys or null
API-->>Dashboard: apiKeys with hashes

Dashboard->>API: DELETE /v1/environments/api-keys/:hash
API->>FF: Check IS_MULTIPLE_SECRET_KEYS_ALLOWED
FF-->>API: enabled
API->>DAL: deleteApiKey(hash) with apiKeys.1 guard
DAL-->>API: matched/modified
API->>Auth: invalidate API_KEY_USER hash
API-->>Dashboard: 204 No Content
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Dashboard
participant API as Environments API
participant FF as FeatureFlagsService
participant DAL as EnvironmentRepository
participant Auth as API Key Auth Cache

Dashboard->>API: POST /v1/environments/api-keys
API->>FF: Check IS_MULTIPLE_SECRET_KEYS_ALLOWED
FF-->>API: enabled
API->>DAL: "addApiKey(maxKeys=2, hash)"
DAL-->>API: updated apiKeys or null
API-->>Dashboard: apiKeys with hashes

Dashboard->>API: DELETE /v1/environments/api-keys/:hash
API->>FF: Check IS_MULTIPLE_SECRET_KEYS_ALLOWED
FF-->>API: enabled
API->>DAL: deleteApiKey(hash) with apiKeys.1 guard
DAL-->>API: matched/modified
API->>Auth: invalidate API_KEY_USER hash
API-->>Dashboard: 204 No Content
```

</a>

<sub>Reviews (4): Last reviewed commit: ["refactor(api): return 204 ack instead of..."](https://github.com/novuhq/novu/commit/e2f27d25374e50cdfe2aae6dde6f82929ac8e0d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41667183)</sub>

<!-- /greptile_comment -->