### PR TITLE
fix(api-service): scope inbox snooze lookups to subscriber fixes NV-8175

### DIFF
--- a/apps/api/src/app/inbox/e2e/snooze-unsnooze-notification.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/snooze-unsnooze-notification.e2e.ts
@@ -203,4 +203,21 @@ describe('Snooze and Unsnooze Notifications - /inbox/notifications/:id/{snooze,u
 
     expect(response.status).to.equal(404);
   });
+
+  it('should ensure notifications can only be unsnoozed by their owner', async () => {
+    const snoozeUntil = new Date();
+    snoozeUntil.setHours(snoozeUntil.getHours() + 1);
+
+    await snoozeNotification(notificationId, snoozeUntil);
+
+    const secondSession = new UserSession();
+    await secondSession.initialize();
+
+    const response = await session.testAgent
+      .patch(`/v1/inbox/notifications/${notificationId}/unsnooze`)
+      .set('Authorization', `Bearer ${secondSession.subscriberToken}`)
+      .send();
+
+    expect(response.status).to.equal(404);
+  });
 });

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
@@ -18,6 +18,7 @@ import { ApiServiceLevelEnum, ChannelTypeEnum, JobStatusEnum, SeverityLevelEnum 
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { InboxNotificationDto } from '../../dtos/inbox-notification.dto';
+import { GetSubscriber } from '../../../subscribers/usecases/get-subscriber';
 import { MarkNotificationAsCommand } from '../mark-notification-as/mark-notification-as.command';
 import { MarkNotificationAs } from '../mark-notification-as/mark-notification-as.usecase';
 import { SnoozeNotificationCommand } from './snooze-notification.command';
@@ -48,6 +49,7 @@ describe('SnoozeNotification', () => {
   let createExecutionDetailsMock: sinon.SinonStubbedInstance<CreateExecutionDetails>;
   let markNotificationAsMock: sinon.SinonStubbedInstance<MarkNotificationAs>;
   let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
+  let getSubscriberMock: sinon.SinonStubbedInstance<GetSubscriber>;
 
   const mockMessage: MessageEntity = {
     _id: validNotificationId,
@@ -96,6 +98,7 @@ describe('SnoozeNotification', () => {
     createExecutionDetailsMock = sinon.createStubInstance(CreateExecutionDetails);
     markNotificationAsMock = sinon.createStubInstance(MarkNotificationAs);
     analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
+    getSubscriberMock = sinon.createStubInstance(GetSubscriber);
 
     // Mock the MarkNotificationAsCommand.create method
     sinon.stub(MarkNotificationAsCommand, 'create').returns({
@@ -120,7 +123,8 @@ describe('SnoozeNotification', () => {
       organizationRepositoryMock as any,
       createExecutionDetailsMock as any,
       markNotificationAsMock as any,
-      analyticsServiceMock as any
+      analyticsServiceMock as any,
+      getSubscriberMock as any
     );
 
     sinon.stub(JobRepository, 'createObjectId').returns('new-job-id');
@@ -140,6 +144,7 @@ describe('SnoozeNotification', () => {
 
     organizationRepositoryMock.findOne.resolves(orgEntity);
     standardQueueServiceMock.add.resolves();
+    getSubscriberMock.execute.resolves({ _id: validSubscriberId } as any);
     messageRepositoryMock.findOne.resolves(mockMessage);
   });
 

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
@@ -1,4 +1,11 @@
-import { HttpException, HttpStatus, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   AnalyticsService,
   CreateExecutionDetails,
@@ -25,6 +32,7 @@ import {
   JobStatusEnum,
 } from '@novu/shared';
 import { v4 as uuidv4 } from 'uuid';
+import { GetSubscriber } from '../../../subscribers/usecases/get-subscriber';
 import { InboxNotificationDto } from '../../dtos/inbox-notification.dto';
 import { AnalyticsEventsEnum } from '../../utils';
 import { MarkNotificationAsCommand } from '../mark-notification-as/mark-notification-as.command';
@@ -43,7 +51,8 @@ export class SnoozeNotification {
     private organizationRepository: CommunityOrganizationRepository,
     private createExecutionDetails: CreateExecutionDetails,
     private markNotificationAs: MarkNotificationAs,
-    private analyticsService: AnalyticsService
+    private analyticsService: AnalyticsService,
+    private getSubscriber: GetSubscriber
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -146,8 +155,18 @@ export class SnoozeNotification {
   }
 
   private async findNotification(command: SnoozeNotificationCommand): Promise<MessageEntity> {
+    const subscriber = await this.getSubscriber.execute({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: command.subscriberId,
+    });
+    if (!subscriber) {
+      throw new BadRequestException(`Subscriber with id: ${command.subscriberId} is not found.`);
+    }
+
     const message = await this.messageRepository.findOne({
       _environmentId: command.environmentId,
+      _subscriberId: subscriber._id,
       channel: ChannelTypeEnum.IN_APP,
       _id: command.notificationId,
       contextKeys: command.contextKeys,

--- a/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
@@ -5,6 +5,7 @@ import { ChannelTypeEnum, JobStatusEnum, SeverityLevelEnum } from '@novu/shared'
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { InboxNotificationDto } from '../../dtos/inbox-notification.dto';
+import { GetSubscriber } from '../../../subscribers/usecases/get-subscriber';
 import { MarkNotificationAsCommand } from '../mark-notification-as/mark-notification-as.command';
 import { MarkNotificationAs } from '../mark-notification-as/mark-notification-as.usecase';
 import { UnsnoozeNotificationCommand } from './unsnooze-notification.command';
@@ -24,6 +25,7 @@ describe('UnsnoozeNotification', () => {
   let jobRepositoryMock: sinon.SinonStubbedInstance<JobRepository>;
   let createExecutionDetailsMock: sinon.SinonStubbedInstance<CreateExecutionDetails>;
   let markNotificationAsMock: sinon.SinonStubbedInstance<MarkNotificationAs>;
+  let getSubscriberMock: sinon.SinonStubbedInstance<GetSubscriber>;
 
   const snoozedUntil = new Date();
   snoozedUntil.setHours(snoozedUntil.getHours() + 1);
@@ -77,6 +79,7 @@ describe('UnsnoozeNotification', () => {
     jobRepositoryMock = sinon.createStubInstance(JobRepository);
     createExecutionDetailsMock = sinon.createStubInstance(CreateExecutionDetails);
     markNotificationAsMock = sinon.createStubInstance(MarkNotificationAs);
+    getSubscriberMock = sinon.createStubInstance(GetSubscriber);
 
     sinon.stub(MarkNotificationAsCommand, 'create').returns({
       environmentId: validEnvId,
@@ -97,12 +100,14 @@ describe('UnsnoozeNotification', () => {
       messageRepositoryMock as any,
       jobRepositoryMock as any,
       markNotificationAsMock as any,
-      createExecutionDetailsMock as any
+      createExecutionDetailsMock as any,
+      getSubscriberMock as any
     );
 
     jobRepositoryMock.findOneAndDelete.resolves(mockJob);
     markNotificationAsMock.execute.resolves(mockNotification);
     createExecutionDetailsMock.execute.resolves();
+    getSubscriberMock.execute.resolves({ _id: validSubscriberId } as any);
     messageRepositoryMock.findOne.resolves(mockMessage);
   });
 

--- a/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import {
   CreateExecutionDetails,
   CreateExecutionDetailsCommand,
@@ -7,6 +7,7 @@ import {
 } from '@novu/application-generic';
 import { ChannelTypeEnum, JobEntity, JobRepository, JobStatusEnum, MessageRepository } from '@novu/dal';
 import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum } from '@novu/shared';
+import { GetSubscriber } from '../../../subscribers/usecases/get-subscriber';
 import { InboxNotificationDto } from '../../dtos/inbox-notification.dto';
 import { MarkNotificationAsCommand } from '../mark-notification-as/mark-notification-as.command';
 import { MarkNotificationAs } from '../mark-notification-as/mark-notification-as.usecase';
@@ -19,15 +20,26 @@ export class UnsnoozeNotification {
     private messageRepository: MessageRepository,
     private jobRepository: JobRepository,
     private markNotificationAs: MarkNotificationAs,
-    private createExecutionDetails: CreateExecutionDetails
+    private createExecutionDetails: CreateExecutionDetails,
+    private getSubscriber: GetSubscriber
   ) {
     this.logger.setContext(this.constructor.name);
   }
 
   async execute(command: UnsnoozeNotificationCommand): Promise<InboxNotificationDto> {
+    const subscriber = await this.getSubscriber.execute({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: command.subscriberId,
+    });
+    if (!subscriber) {
+      throw new BadRequestException(`Subscriber with id: ${command.subscriberId} is not found.`);
+    }
+
     const snoozedNotification = await this.messageRepository.findOne({
       _id: command.notificationId,
       _environmentId: command.environmentId,
+      _subscriberId: subscriber._id,
       channel: ChannelTypeEnum.IN_APP,
       snoozedUntil: { $exists: true, $ne: null },
       contextKeys: command.contextKeys,

--- a/apps/api/src/app/inbox/usecases/update-notification-action/update-notification-action.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-notification-action/update-notification-action.usecase.ts
@@ -69,7 +69,9 @@ export class UpdateNotificationAction {
     return mapToDto(
       (await this.messageRepository.findOneForInbox({
         _environmentId: command.environmentId,
+        _subscriberId: subscriber._id,
         _id: command.notificationId,
+        contextKeys: command.contextKeys,
       })) as MessageEntity
     );
   }

--- a/apps/api/src/app/inbox/usecases/update-notification-action/update-notification-action.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-notification-action/update-notification-action.usecase.ts
@@ -66,13 +66,15 @@ export class UpdateNotificationAction {
       actionStatus: command.actionStatus,
     });
 
-    return mapToDto(
-      (await this.messageRepository.findOneForInbox({
-        _environmentId: command.environmentId,
-        _subscriberId: subscriber._id,
-        _id: command.notificationId,
-        contextKeys: command.contextKeys,
-      })) as MessageEntity
-    );
+    const updatedMessage = await this.messageRepository.findOneForInbox({
+      _environmentId: command.environmentId,
+      _subscriberId: subscriber._id,
+      _id: command.notificationId,
+    });
+    if (!updatedMessage) {
+      throw new NotFoundException(`Notification with id: ${command.notificationId} could not be found after update.`);
+    }
+
+    return mapToDto(updatedMessage);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns inbox snooze and unsnooze notification lookups with other inbox notification endpoints by resolving the authenticated subscriber before querying messages.

## Test plan

- [x] Snooze and unsnooze unit tests
- [x] Inbox snooze/unsnooze e2e ownership checks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef48fa6d-bf45-42a5-8b54-f3c8b6071cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef48fa6d-bf45-42a5-8b54-f3c8b6071cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens inbox notification ownership checks for snooze-related actions. The main changes are:

- Resolves the subscriber before snooze notification lookup.
- Resolves the subscriber before unsnooze notification lookup.
- Keeps update-action response reads scoped to the subscriber after updating.
- Adds unit and end-to-end coverage for snooze and unsnooze ownership behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The update-action fix keeps the final read subscriber-scoped and avoids the earlier uncontrolled missing-message failure.
- The snooze and unsnooze lookups now use the resolved subscriber id for ownership checks.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/inbox/usecases/update-notification-action/update-notification-action.usecase.ts | Changes the post-update read to use subscriber-scoped lookup with an explicit missing-message guard. |
| apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts | Adds subscriber resolution before querying the notification to snooze. |
| apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts | Adds subscriber resolution before querying the snoozed notification. |
| apps/api/src/app/inbox/e2e/snooze-unsnooze-notification.e2e.ts | Adds end-to-end coverage for unsnooze ownership enforcement. |
| apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts | Updates the snooze unit setup for the new subscriber lookup dependency. |
| apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts | Updates the unsnooze unit setup for the new subscriber lookup dependency. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): harden action update r..."](https://github.com/novuhq/novu/commit/fdf6eb127d2eddaace94dbed8410842d8f9e50cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41887294)</sub>

<!-- /greptile_comment -->