### PR TITLE
fix(providers): harden Pusher Beams instanceId against SSRF fixes NV-8178

### DIFF
--- a/packages/providers/src/lib/push/pusher-beams/pusher-beams.provider.spec.ts
+++ b/packages/providers/src/lib/push/pusher-beams/pusher-beams.provider.spec.ts
@@ -8,7 +8,7 @@ test('should trigger pusher-beams library correctly', async () => {
   });
 
   const provider = new PusherBeamsPushProvider({
-    instanceId: '<instance-id>',
+    instanceId: 'test-instance-id',
     secretKey: '<secret-key',
   });
 
@@ -74,7 +74,7 @@ test('should trigger pusher-beams library correctly with _passthrough', async ()
   });
 
   const provider = new PusherBeamsPushProvider({
-    instanceId: '<instance-id>',
+    instanceId: 'test-instance-id',
     secretKey: '<secret-key',
   });
 
@@ -141,4 +141,14 @@ test('should trigger pusher-beams library correctly with _passthrough', async ()
   });
 
   expect(result.id).toEqual('pubid-3a7e97ee-a4bc-4d8f-a40b-74915ce808ae');
+});
+
+test('rejects malicious instance IDs at construction', () => {
+  expect(
+    () =>
+      new PusherBeamsPushProvider({
+        instanceId: 'internal.example/path?x=',
+        secretKey: 'secret',
+      })
+  ).toThrow('Pusher Beams instance ID blocked: Invalid instance ID format.');
 });

--- a/packages/providers/src/lib/push/pusher-beams/pusher-beams.provider.ts
+++ b/packages/providers/src/lib/push/pusher-beams/pusher-beams.provider.ts
@@ -2,6 +2,7 @@ import { PushProviderIdEnum } from '@novu/shared';
 import { ChannelTypeEnum, IPushOptions, IPushProvider, ISendMessageSuccessResponse } from '@novu/stateless';
 import axios, { AxiosInstance } from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
+import { resolveSafePusherBeamsBaseUrl } from '../../../utils/safe-pusher-beams-url';
 import { WithPassthrough } from '../../../utils/types';
 
 export class PusherBeamsPushProvider extends BaseProvider implements IPushProvider {
@@ -18,8 +19,10 @@ export class PusherBeamsPushProvider extends BaseProvider implements IPushProvid
     }
   ) {
     super();
+    const baseURL = resolveSafePusherBeamsBaseUrl(this.config.instanceId);
+
     this.axiosInstance = axios.create({
-      baseURL: `https://${this.config.instanceId}.pushnotifications.pusher.com/publish_api/v1/instances/${this.config.instanceId}`,
+      baseURL,
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${this.config.secretKey}`,

--- a/packages/providers/src/utils/safe-pusher-beams-url.spec.ts
+++ b/packages/providers/src/utils/safe-pusher-beams-url.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest';
+import { resolveSafePusherBeamsBaseUrl } from './safe-pusher-beams-url';
+
+test('accepts valid instance IDs', () => {
+  const baseUrl = resolveSafePusherBeamsBaseUrl('my-instance_123');
+
+  expect(baseUrl).toBe(
+    'https://my-instance_123.pushnotifications.pusher.com/publish_api/v1/instances/my-instance_123'
+  );
+});
+
+test('rejects instance IDs with URL delimiters', () => {
+  expect(() => resolveSafePusherBeamsBaseUrl('internal.example/path?x=')).toThrow(
+    'Pusher Beams instance ID blocked: Invalid instance ID format.'
+  );
+});
+
+test('rejects instance IDs with embedded credentials', () => {
+  expect(() => resolveSafePusherBeamsBaseUrl('evil@internal')).toThrow(
+    'Pusher Beams instance ID blocked: Invalid instance ID format.'
+  );
+});
+
+test('rejects empty instance IDs', () => {
+  expect(() => resolveSafePusherBeamsBaseUrl('')).toThrow(
+    'Pusher Beams instance ID blocked: Invalid instance ID format.'
+  );
+});

--- a/packages/providers/src/utils/safe-pusher-beams-url.spec.ts
+++ b/packages/providers/src/utils/safe-pusher-beams-url.spec.ts
@@ -9,6 +9,15 @@ test('accepts valid instance IDs', () => {
   );
 });
 
+test('accepts mixed-case instance IDs', () => {
+  const instanceId = 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890';
+  const baseUrl = resolveSafePusherBeamsBaseUrl(instanceId);
+
+  expect(baseUrl).toBe(
+    `https://${instanceId}.pushnotifications.pusher.com/publish_api/v1/instances/${instanceId}`
+  );
+});
+
 test('rejects instance IDs with URL delimiters', () => {
   expect(() => resolveSafePusherBeamsBaseUrl('internal.example/path?x=')).toThrow(
     'Pusher Beams instance ID blocked: Invalid instance ID format.'

--- a/packages/providers/src/utils/safe-pusher-beams-url.ts
+++ b/packages/providers/src/utils/safe-pusher-beams-url.ts
@@ -1,0 +1,34 @@
+import { assertSafeOutboundUrl, SsrfBlockedError } from '@novu/shared/utils/ssrf-url-validation';
+
+const PUSHER_BEAMS_INSTANCE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const PUSHER_BEAMS_HOST_SUFFIX = '.pushnotifications.pusher.com';
+const DEFAULT_BLOCKED_PREFIX = 'Pusher Beams instance ID blocked';
+
+export function resolveSafePusherBeamsBaseUrl(
+  instanceId: string,
+  blockedPrefix = DEFAULT_BLOCKED_PREFIX
+): string {
+  if (!PUSHER_BEAMS_INSTANCE_ID_PATTERN.test(instanceId)) {
+    throw new Error(`${blockedPrefix}: Invalid instance ID format.`);
+  }
+
+  const expectedHostname = `${instanceId}${PUSHER_BEAMS_HOST_SUFFIX}`;
+  const baseUrl = `https://${expectedHostname}/publish_api/v1/instances/${encodeURIComponent(instanceId)}`;
+
+  let parsed: URL;
+
+  try {
+    parsed = assertSafeOutboundUrl(baseUrl);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      throw new Error(`${blockedPrefix}: ${err.message}`);
+    }
+    throw err;
+  }
+
+  if (parsed.hostname !== expectedHostname) {
+    throw new Error(`${blockedPrefix}: Invalid hostname.`);
+  }
+
+  return baseUrl;
+}

--- a/packages/providers/src/utils/safe-pusher-beams-url.ts
+++ b/packages/providers/src/utils/safe-pusher-beams-url.ts
@@ -26,7 +26,7 @@ export function resolveSafePusherBeamsBaseUrl(
     throw err;
   }
 
-  if (parsed.hostname !== expectedHostname) {
+  if (parsed.hostname !== expectedHostname.toLowerCase()) {
     throw new Error(`${blockedPrefix}: Invalid hostname.`);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validates `instanceId` charset and asserts the constructed Pusher Beams base URL hostname before use.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8178](https://linear.app/novu/issue/NV-8178/securitycritical-ssrf-pusher-beams-instanceid-is-interpolated-into)

<div><a href="https://cursor.com/agents/bc-587fd81c-337c-4b0d-8be7-0aca31dad75d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-587fd81c-337c-4b0d-8be7-0aca31dad75d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens Pusher Beams URL construction for configured instance IDs. The main changes are:

- Adds a safe base URL resolver for Pusher Beams.
- Validates instance IDs before interpolation into the hostname and path.
- Checks the parsed hostname before axios uses the URL.
- Adds tests for valid, mixed-case, and rejected instance IDs.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the base-commit contract-validation tests and verified hostname parsing changes and credential handling, with an exit code of 0.
- Ran the head-commit contract-validation tests and verified a valid baseURL and blocked invalid-ID errors, with the new helper contract exercised through provider construction and an exit code of 0.

<a href="https://app.greptile.com/trex/runs/13317601/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/providers/src/utils/safe-pusher-beams-url.ts | Adds validation, safe URL construction, SSRF error wrapping, and hostname verification for Pusher Beams. |
| packages/providers/src/lib/push/pusher-beams/pusher-beams.provider.ts | Uses the safe resolver when creating the Pusher Beams axios client. |
| packages/providers/src/utils/safe-pusher-beams-url.spec.ts | Covers accepted instance IDs and rejected unsafe instance ID inputs. |
| packages/providers/src/lib/push/pusher-beams/pusher-beams.provider.spec.ts | Updates fixtures to valid instance IDs and covers malicious instance ID rejection during provider construction. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(providers): compare Pusher Beams hos..."](https://github.com/novuhq/novu/commit/0a6114419942d9983927df9c5adf2d2a11222fa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41900909)</sub>

<!-- /greptile_comment -->