### PR TITLE
fix(agent-toolkit): remove eval from workflow payload schema conversion fixes NV-8177

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -123,7 +123,6 @@
   },
   "dependencies": {
     "@novu/api": "3.15.0",
-    "json-schema-to-zod": "^2.7.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/agent-toolkit/src/tools/workflows-as-tools.ts
+++ b/packages/agent-toolkit/src/tools/workflows-as-tools.ts
@@ -1,8 +1,8 @@
-import { z } from 'zod';
-import { jsonSchemaToZod } from 'json-schema-to-zod';
 import type { Novu } from '@novu/api';
+import { z } from 'zod';
 import { NovuTool } from '../core/novu-tool.js';
 import type { NovuToolDefinition, NovuToolkitConfig } from '../core/types.js';
+import { safeJsonSchemaToZod } from '../utils/safe-json-schema-to-zod.js';
 
 type WorkflowSummary = {
   workflowId: string;
@@ -17,11 +17,7 @@ function buildPayloadSchema(payloadSchema?: Record<string, unknown> | null): z.Z
   }
 
   try {
-    const zodCode = jsonSchemaToZod(payloadSchema as object);
-    // Using Function constructor to avoid bundler warnings about direct eval
-    // This is intentional: we need to dynamically evaluate generated Zod schema code
-    // from the workflow's JSON Schema definition at runtime.
-    const schema = new Function('z', `return ${zodCode}`)(z) as z.ZodTypeAny;
+    const schema = safeJsonSchemaToZod(payloadSchema);
 
     return schema.describe('Payload data to pass to the workflow.');
   } catch {
@@ -78,18 +74,13 @@ function workflowAsTool(workflow: WorkflowSummary): NovuToolDefinition {
   });
 }
 
-export async function createWorkflowTools(
-  client: Novu,
-  config: NovuToolkitConfig,
-): Promise<NovuToolDefinition[]> {
+export async function createWorkflowTools(client: Novu, config: NovuToolkitConfig): Promise<NovuToolDefinition[]> {
   const { tags, workflowIds } = config.workflows ?? {};
 
   const listResponse = await client.workflows.list({ tags });
   const workflows = listResponse.result.workflows ?? [];
 
-  const filtered = workflowIds
-    ? workflows.filter((w) => workflowIds.includes(w.workflowId))
-    : workflows;
+  const filtered = workflowIds ? workflows.filter((w) => workflowIds.includes(w.workflowId)) : workflows;
 
   const tools: NovuToolDefinition[] = [];
 
@@ -109,7 +100,7 @@ export async function createWorkflowTools(
         name: summary.name,
         description: undefined,
         payloadSchema,
-      }),
+      })
     );
   }
 

--- a/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
+++ b/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
@@ -204,25 +204,17 @@ function buildArray(schema: JsonSchema, root: JsonSchema, refStack: Set<string>)
   let arraySchema: ZodTypeAny;
 
   if (isTuple) {
-    const tupleItems = items
-      .filter((value): value is JsonSchema => typeof value === 'object' && value !== null)
-      .map((value) => buildSchema(value, root, refStack));
+    const tupleItems = items.map((item) => buildTupleItemSchema(item, root, refStack));
 
     if (tupleItems.length === 0) {
       arraySchema = z.array(z.unknown());
     } else {
-      const tupleSchema = z.tuple(tupleItems as [ZodTypeAny, ...ZodTypeAny[]]);
-
-      if (schema.additionalItems === false) {
-        arraySchema = tupleSchema;
-      } else if (typeof schema.additionalItems === 'object' && schema.additionalItems !== null) {
-        arraySchema = tupleSchema.rest(buildSchema(schema.additionalItems as JsonSchema, root, refStack));
-      } else {
-        arraySchema = tupleSchema.rest(z.unknown());
-      }
+      arraySchema = buildTupleArraySchema(tupleItems, schema, root, refStack);
     }
   } else if (typeof items === 'object' && items !== null) {
     arraySchema = z.array(buildSchema(items as JsonSchema, root, refStack));
+  } else if (items === false) {
+    arraySchema = z.array(z.never());
   } else {
     arraySchema = z.array(z.unknown());
   }
@@ -230,6 +222,74 @@ function buildArray(schema: JsonSchema, root: JsonSchema, refStack: Set<string>)
   arraySchema = applyArrayLengthConstraints(arraySchema, schema);
 
   return applyDescription(arraySchema, schema);
+}
+
+function buildTupleItemSchema(item: unknown, root: JsonSchema, refStack: Set<string>): ZodTypeAny {
+  if (item === false) {
+    return z.never();
+  }
+
+  if (item === true) {
+    return z.unknown();
+  }
+
+  if (typeof item === 'object' && item !== null) {
+    return buildSchema(item as JsonSchema, root, refStack);
+  }
+
+  return z.unknown();
+}
+
+function buildTupleArraySchema(
+  tupleItems: ZodTypeAny[],
+  schema: JsonSchema,
+  root: JsonSchema,
+  refStack: Set<string>
+): ZodTypeAny {
+  const prefixLength = tupleItems.length;
+  const additionalItemsSchema =
+    schema.additionalItems === false
+      ? null
+      : typeof schema.additionalItems === 'object' && schema.additionalItems !== null
+        ? buildSchema(schema.additionalItems as JsonSchema, root, refStack)
+        : z.unknown();
+
+  return z.array(z.unknown()).superRefine((value, ctx) => {
+    if (!Array.isArray(value)) {
+      return;
+    }
+
+    if (schema.additionalItems === false && value.length > prefixLength) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Array must contain at most ${prefixLength} element(s)`,
+      });
+    }
+
+    for (let index = 0; index < value.length && index < prefixLength; index++) {
+      const result = tupleItems[index].safeParse(value[index]);
+
+      if (!result.success) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Invalid element at index ${index}`,
+        });
+      }
+    }
+
+    if (additionalItemsSchema) {
+      for (let index = prefixLength; index < value.length; index++) {
+        const result = additionalItemsSchema.safeParse(value[index]);
+
+        if (!result.success) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `Invalid element at index ${index}`,
+          });
+        }
+      }
+    }
+  });
 }
 
 function applyArrayLengthConstraints(arraySchema: ZodTypeAny, schema: JsonSchema): ZodTypeAny {

--- a/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
+++ b/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
@@ -211,7 +211,15 @@ function buildArray(schema: JsonSchema, root: JsonSchema, refStack: Set<string>)
     if (tupleItems.length === 0) {
       arraySchema = z.array(z.unknown());
     } else {
-      arraySchema = z.tuple(tupleItems as [ZodTypeAny, ...ZodTypeAny[]]);
+      const tupleSchema = z.tuple(tupleItems as [ZodTypeAny, ...ZodTypeAny[]]);
+
+      if (schema.additionalItems === false) {
+        arraySchema = tupleSchema;
+      } else if (typeof schema.additionalItems === 'object' && schema.additionalItems !== null) {
+        arraySchema = tupleSchema.rest(buildSchema(schema.additionalItems as JsonSchema, root, refStack));
+      } else {
+        arraySchema = tupleSchema.rest(z.unknown());
+      }
     }
   } else if (typeof items === 'object' && items !== null) {
     arraySchema = z.array(buildSchema(items as JsonSchema, root, refStack));
@@ -219,17 +227,44 @@ function buildArray(schema: JsonSchema, root: JsonSchema, refStack: Set<string>)
     arraySchema = z.array(z.unknown());
   }
 
-  if (!isTuple) {
-    if (typeof schema.minItems === 'number') {
-      arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).min(schema.minItems);
-    }
-
-    if (typeof schema.maxItems === 'number') {
-      arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).max(schema.maxItems);
-    }
-  }
+  arraySchema = applyArrayLengthConstraints(arraySchema, schema);
 
   return applyDescription(arraySchema, schema);
+}
+
+function applyArrayLengthConstraints(arraySchema: ZodTypeAny, schema: JsonSchema): ZodTypeAny {
+  const minItems = typeof schema.minItems === 'number' ? schema.minItems : undefined;
+  const maxItems = typeof schema.maxItems === 'number' ? schema.maxItems : undefined;
+
+  if (minItems === undefined && maxItems === undefined) {
+    return arraySchema;
+  }
+
+  return arraySchema.superRefine((value, ctx) => {
+    if (!Array.isArray(value)) {
+      return;
+    }
+
+    if (minItems !== undefined && value.length < minItems) {
+      ctx.addIssue({
+        code: 'too_small',
+        origin: 'array',
+        minimum: minItems,
+        inclusive: true,
+        message: `Array must contain at least ${minItems} element(s)`,
+      });
+    }
+
+    if (maxItems !== undefined && value.length > maxItems) {
+      ctx.addIssue({
+        code: 'too_big',
+        origin: 'array',
+        maximum: maxItems,
+        inclusive: true,
+        message: `Array must contain at most ${maxItems} element(s)`,
+      });
+    }
+  });
 }
 
 function buildString(schema: JsonSchema): ZodTypeAny {

--- a/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
+++ b/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
@@ -5,24 +5,40 @@ type JsonSchema = Record<string, unknown>;
 const SUPPORTED_STRING_FORMATS = new Set(['email', 'uri', 'uuid', 'date-time', 'date', 'time']);
 
 export function safeJsonSchemaToZod(schema: JsonSchema): ZodTypeAny {
-  return buildSchema(schema);
+  return buildSchema(schema, schema);
 }
 
-function buildSchema(schema: JsonSchema): ZodTypeAny {
-  if ('$ref' in schema) {
-    return fallbackSchema();
+function buildSchema(schema: JsonSchema, root: JsonSchema, refStack: Set<string> = new Set()): ZodTypeAny {
+  if ('$ref' in schema && typeof schema.$ref === 'string') {
+    if (refStack.has(schema.$ref)) {
+      return fallbackSchema();
+    }
+
+    const resolved = resolveRef(schema.$ref, root);
+
+    if (!resolved) {
+      return fallbackSchema();
+    }
+
+    refStack.add(schema.$ref);
+
+    const resolvedSchema = buildSchema(resolved, root, refStack);
+
+    refStack.delete(schema.$ref);
+
+    return resolvedSchema;
   }
 
   if (Array.isArray(schema.allOf)) {
-    return buildAllOf(schema.allOf);
+    return buildAllOf(schema.allOf, root, refStack);
   }
 
   if (Array.isArray(schema.anyOf)) {
-    return buildUnion(schema.anyOf);
+    return buildUnion(schema.anyOf, root, refStack);
   }
 
   if (Array.isArray(schema.oneOf)) {
-    return buildUnion(schema.oneOf);
+    return buildUnion(schema.oneOf, root, refStack);
   }
 
   if (Array.isArray(schema.enum)) {
@@ -42,7 +58,7 @@ function buildSchema(schema: JsonSchema): ZodTypeAny {
       return z.null();
     }
 
-    const variants = nonNullTypes.map((value) => buildSchema({ ...schema, type: value }));
+    const variants = nonNullTypes.map((value) => buildSchema({ ...schema, type: value }, root, refStack));
     const unionSchema =
       variants.length === 1 ? variants[0] : z.union(variants as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
 
@@ -54,11 +70,11 @@ function buildSchema(schema: JsonSchema): ZodTypeAny {
   }
 
   if (type === 'object' || schema.properties) {
-    return buildObject(schema);
+    return buildObject(schema, root, refStack);
   }
 
   if (type === 'array') {
-    return buildArray(schema);
+    return buildArray(schema, root, refStack);
   }
 
   if (type === 'string') {
@@ -80,10 +96,41 @@ function buildSchema(schema: JsonSchema): ZodTypeAny {
   return fallbackSchema();
 }
 
-function buildAllOf(schemas: unknown[]): ZodTypeAny {
+function resolveRef(ref: string, root: JsonSchema): JsonSchema | null {
+  if (!ref.startsWith('#/')) {
+    return null;
+  }
+
+  const parts = ref.slice(2).split('/');
+  let current: unknown = root;
+
+  for (const part of parts) {
+    const key = part.replace(/~1/g, '/').replace(/~0/g, '~');
+
+    if (typeof current !== 'object' || current === null) {
+      return null;
+    }
+
+    const record = current as Record<string, unknown>;
+
+    if (!(key in record)) {
+      return null;
+    }
+
+    current = record[key];
+  }
+
+  if (typeof current === 'object' && current !== null) {
+    return current as JsonSchema;
+  }
+
+  return null;
+}
+
+function buildAllOf(schemas: unknown[], root: JsonSchema, refStack: Set<string>): ZodTypeAny {
   const zodSchemas = schemas
     .filter((value): value is JsonSchema => typeof value === 'object' && value !== null)
-    .map((value) => buildSchema(value));
+    .map((value) => buildSchema(value, root, refStack));
 
   if (zodSchemas.length === 0) {
     return fallbackSchema();
@@ -92,10 +139,10 @@ function buildAllOf(schemas: unknown[]): ZodTypeAny {
   return zodSchemas.reduce((left, right) => z.intersection(left, right));
 }
 
-function buildUnion(schemas: unknown[]): ZodTypeAny {
+function buildUnion(schemas: unknown[], root: JsonSchema, refStack: Set<string>): ZodTypeAny {
   const zodSchemas = schemas
     .filter((value): value is JsonSchema => typeof value === 'object' && value !== null)
-    .map((value) => buildSchema(value));
+    .map((value) => buildSchema(value, root, refStack));
 
   if (zodSchemas.length === 0) {
     return fallbackSchema();
@@ -122,13 +169,13 @@ function buildEnum(values: unknown[]): ZodTypeAny {
   return z.union(literals as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
 }
 
-function buildObject(schema: JsonSchema): ZodTypeAny {
+function buildObject(schema: JsonSchema, root: JsonSchema, refStack: Set<string>): ZodTypeAny {
   const properties = (schema.properties as Record<string, JsonSchema> | undefined) ?? {};
   const required = new Set(Array.isArray(schema.required) ? schema.required : []);
   const shape: Record<string, ZodTypeAny> = {};
 
   for (const [key, propertySchema] of Object.entries(properties)) {
-    let property = buildSchema(propertySchema);
+    let property = buildSchema(propertySchema, root, refStack);
 
     if (!required.has(key)) {
       property = property.optional();
@@ -143,22 +190,23 @@ function buildObject(schema: JsonSchema): ZodTypeAny {
     objectSchema = (objectSchema as z.ZodObject<z.ZodRawShape>).strict();
   } else if (typeof schema.additionalProperties === 'object' && schema.additionalProperties !== null) {
     objectSchema = (objectSchema as z.ZodObject<z.ZodRawShape>).catchall(
-      buildSchema(schema.additionalProperties as JsonSchema)
+      buildSchema(schema.additionalProperties as JsonSchema, root, refStack)
     );
   }
 
   return applyDescription(objectSchema, schema);
 }
 
-function buildArray(schema: JsonSchema): ZodTypeAny {
+function buildArray(schema: JsonSchema, root: JsonSchema, refStack: Set<string>): ZodTypeAny {
   const items = schema.items;
+  const isTuple = Array.isArray(items);
 
   let arraySchema: ZodTypeAny;
 
-  if (Array.isArray(items)) {
+  if (isTuple) {
     const tupleItems = items
       .filter((value): value is JsonSchema => typeof value === 'object' && value !== null)
-      .map((value) => buildSchema(value));
+      .map((value) => buildSchema(value, root, refStack));
 
     if (tupleItems.length === 0) {
       arraySchema = z.array(z.unknown());
@@ -166,17 +214,19 @@ function buildArray(schema: JsonSchema): ZodTypeAny {
       arraySchema = z.tuple(tupleItems as [ZodTypeAny, ...ZodTypeAny[]]);
     }
   } else if (typeof items === 'object' && items !== null) {
-    arraySchema = z.array(buildSchema(items as JsonSchema));
+    arraySchema = z.array(buildSchema(items as JsonSchema, root, refStack));
   } else {
     arraySchema = z.array(z.unknown());
   }
 
-  if (typeof schema.minItems === 'number') {
-    arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).min(schema.minItems);
-  }
+  if (!isTuple) {
+    if (typeof schema.minItems === 'number') {
+      arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).min(schema.minItems);
+    }
 
-  if (typeof schema.maxItems === 'number') {
-    arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).max(schema.maxItems);
+    if (typeof schema.maxItems === 'number') {
+      arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).max(schema.maxItems);
+    }
   }
 
   return applyDescription(arraySchema, schema);
@@ -197,7 +247,7 @@ function buildString(schema: JsonSchema): ZodTypeAny {
     try {
       stringSchema = (stringSchema as z.ZodString).regex(new RegExp(schema.pattern));
     } catch {
-      return fallbackSchema();
+      // Keep an unconstrained string when the workflow pattern is invalid.
     }
   }
 

--- a/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
+++ b/packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts
@@ -1,0 +1,257 @@
+import { type ZodTypeAny, z } from 'zod';
+
+type JsonSchema = Record<string, unknown>;
+
+const SUPPORTED_STRING_FORMATS = new Set(['email', 'uri', 'uuid', 'date-time', 'date', 'time']);
+
+export function safeJsonSchemaToZod(schema: JsonSchema): ZodTypeAny {
+  return buildSchema(schema);
+}
+
+function buildSchema(schema: JsonSchema): ZodTypeAny {
+  if ('$ref' in schema) {
+    return fallbackSchema();
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    return buildAllOf(schema.allOf);
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    return buildUnion(schema.anyOf);
+  }
+
+  if (Array.isArray(schema.oneOf)) {
+    return buildUnion(schema.oneOf);
+  }
+
+  if (Array.isArray(schema.enum)) {
+    return buildEnum(schema.enum);
+  }
+
+  if ('const' in schema) {
+    return z.literal(schema.const as never);
+  }
+
+  const type = schema.type;
+
+  if (Array.isArray(type)) {
+    const nonNullTypes = type.filter((value) => value !== 'null');
+
+    if (nonNullTypes.length === 0) {
+      return z.null();
+    }
+
+    const variants = nonNullTypes.map((value) => buildSchema({ ...schema, type: value }));
+    const unionSchema =
+      variants.length === 1 ? variants[0] : z.union(variants as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
+
+    if (type.includes('null')) {
+      return unionSchema.nullable();
+    }
+
+    return unionSchema;
+  }
+
+  if (type === 'object' || schema.properties) {
+    return buildObject(schema);
+  }
+
+  if (type === 'array') {
+    return buildArray(schema);
+  }
+
+  if (type === 'string') {
+    return buildString(schema);
+  }
+
+  if (type === 'number' || type === 'integer') {
+    return buildNumber(schema, type === 'integer');
+  }
+
+  if (type === 'boolean') {
+    return applyDescription(z.boolean(), schema);
+  }
+
+  if (type === 'null') {
+    return applyDescription(z.null(), schema);
+  }
+
+  return fallbackSchema();
+}
+
+function buildAllOf(schemas: unknown[]): ZodTypeAny {
+  const zodSchemas = schemas
+    .filter((value): value is JsonSchema => typeof value === 'object' && value !== null)
+    .map((value) => buildSchema(value));
+
+  if (zodSchemas.length === 0) {
+    return fallbackSchema();
+  }
+
+  return zodSchemas.reduce((left, right) => z.intersection(left, right));
+}
+
+function buildUnion(schemas: unknown[]): ZodTypeAny {
+  const zodSchemas = schemas
+    .filter((value): value is JsonSchema => typeof value === 'object' && value !== null)
+    .map((value) => buildSchema(value));
+
+  if (zodSchemas.length === 0) {
+    return fallbackSchema();
+  }
+
+  if (zodSchemas.length === 1) {
+    return zodSchemas[0];
+  }
+
+  return z.union(zodSchemas as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
+}
+
+function buildEnum(values: unknown[]): ZodTypeAny {
+  const literals = values.map((value) => z.literal(value as never));
+
+  if (literals.length === 0) {
+    return fallbackSchema();
+  }
+
+  if (literals.length === 1) {
+    return literals[0];
+  }
+
+  return z.union(literals as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
+}
+
+function buildObject(schema: JsonSchema): ZodTypeAny {
+  const properties = (schema.properties as Record<string, JsonSchema> | undefined) ?? {};
+  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+  const shape: Record<string, ZodTypeAny> = {};
+
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    let property = buildSchema(propertySchema);
+
+    if (!required.has(key)) {
+      property = property.optional();
+    }
+
+    shape[key] = property;
+  }
+
+  let objectSchema: ZodTypeAny = z.object(shape);
+
+  if (schema.additionalProperties === false) {
+    objectSchema = (objectSchema as z.ZodObject<z.ZodRawShape>).strict();
+  } else if (typeof schema.additionalProperties === 'object' && schema.additionalProperties !== null) {
+    objectSchema = (objectSchema as z.ZodObject<z.ZodRawShape>).catchall(
+      buildSchema(schema.additionalProperties as JsonSchema)
+    );
+  }
+
+  return applyDescription(objectSchema, schema);
+}
+
+function buildArray(schema: JsonSchema): ZodTypeAny {
+  const items = schema.items;
+
+  let arraySchema: ZodTypeAny;
+
+  if (Array.isArray(items)) {
+    const tupleItems = items
+      .filter((value): value is JsonSchema => typeof value === 'object' && value !== null)
+      .map((value) => buildSchema(value));
+
+    if (tupleItems.length === 0) {
+      arraySchema = z.array(z.unknown());
+    } else {
+      arraySchema = z.tuple(tupleItems as [ZodTypeAny, ...ZodTypeAny[]]);
+    }
+  } else if (typeof items === 'object' && items !== null) {
+    arraySchema = z.array(buildSchema(items as JsonSchema));
+  } else {
+    arraySchema = z.array(z.unknown());
+  }
+
+  if (typeof schema.minItems === 'number') {
+    arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).min(schema.minItems);
+  }
+
+  if (typeof schema.maxItems === 'number') {
+    arraySchema = (arraySchema as z.ZodArray<ZodTypeAny>).max(schema.maxItems);
+  }
+
+  return applyDescription(arraySchema, schema);
+}
+
+function buildString(schema: JsonSchema): ZodTypeAny {
+  let stringSchema: ZodTypeAny = z.string();
+
+  if (typeof schema.minLength === 'number') {
+    stringSchema = (stringSchema as z.ZodString).min(schema.minLength);
+  }
+
+  if (typeof schema.maxLength === 'number') {
+    stringSchema = (stringSchema as z.ZodString).max(schema.maxLength);
+  }
+
+  if (typeof schema.pattern === 'string') {
+    try {
+      stringSchema = (stringSchema as z.ZodString).regex(new RegExp(schema.pattern));
+    } catch {
+      return fallbackSchema();
+    }
+  }
+
+  if (typeof schema.format === 'string' && SUPPORTED_STRING_FORMATS.has(schema.format)) {
+    stringSchema = applyStringFormat(stringSchema as z.ZodString, schema.format);
+  }
+
+  return applyDescription(stringSchema, schema);
+}
+
+function applyStringFormat(stringSchema: z.ZodString, format: string): z.ZodString {
+  switch (format) {
+    case 'email':
+      return stringSchema.email();
+    case 'uri':
+      return stringSchema.url();
+    case 'uuid':
+      return stringSchema.uuid();
+    case 'date-time':
+      return stringSchema.datetime();
+    case 'date':
+      return stringSchema.date();
+    case 'time':
+      return stringSchema.time();
+    default: {
+      const _exhaustive: never = format;
+
+      return stringSchema;
+    }
+  }
+}
+
+function buildNumber(schema: JsonSchema, isInteger: boolean): ZodTypeAny {
+  let numberSchema: ZodTypeAny = isInteger ? z.number().int() : z.number();
+
+  if (typeof schema.minimum === 'number') {
+    numberSchema = (numberSchema as z.ZodNumber).min(schema.minimum);
+  }
+
+  if (typeof schema.maximum === 'number') {
+    numberSchema = (numberSchema as z.ZodNumber).max(schema.maximum);
+  }
+
+  return applyDescription(numberSchema, schema);
+}
+
+function applyDescription(schema: ZodTypeAny, jsonSchema: JsonSchema): ZodTypeAny {
+  if (typeof jsonSchema.description === 'string' && jsonSchema.description.length > 0) {
+    return schema.describe(jsonSchema.description);
+  }
+
+  return schema;
+}
+
+function fallbackSchema(): ZodTypeAny {
+  return z.record(z.string(), z.unknown());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3407,9 +3407,6 @@ importers:
       '@novu/api':
         specifier: 3.15.0
         version: 3.15.0
-      json-schema-to-zod:
-        specifier: ^2.7.0
-        version: 2.7.0
       zod:
         specifier: ^4.0.0
         version: 4.3.5
@@ -21119,10 +21116,6 @@ packages:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
-  json-schema-to-zod@2.7.0:
-    resolution: {integrity: sha512-eW59l3NQ6sa3HcB+Ahf7pP6iGU7MY4we5JsPqXQ2ZcIPF8QxSg/lkY8lN0Js/AG0NjMbk+nZGUfHlceiHF+bwQ==}
-    hasBin: true
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -32035,7 +32028,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       kysely: 0.28.17
       nanostores: 1.2.0
@@ -45827,7 +45820,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.6
       jose: 6.1.3
       kysely: 0.28.17
@@ -45845,15 +45838,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.2(zod@4.3.5):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:
@@ -51836,8 +51820,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.3
       ts-algebra: 2.0.0
-
-  json-schema-to-zod@2.7.0: {}
 
   json-schema-traverse@0.4.1: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes `new Function`/`json-schema-to-zod` from workflow payload schema handling and builds Zod schemas programmatically instead.

**Test plan**
- `pnpm --filter @novu/agent-toolkit build`
- Verified malicious payload schema strings do not execute code during conversion
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8177](https://linear.app/novu/issue/NV-8177/securitycritical-rce-workflow-payload-schema-is-evald-via-new-function)

<div><a href="https://cursor.com/agents/bc-79e12fc4-f144-4f28-9859-44b443e50abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79e12fc4-f144-4f28-9859-44b443e50abb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes runtime evaluation from workflow payload schema conversion. The main changes are:

- Replaces `json-schema-to-zod` and `new Function` with a local converter.
- Adds programmatic JSON Schema handling for objects, arrays, refs, strings, numbers, enums, and unions.
- Removes the unused schema conversion dependency from package metadata and the lockfile.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The eval-based schema conversion path was removed, and the converter handles the reviewed tuple, ref, and invalid-pattern paths.

No blocking issue cleared the follow-up review scope.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The safe-conversion validation was run and compared between before and after runs, and the after run shows successful tool construction and validation with head commit 6fce5d41..., validationStatus 200 OK, and validationSuccess true, with sentinelExists false.
- The after run confirms that the safeJsonSchemaToZod path does not evaluate the malicious schema string and keeps the tool construction functional.
- The workflow payload validation was exercised before and after the change; both runs rejected missing required email and invalid constraints, and the after run additionally rejected the nested $defs/$ref missing zip case.
- Both runs exited with code 0, indicating no crashes or regressions in the representative validation scenarios.

<a href="https://app.greptile.com/trex/runs/13318558/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/agent-toolkit/src/tools/workflows-as-tools.ts | Switches workflow payload schema conversion to the safe local converter. |
| packages/agent-toolkit/src/utils/safe-json-schema-to-zod.ts | Adds the programmatic JSON Schema-to-Zod converter used by workflow tools. |
| packages/agent-toolkit/package.json | Removes the unused `json-schema-to-zod` dependency. |
| pnpm-lock.yaml | Updates dependency resolution after removing the converter package. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(agent-toolkit): handle boolean tuple..."](https://github.com/novuhq/novu/commit/6fce5d41fdc80001717387287c1532dba5fc3b9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41901098)</sub>

<!-- /greptile_comment -->