### PR TITLE
fix(api-service): scope env variable writes and environment deletes to API key environment fixes NV-8182

### DIFF
--- a/apps/api/src/app/environment-variables/e2e/api-key-environment-scope.e2e.ts
+++ b/apps/api/src/app/environment-variables/e2e/api-key-environment-scope.e2e.ts
@@ -1,0 +1,106 @@
+import { EnvironmentRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('Environment Variables API key environment scope - /environment-variables #novu-v2', () => {
+  let session: UserSession;
+  let devEnvironmentId: string;
+  let prodEnvironmentId: string;
+  const environmentRepository = new EnvironmentRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    devEnvironmentId = session.environment._id;
+    const prod = await environmentRepository.findOne({
+      _parentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    if (!prod) {
+      throw new Error('Production environment not found for test session');
+    }
+
+    prodEnvironmentId = prod._id;
+  });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid creating variables for a different environment via API key', async () => {
+      const { body } = await session.testAgent
+        .post('/v1/environment-variables')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({
+          key: 'CROSS_ENV_CREATE',
+          values: [{ _environmentId: prodEnvironmentId, value: 'prod-only-value' }],
+        });
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+    });
+
+    it('should allow creating variables for the API key environment via API key', async () => {
+      const {
+        body: { data },
+      } = await session.testAgent
+        .post('/v1/environment-variables')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({
+          key: 'SAME_ENV_CREATE',
+          values: [{ _environmentId: devEnvironmentId, value: 'dev-value' }],
+        });
+
+      expect(data.key).to.equal('SAME_ENV_CREATE');
+      expect(data.values).to.have.length(1);
+      expect(data.values[0]._environmentId).to.equal(devEnvironmentId);
+    });
+
+    it('should forbid updating variables for a different environment via API key', async () => {
+      const {
+        body: { data: created },
+      } = await session.testAgent.post('/v1/environment-variables').send({
+        key: 'CROSS_ENV_UPDATE',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-value' },
+        ],
+      });
+
+      expect(created.key).to.equal('CROSS_ENV_UPDATE');
+
+      const { body } = await session.testAgent
+        .patch('/v1/environment-variables/CROSS_ENV_UPDATE')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({
+          values: [{ _environmentId: prodEnvironmentId, value: 'hijacked-prod-value' }],
+        });
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+    });
+
+    it('should allow bearer auth to update variables across environments in the same org', async () => {
+      const {
+        body: { data: created },
+      } = await session.testAgent.post('/v1/environment-variables').send({
+        key: 'BEARER_CROSS_ENV_UPDATE',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-value' },
+        ],
+      });
+
+      expect(created.key).to.equal('BEARER_CROSS_ENV_UPDATE');
+
+      const {
+        body: { data: updated },
+      } = await session.testAgent.patch('/v1/environment-variables/BEARER_CROSS_ENV_UPDATE').send({
+        values: [{ _environmentId: prodEnvironmentId, value: 'updated-prod-value' }],
+      });
+
+      expect(updated.values).to.have.length(2);
+      expect(updated.values.some((value: { _environmentId: string }) => value._environmentId === prodEnvironmentId)).to
+        .be.true;
+    });
+  });
+});

--- a/apps/api/src/app/environment-variables/e2e/api-key-environment-scope.e2e.ts
+++ b/apps/api/src/app/environment-variables/e2e/api-key-environment-scope.e2e.ts
@@ -79,6 +79,49 @@ describe('Environment Variables API key environment scope - /environment-variabl
       expect(body.message).to.contain('is scoped to a single environment');
     });
 
+    it('should forbid updating shared variable metadata without values via API key', async () => {
+      const {
+        body: { data: created },
+      } = await session.testAgent.post('/v1/environment-variables').send({
+        key: 'METADATA_SCOPE_TEST',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-value' },
+        ],
+      });
+
+      expect(created.key).to.equal('METADATA_SCOPE_TEST');
+
+      const { body } = await session.testAgent
+        .patch('/v1/environment-variables/METADATA_SCOPE_TEST')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({
+          key: 'RENAMED_BY_API_KEY',
+        });
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('cannot update shared environment variable metadata');
+    });
+
+    it('should allow bearer auth to update shared variable metadata', async () => {
+      const {
+        body: { data: created },
+      } = await session.testAgent.post('/v1/environment-variables').send({
+        key: 'BEARER_METADATA_UPDATE',
+        values: [{ _environmentId: devEnvironmentId, value: 'dev-value' }],
+      });
+
+      expect(created.key).to.equal('BEARER_METADATA_UPDATE');
+
+      const {
+        body: { data: updated },
+      } = await session.testAgent.patch('/v1/environment-variables/BEARER_METADATA_UPDATE').send({
+        key: 'BEARER_METADATA_RENAMED',
+      });
+
+      expect(updated.key).to.equal('BEARER_METADATA_RENAMED');
+    });
+
     it('should allow bearer auth to update variables across environments in the same org', async () => {
       const {
         body: { data: created },

--- a/apps/api/src/app/environment-variables/environment-variables.controller.ts
+++ b/apps/api/src/app/environment-variables/environment-variables.controller.ts
@@ -18,6 +18,7 @@ import { ApiRateLimitCategoryEnum, PermissionsEnum, UserSessionData } from '@nov
 import { ErrorDto } from '../../error-dto';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { ExternalApiAccessible } from '../auth/framework/external-api.decorator';
+import { isEnvironmentScopedAuthScheme } from '../shared/utils/auth.utils';
 import { ThrottlerCategory } from '../rate-limiting/guards';
 import {
   ApiCommonResponses,
@@ -167,14 +168,18 @@ export class EnvironmentVariablesController {
     @UserSession() user: UserSessionData,
     @Body() body: CreateEnvironmentVariableRequestDto
   ): Promise<EnvironmentVariableResponseDto> {
+    const restrictToUserEnvironment = isEnvironmentScopedAuthScheme(user.scheme);
+
     return this.createEnvironmentVariableUsecase.execute(
       CreateEnvironmentVariableCommand.create({
         organizationId: user.organizationId,
+        environmentId: user.environmentId,
         userId: user._id,
         key: body.key,
         type: body.type,
         isSecret: body.isSecret,
         values: body.values,
+        restrictToUserEnvironment,
       })
     );
   }
@@ -204,15 +209,19 @@ export class EnvironmentVariablesController {
     @Param('variableKey') variableKey: string,
     @Body() body: UpdateEnvironmentVariableRequestDto
   ): Promise<EnvironmentVariableResponseDto> {
+    const restrictToUserEnvironment = isEnvironmentScopedAuthScheme(user.scheme);
+
     return this.updateEnvironmentVariableUsecase.execute(
       UpdateEnvironmentVariableCommand.create({
         organizationId: user.organizationId,
+        environmentId: user.environmentId,
         userId: user._id,
         variableKey,
         key: body.key,
         type: body.type,
         isSecret: body.isSecret,
         values: body.values,
+        restrictToUserEnvironment,
       })
     );
   }

--- a/apps/api/src/app/environment-variables/usecases/create-environment-variable/create-environment-variable.command.ts
+++ b/apps/api/src/app/environment-variables/usecases/create-environment-variable/create-environment-variable.command.ts
@@ -1,7 +1,16 @@
 import { OrganizationLevelWithUserCommand } from '@novu/application-generic';
 import { EnvironmentVariableType } from '@novu/shared';
 import { Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsEnum, IsNotEmpty, IsOptional, IsString, Matches, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
 
 export class EnvironmentVariableValueCommand {
   @IsString()
@@ -31,4 +40,8 @@ export class CreateEnvironmentVariableCommand extends OrganizationLevelWithUserC
   @Type(() => EnvironmentVariableValueCommand)
   @IsOptional()
   values?: EnvironmentVariableValueCommand[];
+
+  @IsBoolean()
+  @IsOptional()
+  restrictToUserEnvironment?: boolean;
 }

--- a/apps/api/src/app/environment-variables/usecases/create-environment-variable/create-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/create-environment-variable/create-environment-variable.usecase.ts
@@ -32,7 +32,11 @@ export class CreateEnvironmentVariable {
     await validateEnvironmentVariableValues(
       this.environmentRepository,
       command.organizationId,
-      incomingValues
+      incomingValues,
+      {
+        restrictToUserEnvironment: command.restrictToUserEnvironment,
+        userEnvironmentId: command.environmentId,
+      }
     );
 
     const maskedValue = incomingValues.find((v) => v.value === SECRET_MASK);

--- a/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.command.ts
+++ b/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.command.ts
@@ -27,4 +27,8 @@ export class UpdateEnvironmentVariableCommand extends OrganizationLevelWithUserC
   @Type(() => EnvironmentVariableValueCommand)
   @IsOptional()
   values?: EnvironmentVariableValueCommand[];
+
+  @IsBoolean()
+  @IsOptional()
+  restrictToUserEnvironment?: boolean;
 }

--- a/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
@@ -40,7 +40,11 @@ export class UpdateEnvironmentVariable {
       await validateEnvironmentVariableValues(
         this.environmentRepository,
         command.organizationId,
-        command.values
+        command.values,
+        {
+          restrictToUserEnvironment: command.restrictToUserEnvironment,
+          userEnvironmentId: command.environmentId,
+        }
       );
 
       // Defense in depth: never let the public secret mask string be persisted as an

--- a/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { encryptSecret } from '@novu/application-generic';
 import { EnvironmentRepository, EnvironmentVariableRepository } from '@novu/dal';
 import { SECRET_MASK } from '@novu/shared';
@@ -22,6 +22,16 @@ export class UpdateEnvironmentVariable {
 
     if (!existing) {
       throw new NotFoundException(`Environment variable with key "${command.variableKey}" not found`);
+    }
+
+    if (
+      command.restrictToUserEnvironment &&
+      (command.key !== undefined || command.type !== undefined || command.isSecret !== undefined)
+    ) {
+      throw new ForbiddenException(
+        'This authentication scheme is scoped to a single environment and cannot update shared environment variable metadata. ' +
+          'Only per-environment values can be updated, or authenticate with a session token.'
+      );
     }
 
     const updateBody: Record<string, unknown> = {};

--- a/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.spec.ts
+++ b/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { EnvironmentRepository } from '@novu/dal';
 import { expect } from 'chai';
 import { stub } from 'sinon';
@@ -58,5 +58,25 @@ describe('validateEnvironmentVariableValues', () => {
       expect(error).to.be.instanceOf(NotFoundException);
       expect(error.message).to.equal('Environment with id foreign-env-id not found');
     }
+  });
+
+  it('should reject cross-environment values when scoped to the authenticated environment', async () => {
+    try {
+      await validateEnvironmentVariableValues(
+        environmentRepositoryMock as unknown as EnvironmentRepository,
+        organizationId,
+        [{ _environmentId: 'env-b', value: 'value' }],
+        {
+          restrictToUserEnvironment: true,
+          userEnvironmentId: 'env-a',
+        }
+      );
+      throw new Error('Should not reach here');
+    } catch (error) {
+      expect(error).to.be.instanceOf(ForbiddenException);
+      expect(error.message).to.contain('is scoped to a single environment');
+    }
+
+    expect(environmentRepositoryMock.findByIdAndOrganization.called).to.equal(false);
   });
 });

--- a/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.ts
+++ b/apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.ts
@@ -1,17 +1,34 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { EnvironmentRepository } from '@novu/dal';
 
 type EnvironmentVariableValueInput = {
   _environmentId: string;
 };
 
+type ValidateEnvironmentVariableValuesOptions = {
+  restrictToUserEnvironment?: boolean;
+  userEnvironmentId?: string;
+};
+
 export async function validateEnvironmentVariableValues(
   environmentRepository: EnvironmentRepository,
   organizationId: string,
-  values: EnvironmentVariableValueInput[] | undefined
+  values: EnvironmentVariableValueInput[] | undefined,
+  options?: ValidateEnvironmentVariableValuesOptions
 ): Promise<void> {
   if (!values?.length) {
     return;
+  }
+
+  if (options?.restrictToUserEnvironment && options.userEnvironmentId) {
+    const crossEnvironmentValue = values.find((value) => value._environmentId !== options.userEnvironmentId);
+
+    if (crossEnvironmentValue) {
+      throw new ForbiddenException(
+        'This authentication scheme is scoped to a single environment and cannot target a different `_environmentId`. ' +
+          'Use credentials from the target environment, or authenticate with a session token.'
+      );
+    }
   }
 
   const uniqueEnvironmentIds = [...new Set(values.map((value) => value._environmentId))];

--- a/apps/api/src/app/environments-v1/e2e/delete-environment-api-key-scope.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/delete-environment-api-key-scope.e2e.ts
@@ -1,0 +1,46 @@
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('Delete Environment API key environment scope - DELETE /environments/:environmentId #novu-v2', () => {
+  let session: UserSession;
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    await session.updateOrganizationServiceLevel(ApiServiceLevelEnum.BUSINESS);
+  });
+
+  it('should forbid deleting a sibling environment via API key', async () => {
+    const {
+      body: { data: createdEnv },
+    } = await session.testAgent.post('/v1/environments').send({
+      name: 'Sibling Env To Delete',
+      color: '#ff0000',
+    });
+
+    expect(createdEnv._id, 'Expected custom environment to be created').to.exist;
+
+    const { body } = await session.testAgent
+      .delete(`/v1/environments/${createdEnv._id}`)
+      .set('authorization', `ApiKey ${session.apiKey}`);
+
+    expect(body.statusCode).to.equal(403);
+    expect(body.message).to.contain('is scoped to a single environment');
+  });
+
+  it('should allow bearer auth to delete a sibling environment in the same org', async () => {
+    const {
+      body: { data: createdEnv },
+    } = await session.testAgent.post('/v1/environments').send({
+      name: 'Bearer Deletable Env',
+      color: '#00ff00',
+    });
+
+    expect(createdEnv._id, 'Expected custom environment to be created').to.exist;
+
+    const { status } = await session.testAgent.delete(`/v1/environments/${createdEnv._id}`);
+
+    expect(status).to.equal(200);
+  });
+});

--- a/apps/api/src/app/environments-v1/environments-v1.controller.ts
+++ b/apps/api/src/app/environments-v1/environments-v1.controller.ts
@@ -32,6 +32,7 @@ import {
 import { ErrorDto } from '../../error-dto';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { ExternalApiAccessible } from '../auth/framework/external-api.decorator';
+import { isEnvironmentScopedAuthScheme } from '../shared/utils/auth.utils';
 import { ApiKey } from '../shared/dtos/api-key';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
@@ -286,6 +287,8 @@ export class EnvironmentsControllerV1 {
         userId: user._id,
         organizationId: user.organizationId,
         environmentId,
+        userEnvironmentId: user.environmentId,
+        restrictToUserEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
   }

--- a/apps/api/src/app/environments-v1/usecases/delete-environment/delete-environment.command.ts
+++ b/apps/api/src/app/environments-v1/usecases/delete-environment/delete-environment.command.ts
@@ -1,3 +1,12 @@
+import { IsBoolean, IsMongoId, IsOptional } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class DeleteEnvironmentCommand extends EnvironmentWithUserCommand {}
+export class DeleteEnvironmentCommand extends EnvironmentWithUserCommand {
+  @IsOptional()
+  @IsBoolean()
+  restrictToUserEnvironment?: boolean;
+
+  @IsOptional()
+  @IsMongoId()
+  userEnvironmentId?: string;
+}

--- a/apps/api/src/app/environments-v1/usecases/delete-environment/delete-environment.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/delete-environment/delete-environment.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { EnvironmentEnum, PROTECTED_ENVIRONMENTS } from '@novu/shared';
 import { RemoveIntegrationCommand } from '../../../integrations/usecases/remove-integration/remove-integration.command';
@@ -14,6 +14,17 @@ export class DeleteEnvironment {
   ) {}
 
   async execute(command: DeleteEnvironmentCommand): Promise<void> {
+    if (
+      command.restrictToUserEnvironment &&
+      command.userEnvironmentId &&
+      command.environmentId !== command.userEnvironmentId
+    ) {
+      throw new ForbiddenException(
+        'This authentication scheme is scoped to a single environment and cannot delete a different environment. ' +
+          'Use credentials from the target environment, or authenticate with a session token.'
+      );
+    }
+
     const environment = await this.environmentRepository.findOne({
       _id: command.environmentId,
       _organizationId: command.organizationId,

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -4,7 +4,6 @@ import {
   ClassSerializerInterceptor,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   HttpCode,
   HttpStatus,
@@ -56,7 +55,7 @@ import { KeylessAccessible } from '../shared/framework/swagger/keyless.security'
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { UserSession } from '../shared/framework/user.decorator';
 import { CONNECTION_RESULT_CSP } from '../shared/html/connection-result-page';
-import { isEnvironmentScopedAuthScheme } from '../shared/utils/auth.utils';
+import { isEnvironmentScopedAuthScheme, assertEnvironmentScopedAccess } from '../shared/utils/auth.utils';
 import { ConfigureTelegramWebhookCommand } from '../telegram-linking/configure-telegram-webhook/configure-telegram-webhook.command';
 import { ConfigureTelegramWebhook } from '../telegram-linking/configure-telegram-webhook/configure-telegram-webhook.usecase';
 import { IssueTelegramMobileLinkCommand } from '../telegram-linking/issue-telegram-mobile-link/issue-telegram-mobile-link.command';
@@ -261,7 +260,7 @@ export class IntegrationsController {
     @Body() body: CreateIntegrationRequestDto
   ): Promise<IntegrationResponseDto> {
     try {
-      this.assertEnvironmentScopedForApiKey(user, body._environmentId);
+      assertEnvironmentScopedAccess(user.scheme, user.environmentId, body._environmentId);
 
       const canAccessCredentials = await this.canUserAccessCredentials(user);
       const integration = await this.createIntegrationUsecase.execute(
@@ -317,7 +316,7 @@ export class IntegrationsController {
     @Body() body: UpdateIntegrationRequestDto
   ): Promise<IntegrationResponseDto> {
     try {
-      this.assertEnvironmentScopedForApiKey(user, body._environmentId);
+      assertEnvironmentScopedAccess(user.scheme, user.environmentId, body._environmentId);
 
       const canAccessCredentials = await this.canUserAccessCredentials(user);
       const integration = await this.updateIntegrationUsecase.execute(
@@ -1053,20 +1052,6 @@ export class IntegrationsController {
         connectionIdentifier: body.connectionIdentifier,
       })
     );
-  }
-
-  private assertEnvironmentScopedForApiKey(user: UserSessionData, requestedEnvironmentId?: string): void {
-    const isEnvironmentScopedScheme = isEnvironmentScopedAuthScheme(user.scheme);
-    if (!isEnvironmentScopedScheme) {
-      return;
-    }
-
-    if (requestedEnvironmentId && requestedEnvironmentId !== user.environmentId) {
-      throw new ForbiddenException(
-        'This authentication scheme is scoped to a single environment and cannot target a different `_environmentId`. ' +
-          'Use credentials from the target environment, or authenticate with a session token.'
-      );
-    }
   }
 
   private async canUserAccessCredentials(user: UserSessionData): Promise<boolean> {

--- a/apps/api/src/app/shared/utils/auth.utils.ts
+++ b/apps/api/src/app/shared/utils/auth.utils.ts
@@ -1,9 +1,41 @@
+import { ForbiddenException } from '@nestjs/common';
 import { ApiAuthSchemeEnum } from '@novu/shared';
 
 import { KEYLESS_ENVIRONMENT_PREFIX } from '../../inbox/utils/keyless.constants';
 
 export function isEnvironmentScopedAuthScheme(scheme: ApiAuthSchemeEnum): boolean {
   return scheme === ApiAuthSchemeEnum.API_KEY || scheme === ApiAuthSchemeEnum.KEYLESS;
+}
+
+export function assertEnvironmentScopedAccess(
+  scheme: ApiAuthSchemeEnum,
+  userEnvironmentId: string,
+  requestedEnvironmentId?: string
+): void {
+  if (!isEnvironmentScopedAuthScheme(scheme)) {
+    return;
+  }
+
+  if (requestedEnvironmentId && requestedEnvironmentId !== userEnvironmentId) {
+    throw new ForbiddenException(
+      'This authentication scheme is scoped to a single environment and cannot target a different `_environmentId`. ' +
+        'Use credentials from the target environment, or authenticate with a session token.'
+    );
+  }
+}
+
+export function assertEnvironmentScopedAccessForValues(
+  scheme: ApiAuthSchemeEnum,
+  userEnvironmentId: string,
+  values: Array<{ _environmentId: string }> | undefined
+): void {
+  if (!values?.length) {
+    return;
+  }
+
+  for (const value of values) {
+    assertEnvironmentScopedAccess(scheme, userEnvironmentId, value._environmentId);
+  }
 }
 
 export function isResolvedKeylessAuthScheme(authScheme: string | undefined): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a P1 IDOR where environment-scoped API keys could mutate sibling environments within the same organization.

### Changes

1. **Environment variable create/update** — Pass the authenticated `environmentId` into commands and reject API key / keyless writes when `values[]._environmentId` targets a different environment. Bearer session auth continues to work across all org environments.

2. **Environment variable metadata updates** — Block API key / keyless callers from updating shared org-level fields (`key`, `type`, `isSecret`) without `values`; only per-environment value patches are allowed for scoped credentials.

3. **Delete environment** — Reject API key / keyless callers attempting to delete an environment other than the one bound to their credentials. Bearer auth can still delete sibling custom environments.

4. **Shared utility** — Extracted `assertEnvironmentScopedAccess` into `auth.utils.ts` (also used by integrations controller).

### Security model

```mermaid
flowchart TD
  A[Authenticated request] --> B{Auth scheme?}
  B -->|Bearer| C[Allow org-scoped access]
  B -->|API key / Keyless| D{Target env == caller env?}
  D -->|Yes| E[Allow]
  D -->|No| F[403 Forbidden]
```

### Tests

- Unit: `validate-environment-variable-values.spec.ts` — cross-env scope rejection
- E2E: `api-key-environment-scope.e2e.ts` — variable create/update IDOR blocked for API keys, metadata rename blocked, bearer allowed
- E2E: `delete-environment-api-key-scope.e2e.ts` — sibling env delete blocked for API keys, allowed for bearer

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8182](https://linear.app/novu/issue/NV-8182/securityp1-environment-scoping-idor-env-scoped-api-key-can-writedelete)

<div><a href="https://cursor.com/agents/bc-5d05fa57-1d57-41fe-8fba-c11a61ce467f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d05fa57-1d57-41fe-8fba-c11a61ce467f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens environment-scoped access for API-key and keyless callers. The main changes are:

- Environment-variable create and update now receive the authenticated environment context.
- Scoped callers are blocked from writing values for sibling environments.
- Scoped callers are blocked from changing shared environment-variable metadata.
- Environment deletes now check the caller environment before deleting.
- Integration scope checks now use a shared auth utility.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the env-var scope proofs and noted the pre-run blocker and the post-run state after the failed install.
- Examined the direct mocha retry attempt and confirmed the binary was not found with exit code 127.
- Compared the delete-env-scope before and after results, recording the status and target existence changes along with bearer deletion outcomes.
- Reviewed the integrations-auth-scope attempts, observing that dependency installs and SIGKILL prevented endpoint execution in both the base and head runs, with no HTTP response produced.

<a href="https://app.greptile.com/trex/runs/13318138/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts | Rejects scoped shared metadata updates and validates value patches against the authenticated environment. |
| apps/api/src/app/environment-variables/usecases/validate-environment-variable-values.ts | Adds scoped environment validation for submitted environment-variable values. |
| apps/api/src/app/environments-v1/usecases/delete-environment/delete-environment.usecase.ts | Blocks scoped callers from deleting a different environment. |
| apps/api/src/app/shared/utils/auth.utils.ts | Adds shared helpers for environment-scoped auth checks. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts`, line 39 ([link](https://github.com/novuhq/novu/blob/605e6801966b03f6155d8d3b8872a9858e815914/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts#L39)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Metadata Update Skips Scope Check**

   When an API-key or keyless caller patches a multi-environment variable without `values`, this branch skips the new environment-scope validation but still applies global fields like `key`, `type`, and `isSecret`. That lets credentials scoped to one environment rename or change metadata for the shared variable record that sibling environments also use.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
   Line: 39

   Comment:
   **Metadata Update Skips Scope Check**

   When an API-key or keyless caller patches a multi-environment variable without `values`, this branch skips the new environment-scope validation but still applies global fields like `key`, `type`, and `isSecret`. That lets credentials scoped to one environment rename or change metadata for the shared variable record that sibling environments also use.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fenvironment-variables%2Fusecases%2Fupdate-environment-variable%2Fupdate-environment-variable.usecase.ts%0ALine%3A%2039%0A%0AComment%3A%0A**Metadata%20Update%20Skips%20Scope%20Check**%0A%0AWhen%20an%20API-key%20or%20keyless%20caller%20patches%20a%20multi-environment%20variable%20without%20%60values%60%2C%20this%20branch%20skips%20the%20new%20environment-scope%20validation%20but%20still%20applies%20global%20fields%20like%20%60key%60%2C%20%60type%60%2C%20and%20%60isSecret%60.%20That%20lets%20credentials%20scoped%20to%20one%20environment%20rename%20or%20change%20metadata%20for%20the%20shared%20variable%20record%20that%20sibling%20environments%20also%20use.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): block org-wide env var..."](https://github.com/novuhq/novu/commit/a4644feee9c300bc867bbee4db9dede18d20e617) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41902064)</sub>

<!-- /greptile_comment -->