### PR TITLE
fix(shared): block prototype pollution in verify-payload service fixes NV-8188

### DIFF
--- a/libs/application-generic/src/services/verify-payload.service.spec.ts
+++ b/libs/application-generic/src/services/verify-payload.service.spec.ts
@@ -141,6 +141,26 @@ describe('VerifyPayloadService', () => {
       });
     });
 
+    it('should fill defaults for chained bracket-notation path segments', () => {
+      const variables = [
+        {
+          name: 'data.matrix[0][1]',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'fallback',
+          required: false,
+        },
+      ];
+
+      const result = service.fillDefaults(variables);
+
+      expect(result).to.deep.equal({
+        data: {
+          matrix: [[undefined, 'fallback']],
+        },
+      });
+      expect((result.data as { matrix: string[][] }).matrix[0][1]).to.equal('fallback');
+    });
+
     it('should preserve scalar prefix defaults when a nested default is incompatible', () => {
       const variables = [
         {

--- a/libs/application-generic/src/services/verify-payload.service.spec.ts
+++ b/libs/application-generic/src/services/verify-payload.service.spec.ts
@@ -1,0 +1,97 @@
+import { TemplateVariableTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { VerifyPayloadService } from './verify-payload.service';
+
+describe('VerifyPayloadService', () => {
+  const service = new VerifyPayloadService();
+
+  describe('prototype pollution guard', () => {
+    it('should not allow __proto__ pollution via default values', () => {
+      const variables = [
+        {
+          name: '__proto__.polluted',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'yes',
+          required: false,
+        },
+      ];
+
+      const before = ({} as Record<string, unknown>).polluted;
+      service.fillDefaults(variables);
+      const after = ({} as Record<string, unknown>).polluted;
+
+      expect(before).to.equal(undefined);
+      expect(after).to.equal(undefined);
+    });
+
+    it('should not allow constructor pollution via default values', () => {
+      const variables = [
+        {
+          name: 'constructor.prototype.polluted',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'yes',
+          required: false,
+        },
+      ];
+
+      const before = ({} as Record<string, unknown>).polluted;
+      service.fillDefaults(variables);
+      const after = ({} as Record<string, unknown>).polluted;
+
+      expect(before).to.equal(undefined);
+      expect(after).to.equal(undefined);
+    });
+
+    it('should not allow prototype segment pollution via default values', () => {
+      const variables = [
+        {
+          name: 'user.prototype.polluted',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'yes',
+          required: false,
+        },
+      ];
+
+      const before = ({} as Record<string, unknown>).polluted;
+      service.fillDefaults(variables);
+      const after = ({} as Record<string, unknown>).polluted;
+
+      expect(before).to.equal(undefined);
+      expect(after).to.equal(undefined);
+    });
+
+    it('should reject variable path segments outside the allowlist', () => {
+      const variables = [
+        {
+          name: 'user.$invalid',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'value',
+          required: false,
+        },
+      ];
+
+      const result = service.fillDefaults(variables);
+
+      expect(result).to.deep.equal({});
+    });
+
+    it('should still set safe nested properties', () => {
+      const variables = [
+        {
+          name: 'user.firstName',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'John',
+          required: false,
+        },
+      ];
+
+      const result = service.fillDefaults(variables);
+
+      expect(result).to.deep.equal({
+        user: {
+          firstName: 'John',
+        },
+      });
+    });
+  });
+});

--- a/libs/application-generic/src/services/verify-payload.service.spec.ts
+++ b/libs/application-generic/src/services/verify-payload.service.spec.ts
@@ -93,5 +93,49 @@ describe('VerifyPayloadService', () => {
         },
       });
     });
+
+    it('should fill defaults for bracket-notation path segments', () => {
+      const variables = [
+        {
+          name: 'data.items[0].name',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'fallback',
+          required: false,
+        },
+      ];
+
+      const result = service.fillDefaults(variables);
+
+      expect(result).to.deep.equal({
+        data: {
+          'items[0]': {
+            name: 'fallback',
+          },
+        },
+      });
+    });
+
+    it('should preserve scalar prefix defaults when a nested default is incompatible', () => {
+      const variables = [
+        {
+          name: 'user',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'scalar-user',
+          required: false,
+        },
+        {
+          name: 'user.firstName',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'John',
+          required: false,
+        },
+      ];
+
+      const result = service.fillDefaults(variables);
+
+      expect(result).to.deep.equal({
+        user: 'scalar-user',
+      });
+    });
   });
 });

--- a/libs/application-generic/src/services/verify-payload.service.spec.ts
+++ b/libs/application-generic/src/services/verify-payload.service.spec.ts
@@ -108,9 +108,35 @@ describe('VerifyPayloadService', () => {
 
       expect(result).to.deep.equal({
         data: {
-          'items[0]': {
-            name: 'fallback',
-          },
+          items: [
+            {
+              name: 'fallback',
+            },
+          ],
+        },
+      });
+      expect((result.data as { items: Array<{ name: string }> }).items[0].name).to.equal('fallback');
+    });
+
+    it('should fill defaults for nested bracket-notation path segments', () => {
+      const variables = [
+        {
+          name: 'payload.items[0].products[1].name',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'widget',
+          required: false,
+        },
+      ];
+
+      const result = service.fillDefaults(variables);
+
+      expect(result).to.deep.equal({
+        payload: {
+          items: [
+            {
+              products: [undefined, { name: 'widget' }],
+            },
+          ],
         },
       });
     });

--- a/libs/application-generic/src/services/verify-payload.service.ts
+++ b/libs/application-generic/src/services/verify-payload.service.ts
@@ -2,10 +2,18 @@ import { BadRequestException } from '@nestjs/common';
 import { ITemplateVariable, TemplateSystemVariables } from '@novu/shared';
 
 const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-const TEMPLATE_VARIABLE_SEGMENT_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+const TEMPLATE_VARIABLE_SEGMENT_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*(?:\[\d+\])?$/;
+
+function getSegmentBaseName(segment: string): string {
+  const bracketIndex = segment.indexOf('[');
+
+  return bracketIndex === -1 ? segment : segment.slice(0, bracketIndex);
+}
 
 function isSafeVariablePathSegment(segment: string): boolean {
-  if (PROTOTYPE_POLLUTION_KEYS.has(segment)) {
+  const baseName = getSegmentBaseName(segment);
+
+  if (PROTOTYPE_POLLUTION_KEYS.has(baseName)) {
     return false;
   }
 
@@ -82,7 +90,13 @@ export class VerifyPayloadService {
       return;
     }
 
-    if (!obj[path[0]] || typeof obj[path[0]] !== 'object') {
+    const existing = obj[path[0]];
+
+    if (existing !== undefined && existing !== null && typeof existing !== 'object') {
+      return;
+    }
+
+    if (!existing) {
       obj[path[0]] = Object.create(null);
     }
 

--- a/libs/application-generic/src/services/verify-payload.service.ts
+++ b/libs/application-generic/src/services/verify-payload.service.ts
@@ -1,6 +1,17 @@
 import { BadRequestException } from '@nestjs/common';
 import { ITemplateVariable, TemplateSystemVariables } from '@novu/shared';
 
+const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const TEMPLATE_VARIABLE_SEGMENT_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+
+function isSafeVariablePathSegment(segment: string): boolean {
+  if (PROTOTYPE_POLLUTION_KEYS.has(segment)) {
+    return false;
+  }
+
+  return TEMPLATE_VARIABLE_SEGMENT_REGEX.test(segment);
+}
+
 export class VerifyPayloadService {
   checkRequired(variables: ITemplateVariable[], payload: Record<string, unknown>): string[] {
     const invalidKeys: string[] = [];
@@ -41,18 +52,28 @@ export class VerifyPayloadService {
   }
 
   fillDefaults(variables: ITemplateVariable[]): Record<string, unknown> {
-    const payload = {};
+    const payload = Object.create(null) as Record<string, unknown>;
 
     for (const variable of variables.filter(
       (elem) => elem.defaultValue !== undefined && elem.defaultValue !== null && !this.isSystemVariable(elem.name)
     )) {
-      this.setNestedKey(payload, variable.name.split('.'), variable.defaultValue);
+      const pathSegments = variable.name.split('.');
+
+      if (!pathSegments.every(isSafeVariablePathSegment)) {
+        continue;
+      }
+
+      this.setNestedKey(payload, pathSegments, variable.defaultValue);
     }
 
     return payload;
   }
 
-  private setNestedKey(obj, path, value) {
+  private setNestedKey(obj: Record<string, unknown>, path: string[], value: string | boolean): void {
+    if (path.length === 0 || !path.every(isSafeVariablePathSegment)) {
+      return;
+    }
+
     if (path.length === 1) {
       if (value !== '') {
         obj[path[0]] = value;
@@ -61,11 +82,11 @@ export class VerifyPayloadService {
       return;
     }
 
-    if (!obj[path[0]]) {
-      obj[path[0]] = {};
+    if (!obj[path[0]] || typeof obj[path[0]] !== 'object') {
+      obj[path[0]] = Object.create(null);
     }
 
-    return this.setNestedKey(obj[path[0]], path.slice(1), value);
+    this.setNestedKey(obj[path[0]] as Record<string, unknown>, path.slice(1), value);
   }
 
   isSystemVariable(variableName: string): boolean {

--- a/libs/application-generic/src/services/verify-payload.service.ts
+++ b/libs/application-generic/src/services/verify-payload.service.ts
@@ -4,6 +4,8 @@ import { ITemplateVariable, TemplateSystemVariables } from '@novu/shared';
 const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 const TEMPLATE_VARIABLE_SEGMENT_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*(?:\[\d+\])?$/;
 
+type PathPart = { kind: 'key'; value: string } | { kind: 'index'; value: number };
+
 function getSegmentBaseName(segment: string): string {
   const bracketIndex = segment.indexOf('[');
 
@@ -20,6 +22,70 @@ function isSafeVariablePathSegment(segment: string): boolean {
   return TEMPLATE_VARIABLE_SEGMENT_REGEX.test(segment);
 }
 
+function parseVariablePath(variableName: string): PathPart[] | null {
+  const segments = variableName.split('.');
+
+  if (!segments.every(isSafeVariablePathSegment)) {
+    return null;
+  }
+
+  const parts: PathPart[] = [];
+
+  for (const segment of segments) {
+    const bracketIndex = segment.indexOf('[');
+
+    if (bracketIndex === -1) {
+      parts.push({ kind: 'key', value: segment });
+      continue;
+    }
+
+    const baseName = segment.slice(0, bracketIndex);
+    const indexMatch = segment.slice(bracketIndex).match(/^\[(\d+)\]$/);
+
+    if (!indexMatch) {
+      return null;
+    }
+
+    parts.push({ kind: 'key', value: baseName });
+    parts.push({ kind: 'index', value: Number(indexMatch[1]) });
+  }
+
+  return parts;
+}
+
+function getValueAtPath(payload: Record<string, unknown>, variableName: string): unknown {
+  const pathParts = parseVariablePath(variableName);
+
+  if (!pathParts) {
+    return undefined;
+  }
+
+  let current: unknown = payload;
+
+  for (const part of pathParts) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+
+    if (part.kind === 'key') {
+      if (typeof current !== 'object' || Array.isArray(current)) {
+        return undefined;
+      }
+
+      current = (current as Record<string, unknown>)[part.value];
+      continue;
+    }
+
+    if (!Array.isArray(current)) {
+      return undefined;
+    }
+
+    current = current[part.value];
+  }
+
+  return current;
+}
+
 export class VerifyPayloadService {
   checkRequired(variables: ITemplateVariable[], payload: Record<string, unknown>): string[] {
     const invalidKeys: string[] = [];
@@ -28,7 +94,7 @@ export class VerifyPayloadService {
       let value;
 
       try {
-        value = variable.name.split('.').reduce((a: any, b) => a[b], payload);
+        value = getValueAtPath(payload, variable.name);
       } catch (e) {
         value = null;
       }
@@ -65,42 +131,91 @@ export class VerifyPayloadService {
     for (const variable of variables.filter(
       (elem) => elem.defaultValue !== undefined && elem.defaultValue !== null && !this.isSystemVariable(elem.name)
     )) {
-      const pathSegments = variable.name.split('.');
+      const pathParts = parseVariablePath(variable.name);
 
-      if (!pathSegments.every(isSafeVariablePathSegment)) {
+      if (!pathParts) {
         continue;
       }
 
-      this.setNestedKey(payload, pathSegments, variable.defaultValue);
+      this.setNestedValue(payload, pathParts, variable.defaultValue);
     }
 
     return payload;
   }
 
-  private setNestedKey(obj: Record<string, unknown>, path: string[], value: string | boolean): void {
-    if (path.length === 0 || !path.every(isSafeVariablePathSegment)) {
+  private setNestedValue(target: unknown, parts: PathPart[], value: string | boolean): void {
+    if (parts.length === 0) {
       return;
     }
 
-    if (path.length === 1) {
-      if (value !== '') {
-        obj[path[0]] = value;
+    if (parts.length === 1) {
+      const [part] = parts;
+
+      if (value === '') {
+        return;
       }
 
+      if (part.kind === 'key') {
+        (target as Record<string, unknown>)[part.value] = value;
+
+        return;
+      }
+
+      const array = target as unknown[];
+
+      while (array.length <= part.value) {
+        array.push(undefined);
+      }
+
+      array[part.value] = value;
+
       return;
     }
 
-    const existing = obj[path[0]];
+    const [head, ...tail] = parts;
+    const next = tail[0];
+
+    if (head.kind === 'key') {
+      const record = target as Record<string, unknown>;
+      const existing = record[head.value];
+
+      if (existing !== undefined && existing !== null && typeof existing !== 'object') {
+        return;
+      }
+
+      if (!existing) {
+        record[head.value] = next.kind === 'index' ? [] : Object.create(null);
+      } else if (next.kind === 'index' && !Array.isArray(existing)) {
+        return;
+      } else if (next.kind === 'key' && (typeof existing !== 'object' || Array.isArray(existing))) {
+        return;
+      }
+
+      this.setNestedValue(record[head.value], tail, value);
+
+      return;
+    }
+
+    const array = target as unknown[];
+    const existing = array[head.value];
 
     if (existing !== undefined && existing !== null && typeof existing !== 'object') {
       return;
     }
 
-    if (!existing) {
-      obj[path[0]] = Object.create(null);
+    while (array.length <= head.value) {
+      array.push(undefined);
     }
 
-    this.setNestedKey(obj[path[0]] as Record<string, unknown>, path.slice(1), value);
+    if (existing === undefined || existing === null) {
+      array[head.value] = next.kind === 'index' ? [] : Object.create(null);
+    } else if (next.kind === 'index' && !Array.isArray(existing)) {
+      return;
+    } else if (next.kind === 'key' && (typeof existing !== 'object' || Array.isArray(existing))) {
+      return;
+    }
+
+    this.setNestedValue(array[head.value], tail, value);
   }
 
   isSystemVariable(variableName: string): boolean {

--- a/libs/application-generic/src/services/verify-payload.service.ts
+++ b/libs/application-generic/src/services/verify-payload.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { ITemplateVariable, TemplateSystemVariables } from '@novu/shared';
 
 const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-const TEMPLATE_VARIABLE_SEGMENT_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*(?:\[\d+\])?$/;
+const TEMPLATE_VARIABLE_SEGMENT_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*(?:\[\d+\])*$/;
 
 type PathPart = { kind: 'key'; value: string } | { kind: 'index'; value: number };
 
@@ -22,6 +22,31 @@ function isSafeVariablePathSegment(segment: string): boolean {
   return TEMPLATE_VARIABLE_SEGMENT_REGEX.test(segment);
 }
 
+function expandPathSegment(segment: string): PathPart[] | null {
+  const bracketIndex = segment.indexOf('[');
+
+  if (bracketIndex === -1) {
+    return [{ kind: 'key', value: segment }];
+  }
+
+  const baseName = segment.slice(0, bracketIndex);
+  const parts: PathPart[] = [{ kind: 'key', value: baseName }];
+  let remaining = segment.slice(bracketIndex);
+
+  while (remaining.length > 0) {
+    const indexMatch = remaining.match(/^\[(\d+)\]/);
+
+    if (!indexMatch) {
+      return null;
+    }
+
+    parts.push({ kind: 'index', value: Number(indexMatch[1]) });
+    remaining = remaining.slice(indexMatch[0].length);
+  }
+
+  return parts;
+}
+
 function parseVariablePath(variableName: string): PathPart[] | null {
   const segments = variableName.split('.');
 
@@ -32,22 +57,13 @@ function parseVariablePath(variableName: string): PathPart[] | null {
   const parts: PathPart[] = [];
 
   for (const segment of segments) {
-    const bracketIndex = segment.indexOf('[');
+    const expanded = expandPathSegment(segment);
 
-    if (bracketIndex === -1) {
-      parts.push({ kind: 'key', value: segment });
-      continue;
-    }
-
-    const baseName = segment.slice(0, bracketIndex);
-    const indexMatch = segment.slice(bracketIndex).match(/^\[(\d+)\]$/);
-
-    if (!indexMatch) {
+    if (!expanded) {
       return null;
     }
 
-    parts.push({ kind: 'key', value: baseName });
-    parts.push({ kind: 'index', value: Number(indexMatch[1]) });
+    parts.push(...expanded);
   }
 
   return parts;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a P1 prototype pollution vulnerability in `VerifyPayloadService.fillDefaults()` where template/layout variable names containing `__proto__`, `constructor`, or `prototype` path segments could pollute `Object.prototype` during trigger payload verification.

## Changes

- Reject dangerous path segments (`__proto__`, `constructor`, `prototype`) before writing defaults
- Build the defaults accumulator with `Object.create(null)` to avoid inheriting from `Object.prototype`
- Enforce a per-segment variable-name allowlist at write time, including single and chained bracket notation (e.g. `items[0]`, `matrix[0][1]`)
- Expand bracket notation into real array paths so defaults are written to array indices rather than literal keys
- Use null-prototype objects for nested intermediate nodes
- Preserve existing scalar prefix defaults when a later nested default is incompatible
- Align `checkRequired` path reads with the same bracket-aware path parser
- Add unit tests covering pollution vectors, bracket paths, chained brackets, nested arrays, scalar prefix preservation, and safe nested writes

## Attack vector

An authenticated tenant/API-key caller could create a template or layout variable named `__proto__.polluted` with a `defaultValue`. During trigger payload verification, `setNestedKey()` would split on `.` and write to the prototype chain, causing process-wide pollution.

## Test plan

- [x] `verify-payload.service.spec.ts` — 9 tests for pollution guard and compatibility
- [x] `verify-payload.spec.ts` — existing usecase tests still pass
- [x] `pnpm --filter @novu/application-generic build` succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8188](https://linear.app/novu/issue/NV-8188/securityp1-prototype-pollution-in-trigger-payload-verification-verify)

<div><a href="https://cursor.com/agents/bc-6a7c1663-d4e7-41d2-8150-1dd5d4dae660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7c1663-d4e7-41d2-8150-1dd5d4dae660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens payload default generation against unsafe template variable paths. The main changes are:

- Dangerous path segments are rejected before defaults are written.
- Default payload objects now use null prototypes.
- Bracket notation is parsed into real array paths.
- Required-field checks use the same path parser.
- Unit tests cover pollution vectors, bracket paths, nested arrays, and scalar-prefix defaults.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the artifact, the contract-validation run demonstrated the baseline prototype pollution pattern, showing how Object.prototype for \_\_proto\_\_ and constructor.prototype could be polluted, that user.$invalid could be written, that Object.prototype was used for result objects, that bracket notation was treated as literal keys, that a scalar prefix collision could be thrown, and that checkRequired only succeeded for the literal bracket-key payload.
- After the artifact, the head skips unsafe paths, avoids pollution, uses null prototypes for root and nested objects, expands bracket paths to arrays and indices, preserves the scalar user, and checkRequired behaves as expected for real bracket-aware paths; both runs exited 0.

<a href="https://app.greptile.com/trex/runs/13318795/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/verify-payload.service.ts | Adds safe path parsing, null-prototype default creation, bracket-aware reads and writes, and scalar-prefix handling. |
| libs/application-generic/src/services/verify-payload.service.spec.ts | Adds tests for pollution guards, invalid paths, bracket defaults, chained brackets, nested arrays, and scalar-prefix behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(shared): support chained bracket def..."](https://github.com/novuhq/novu/commit/abe3052754ea839378ee619d4e6a9a4e3c0e9de3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41902324)</sub>

<!-- /greptile_comment -->