### PR TITLE
fix(api-service): disable Vercel partner integrations for Better Auth fixes NV-8181

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -147,7 +147,6 @@ const baseModules: Array<Type | DynamicModule | Promise<DynamicModule> | Forward
   LayoutsV1Module,
   LayoutsV2Module,
   MessagesModule,
-  PartnerIntegrationsModule,
   TopicsV1Module,
   TopicsV2Module,
   BlueprintModule,
@@ -173,6 +172,8 @@ const enterpriseModules = enterpriseImports();
 if (!isClerkEnabled()) {
   const communityModules = [InvitesModule];
   baseModules.push(...communityModules);
+} else if (process.env.IS_SELF_HOSTED !== 'true') {
+  baseModules.push(PartnerIntegrationsModule);
 }
 
 const modules = baseModules.concat(enterpriseModules);

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -40,7 +40,7 @@ import { ConnectSubscriberProvider } from './components/connect/connect-subscrib
 import { CreateIntegrationSidebar } from './components/integrations/components/create-integration-sidebar';
 import { UpdateIntegrationSidebar } from './components/integrations/components/update-integration-sidebar';
 import { ChannelPreferences } from './components/workflow-editor/channel-preferences';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from './config';
+import { EE_AUTH_PROVIDER, IS_ENTERPRISE, IS_SELF_HOSTED } from './config';
 import { FeatureFlagsProvider } from './context/feature-flags-provider';
 import { AgentDetailsPage } from './pages/agent-details';
 import { AgentSlackSetupPage } from './pages/agent-slack-setup-page';
@@ -681,11 +681,14 @@ const router = createBrowserRouter([
           },
           {
             path: ROUTES.PARTNER_INTEGRATIONS_VERCEL,
-            element: (
-              <ProtectedRoute permission={PermissionsEnum.PARTNER_INTEGRATION_READ}>
-                <VercelIntegrationPage />
-              </ProtectedRoute>
-            ),
+            element:
+              EE_AUTH_PROVIDER === 'clerk' && !IS_SELF_HOSTED ? (
+                <ProtectedRoute permission={PermissionsEnum.PARTNER_INTEGRATION_READ}>
+                  <VercelIntegrationPage />
+                </ProtectedRoute>
+              ) : (
+                <Navigate to={ROUTES.ROOT} replace />
+              ),
           },
           {
             path: ROUTES.SETTINGS,


### PR DESCRIPTION
## Summary

- Disable Vercel partner integration on Better Auth and self-hosted deployments
- Load `PartnerIntegrationsModule` only on Enterprise Cloud with Clerk enabled
- Redirect the dashboard Vercel integration route unless `EE_AUTH_PROVIDER === 'clerk'` and not self-hosted
- Bump `.source` submodule to stub partner configuration methods in `BetterAuthOrganizationRepository`

## Context

Fixes [NV-8181](https://linear.app/novu/issue/NV-8181) — a P0 cross-tenant IDOR where `findByPartnerConfigurationId` ignored caller org membership, allowing any authenticated Better Auth user to read or act through another tenant's Vercel integration via a known `configurationId`.

Vercel partner integration is only relevant for Novu Enterprise Cloud (Clerk). This PR removes the feature from Better Auth flows instead of adding membership scoping.

```mermaid
flowchart LR
  Request[Authenticated request] --> AuthProvider{Auth provider?}
  AuthProvider -->|Clerk + Cloud| PartnerAPI[PartnerIntegrationsModule]
  AuthProvider -->|Better Auth or self-hosted| Blocked[Module not loaded / route redirected]
  PartnerAPI --> EEOrgRepo[EEOrganizationRepository scoped lookups]
  Blocked --> NoOpRepo[BetterAuthOrganizationRepository no-op stubs]
```

## Enterprise submodule

Requires https://github.com/novuhq/packages-enterprise/pull/467 — merge the enterprise PR first.

> **Note:** Validate Submodule Sync CI is expected to fail until the enterprise PR is merged.

## Test plan

- [ ] On Better Auth deployment: `/v1/partner-integrations/vercel/*` routes are unavailable
- [ ] On Better Auth dashboard: `/partner-integrations/vercel` redirects to home
- [ ] On Enterprise Cloud (Clerk): Vercel partner integration create/read/update still works
- [ ] Attempt cross-tenant `configurationId` lookup on Better Auth returns no data

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables Vercel partner integrations outside the intended Enterprise Cloud Clerk path. The main changes are:

- Moves `PartnerIntegrationsModule` out of the API base module list.
- Registers the API module only for Clerk and non-self-hosted API deployments.
- Redirects the dashboard Vercel integration route for unsupported auth and self-hosted cases.
- Updates the enterprise submodule pointer for related repository behavior.

<h3>Confidence Score: 4/5</h3>

This is close, but the dashboard guard should be fixed before merging.

- The API module is now gated to the intended Clerk enterprise path.
- The dashboard route can still show the Vercel page when the matching API endpoints are not registered.
- The fix is small and localized to the route condition.

apps/dashboard/src/main.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app.module.ts | Registers `PartnerIntegrationsModule` only when Clerk is enabled and the API is not self-hosted. |
| apps/dashboard/src/main.tsx | Redirects the Vercel integration route for some unsupported builds, but the route guard still misses the enterprise requirement. |
| .source | Updates the enterprise submodule pointer used by the partner integration fix. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fmain.tsx%3A685%0A**Match%20API%20Availability**%0A%0AThis%20route%20can%20still%20render%20the%20Vercel%20integration%20page%20when%20the%20API%20has%20not%20loaded%20the%20partner%20integration%20module.%20The%20API%20only%20registers%20those%20endpoints%20when%20Clerk%20is%20enabled%20through%20enterprise%20mode%20and%20the%20deployment%20is%20not%20self-hosted%2C%20but%20this%20guard%20only%20checks%20%60EE_AUTH_PROVIDER%20%3D%3D%3D%20'clerk'%20%26%26%20!IS_SELF_HOSTED%60.%20In%20a%20hosted%20non-enterprise%2Fdefault%20dashboard%20build%20where%20%60EE_AUTH_PROVIDER%60%20resolves%20to%20%60clerk%60%2C%20users%20can%20open%20the%20page%20and%20then%20hit%20missing%20%60%2Fpartner-integrations%2Fvercel%2F*%60%20endpoints.%20Add%20the%20enterprise%20check%20here%20so%20the%20dashboard%20redirects%20whenever%20the%20API%20module%20is%20absent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20IS_ENTERPRISE%20%26%26%20EE_AUTH_PROVIDER%20%3D%3D%3D%20'clerk'%20%26%26%20!IS_SELF_HOSTED%20%3F%20%28%0A%60%60%60%0A%0A&pr=11783&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/main.tsx:685
**Match API Availability**

This route can still render the Vercel integration page when the API has not loaded the partner integration module. The API only registers those endpoints when Clerk is enabled through enterprise mode and the deployment is not self-hosted, but this guard only checks `EE_AUTH_PROVIDER === 'clerk' && !IS_SELF_HOSTED`. In a hosted non-enterprise/default dashboard build where `EE_AUTH_PROVIDER` resolves to `clerk`, users can open the page and then hit missing `/partner-integrations/vercel/*` endpoints. Add the enterprise check here so the dashboard redirects whenever the API module is absent.

```suggestion
              IS_ENTERPRISE && EE_AUTH_PROVIDER === 'clerk' && !IS_SELF_HOSTED ? (
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Update .source"](https://github.com/novuhq/novu/commit/305174cade76834d2940c1e09ddcd5bfb842b631) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41902408)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->