### PR TITLE
fix(api-service): block SSRF via SMTP check-integration and Sinch region fixes NV-8186

### DIFF
--- a/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
@@ -33,6 +33,7 @@ import shortid from 'shortid';
 import { CheckIntegrationCommand } from '../check-integration/check-integration.command';
 import { CheckIntegration } from '../check-integration/check-integration.usecase';
 import { ensureWhatsAppManagedCredentials } from '../whatsapp/whatsapp-credentials.utils';
+import { validateOutboundIntegrationCredentials } from '../../utils/validate-outbound-integration-credentials';
 import { CreateIntegrationCommand } from './create-integration.command';
 
 @Injectable()
@@ -163,6 +164,12 @@ export class CreateIntegration {
 
     await this.validate(command);
 
+    const isAgentKind = command.kind === IntegrationKindEnum.AGENT;
+
+    if (!isAgentKind) {
+      await validateOutboundIntegrationCredentials(command.providerId, command.credentials);
+    }
+
     this.analyticsService.track('Create Integration - [Integrations]', command.userId, {
       providerId: command.providerId,
       channel: command.channel,
@@ -171,8 +178,6 @@ export class CreateIntegration {
     });
 
     try {
-      const isAgentKind = command.kind === IntegrationKindEnum.AGENT;
-
       if (command.check && !isAgentKind) {
         await this.checkIntegration.execute(
           CheckIntegrationCommand.create({

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
@@ -5,6 +5,7 @@ import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
 import { CheckIntegrationCommand } from '../check-integration/check-integration.command';
 import { CheckIntegration } from '../check-integration/check-integration.usecase';
 import { assertIntegrationEnvironmentScope } from '../../utils/assert-integration-environment-scope';
+import { validateOutboundIntegrationCredentials } from '../../utils/validate-outbound-integration-credentials';
 import { ensureNovuAgentManagedCredentials } from '../novu-agent/novu-agent-credentials.utils';
 import { ensureWhatsAppManagedCredentials } from '../whatsapp/whatsapp-credentials.utils';
 import { UpdateIntegrationCommand } from './update-integration.command';
@@ -141,13 +142,18 @@ export class UpdateIntegration {
     });
 
     const environmentId = command.environmentId ?? existingIntegration._environmentId;
+    const credentialsForValidation = command.credentials ?? existingIntegration.credentials ?? {};
+
+    if (command.check || command.credentials) {
+      await validateOutboundIntegrationCredentials(existingIntegration.providerId, credentialsForValidation);
+    }
 
     if (command.check) {
       await this.checkIntegration.execute(
         CheckIntegrationCommand.create({
           environmentId,
           organizationId: command.organizationId,
-          credentials: command.credentials ?? existingIntegration.credentials ?? {},
+          credentials: credentialsForValidation,
           providerId: existingIntegration.providerId,
           channel: existingIntegration.channel,
         })

--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
@@ -1,0 +1,38 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  assertAllowedSinchSmsRegion,
+  assertSafeSmtpOutboundTarget,
+  EmailProviderIdEnum,
+  ICredentials,
+  SmsProviderIdEnum,
+  SsrfBlockedError,
+} from '@novu/shared';
+
+export async function validateOutboundIntegrationCredentials(
+  providerId: string,
+  credentials?: ICredentials
+): Promise<void> {
+  if (!credentials) {
+    return;
+  }
+
+  try {
+    if (providerId === EmailProviderIdEnum.CustomSMTP) {
+      await assertSafeSmtpOutboundTarget(credentials.host, credentials.port, {
+        secure: credentials.secure,
+        requireTls: credentials.requireTls,
+        ignoreTls: credentials.ignoreTls,
+      });
+    }
+
+    if (providerId === SmsProviderIdEnum.Sinch) {
+      assertAllowedSinchSmsRegion(credentials.region);
+    }
+  } catch (error) {
+    if (error instanceof SsrfBlockedError) {
+      throw new BadRequestException(error.message);
+    }
+
+    throw error;
+  }
+}

--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
@@ -4,7 +4,7 @@ import { assertAllowedSinchSmsRegion, EmailProviderIdEnum, ICredentials, SmsProv
 type ValidateSmtpOutboundTargetModule = typeof import('@novu/shared/dist/cjs/utils/validate-smtp-outbound-target');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { assertSafeSmtpOutboundTargetSync, SsrfBlockedError } =
+const { assertSafeSmtpOutboundTargetSync } =
   require('@novu/shared/utils/validate-smtp-outbound-target') as ValidateSmtpOutboundTargetModule;
 
 export async function validateOutboundIntegrationCredentials(
@@ -28,7 +28,7 @@ export async function validateOutboundIntegrationCredentials(
       assertAllowedSinchSmsRegion(credentials.region);
     }
   } catch (error) {
-    if (error instanceof SsrfBlockedError) {
+    if (error instanceof Error) {
       throw new BadRequestException(error.message);
     }
 

--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import {
   assertAllowedSinchSmsRegion,
-  assertSafeSmtpOutboundTarget,
+  assertSafeSmtpOutboundTargetSync,
   EmailProviderIdEnum,
   ICredentials,
   SmsProviderIdEnum,
@@ -18,7 +18,7 @@ export async function validateOutboundIntegrationCredentials(
 
   try {
     if (providerId === EmailProviderIdEnum.CustomSMTP) {
-      await assertSafeSmtpOutboundTarget(credentials.host, credentials.port, {
+      assertSafeSmtpOutboundTargetSync(credentials.host, credentials.port, {
         secure: credentials.secure,
         requireTls: credentials.requireTls,
         ignoreTls: credentials.ignoreTls,

--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
@@ -1,12 +1,11 @@
 import { BadRequestException } from '@nestjs/common';
-import {
-  assertAllowedSinchSmsRegion,
-  assertSafeSmtpOutboundTargetSync,
-  EmailProviderIdEnum,
-  ICredentials,
-  SmsProviderIdEnum,
-  SsrfBlockedError,
-} from '@novu/shared';
+import { assertAllowedSinchSmsRegion, EmailProviderIdEnum, ICredentials, SmsProviderIdEnum } from '@novu/shared';
+
+type ValidateSmtpOutboundTargetModule = typeof import('@novu/shared/dist/cjs/utils/validate-smtp-outbound-target');
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { assertSafeSmtpOutboundTargetSync, SsrfBlockedError } =
+  require('@novu/shared/utils/validate-smtp-outbound-target') as ValidateSmtpOutboundTargetModule;
 
 export async function validateOutboundIntegrationCredentials(
   providerId: string,

--- a/libs/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
@@ -1,5 +1,5 @@
 import { NodemailerProvider } from '@novu/providers';
-import { ChannelTypeEnum, EmailProviderIdEnum, ICredentials } from '@novu/shared';
+import { assertSafeSmtpOutboundTargetSync, ChannelTypeEnum, EmailProviderIdEnum, ICredentials } from '@novu/shared';
 import { BaseEmailHandler } from './base.handler';
 
 export class NodemailerHandler extends BaseEmailHandler {
@@ -7,6 +7,12 @@ export class NodemailerHandler extends BaseEmailHandler {
     super(EmailProviderIdEnum.CustomSMTP, ChannelTypeEnum.EMAIL);
   }
   buildProvider(credentials: ICredentials, from?: string) {
+    assertSafeSmtpOutboundTargetSync(credentials.host, credentials.port, {
+      secure: credentials.secure,
+      requireTls: credentials.requireTls,
+      ignoreTls: credentials.ignoreTls,
+    });
+
     this.provider = new NodemailerProvider({
       from,
       host: credentials.host,

--- a/libs/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/nodemailer.handler.ts
@@ -1,6 +1,12 @@
 import { NodemailerProvider } from '@novu/providers';
-import { assertSafeSmtpOutboundTargetSync, ChannelTypeEnum, EmailProviderIdEnum, ICredentials } from '@novu/shared';
+import { ChannelTypeEnum, EmailProviderIdEnum, ICredentials } from '@novu/shared';
 import { BaseEmailHandler } from './base.handler';
+
+type ValidateSmtpOutboundTargetModule = typeof import('@novu/shared/dist/cjs/utils/validate-smtp-outbound-target');
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { assertSafeSmtpOutboundTargetSync } =
+  require('@novu/shared/utils/validate-smtp-outbound-target') as ValidateSmtpOutboundTargetModule;
 
 export class NodemailerHandler extends BaseEmailHandler {
   constructor() {

--- a/libs/application-generic/src/factories/sms/handlers/sinch.handler.ts
+++ b/libs/application-generic/src/factories/sms/handlers/sinch.handler.ts
@@ -1,5 +1,5 @@
 import { SinchSmsProvider } from '@novu/providers';
-import { ChannelTypeEnum, ICredentials, SmsProviderIdEnum } from '@novu/shared';
+import { assertAllowedSinchSmsRegion, ChannelTypeEnum, ICredentials, SmsProviderIdEnum } from '@novu/shared';
 import { BaseSmsHandler } from './base.handler';
 
 export class SinchHandler extends BaseSmsHandler {
@@ -9,11 +9,13 @@ export class SinchHandler extends BaseSmsHandler {
 
   buildProvider(credentials: ICredentials) {
     const config = credentials as Record<string, string>;
+    const region = assertAllowedSinchSmsRegion(config.region);
+
     this.provider = new SinchSmsProvider({
       servicePlanId: config.servicePlanId,
       apiToken: config.apiToken,
       from: config.from,
-      region: config.region,
+      region,
     });
   }
 }

--- a/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
+++ b/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
@@ -1,4 +1,5 @@
-import { EmailProviderIdEnum, assertSafeSmtpOutboundTarget } from '@novu/shared';
+import { EmailProviderIdEnum } from '@novu/shared';
+import { assertSafeSmtpOutboundTarget } from '@novu/shared/utils/validate-smtp-outbound-target';
 import {
   ChannelTypeEnum,
   CheckIntegrationResponseEnum,

--- a/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
+++ b/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
@@ -1,5 +1,8 @@
 import { EmailProviderIdEnum } from '@novu/shared';
-import { assertSafeSmtpOutboundTarget } from '@novu/shared/utils/validate-smtp-outbound-target';
+import {
+  resolveSafeSmtpPinnedTarget,
+  SmtpOutboundTlsOptions,
+} from '@novu/shared/utils/validate-smtp-outbound-target';
 import {
   ChannelTypeEnum,
   CheckIntegrationResponseEnum,
@@ -35,10 +38,18 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
 
   channelType = ChannelTypeEnum.EMAIL as ChannelTypeEnum.EMAIL;
 
-  private transports: Transporter;
-
   constructor(private config: INodemailerConfig) {
     super();
+  }
+
+  private getTlsConfig(servername: string): ConnectionOptions {
+    return {
+      ...(this.getTlsOptions() ?? {}),
+      servername,
+    };
+  }
+
+  private buildTransportOptions(connectionHost: string, port: number, tlsServername: string): SMTPTransport.Options {
     let { dkim } = this.config;
 
     if (!dkim?.domainName || !dkim?.privateKey || !dkim?.keySelector) {
@@ -46,13 +57,12 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
     }
 
     const authEnabled = this.config.user && this.config.password;
+    const tls = this.getTlsConfig(tlsServername);
 
-    const tls: ConnectionOptions = this.getTlsOptions();
-
-    const smtpTransportOptions: SMTPTransport.Options = {
-      name: this.config.host,
-      host: this.config.host,
-      port: this.config.port,
+    return {
+      name: tlsServername,
+      host: connectionHost,
+      port,
       secure: this.config.secure,
       connectionTimeout: 10000,
       socketTimeout: 10000,
@@ -65,10 +75,29 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
       dkim,
       ignoreTLS: this.config.ignoreTls,
       requireTLS: this.config.requireTls,
-      ...(tls && { tls }),
+      tls,
     };
+  }
 
-    this.transports = nodemailer.createTransport(smtpTransportOptions);
+  private getSmtpTlsOptions(): SmtpOutboundTlsOptions {
+    return {
+      secure: this.config.secure,
+      requireTls: this.config.requireTls,
+      ignoreTls: this.config.ignoreTls,
+    };
+  }
+
+  private async withPinnedTransport<T>(operation: (transport: Transporter) => Promise<T>): Promise<T> {
+    const pinned = await resolveSafeSmtpPinnedTarget(this.config.host, this.config.port, this.getSmtpTlsOptions());
+    const transport = nodemailer.createTransport(
+      this.buildTransportOptions(pinned.address, pinned.port, pinned.hostname)
+    );
+
+    try {
+      return await operation(transport);
+    } finally {
+      transport.close();
+    }
   }
 
   getTlsOptions(): ConnectionOptions | undefined {
@@ -98,15 +127,9 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
     options: IEmailOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
-    await assertSafeSmtpOutboundTarget(this.config.host, this.config.port, {
-      secure: this.config.secure,
-      requireTls: this.config.requireTls,
-      ignoreTls: this.config.ignoreTls,
-    });
-
     const mailData = this.createMailData(options);
     const merged = this.transform(bridgeProviderData, mailData);
-    const info = await this.transports.sendMail(merged.body);
+    const info = await this.withPinnedTransport((transport) => transport.sendMail(merged.body));
 
     return {
       id: info?.messageId,
@@ -116,14 +139,8 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
 
   async checkIntegration(options: IEmailOptions): Promise<ICheckIntegrationResponse> {
     try {
-      await assertSafeSmtpOutboundTarget(this.config.host, this.config.port, {
-        secure: this.config.secure,
-        requireTls: this.config.requireTls,
-        ignoreTls: this.config.ignoreTls,
-      });
-
       const mailData = this.createMailData(options);
-      await this.transports.sendMail(mailData);
+      await this.withPinnedTransport((transport) => transport.sendMail(mailData));
 
       return {
         success: true,

--- a/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
+++ b/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
@@ -1,4 +1,4 @@
-import { EmailProviderIdEnum } from '@novu/shared';
+import { EmailProviderIdEnum, assertSafeSmtpOutboundTarget } from '@novu/shared';
 import {
   ChannelTypeEnum,
   CheckIntegrationResponseEnum,
@@ -97,6 +97,12 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
     options: IEmailOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
+    await assertSafeSmtpOutboundTarget(this.config.host, this.config.port, {
+      secure: this.config.secure,
+      requireTls: this.config.requireTls,
+      ignoreTls: this.config.ignoreTls,
+    });
+
     const mailData = this.createMailData(options);
     const merged = this.transform(bridgeProviderData, mailData);
     const info = await this.transports.sendMail(merged.body);
@@ -109,6 +115,12 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
 
   async checkIntegration(options: IEmailOptions): Promise<ICheckIntegrationResponse> {
     try {
+      await assertSafeSmtpOutboundTarget(this.config.host, this.config.port, {
+        secure: this.config.secure,
+        requireTls: this.config.requireTls,
+        ignoreTls: this.config.ignoreTls,
+      });
+
       const mailData = this.createMailData(options);
       await this.transports.sendMail(mailData);
 

--- a/packages/providers/src/lib/sms/sinch/sinch.provider.spec.ts
+++ b/packages/providers/src/lib/sms/sinch/sinch.provider.spec.ts
@@ -107,5 +107,15 @@ describe('SinchSmsProvider', () => {
         expect.any(Object)
       );
     });
+
+    it('should reject invalid regions', () => {
+      expect(
+        () =>
+          new SinchSmsProvider({
+            ...mockConfig,
+            region: 'evil.com#@sinch.com',
+          })
+      ).toThrow(/Invalid Sinch region/);
+    });
   });
 });

--- a/packages/providers/src/lib/sms/sinch/sinch.provider.ts
+++ b/packages/providers/src/lib/sms/sinch/sinch.provider.ts
@@ -1,4 +1,4 @@
-import { SmsProviderIdEnum } from '@novu/shared';
+import { SmsProviderIdEnum, assertAllowedSinchSmsRegion } from '@novu/shared';
 import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
 
 import axios from 'axios';
@@ -9,6 +9,7 @@ export class SinchSmsProvider extends BaseProvider implements ISmsProvider {
   id = SmsProviderIdEnum.Sinch;
   protected casing = CasingEnum.CAMEL_CASE;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
+  private readonly region: ReturnType<typeof assertAllowedSinchSmsRegion>;
 
   constructor(
     private config: {
@@ -19,14 +20,14 @@ export class SinchSmsProvider extends BaseProvider implements ISmsProvider {
     }
   ) {
     super();
+    this.region = assertAllowedSinchSmsRegion(this.config.region);
   }
 
   async sendMessage(
     options: ISmsOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
-    const region = this.config.region || 'eu';
-    const url = `https://${region}.sms.api.sinch.com/xms/v1/${this.config.servicePlanId}/batches`;
+    const url = `https://${this.region}.sms.api.sinch.com/xms/v1/${this.config.servicePlanId}/batches`;
 
     const payload = this.transform<Record<string, unknown>>(bridgeProviderData, {
       from: options.from || this.config.from,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -64,6 +64,11 @@
       "import": "./dist/esm/utils/safe-outbound-http.js",
       "types": "./dist/esm/utils/safe-outbound-http.d.ts"
     },
+    "./utils/validate-smtp-outbound-target": {
+      "require": "./dist/cjs/utils/validate-smtp-outbound-target.js",
+      "import": "./dist/esm/utils/validate-smtp-outbound-target.js",
+      "types": "./dist/esm/utils/validate-smtp-outbound-target.d.ts"
+    },
     "./docs/agent-onboarding.md": "./docs/agent-onboarding.md"
   },
   "dependencies": {

--- a/packages/shared/src/consts/index.ts
+++ b/packages/shared/src/consts/index.ts
@@ -1,6 +1,7 @@
 export * from './connect-claim';
 export * from './data-retention';
 export * from './aws-claude-regions';
+export * from './sinch-sms-regions';
 export * from './feature-tiers-constants';
 export * from './filters';
 export * from './handlebar-helpers';

--- a/packages/shared/src/consts/sinch-sms-regions.spec.ts
+++ b/packages/shared/src/consts/sinch-sms-regions.spec.ts
@@ -1,0 +1,16 @@
+import { assertAllowedSinchSmsRegion } from '../consts/sinch-sms-regions';
+import { SsrfBlockedError } from '../utils/ssrf-url-validation';
+import { describe, expect, it } from 'vitest';
+
+describe('sinch-sms-regions', () => {
+  it('accepts known regions', () => {
+    expect(assertAllowedSinchSmsRegion('eu')).toBe('eu');
+    expect(assertAllowedSinchSmsRegion('US')).toBe('us');
+    expect(assertAllowedSinchSmsRegion(undefined)).toBe('eu');
+  });
+
+  it('rejects unknown or injected regions', () => {
+    expect(() => assertAllowedSinchSmsRegion('evil.com#@sinch.com')).toThrow(SsrfBlockedError);
+    expect(() => assertAllowedSinchSmsRegion('eu/internal')).toThrow(SsrfBlockedError);
+  });
+});

--- a/packages/shared/src/consts/sinch-sms-regions.spec.ts
+++ b/packages/shared/src/consts/sinch-sms-regions.spec.ts
@@ -1,5 +1,4 @@
 import { assertAllowedSinchSmsRegion } from '../consts/sinch-sms-regions';
-import { SsrfBlockedError } from '../utils/ssrf-url-validation';
 import { describe, expect, it } from 'vitest';
 
 describe('sinch-sms-regions', () => {
@@ -10,7 +9,7 @@ describe('sinch-sms-regions', () => {
   });
 
   it('rejects unknown or injected regions', () => {
-    expect(() => assertAllowedSinchSmsRegion('evil.com#@sinch.com')).toThrow(SsrfBlockedError);
-    expect(() => assertAllowedSinchSmsRegion('eu/internal')).toThrow(SsrfBlockedError);
+    expect(() => assertAllowedSinchSmsRegion('evil.com#@sinch.com')).toThrow(/Invalid Sinch region/);
+    expect(() => assertAllowedSinchSmsRegion('eu/internal')).toThrow(/Invalid Sinch region/);
   });
 });

--- a/packages/shared/src/consts/sinch-sms-regions.ts
+++ b/packages/shared/src/consts/sinch-sms-regions.ts
@@ -1,0 +1,20 @@
+import { SsrfBlockedError } from '../utils/ssrf-url-validation';
+
+export const SINCH_SMS_REGIONS = ['eu', 'us', 'au', 'br', 'ca'] as const;
+
+export type SinchSmsRegion = (typeof SINCH_SMS_REGIONS)[number];
+
+const SINCH_SMS_REGION_SET = new Set<string>(SINCH_SMS_REGIONS);
+
+export function assertAllowedSinchSmsRegion(region: string | undefined): SinchSmsRegion {
+  const normalized = (region ?? 'eu').trim().toLowerCase();
+
+  if (!normalized || !SINCH_SMS_REGION_SET.has(normalized)) {
+    throw new SsrfBlockedError(
+      'INVALID_URL',
+      `Invalid Sinch region. Allowed regions: ${SINCH_SMS_REGIONS.join(', ')}.`
+    );
+  }
+
+  return normalized as SinchSmsRegion;
+}

--- a/packages/shared/src/consts/sinch-sms-regions.ts
+++ b/packages/shared/src/consts/sinch-sms-regions.ts
@@ -1,5 +1,3 @@
-import { SsrfBlockedError } from '../utils/ssrf-url-validation';
-
 export const SINCH_SMS_REGIONS = ['eu', 'us', 'au', 'br', 'ca'] as const;
 
 export type SinchSmsRegion = (typeof SINCH_SMS_REGIONS)[number];
@@ -10,10 +8,7 @@ export function assertAllowedSinchSmsRegion(region: string | undefined): SinchSm
   const normalized = (region ?? 'eu').trim().toLowerCase();
 
   if (!normalized || !SINCH_SMS_REGION_SET.has(normalized)) {
-    throw new SsrfBlockedError(
-      'INVALID_URL',
-      `Invalid Sinch region. Allowed regions: ${SINCH_SMS_REGIONS.join(', ')}.`
-    );
+    throw new Error(`Invalid Sinch region. Allowed regions: ${SINCH_SMS_REGIONS.join(', ')}.`);
   }
 
   return normalized as SinchSmsRegion;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -13,11 +13,3 @@ export { safeJsonStringify } from './safe-json-stringify';
 export { createMockObjectFromSchema } from './schema/create-mock-object-from-schema';
 export { slugify } from './slugify';
 export * from './tags-filter';
-export {
-  assertSafeSmtpOutboundTarget,
-  assertSafeSmtpOutboundTargetSync,
-  assertSafeSmtpHostFormat,
-  assertSafeSmtpPort,
-  assertSmtpTlsRequired,
-  SsrfBlockedError,
-} from './validate-smtp-outbound-target';

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -13,3 +13,11 @@ export { safeJsonStringify } from './safe-json-stringify';
 export { createMockObjectFromSchema } from './schema/create-mock-object-from-schema';
 export { slugify } from './slugify';
 export * from './tags-filter';
+export {
+  assertSafeSmtpOutboundTarget,
+  assertSafeSmtpOutboundTargetSync,
+  assertSafeSmtpHostFormat,
+  assertSafeSmtpPort,
+  assertSmtpTlsRequired,
+  SsrfBlockedError,
+} from './validate-smtp-outbound-target';

--- a/packages/shared/src/utils/validate-smtp-outbound-target.spec.ts
+++ b/packages/shared/src/utils/validate-smtp-outbound-target.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertSafeSmtpOutboundTarget,
+  assertSafeSmtpOutboundTargetSync,
+  SsrfBlockedError,
+} from './validate-smtp-outbound-target';
+
+describe('validate-smtp-outbound-target', () => {
+  const tlsEnabled = { secure: true, requireTls: false, ignoreTls: false };
+
+  describe('assertSafeSmtpOutboundTargetSync', () => {
+    it('rejects private IP hosts', () => {
+      expect(() => assertSafeSmtpOutboundTargetSync('127.0.0.1', 587, tlsEnabled)).toThrow(SsrfBlockedError);
+    });
+
+    it('rejects localhost', () => {
+      expect(() => assertSafeSmtpOutboundTargetSync('localhost', 587, tlsEnabled)).toThrow(SsrfBlockedError);
+    });
+
+    it('rejects hostnames with URL injection characters', () => {
+      expect(() => assertSafeSmtpOutboundTargetSync('evil.com#@sinch.com', 587, tlsEnabled)).toThrow(SsrfBlockedError);
+      expect(() => assertSafeSmtpOutboundTargetSync('evil.com/internal', 587, tlsEnabled)).toThrow(SsrfBlockedError);
+    });
+
+    it('rejects non-TLS SMTP configurations', () => {
+      expect(() =>
+        assertSafeSmtpOutboundTargetSync('smtp.example.com', 25, {
+          secure: false,
+          requireTls: false,
+        })
+      ).toThrow(SsrfBlockedError);
+    });
+
+    it('allows STARTTLS configurations', () => {
+      expect(() =>
+        assertSafeSmtpOutboundTargetSync('smtp.example.com', 587, {
+          secure: false,
+          requireTls: true,
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('assertSafeSmtpOutboundTarget', () => {
+    it('rejects hosts that resolve to private addresses', async () => {
+      await expect(assertSafeSmtpOutboundTarget('ssrf-link-local-test.invalid', 587, tlsEnabled)).rejects.toThrow(
+        SsrfBlockedError
+      );
+    });
+  });
+});

--- a/packages/shared/src/utils/validate-smtp-outbound-target.spec.ts
+++ b/packages/shared/src/utils/validate-smtp-outbound-target.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertSafeSmtpOutboundTarget,
   assertSafeSmtpOutboundTargetSync,
+  resolveSafeSmtpPinnedTarget,
   SsrfBlockedError,
 } from './validate-smtp-outbound-target';
 
@@ -46,6 +47,18 @@ describe('validate-smtp-outbound-target', () => {
       await expect(assertSafeSmtpOutboundTarget('ssrf-link-local-test.invalid', 587, tlsEnabled)).rejects.toThrow(
         SsrfBlockedError
       );
+    });
+  });
+
+  describe('resolveSafeSmtpPinnedTarget', () => {
+    it('returns a pinned public address for literal IPs', async () => {
+      const pinned = await resolveSafeSmtpPinnedTarget('8.8.8.8', 587, tlsEnabled);
+
+      expect(pinned).toEqual({
+        hostname: '8.8.8.8',
+        address: '8.8.8.8',
+        port: 587,
+      });
     });
   });
 });

--- a/packages/shared/src/utils/validate-smtp-outbound-target.ts
+++ b/packages/shared/src/utils/validate-smtp-outbound-target.ts
@@ -1,0 +1,91 @@
+import { isIP } from 'node:net';
+import {
+  assertSafeOutboundUrl,
+  isPrivateIp,
+  normalizeHostnameForLookup,
+  resolvePublicAddresses,
+  SsrfBlockedError,
+} from './ssrf-url-validation';
+
+export { SsrfBlockedError };
+
+const UNSAFE_SMTP_HOST_PATTERN = /[\s/\\#?@&=:;%]/;
+
+export type SmtpOutboundTlsOptions = {
+  secure?: boolean;
+  requireTls?: boolean;
+  ignoreTls?: boolean;
+};
+
+export function assertSmtpTlsRequired(options: SmtpOutboundTlsOptions): void {
+  if (options.ignoreTls) {
+    throw new SsrfBlockedError('UNSUPPORTED_SCHEME', 'SMTP connections with TLS disabled are not allowed.');
+  }
+
+  if (!options.secure && !options.requireTls) {
+    throw new SsrfBlockedError(
+      'UNSUPPORTED_SCHEME',
+      'SMTP connections must use TLS (enable Secure or Require TLS).'
+    );
+  }
+}
+
+export function assertSafeSmtpHostFormat(host: string | undefined): string {
+  const trimmed = host?.trim();
+
+  if (!trimmed) {
+    throw new SsrfBlockedError('INVALID_URL', 'SMTP host is required.');
+  }
+
+  if (UNSAFE_SMTP_HOST_PATTERN.test(trimmed)) {
+    throw new SsrfBlockedError('INVALID_URL', 'SMTP host contains invalid characters.');
+  }
+
+  const normalized = normalizeHostnameForLookup(trimmed);
+
+  assertSafeOutboundUrl(`https://${normalized}`);
+
+  const literalFamily = isIP(normalized);
+
+  if (literalFamily !== 0 && isPrivateIp(normalized)) {
+    throw new SsrfBlockedError(
+      'PRIVATE_IP',
+      `Requests to private or reserved IP addresses are not allowed (resolved: ${normalized}).`,
+      { hostname: normalized, resolvedAddress: normalized }
+    );
+  }
+
+  return normalized;
+}
+
+export function assertSafeSmtpPort(port: number | string | undefined): number {
+  const parsed = Number(port);
+
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    throw new SsrfBlockedError('INVALID_URL', 'SMTP port must be an integer between 1 and 65535.');
+  }
+
+  return parsed;
+}
+
+export function assertSafeSmtpOutboundTargetSync(
+  host: string | undefined,
+  port: number | string | undefined,
+  tlsOptions: SmtpOutboundTlsOptions
+): void {
+  assertSmtpTlsRequired(tlsOptions);
+  assertSafeSmtpHostFormat(host);
+  assertSafeSmtpPort(port);
+}
+
+export async function assertSafeSmtpOutboundTarget(
+  host: string | undefined,
+  port: number | string | undefined,
+  tlsOptions: SmtpOutboundTlsOptions
+): Promise<void> {
+  assertSafeSmtpOutboundTargetSync(host, port, tlsOptions);
+
+  const normalizedHost = assertSafeSmtpHostFormat(host);
+
+  await resolvePublicAddresses(normalizedHost);
+}

--- a/packages/shared/src/utils/validate-smtp-outbound-target.ts
+++ b/packages/shared/src/utils/validate-smtp-outbound-target.ts
@@ -78,14 +78,39 @@ export function assertSafeSmtpOutboundTargetSync(
   assertSafeSmtpPort(port);
 }
 
+export type SafeSmtpPinnedTarget = {
+  hostname: string;
+  address: string;
+  port: number;
+};
+
+export async function resolveSafeSmtpPinnedTarget(
+  host: string | undefined,
+  port: number | string | undefined,
+  tlsOptions: SmtpOutboundTlsOptions
+): Promise<SafeSmtpPinnedTarget> {
+  assertSmtpTlsRequired(tlsOptions);
+
+  const hostname = assertSafeSmtpHostFormat(host);
+  const parsedPort = assertSafeSmtpPort(port);
+  const addresses = await resolvePublicAddresses(hostname);
+  const chosen = addresses[0];
+
+  if (!chosen) {
+    throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${hostname}".`, { hostname });
+  }
+
+  return {
+    hostname,
+    address: chosen.address,
+    port: parsedPort,
+  };
+}
+
 export async function assertSafeSmtpOutboundTarget(
   host: string | undefined,
   port: number | string | undefined,
   tlsOptions: SmtpOutboundTlsOptions
 ): Promise<void> {
-  assertSafeSmtpOutboundTargetSync(host, port, tlsOptions);
-
-  const normalizedHost = assertSafeSmtpHostFormat(host);
-
-  await resolvePublicAddresses(normalizedHost);
+  await resolveSafeSmtpPinnedTarget(host, port, tlsOptions);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes authenticated tenant SSRF paths where tenant-controlled destinations reached outbound connects without SSRF policy enforcement.

### Custom SMTP (`check-integration`)

- Added `assertSafeSmtpOutboundTarget` helpers in `@novu/shared` that reuse the existing SSRF URL validation primitives (`assertSafeOutboundUrl`, `resolvePublicAddresses`).
- Rejects private/loopback/link-local hosts, malformed host injection (`/`, `#`, etc.), and non-TLS SMTP configurations.
- Validation runs when:
  - Creating/updating integrations (sync host/TLS checks before store)
  - Building the nodemailer handler/provider (sync)
  - Sending or checking SMTP connectivity (async DNS resolution)

### Sinch SMS region

- Added server-side allowlist for Sinch regions: `eu`, `us`, `au`, `br`, `ca`.
- Region is validated before provider construction, handler build, and integration create/update.

## Test plan

- [x] `pnpm --filter @novu/shared test` (new SMTP + Sinch region specs)
- [x] `pnpm --filter @novu/providers test src/lib/sms/sinch/sinch.provider.spec.ts`
- [x] `pnpm --filter @novu/shared build`
- [x] `pnpm --filter @novu/providers build`
- [x] `pnpm --filter @novu/application-generic build`
- [x] `pnpm --filter @novu/api-service build`
- [x] Integration e2e: `create-integration`, `update-integration`, `get-integration`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8186](https://linear.app/novu/issue/NV-8186/securityp1-ssrf-via-smtp-check-integration-sinch-region-route-through)

<div><a href="https://cursor.com/agents/bc-64d5dca3-79d9-40cd-a11c-ea5295ca99f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64d5dca3-79d9-40cd-a11c-ea5295ca99f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens outbound checks for tenant-controlled SMTP and Sinch integrations. The main changes are:

- SMTP host, port, and TLS validation in shared code.
- Pinned SMTP connection targets for Nodemailer sends and checks.
- API-side credential validation during integration create and update.
- Sinch SMS region normalization and allowlisting.
- Tests for SMTP outbound validation and Sinch region handling.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts | Creates a fresh Nodemailer transport from a resolved public address while keeping the original hostname for TLS. |
| packages/shared/src/utils/validate-smtp-outbound-target.ts | Adds shared SMTP outbound target validation and pinned target resolution. |
| apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts | Maps outbound credential validation failures to bad-request responses. |
| packages/providers/src/lib/sms/sinch/sinch.provider.ts | Uses a validated Sinch region when building the SMS API URL. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): pin SMTP DNS and map i..."](https://github.com/novuhq/novu/commit/f0d5250a2bdbae91bb9c71df1373978a23913bf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41902448)</sub>

<!-- /greptile_comment -->