### PR TITLE
feat(framework,api-service): expose delete message on self-hosted agent reply contract fixes NV-8197

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
@@ -38,6 +38,7 @@ export class AgentReplyController {
         signals: body.signals as Signal[],
         toolResults: body.toolResults as ToolResult[],
         addReactions: body.addReactions,
+        deleteMessages: body.deleteMessages,
         typing: body.typing,
       })
     );

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command.ts
@@ -5,6 +5,7 @@ import { IsArray, IsBoolean, IsNotEmpty, IsObject, IsOptional, IsString, Validat
 import { EnvironmentWithUserCommand } from '../../../../shared/commands/project.command';
 import {
   AddReactionPayloadDto,
+  DeleteMessagePayloadDto,
   EditPayloadDto,
   ReplyContentDto,
   ToolApprovalRequestPayloadDto,
@@ -57,6 +58,12 @@ export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
   @ValidateNested({ each: true })
   @Type(() => AddReactionPayloadDto)
   addReactions?: AddReactionPayloadDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DeleteMessagePayloadDto)
+  deleteMessages?: DeleteMessagePayloadDto[];
 
   @IsOptional()
   @IsObject()

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.spec.ts
@@ -23,6 +23,7 @@ describe('HandleAgentReply - active-conversation counting', () => {
     const analyticsService = { track: sinon.stub() };
     const outboundGateway = {
       deliver: sinon.stub().resolves({ messageId: 'm1', platformThreadId: 'thread1' }),
+      deleteInConversation: sinon.stub().resolves(undefined),
     };
     const inboundAck = { onBridgeReplyDelivered: sinon.stub().resolves(undefined) };
     const conversationActivation = {
@@ -74,5 +75,19 @@ describe('HandleAgentReply - active-conversation counting', () => {
     expect(outboundGateway.deliver.calledOnce).to.equal(true);
     expect(conversationActivation.assertOutboundWithinLimit.called).to.equal(false);
     expect(conversationActivation.registerEngagement.called).to.equal(false);
+  });
+
+  it('deletes platform messages for a deleteMessages-only request', async () => {
+    const { usecase, baseCommand, outboundGateway } = setup();
+
+    await usecase.execute({
+      ...baseCommand,
+      deleteMessages: [{ messageId: 'msg-abc' }, { messageId: 'msg-def' }],
+    } as any);
+
+    expect(outboundGateway.deliver.called).to.equal(false);
+    expect(outboundGateway.deleteInConversation.callCount).to.equal(2);
+    expect(outboundGateway.deleteInConversation.getCall(0).args[4]).to.equal('msg-abc');
+    expect(outboundGateway.deleteInConversation.getCall(1).args[4]).to.equal('msg-def');
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -58,10 +58,11 @@ export class HandleAgentReply {
         command.signals?.length ||
         command.toolResults?.length ||
         command.toolApprovalRequest ||
-        command.addReactions?.length)
+        command.addReactions?.length ||
+        command.deleteMessages?.length)
     ) {
       throw new BadRequestException(
-        'edit cannot be combined with resolve, signals, toolResults, toolApprovalRequest, or addReactions'
+        'edit cannot be combined with resolve, signals, toolResults, toolApprovalRequest, addReactions, or deleteMessages'
       );
     }
     if (
@@ -72,11 +73,12 @@ export class HandleAgentReply {
       !command.toolResults?.length &&
       !command.toolApprovalRequest &&
       !command.addReactions?.length &&
+      !command.deleteMessages?.length &&
       !command.plan &&
       !command.typing
     ) {
       throw new BadRequestException(
-        'At least one of reply, edit, resolve, signals, toolResults, toolApprovalRequest, addReactions, plan, or typing must be provided'
+        'At least one of reply, edit, resolve, signals, toolResults, toolApprovalRequest, addReactions, deleteMessages, plan, or typing must be provided'
       );
     }
 
@@ -181,6 +183,20 @@ export class HandleAgentReply {
       );
     }
 
+    if (command.deleteMessages?.length) {
+      await Promise.allSettled(
+        command.deleteMessages.map((d) =>
+          this.outboundGateway.deleteInConversation(
+            conversation._agentId,
+            command.integrationIdentifier,
+            channel.platform,
+            channel.platformThreadId,
+            d.messageId
+          )
+        )
+      );
+    }
+
     if (command.resolve) {
       await this.resolveConversation(command, config!, conversation, channel, command.resolve);
     }
@@ -188,6 +204,7 @@ export class HandleAgentReply {
     const triggerSignalCount = (command.signals ?? []).filter((s) => s.type === 'trigger').length;
     const metadataSignalCount = (command.signals ?? []).filter((s) => s.type === 'metadata').length;
     const reactionCount = command.addReactions?.length ?? 0;
+    const deleteMessageCount = command.deleteMessages?.length ?? 0;
     const actions: string[] = [];
 
     if (command.reply) actions.push('reply');
@@ -197,6 +214,7 @@ export class HandleAgentReply {
     if (triggerSignalCount > 0) actions.push('trigger_signals');
     if (metadataSignalCount > 0) actions.push('metadata_signals');
     if (reactionCount > 0) actions.push('add_reactions');
+    if (deleteMessageCount > 0) actions.push('delete_messages');
     if (command.typing) actions.push('typing');
 
     trackAgentReplyProcessed(this.analyticsService, {

--- a/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
@@ -37,6 +37,7 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
       .stub(outboundGateway, 'editInConversation')
       .resolves({ messageId: 'platform-msg-1', platformThreadId: 'platform-thread-1' });
     sinon.stub(outboundGateway, 'reactToMessage').resolves();
+    sinon.stub(outboundGateway, 'deleteInConversation').resolves();
     sinon.stub(outboundGateway, 'removeReaction').resolves();
     sinon.stub(outboundGateway, 'startTypingInConversation').resolves();
   });
@@ -320,6 +321,40 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
         integrationIdentifier: ctx.integrationIdentifier,
         edit: { messageId: 'msg-edit', content: { markdown: 'updated' } },
         addReactions: [{ messageId: 'msg-abc', emojiName: 'thumbs_up' }],
+      });
+
+      expect(res.status).to.equal(400);
+    });
+  });
+
+  describe('deleteMessages', () => {
+    it('should call deleteInConversation for each deleteMessages entry', async () => {
+      const conversationId = await seedConversation(ctx);
+      const outboundGateway = testServer.getService(OutboundGateway);
+
+      const res = await postReply({
+        conversationId,
+        integrationIdentifier: ctx.integrationIdentifier,
+        deleteMessages: [{ messageId: 'msg-abc' }, { messageId: 'msg-def' }],
+      });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.data).to.be.null;
+
+      const stub = outboundGateway.deleteInConversation as sinon.SinonStub;
+      expect(stub.callCount).to.equal(2);
+      expect(stub.getCall(0).args[4]).to.equal('msg-abc');
+      expect(stub.getCall(1).args[4]).to.equal('msg-def');
+    });
+
+    it('should return 400 when edit and deleteMessages are combined', async () => {
+      const conversationId = await seedConversation(ctx);
+
+      const res = await postReply({
+        conversationId,
+        integrationIdentifier: ctx.integrationIdentifier,
+        edit: { messageId: 'msg-edit', content: { markdown: 'updated' } },
+        deleteMessages: [{ messageId: 'msg-abc' }],
       });
 
       expect(res.status).to.equal(400);

--- a/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
@@ -241,6 +241,13 @@ export class AddReactionPayloadDto {
   emojiName: string;
 }
 
+export class DeleteMessagePayloadDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  messageId: string;
+}
+
 export class SignalDto {
   @ApiProperty({ enum: SIGNAL_TYPES })
   @IsString()
@@ -365,6 +372,17 @@ export class AgentReplyPayloadDto {
   @ValidateNested({ each: true })
   @Type(() => AddReactionPayloadDto)
   addReactions?: AddReactionPayloadDto[];
+
+  @ApiPropertyOptional({
+    type: [DeleteMessagePayloadDto],
+    description:
+      'Delete previously posted platform messages. Removes the rendered message only — history is preserved.',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DeleteMessagePayloadDto)
+  deleteMessages?: DeleteMessagePayloadDto[];
 
   @ApiPropertyOptional({
     description:

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -24,6 +24,7 @@ export type {
   AgentToolCall,
   CardChild,
   CardElement,
+  DeleteMessagePayload,
   EditPayload,
   FileRef,
   MessageContent,

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -14,6 +14,7 @@ import type {
   AgentReplyPayload,
   AgentSubscriber,
   AgentToolCall,
+  DeleteMessagePayload,
   FileRef,
   MessageContent,
   PendingApproval as PendingApprovalType,
@@ -257,6 +258,14 @@ class ReplyHandleImpl implements ReplyHandle {
 
     return this;
   }
+
+  async delete(): Promise<void> {
+    await this.poster.post({
+      conversationId: this.conversationId,
+      integrationIdentifier: this.integrationIdentifier,
+      deleteMessages: [{ messageId: this.messageId }],
+    });
+  }
 }
 
 export class AgentContextImpl implements AgentRuntimeContext {
@@ -285,6 +294,7 @@ export class AgentContextImpl implements AgentRuntimeContext {
   private _toolResults: ToolResult[] = [];
   private _pendingToolApprovalRequest: ToolApprovalRequestPayload | null = null;
   private _pendingReactions: AddReactionPayload[] = [];
+  private _pendingDeletes: DeleteMessagePayload[] = [];
   private _resolveSignal: { summary?: string } | null = null;
   private _metadataState: Record<string, unknown>;
   private readonly _toolApprovalConfig?: ToolApprovalConfig;
@@ -416,6 +426,10 @@ export class AgentContextImpl implements AgentRuntimeContext {
     this._pendingReactions.push({ messageId, emojiName });
   }
 
+  deleteMessage(messageId: string): void {
+    this._pendingDeletes.push({ messageId });
+  }
+
   /**
    * Flush any remaining signals that weren't sent with reply().
    * Called internally after onResolve returns.
@@ -441,7 +455,8 @@ export class AgentContextImpl implements AgentRuntimeContext {
       this._signals.length ||
       this._toolResults.length ||
       this._resolveSignal ||
-      this._pendingReactions.length
+      this._pendingReactions.length ||
+      this._pendingDeletes.length
     );
   }
 
@@ -464,6 +479,11 @@ export class AgentContextImpl implements AgentRuntimeContext {
     if (this._pendingReactions.length) {
       body.addReactions = this._pendingReactions;
       this._pendingReactions = [];
+    }
+
+    if (this._pendingDeletes.length) {
+      body.deleteMessages = this._pendingDeletes;
+      this._pendingDeletes = [];
     }
 
     if (this._resolveSignal) {

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -1442,6 +1442,122 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(replyBody.addReactions[0]).toEqual({ messageId: 'msg-reacted', emojiName: 'thumbs_up' });
   });
 
+  it('should delete a previously sent reply via the returned handle', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (_message, ctx) => {
+        const msg = await ctx.reply('Temporary notice');
+        await msg.delete();
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+
+    await vi.waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+
+    const replyCalls = fetchMock.mock.calls.filter(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const parsedBodies = replyCalls.map(([, init]: any[]) => JSON.parse(init.body));
+    const deleteBody = parsedBodies.find((body: any) => body.deleteMessages);
+
+    expect(deleteBody).toBeDefined();
+    expect(deleteBody.deleteMessages).toEqual([{ messageId: 'msg-1' }]);
+    expect(deleteBody.reply).toBeUndefined();
+  });
+
+  it('should flush deleteMessage without a reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (_message, ctx) => {
+        ctx.deleteMessage('msg-stale');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const flushBody = JSON.parse(replyCall![1].body);
+
+    expect(flushBody.reply).toBeUndefined();
+    expect(flushBody.deleteMessages).toEqual([{ messageId: 'msg-stale' }]);
+  });
+
+  it('should batch deleteMessage with reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (_message, ctx) => {
+        ctx.deleteMessage('msg-stale');
+        await ctx.reply('Got it');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply' && JSON.parse(call[1].body).reply
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.reply.markdown).toBe('Got it');
+    expect(replyBody.deleteMessages).toEqual([{ messageId: 'msg-stale' }]);
+  });
+
   it('should have null reaction on non-reaction events', async () => {
     let capturedCtx: any;
 

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -290,6 +290,8 @@ export interface ReplyHandle {
   readonly platformThreadId: string;
   /** Edit this message in place with new content. Returns the same handle for chaining. */
   edit(content: MessageContent, options?: { files?: FileRef[] }): Promise<ReplyHandle>;
+  /** Delete this message from the platform. Removes the rendered message only — history is preserved. */
+  delete(): Promise<void>;
 }
 
 export interface AgentHandlerContext {
@@ -389,6 +391,16 @@ export interface AgentHandlerContext {
    *   await ctx.reply('Done!');
    */
   addReaction(messageId: string, emojiName: Emoji): void;
+  /**
+   * Delete a platform message by id. Queued and flushed with the next `ctx.reply()`,
+   * or automatically when the handler completes (same batching as `ctx.addReaction()`).
+   * Deletes the rendered message only — conversation history is preserved.
+   *
+   * @example
+   *   ctx.deleteMessage(ctx.action!.sourceMessageId!);
+   *   await ctx.reply('Processing…');
+   */
+  deleteMessage(messageId: string): void;
   /**
    * Control the typing / "Thinking…" status for the current turn.
    * Posts immediately (like `reply()`), updating the indicator Novu already shows on inbound.
@@ -562,6 +574,11 @@ export interface AddReactionPayload {
   emojiName: Emoji;
 }
 
+/** Delete a previously posted platform message. Removes the rendered message only — history is preserved. */
+export interface DeleteMessagePayload {
+  messageId: string;
+}
+
 /**
  * Per-turn typing/status control op sent on the reply contract.
  * - `{ status?: string }` — set/replace the status; omit `status` for the default "Thinking…".
@@ -586,6 +603,7 @@ export interface AgentReplyPayload {
   toolResults?: ToolResult[];
   toolApprovalRequest?: ToolApprovalRequestPayload;
   addReactions?: AddReactionPayload[];
+  deleteMessages?: DeleteMessagePayload[];
   typing?: TypingOp;
 }
 

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -35,6 +35,7 @@ export type {
   AgentResolveContext,
   AgentSubscriber,
   AgentToolCall,
+  DeleteMessagePayload,
   EditPayload,
   FileRef,
   MessageContent,


### PR DESCRIPTION
## Summary
- Expose `deleteMessages` on the public agent reply contract (`AgentReplyPayload`, DTO, controller, `HandleAgentReply`) so self-hosted bridge brains can delete platform messages fail-soft via existing `OutboundGateway.deleteInConversation`.
- Add framework SDK surfaces: `ReplyHandle.delete()` (immediate) and `ctx.deleteMessage(messageId)` (queued/batched like `addReaction`).
- Platform-only delete — rendered message is removed; conversation history/ledger is preserved (matches managed behavior).

## Test plan
- [x] Framework unit tests for `handle.delete()`, flush-only `ctx.deleteMessage`, and batch delete + reply
- [x] `HandleAgentReply` unit test for deleteMessages-only requests
- [x] API e2e: deleteMessages delivery + edit/deleteMessages validation rejection

## Notes
- Approval-card auto-delete on verdict is intentionally out of scope (follow-up PR).
- Linear: https://linear.app/novu/issue/NV-8197/expose-delete-message-on-self-hosted-agent-reply-contract

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds platform message deletion to agent replies and the framework SDK. The main changes are:

- `deleteMessages` on the public agent reply payload and API command path.
- Delete execution through the existing outbound conversation gateway.
- `ReplyHandle.delete()` for immediate framework deletes.
- `ctx.deleteMessage(messageId)` for queued framework deletes.
- Tests for delete-only requests, batched delete with replies, edit validation, and framework export coverage.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The public `DeleteMessagePayload` export is now present at the package root.
- The delete request paths are covered by the added API and framework tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts | Adds delete request validation, accepts delete-only requests, and sends platform delete operations through the outbound gateway. |
| apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts | Adds the delete message DTO and exposes `deleteMessages` on the agent reply payload. |
| packages/framework/src/resources/agent/agent.context.ts | Adds immediate reply-handle deletes and queued context deletes with flush support. |
| packages/framework/src/resources/agent/agent.types.ts | Adds public framework types and method contracts for message deletion. |
| packages/framework/src/index.ts | Exports `DeleteMessagePayload` from the package root. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(framework): export DeleteMessagePayl..."](https://github.com/novuhq/novu/commit/c428f6a9446b7c8228c5c3da6d12718adff34c93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41913434)</sub>

<!-- /greptile_comment -->