### PR TITLE
feat(framework,api-service): improve self-hosted tool approval card cleanup fixes NV-8199

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.spec.ts
@@ -1,0 +1,92 @@
+import { ConversationActivityTypeEnum } from '@novu/dal';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BridgeExpireSupersededApprovalsService } from './bridge-expire-superseded-approvals.service';
+
+describe('BridgeExpireSupersededApprovalsService', () => {
+  function makeLogger() {
+    return {
+      warn: sinon.stub(),
+      setContext: sinon.stub(),
+    };
+  }
+
+  function makeTurn(overrides: Record<string, unknown> = {}) {
+    return {
+      agentId: 'agent-id',
+      config: {
+        environmentId: 'env-id',
+        organizationId: 'org-id',
+        agentIdentifier: 'billing-agent',
+        integrationIdentifier: 'slack-int',
+      },
+      conversation: { _id: 'conv-id' },
+      ...overrides,
+    };
+  }
+
+  it('should persist a system denial and delete the pending approval card', async () => {
+    const pendingRequest = {
+      type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
+      platformMessageId: 'msg-approval',
+      toolData: { approvalId: 'approval-1', toolCallId: 'tc-1', toolName: 'issueRefund' },
+    };
+    const channel = { platform: 'slack', platformThreadId: 'thread-1' };
+    const conversationService = {
+      getHistory: sinon.stub().resolves([pendingRequest]),
+      getPrimaryChannel: sinon.stub().returns(channel),
+      persistToolApprovalDecision: sinon.stub().resolves(undefined),
+    };
+    const outboundGateway = {
+      deleteInConversation: sinon.stub().resolves(undefined),
+      edit: sinon.stub(),
+    };
+    const service = new BridgeExpireSupersededApprovalsService(
+      conversationService as any,
+      outboundGateway as any,
+      makeLogger() as any
+    );
+
+    await service.expireOnNewMessage(makeTurn() as any);
+
+    expect(conversationService.persistToolApprovalDecision.calledOnce).to.equal(true);
+    expect(conversationService.persistToolApprovalDecision.firstCall.args[0]).to.include({
+      approvalId: 'approval-1',
+      approved: false,
+    });
+    expect(
+      outboundGateway.deleteInConversation.calledOnceWithExactly(
+        'agent-id',
+        'slack-int',
+        'slack',
+        'thread-1',
+        'msg-approval'
+      )
+    ).to.equal(true);
+    expect(outboundGateway.edit.called).to.equal(false);
+  });
+
+  it('should skip channel cleanup when the approval request has no platform message id', async () => {
+    const pendingRequest = {
+      type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
+      toolData: { approvalId: 'approval-1', toolCallId: 'tc-1', toolName: 'issueRefund' },
+    };
+    const conversationService = {
+      getHistory: sinon.stub().resolves([pendingRequest]),
+      getPrimaryChannel: sinon.stub().returns({ platform: 'slack', platformThreadId: 'thread-1' }),
+      persistToolApprovalDecision: sinon.stub().resolves(undefined),
+    };
+    const outboundGateway = {
+      deleteInConversation: sinon.stub().resolves(undefined),
+    };
+    const service = new BridgeExpireSupersededApprovalsService(
+      conversationService as any,
+      outboundGateway as any,
+      makeLogger() as any
+    );
+
+    await service.expireOnNewMessage(makeTurn() as any);
+
+    expect(outboundGateway.deleteInConversation.called).to.equal(false);
+  });
+});

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.ts
@@ -7,7 +7,6 @@ import {
   ConversationChannel,
   ConversationEntity,
 } from '@novu/dal';
-import { Card, CardText } from '@novu/framework';
 import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { OutboundGateway } from '../egress/outbound.gateway';
@@ -55,19 +54,9 @@ function findUnresolvedToolApprovalRequests(activities: ConversationActivityEnti
   return unresolved;
 }
 
-function buildDeniedApprovalCard(toolName: string): Record<string, unknown> {
-  const card = Card({
-    title: 'Denied',
-    subtitle: toolName,
-    children: [CardText(`Skipped ${toolName}.`)],
-  });
-
-  return card as unknown as Record<string, unknown>;
-}
-
 /**
  * Self-hosted bridge only: when the user sends a new message while tool-approval
- * cards are still pending, auto-deny them in the ledger and resolve the cards in Slack.
+ * cards are still pending, auto-deny them in the ledger and delete the cards on-channel.
  */
 @Injectable()
 export class BridgeExpireSupersededApprovalsService {
@@ -103,7 +92,6 @@ export class BridgeExpireSupersededApprovalsService {
   ): Promise<void> {
     const { config } = turn;
     const approvalId = request.toolData?.approvalId;
-    const toolName = request.toolData?.toolName ?? 'tool call';
 
     if (typeof approvalId !== 'string') {
       return;
@@ -140,28 +128,18 @@ export class BridgeExpireSupersededApprovalsService {
     }
 
     try {
-      await this.outboundGateway.edit(
-        {
-          agentId: turn.agentId,
-          integrationIdentifier: config.integrationIdentifier,
-          platform: channel.platform,
-          platformThreadId: channel.platformThreadId,
-        },
-        platformMessageId,
-        { card: buildDeniedApprovalCard(toolName) },
-        {
-          conversationId: conversation._id,
-          channel,
-          agentIdentifier: config.agentIdentifier,
-          environmentId: config.environmentId,
-          organizationId: config.organizationId,
-        }
+      await this.outboundGateway.deleteInConversation(
+        turn.agentId,
+        config.integrationIdentifier,
+        channel.platform,
+        channel.platformThreadId,
+        platformMessageId
       );
     } catch (err) {
-      this.logger.warn(err, `[agent:${config.agentIdentifier}] Failed to edit superseded tool-approval card`);
+      this.logger.warn(err, `[agent:${config.agentIdentifier}] Failed to delete superseded tool-approval card`);
       captureAgentWarning(err, {
         component: 'bridge-expire-superseded-approvals',
-        operation: 'edit-tool-approval-card',
+        operation: 'delete-tool-approval-card',
         agentIdentifier: config.agentIdentifier,
         extra: { approvalId, platformMessageId },
       });

--- a/packages/framework/src/ai-sdk/ai-sdk-agent.ts
+++ b/packages/framework/src/ai-sdk/ai-sdk-agent.ts
@@ -1,6 +1,11 @@
-import { agent as frameworkAgent } from '../resources/agent/agent.resource';
 import { requireRuntimeContext } from '../resources/agent/agent.runtime';
-import type { Agent, AgentActionContext, AgentMessage, ReplyHandle } from '../resources/agent/agent.types';
+import type {
+  Agent,
+  AgentActionContext,
+  AgentHandlers,
+  AgentMessage,
+  ReplyHandle,
+} from '../resources/agent/agent.types';
 import { handleAiSdkResult, isAiSdkResult } from './reply-mapper';
 import type { AiSdkAgentHandlers } from './types';
 
@@ -28,8 +33,13 @@ function normalize(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHandler
 }
 
 export function agent(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHandlers): Agent {
+  if (!id) {
+    throw new Error('agent() requires a non-empty agentId');
+  }
+
   const h = normalize(id, handlers);
   const config = h.toolApproval;
+  const userOnToolApproval = typeof h.onToolApproval === 'function';
 
   // The decision is persisted to `ctx.history` by Novu before this turn fires, so
   // resuming is just re-running `onMessage`: `toModelMessages(ctx.history)` now
@@ -42,7 +52,7 @@ export function agent(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHand
     }
   };
 
-  return frameworkAgent(id, {
+  const wrappedHandlers: AgentHandlers = {
     onMessage: async (message, ctx) => {
       const result = await h.onMessage(message, ctx);
 
@@ -75,5 +85,7 @@ export function agent(id: string, handlers: AiSdkMessageHandler | AiSdkAgentHand
     ...(h.onAction && { onAction: h.onAction }),
     ...(h.onReaction && { onReaction: h.onReaction }),
     ...(h.onResolve && { onResolve: h.onResolve }),
-  });
+  };
+
+  return { id, handlers: wrappedHandlers, userOnToolApproval };
 }

--- a/packages/framework/src/resources/agent/agent-dispatch.ts
+++ b/packages/framework/src/resources/agent/agent-dispatch.ts
@@ -84,12 +84,17 @@ async function runAgentHandler(registeredAgent: Agent, event: string, ctx: Agent
         const approvalMessage = ctx.createReplyHandle(ctx.action!.sourceMessageId ?? '');
 
         const decision: ToolApprovalDecision = { toolCall, approved, approvalMessage };
+
+        if (!registeredAgent.userOnToolApproval) {
+          await ctx.typing();
+
+          if (ctx.action!.sourceMessageId) {
+            await approvalMessage.delete();
+          }
+        }
+
         const result = await registeredAgent.handlers.onToolApproval(decision, ctx as AgentActionContext);
         await replyIfPresent(result);
-
-        if (!registeredAgent.userOnToolApproval && ctx.action!.sourceMessageId) {
-          await approvalMessage.delete();
-        }
         break;
       }
 

--- a/packages/framework/src/resources/agent/agent-dispatch.ts
+++ b/packages/framework/src/resources/agent/agent-dispatch.ts
@@ -85,7 +85,7 @@ async function runAgentHandler(registeredAgent: Agent, event: string, ctx: Agent
 
         const decision: ToolApprovalDecision = { toolCall, approved, approvalMessage };
 
-        if (!registeredAgent.userOnToolApproval) {
+        if (registeredAgent.userOnToolApproval === false) {
           await ctx.typing();
 
           if (ctx.action!.sourceMessageId) {

--- a/packages/framework/src/resources/agent/agent-dispatch.ts
+++ b/packages/framework/src/resources/agent/agent-dispatch.ts
@@ -15,7 +15,6 @@ import type {
 } from './agent.types';
 import { AgentEventEnum, PendingApproval } from './agent.types';
 import { parseApprovalActionId, type ToolApprovalRequestPayload } from './tool-approval/action-id';
-import { resolvedApprovalCard } from './tool-approval/approval-card';
 
 function findApprovalInHistory(
   history: AgentHistoryEntry[],
@@ -88,8 +87,8 @@ async function runAgentHandler(registeredAgent: Agent, event: string, ctx: Agent
         const result = await registeredAgent.handlers.onToolApproval(decision, ctx as AgentActionContext);
         await replyIfPresent(result);
 
-        if (!approvalMessage.editedByHandler && ctx.action!.sourceMessageId) {
-          await approvalMessage.edit(resolvedApprovalCard({ name: toolCall.name, approved }));
+        if (!registeredAgent.userOnToolApproval && ctx.action!.sourceMessageId) {
+          await approvalMessage.delete();
         }
         break;
       }

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -221,7 +221,7 @@ interface ReplyPoster {
 class ReplyHandleImpl implements ReplyHandle {
   public messageId: string;
   public platformThreadId: string;
-  /** @internal set when the handler calls `edit()`; dispatch skips the default resolved card. */
+  /** @internal set when the handler calls `edit()`; dispatch skips default approval card cleanup. */
   public editedByHandler = false;
 
   constructor(

--- a/packages/framework/src/resources/agent/agent.resource.ts
+++ b/packages/framework/src/resources/agent/agent.resource.ts
@@ -15,5 +15,5 @@ export function agent(agentId: string, handlers: AgentHandlers): Agent {
     throw new Error(`agent('${agentId}') requires an onMessage handler`);
   }
 
-  return { id: agentId, handlers };
+  return { id: agentId, handlers, userOnToolApproval: typeof handlers.onToolApproval === 'function' };
 }

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -2152,7 +2152,7 @@ describe('tool approval', () => {
     expect(posts.some((p) => p.reply instanceof PendingApproval)).toBe(false);
   });
 
-  it('routes an approval click to onToolApproval and resolves the card by default', async () => {
+  it('routes an approval click to onToolApproval without auto card cleanup when user-defined', async () => {
     const posts: any[] = [];
     vi.stubGlobal(
       'fetch',
@@ -2166,6 +2166,7 @@ describe('tool approval', () => {
     const seen: { decision?: { approved: boolean; toolCall: unknown } } = {};
     const testAgent = {
       id: 'a',
+      userOnToolApproval: true,
       handlers: {
         onMessage: () => undefined,
         onToolApproval: (decision: { approved: boolean; toolCall: unknown }) => {
@@ -2199,9 +2200,56 @@ describe('tool approval', () => {
 
     expect(seen.decision?.approved).toBe(true);
     expect(seen.decision?.toolCall).toMatchObject({ id: 'tc', name: 'doIt', input: { x: 1 } });
-    const editPost = posts.find((p) => p.edit?.messageId === 'm_prev');
-    expect(editPost).toBeTruthy();
-    // Default resolution edits the card to a resolved state (no actionable buttons).
-    expect(editPost.edit.content.card.title).toBe('Approved');
+    expect(posts.find((p) => p.edit?.messageId === 'm_prev')).toBeUndefined();
+    expect(
+      posts.find((p) => p.deleteMessages?.some((d: { messageId: string }) => d.messageId === 'm_prev'))
+    ).toBeUndefined();
+  });
+
+  it('auto-deletes the approval card when onToolApproval is framework-provided', async () => {
+    const posts: any[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url, init: any) => {
+        posts.push(JSON.parse(init.body));
+
+        return new Response(JSON.stringify({ messageId: 'm', platformThreadId: 't' }), { status: 200 });
+      })
+    );
+
+    const testAgent = {
+      id: 'a',
+      userOnToolApproval: false,
+      handlers: {
+        onMessage: () => undefined,
+        onToolApproval: async () => undefined,
+      },
+    };
+
+    await dispatchAgentEvent({
+      agent: testAgent as never,
+      event: 'onAction',
+      bridge: approvalBridge({
+        event: 'onAction',
+        message: null,
+        history: [
+          {
+            role: 'agent',
+            type: 'tool_approval_request',
+            content: '',
+            toolData: { approvalId: 'tc', toolCallId: 'tc', toolName: 'doIt', input: { x: 1 } },
+            createdAt: '1',
+          },
+        ],
+        action: { id: buildApprovalActionId('approve', 'tc'), sourceMessageId: 'm_prev' },
+      }),
+      secretKey: 's',
+    });
+
+    const deletePost = posts.find((p) =>
+      p.deleteMessages?.some((d: { messageId: string }) => d.messageId === 'm_prev')
+    );
+    expect(deletePost).toBeTruthy();
+    expect(posts.find((p) => p.edit?.messageId === 'm_prev')).toBeUndefined();
   });
 });

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -2246,10 +2246,59 @@ describe('tool approval', () => {
       secretKey: 's',
     });
 
+    expect(posts[0].typing).toEqual({});
     const deletePost = posts.find((p) =>
       p.deleteMessages?.some((d: { messageId: string }) => d.messageId === 'm_prev')
     );
     expect(deletePost).toBeTruthy();
+    expect(posts.indexOf(deletePost!)).toBe(1);
     expect(posts.find((p) => p.edit?.messageId === 'm_prev')).toBeUndefined();
+  });
+
+  it('starts typing before handler when onToolApproval is framework-provided', async () => {
+    const posts: any[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url, init: any) => {
+        posts.push(JSON.parse(init.body));
+
+        return new Response(JSON.stringify({ messageId: 'm', platformThreadId: 't' }), { status: 200 });
+      })
+    );
+
+    const testAgent = {
+      id: 'a',
+      userOnToolApproval: false,
+      handlers: {
+        onMessage: () => undefined,
+        onToolApproval: async (_decision: unknown, ctx: { reply: (text: string) => Promise<unknown> }) => {
+          await ctx.reply('resumed');
+        },
+      },
+    };
+
+    await dispatchAgentEvent({
+      agent: testAgent as never,
+      event: 'onAction',
+      bridge: approvalBridge({
+        event: 'onAction',
+        message: null,
+        history: [
+          {
+            role: 'agent',
+            type: 'tool_approval_request',
+            content: '',
+            toolData: { approvalId: 'tc', toolCallId: 'tc', toolName: 'doIt', input: { x: 1 } },
+            createdAt: '1',
+          },
+        ],
+        action: { id: buildApprovalActionId('approve', 'tc'), sourceMessageId: 'm_prev' },
+      }),
+      secretKey: 's',
+    });
+
+    expect(posts[0].typing).toEqual({});
+    expect(posts[1].deleteMessages).toEqual([{ messageId: 'm_prev' }]);
+    expect(posts[2].reply).toEqual({ markdown: 'resumed' });
   });
 });

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -2206,6 +2206,51 @@ describe('tool approval', () => {
     ).toBeUndefined();
   });
 
+  it('does not auto-delete when userOnToolApproval is unset on a hand-built agent', async () => {
+    const posts: any[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url, init: any) => {
+        posts.push(JSON.parse(init.body));
+
+        return new Response(JSON.stringify({ messageId: 'm', platformThreadId: 't' }), { status: 200 });
+      })
+    );
+
+    const testAgent = {
+      id: 'a',
+      handlers: {
+        onMessage: () => undefined,
+        onToolApproval: () => undefined,
+      },
+    };
+
+    await dispatchAgentEvent({
+      agent: testAgent as never,
+      event: 'onAction',
+      bridge: approvalBridge({
+        event: 'onAction',
+        message: null,
+        history: [
+          {
+            role: 'agent',
+            type: 'tool_approval_request',
+            content: '',
+            toolData: { approvalId: 'tc', toolCallId: 'tc', toolName: 'doIt', input: { x: 1 } },
+            createdAt: '1',
+          },
+        ],
+        action: { id: buildApprovalActionId('approve', 'tc'), sourceMessageId: 'm_prev' },
+      }),
+      secretKey: 's',
+    });
+
+    expect(posts.find((p) => p.typing !== undefined)).toBeUndefined();
+    expect(
+      posts.find((p) => p.deleteMessages?.some((d: { messageId: string }) => d.messageId === 'm_prev'))
+    ).toBeUndefined();
+  });
+
   it('auto-deletes the approval card when onToolApproval is framework-provided', async () => {
     const posts: any[] = [];
     vi.stubGlobal(

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -247,8 +247,9 @@ export interface ToolApprovalDecision {
   /** `true` if the user approved, `false` if they denied. */
   approved: boolean;
   /**
-   * Handle to the approval message. Edit it to show a custom resolved state,
-   * or leave it unchanged to use the default resolved card.
+   * Handle to the approval message. When you register `onToolApproval`, you own
+   * card cleanup — call `edit()` or `delete()` as needed. When the framework
+   * handles the approval click, the card is deleted for you.
    */
   approvalMessage: ReplyHandle;
 }
@@ -502,6 +503,12 @@ export interface AgentHandlers {
 export interface Agent {
   id: string;
   handlers: AgentHandlers;
+  /**
+   * @internal Set by `agent()` / ai-sdk registration. True when the application
+   * author registered `onToolApproval` (full manual card cleanup). False when
+   * only a framework wrapper handles approval clicks (auto-delete after handler).
+   */
+  userOnToolApproval?: boolean;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Default approve/deny (ai-sdk / framework-owned `onToolApproval`)**: show `ctx.typing()` and **delete** the approval card **before** resume — matches managed timing and closes the silent gap after clicking Approve.
- **Auto-deny on next message**: superseded pending approval cards are **deleted** instead of edited to a static "Denied" card (ledger denial unchanged).
- **User-defined `onToolApproval`**: unchanged — no auto typing/delete; handler owns card lifecycle via `userOnToolApproval`.
- Builds on NV-8197 (`deleteMessage` on reply contract) and replaces the previous edit-to-resolved default for framework-owned cleanup.

```mermaid
sequenceDiagram
    participant U as User
    participant N as Novu dispatch
    participant B as Brain

    U->>N: Approve click
    N->>N: typing + delete card
    N->>B: onToolApproval → resume
    B->>N: final reply

    U->>N: New message (stale card pending)
    N->>N: ledger deny + delete card
    N->>B: onMessage
```

## Test plan

- [x] `pnpm exec vitest run src/resources/agent/agent.test.ts -t "tool approval"`
- [x] `mocha bridge-expire-superseded-approvals.service.spec.ts` (2 passing)
- [ ] Manual: approve tool on Slack — card disappears, typing shows, reply follows
- [ ] Manual: send new message while approval pending — card deleted (not edited to Denied)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates tool approval cleanup for framework-owned and self-hosted approval flows. The main changes are:

- Framework-owned approval clicks now show typing and delete the approval card before resume.
- User-defined approval handlers keep ownership of card cleanup.
- Superseded self-hosted approval cards are deleted instead of edited to a denied card.
- Tests cover ownership flags, approval-card deletion, and missing platform message IDs.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that after the change, the head operation sequence starts with post:typing and post:deleteMessages, followed by handler start, final reply, and handler end, with no resolved-card edit.
- Compared the superseded-approval-delete flow and confirmed the after state uses deleteInConversation while the before state used an edit, with one persistToolApprovalDecision call where approved is false; both commands exited with code 0.
- Observed that the user-tool approval lifecycle now aligns with the base flow, with the user handler retaining lifecycle ownership and no framework automatic cleanup; harness source for testing is saved.

<a href="https://app.greptile.com/trex/runs/13327954/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/resources/agent/agent-dispatch.ts | Approval dispatch now deletes cards only for explicitly framework-owned approval handlers. |
| packages/framework/src/resources/agent/agent.resource.ts | The framework agent factory now records whether approval cleanup belongs to the user handler. |
| packages/framework/src/ai-sdk/ai-sdk-agent.ts | The AI SDK wrapper now sets approval ownership while preserving wrapped message and action handlers. |
| apps/api/src/app/agents/conversation-runtime/runtime/bridge-expire-superseded-approvals.service.ts | Superseded approval cleanup now persists the denial and deletes the pending platform card. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(framework): only auto-delete approva..."](https://github.com/novuhq/novu/commit/072157ab97cc0ee0764b584349fb1e31583798d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41920164)</sub>

<!-- /greptile_comment -->