### PR TITLE
fix(api-service): scope workflow reads and environment diff to API key environment fixes NV-8200

### DIFF
--- a/apps/api/src/app/environments-v2/e2e/api-key-environment-diff-scope.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/api-key-environment-diff-scope.e2e.ts
@@ -1,0 +1,113 @@
+import { Novu } from '@novu/api';
+import { WorkflowCreationSourceEnum } from '@novu/api/models/components';
+import { EnvironmentRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import { initNovuClassSdkInternalAuth } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
+
+describe('Environment Diff API key environment scope - /v2/environments/:targetEnvironmentId/diff (POST) #novu-v2', () => {
+  let session: UserSession;
+  let novuClient: Novu;
+  const environmentRepository = new EnvironmentRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    novuClient = initNovuClassSdkInternalAuth(session);
+  });
+
+  async function getProductionEnvironment() {
+    const prodEnv = await environmentRepository.findOne({
+      _parentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    if (!prodEnv) {
+      throw new Error('Production environment not found');
+    }
+
+    return prodEnv;
+  }
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid diffing against a different target environment via API key', async () => {
+      const prodEnv = await getProductionEnvironment();
+
+      await novuClient.workflows.create({
+        name: 'Diff Scope Target Test',
+        workflowId: `diff-scope-target-${Date.now()}`,
+        description: 'Workflow for diff target scope testing',
+        active: true,
+        steps: [
+          {
+            name: 'Email Step',
+            type: 'email',
+            controlValues: {
+              subject: 'Test Subject',
+              body: 'Test email content',
+            },
+          },
+        ],
+        source: WorkflowCreationSourceEnum.Editor,
+      });
+
+      const { body } = await session.testAgent
+        .post(`/v2/environments/${prodEnv._id}/diff`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({
+          sourceEnvironmentId: session.environment._id,
+        });
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+    });
+
+    it('should forbid diffing with a different source environment via API key', async () => {
+      const prodEnv = await getProductionEnvironment();
+
+      const { body } = await session.testAgent
+        .post(`/v2/environments/${session.environment._id}/diff`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({
+          sourceEnvironmentId: prodEnv._id,
+        });
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+    });
+
+    it('should still allow bearer auth to diff across environments in the same org', async () => {
+      const prodEnv = await getProductionEnvironment();
+      const workflowId = `bearer-diff-${Date.now()}`;
+
+      await novuClient.workflows.create({
+        name: 'Bearer Diff Test',
+        workflowId,
+        description: 'Workflow for bearer diff test',
+        active: true,
+        steps: [
+          {
+            name: 'Email Step',
+            type: 'email',
+            controlValues: {
+              subject: 'Test Subject',
+              body: 'Test email content',
+            },
+          },
+        ],
+        source: WorkflowCreationSourceEnum.Editor,
+      });
+
+      const { body } = await session.testAgent
+        .post(`/v2/environments/${prodEnv._id}/diff`)
+        .send({
+          sourceEnvironmentId: session.environment._id,
+        })
+        .expect(200);
+
+      expect(body.data.sourceEnvironmentId).to.equal(session.environment._id);
+      expect(body.data.targetEnvironmentId).to.equal(prodEnv._id);
+      expect(body.data.resources).to.be.an('array');
+    });
+  });
+});

--- a/apps/api/src/app/environments-v2/services/environment-validation.service.ts
+++ b/apps/api/src/app/environments-v2/services/environment-validation.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { BaseRepository, EnvironmentRepository } from '@novu/dal';
 import { EnvironmentEnum, UserSessionData } from '@novu/shared';
+import { assertEnvironmentScopedAccess } from '../../shared/utils/auth.utils';
 
 export interface IEnvironmentValidationParams {
   sourceEnvironmentId: string;
@@ -42,6 +43,9 @@ export class EnvironmentValidationService {
       if (!targetEnv) {
         throw new BadRequestException('Target environment not found');
       }
+
+      assertEnvironmentScopedAccess(user.scheme, user.environmentId, sourceEnvironmentId);
+      assertEnvironmentScopedAccess(user.scheme, user.environmentId, targetEnvironmentId);
     } catch (error) {
       if (error.name === 'CastError') {
         throw new BadRequestException('Invalid environment ID format');

--- a/apps/api/src/app/workflows-v2/e2e/api-key-workflow-environment-scope.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/api-key-workflow-environment-scope.e2e.ts
@@ -1,0 +1,135 @@
+import { Novu } from '@novu/api';
+import { WorkflowCreationSourceEnum } from '@novu/api/models/components';
+import { EnvironmentRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import { initNovuClassSdkInternalAuth } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
+
+describe('Workflow API key environment scope - /v2/workflows (GET) #novu-v2', () => {
+  let session: UserSession;
+  let novuClient: Novu;
+  const environmentRepository = new EnvironmentRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    novuClient = initNovuClassSdkInternalAuth(session);
+  });
+
+  async function getProductionEnvironment() {
+    const prodEnv = await environmentRepository.findOne({
+      _parentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    if (!prodEnv) {
+      throw new Error('Production environment not found');
+    }
+
+    return prodEnv;
+  }
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid reading a workflow from a different environment via API key', async () => {
+      const prodEnv = await getProductionEnvironment();
+      const workflowId = `cross-env-read-${Date.now()}`;
+
+      await novuClient.workflows.create({
+        name: 'Cross Env Read Test',
+        workflowId,
+        description: 'Workflow created in development for scope testing',
+        active: true,
+        steps: [
+          {
+            name: 'Email Step',
+            type: 'email',
+            controlValues: {
+              subject: 'Test Subject',
+              body: 'Test email content',
+            },
+          },
+        ],
+        source: WorkflowCreationSourceEnum.Editor,
+      });
+
+      await session.testAgent
+        .post(`/v2/environments/${prodEnv._id}/publish`)
+        .send({
+          sourceEnvironmentId: session.environment._id,
+          dryRun: false,
+        })
+        .expect(200);
+
+      const { body } = await session.testAgent
+        .get(`/v2/workflows/${workflowId}`)
+        .query({ environmentId: prodEnv._id })
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('is scoped to a single environment');
+    });
+
+    it('should allow reading a workflow from the API key environment via API key', async () => {
+      const workflowId = `same-env-read-${Date.now()}`;
+
+      await novuClient.workflows.create({
+        name: 'Same Env Read Test',
+        workflowId,
+        description: 'Workflow readable with scoped API key',
+        active: true,
+        steps: [
+          {
+            name: 'Email Step',
+            type: 'email',
+            controlValues: {
+              subject: 'Test Subject',
+              body: 'Test email content',
+            },
+          },
+        ],
+        source: WorkflowCreationSourceEnum.Editor,
+      });
+
+      const { body } = await session.testAgent
+        .get(`/v2/workflows/${workflowId}`)
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      expect(body.data.workflowId).to.equal(workflowId);
+    });
+
+    it('should still allow bearer auth to read a workflow from another environment in the same org', async () => {
+      const prodEnv = await getProductionEnvironment();
+      const workflowId = `bearer-cross-env-read-${Date.now()}`;
+
+      await novuClient.workflows.create({
+        name: 'Bearer Cross Env Read Test',
+        workflowId,
+        description: 'Workflow published to production for bearer auth test',
+        active: true,
+        steps: [
+          {
+            name: 'Email Step',
+            type: 'email',
+            controlValues: {
+              subject: 'Test Subject',
+              body: 'Test email content',
+            },
+          },
+        ],
+        source: WorkflowCreationSourceEnum.Editor,
+      });
+
+      await session.testAgent
+        .post(`/v2/environments/${prodEnv._id}/publish`)
+        .send({
+          sourceEnvironmentId: session.environment._id,
+          dryRun: false,
+        })
+        .expect(200);
+
+      const { body } = await session.testAgent.get(`/v2/workflows/${workflowId}`).query({ environmentId: prodEnv._id });
+
+      expect(body.data.workflowId).to.equal(workflowId);
+    });
+  });
+});

--- a/apps/api/src/app/workflows-v2/workflow.controller.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.ts
@@ -41,6 +41,7 @@ import {
 } from '@novu/shared';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { ThrottlerCategory } from '../rate-limiting/guards/throttler.decorator';
+import { assertEnvironmentScopedAccess } from '../shared/utils/auth.utils';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { DeleteWorkflowCommand } from '../workflows-v1/usecases/delete-workflow/delete-workflow.command';
@@ -199,6 +200,8 @@ export class WorkflowController {
     @Param('workflowId', ParseSlugIdPipe) workflowIdOrInternalId: string,
     @Query('environmentId') environmentId?: string
   ): Promise<WorkflowResponseDto> {
+    assertEnvironmentScopedAccess(user.scheme, user.environmentId, environmentId);
+
     return this.getWorkflowUseCase.execute(
       GetWorkflowCommand.create({
         workflowIdOrInternalId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Confirms and fixes a security gap where environment-scoped API keys could read workflow configuration from sibling environments in the same organization.

The 3.17.0 hardening added environment-scope guards to integrations, environment variables, and environment deletes (NV-8182), but workflow reads and environment diff/publish validation were missed.

## Root cause

- `GET /v2/workflows/:workflowId?environmentId=<otherEnv>` resolved the requested environment after only checking org membership in `GetWorkflowUseCase.resolveEnvironmentId`.
- `POST /v2/environments/:targetEnvironmentId/diff` (and publish) validated that environments belong to the org, but did not enforce API key environment scope.

## Fix

- Apply `assertEnvironmentScopedAccess` in `WorkflowController.getWorkflow` when an `environmentId` query param is provided.
- Apply the same guard in `EnvironmentValidationService.validateEnvironments` for both source and target environment IDs (covers diff and publish).

Bearer/session auth is unchanged and can still read or diff across environments within the org.

## Test plan

- [x] Added e2e: `api-key-workflow-environment-scope.e2e.ts`
  - API key forbidden from reading prod workflow via `environmentId` query param
  - API key allowed to read own-environment workflow
  - Bearer auth still allowed cross-environment read
- [x] Added e2e: `api-key-environment-diff-scope.e2e.ts`
  - API key forbidden from diff with foreign target or source environment
  - Bearer auth still allowed cross-environment diff
- [x] All 6 new tests passing locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb5d57c0-93b2-4e8f-88f2-d3168b8d32d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb5d57c0-93b2-4e8f-88f2-d3168b8d32d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes missing environment-scope checks for workflow reads and environment comparison flows. The main changes are:

- Adds `assertEnvironmentScopedAccess` before workflow reads use an explicit `environmentId` query value.
- Applies the same scope check to both source and target environments during diff and publish validation.
- Adds e2e tests for API-key denial across sibling environments and bearer-auth cross-environment access.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The updated code reuses the existing scoped-auth helper at the missing authorization boundaries and keeps bearer/session behavior unchanged.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the direct PR-stated Mocha command for the API key env scope e2e tests, capturing the working directory, output, and an EXIT\_CODE of 1 with no tests executed due to a TypeScript module-resolution failure in setup.
- To diagnose, T-Rex ran with TS\_NODE\_TRANSPILE\_ONLY=true, and the run failed before tests could start because the build output at @novu/application-generic/build/main/index.js was missing.
- T-Rex inspected the environment's dependency layout and confirmed certain workspace symlinks are in place for key packages while others are not resolved as expected in apps/api/node\_modules.

<a href="https://app.greptile.com/trex/runs/13328970/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/environments-v2/services/environment-validation.service.ts | Adds API key/keyless environment-scope assertions for both source and target environment validation used by diff and publish. |
| apps/api/src/app/workflows-v2/workflow.controller.ts | Adds an environment-scope guard before workflow reads honor an explicit `environmentId` query parameter. |
| apps/api/src/app/workflows-v2/e2e/api-key-workflow-environment-scope.e2e.ts | Covers API-key denial for cross-environment workflow reads plus same-environment and bearer-auth allowed cases. |
| apps/api/src/app/environments-v2/e2e/api-key-environment-diff-scope.e2e.ts | Covers API-key denial when either diff source or target is outside the key environment plus bearer-auth allowed behavior. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant WorkflowController
participant EnvValidation as EnvironmentValidationService
participant UseCase
participant Repo as EnvironmentRepository

Client->>WorkflowController: GET /v2/workflows/:workflowId?environmentId
WorkflowController->>WorkflowController: assertEnvironmentScopedAccess(scheme, userEnv, queryEnv)
WorkflowController->>UseCase: GetWorkflowCommand(environmentId)
UseCase->>Repo: validate env belongs to org when cross-env
Repo-->>UseCase: environment
UseCase-->>Client: workflow response

Client->>UseCase: POST /v2/environments/:target/diff or publish
UseCase->>EnvValidation: validateEnvironments(source, target, user)
EnvValidation->>Repo: load source and target by org
Repo-->>EnvValidation: environments
EnvValidation->>EnvValidation: assertEnvironmentScopedAccess for source and target
EnvValidation-->>UseCase: validated or forbidden
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant WorkflowController
participant EnvValidation as EnvironmentValidationService
participant UseCase
participant Repo as EnvironmentRepository

Client->>WorkflowController: GET /v2/workflows/:workflowId?environmentId
WorkflowController->>WorkflowController: assertEnvironmentScopedAccess(scheme, userEnv, queryEnv)
WorkflowController->>UseCase: GetWorkflowCommand(environmentId)
UseCase->>Repo: validate env belongs to org when cross-env
Repo-->>UseCase: environment
UseCase-->>Client: workflow response

Client->>UseCase: POST /v2/environments/:target/diff or publish
UseCase->>EnvValidation: validateEnvironments(source, target, user)
EnvValidation->>Repo: load source and target by org
Repo-->>EnvValidation: environments
EnvValidation->>EnvValidation: assertEnvironmentScopedAccess for source and target
EnvValidation-->>UseCase: validated or forbidden
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): scope workflow reads a..."](https://github.com/novuhq/novu/commit/62655089ab1aa6f19cb933b21e0709494044c3e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41926204)</sub>

<!-- /greptile_comment -->