### PR TITLE
fix(api-service): use Slack mrkdwn links in Powered by watermark fixes NV-8206

### DIFF
--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts
@@ -17,14 +17,25 @@ describe('novu-powered-by-watermark', () => {
     expect(watermark.length).to.be.greaterThan(NOVU_AGENT_POWERED_WATERMARK_TEXT.length);
   });
 
-  it('returns attributed markdown link on Slack with only Novu linked', () => {
+  it('returns attributed Slack mrkdwn link on Slack with only Novu linked', () => {
     const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.SLACK);
+
+    expect(watermark.startsWith('Powered by <')).to.equal(true);
+    expect(watermark).to.include('|Novu>');
+    expect(watermark).to.not.include('[Novu](');
+    expect(watermark).to.include(NOVU_AGENT_POWERED_URL);
+    expect(watermark).to.include('utm_source=my-agent');
+    expect(watermark).to.include('utm_channel=slack');
+  });
+
+  it('returns attributed markdown link on Teams with only Novu linked', () => {
+    const watermark = buildPoweredByWatermark('my-agent', AgentPlatformEnum.TEAMS);
 
     expect(watermark.startsWith('Powered by [Novu](')).to.equal(true);
     expect(watermark).to.not.include('[Powered by Novu](');
     expect(watermark).to.include(NOVU_AGENT_POWERED_URL);
     expect(watermark).to.include('utm_source=my-agent');
-    expect(watermark).to.include('utm_channel=slack');
+    expect(watermark).to.include('utm_channel=teams');
   });
 
   it('wraps markdown in a card with a muted watermark footnote', () => {
@@ -35,7 +46,14 @@ describe('novu-powered-by-watermark', () => {
     expect(card.children[0]).to.deep.equal({ type: 'text', content: 'Hello there' });
     expect(card.children[1]?.type).to.equal('text');
     expect((card.children[1] as { style?: string }).style).to.equal('muted');
-    expect((card.children[1] as { content?: string }).content).to.include('Powered by [Novu](');
+    expect((card.children[1] as { content?: string }).content).to.include('Powered by <');
+    expect((card.children[1] as { content?: string }).content).to.include('|Novu>');
+  });
+
+  it('detects Slack mrkdwn watermark in markdown', () => {
+    const markdown = `Hello\n\nPowered by <${NOVU_AGENT_POWERED_URL}?utm_campaign=agent-powered|Novu>`;
+
+    expect(contentHasPoweredByWatermark(markdown)).to.equal(true);
   });
 
   it('detects attributed watermark in markdown', () => {

--- a/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
+++ b/apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts
@@ -1,5 +1,5 @@
 import type { CardElement } from 'chat';
-import { supportsMarkdownLinks } from '../enums/agent-platform.enum';
+import { AgentPlatformEnum, supportsMarkdownLinks } from '../enums/agent-platform.enum';
 import { buildAttributedNovuUrl } from './novu-attribution-url';
 
 export const NOVU_AGENT_POWERED_URL = 'https://go.novu.co/agent-powered';
@@ -10,14 +10,26 @@ const NOVU_POWERED_WATERMARK_MARKER = '\u200B';
 
 const ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `Powered by [Novu](${NOVU_AGENT_POWERED_URL}`;
 
+const SLACK_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `Powered by <${NOVU_AGENT_POWERED_URL}`;
+
 const LEGACY_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX = `[${NOVU_AGENT_POWERED_WATERMARK_TEXT}](${NOVU_AGENT_POWERED_URL}`;
+
+function formatPoweredByLink(label: string, url: string, platform: string): string {
+  if (platform === AgentPlatformEnum.SLACK) {
+    return `<${url}|${label}>`;
+  }
+
+  return `[${label}](${url})`;
+}
 
 export function buildPoweredByWatermark(agentIdentifier: string, platform: string): string {
   if (!supportsMarkdownLinks(platform)) {
     return `${NOVU_AGENT_POWERED_WATERMARK_TEXT}${NOVU_POWERED_WATERMARK_MARKER}`;
   }
 
-  return `Powered by [Novu](${buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform)})`;
+  const url = buildAttributedNovuUrl(NOVU_AGENT_POWERED_URL, 'agent-powered', agentIdentifier, platform);
+
+  return `Powered by ${formatPoweredByLink('Novu', url, platform)}`;
 }
 
 export function buildBrandedMarkdownReply(
@@ -39,6 +51,7 @@ export function buildBrandedMarkdownReply(
 export function contentHasPoweredByWatermark(markdown: string): boolean {
   if (
     markdown.includes(ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX) ||
+    markdown.includes(SLACK_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX) ||
     markdown.includes(LEGACY_ATTRIBUTED_POWERED_BY_WATERMARK_PREFIX)
   ) {
     return true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the "Powered by Novu" watermark rendering as escaped markdown on Slack agent messages.

**Before:** `Powered by [Novu](<https://go.novu.co/agent-powered?...|go.novu.co/agent-powered?…>)`

**After:** `Powered by Novu` with "Novu" as a clickable link.

## Root cause

The watermark is appended as muted text inside a Chat SDK card. The Slack adapter renders card text as Block Kit `mrkdwn`, which uses `<url|label>` link syntax — not markdown `[label](url)`. Slack auto-linked the bare URL inside the markdown brackets, producing the broken hybrid text.

## Fix

- Use Slack mrkdwn link format (`<url|Novu>`) when the delivery platform is Slack
- Keep markdown link format (`[Novu](url)`) for Teams, Telegram, and other platforms
- Extend watermark detection to recognize the Slack mrkdwn prefix

## Test plan

- [x] Unit tests updated and passing (`novu-powered-by-watermark.spec.ts`)
- [ ] Verify on Slack: agent reply shows "Powered by **Novu**" with Novu as a clickable link in the muted footnote
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1783339394431059?thread_ts=1783339394.431059&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-1c16ee05-90c3-5c55-ba4d-7b6aa890dc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c16ee05-90c3-5c55-ba4d-7b6aa890dc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the agent Powered by watermark for Slack rendering. The main changes are:

- Uses Slack mrkdwn link syntax for Slack watermarks.
- Keeps markdown link syntax for Teams and other markdown-capable platforms.
- Extends watermark detection to recognize the Slack mrkdwn link prefix.
- Adds tests for Slack formatting, Teams formatting, and Slack watermark detection.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is small and localized to watermark formatting and detection. Existing non-Slack behavior is preserved. Tests cover the new Slack path and the existing markdown path.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification for the pull request, but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/shared/util/novu-powered-by-watermark.ts | Updates watermark link formatting to emit Slack mrkdwn links for Slack while preserving markdown links and existing watermark detection for other platforms. |
| apps/api/src/app/agents/shared/util/novu-powered-by-watermark.spec.ts | Adds coverage for Slack mrkdwn watermark formatting, Teams markdown formatting, and detecting the Slack watermark prefix. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
A[buildPoweredByWatermark] --> B{supportsMarkdownLinks platform?}
B -- No --> C[Return plain Powered by Novu with zero-width marker]
B -- Yes --> D[Build attributed Novu URL]
D --> E{platform is Slack?}
E -- Yes --> F[Format as Slack mrkdwn link: url pipe Novu]
E -- No --> G[Format as markdown link: Novu url]
F --> H[Return Powered by watermark]
G --> H
I[contentHasPoweredByWatermark] --> J[Detect markdown, Slack mrkdwn, legacy, or marker watermark]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
A[buildPoweredByWatermark] --> B{supportsMarkdownLinks platform?}
B -- No --> C[Return plain Powered by Novu with zero-width marker]
B -- Yes --> D[Build attributed Novu URL]
D --> E{platform is Slack?}
E -- Yes --> F[Format as Slack mrkdwn link: url pipe Novu]
E -- No --> G[Format as markdown link: Novu url]
F --> H[Return Powered by watermark]
G --> H
I[contentHasPoweredByWatermark] --> J[Detect markdown, Slack mrkdwn, legacy, or marker watermark]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): use Slack mrkdwn links..."](https://github.com/novuhq/novu/commit/265b298ffcee3b24176d4e6a4052ef556a24c63b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42057166)</sub>

<!-- /greptile_comment -->