### PR TITLE
feat(shared,api-service,dashboard): align agent name length on a single 60-char limit

### DIFF
--- a/apps/api/src/app/agents/e2e/agents.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agents.e2e.ts
@@ -303,6 +303,99 @@ describe('Agents API - /agents #novu-v2', () => {
     expect(agentAfter).to.equal(null);
   });
 
+  describe('Name length validation', () => {
+    // Kept in sync with AGENT_NAME_MAX_LENGTH in @novu/shared. Validation failures are
+    // surfaced by AllExceptionsFilter as 422 (not the class-validator default 400).
+    const MAX = 60;
+
+    it('should reject creating an agent with a name longer than the limit', async () => {
+      const identifier = `e2e-name-too-long-${Date.now()}`;
+
+      const res = await session.testAgent.post('/v1/agents').send({
+        name: 'a'.repeat(MAX + 1),
+        identifier,
+      });
+
+      expect(res.status).to.equal(422);
+      const messages = res.body?.errors?.general?.messages;
+      const text = Array.isArray(messages) ? messages.join(' ') : String(messages ?? '');
+      expect(text.toLowerCase()).to.contain(`${MAX} characters`);
+
+      const leftover = await agentRepository.findOne(
+        {
+          identifier,
+          _environmentId: session.environment._id,
+          _organizationId: session.organization._id,
+        },
+        ['_id']
+      );
+      expect(leftover, 'no agent should be created when the name is too long').to.equal(null);
+    });
+
+    it('should allow creating an agent with a name exactly at the limit', async () => {
+      const identifier = `e2e-name-exact-${Date.now()}`;
+      const name = 'a'.repeat(MAX);
+
+      const res = await session.testAgent.post('/v1/agents').send({ name, identifier });
+
+      expect(res.status, JSON.stringify(res.body)).to.equal(201);
+      expect(res.body.data.name).to.equal(name);
+      expect(res.body.data.name.length).to.equal(MAX);
+
+      await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
+    });
+
+    it('should trim trailing whitespace before measuring the name length', async () => {
+      const identifier = `e2e-name-trim-${Date.now()}`;
+      const trimmedName = 'a'.repeat(MAX);
+
+      // 60 real chars + trailing whitespace => 63 raw chars, but trims back to 60.
+      const res = await session.testAgent.post('/v1/agents').send({
+        name: `${trimmedName}   `,
+        identifier,
+      });
+
+      expect(res.status, JSON.stringify(res.body)).to.equal(201);
+      expect(res.body.data.name).to.equal(trimmedName);
+      expect(res.body.data.name.length).to.equal(MAX);
+
+      await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
+    });
+
+    it('should reject updating an agent with a name longer than the limit', async () => {
+      const identifier = `e2e-name-update-long-${Date.now()}`;
+      await session.testAgent.post('/v1/agents').send({ name: 'Update Name Agent', identifier });
+
+      const res = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
+        name: 'a'.repeat(MAX + 1),
+      });
+
+      expect(res.status).to.equal(422);
+      const messages = res.body?.errors?.general?.messages;
+      const text = Array.isArray(messages) ? messages.join(' ') : String(messages ?? '');
+      expect(text.toLowerCase()).to.contain(`${MAX} characters`);
+
+      const getRes = await session.testAgent.get(`/v1/agents/${encodeURIComponent(identifier)}`);
+      expect(getRes.body.data.name, 'name must be unchanged after a rejected update').to.equal('Update Name Agent');
+
+      await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
+    });
+
+    it('should allow updating an agent with a name exactly at the limit', async () => {
+      const identifier = `e2e-name-update-exact-${Date.now()}`;
+      await session.testAgent.post('/v1/agents').send({ name: 'Update Name Agent', identifier });
+
+      const name = 'b'.repeat(MAX);
+      const res = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({ name });
+
+      expect(res.status, JSON.stringify(res.body)).to.equal(200);
+      expect(res.body.data.name).to.equal(name);
+      expect(res.body.data.name.length).to.equal(MAX);
+
+      await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
+    });
+  });
+
   describe('Bridge URL management', () => {
     let identifier: string;
 

--- a/apps/api/src/app/agents/e2e/managed-agent.e2e.ts
+++ b/apps/api/src/app/agents/e2e/managed-agent.e2e.ts
@@ -6,7 +6,7 @@ import {
   decryptCredentials,
 } from '@novu/application-generic';
 import { AgentMcpServerRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
-import { AgentRuntimeProviderIdEnum, IntegrationKindEnum } from '@novu/shared';
+import { AGENT_NAME_MAX_LENGTH, AgentRuntimeProviderIdEnum, IntegrationKindEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -879,6 +879,23 @@ describe('Managed Agents API #novu-v2', () => {
       expect(mockProvider.getAgent.firstCall.args[0]).to.equal(FAKE_ADOPT_AGENT_ID);
       expect(mockProvider.getConfig.called, 'getConfig should be called').to.be.true;
       expect(mockProvider.getConfig.firstCall.args[0]).to.equal(FAKE_ADOPT_AGENT_ID);
+    });
+
+    it('should truncate an externally-sourced provider name that exceeds the limit instead of rejecting it', async () => {
+      const integrationId = await createAgentRuntimeIntegration();
+
+      // Provider names are outside our control — a long one must be truncated, not rejected.
+      const longProviderName = 'Extremely Long Provider Agent Name '.repeat(5).trim();
+      expect(longProviderName.length).to.be.greaterThan(AGENT_NAME_MAX_LENGTH);
+      mockProvider.getAgent.resolves({ externalAgentId: FAKE_ADOPT_AGENT_ID, name: longProviderName });
+
+      const res = await session.testAgent.post('/v1/agents').send(adoptBody(integrationId));
+
+      expect(res.status, `adopt failed: ${JSON.stringify(res.body)}`).to.equal(201);
+      expect(res.body.data.name.length).to.equal(AGENT_NAME_MAX_LENGTH);
+      expect(res.body.data.name).to.equal(longProviderName.slice(0, AGENT_NAME_MAX_LENGTH));
+
+      createdAgentIdentifiers.push(res.body.data.identifier);
     });
   });
 

--- a/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
@@ -9,7 +9,13 @@ import {
   throwPlanLimitExceeded,
 } from '@novu/application-generic';
 import { AgentRepository, CommunityOrganizationRepository, EnvironmentRepository } from '@novu/dal';
-import { ApiServiceLevelEnum, EnvironmentTypeEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
+import {
+  AGENT_NAME_MAX_LENGTH,
+  ApiServiceLevelEnum,
+  EnvironmentTypeEnum,
+  FeatureNameEnum,
+  getFeatureForTierAsBoolean,
+} from '@novu/shared';
 import { KeylessAbuseGuardService } from '../../../../keyless/keyless-abuse-guard.service';
 import { NovuEmailProvisioningService } from '../../../email/novu-email/find-or-create-novu-email/find-or-create-novu-email.service';
 import { trackAgentCreated } from '../../../shared/analytics/agent-analytics';
@@ -132,10 +138,14 @@ export class CreateAgent {
             }
 
             if (isAdoptMode && provisionResult.adoptedName) {
+              // Externally-sourced provider names may exceed our limit. Truncate
+              // instead of rejecting so adopting a long-named provider agent never fails.
+              const adoptedName = provisionResult.adoptedName.slice(0, AGENT_NAME_MAX_LENGTH);
+
               // Resolve a unique identifier from the Claude agent name, following the
               // same pattern used elsewhere in the platform: slugify + random short ID on collision.
               const resolvedIdentifier = await this.resolveUniqueIdentifier(
-                provisionResult.adoptedName,
+                adoptedName,
                 command.environmentId,
                 command.organizationId,
                 created._id
@@ -149,7 +159,7 @@ export class CreateAgent {
                 },
                 {
                   $set: {
-                    name: provisionResult.adoptedName,
+                    name: adoptedName,
                     identifier: resolvedIdentifier,
                   },
                 },

--- a/apps/api/src/app/agents/shared/dtos/create-agent-request.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/create-agent-request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { AgentRuntime, SLUG_IDENTIFIER_REGEX, slugIdentifierFormatMessage } from '@novu/shared';
-import { Type } from 'class-transformer';
+import { AGENT_NAME_MAX_LENGTH, AgentRuntime, SLUG_IDENTIFIER_REGEX, slugIdentifierFormatMessage } from '@novu/shared';
+import { Transform, Type } from 'class-transformer';
 import {
   IsBoolean,
   IsEnum,
@@ -8,6 +8,7 @@ import {
   IsOptional,
   IsString,
   Matches,
+  MaxLength,
   ValidateIf,
   ValidateNested,
 } from 'class-validator';
@@ -18,9 +19,15 @@ export class CreateAgentRequestDto {
     description:
       'Required when not adopting an existing managed agent (i.e. when managedRuntime.externalAgentId is absent). ' +
       'Optional in adopt mode where the name is resolved from the provider.',
+    maxLength: AGENT_NAME_MAX_LENGTH,
   })
   @IsOptional()
   @IsString()
+  // Trim before measuring so trailing whitespace can't push a valid name over the limit.
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @MaxLength(AGENT_NAME_MAX_LENGTH, {
+    message: `Agent name must be ${AGENT_NAME_MAX_LENGTH} characters or fewer.`,
+  })
   name: string;
 
   @ApiProperty({

--- a/apps/api/src/app/agents/shared/dtos/update-agent-request.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/update-agent-request.dto.ts
@@ -1,13 +1,19 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsBoolean, IsOptional, IsString, IsUrl, ValidateNested } from 'class-validator';
+import { AGENT_NAME_MAX_LENGTH } from '@novu/shared';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString, IsUrl, MaxLength, ValidateNested } from 'class-validator';
 
 import { AgentBehaviorDto } from './agent-behavior.dto';
 
 export class UpdateAgentRequestDto {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ maxLength: AGENT_NAME_MAX_LENGTH })
   @IsString()
   @IsOptional()
+  // Trim before measuring so trailing whitespace can't push a valid name over the limit.
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @MaxLength(AGENT_NAME_MAX_LENGTH, {
+    message: `Agent name must be ${AGENT_NAME_MAX_LENGTH} characters or fewer.`,
+  })
   name?: string;
 
   @ApiPropertyOptional()

--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -1,4 +1,4 @@
-import { MAX_DESCRIPTION_LENGTH, PermissionsEnum } from '@novu/shared';
+import { AGENT_NAME_MAX_LENGTH, MAX_DESCRIPTION_LENGTH, PermissionsEnum } from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
 import { AnimatePresence, motion } from 'motion/react';
@@ -33,8 +33,6 @@ import { ConnectorSection } from './connector-section';
 type AgentSidebarWidgetProps = {
   agent: AgentResponse;
 };
-
-const AGENT_NAME_MAX_LENGTH = 64;
 
 const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',

--- a/apps/dashboard/src/components/agents/create-agent-fields/agent-form-validation.ts
+++ b/apps/dashboard/src/components/agents/create-agent-fields/agent-form-validation.ts
@@ -1,4 +1,9 @@
-import { AgentRuntimeProviderIdEnum, SLUG_IDENTIFIER_REGEX, slugIdentifierFormatMessage } from '@novu/shared';
+import {
+  AGENT_NAME_MAX_LENGTH,
+  AgentRuntimeProviderIdEnum,
+  SLUG_IDENTIFIER_REGEX,
+  slugIdentifierFormatMessage,
+} from '@novu/shared';
 import type { CreateAgentForm, CreateAgentFormErrors } from './types';
 
 export function validateManagedCredentialFields(fields: {
@@ -37,7 +42,11 @@ export function validateCreateAgentForm(form: CreateAgentForm): CreateAgentFormE
     const trimmedName = form.name.trim();
     const trimmedIdentifier = form.identifier.trim();
 
-    if (!trimmedName) errors.name = 'Name is required.';
+    if (!trimmedName) {
+      errors.name = 'Name is required.';
+    } else if (trimmedName.length > AGENT_NAME_MAX_LENGTH) {
+      errors.name = `Name must be ${AGENT_NAME_MAX_LENGTH} characters or fewer.`;
+    }
 
     if (!trimmedIdentifier) {
       errors.identifier = 'Identifier is required.';

--- a/apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx
@@ -1,4 +1,4 @@
-import { slugify } from '@novu/shared';
+import { AGENT_NAME_MAX_LENGTH, slugify } from '@novu/shared';
 import { useId } from 'react';
 import { RiInformation2Line } from 'react-icons/ri';
 import { Input } from '@/components/primitives/input';
@@ -58,6 +58,7 @@ export function ScratchAgentFields({
             id={nameId}
             size="xs"
             value={name}
+            maxLength={AGENT_NAME_MAX_LENGTH}
             onChange={(e) => {
               const nextName = e.target.value;
               onNameChange(nextName);

--- a/packages/shared/src/consts/providers/managed-agent-spec.ts
+++ b/packages/shared/src/consts/providers/managed-agent-spec.ts
@@ -1,10 +1,12 @@
+import { AGENT_NAME_MAX_LENGTH } from '../upsert-validation-constants';
 import { CLAUDE_ANTHROPIC_SKILLS } from './claude-skills';
 import { CLAUDE_BUILTIN_TOOLS } from './claude-tools';
 import { MCP_SERVERS } from './mcp-servers';
 
 export const MAX_GENERATED_MCP_SERVERS = 5;
 export const MAX_GENERATED_SKILLS = 4;
-export const MANAGED_AGENT_NAME_MAX_LENGTH = 60;
+// Managed agents share the general agent name limit — keep a single source of truth.
+export const MANAGED_AGENT_NAME_MAX_LENGTH = AGENT_NAME_MAX_LENGTH;
 export const MANAGED_AGENT_IDENTIFIER_MAX_LENGTH = 60;
 export const MANAGED_AGENT_SYSTEM_PROMPT_MAX_LENGTH = 4000;
 

--- a/packages/shared/src/consts/upsert-validation-constants.ts
+++ b/packages/shared/src/consts/upsert-validation-constants.ts
@@ -2,3 +2,12 @@ export const MAX_TAG_ELEMENTS = 16;
 export const MAX_TAG_LENGTH = 64;
 export const MAX_NAME_LENGTH = 128;
 export const MAX_DESCRIPTION_LENGTH = 256;
+
+/**
+ * Single source of truth for the maximum length of an agent name across Novu
+ * (API DTOs, dashboard forms, managed-agent generation, and CLI managed-spec
+ * validation). Enforced on input only — existing agents with longer names keep
+ * working and externally-sourced names (e.g. adopted provider agents) are
+ * truncated to this length rather than rejected.
+ */
+export const AGENT_NAME_MAX_LENGTH = 60;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Agent name length limits were inconsistent across Novu:

- `MANAGED_AGENT_NAME_MAX_LENGTH = 60` (AI generation + CLI managed-spec validation)
- Dashboard sidebar rename used a local `AGENT_NAME_MAX_LENGTH = 64` (drifted)
- Create/update API DTOs had `@IsString()` only — no length validation
- The create-agent form only checked the name was non-empty

This PR makes **60** the single source of truth and enforces it consistently on input.

## Walkthrough

Create-agent name input caps at 60 characters (a 75-char input is truncated to 60; DevTools console confirms `value.length === 60`):

<a href="https://cursor.com/agents/bc-23d1bc34-147d-4551-babc-972dc97f4c97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_name_maxlength_60_cap_demo.mp4"><img src="https://cursor.com/artifacts/c/art-962e07bb-25c4-470c-81d3-429395a1d191" alt="agent_name_maxlength_60_cap_demo.mp4" /></a>

![Console shows agent name value.length is 60 after a 75-char input](https://cursor.com/artifacts/c/art-a29954ae-7df2-4035-a053-a60aad2642f8)
![Typing extra characters is rejected; length stays 60](https://cursor.com/artifacts/c/art-c29fd9d2-3506-4e6b-b467-ee3c2acce3b4)

## Changes

- **`packages/shared`**: new general `AGENT_NAME_MAX_LENGTH = 60` in `upsert-validation-constants.ts`; `MANAGED_AGENT_NAME_MAX_LENGTH` now references it (one source of truth).
- **API enforcement**: `CreateAgentRequestDto.name` and `UpdateAgentRequestDto.name` get `@MaxLength(AGENT_NAME_MAX_LENGTH)` + `@ApiProperty({ maxLength })`, with a `@Transform` trim so trailing whitespace can't push a valid name over the limit (matches the managed-spec validator semantics). `@IsOptional` keeps update's `name` optional.
- **Adopt mode**: in `CreateAgent`, externally-sourced provider names are truncated to 60 rather than rejected, so adopting a long-named provider agent never fails.
- **Dashboard**: sidebar uses the shared constant; the create form name input gets `maxLength`; `validateCreateAgentForm` adds a max-length check with a clear message.

## Edge cases

- **Existing data**: enforced on input only. No Mongo `maxlength` and no migration — agents with longer names keep working.
- **Update optionality**: `@MaxLength` only applies when `name` is present.
- **Adopt mode**: long provider names are truncated, not rejected.

## Behavior note

DTO validation failures on this controller are surfaced by `AllExceptionsFilter` as **422 Unprocessable Entity** (not the class-validator default 400) — consistent with the existing `identifier` slug validation test. e2e assertions use 422 accordingly.

## SDK

The agents controller is `@ApiExcludeController()`, so these DTOs are not part of the public OpenAPI spec / `libs/internal-sdk`; no SDK regeneration is required (verified: no `CreateAgentRequest`/`UpdateAgentRequest` models exist in the SDK).

## Flow

```mermaid
flowchart TD
    A[POST/PATCH /v1/agents name] --> B[ValidationPipe: trim then MaxLength 60]
    B -->|<= 60| C[persist name]
    B -->|> 60| D[422 Validation Error]
    E[Adopt existing provider agent] --> F[provider returns name]
    F --> G[truncate to 60]
    G --> C
```

## Testing

- Agents API e2e (`agents.e2e.ts`, `managed-agent.e2e.ts`): over-limit create/update rejected (422); exactly-60 succeeds; trailing whitespace trimmed before measuring; adopt with a long provider name truncates to 60. All 62 tests pass.
- Dashboard `tsc --noEmit` type-check and Biome lint pass.
- Manual UI test (see Walkthrough): create-agent name input caps at 60.

> Note: no Linear MCP was available in this environment, so a Linear ticket could not be created/linked automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23d1bc34-147d-4551-babc-972dc97f4c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23d1bc34-147d-4551-babc-972dc97f4c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes agent name length validation at 60 characters. The main changes are:

- Adds `AGENT_NAME_MAX_LENGTH` as the shared source of truth.
- Applies trim and max-length validation to create and update agent DTOs.
- Truncates long provider names during managed-agent adoption.
- Updates dashboard create and rename inputs to use the shared limit.
- Adds e2e coverage for rejection, exact-limit acceptance, trimming, and adoption truncation.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to shared constants, DTO validation, dashboard input limits, and managed-agent adoption behavior. Tests cover over-limit rejection, exact-limit acceptance, trimming semantics, and provider-name truncation. No functional or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex surfaced a setup blocker in the e2e environment by showing a Cannot find module error in the initial run.
- A TypeScript harness was generated that imports the changed DTOs and shared constant and runs real class-transformer/class-validator validation.
- The harness completed successfully on a subsequent run, exiting with code 0 and producing detailed per-case results including transformed lengths, validity, 422-equivalent errors, and truncation evidence.
- A concise notes file was created to map the observed proof to the PR test plan.

<a href="https://app.greptile.com/trex/runs/13391806/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/consts/upsert-validation-constants.ts | Introduces the shared 60-character agent-name length constant. |
| packages/shared/src/consts/providers/managed-agent-spec.ts | Points managed-agent name validation at the shared general agent-name limit. |
| apps/api/src/app/agents/shared/dtos/create-agent-request.dto.ts | Adds trimming and max-length validation metadata for create-agent names. |
| apps/api/src/app/agents/shared/dtos/update-agent-request.dto.ts | Adds trimming and optional max-length validation metadata for update-agent names. |
| apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts | Truncates externally sourced adopted agent names before updating the created agent and deriving its identifier. |
| apps/dashboard/src/components/agents/agent-sidebar-widget.tsx | Replaces the local sidebar rename limit with the shared agent-name length constant. |
| apps/dashboard/src/components/agents/create-agent-fields/agent-form-validation.ts | Adds dashboard create-form validation for names exceeding the shared limit. |
| apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx | Applies the shared name `maxLength` to the scratch-agent name input. |
| apps/api/src/app/agents/e2e/agents.e2e.ts | Adds e2e coverage for create/update agent name length rejection, exact-limit acceptance, and whitespace trimming. |
| apps/api/src/app/agents/e2e/managed-agent.e2e.ts | Adds managed-agent adoption coverage to ensure long provider names are truncated to the shared limit. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as API/Dashboard Client
participant DTO as Agent DTO Validation
participant Usecase as CreateAgent Usecase
participant Provider as Managed Runtime Provider
participant DB as Agent Repository

Client->>DTO: POST/PATCH agent name
DTO->>DTO: Trim name and enforce maxLength 60
alt name within limit
    DTO->>Usecase: Validated command
    Usecase->>DB: Persist/update agent name
    DB-->>Client: Agent response
else name over limit
    DTO-->>Client: 422 validation error
end

Client->>Usecase: Adopt managed provider agent
Usecase->>Provider: Fetch provider agent
Provider-->>Usecase: Provider name
Usecase->>Usecase: Truncate name to 60 chars
Usecase->>DB: Persist truncated name and identifier
DB-->>Client: Agent response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as API/Dashboard Client
participant DTO as Agent DTO Validation
participant Usecase as CreateAgent Usecase
participant Provider as Managed Runtime Provider
participant DB as Agent Repository

Client->>DTO: POST/PATCH agent name
DTO->>DTO: Trim name and enforce maxLength 60
alt name within limit
    DTO->>Usecase: Validated command
    Usecase->>DB: Persist/update agent name
    DB-->>Client: Agent response
else name over limit
    DTO-->>Client: 422 validation error
end

Client->>Usecase: Adopt managed provider agent
Usecase->>Provider: Fetch provider agent
Provider-->>Usecase: Provider name
Usecase->>Usecase: Truncate name to 60 chars
Usecase->>DB: Persist truncated name and identifier
DB-->>Client: Agent response
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(api-service): cover agent name leng..."](https://github.com/novuhq/novu/commit/f388b50965299fd1d9b126da3755ef4e8d6874d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42059522)</sub>

<!-- /greptile_comment -->