### PR TITLE
chore(api-service): remove legacy managed agent onFinish content fallback fixes NV-8209

### DIFF
--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -191,16 +191,6 @@ export class ManagedAgentEventHandler {
             return;
           }
 
-          // TODO: remove after the observer is fully rolled out.
-          // Old observers still send `response.content`; new ones reply via `onMessage`
-          // and never set `content`, so this only runs against an old observer.
-          const legacyContent = (event.response as { content?: string }).content?.trim();
-          if (legacyContent) {
-            await this.handleAgentReply.execute(
-              HandleAgentReplyCommand.create({ ...baseFields, reply: { markdown: legacyContent } })
-            );
-          }
-
           await this.inboundAck.onManagedTurnComplete(metadata);
 
           await this.demoQuota.recordUsage(


### PR DESCRIPTION
## Summary

- Removes the backward-compat shim in `ManagedAgentEventHandler.onFinish` that delivered agent replies from `response.content`.
- Managed agent replies are now delivered exclusively via the `onMessage` webhook path introduced in NV-7420; the thalamus observer rollout is complete.

## Test plan

- [x] Verified no other references to `response.content` remain in managed agent reply handling
- [ ] Confirm managed agent Slack roundtrip still delivers replies via `onMessage` webhooks
- [ ] Smoke test a tool-approval turn (requires-action finish path unchanged)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the legacy managed-agent reply fallback from the finish handler. The main changes are:

- Removed `response.content` handling from `ManagedAgentEventHandler.onFinish`.
- Keeps managed replies on the existing `onMessage` webhook path.
- Leaves tool approval, acknowledgement, quota, and progress completion handling unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to removing an intentionally deprecated fallback, and the reviewed finish and message paths remain consistent.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The before-state log shows the previous handler delivered normal onFinish.response.content through HandleAgentReply, causing the new assertion to fail as expected.
- The after-state log shows the current handler passes all assertions; onMessage contains one HandleAgentReply with hello from webhook, onFinish has zero HandleAgentReply calls plus ack/quota/plan progress, and requires-action has one HandlePendingToolApprovals call plus ack.
- The before-grep log shows the presence of a legacy response.content reference in the code path.
- The after-grep log shows no matches, confirming the legacy response.content reference was removed.
- Artifacts were uploaded to support reviewer inspection, including the before/after handler logs and grep results.

<a href="https://app.greptile.com/trex/runs/13406315/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts | Removes the legacy `response.content` fallback from `onFinish`, leaving managed replies to the existing `onMessage` path while preserving ack, quota, progress, and tool-approval handling. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Observer as Thalamus observer
participant Handler as ManagedAgentEventHandler
participant Reply as HandleAgentReply
participant Ack as InboundAckService
participant Progress as HandlePlanProgress

Observer->>Handler: "onMessage({ text })"
Handler->>Reply: persist/deliver markdown reply
Observer->>Handler: "onFinish({ response })"
alt "finishReason == requires-action"
    Handler->>Handler: handle pending tool approvals
    Handler->>Ack: onManagedTurnComplete(metadata)
else normal finish
    Handler->>Ack: onManagedTurnComplete(metadata)
    Handler->>Progress: "phase = finished"
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Observer as Thalamus observer
participant Handler as ManagedAgentEventHandler
participant Reply as HandleAgentReply
participant Ack as InboundAckService
participant Progress as HandlePlanProgress

Observer->>Handler: "onMessage({ text })"
Handler->>Reply: persist/deliver markdown reply
Observer->>Handler: "onFinish({ response })"
alt "finishReason == requires-action"
    Handler->>Handler: handle pending tool approvals
    Handler->>Ack: onManagedTurnComplete(metadata)
else normal finish
    Handler->>Ack: onManagedTurnComplete(metadata)
    Handler->>Progress: "phase = finished"
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(api-service): remove legacy manage..."](https://github.com/novuhq/novu/commit/174d232274aefec8af49d444524dc1b8da8a3e0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42091827)</sub>

<!-- /greptile_comment -->