### PR TITLE
fix(application-generic): use safe path setter in keysToObject fixes NV-8210

### DIFF
--- a/libs/application-generic/src/services/verify-payload.service.spec.ts
+++ b/libs/application-generic/src/services/verify-payload.service.spec.ts
@@ -60,6 +60,23 @@ describe('VerifyPayloadService', () => {
       expect(after).to.equal(undefined);
     });
 
+    it('should not allow unsafe inherited property names via default values', () => {
+      const variables = [
+        {
+          name: 'toString.call',
+          type: TemplateVariableTypeEnum.STRING,
+          defaultValue: 'yes',
+          required: false,
+        },
+      ];
+      const toStringCall = Object.prototype.toString.call;
+
+      service.fillDefaults(variables);
+
+      expect(Object.prototype.toString.call).to.equal(toStringCall);
+      expect(typeof Object.prototype.toString.call).to.equal('function');
+    });
+
     it('should reject variable path segments outside the allowlist', () => {
       const variables = [
         {

--- a/libs/application-generic/src/services/verify-payload.service.ts
+++ b/libs/application-generic/src/services/verify-payload.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { ITemplateVariable, TemplateSystemVariables } from '@novu/shared';
+import { isUnsafePathSegment, safeSetPath } from '../utils/safe-set-path';
 
-const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 const TEMPLATE_VARIABLE_SEGMENT_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*(?:\[\d+\])*$/;
 
 type PathPart = { kind: 'key'; value: string } | { kind: 'index'; value: number };
@@ -15,7 +15,7 @@ function getSegmentBaseName(segment: string): string {
 function isSafeVariablePathSegment(segment: string): boolean {
   const baseName = getSegmentBaseName(segment);
 
-  if (PROTOTYPE_POLLUTION_KEYS.has(baseName)) {
+  if (isUnsafePathSegment(baseName)) {
     return false;
   }
 
@@ -153,85 +153,14 @@ export class VerifyPayloadService {
         continue;
       }
 
-      this.setNestedValue(payload, pathParts, variable.defaultValue);
+      if (pathParts.length === 1 && variable.defaultValue === '') {
+        continue;
+      }
+
+      safeSetPath(payload, variable.name, variable.defaultValue);
     }
 
     return payload;
-  }
-
-  private setNestedValue(target: unknown, parts: PathPart[], value: string | boolean): void {
-    if (parts.length === 0) {
-      return;
-    }
-
-    if (parts.length === 1) {
-      const [part] = parts;
-
-      if (value === '') {
-        return;
-      }
-
-      if (part.kind === 'key') {
-        (target as Record<string, unknown>)[part.value] = value;
-
-        return;
-      }
-
-      const array = target as unknown[];
-
-      while (array.length <= part.value) {
-        array.push(undefined);
-      }
-
-      array[part.value] = value;
-
-      return;
-    }
-
-    const [head, ...tail] = parts;
-    const next = tail[0];
-
-    if (head.kind === 'key') {
-      const record = target as Record<string, unknown>;
-      const existing = record[head.value];
-
-      if (existing !== undefined && existing !== null && typeof existing !== 'object') {
-        return;
-      }
-
-      if (!existing) {
-        record[head.value] = next.kind === 'index' ? [] : Object.create(null);
-      } else if (next.kind === 'index' && !Array.isArray(existing)) {
-        return;
-      } else if (next.kind === 'key' && (typeof existing !== 'object' || Array.isArray(existing))) {
-        return;
-      }
-
-      this.setNestedValue(record[head.value], tail, value);
-
-      return;
-    }
-
-    const array = target as unknown[];
-    const existing = array[head.value];
-
-    if (existing !== undefined && existing !== null && typeof existing !== 'object') {
-      return;
-    }
-
-    while (array.length <= head.value) {
-      array.push(undefined);
-    }
-
-    if (existing === undefined || existing === null) {
-      array[head.value] = next.kind === 'index' ? [] : Object.create(null);
-    } else if (next.kind === 'index' && !Array.isArray(existing)) {
-      return;
-    } else if (next.kind === 'key' && (typeof existing !== 'object' || Array.isArray(existing))) {
-      return;
-    }
-
-    this.setNestedValue(array[head.value], tail, value);
   }
 
   isSystemVariable(variableName: string): boolean {

--- a/libs/application-generic/src/utils/index.ts
+++ b/libs/application-generic/src/utils/index.ts
@@ -31,6 +31,7 @@ export * from './novu-integrations';
 export * from './object';
 export * from './parse-payload-schema';
 export * from './parse-step-variables';
+export * from './safe-set-path';
 export * from './sanitize-control-values';
 export * from './shorten-environment-name';
 export * from './slugify-or-random';

--- a/libs/application-generic/src/utils/json-schema-utils.spec.ts
+++ b/libs/application-generic/src/utils/json-schema-utils.spec.ts
@@ -297,6 +297,26 @@ describe('prototype pollution guard', () => {
       },
     });
   });
+
+  it('should ignore unsafe array variable paths', () => {
+    const arrayVariables: ArrayVariable[] = [{ path: 'toString.call', iterations: 3 }];
+    const toStringCall = Object.prototype.toString.call;
+
+    keysToObject([], arrayVariables);
+
+    expect(Object.prototype.toString.call).to.equal(toStringCall);
+    expect(typeof Object.prototype.toString.call).to.equal('function');
+  });
+
+  it('should ignore unsafe nested variable paths', () => {
+    const arrayVariables: ArrayVariable[] = [{ path: 'payload.toString.call', iterations: 3 }];
+    const toStringCall = Object.prototype.toString.call;
+
+    keysToObject(['payload.name'], arrayVariables);
+
+    expect(Object.prototype.toString.call).to.equal(toStringCall);
+    expect(typeof Object.prototype.toString.call).to.equal('function');
+  });
 });
 
 describe('mockSchemaDefaults', () => {

--- a/libs/application-generic/src/utils/json-schema-utils.ts
+++ b/libs/application-generic/src/utils/json-schema-utils.ts
@@ -3,7 +3,6 @@ import difference from 'lodash/difference';
 import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 import reduce from 'lodash/reduce';
-import set from 'lodash/set';
 import { JSONSchemaDto } from '../dtos/json-schema.dto';
 import { DIGEST_EVENTS_VARIABLE_PATTERN } from './template-parser/parser-utils';
 
@@ -139,11 +138,11 @@ function buildObjectFromPaths(
   arrayVariables: Array<ArrayVariable>,
   showIfVariablesPaths?: string[]
 ): Record<string, unknown> {
-  const result = {};
+  const result = Object.create(null) as Record<string, unknown>;
 
   // Initialize arrays with the correct number of iterations
   arrayVariables.forEach((arrayVariable) => {
-    set(result, arrayVariable.path, Array(arrayVariable.iterations).fill({}));
+    safeSet(result, arrayVariable.path, Array(arrayVariable.iterations).fill({}));
   });
 
   // Sort paths by number of dots (depth) in ascending order
@@ -201,7 +200,7 @@ function buildObjectFromPaths(
       const normalizedKey = finalPart.replace(/\[\d+\]/g, '');
       const payloadProperties = digestPayloadProperties.get(normalizedKey);
       if (payloadProperties && payloadProperties.size > 0) {
-        const payload = {};
+        const payload = Object.create(null) as Record<string, unknown>;
         payloadProperties.forEach((property) => {
           const propertyParts = property.split('.');
           const propertyValue = propertyParts[propertyParts.length - 1];
@@ -217,7 +216,7 @@ function buildObjectFromPaths(
       (arrayVariable) => arrayVariable.path === path || path.startsWith(`${arrayVariable.path}.`)
     );
     if (!arrayParent) {
-      set(result, path.replace(/\[\d+\]/g, '[0]'), value);
+      safeSet(result, path.replace(/\[\d+\]/g, '[0]'), value);
 
       return;
     }
@@ -226,33 +225,126 @@ function buildObjectFromPaths(
     const targetPath = isDirectArrayPath ? path : `${arrayParent.path}[0].${path.slice(arrayParent.path.length + 1)}`;
 
     if (isDirectArrayPath) {
-      set(result, targetPath, Array(arrayParent.iterations).fill(value));
+      safeSet(result, targetPath, Array(arrayParent.iterations).fill(value));
     } else {
-      set(result, targetPath, value);
+      safeSet(result, targetPath, value);
     }
   });
 
   return result;
 }
 
-const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const UNSAFE_PATH_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+]);
 
-function isPrototypePollutionKey(key: string): boolean {
-  return PROTOTYPE_POLLUTION_KEYS.has(key);
+function isUnsafePathKey(key: string): boolean {
+  return UNSAFE_PATH_KEYS.has(key);
+}
+
+function parseVariablePath(path: string): string[] {
+  return path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter((segment) => segment.length > 0);
+}
+
+function isSafeVariablePath(path: string): boolean {
+  return parseVariablePath(path).every((segment) => /^\d+$/.test(segment) || !isUnsafePathKey(segment));
+}
+
+function createPathNode(nextSegment: string): Record<string, unknown> | unknown[] {
+  return /^\d+$/.test(nextSegment) ? [] : Object.create(null);
+}
+
+function safeSet(root: Record<string, unknown>, path: string, value: unknown): void {
+  if (!isSafeVariablePath(path)) {
+    return;
+  }
+
+  const segments = parseVariablePath(path);
+  if (segments.length === 0) {
+    return;
+  }
+
+  let node: Record<string, unknown> | unknown[] = root;
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const isLast = index === segments.length - 1;
+    const isIndex = /^\d+$/.test(segment);
+
+    if (isLast) {
+      if (isIndex) {
+        if (!Array.isArray(node)) {
+          return;
+        }
+
+        node[Number(segment)] = value;
+      } else {
+        (node as Record<string, unknown>)[segment] = value;
+      }
+
+      return;
+    }
+
+    if (isIndex) {
+      if (!Array.isArray(node)) {
+        return;
+      }
+
+      const arrayNode = node as unknown[];
+      const arrayIndex = Number(segment);
+      const nextSegment = segments[index + 1];
+      const existing = arrayNode[arrayIndex];
+
+      if (existing === undefined || existing === null || typeof existing !== 'object') {
+        arrayNode[arrayIndex] = createPathNode(nextSegment);
+      }
+
+      node = arrayNode[arrayIndex] as Record<string, unknown> | unknown[];
+
+      continue;
+    }
+
+    const record = node as Record<string, unknown>;
+    const nextSegment = segments[index + 1];
+    const existing = Object.prototype.hasOwnProperty.call(record, segment) ? record[segment] : undefined;
+
+    if (existing === undefined || existing === null || typeof existing !== 'object') {
+      record[segment] = createPathNode(nextSegment);
+      node = record[segment] as Record<string, unknown> | unknown[];
+
+      continue;
+    }
+
+    node = existing as Record<string, unknown> | unknown[];
+  }
 }
 
 function setNestedProperty(obj: Record<string, unknown>, path: string, value: string) {
   const keys = path.split('.');
 
-  if (keys.some(isPrototypePollutionKey)) return;
+  if (keys.some(isUnsafePathKey)) return;
 
   let current = obj;
 
   for (let i = 0; i < keys.length - 1; i += 1) {
     const key = keys[i];
-    if (!(key in current) || typeof current[key] !== 'object' || current[key] === null) {
-      current[key] = {};
+    const existing = Object.prototype.hasOwnProperty.call(current, key) ? current[key] : undefined;
+
+    if (existing === undefined || existing === null || typeof existing !== 'object') {
+      current[key] = Object.create(null);
     }
+
     current = current[key] as Record<string, unknown>;
   }
 

--- a/libs/application-generic/src/utils/json-schema-utils.ts
+++ b/libs/application-generic/src/utils/json-schema-utils.ts
@@ -4,6 +4,7 @@ import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 import reduce from 'lodash/reduce';
 import { JSONSchemaDto } from '../dtos/json-schema.dto';
+import { safeSetPath } from './safe-set-path';
 import { DIGEST_EVENTS_VARIABLE_PATTERN } from './template-parser/parser-utils';
 
 export type ArrayVariable = {
@@ -142,7 +143,7 @@ function buildObjectFromPaths(
 
   // Initialize arrays with the correct number of iterations
   arrayVariables.forEach((arrayVariable) => {
-    safeSet(result, arrayVariable.path, Array(arrayVariable.iterations).fill({}));
+    safeSetPath(result, arrayVariable.path, Array(arrayVariable.iterations).fill({}));
   });
 
   // Sort paths by number of dots (depth) in ascending order
@@ -204,7 +205,7 @@ function buildObjectFromPaths(
         payloadProperties.forEach((property) => {
           const propertyParts = property.split('.');
           const propertyValue = propertyParts[propertyParts.length - 1];
-          setNestedProperty(payload, property, propertyValue);
+          safeSetPath(payload, property, propertyValue);
         });
         value = payload;
       } else {
@@ -216,7 +217,7 @@ function buildObjectFromPaths(
       (arrayVariable) => arrayVariable.path === path || path.startsWith(`${arrayVariable.path}.`)
     );
     if (!arrayParent) {
-      safeSet(result, path.replace(/\[\d+\]/g, '[0]'), value);
+      safeSetPath(result, path.replace(/\[\d+\]/g, '[0]'), value);
 
       return;
     }
@@ -225,90 +226,13 @@ function buildObjectFromPaths(
     const targetPath = isDirectArrayPath ? path : `${arrayParent.path}[0].${path.slice(arrayParent.path.length + 1)}`;
 
     if (isDirectArrayPath) {
-      safeSet(result, targetPath, Array(arrayParent.iterations).fill(value));
+      safeSetPath(result, targetPath, Array(arrayParent.iterations).fill(value));
     } else {
-      safeSet(result, targetPath, value);
+      safeSetPath(result, targetPath, value);
     }
   });
 
   return result;
-}
-
-const UNSAFE_PATH_KEYS = new Set([
-  '__proto__',
-  'constructor',
-  'prototype',
-  'toString',
-  'valueOf',
-  'hasOwnProperty',
-  'isPrototypeOf',
-  'propertyIsEnumerable',
-  'toLocaleString',
-]);
-
-function isIndexSegment(segment: string): boolean {
-  return /^\d+$/.test(segment);
-}
-
-function isUnsafeSegment(segment: string): boolean {
-  return !isIndexSegment(segment) && UNSAFE_PATH_KEYS.has(segment);
-}
-
-function parseVariablePath(path: string): string[] {
-  return path
-    .replace(/\[(\d+)\]/g, '.$1')
-    .split('.')
-    .filter((segment) => segment.length > 0);
-}
-
-function createPathNode(nextSegment: string): Record<string, unknown> | unknown[] {
-  return isIndexSegment(nextSegment) ? [] : {};
-}
-
-/**
- * Assigns `value` at a dot/bracket path, only reusing own properties and never
- * following inherited ones, so a user-controlled path cannot reach a builtin on
- * the prototype chain (second-order prototype pollution).
- */
-function safeSet(root: Record<string, unknown>, path: string, value: unknown): void {
-  const segments = parseVariablePath(path);
-
-  if (segments.length === 0 || segments.some(isUnsafeSegment)) {
-    return;
-  }
-
-  let node: Record<string, unknown> | unknown[] = root;
-
-  for (let index = 0; index < segments.length; index += 1) {
-    const segment = segments[index];
-    const isIndex = isIndexSegment(segment);
-
-    if (isIndex && !Array.isArray(node)) {
-      return;
-    }
-
-    const container = node as Record<string, unknown> | unknown[];
-    const key = isIndex ? Number(segment) : segment;
-
-    if (index === segments.length - 1) {
-      (container as Record<string | number, unknown>)[key] = value;
-
-      return;
-    }
-
-    const hasOwn = isIndex ? true : Object.prototype.hasOwnProperty.call(container, key);
-    const existing = hasOwn ? (container as Record<string | number, unknown>)[key] : undefined;
-
-    if (existing === null || typeof existing !== 'object') {
-      (container as Record<string | number, unknown>)[key] = createPathNode(segments[index + 1]);
-    }
-
-    node = (container as Record<string | number, unknown>)[key] as Record<string, unknown> | unknown[];
-  }
-}
-
-function setNestedProperty(obj: Record<string, unknown>, path: string, value: string) {
-  safeSet(obj, path, value);
 }
 
 /**

--- a/libs/application-generic/src/utils/json-schema-utils.ts
+++ b/libs/application-generic/src/utils/json-schema-utils.ts
@@ -138,7 +138,7 @@ function buildObjectFromPaths(
   arrayVariables: Array<ArrayVariable>,
   showIfVariablesPaths?: string[]
 ): Record<string, unknown> {
-  const result = Object.create(null) as Record<string, unknown>;
+  const result = {};
 
   // Initialize arrays with the correct number of iterations
   arrayVariables.forEach((arrayVariable) => {
@@ -200,7 +200,7 @@ function buildObjectFromPaths(
       const normalizedKey = finalPart.replace(/\[\d+\]/g, '');
       const payloadProperties = digestPayloadProperties.get(normalizedKey);
       if (payloadProperties && payloadProperties.size > 0) {
-        const payload = Object.create(null) as Record<string, unknown>;
+        const payload = {};
         payloadProperties.forEach((property) => {
           const propertyParts = property.split('.');
           const propertyValue = propertyParts[propertyParts.length - 1];
@@ -246,8 +246,12 @@ const UNSAFE_PATH_KEYS = new Set([
   'toLocaleString',
 ]);
 
-function isUnsafePathKey(key: string): boolean {
-  return UNSAFE_PATH_KEYS.has(key);
+function isIndexSegment(segment: string): boolean {
+  return /^\d+$/.test(segment);
+}
+
+function isUnsafeSegment(segment: string): boolean {
+  return !isIndexSegment(segment) && UNSAFE_PATH_KEYS.has(segment);
 }
 
 function parseVariablePath(path: string): string[] {
@@ -257,21 +261,19 @@ function parseVariablePath(path: string): string[] {
     .filter((segment) => segment.length > 0);
 }
 
-function isSafeVariablePath(path: string): boolean {
-  return parseVariablePath(path).every((segment) => /^\d+$/.test(segment) || !isUnsafePathKey(segment));
-}
-
 function createPathNode(nextSegment: string): Record<string, unknown> | unknown[] {
-  return /^\d+$/.test(nextSegment) ? [] : Object.create(null);
+  return isIndexSegment(nextSegment) ? [] : {};
 }
 
+/**
+ * Assigns `value` at a dot/bracket path, only reusing own properties and never
+ * following inherited ones, so a user-controlled path cannot reach a builtin on
+ * the prototype chain (second-order prototype pollution).
+ */
 function safeSet(root: Record<string, unknown>, path: string, value: unknown): void {
-  if (!isSafeVariablePath(path)) {
-    return;
-  }
-
   const segments = parseVariablePath(path);
-  if (segments.length === 0) {
+
+  if (segments.length === 0 || segments.some(isUnsafeSegment)) {
     return;
   }
 
@@ -279,76 +281,34 @@ function safeSet(root: Record<string, unknown>, path: string, value: unknown): v
 
   for (let index = 0; index < segments.length; index += 1) {
     const segment = segments[index];
-    const isLast = index === segments.length - 1;
-    const isIndex = /^\d+$/.test(segment);
+    const isIndex = isIndexSegment(segment);
 
-    if (isLast) {
-      if (isIndex) {
-        if (!Array.isArray(node)) {
-          return;
-        }
+    if (isIndex && !Array.isArray(node)) {
+      return;
+    }
 
-        node[Number(segment)] = value;
-      } else {
-        (node as Record<string, unknown>)[segment] = value;
-      }
+    const container = node as Record<string, unknown> | unknown[];
+    const key = isIndex ? Number(segment) : segment;
+
+    if (index === segments.length - 1) {
+      (container as Record<string | number, unknown>)[key] = value;
 
       return;
     }
 
-    if (isIndex) {
-      if (!Array.isArray(node)) {
-        return;
-      }
+    const hasOwn = isIndex ? true : Object.prototype.hasOwnProperty.call(container, key);
+    const existing = hasOwn ? (container as Record<string | number, unknown>)[key] : undefined;
 
-      const arrayNode = node as unknown[];
-      const arrayIndex = Number(segment);
-      const nextSegment = segments[index + 1];
-      const existing = arrayNode[arrayIndex];
-
-      if (existing === undefined || existing === null || typeof existing !== 'object') {
-        arrayNode[arrayIndex] = createPathNode(nextSegment);
-      }
-
-      node = arrayNode[arrayIndex] as Record<string, unknown> | unknown[];
-
-      continue;
+    if (existing === null || typeof existing !== 'object') {
+      (container as Record<string | number, unknown>)[key] = createPathNode(segments[index + 1]);
     }
 
-    const record = node as Record<string, unknown>;
-    const nextSegment = segments[index + 1];
-    const existing = Object.prototype.hasOwnProperty.call(record, segment) ? record[segment] : undefined;
-
-    if (existing === undefined || existing === null || typeof existing !== 'object') {
-      record[segment] = createPathNode(nextSegment);
-      node = record[segment] as Record<string, unknown> | unknown[];
-
-      continue;
-    }
-
-    node = existing as Record<string, unknown> | unknown[];
+    node = (container as Record<string | number, unknown>)[key] as Record<string, unknown> | unknown[];
   }
 }
 
 function setNestedProperty(obj: Record<string, unknown>, path: string, value: string) {
-  const keys = path.split('.');
-
-  if (keys.some(isUnsafePathKey)) return;
-
-  let current = obj;
-
-  for (let i = 0; i < keys.length - 1; i += 1) {
-    const key = keys[i];
-    const existing = Object.prototype.hasOwnProperty.call(current, key) ? current[key] : undefined;
-
-    if (existing === undefined || existing === null || typeof existing !== 'object') {
-      current[key] = Object.create(null);
-    }
-
-    current = current[key] as Record<string, unknown>;
-  }
-
-  current[keys[keys.length - 1]] = value;
+  safeSet(obj, path, value);
 }
 
 /**

--- a/libs/application-generic/src/utils/safe-set-path.spec.ts
+++ b/libs/application-generic/src/utils/safe-set-path.spec.ts
@@ -1,0 +1,93 @@
+import { expect } from 'chai';
+import { isSafeDotBracketPath, parseDotBracketPath, safeSetPath } from './safe-set-path';
+
+describe('safeSetPath', () => {
+  it('should set nested dot-notation paths', () => {
+    const root: Record<string, unknown> = {};
+
+    safeSetPath(root, 'payload.user.name', 'name');
+
+    expect(root).to.deep.equal({
+      payload: {
+        user: {
+          name: 'name',
+        },
+      },
+    });
+  });
+
+  it('should set bracket-notation paths', () => {
+    const root: Record<string, unknown> = {};
+
+    safeSetPath(root, 'payload.items[0].name', 'fallback');
+
+    expect(root).to.deep.equal({
+      payload: {
+        items: [{ name: 'fallback' }],
+      },
+    });
+  });
+
+  it('should set chained bracket-notation paths', () => {
+    const root: Record<string, unknown> = {};
+
+    safeSetPath(root, 'data.matrix[0][1]', 'fallback');
+
+    expect(root).to.deep.equal({
+      data: {
+        matrix: [[undefined, 'fallback']],
+      },
+    });
+  });
+
+  it('should not traverse into an existing scalar value', () => {
+    const root: Record<string, unknown> = { user: 'scalar-user' };
+
+    safeSetPath(root, 'user.firstName', 'John');
+
+    expect(root).to.deep.equal({ user: 'scalar-user' });
+  });
+
+  it('should ignore unsafe path segments', () => {
+    const root: Record<string, unknown> = {};
+    const toStringCall = Object.prototype.toString.call;
+
+    safeSetPath(root, 'toString.call', [{}]);
+    safeSetPath(root, 'payload.toString.call', [{}]);
+
+    expect(root).to.deep.equal({});
+    expect(Object.prototype.toString.call).to.equal(toStringCall);
+    expect(typeof Object.prototype.toString.call).to.equal('function');
+  });
+
+  it('should ignore prototype pollution segments', () => {
+    const root: Record<string, unknown> = {};
+
+    safeSetPath(root, '__proto__.polluted', 'yes');
+    safeSetPath(root, 'constructor.prototype.polluted', 'yes');
+
+    expect(({} as Record<string, unknown>).polluted).to.equal(undefined);
+    expect(root).to.deep.equal({});
+  });
+});
+
+describe('parseDotBracketPath', () => {
+  it('should expand bracket indices into segments', () => {
+    expect(parseDotBracketPath('payload.items[0].products[1].name')).to.deep.equal([
+      'payload',
+      'items',
+      '0',
+      'products',
+      '1',
+      'name',
+    ]);
+  });
+});
+
+describe('isSafeDotBracketPath', () => {
+  it('should reject unsafe segments', () => {
+    expect(isSafeDotBracketPath('payload.name')).to.equal(true);
+    expect(isSafeDotBracketPath('toString.call')).to.equal(false);
+    expect(isSafeDotBracketPath('')).to.equal(false);
+  });
+});

--- a/libs/application-generic/src/utils/safe-set-path.ts
+++ b/libs/application-generic/src/utils/safe-set-path.ts
@@ -1,0 +1,82 @@
+export const UNSAFE_PATH_SEGMENT_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+]);
+
+function isIndexSegment(segment: string): boolean {
+  return /^\d+$/.test(segment);
+}
+
+export function isUnsafePathSegment(segment: string): boolean {
+  return !isIndexSegment(segment) && UNSAFE_PATH_SEGMENT_KEYS.has(segment);
+}
+
+export function parseDotBracketPath(path: string): string[] {
+  return path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter((segment) => segment.length > 0);
+}
+
+export function isSafeDotBracketPath(path: string): boolean {
+  const segments = parseDotBracketPath(path);
+
+  return segments.length > 0 && !segments.some(isUnsafePathSegment);
+}
+
+function createPathNode(nextSegment: string): Record<string, unknown> | unknown[] {
+  return isIndexSegment(nextSegment) ? [] : {};
+}
+
+/**
+ * Assigns `value` at a dot/bracket path, only reusing own properties and never
+ * following inherited ones, so a user-controlled path cannot reach a builtin on
+ * the prototype chain.
+ */
+export function safeSetPath(root: Record<string, unknown>, path: string, value: unknown): void {
+  const segments = parseDotBracketPath(path);
+
+  if (segments.length === 0 || segments.some(isUnsafePathSegment)) {
+    return;
+  }
+
+  let node: Record<string, unknown> | unknown[] = root;
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const isIndex = isIndexSegment(segment);
+
+    if (isIndex && !Array.isArray(node)) {
+      return;
+    }
+
+    const container = node as Record<string, unknown> | unknown[];
+    const key = isIndex ? Number(segment) : segment;
+
+    if (index === segments.length - 1) {
+      (container as Record<string | number, unknown>)[key] = value;
+
+      return;
+    }
+
+    const hasOwn = isIndex ? true : Object.prototype.hasOwnProperty.call(container, key);
+    const existing = hasOwn ? (container as Record<string | number, unknown>)[key] : undefined;
+
+    if (existing !== undefined && existing !== null && typeof existing !== 'object') {
+      return;
+    }
+
+    if (existing === null || typeof existing !== 'object') {
+      (container as Record<string | number, unknown>)[key] = createPathNode(segments[index + 1]);
+    }
+
+    node = (container as Record<string | number, unknown>)[key] as Record<string, unknown> | unknown[];
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts a canonical `safeSetPath` utility and routes variable object construction through it.

## Changes

- Add `libs/application-generic/src/utils/safe-set-path.ts` as the shared path setter
- Use it in `keysToObject` and `VerifyPayloadService.fillDefaults`
- Export from `@novu/application-generic` utils

## Test plan

- [x] `safe-set-path.spec.ts`
- [x] `json-schema-utils.spec.ts`
- [x] `verify-payload.service.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baeaab70-6cdd-4384-be06-0c87ed084063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baeaab70-6cdd-4384-be06-0c87ed084063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes path-setting logic into a new `safeSetPath` utility and routes both `VerifyPayloadService.fillDefaults` and `keysToObject`/`buildObjectFromPaths` through it, replacing `lodash/set` and two local ad-hoc implementations that had an incomplete prototype-pollution blocklist and used the `in` operator (which traverses the prototype chain).

- **`safe-set-path.ts`**: New canonical utility that uses `Object.prototype.hasOwnProperty.call` instead of `in` for property existence checks, extends the blocked-key set from the classic three (`__proto__`, `constructor`, `prototype`) to also cover `toString`, `valueOf`, `hasOwnProperty`, and other `Object.prototype` builtins that can be exploited via path traversal.
- **`json-schema-utils.ts`**: Drops `lodash/set` (no prototype guard) and the local `setNestedProperty` (used `in` operator with only the minimal blocklist); all five call sites now go through `safeSetPath`, gaining the extended guard and `hasOwnProperty`-based traversal.
- **`verify-payload.service.ts`**: Removes the 85-line `setNestedValue` private method; retains `parseVariablePath` for the `pathParts.length === 1 && empty-default` skip guard, then delegates the actual write to `safeSetPath`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactoring is mechanically correct, the extended blocklist closes a real gap, and all three call sites are covered by new tests.

Every changed path-write site is now guarded by `hasOwnProperty`-based traversal and an expanded unsafe-key set. The `fillDefaults` refactor preserves the original empty-string-skip logic exactly. The `buildObjectFromPaths` replacement of `lodash/set` and the old `setNestedProperty` (which used the `in` operator) is a clear correctness improvement. No data-loss or functional regression is introduced.

No files require special attention — the utility, its consumers, and the tests are all consistent.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/utils/safe-set-path.ts | New canonical utility for safe path assignment — correctly uses `hasOwnProperty` instead of the `in` operator, blocks an expanded set of dangerous segments (including `toString`, `valueOf`, etc.), and handles both dot and bracket notation. |
| libs/application-generic/src/utils/safe-set-path.spec.ts | Comprehensive tests for the new utility covering dot notation, bracket notation, chained brackets, scalar guard, prototype pollution keys, and the expanded unsafe-segment list. |
| libs/application-generic/src/services/verify-payload.service.ts | Removes the local `setNestedValue` implementation and delegates to `safeSetPath`; retains the `parseVariablePath` gate (for the `pathParts.length === 1 && empty-default` guard) then re-parses through `safeSetPath`, which is redundant but safe. |
| libs/application-generic/src/utils/json-schema-utils.ts | Replaces both `lodash/set` (no prototype guard) and the local `setNestedProperty` (used `in` operator traversing prototype chain with only the classic three-key blocklist) with `safeSetPath`; fixes the extended unsafe-key coverage gap. |
| libs/application-generic/src/utils/index.ts | Adds `safe-set-path` to the barrel export, making `safeSetPath`, `isSafeDotBracketPath`, `parseDotBracketPath`, `isUnsafePathSegment`, and `UNSAFE_PATH_SEGMENT_KEYS` part of the public API of `@novu/application-generic`. |
| libs/application-generic/src/services/verify-payload.service.spec.ts | Adds a test asserting `toString.call` default-value paths leave `Object.prototype.toString.call` untouched, exercising the new guard through `fillDefaults`. |
| libs/application-generic/src/utils/json-schema-utils.spec.ts | Adds two tests for `toString.call` style paths in both simple and nested positions, confirming the new guard covers the previously missing `Object.prototype` built-in methods. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User-controlled path string] --> B{Call site}

    B -->|fillDefaults| C[parseVariablePath\nREGEX + UNSAFE_PATH_SEGMENT_KEYS]
    B -->|buildObjectFromPaths\nkeysToObject| D[safeSetPath directly]

    C -->|null → skip| E[skip variable]
    C -->|PathPart list| F{pathParts.length === 1\n&& defaultValue === empty?}
    F -->|yes| E
    F -->|no| G[safeSetPath\nvariable.name, value]

    D --> G

    G --> H[parseDotBracketPath\nbracket → dot expansion]
    H --> I{Any segment in\nUNSAFE_PATH_SEGMENT_KEYS?}
    I -->|yes| J[return early — no write]
    I -->|no| K[Walk segments]

    K --> L{Segment is numeric index?}
    L -->|yes| M{Array.isArray node?}
    M -->|no| J
    M -->|yes| N[Use numeric key]
    L -->|no| O[hasOwnProperty.call\nnever follows prototype chain]
    O --> P{Existing value\nis scalar?}
    P -->|yes| J
    P -->|no| Q[Create array or plain object\nfor next segment]
    N --> R{Last segment?}
    Q --> R
    R -->|yes| S[Assign value ✓]
    R -->|no| K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User-controlled path string] --> B{Call site}

    B -->|fillDefaults| C[parseVariablePath\nREGEX + UNSAFE_PATH_SEGMENT_KEYS]
    B -->|buildObjectFromPaths\nkeysToObject| D[safeSetPath directly]

    C -->|null → skip| E[skip variable]
    C -->|PathPart list| F{pathParts.length === 1\n&& defaultValue === empty?}
    F -->|yes| E
    F -->|no| G[safeSetPath\nvariable.name, value]

    D --> G

    G --> H[parseDotBracketPath\nbracket → dot expansion]
    H --> I{Any segment in\nUNSAFE_PATH_SEGMENT_KEYS?}
    I -->|yes| J[return early — no write]
    I -->|no| K[Walk segments]

    K --> L{Segment is numeric index?}
    L -->|yes| M{Array.isArray node?}
    M -->|no| J
    M -->|yes| N[Use numeric key]
    L -->|no| O[hasOwnProperty.call\nnever follows prototype chain]
    O --> P{Existing value\nis scalar?}
    P -->|yes| J
    P -->|no| Q[Create array or plain object\nfor next segment]
    N --> R{Last segment?}
    Q --> R
    R -->|yes| S[Assign value ✓]
    R -->|no| K
```

</a>

<sub>Reviews (3): Last reviewed commit: ["refactor(application-generic): extract c..."](https://github.com/novuhq/novu/commit/d72fd98188ee26e9fcc8948e98f546650b3870dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42100809)</sub>

<!-- /greptile_comment -->