### PR TITLE
docs(docs): add contexts concept and update multi-tenancy docs fixes DOC-403

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,6 +54,7 @@
                   "platform/concepts/integrations",
                   "platform/concepts/trigger",
                   "platform/concepts/preferences",
+                  "platform/concepts/contexts",
                   "platform/concepts/tenants"
                 ]
               },

--- a/docs/platform/additional-resources/glossary.mdx
+++ b/docs/platform/additional-resources/glossary.mdx
@@ -138,11 +138,11 @@ Per-trigger customizations that override default template content or [integratio
 
 ### Context
 
-Multi-dimensional metadata passed at trigger time as `{ type: id | { id, data } }`—for example, `tenant`, `app`, or `region`. Context data is available in templates (`{{context.tenant.data.name}}`), [step conditions](#step-conditions), [Inbox](#inbox) filtering, and Activity Feed search. You can pass up to five contexts per trigger. See [Manage contexts](/platform/workflow/advanced-features/contexts/manage-contexts).
+Multi-dimensional metadata passed at trigger time as `{ type: id | { id, data } }`—for example, `tenant`, `app`, or `region`. Context data is available in templates (`{{context.tenant.data.name}}`), [step conditions](#step-conditions), [Inbox](#inbox) filtering, and Activity Feed search. You can pass up to five contexts per trigger. See [Contexts](/platform/concepts/contexts).
 
 ### Tenant
 
-A legacy multi-tenancy approach using environment-scoped tenant entities and subscriber ID prefixing. For new implementations, prefer [contexts](#context). See [Multi-tenancy](/platform/concepts/tenants).
+A logical organization, workspace, or customer boundary within your application. In Novu, implement multi-tenancy with a `tenant` [context](#context) rather than prefixing subscriber IDs. See [Multi-tenancy](/platform/concepts/tenants).
 
 ## Environments and account
 

--- a/docs/platform/concepts/contexts.mdx
+++ b/docs/platform/concepts/contexts.mdx
@@ -1,0 +1,307 @@
+---
+title: 'How do contexts work in Novu?'
+sidebarTitle: 'Contexts'
+description: "Learn what contexts are in Novu, how they differ from payloads, and how they help you scope, personalize, and filter notifications across workflows and the Inbox."
+---
+
+A _context_ is user-defined metadata you attach when triggering a workflow. Contexts let you scope, personalize, and filter notifications without duplicating subscribers, workflows, or templates.
+
+Common context types include `tenant`, `app`, `region`, or any key that matches your product model. Each context entry is either a simple identifier or a rich object with an `id` and optional `data` fields.
+
+![Novu contexts feature showing tenant-scoped notification isolation in the dashboard](/images/inbox/Contexts.png)
+
+## How contexts fit into Novu's model
+
+When you [trigger](/platform/concepts/trigger) a workflow, you pass:
+
+- A **subscriber** (who receives the notification)
+- A **payload** (event-specific data for this run)
+- An optional **context** (shared metadata that scopes and personalizes the notification)
+
+Contexts are persistent. Unlike a payload, which exists only for a single workflow execution, context data is stored in Novu and reused across triggers, templates, the [Inbox](/platform/inbox), and the Activity Feed.
+
+<Note>
+  You can pass up to five context keys per trigger. Each context `data` object is limited to 64KB. See [Manage contexts](/platform/workflow/advanced-features/contexts/manage-contexts) for schema details.
+</Note>
+
+## Context vs payload
+
+| | Payload | Context |
+| --- | --- | --- |
+| **Scope** | Single workflow execution | Persistent across triggers |
+| **Typical use** | Order ID, message text, action URL | Tenant name, app branding, region |
+| **In templates** | `{{payload.field}}` | `{{context.tenant.data.name}}` |
+| **Inbox filtering** | Not used for scoping | Exact-match filtering |
+| **Auto-created** | No | Yes, on first reference |
+
+Use the payload for data that changes on every event. Use context for metadata that defines _where_ or _for whom_ a notification belongs.
+
+## Context structure
+
+Each key in the `context` object is a context type. Novu supports three formats per key:
+
+```ts
+context: {
+  // Simple string — type and id only
+  tenant: "acme-corp",
+
+  // Object with id
+  app: { id: "billing" },
+
+  // Object with id and metadata
+  region: {
+    id: "us-east",
+    data: {
+      name: "US East",
+      timezone: "America/New_York",
+    },
+  },
+}
+```
+
+Contexts are **auto-created** the first time Novu sees them (via a trigger or the Inbox). Existing context data is **not** auto-updated, which prevents accidental overwrites. Update context data through the [Contexts API](/api-reference/contexts/context-schema) or the Novu dashboard.
+
+## What you can use contexts for
+
+<CardGroup cols={2}>
+  <Card title="Multi-tenancy" icon="building-2" href="/platform/concepts/tenants">
+    Isolate notifications per organization, workspace, or customer using a `tenant` context—without prefixing subscriber IDs or duplicating workflows.
+  </Card>
+  <Card title="App or feature scoping" icon="layout-grid">
+    Route notifications to the right Inbox by scoping with an `app` or feature key when one subscriber uses multiple products.
+  </Card>
+  <Card title="Dynamic branding" icon="palette" href="/platform/workflow/advanced-features/contexts/contexts-in-workflows">
+    Store logos, colors, and plan names in context `data` and reference them in templates with `{{context}}`.
+  </Card>
+  <Card title="Conditional workflow logic" icon="git-branch" href="/platform/workflow/add-and-configure-steps/step-conditions">
+    Branch workflow steps based on context values, such as sending enterprise-only emails when `context.tenant.data.plan` is `enterprise`.
+  </Card>
+</CardGroup>
+
+## How context scoping works
+
+### In workflows and templates
+
+Context data is available in every template editor through the `{{context}}` helper:
+
+```liquid
+Welcome to {{context.tenant.data.name}}! Your {{context.tenant.data.plan}} plan is active.
+```
+
+You can also use context in [step conditions](/platform/workflow/add-and-configure-steps/step-conditions) to control which steps run.
+
+### In the Inbox
+
+The [Inbox](/platform/inbox) uses **exact-match** filtering. The `context` prop on `<Inbox />` must match the context used at trigger time, key for key and value for value. Notifications triggered with a tenant context only appear in an Inbox initialized with the same tenant context.
+
+| Workflow context | Inbox context | Displayed? |
+| --- | --- | --- |
+| `{ tenant: "acme" }` | `{ tenant: "acme" }` | Yes |
+| `{ tenant: "acme" }` | `{ tenant: "globex" }` | No |
+| `{ tenant: "acme" }` | `{}` | No |
+
+When a subscriber switches tenants in your app, re-render the Inbox with the new context. Novu refetches notifications and reconnects the WebSocket scope automatically.
+
+<Warning>
+  Because `context` is set on the client, secure it with `contextHash` in production. See [Inbox with context](/platform/inbox/configuration/inbox-with-context).
+</Warning>
+
+## Trigger a workflow with context
+
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api";
+
+const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
+
+await novu.trigger({
+  workflowId: "invoice-paid",
+  to: { subscriberId: "user-123" },
+  payload: { amount: "$250" },
+  context: {
+    tenant: {
+      id: "acme-corp",
+      data: { name: "Acme Corporation", plan: "enterprise" },
+    },
+  },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="invoice-paid",
+        to={"subscriber_id": "user-123"},
+        payload={"amount": "$250"},
+        context={
+            "tenant": {
+                "id": "acme-corp",
+                "data": {
+                    "name": "Acme Corporation",
+                    "plan": "enterprise",
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "invoice-paid",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user-123",
+    }),
+    Payload: map[string]any{"amount": "$250"},
+    Context: map[string]any{
+        "tenant": map[string]any{
+            "id": "acme-corp",
+            "data": map[string]any{
+                "name": "Acme Corporation",
+                "plan": "enterprise",
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'invoice-paid',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: ['amount' => '$250'],
+        context: [
+            'tenant' => [
+                'id' => 'acme-corp',
+                'data' => [
+                    'name' => 'Acme Corporation',
+                    'plan' => 'enterprise',
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "invoice-paid",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "user-123",
+    }),
+    Payload = new Dictionary<string, object>() {
+        { "amount", "$250" },
+    },
+    Context = new Dictionary<string, object>() {
+        { "tenant", new Dictionary<string, object>() {
+            { "id", "acme-corp" },
+            { "data", new Dictionary<string, object>() {
+                { "name", "Acme Corporation" },
+                { "plan", "enterprise" },
+            } },
+        } },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey("<YOUR_SECRET_KEY_HERE>")
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("invoice-paid")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("user-123")
+            .build()))
+        .payload(Map.of("amount", "$250"))
+        .context(Map.ofEntries(
+            Map.entry("tenant", TriggerEventRequestDtoContextUnion.of(
+                TriggerEventRequestDtoContext2.builder()
+                    .id("acme-corp")
+                    .data(Map.ofEntries(
+                        Map.entry("name", "Acme Corporation"),
+                        Map.entry("plan", "enterprise")))
+                    .build()))))
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+-H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+-d '{
+    "name": "invoice-paid",
+    "to": { "subscriberId": "user-123" },
+    "payload": { "amount": "$250" },
+    "context": {
+        "tenant": {
+            "id": "acme-corp",
+            "data": {
+                "name": "Acme Corporation",
+                "plan": "enterprise"
+            }
+        }
+    }
+}'
+```
+  </Tab>
+</Tabs>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Multi-tenancy" icon="building-2" href="/platform/concepts/tenants">
+    Implement tenant isolation with contexts end to end.
+  </Card>
+  <Card title="Manage contexts" icon="database" href="/platform/workflow/advanced-features/contexts/manage-contexts">
+    Create, update, and delete contexts through the API or dashboard.
+  </Card>
+  <Card title="Contexts in workflows" icon="git-branch" href="/platform/workflow/advanced-features/contexts/contexts-in-workflows">
+    Personalize templates and add conditional logic with context data.
+  </Card>
+  <Card title="Inbox with context" icon="inbox" href="/platform/inbox/configuration/inbox-with-context">
+    Filter the Inbox by context and secure it with `contextHash`.
+  </Card>
+</CardGroup>

--- a/docs/platform/concepts/tenants.mdx
+++ b/docs/platform/concepts/tenants.mdx
@@ -1,228 +1,109 @@
 ---
 title: 'Multi-tenancy'
-description: "Learn how to implement multi-tenant notifications in Novu by scoping subscribers and workflow content per tenant using the tenants API and template overrides."
+description: "Learn how to implement multi-tenant notifications in Novu using contexts to isolate Inbox feeds, scope preferences, and personalize workflow content per tenant."
 ---
 
+Multi-tenancy is a common requirement for applications that serve multiple organizations, workspaces, or customers from a single Novu project. Tenants are also commonly called workspaces or organizations.
 
-Multi-tenancy is a common use case for a lot of companies that have multiple organizations that use their applications. In some cases, there is a need to separate the behavior of the notification system depending on the individual tenants.
+Typical multi-tenancy goals include:
 
-Tenants are also commonly called workspaces or organizations.
+- Grouping each subscriber's Inbox feed by tenant
+- Scoping notification preferences per tenant
+- Adjusting notification content and branding per tenant
 
-Some of the common multi-tenancy use cases are:
+Novu supports multi-tenancy through [contexts](/platform/concepts/contexts). Use a `tenant` context to define tenant boundaries instead of duplicating subscribers, prefixing subscriber IDs, or maintaining separate workflows per tenant.
 
-- Group subscribers notification feeds by the tenant
-- Adjust the content of the notification depending on the tenant
+<Note>
+  New to contexts? Start with [Contexts](/platform/concepts/contexts) to understand how context scoping, persistence, and Inbox filtering work.
+</Note>
 
-## How to implement multi-tenancy in Novu
+## How multi-tenancy works in Novu
 
-Novu supports multi-tenancy out of the box, the most simple way to implement tenant separation is by prefixing the subscriber identifier with the <Tooltip tip="The tenant identifier is a unique identifier for the tenant in your application. Usually the tenant id in your database.">tenant identifier</Tooltip>
+Multi-tenancy in Novu is built on top of contexts. A `tenant` context identifies which organization a notification belongs to.
 
-<Tabs>
-  <Tab title="Node.js">
+When you trigger a workflow with a tenant context:
+
+- Notifications are associated with that tenant
+- The same subscriber can receive different notifications per tenant
+- [Inbox](/platform/inbox) preferences are scoped to the subscriber and tenant context combination
+
+When you initialize the Inbox with the same tenant context, the subscriber sees only notifications for that tenant.
+
+## Implement multi-tenancy with contexts
+
+<Steps>
+  <Step title="Define a tenant context">
+    A tenant context identifies a specific tenant. Use a simple string for the tenant ID, or a rich object when you need metadata such as company name, logo, or plan type.
+
+    ```ts
+    const tenantContext = {
+      tenant: {
+        id: "acme-corp",
+        data: {
+          name: "Acme Corporation",
+          plan: "enterprise",
+          logo: "https://cdn.acme.com/logo.png",
+        },
+      },
+    };
+    ```
+
+    Contexts are auto-created on first use. Manage them from the **Contexts** section in the Novu dashboard or through the [Contexts API](/api-reference/contexts/context-schema).
+  </Step>
+
+  <Step title="Trigger workflows with a tenant context">
+    Pass the tenant context when triggering a workflow. Keep the subscriber ID stable—use your application's user ID, not a tenant-prefixed value.
+
+    <Tabs>
+      <Tab title="Node.js">
 ```ts
 import { Novu } from "@novu/api";
 
 const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
 
-const subscriberId = `${tenantId}:${userId}`;
-
 await novu.trigger({
-  workflowId: "workflow_identifier",
-  to: { subscriberId },
-  payload: { tenantId },
-});
-```
-  </Tab>
-  <Tab title="Python">
-```python
-import os
-import novu_py
-from novu_py import Novu
-
-subscriber_id = f"{tenant_id}:{user_id}"
-
-with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
-    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
-        workflow_id="workflow_identifier",
-        to={"subscriber_id": subscriber_id},
-        payload={"tenantId": tenant_id},
-    ))
-```
-  </Tab>
-  <Tab title="Go">
-```go
-import (
-    "context"
-    "fmt"
-    "os"
-
-    novugo "github.com/novuhq/novu-go"
-    "github.com/novuhq/novu-go/models/components"
-)
-
-s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
-
-subscriberID := fmt.Sprintf("%s:%s", tenantID, userID)
-
-res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
-    WorkflowID: "workflow_identifier",
-    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
-        SubscriberID: subscriberID,
-    }),
-    Payload: map[string]any{
-        "tenantId": tenantID,
-    },
-}, nil)
-```
-  </Tab>
-  <Tab title="PHP">
-```php
-use novu;
-use novu\Models\Components;
-
-$sdk = novu\Novu::builder()
-    ->setSecurity('<YOUR_SECRET_KEY_HERE>')
-    ->build();
-
-$subscriberId = "{$tenantId}:{$userId}";
-
-$sdk->trigger(
-    triggerEventRequestDto: new Components\TriggerEventRequestDto(
-        workflowId: 'workflow_identifier',
-        to: new Components\SubscriberPayloadDto(subscriberId: $subscriberId),
-        payload: ['tenantId' => $tenantId],
-    ),
-);
-```
-  </Tab>
-  <Tab title=".NET">
-```csharp
-using Novu;
-using Novu.Models.Components;
-using System.Collections.Generic;
-
-var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
-
-var subscriberId = $"{tenantId}:{userId}";
-
-await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
-    WorkflowId = "workflow_identifier",
-    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
-        SubscriberId = subscriberId,
-    }),
-    Payload = new Dictionary<string, object>() {
-        { "tenantId", tenantId },
-    },
-});
-```
-  </Tab>
-  <Tab title="Java">
-```java
-import co.novu.Novu;
-import co.novu.models.components.*;
-import java.util.Map;
-
-Novu novu = Novu.builder()
-    .secretKey("<YOUR_SECRET_KEY_HERE>")
-    .build();
-
-String subscriberId = tenantId + ":" + userId;
-
-novu.trigger()
-    .body(TriggerEventRequestDto.builder()
-        .workflowId("workflow_identifier")
-        .to(To2.of(SubscriberPayloadDto.builder()
-            .subscriberId(subscriberId)
-            .build()))
-        .payload(Map.of("tenantId", tenantId))
-        .build())
-    .call();
-```
-  </Tab>
-  <Tab title="cURL">
-```bash
-curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
--H 'Content-Type: application/json' \
--H 'Accept: application/json' \
--H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
--d '{
-    "name": "workflow_identifier",
-    "to": { "subscriberId": "TENANT_ID:USER_ID" },
-    "payload": { "tenantId": "TENANT_ID" }
-}'
-```
-  </Tab>
-</Tabs>
-
-### Tenant in Inbox
-
-When using the Inbox feature, you can use the tenant identifier to group notifications by tenant.
-
-```tsx
-import { Inbox } from "@novu/react";
-
-function InboxComponent({ tenantId, userId }) {
-  return <Inbox subscriber={`${tenantId}:${userId}`} />;
-}
-```
-
-Each subscriber in a tenant will have it's own unique inbox feed, including a separate preference configuration set.
-
-## Adjusting notification content based on tenant
-
-When triggering a notification, you can pass a custom tenant object or identifier and use it to manipulate workflows or content.
-
-<Tabs>
-  <Tab title="Node.js">
-```ts
-import { Novu } from "@novu/api";
-
-const novu = new Novu({ secretKey: "<YOUR_SECRET_KEY_HERE>" });
-
-const subscriberId = `${tenantId}:${userId}`;
-
-await novu.trigger({
-  workflowId: "workflow_identifier",
-  to: { subscriberId },
-  payload: {
+  workflowId: "invoice-paid",
+  to: { subscriberId: "user-123" },
+  payload: { amount: "$250" },
+  context: {
     tenant: {
-      id: tenantId,
-      name: "Airbnb",
-      logo: "https://airbnb.com/logo.png",
-      primaryColor: "red",
+      id: "acme-corp",
+      data: {
+        name: "Acme Corporation",
+        plan: "enterprise",
+      },
     },
   },
 });
 ```
-  </Tab>
-  <Tab title="Python">
+      </Tab>
+      <Tab title="Python">
 ```python
 import os
 import novu_py
 from novu_py import Novu
 
-subscriber_id = f"{tenant_id}:{user_id}"
-
 with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
     novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
-        workflow_id="workflow_identifier",
-        to={"subscriber_id": subscriber_id},
-        payload={
+        workflow_id="invoice-paid",
+        to={"subscriber_id": "user-123"},
+        payload={"amount": "$250"},
+        context={
             "tenant": {
-                "id": tenant_id,
-                "name": "Airbnb",
-                "logo": "https://airbnb.com/logo.png",
-                "primaryColor": "red",
+                "id": "acme-corp",
+                "data": {
+                    "name": "Acme Corporation",
+                    "plan": "enterprise",
+                },
             },
         },
     ))
 ```
-  </Tab>
-  <Tab title="Go">
+      </Tab>
+      <Tab title="Go">
 ```go
 import (
     "context"
-    "fmt"
     "os"
 
     novugo "github.com/novuhq/novu-go"
@@ -231,25 +112,25 @@ import (
 
 s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
 
-subscriberID := fmt.Sprintf("%s:%s", tenantID, userID)
-
-res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
-    WorkflowID: "workflow_identifier",
+s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "invoice-paid",
     To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
-        SubscriberID: subscriberID,
+        SubscriberID: "user-123",
     }),
-    Payload: map[string]any{
+    Payload: map[string]any{"amount": "$250"},
+    Context: map[string]any{
         "tenant": map[string]any{
-            "id":           tenantID,
-            "name":         "Airbnb",
-            "logo":         "https://airbnb.com/logo.png",
-            "primaryColor": "red",
+            "id": "acme-corp",
+            "data": map[string]any{
+                "name": "Acme Corporation",
+                "plan": "enterprise",
+            },
         },
     },
 }, nil)
 ```
-  </Tab>
-  <Tab title="PHP">
+      </Tab>
+      <Tab title="PHP">
 ```php
 use novu;
 use novu\Models\Components;
@@ -258,25 +139,25 @@ $sdk = novu\Novu::builder()
     ->setSecurity('<YOUR_SECRET_KEY_HERE>')
     ->build();
 
-$subscriberId = "{$tenantId}:{$userId}";
-
 $sdk->trigger(
     triggerEventRequestDto: new Components\TriggerEventRequestDto(
-        workflowId: 'workflow_identifier',
-        to: new Components\SubscriberPayloadDto(subscriberId: $subscriberId),
-        payload: [
+        workflowId: 'invoice-paid',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: ['amount' => '$250'],
+        context: [
             'tenant' => [
-                'id' => $tenantId,
-                'name' => 'Airbnb',
-                'logo' => 'https://airbnb.com/logo.png',
-                'primaryColor' => 'red',
+                'id' => 'acme-corp',
+                'data' => [
+                    'name' => 'Acme Corporation',
+                    'plan' => 'enterprise',
+                ],
             ],
         ],
     ),
 );
 ```
-  </Tab>
-  <Tab title=".NET">
+      </Tab>
+      <Tab title=".NET">
 ```csharp
 using Novu;
 using Novu.Models.Components;
@@ -284,25 +165,27 @@ using System.Collections.Generic;
 
 var sdk = new NovuSDK(secretKey: "<YOUR_SECRET_KEY_HERE>");
 
-var subscriberId = $"{tenantId}:{userId}";
-
 await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
-    WorkflowId = "workflow_identifier",
+    WorkflowId = "invoice-paid",
     To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
-        SubscriberId = subscriberId,
+        SubscriberId = "user-123",
     }),
     Payload = new Dictionary<string, object>() {
+        { "amount", "$250" },
+    },
+    Context = new Dictionary<string, object>() {
         { "tenant", new Dictionary<string, object>() {
-            { "id", tenantId },
-            { "name", "Airbnb" },
-            { "logo", "https://airbnb.com/logo.png" },
-            { "primaryColor", "red" },
+            { "id", "acme-corp" },
+            { "data", new Dictionary<string, object>() {
+                { "name", "Acme Corporation" },
+                { "plan", "enterprise" },
+            } },
         } },
     },
 });
 ```
-  </Tab>
-  <Tab title="Java">
+      </Tab>
+      <Tab title="Java">
 ```java
 import co.novu.Novu;
 import co.novu.models.components.*;
@@ -312,61 +195,132 @@ Novu novu = Novu.builder()
     .secretKey("<YOUR_SECRET_KEY_HERE>")
     .build();
 
-String subscriberId = tenantId + ":" + userId;
-
 novu.trigger()
     .body(TriggerEventRequestDto.builder()
-        .workflowId("workflow_identifier")
+        .workflowId("invoice-paid")
         .to(To2.of(SubscriberPayloadDto.builder()
-            .subscriberId(subscriberId)
+            .subscriberId("user-123")
             .build()))
-        .payload(Map.of("tenant", Map.ofEntries(
-            Map.entry("id", tenantId),
-            Map.entry("name", "Airbnb"),
-            Map.entry("logo", "https://airbnb.com/logo.png"),
-            Map.entry("primaryColor", "red"))))
+        .payload(Map.of("amount", "$250"))
+        .context(Map.ofEntries(
+            Map.entry("tenant", TriggerEventRequestDtoContextUnion.of(
+                TriggerEventRequestDtoContext2.builder()
+                    .id("acme-corp")
+                    .data(Map.ofEntries(
+                        Map.entry("name", "Acme Corporation"),
+                        Map.entry("plan", "enterprise")))
+                    .build()))))
         .build())
     .call();
 ```
-  </Tab>
-  <Tab title="cURL">
+      </Tab>
+      <Tab title="cURL">
 ```bash
 curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
-    "name": "workflow_identifier",
-    "to": { "subscriberId": "TENANT_ID:USER_ID" },
-    "payload": {
+    "name": "invoice-paid",
+    "to": { "subscriberId": "user-123" },
+    "payload": { "amount": "$250" },
+    "context": {
         "tenant": {
-            "id": "TENANT_ID",
-            "name": "Airbnb",
-            "logo": "https://airbnb.com/logo.png",
-            "primaryColor": "red"
+            "id": "acme-corp",
+            "data": {
+                "name": "Acme Corporation",
+                "plan": "enterprise"
+            }
         }
     }
 }'
 ```
-  </Tab>
-</Tabs>
+      </Tab>
+    </Tabs>
+  </Step>
 
-The tenant object will be available to use in the workflow editor as a variable for the following areas:
+  <Step title="Filter the Inbox by tenant">
+    Pass the same tenant context to the Inbox so each subscriber sees only notifications for their active tenant.
 
-- Content (use `{{payload.tenant.name}}` to display the tenant name in an email or any other channel)
-- Step Conditions (use `{{payload.tenant.id}}` to conditionally execute a step based on the tenant)
-- Use the Inbox [data object](/platform/inbox/configuration/data-object) to filter notifications by tenant.
+    ```tsx
+    import { Inbox } from "@novu/react";
+
+    function TenantInbox({ userId, tenant }) {
+      return (
+        <Inbox
+          applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+          subscriberId={userId}
+          context={{
+            tenant: {
+              id: tenant.id,
+              data: tenant.data,
+            },
+          }}
+        />
+      );
+    }
+    ```
+
+    When a subscriber switches tenants, re-render the Inbox with the new context. Novu refetches notifications and reconnects the WebSocket scope.
+
+    <Note>
+      Secure tenant context in production with `contextHash`. See [Inbox with context](/platform/inbox/configuration/inbox-with-context).
+    </Note>
+  </Step>
+
+  <Step title="Personalize content per tenant">
+    Use tenant metadata in templates with the `{{context}}` helper:
+
+    ```liquid
+    Hello {{subscriber.firstName}}, your {{context.tenant.data.plan}} plan
+    on {{context.tenant.data.name}} just renewed.
+    ```
+
+    You can also branch workflow logic on tenant data in [step conditions](/platform/workflow/add-and-configure-steps/step-conditions). See [Contexts in workflows](/platform/workflow/advanced-features/contexts/contexts-in-workflows).
+  </Step>
+</Steps>
+
+## Tenant context in the Inbox
+
+The Inbox uses exact-match context filtering. The tenant context on `<Inbox />` must match the context used at trigger time.
+
+| Workflow context | Inbox context | Displayed? |
+| --- | --- | --- |
+| `{ tenant: { id: "acme-corp" } }` | `{ tenant: { id: "acme-corp" } }` | Yes |
+| `{ tenant: { id: "acme-corp" } }` | `{ tenant: { id: "globex" } }` | No |
+| `{ tenant: { id: "acme-corp" } }` | `{}` | No |
+
+Each subscriber gets a separate Inbox feed and preference configuration per tenant context.
 
 ## Frequently asked questions
 
-The following are the frequently asked questions about multi-tenancy in Novu.
-
 <AccordionGroup>
   <Accordion title="Can I use a different delivery provider for each tenant?">
-    Currently, we do not support using a different delivery provider for each tenant. You can reach out to support@novu.co in case this is a feature required for your use case.
+    Currently, Novu does not support using a different delivery provider per tenant. Contact support@novu.co if this is required for your use case.
   </Accordion>
 
-  <Accordion title="Can I specify different workflow preferences for each tenant?">
-    We don't support specifying different workflow preferences for each tenant. You can reach out to support@novu.co in case this is a feature required for your use case.
+  <Accordion title="Can subscribers manage different preferences per tenant?">
+    Yes. When you scope the Inbox with a tenant context, preferences are stored per subscriber and tenant context combination. A subscriber can enable email for one tenant and disable it for another.
+  </Accordion>
+
+  <Accordion title="Can I combine tenant context with other context types?">
+    Yes. You can pass up to five context keys per trigger—for example, `tenant` and `app` together. The Inbox must declare the same combined context to display those notifications. See [Contexts](/platform/concepts/contexts).
   </Accordion>
 </AccordionGroup>
+
+## Related guides
+
+<CardGroup cols={2}>
+  <Card title="Contexts" icon="layers" href="/platform/concepts/contexts">
+    Learn what contexts are and how they work across Novu.
+  </Card>
+  <Card title="Multi-tenancy in the Inbox" icon="inbox" href="/platform/inbox/advanced-features/multi-tenancy">
+    End-to-end Inbox setup for multi-tenant applications.
+  </Card>
+  <Card title="Manage contexts" icon="database" href="/platform/workflow/advanced-features/contexts/manage-contexts">
+    Create, update, and delete tenant contexts through the API.
+  </Card>
+  <Card title="Inbox with context" icon="shield" href="/platform/inbox/configuration/inbox-with-context">
+    Secure tenant context with `contextHash`.
+  </Card>
+</CardGroup>

--- a/docs/platform/inbox/advanced-features/multi-tenancy.mdx
+++ b/docs/platform/inbox/advanced-features/multi-tenancy.mdx
@@ -3,10 +3,10 @@ title: 'Multi-tenancy'
 description: 'Learn how to use context to implement multi-tenant notifications to support different organizations or workspaces within your application.'
 ---
 
-Multi-tenancy in Novu lets you isolate notifications for different organizations, environments, or workspaces within the same Novu project. Instead of creating separate subscribers or workflows for each tenant, you can use [Contexts](/platform/workflow/advanced-features/contexts) to define and manage tenant boundaries.
+Multi-tenancy in Novu lets you isolate notifications for different organizations, environments, or workspaces within the same Novu project. Instead of creating separate subscribers or workflows for each tenant, you can use [contexts](/platform/concepts/contexts) to define and manage tenant boundaries.
 
 <Note>
-  This guide assumes you already understand what Contexts are. If not, start with the [Contexts](/platform/workflow/advanced-features/contexts) documentation.
+  This guide assumes you already understand what contexts are. If not, start with [Contexts](/platform/concepts/contexts).
 </Note>
 
 ## How multi-tenancy works in Novu
@@ -50,7 +50,7 @@ context: {
 You can also manage all tenant contexts centrally from the Novu dashboard or API.
 
 <Note>
-  To learn more about creating, updating, and deleting contexts, see the [Manage Contexts](/platform/workflow/advanced-features/contexts) guide.
+  To learn more about creating, updating, and deleting contexts, see [Manage contexts](/platform/workflow/advanced-features/contexts/manage-contexts).
 </Note>
 
 ### Applying tenant context in workflows

--- a/docs/platform/inbox/configuration/inbox-with-context.mdx
+++ b/docs/platform/inbox/configuration/inbox-with-context.mdx
@@ -6,7 +6,7 @@ description: 'Learn how to use contexts in the Inbox component to filter and per
 _Contexts_ let you scope each `<Inbox />` instance to a specific environment, tenant, or app within your product. When combined with workflow-level contexts, they ensure that each `<Inbox />` displays only the notifications relevant to that specific context.
 
 <Note>
-  If you’re new to contexts, start from the [Contexts](/platform/workflow/advanced-features/contexts) section to understand how contexts are created, managed in Novu and how they used in workflows.
+  If you’re new to contexts, start from [Contexts](/platform/concepts/contexts) to understand how contexts are created, managed in Novu, and used in workflows.
 </Note>
 
 ## How context works in `<Inbox/>`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates customer-facing documentation to reflect the recommended multi-tenancy flow using **contexts** instead of the legacy subscriber ID prefixing approach.

## Changes

- **New page:** [Contexts](/platform/concepts/contexts) under Core Concepts — explains what contexts are, how they differ from payloads, common use cases, scoping behavior, and links to deeper guides.
- **Updated page:** [Multi-tenancy](/platform/concepts/tenants) — rewritten to document tenant isolation via `tenant` context (trigger, Inbox filtering, template personalization, per-tenant preferences).
- **Navigation:** Added `platform/concepts/contexts` to `docs.json` Core Concepts group.
- **Glossary:** Updated Context and Tenant definitions to point at the new concept pages.
- **Cross-links:** Updated inbox multi-tenancy guides to reference the new Contexts concept page as the starting point.

## Why

The tenants concept page previously recommended prefixing subscriber IDs (`tenantId:userId`) and passing tenant data in the payload. Contexts are the supported primitive for multi-tenancy — they provide Inbox scoping, persistent tenant metadata, template access via `{{context}}`, and per-tenant preferences without duplicating subscribers.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GFC06JS3/p1783354290217079?thread_ts=1783354290.217079&cid=C06GFC06JS3)

<div><a href="https://cursor.com/agents/bc-5af8d4d7-06fe-5fe8-bf4d-7133d95772dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5af8d4d7-06fe-5fe8-bf4d-7133d95772dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the docs to explain context-based multi-tenancy. The main changes are:

- Adds a new `Contexts` concept page under Core Concepts.
- Rewrites the `Multi-tenancy` concept page around tenant contexts instead of subscriber ID prefixing.
- Updates glossary definitions for `Context` and `Tenant`.
- Updates Inbox multi-tenancy and context guide links to point at the new concept page.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changes are limited to MDX documentation and navigation. The new links resolve to files present in the docs tree, the added image exists, and the SDK examples follow the documented server-side SDK tab order.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the preview blocker sequence by recording the before-state and after-state logs of the Mintlify preview, including their exit codes.
- T-Rex validated the pre-proof link-check step and confirmed that HEAD^:docs/docs.json did not contain platform/concepts/contexts.
- T-Rex observed that after proof the link-check result indicated a successful validation with SUMMARY failures=0 and EXIT\_CODE=0.

<a href="https://app.greptile.com/trex/runs/13417515/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Adds the new contexts concept page to the Core Concepts navigation. |
| docs/platform/additional-resources/glossary.mdx | Updates glossary definitions for Context and Tenant to align with context-based multi-tenancy guidance. |
| docs/platform/concepts/contexts.mdx | Adds a new contexts concept page covering structure, persistence, scoping, Inbox filtering, and SDK trigger examples. |
| docs/platform/concepts/tenants.mdx | Rewrites multi-tenancy guidance around tenant contexts instead of subscriber ID prefixing. |
| docs/platform/inbox/advanced-features/multi-tenancy.mdx | Updates context-related cross-links to point to the new concepts and manage-contexts pages. |
| docs/platform/inbox/configuration/inbox-with-context.mdx | Updates the introductory contexts link to the new concept page. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant App as Customer app
participant Novu as Novu trigger/API
participant Store as Context + notification storage
participant Inbox as Tenant-scoped Inbox

App->>Novu: Trigger workflow with subscriber, payload, tenant context
Novu->>Store: Find or create context and persist notification scope
App->>Inbox: "Render <Inbox /> with matching tenant context"
Inbox->>Store: Request notifications scoped by subscriber + context
Store-->>Inbox: Return only exact-match tenant notifications
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant App as Customer app
participant Novu as Novu trigger/API
participant Store as Context + notification storage
participant Inbox as Tenant-scoped Inbox

App->>Novu: Trigger workflow with subscriber, payload, tenant context
Novu->>Store: Find or create context and persist notification scope
App->>Inbox: "Render <Inbox /> with matching tenant context"
Inbox->>Store: Request notifications scoped by subscriber + context
Store-->>Inbox: Return only exact-match tenant notifications
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(platform): add contexts concept and..."](https://github.com/novuhq/novu/commit/ff075e53b435600e8f0885375a47b9e4a6fdb889) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42113605)</sub>

<!-- /greptile_comment -->