### PR TITLE
fix(providers): process each SendGrid batched webhook event fixes NV-8211

### DIFF
--- a/apps/webhook/src/webhooks/usecases/webhook/webhook.usecase.ts
+++ b/apps/webhook/src/webhooks/usecases/webhook/webhook.usecase.ts
@@ -80,8 +80,9 @@ export class Webhook {
 
     const events: IWebhookResult[] = [];
 
-    for (const messageIdentifier of messageIdentifiers) {
-      const event = await this.parseEvent(messageIdentifier, command, providerId, channel);
+    for (let eventIndex = 0; eventIndex < messageIdentifiers.length; eventIndex++) {
+      const messageIdentifier = messageIdentifiers[eventIndex];
+      const event = await this.parseEvent(messageIdentifier, command, providerId, channel, eventIndex);
 
       if (event === undefined) {
         continue;
@@ -97,7 +98,8 @@ export class Webhook {
     messageIdentifier: string,
     command: WebhookCommand,
     providerId: string,
-    channel: ChannelTypeEnum
+    channel: ChannelTypeEnum,
+    eventIndex: number
   ): Promise<IWebhookResult | undefined> {
     const message = await this.messageRepository.findOne({
       identifier: messageIdentifier,
@@ -111,7 +113,11 @@ export class Webhook {
       return;
     }
 
-    const event = this.provider.parseEventBody(command.body, messageIdentifier);
+    const event = this.provider.parseEventBody(
+      command.body,
+      messageIdentifier,
+      Array.isArray(command.body) ? eventIndex : undefined
+    );
 
     if (event === undefined) {
       return undefined;

--- a/libs/application-generic/src/factories/mail/handlers/base.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/base.handler.ts
@@ -59,12 +59,12 @@ export abstract class BaseEmailHandler extends BaseHandler<IEmailProvider> imple
     return this.provider.verifySignature({ body, headers, rawBody });
   }
 
-  public parseEventBody(body: any, identifier: string): IEmailEventBody | undefined {
+  public parseEventBody(body: any, identifier: string, eventIndex?: number): IEmailEventBody | undefined {
     if (!this.provider.parseEventBody) {
       return undefined;
     }
 
-    return this.provider.parseEventBody(body, identifier);
+    return this.provider.parseEventBody(body, identifier, eventIndex);
   }
 
   async check() {

--- a/libs/application-generic/src/factories/shared/interfaces.ts
+++ b/libs/application-generic/src/factories/shared/interfaces.ts
@@ -6,7 +6,7 @@ export interface IHandler {
 
   getMessageId: (body: unknown | unknown[]) => string[];
 
-  parseEventBody: (body: unknown | unknown[], identifier: string) => IEmailEventBody | ISMSEventBody | undefined;
+  parseEventBody: (body: unknown | unknown[], identifier: string, eventIndex?: number) => IEmailEventBody | ISMSEventBody | undefined;
 
   verifySignature: ({
     body,
@@ -55,12 +55,16 @@ export abstract class BaseHandler<T extends ChannelProvider = ChannelProvider> i
     return this.provider.getMessageId(body);
   }
 
-  public parseEventBody(body: unknown | unknown[], identifier: string): IEmailEventBody | ISMSEventBody | undefined {
+  public parseEventBody(
+    body: unknown | unknown[],
+    identifier: string,
+    eventIndex?: number
+  ): IEmailEventBody | ISMSEventBody | undefined {
     if (!this.provider?.parseEventBody) {
       return undefined;
     }
 
-    const result = this.provider.parseEventBody(body, identifier);
+    const result = this.provider.parseEventBody(body, identifier, eventIndex);
 
     return result && typeof result === 'object' ? (result as IEmailEventBody | ISMSEventBody) : undefined;
   }

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -284,7 +284,7 @@ test('parseEventBody processes each batched event by index when message ids repe
   expect(opened?.status).toBe(EmailEventStatusEnum.OPENED);
 });
 
-test('parseEventBody returns undefined when batched event index does not match identifier', () => {
+test('parseEventBody falls back to identifier lookup when indexed event does not match', () => {
   const provider = new SendgridEmailProvider(mockConfig);
   const batch = [
     {
@@ -299,7 +299,8 @@ test('parseEventBody returns undefined when batched event index does not match i
 
   const result = provider.parseEventBody(batch, 'message-b', 0);
 
-  expect(result).toBeUndefined();
+  expect(result?.status).toBe(EmailEventStatusEnum.OPENED);
+  expect(result?.externalId).toBe('message-b');
 });
 
 test('getMessageId returns one id per batched event including duplicates', () => {

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -259,3 +259,56 @@ test('parseEventBody maps SendGrid blocked event to BLOCKED status', () => {
     row: expect.any(String),
   });
 });
+
+test('parseEventBody processes each batched event by index when message ids repeat', () => {
+  const provider = new SendgridEmailProvider(mockConfig);
+  const messageId = '6a4bdaeb6baa48da73d25308';
+  const batch = [
+    {
+      id: messageId,
+      event: 'delivered',
+      response: '250 OK',
+      attempt: '1',
+    },
+    {
+      id: messageId,
+      event: 'open',
+      attempt: '1',
+    },
+  ];
+
+  const delivered = provider.parseEventBody(batch, messageId, 0);
+  const opened = provider.parseEventBody(batch, messageId, 1);
+
+  expect(delivered?.status).toBe(EmailEventStatusEnum.DELIVERED);
+  expect(opened?.status).toBe(EmailEventStatusEnum.OPENED);
+});
+
+test('parseEventBody returns undefined when batched event index does not match identifier', () => {
+  const provider = new SendgridEmailProvider(mockConfig);
+  const batch = [
+    {
+      id: 'message-a',
+      event: 'delivered',
+    },
+    {
+      id: 'message-b',
+      event: 'open',
+    },
+  ];
+
+  const result = provider.parseEventBody(batch, 'message-b', 0);
+
+  expect(result).toBeUndefined();
+});
+
+test('getMessageId returns one id per batched event including duplicates', () => {
+  const provider = new SendgridEmailProvider(mockConfig);
+  const messageId = '6a4bdaeb6baa48da73d25308';
+  const batch = [
+    { id: messageId, event: 'delivered' },
+    { id: messageId, event: 'open' },
+  ];
+
+  expect(provider.getMessageId(batch)).toEqual([messageId, messageId]);
+});

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -315,7 +315,11 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
     if (Array.isArray(body)) {
       if (eventIndex !== undefined) {
         const item = body[eventIndex] as Record<string, unknown> | undefined;
-        eventBody = item?.id === identifier ? item : undefined;
+        if (item?.id === identifier) {
+          eventBody = item;
+        } else {
+          eventBody = body.find((entry: Record<string, unknown>) => entry.id === identifier);
+        }
       } else {
         eventBody = body.find((item: Record<string, unknown>) => item.id === identifier);
       }

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -310,10 +310,15 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
     return key ? headers[key] : undefined;
   }
 
-  parseEventBody(body: unknown | unknown[], identifier: string): IEmailEventBody | undefined {
-    let eventBody: Record<string, unknown>;
+  parseEventBody(body: unknown | unknown[], identifier: string, eventIndex?: number): IEmailEventBody | undefined {
+    let eventBody: Record<string, unknown> | undefined;
     if (Array.isArray(body)) {
-      eventBody = body.find((item: Record<string, unknown>) => item.id === identifier);
+      if (eventIndex !== undefined) {
+        const item = body[eventIndex] as Record<string, unknown> | undefined;
+        eventBody = item?.id === identifier ? item : undefined;
+      } else {
+        eventBody = body.find((item: Record<string, unknown>) => item.id === identifier);
+      }
     } else {
       eventBody = body as Record<string, unknown>;
     }

--- a/packages/stateless/src/lib/provider/provider.interface.ts
+++ b/packages/stateless/src/lib/provider/provider.interface.ts
@@ -194,7 +194,7 @@ export interface IEmailProvider extends IProvider {
 
   getMessageId?: (body: any | any[]) => string[];
 
-  parseEventBody?: (body: any | any[], identifier: string) => IEmailEventBody | undefined;
+  parseEventBody?: (body: any | any[], identifier: string, eventIndex?: number) => IEmailEventBody | undefined;
 
   checkIntegration?: (options: IEmailOptions) => Promise<ICheckIntegrationResponse>;
 }
@@ -206,7 +206,7 @@ export interface ISmsProvider extends IProvider {
 
   getMessageId?: (body: any) => string[];
 
-  parseEventBody?: (body: any | any[], identifier: string) => ISMSEventBody | undefined;
+  parseEventBody?: (body: any | any[], identifier: string, eventIndex?: number) => ISMSEventBody | undefined;
 }
 
 export interface IChatProvider extends IProvider {
@@ -215,7 +215,7 @@ export interface IChatProvider extends IProvider {
 
   getMessageId?: (body: any | any[]) => string[];
 
-  parseEventBody?: (body: any | any[], identifier: string) => unknown | undefined;
+  parseEventBody?: (body: any | any[], identifier: string, eventIndex?: number) => unknown | undefined;
 }
 
 export interface IPushProvider extends IProvider {
@@ -227,7 +227,7 @@ export interface IPushProvider extends IProvider {
 
   getMessageId?: (body: any | any[]) => string[];
 
-  parseEventBody?: (body: any | any[], identifier: string) => unknown | undefined;
+  parseEventBody?: (body: any | any[], identifier: string, eventIndex?: number) => unknown | undefined;
 }
 
 export type ChannelProvider = IEmailProvider | ISmsProvider | IChatProvider | IPushProvider;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When SendGrid posts multiple events for the same message in a single batched array (e.g. `delivered` and `open` sharing the same `id`), Novu only processed the first matching event. Subsequent events in the batch were dropped or duplicated.

## Root cause

`ProcessInboundWebhookUsecase` iterated over message IDs from `getMessageId()`, but `parseEventBody()` always used `.find()` by message ID — so every iteration resolved to the first event in the batch.

## Fix

- Pass an `eventIndex` through the handler chain when the webhook body is an array.
- Update SendGrid `parseEventBody()` to select the event at that index (with identifier validation) instead of always using `.find()`.
- Apply the same index-based iteration in the legacy `apps/webhook` use case.

```mermaid
sequenceDiagram
    participant SG as SendGrid
    participant API as ProcessInboundWebhookUsecase
    participant Provider as SendgridEmailProvider

    SG->>API: POST [{delivered,id:X},{open,id:X}]
    API->>API: getMessageId → [X, X]
    loop eventIndex 0..1
        API->>Provider: parseEventBody(body, X, eventIndex)
        Provider-->>API: delivered / opened
    end
```

## Testing

- Added SendGrid provider unit tests for batched events with duplicate message IDs.
- `pnpm test src/lib/email/sendgrid/sendgrid.provider.spec.ts -t "batched|getMessageId returns"` passes.

## Enterprise submodule

Requires matching PR in `novuhq/packages-enterprise`:
https://github.com/novuhq/packages-enterprise/compare/next...fix/sendgrid-batched-webhook-events-9a51

Merge the enterprise PR first, then this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8211](https://linear.app/novu/issue/NV-8211/sendgrid-inbound-webhook-drops-events-when-multiple-events-for-the)

<div><a href="https://cursor.com/agents/bc-e5171683-7349-481f-a408-24fc7a4a9a51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5171683-7349-481f-a408-24fc7a4a9a51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes SendGrid batched webhook handling when multiple events share the same message ID. The main changes are:

- Threads an optional `eventIndex` through webhook parsing and provider handler interfaces.
- Updates SendGrid event parsing to select the indexed batch item when it matches the message ID.
- Keeps identifier-based lookup as a fallback for non-indexed callers or mismatched indexes.
- Adds SendGrid tests for duplicate IDs, indexed parsing, and fallback lookup.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to an optional webhook parsing parameter. Existing non-array and non-indexed parsing paths keep their prior fallback behavior. Targeted tests cover the SendGrid duplicate-ID batch case fixed by this PR.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex verified the test environment as Node v24.18.0, pnpm 11.0.9, and git head 7899692fd54986fcac07239e492dfb5c83347b4e; an unsupported-engine warning was emitted as expected.
- An initial capture of the test run completed the same test but the shell wrapper exited with code 2 because /bin/sh did not support ${PIPESTATUS\[0\]}.
- A following bash rerun provided reliable exit-code proof showing the tests finished with exit code 0 and the final summary: Test Files 1 passed (1), Tests 2 passed | 11 skipped (13).

<a href="https://app.greptile.com/trex/runs/13813089/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/webhook/src/webhooks/usecases/webhook/webhook.usecase.ts | Passes the current batched event index into provider parsing while preserving scalar body behavior. |
| libs/application-generic/src/factories/shared/interfaces.ts | Extends handler interfaces and shared forwarding logic with an optional event index. |
| packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts | Adds SendGrid tests for duplicate IDs in batched events, index-based parsing, and fallback lookup. |
| packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts | Selects SendGrid batched webhook events by matching event index when available, falling back to identifier lookup. |
| packages/stateless/src/lib/provider/provider.interface.ts | Updates stateless provider webhook parse signatures to accept an optional event index across channels. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant SG as SendGrid
participant Hook as WebhookUsecase
participant Provider as SendgridEmailProvider
participant Exec as ExecutionDetails

SG->>Hook: Batched webhook events with duplicate id X
Hook->>Provider: getMessageId(body)
Provider-->>Hook: [X, X]
loop for each eventIndex
    Hook->>Provider: parseEventBody(body, X, eventIndex)
    Provider-->>Hook: Event at matching index
    Hook->>Exec: Persist parsed webhook event
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant SG as SendGrid
participant Hook as WebhookUsecase
participant Provider as SendgridEmailProvider
participant Exec as ExecutionDetails

SG->>Hook: Batched webhook events with duplicate id X
Hook->>Provider: getMessageId(body)
Provider-->>Hook: [X, X]
loop for each eventIndex
    Hook->>Provider: parseEventBody(body, X, eventIndex)
    Provider-->>Hook: Event at matching index
    Hook->>Exec: Persist parsed webhook event
end
```

</a>

<sub>Reviews (4): Last reviewed commit: ["chore: update subproject commit referenc..."](https://github.com/novuhq/novu/commit/7899692fd54986fcac07239e492dfb5c83347b4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42132351)</sub>

<!-- /greptile_comment -->