### PR TITLE
docs(docs): document Slack Block Kit for dashboard workflows fixes DOC-404

### DIFF
--- a/docs/framework/typescript/steps.mdx
+++ b/docs/framework/typescript/steps.mdx
@@ -145,6 +145,10 @@ This object used to access and override the underlying deliver providers SDKs. T
 
 An example of this is the `slack` provider, which allows you to customize the content of the notification with Slack `blocks` to create a rich notification experience.
 
+<Note>
+  If you build workflows in the dashboard instead of Framework, you can still send Block Kit messages using [trigger overrides](/platform/integrations/chat/slack#format-messages-with-block-kit).
+</Note>
+
 ```typescript
 type ProvidersOverride = {
   [key: ProviderEnum]: ProviderCallback;

--- a/docs/platform/integrations.mdx
+++ b/docs/platform/integrations.mdx
@@ -55,7 +55,7 @@ This separation ensures that test messages don’t accidentally go to production
 
 Novu provides an `overrides` object that can be used to access features that Novu doesn't currently support but are supported by certain providers. This feature includes: 
 - Setting custom SendGrid headers.
-- Using Slack blocks. 
+- Using [Slack Block Kit](/platform/integrations/chat/slack#format-messages-with-block-kit).
 - Defining platform-specific sounds for FCM push notifications.
 
 <Note>

--- a/docs/platform/integrations/chat/slack.mdx
+++ b/docs/platform/integrations/chat/slack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Slack Chat Integration with Novu"
 sidebarTitle: 'Slack'
-description: "Connect Slack to Novu to send chat notifications through workflows using OAuth. Deliver messages to channels or DMs and manage subscriber Slack credentials."
+description: "Connect Slack to Novu to send chat notifications through workflows using OAuth. Deliver messages to channels or DMs, format messages with Block Kit, and manage subscriber Slack credentials."
 ---
 
 <Note>
@@ -13,6 +13,19 @@ The Slack chat integration lets your application send notifications directly to 
 Novu handles the full lifecycle of Slack connections and message delivery. You define where notifications should be delivered, and Novu automatically routes each message to the correct Slack workspace, channel, or user.
 
 This guide walks you through setting up Slack chat, connect workspaces, and deliver notifications to the exact Slack destinations your users expect it.
+
+<CardGroup cols={2}>
+  <Card title="Send notifications" icon="send" href="#send-notifications">
+    Trigger a workflow to deliver a message to a subscriber's Slack channel, DM, or webhook.
+  </Card>
+  <Card title="Format with Block Kit" icon="layout-template" href="#format-messages-with-block-kit">
+    Send rich Slack messages with sections, buttons, and context blocks using trigger overrides or Framework.
+  </Card>
+</CardGroup>
+
+<Note>
+  The Chat step in the dashboard sends plain text by default. To send [Slack Block Kit](https://api.slack.com/block-kit) messages from a dashboard workflow, pass `blocks` in [trigger overrides](/platform/integrations/trigger-overrides) when you call the API. See [Format messages with Block Kit](#format-messages-with-block-kit) for examples, including `_passthrough` for raw Slack API fields.
+</Note>
 
 <Note>
   Check out the [agents](/agents) documentation for more information on how to build agents using Slack.
@@ -827,13 +840,712 @@ When the workflow is triggered, Novu will:
   </Step>
 
   <Step title="Deliver messages">
-    Novu sends the notification to each configured Slack destination.
+    Novu sends the notification to each configured Slack destination. By default, the Chat step body is sent as plain text. To send Block Kit formatting, see [Format messages with Block Kit](#format-messages-with-block-kit).
   </Step>
 </Steps>
 
+<Note>
+  **Message formatting:** The dashboard Chat step editor supports a plain text `body`. For rich Slack messages (sections, buttons, context blocks), use trigger overrides at send time or Framework provider overrides in code-first workflows. Digest summaries in the dashboard work as plain text using [digest variables](/platform/workflow/add-notification-content/personalize-content#digest-variables).
+</Note>
+
+## Format messages with Block Kit
+
+The Chat step in the Novu dashboard sends a plain text message body to Slack. There is no Block Kit editor in the workflow UI today.
+
+You still have a few ways to send richer Slack messages:
+
+| Approach | Best for |
+| --- | --- |
+| **Chat step body (dashboard)** | Plain text summaries, including [digest variables](/platform/workflow/add-notification-content/personalize-content#digest-variables) |
+| **Trigger overrides (API)** | Block Kit sections, buttons, and context blocks built from your trigger payload |
+| **Framework provider overrides** | Full Block Kit control in code-first workflows, including dynamic digest formatting |
+
+### Plain text and digest summaries
+
+For digest workflows built in the dashboard, use digest variables in the Chat step body to build a text summary. For example:
+
+```liquid
+{{ steps.digest-step.countSummary }}
+
+{% for event in steps.digest-step.events %}
+• {{ event.payload.title }}
+{% endfor %}
+```
+
+This renders as plain text in Slack. It does not produce Block Kit formatting such as buttons or styled sections.
+
+### Send Block Kit with trigger overrides
+
+To send [Slack Block Kit](https://api.slack.com/block-kit) messages from a dashboard workflow, pass `blocks` in the `overrides` object when you trigger the workflow. The Chat step `body` from your template is still sent as the fallback `text` field unless you override it.
+
+Copy the **step identifier** from your workflow in the dashboard and use it under `overrides.steps`.
+
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: '<NOVU_SECRET_KEY>' });
+
+await novu.trigger({
+  workflowId: 'comment-alert',
+  to: { subscriberId: 'user-123' },
+  payload: {
+    postTitle: 'Q1 planning thread',
+    postUrl: 'https://app.example.com/posts/456',
+  },
+  overrides: {
+    steps: {
+      'slack-chat-step': {
+        providers: {
+          slack: {
+            text: 'You have new comments',
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: '*New comments on Q1 planning thread*',
+                },
+              },
+              {
+                type: 'actions',
+                elements: [
+                  {
+                    type: 'button',
+                    text: { type: 'plain_text', text: 'View thread' },
+                    url: 'https://app.example.com/posts/456',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv('NOVU_SECRET_KEY', '')) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id='comment-alert',
+        to={'subscriber_id': 'user-123'},
+        payload={
+            'postTitle': 'Q1 planning thread',
+            'postUrl': 'https://app.example.com/posts/456',
+        },
+        overrides={
+            'steps': {
+                'slack-chat-step': {
+                    'providers': {
+                        'slack': {
+                            'text': 'You have new comments',
+                            'blocks': [
+                                {
+                                    'type': 'section',
+                                    'text': {
+                                        'type': 'mrkdwn',
+                                        'text': '*New comments on Q1 planning thread*',
+                                    },
+                                },
+                                {
+                                    'type': 'actions',
+                                    'elements': [
+                                        {
+                                            'type': 'button',
+                                            'text': {'type': 'plain_text', 'text': 'View thread'},
+                                            'url': 'https://app.example.com/posts/456',
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "comment-alert",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user-123",
+    }),
+    Payload: map[string]any{
+        "postTitle": "Q1 planning thread",
+        "postUrl":   "https://app.example.com/posts/456",
+    },
+    Overrides: map[string]map[string]any{
+        "steps": {
+            "slack-chat-step": map[string]any{
+                "providers": map[string]any{
+                    "slack": map[string]any{
+                        "text": "You have new comments",
+                        "blocks": []map[string]any{
+                            {
+                                "type": "section",
+                                "text": map[string]any{
+                                    "type": "mrkdwn",
+                                    "text": "*New comments on Q1 planning thread*",
+                                },
+                            },
+                            {
+                                "type": "actions",
+                                "elements": []map[string]any{
+                                    {
+                                        "type": "button",
+                                        "text": map[string]any{
+                                            "type": "plain_text",
+                                            "text": "View thread",
+                                        },
+                                        "url": "https://app.example.com/posts/456",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'comment-alert',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: [
+            'postTitle' => 'Q1 planning thread',
+            'postUrl' => 'https://app.example.com/posts/456',
+        ],
+        overrides: [
+            'steps' => [
+                'slack-chat-step' => [
+                    'providers' => [
+                        'slack' => [
+                            'text' => 'You have new comments',
+                            'blocks' => [
+                                [
+                                    'type' => 'section',
+                                    'text' => [
+                                        'type' => 'mrkdwn',
+                                        'text' => '*New comments on Q1 planning thread*',
+                                    ],
+                                ],
+                                [
+                                    'type' => 'actions',
+                                    'elements' => [
+                                        [
+                                            'type' => 'button',
+                                            'text' => ['type' => 'plain_text', 'text' => 'View thread'],
+                                            'url' => 'https://app.example.com/posts/456',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "comment-alert",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "user-123" }),
+    Payload = new Dictionary<string, object>() {
+        { "postTitle", "Q1 planning thread" },
+        { "postUrl", "https://app.example.com/posts/456" },
+    },
+    Overrides = new Overrides() {
+        Steps = new Dictionary<string, Dictionary<string, Dictionary<string, object>>>() {
+            { "slack-chat-step", new Dictionary<string, Dictionary<string, object>>() {
+                { "providers", new Dictionary<string, object>() {
+                    { "slack", new Dictionary<string, object>() {
+                        { "text", "You have new comments" },
+                        { "blocks", new List<Dictionary<string, object>>() {
+                            new Dictionary<string, object>() {
+                                { "type", "section" },
+                                { "text", new Dictionary<string, object>() {
+                                    { "type", "mrkdwn" },
+                                    { "text", "*New comments on Q1 planning thread*" },
+                                } },
+                            },
+                            new Dictionary<string, object>() {
+                                { "type", "actions" },
+                                { "elements", new List<Dictionary<string, object>>() {
+                                    new Dictionary<string, object>() {
+                                        { "type", "button" },
+                                        { "text", new Dictionary<string, object>() {
+                                            { "type", "plain_text" },
+                                            { "text", "View thread" },
+                                        } },
+                                        { "url", "https://app.example.com/posts/456" },
+                                    },
+                                } },
+                            },
+                        } },
+                    } },
+                } },
+            } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.List;
+import java.util.Map;
+
+Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("comment-alert")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("user-123").build()))
+        .payload(Map.of(
+            "postTitle", "Q1 planning thread",
+            "postUrl", "https://app.example.com/posts/456"))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of(
+                "steps", Map.of(
+                    "slack-chat-step", Map.of(
+                        "providers", Map.of(
+                            "slack", Map.of(
+                                "text", "You have new comments",
+                                "blocks", List.of(
+                                    Map.of(
+                                        "type", "section",
+                                        "text", Map.of(
+                                            "type", "mrkdwn",
+                                            "text", "*New comments on Q1 planning thread*")),
+                                    Map.of(
+                                        "type", "actions",
+                                        "elements", List.of(
+                                            Map.of(
+                                                "type", "button",
+                                                "text", Map.of("type", "plain_text", "text", "View thread"),
+                                                "url", "https://app.example.com/posts/456")))))))))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+  -d '{
+    "name": "comment-alert",
+    "to": { "subscriberId": "user-123" },
+    "payload": {
+      "postTitle": "Q1 planning thread",
+      "postUrl": "https://app.example.com/posts/456"
+    },
+    "overrides": {
+      "steps": {
+        "slack-chat-step": {
+          "providers": {
+            "slack": {
+              "text": "You have new comments",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*New comments on Q1 planning thread*"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "View thread" },
+                      "url": "https://app.example.com/posts/456"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+  </Tab>
+</Tabs>
+
+Replace `slack-chat-step` with the step identifier from your workflow. Step-level overrides take priority over workflow-level overrides.
+
+#### Workflow-level overrides
+
+If your workflow has a single Slack Chat step, you can apply Block Kit to all Slack steps in that workflow without targeting a step ID:
+
+```json
+"overrides": {
+  "providers": {
+    "slack": {
+      "blocks": [
+        {
+          "type": "section",
+          "text": { "type": "mrkdwn", "text": "*Deploy succeeded*" }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Send extra Slack fields with `_passthrough`
+
+Use `_passthrough` when you need raw [Slack `chat.postMessage`](https://api.slack.com/methods/chat.postMessage) fields that are not exposed in the dashboard. Values in `_passthrough.body` are merged last and take priority over other override fields.
+
+<Tabs>
+  <Tab title="Node.js">
+```typescript
+await novu.trigger({
+  workflowId: 'comment-alert',
+  to: { subscriberId: 'user-123' },
+  payload: {
+    postTitle: 'Q1 planning thread',
+    postUrl: 'https://app.example.com/posts/456',
+  },
+  overrides: {
+    steps: {
+      'slack-chat-step': {
+        providers: {
+          slack: {
+            _passthrough: {
+              body: {
+                text: 'You have new comments',
+                unfurl_links: false,
+                blocks: [
+                  {
+                    type: 'section',
+                    text: {
+                      type: 'mrkdwn',
+                      text: '*New comments on Q1 planning thread*',
+                    },
+                  },
+                  {
+                    type: 'context',
+                    elements: [
+                      {
+                        type: 'mrkdwn',
+                        text: 'Sent via Novu',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+    workflow_id='comment-alert',
+    to={'subscriber_id': 'user-123'},
+    payload={
+        'postTitle': 'Q1 planning thread',
+        'postUrl': 'https://app.example.com/posts/456',
+    },
+    overrides={
+        'steps': {
+            'slack-chat-step': {
+                'providers': {
+                    'slack': {
+                        '_passthrough': {
+                            'body': {
+                                'text': 'You have new comments',
+                                'unfurl_links': False,
+                                'blocks': [
+                                    {
+                                        'type': 'section',
+                                        'text': {
+                                            'type': 'mrkdwn',
+                                            'text': '*New comments on Q1 planning thread*',
+                                        },
+                                    },
+                                    {
+                                        'type': 'context',
+                                        'elements': [
+                                            {
+                                                'type': 'mrkdwn',
+                                                'text': 'Sent via Novu',
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "comment-alert",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user-123",
+    }),
+    Payload: map[string]any{
+        "postTitle": "Q1 planning thread",
+        "postUrl":   "https://app.example.com/posts/456",
+    },
+    Overrides: map[string]map[string]any{
+        "steps": {
+            "slack-chat-step": map[string]any{
+                "providers": map[string]any{
+                    "slack": map[string]any{
+                        "_passthrough": map[string]any{
+                            "body": map[string]any{
+                                "text":         "You have new comments",
+                                "unfurl_links": false,
+                                "blocks": []map[string]any{
+                                    {
+                                        "type": "section",
+                                        "text": map[string]any{
+                                            "type": "mrkdwn",
+                                            "text": "*New comments on Q1 planning thread*",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'comment-alert',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: [
+            'postTitle' => 'Q1 planning thread',
+            'postUrl' => 'https://app.example.com/posts/456',
+        ],
+        overrides: [
+            'steps' => [
+                'slack-chat-step' => [
+                    'providers' => [
+                        'slack' => [
+                            '_passthrough' => [
+                                'body' => [
+                                    'text' => 'You have new comments',
+                                    'unfurl_links' => false,
+                                    'blocks' => [
+                                        [
+                                            'type' => 'section',
+                                            'text' => [
+                                                'type' => 'mrkdwn',
+                                                'text' => '*New comments on Q1 planning thread*',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "comment-alert",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "user-123" }),
+    Payload = new Dictionary<string, object>() {
+        { "postTitle", "Q1 planning thread" },
+        { "postUrl", "https://app.example.com/posts/456" },
+    },
+    Overrides = new Overrides() {
+        Steps = new Dictionary<string, Dictionary<string, Dictionary<string, object>>>() {
+            { "slack-chat-step", new Dictionary<string, Dictionary<string, object>>() {
+                { "providers", new Dictionary<string, object>() {
+                    { "slack", new Dictionary<string, object>() {
+                        { "_passthrough", new Dictionary<string, object>() {
+                            { "body", new Dictionary<string, object>() {
+                                { "text", "You have new comments" },
+                                { "unfurl_links", false },
+                                { "blocks", new List<Dictionary<string, object>>() {
+                                    new Dictionary<string, object>() {
+                                        { "type", "section" },
+                                        { "text", new Dictionary<string, object>() {
+                                            { "type", "mrkdwn" },
+                                            { "text", "*New comments on Q1 planning thread*" },
+                                        } },
+                                    },
+                                } },
+                            } },
+                        } },
+                    } },
+                } },
+            } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("comment-alert")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("user-123").build()))
+        .payload(Map.of(
+            "postTitle", "Q1 planning thread",
+            "postUrl", "https://app.example.com/posts/456"))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of(
+                "steps", Map.of(
+                    "slack-chat-step", Map.of(
+                        "providers", Map.of(
+                            "slack", Map.of(
+                                "_passthrough", Map.of(
+                                    "body", Map.of(
+                                        "text", "You have new comments",
+                                        "unfurl_links", false,
+                                        "blocks", List.of(
+                                            Map.of(
+                                                "type", "section",
+                                                "text", Map.of(
+                                                    "type", "mrkdwn",
+                                                    "text", "*New comments on Q1 planning thread*"))))))))))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+  -d '{
+    "name": "comment-alert",
+    "to": { "subscriberId": "user-123" },
+    "payload": {
+      "postTitle": "Q1 planning thread",
+      "postUrl": "https://app.example.com/posts/456"
+    },
+    "overrides": {
+      "steps": {
+        "slack-chat-step": {
+          "providers": {
+            "slack": {
+              "_passthrough": {
+                "body": {
+                  "text": "You have new comments",
+                  "unfurl_links": false,
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*New comments on Q1 planning thread*"
+                      }
+                    },
+                    {
+                      "type": "context",
+                      "elements": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "Sent via Novu"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+  </Tab>
+</Tabs>
+
+<Note>
+  For a full guide on how overrides work, including workflow-level and step-level scopes, see [Trigger overrides](/platform/integrations/trigger-overrides).
+</Note>
+
+### Block Kit with digest workflows
+
+Trigger overrides are set when you call the trigger API. They work well when each trigger carries the data you need to build the message.
+
+For [digest workflows](/platform/workflow/add-and-configure-steps/configure-action-steps/digest), Novu batches multiple triggers into one notification. The Chat step body can use [digest variables](/platform/workflow/add-notification-content/personalize-content#digest-variables) to summarize batched events, but `overrides` are not re-evaluated with that aggregated data. To build Block Kit dynamically from a digest batch, use [Framework provider overrides](/framework/typescript/steps#provider-overrides) in a code-first workflow.
+
 ## Using Slack with agents
 
-Slack is a supported [agent provider](/agents/get-started/agents-and-providers). Connect your Slack app to an agent so users can message in channels or DMs and get replies in the same thread — without building Slack event handling yourself.
+Slack is a supported [agent provider](/agents/get-started/agents-and-providers). Connect your Slack app to an agent so users can message in channels or DMs and get replies in the same thread, without building Slack event handling yourself.
 
 <Card title="Build agents on Slack" icon="bot" href="/agents">
   Learn how Novu agents work, including managed and custom code agents.
@@ -860,6 +1572,11 @@ Both can use the same Slack integration. Your agent handles back-and-forth conve
 
 ## Related
 
-<Card icon="bot" href="/agents/get-started/agents-and-providers" title="Agents and providers">
-  Connect Slack and other providers to an agent.
-</Card>
+<CardGroup cols={2}>
+  <Card icon="messages-square" href="/platform/integrations/trigger-overrides" title="Trigger overrides">
+    Pass Slack `blocks` and `_passthrough` fields when triggering a workflow from your application.
+  </Card>
+  <Card icon="bot" href="/agents/get-started/agents-and-providers" title="Agents and providers">
+    Connect Slack and other providers to an agent.
+  </Card>
+</CardGroup>

--- a/docs/platform/integrations/trigger-overrides.mdx
+++ b/docs/platform/integrations/trigger-overrides.mdx
@@ -34,7 +34,7 @@ Provider overrides give you fine-tuned control over how messages are delivered b
 This feature is designed for advanced use cases where Novu's default message editor or UI does not expose specific provider capabilities.
 
 Use provider overrides to:
-- Access native provider features not surfaced by Novu’s abstraction layer. For example, custom headers in SendGrid, topic messaging in FCM, or Slack blocks.
+- Access native provider features not surfaced by Novu’s abstraction layer. For example, custom headers in SendGrid, topic messaging in FCM, or [Slack Block Kit](/platform/integrations/chat/slack#format-messages-with-block-kit).
 - Adapt to provider-specific options by injecting parameters that Novu doesn’t yet officially support.
 - Configure shared or unique settings across steps without altering templates or workflow logic.
 
@@ -699,3 +699,244 @@ curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
 </Note>
 
 In this example, only the `push-step` is affected, and multiple FCM-specific settings are overridden for that step, which are the notification title, body, and sound configurations for both Android and iOS platforms.
+
+### Slack Block Kit overrides
+
+Use provider overrides to send [Slack Block Kit](https://api.slack.com/block-kit) messages from a dashboard workflow. Pass a `blocks` array under `overrides.steps.<step-id>.providers.slack`, or use `_passthrough.body` for raw Slack API fields.
+
+<Card title="Slack Block Kit guide" icon="messages-square" href="/platform/integrations/chat/slack#format-messages-with-block-kit">
+  Step-by-step examples for plain text digests, direct `blocks` overrides, and `_passthrough` for all supported SDKs.
+</Card>
+
+<Tabs>
+  <Tab title="Node.js">
+```ts
+await novu.trigger({
+  workflowId: 'comment-alert',
+  to: { subscriberId: 'user-123' },
+  payload: {
+    postTitle: 'Q1 planning thread',
+    postUrl: 'https://app.example.com/posts/456',
+  },
+  overrides: {
+    steps: {
+      'slack-chat-step': {
+        providers: {
+          slack: {
+            text: 'You have new comments',
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: '*New comments on Q1 planning thread*',
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+```
+  </Tab>
+  <Tab title="Python">
+```python
+novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+    workflow_id='comment-alert',
+    to={'subscriber_id': 'user-123'},
+    payload={
+        'postTitle': 'Q1 planning thread',
+        'postUrl': 'https://app.example.com/posts/456',
+    },
+    overrides={
+        'steps': {
+            'slack-chat-step': {
+                'providers': {
+                    'slack': {
+                        'text': 'You have new comments',
+                        'blocks': [
+                            {
+                                'type': 'section',
+                                'text': {
+                                    'type': 'mrkdwn',
+                                    'text': '*New comments on Q1 planning thread*',
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
+))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+_, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "comment-alert",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "user-123",
+    }),
+    Payload: map[string]any{
+        "postTitle": "Q1 planning thread",
+        "postUrl":   "https://app.example.com/posts/456",
+    },
+    Overrides: map[string]map[string]any{
+        "steps": {
+            "slack-chat-step": map[string]any{
+                "providers": map[string]any{
+                    "slack": map[string]any{
+                        "text": "You have new comments",
+                        "blocks": []map[string]any{
+                            {
+                                "type": "section",
+                                "text": map[string]any{
+                                    "type": "mrkdwn",
+                                    "text": "*New comments on Q1 planning thread*",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}, nil)
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'comment-alert',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'user-123'),
+        payload: [
+            'postTitle' => 'Q1 planning thread',
+            'postUrl' => 'https://app.example.com/posts/456',
+        ],
+        overrides: [
+            'steps' => [
+                'slack-chat-step' => [
+                    'providers' => [
+                        'slack' => [
+                            'text' => 'You have new comments',
+                            'blocks' => [
+                                [
+                                    'type' => 'section',
+                                    'text' => [
+                                        'type' => 'mrkdwn',
+                                        'text' => '*New comments on Q1 planning thread*',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "comment-alert",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() { SubscriberId = "user-123" }),
+    Payload = new Dictionary<string, object>() {
+        { "postTitle", "Q1 planning thread" },
+        { "postUrl", "https://app.example.com/posts/456" },
+    },
+    Overrides = new Overrides() {
+        Steps = new Dictionary<string, Dictionary<string, Dictionary<string, object>>>() {
+            { "slack-chat-step", new Dictionary<string, Dictionary<string, object>>() {
+                { "providers", new Dictionary<string, object>() {
+                    { "slack", new Dictionary<string, object>() {
+                        { "text", "You have new comments" },
+                        { "blocks", new List<Dictionary<string, object>>() {
+                            new Dictionary<string, object>() {
+                                { "type", "section" },
+                                { "text", new Dictionary<string, object>() {
+                                    { "type", "mrkdwn" },
+                                    { "text", "*New comments on Q1 planning thread*" },
+                                } },
+                            },
+                        } },
+                    } },
+                } },
+            } },
+        },
+    },
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("comment-alert")
+        .to(To2.of(SubscriberPayloadDto.builder().subscriberId("user-123").build()))
+        .payload(Map.of(
+            "postTitle", "Q1 planning thread",
+            "postUrl", "https://app.example.com/posts/456"))
+        .overrides(TriggerEventRequestDtoOverrides.builder()
+            .additionalProperties(Map.of(
+                "steps", Map.of(
+                    "slack-chat-step", Map.of(
+                        "providers", Map.of(
+                            "slack", Map.of(
+                                "text", "You have new comments",
+                                "blocks", List.of(
+                                    Map.of(
+                                        "type", "section",
+                                        "text", Map.of(
+                                            "type", "mrkdwn",
+                                            "text", "*New comments on Q1 planning thread*"))))))))
+            .build())
+        .build())
+    .call();
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST 'https://api.novu.co/v1/events/trigger' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
+  -d '{
+    "name": "comment-alert",
+    "to": { "subscriberId": "user-123" },
+    "payload": {
+      "postTitle": "Q1 planning thread",
+      "postUrl": "https://app.example.com/posts/456"
+    },
+    "overrides": {
+      "steps": {
+        "slack-chat-step": {
+          "providers": {
+            "slack": {
+              "text": "You have new comments",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*New comments on Q1 planning thread*"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+  </Tab>
+</Tabs>
+
+<Note>
+  Replace `slack-chat-step` with the Chat step identifier from your workflow. For digest workflows, trigger overrides do not automatically reflect batched events. See [Slack Block Kit](/platform/integrations/chat/slack#block-kit-with-digest-workflows) for details.
+</Note>


### PR DESCRIPTION
Explain how to send rich Slack messages via trigger overrides and _passthrough, including digest limitations and cross-links from the integrations and Framework steps guides.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the Slack integration docs for Block Kit messages. The main changes are:

- Adds trigger override examples for Slack `blocks` across official server-side SDKs and cURL.
- Documents `_passthrough.body` for raw Slack `chat.postMessage` fields.
- Explains dashboard digest limitations and points dynamic digest formatting to Framework provider overrides.
- Adds cross-links from the integrations overview, trigger overrides page, and Framework steps guide.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge with minimal risk.

The changes are scoped to documentation pages and examples. No runtime code or security-sensitive behavior is changed. No blocking correctness issues were identified in the changed content.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex posted a proof for the first P1 finding in the review comment.
- T-Rex posted a proof for the second P1 finding in the review comment.
- T-Rex documented contract-validation observations, including a docs preview timeout, a markdownlint failure on changed MDX files, and the docs-anchor notes used to validate the finding.

<a href="https://app.greptile.com/trex/runs/13431918/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/framework/typescript/steps.mdx | Adds a note linking Framework provider overrides to dashboard trigger override guidance for Slack Block Kit. |
| docs/platform/integrations.mdx | Updates the integrations overview to link Slack blocks wording to the new Slack Block Kit section. |
| docs/platform/integrations/chat/slack.mdx | Adds Slack Block Kit documentation, trigger override examples across official SDKs, `_passthrough` guidance, and digest limitations. |
| docs/platform/integrations/trigger-overrides.mdx | Adds a Slack Block Kit provider overrides section with cross-links and SDK examples. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant App as Application
participant Novu as Novu Trigger API
participant Workflow as Dashboard Workflow
participant Slack as Slack Provider

App->>Novu: Trigger workflow with payload and overrides
Novu->>Workflow: Resolve Chat step and step identifier
alt Plain dashboard body
    Workflow->>Slack: Send Chat step body as text
else Block Kit override
    Workflow->>Slack: Send providers.slack.blocks and fallback text
else Raw Slack fields
    Workflow->>Slack: Merge _passthrough.body last
end
Slack-->>App: Deliver Slack message
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant App as Application
participant Novu as Novu Trigger API
participant Workflow as Dashboard Workflow
participant Slack as Slack Provider

App->>Novu: Trigger workflow with payload and overrides
Novu->>Workflow: Resolve Chat step and step identifier
alt Plain dashboard body
    Workflow->>Slack: Send Chat step body as text
else Block Kit override
    Workflow->>Slack: Send providers.slack.blocks and fallback text
else Raw Slack fields
    Workflow->>Slack: Merge _passthrough.body last
end
Slack-->>App: Deliver Slack message
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **New Framework note links to a non-existent page fragment**

   - **Bug**
     - The changed `docs/framework/typescript/steps.mdx` adds a note linking to `/platform/integrations/chat/slack#format-messages-with-block-kit`, but markdownlint reports `MD051/link-fragments` at `docs/framework/typescript/steps.mdx:119:56` for the page's existing fragment list context. This means at least one in-page/cross-page fragment in the changed docs set is not valid under the repository's docs lint rules, so the cross-link/navigation validation objective is not met.
   - **Cause**
     - The changed docs introduced or left an invalid heading fragment reference in a changed file, and the fallback docs check rejects it.
   - **Fix**
     - Update the fragment to match the generated heading slug exactly, or add/rename the target heading so the fragment exists. Then rerun `pnpm exec markdownlint docs/framework/typescript/steps.mdx docs/platform/integrations.mdx docs/platform/integrations/chat/slack.mdx docs/platform/integrations/trigger-overrides.mdx`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Changed Slack and trigger-overrides MDX files fail repository markdownlint**

   - **Bug**
     - The fallback docs validation failed with many lint errors in changed files, including missing blank lines around headings in `docs/platform/integrations/chat/slack.mdx`, missing fenced code languages, indented code blocks where fenced blocks are expected, improper lowercase `markdown`, and a trailing newline issue in `docs/platform/integrations/trigger-overrides.mdx`. Even if some violations predate this PR, the changed-file docs check requested for this PR currently fails and blocks confidence that these MDX pages render cleanly.
   - **Cause**
     - The changed MDX files do not satisfy the repository's markdownlint rules, and the docs preview was unavailable to supersede lint with rendered-page proof.
   - **Fix**
     - Normalize headings with surrounding blank lines, add languages to fenced code blocks, convert indented code blocks to fenced blocks, fix proper-name capitalization, ensure a single trailing newline, and rerun the changed-file markdownlint command.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs(docs): document Slack Block Kit for..."](https://github.com/novuhq/novu/commit/261027ca27b6eda063bf3d7f695746c54cdd7e61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42145807)</sub>

<!-- /greptile_comment -->