### PR TITLE
feat(cli): add --version flag to the CLI

### DIFF
--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { Command } from 'commander';
 import { v4 as uuidv4 } from 'uuid';
 import { DevCommandOptions, devCommand } from './commands';
@@ -37,9 +39,33 @@ const anonymousId = anonymousIdLocalState || uuidv4();
 if (!anonymousIdLocalState) {
   config.setValue('anonymousId', anonymousId);
 }
+/**
+ * Resolve the CLI version from package.json at runtime so `novu --version`
+ * always matches the published package. `__dirname` differs between the
+ * compiled build (`dist/src/index.js`) and local ts-node dev (`src/index.ts`),
+ * so we try both relative locations and fall back gracefully.
+ */
+function getCliVersion(): string {
+  for (const candidate of ['../../package.json', '../package.json']) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, candidate), 'utf8')) as { version?: string };
+      if (pkg.version) {
+        return pkg.version;
+      }
+    } catch {
+      // Try the next candidate location.
+    }
+  }
+
+  return '0.0.0';
+}
+
 const program = new Command();
 
-program.name('novu').description(`A CLI tool to interact with Novu Cloud`);
+program
+  .name('novu')
+  .description(`A CLI tool to interact with Novu Cloud`)
+  .version(getCliVersion(), '-v, --version', 'Output the Novu CLI version');
 
 program
   .command('sync')


### PR DESCRIPTION
`npx novu@latest --version` (and `-V`/`-v`) currently errors with "unknown option" because the program is created with `new Command()` but never calls `.version()`. That makes "which CLI version are you on?" impossible to answer in bug reports.

This registers `-v, --version`, reading the version from `package.json` at runtime so it always tracks the published version instead of a hardcoded string. `getCliVersion()` resolves the file from both the built (`dist/src/index.js`) and ts-node dev (`src/index.ts`) layouts and falls back gracefully. One file changed; validated against `commander@9` in both layouts.

Used `-v, --version`; I'd be happy to switch to Commander's default `-V` if you'd prefer.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a root CLI version flag for the Novu CLI. The main changes are:

- Registers `novu --version` and `novu -v` with Commander.
- Reads the version from `packages/novu/package.json` at runtime.
- Supports both built `dist/src/index.js` and local `src/index.ts` layouts.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is small, localized to CLI initialization, and matches the package layouts declared in `package.json`.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The PR run performed the dist and ts-node version checks to validate the runtime toolchain.
- dist --version and dist -v both reported version 2.18.1 and exited cleanly with code 0.
- ts-node --version reported version 2.18.1 with exit code 0, and a Node engine warning appeared but was not treated as a failure for this PR.
- dist -V was attempted in this PR but shows an unknown option error and exited with code 1, indicating the flag is unsupported.

<a href="https://app.greptile.com/trex/runs/13521706/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/index.ts | Registers the root CLI version option and resolves the package version from runtime `package.json` locations. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant CLI as novu CLI
participant Commander
participant Package as package.json

User->>CLI: novu --version / -v
CLI->>Package: read candidate package.json path
Package-->>CLI: version
CLI->>Commander: register .version(version, "-v, --version")
CLI->>Commander: parse(process.argv)
Commander-->>User: print version and exit
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant CLI as novu CLI
participant Commander
participant Package as package.json

User->>CLI: novu --version / -v
CLI->>Package: read candidate package.json path
Package-->>CLI: version
CLI->>Commander: register .version(version, "-v, --version")
CLI->>Commander: parse(process.argv)
Commander-->>User: print version and exit
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into feat/cli-versio..."](https://github.com/novuhq/novu/commit/3c804544a50776d27c86fcfa5487165a31978363) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42249418)</sub>

<!-- /greptile_comment -->