### PR TITLE
fix(shared): remove SMTP TLS requirement assertion fixes NV-8214

### DIFF
--- a/packages/shared/src/utils/validate-smtp-outbound-target.spec.ts
+++ b/packages/shared/src/utils/validate-smtp-outbound-target.spec.ts
@@ -23,20 +23,11 @@ describe('validate-smtp-outbound-target', () => {
       expect(() => assertSafeSmtpOutboundTargetSync('evil.com/internal', 587, tlsEnabled)).toThrow(SsrfBlockedError);
     });
 
-    it('rejects non-TLS SMTP configurations', () => {
+    it('allows non-TLS SMTP configurations', () => {
       expect(() =>
         assertSafeSmtpOutboundTargetSync('smtp.example.com', 25, {
           secure: false,
           requireTls: false,
-        })
-      ).toThrow(SsrfBlockedError);
-    });
-
-    it('allows STARTTLS configurations', () => {
-      expect(() =>
-        assertSafeSmtpOutboundTargetSync('smtp.example.com', 587, {
-          secure: false,
-          requireTls: true,
         })
       ).not.toThrow();
     });

--- a/packages/shared/src/utils/validate-smtp-outbound-target.ts
+++ b/packages/shared/src/utils/validate-smtp-outbound-target.ts
@@ -17,16 +17,6 @@ export type SmtpOutboundTlsOptions = {
   ignoreTls?: boolean;
 };
 
-export function assertSmtpTlsRequired(options: SmtpOutboundTlsOptions): void {
-  if (options.ignoreTls) {
-    throw new SsrfBlockedError('UNSUPPORTED_SCHEME', 'SMTP connections with TLS disabled are not allowed.');
-  }
-
-  if (!options.secure && !options.requireTls) {
-    throw new SsrfBlockedError('UNSUPPORTED_SCHEME', 'SMTP connections must use TLS (enable Secure or Require TLS).');
-  }
-}
-
 export function assertSafeSmtpHostFormat(host: string | undefined): string {
   const trimmed = host?.trim();
 
@@ -68,9 +58,8 @@ export function assertSafeSmtpPort(port: number | string | undefined): number {
 export function assertSafeSmtpOutboundTargetSync(
   host: string | undefined,
   port: number | string | undefined,
-  tlsOptions: SmtpOutboundTlsOptions
+  _tlsOptions: SmtpOutboundTlsOptions
 ): void {
-  assertSmtpTlsRequired(tlsOptions);
   assertSafeSmtpHostFormat(host);
   assertSafeSmtpPort(port);
 }
@@ -84,10 +73,8 @@ export type SafeSmtpPinnedTarget = {
 export async function resolveSafeSmtpPinnedTarget(
   host: string | undefined,
   port: number | string | undefined,
-  tlsOptions: SmtpOutboundTlsOptions
+  _tlsOptions: SmtpOutboundTlsOptions
 ): Promise<SafeSmtpPinnedTarget> {
-  assertSmtpTlsRequired(tlsOptions);
-
   const hostname = assertSafeSmtpHostFormat(host);
   const parsedPort = assertSafeSmtpPort(port);
   const addresses = await resolvePublicAddresses(hostname);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the `assertSmtpTlsRequired` check that rejected SMTP integrations without TLS enabled.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8394dfb1-0953-41d3-bbe1-88123353e780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8394dfb1-0953-41d3-bbe1-88123353e780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the TLS requirement from shared SMTP outbound-target validation. The main changes are:

- Non-TLS SMTP configurations are now allowed by the validator.
- Host format, port range, and public-address checks remain in place.
- The unit test expectation was updated to cover the non-TLS path.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is small and matches the PR intent. Existing SSRF-related host, port, and DNS validation paths remain active. No supported bug findings were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the spec validation for the changed spec and the shared package build, and captured smtp-validation-02-after.log showing the command, cwd, engine warning, verbose test names, summary, and EXIT\_CODE: 0.
- Ran the TypeScript build steps and circular dependency check for the same scope, captured smtp-validation-build-02-after.log showing the command, cwd, TypeScript build steps, circular dependency check, and EXIT\_CODE: 0.
- Confirmed the validation scope to cover only the changed spec and shared package build per request, with no broad package-wide tests run.

<a href="https://app.greptile.com/trex/runs/13513663/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/validate-smtp-outbound-target.ts | Removes TLS enforcement from SMTP outbound target validation while retaining host, port, and DNS/public-address checks. |
| packages/shared/src/utils/validate-smtp-outbound-target.spec.ts | Updates validation coverage to assert non-TLS SMTP configurations are accepted while existing SSRF protections remain tested. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): remove SMTP TLS requirement..."](https://github.com/novuhq/novu/commit/d448e54dbfc4a4e39459ff636ec248524d9b49bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42302070)</sub>

<!-- /greptile_comment -->