### PR TITLE
fix(worker): correct inverted monthDays digest validation fixes NV-8201

### DIFF
--- a/apps/worker/src/app/workflow/usecases/add-job/validation.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/validation.spec.ts
@@ -1,0 +1,50 @@
+import { BadRequestException } from '@nestjs/common';
+import { JobEntity } from '@novu/dal';
+import {
+  DigestTypeEnum,
+  DigestUnitEnum,
+  MonthlyTypeEnum,
+  StepTypeEnum,
+} from '@novu/shared';
+import { expect } from 'chai';
+import { validateDigest } from './validation';
+
+function createMonthlyDigestJob(monthDays: number[]): JobEntity {
+  return {
+    type: StepTypeEnum.DIGEST,
+    digest: {
+      type: DigestTypeEnum.TIMED,
+      amount: 1,
+      unit: DigestUnitEnum.MONTHS,
+      timed: {
+        atTime: '09:00',
+        monthlyType: MonthlyTypeEnum.EACH,
+        monthDays,
+      },
+    },
+  } as JobEntity;
+}
+
+describe('validateDigest', () => {
+  describe('monthDays validation', () => {
+    it('should accept valid month days between 1 and 31', () => {
+      expect(() => validateDigest(createMonthlyDigestJob([1]))).to.not.throw();
+      expect(() => validateDigest(createMonthlyDigestJob([15]))).to.not.throw();
+      expect(() => validateDigest(createMonthlyDigestJob([1, 28, 31]))).to.not.throw();
+    });
+
+    it('should reject out-of-range month days', () => {
+      expect(() => validateDigest(createMonthlyDigestJob([0])))
+        .to.throw(BadRequestException)
+        .with.property('message', 'Digest timed config monthDays values are invalid');
+
+      expect(() => validateDigest(createMonthlyDigestJob([32])))
+        .to.throw(BadRequestException)
+        .with.property('message', 'Digest timed config monthDays values are invalid');
+
+      expect(() => validateDigest(createMonthlyDigestJob([40, 99])))
+        .to.throw(BadRequestException)
+        .with.property('message', 'Digest timed config monthDays values are invalid');
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/usecases/add-job/validation.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/validation.ts
@@ -53,14 +53,14 @@ const validateWeekDays = (weekDays?: DaysEnum[]) => {
   }
 };
 
-const validMonthDayRange = (monthDay: number) => monthDay < 1 || monthDay > 31;
+const isValidMonthDay = (monthDay: number) => monthDay >= 1 && monthDay <= 31;
 
 const validateMonthDays = (monthDays?: number[]) => {
   if (!monthDays) {
     throw new BadRequestException('Digest timed config monthDays is missing');
   }
 
-  const allValid = monthDays.every((day) => validMonthDayRange(day));
+  const allValid = monthDays.every(isValidMonthDay);
   if (!allValid) {
     throw new BadRequestException('Digest timed config monthDays values are invalid');
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`validateMonthDays` in the worker digest validation path had inverted logic: `validMonthDayRange` returned `true` for out-of-range values (1–31), and the validator required every day to satisfy that predicate. Valid monthly digest days were rejected, while invalid values passed through to RRule `bymonthday`.

## Changes

- Rename and fix the predicate to `isValidMonthDay` (`monthDay >= 1 && monthDay <= 31`)
- Align `validateMonthDays` with the existing `validateWeekDays` pattern (`every` must hold for valid values)
- Add unit tests covering valid days (1, 15, 28, 31) and invalid days (0, 32, 40, 99)

## Test plan

- [x] `cd apps/worker && pnpm test -- --grep "validateDigest"` — 2 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8201](https://linear.app/novu/issue/NV-8201/validatemonthdays-validation-is-inverted-valid-monthly-digest-days)

<div><a href="https://cursor.com/agents/bc-a00fb42a-82e1-40ef-a259-bcf698609b6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a00fb42a-82e1-40ef-a259-bcf698609b6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes monthly timed digest validation for `monthDays`. The main changes are:

- Replace the inverted month-day predicate with an inclusive `1..31` validity check.
- Update `validateMonthDays` so every supplied day must be valid.
- Add tests for accepted month days and rejected out-of-range values.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is small and localized to the monthly digest validation path. Tests cover the corrected valid and invalid boundary behavior. No functional or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The worker digest validation test was attempted and its log shows the PR command, the working directory apps/worker, a Node warning for v24.18.0, setup traces, and an EXIT\_CODE: 1.
- A fallback direct spec command attempt was recorded, showing the usable pnpm exec mocha ... validation.spec.ts -- --grep "validateDigest" command, but it failed during setup/module loading with EXIT\_CODE: 1.
- Mocha failed before test discovery/output, so the changed valid/invalid month day test cases could not be evidenced as run.

<a href="https://app.greptile.com/trex/runs/13515033/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/add-job/validation.ts | Fixes monthly digest day validation by accepting values in the inclusive 1-31 range and rejecting out-of-range values. |
| apps/worker/src/app/workflow/usecases/add-job/validation.spec.ts | Adds focused unit coverage for accepted and rejected monthly digest day values. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): correct inverted monthDays ..."](https://github.com/novuhq/novu/commit/b8b890742271531f7d1e29283349af95569761a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42304695)</sub>

<!-- /greptile_comment -->