### PR TITLE
feat(framework): add agent langchain adapter fixes NV-8208

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -30,6 +30,7 @@
     "jsx-dev-runtime",
     "validators",
     "ai-sdk",
+    "langchain",
     "cards",
     "README.md"
   ],
@@ -42,7 +43,7 @@
     "debug": "NODE_ENV=production tsup --config tsup-debug.config.ts",
     "build:watch": "tsup --watch",
     "postbuild": "pnpm run check:exports && pnpm check:circulars",
-    "check:exports": "attw --pack .",
+    "check:exports": "attw --pack . --exclude-entrypoints ./langchain && attw --pack . --entrypoints ./langchain --ignore-rules no-resolution",
     "check:circulars": "madge --circular --extensions ts ./src",
     "bump:prerelease": "npm version prerelease --preid=alpha & PID=$!; (sleep 1 && kill -9 $PID) & wait $PID",
     "release:alpha": "pnpm bump:prerelease || pnpm build && npm publish",
@@ -217,6 +218,16 @@
         "default": "./dist/esm/ai-sdk/index.js"
       }
     },
+    "./langchain": {
+      "require": {
+        "types": "./dist/cjs/langchain/index.d.cts",
+        "default": "./dist/cjs/langchain/index.cjs"
+      },
+      "import": {
+        "types": "./dist/esm/langchain/index.d.ts",
+        "default": "./dist/esm/langchain/index.js"
+      }
+    },
     "./cards": {
       "require": {
         "types": "./dist/cjs/cards.d.cts",
@@ -229,6 +240,7 @@
     }
   },
   "peerDependencies": {
+    "@langchain/core": ">=1.0.0",
     "@nestjs/common": ">=10.0.0",
     "@sveltejs/kit": ">=1.27.3",
     "@vercel/node": ">=2.15.9",
@@ -236,11 +248,18 @@
     "aws-lambda": ">=1.0.7",
     "express": ">=4.19.2",
     "h3": ">=1.8.1",
+    "langchain": ">=1.0.0",
     "next": ">=12.0.0",
     "zod": ">=3.0.0",
     "zod-to-json-schema": ">=3.0.0"
   },
   "peerDependenciesMeta": {
+    "@langchain/core": {
+      "optional": true
+    },
+    "langchain": {
+      "optional": true
+    },
     "@nestjs/common": {
       "optional": true
     },
@@ -278,6 +297,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "11.6.4",
     "@arethetypeswrong/cli": "^0.17.4",
+    "@langchain/core": "^1.1.44",
     "@nestjs/common": "11.1.27",
     "@sveltejs/kit": "^1.27.3",
     "@types/aws-lambda": "^8.10.141",
@@ -290,6 +310,7 @@
     "aws-lambda": "^1.0.7",
     "express": "^4.19.2",
     "h3": "^1.11.1",
+    "langchain": "^1.2.16",
     "madge": "^8.0.0",
     "next": "^16.2.1",
     "ts-node": "^10.9.2",

--- a/packages/framework/src/langchain/history-mapper/approval-cycles.ts
+++ b/packages/framework/src/langchain/history-mapper/approval-cycles.ts
@@ -1,0 +1,245 @@
+import { AIMessage, type BaseMessage, ToolMessage } from '@langchain/core/messages';
+import type { AgentHistoryEntry } from '../../resources/agent/agent.types';
+import type { ToolApprovalRequestPayload } from '../../resources/agent/tool-approval/action-id';
+
+/**
+ * Reconstructs tool-approval cycles from the Novu ledger into LangChain messages.
+ *
+ * ## Why this module exists
+ * Novu persists approval as separate ledger rows (request, decision, side-effect replies,
+ * tool_result) in chronological order. LangChain / chat providers require every AIMessage
+ * `tool_call` to be paired with a matching `ToolMessage` (`tool_call_id`) — an unmatched
+ * call is rejected once converted to the provider's native API shape.
+ *
+ * We pre-scan the ledger once, classify each cycle, then replay it as a provider-safe pair:
+ *
+ * | State     | Meaning                    | Emitted at request entry        |
+ * |-----------|----------------------------|---------------------------------|
+ * | resolved  | Tool executed              | AIMessage(tool_call) + Tool msg |
+ * | denied    | User/system denied         | AIMessage(tool_call) + denied   |
+ * | in-flight | Approved, tool not run yet | resolved once its result is     |
+ * |           |                            | supplied via `freshResults`     |
+ *
+ * On resume the adapter executes the just-approved tool itself and passes the output in
+ * `freshResults`, so an in-flight cycle is emitted as a resolved call+result pair. A cycle
+ * that is still genuinely pending (no decision, no result) is dropped to avoid a dangling
+ * `tool_call` — this only happens outside the normal pause/resume flow.
+ */
+
+const TYPE_TOOL_APPROVAL_REQUEST = 'tool_approval_request';
+const TYPE_TOOL_APPROVAL_DECISION = 'tool_approval_decision';
+const TYPE_TOOL_RESULT = 'tool_result';
+
+const EXECUTION_DENIED = JSON.stringify({ type: 'execution-denied' });
+
+// ─── Payload extractors ───────────────────────────────────────────────────────
+
+function approvalOf(entry: AgentHistoryEntry): ToolApprovalRequestPayload | undefined {
+  const tool = entry.toolData;
+  if (!tool || typeof tool.approvalId !== 'string' || typeof tool.toolCallId !== 'string') {
+    return undefined;
+  }
+
+  return { approvalId: tool.approvalId, toolCallId: tool.toolCallId, name: tool.toolName ?? 'tool', input: tool.input };
+}
+
+interface DecisionPayload {
+  approvalId: string;
+  approved: boolean;
+}
+
+function decisionOf(entry: AgentHistoryEntry): DecisionPayload | undefined {
+  const tool = entry.toolData;
+  if (!tool || typeof tool.approvalId !== 'string' || typeof tool.approved !== 'boolean') {
+    return undefined;
+  }
+
+  return { approvalId: tool.approvalId, approved: tool.approved };
+}
+
+export interface ToolResultPayload {
+  toolCallId: string;
+  toolName?: string;
+  output: unknown;
+}
+
+function toolResultOf(entry: AgentHistoryEntry): ToolResultPayload | undefined {
+  const tool = entry.toolData;
+  if (!tool || typeof tool.toolCallId !== 'string') {
+    return undefined;
+  }
+
+  return { toolCallId: tool.toolCallId, toolName: tool.toolName, output: tool.output };
+}
+
+// ─── Approval index (one pre-scan per turn) ───────────────────────────────────
+
+/** Snapshot of all approval cycles in the ledger, built before mapping any entry. */
+export interface ApprovalIndex {
+  deniedApprovalIds: Set<string>;
+  /** toolCallId → result payload (ledger `tool_result` rows, plus any `freshResults`). */
+  toolResults: Map<string, ToolResultPayload>;
+  approvalIdToToolCallId: Map<string, string>;
+}
+
+export function buildApprovalIndex(
+  history: AgentHistoryEntry[],
+  freshResults?: Map<string, ToolResultPayload>
+): ApprovalIndex {
+  const deniedApprovalIds = new Set<string>();
+  const toolResults = new Map<string, ToolResultPayload>();
+  const approvalIdToToolCallId = new Map<string, string>();
+
+  for (const entry of history) {
+    if (entry.type === TYPE_TOOL_APPROVAL_REQUEST) {
+      const approval = approvalOf(entry);
+      if (approval) {
+        approvalIdToToolCallId.set(approval.approvalId, approval.toolCallId);
+      }
+    } else if (entry.type === TYPE_TOOL_APPROVAL_DECISION) {
+      const decision = decisionOf(entry);
+      if (decision && !decision.approved) {
+        deniedApprovalIds.add(decision.approvalId);
+      }
+    } else if (entry.type === TYPE_TOOL_RESULT) {
+      const result = toolResultOf(entry);
+      if (result) {
+        toolResults.set(result.toolCallId, result);
+      }
+    }
+  }
+
+  if (freshResults) {
+    for (const [toolCallId, result] of freshResults) {
+      toolResults.set(toolCallId, result);
+    }
+  }
+
+  return { deniedApprovalIds, toolResults, approvalIdToToolCallId };
+}
+
+// ─── Cycle classification ─────────────────────────────────────────────────────
+
+type ApprovalCycleState = 'in-flight' | 'denied' | 'resolved';
+
+function cycleState(approval: ToolApprovalRequestPayload, index: ApprovalIndex): ApprovalCycleState {
+  if (index.deniedApprovalIds.has(approval.approvalId)) {
+    return 'denied';
+  }
+
+  if (index.toolResults.has(approval.toolCallId)) {
+    return 'resolved';
+  }
+
+  return 'in-flight';
+}
+
+// ─── LangChain message builders ───────────────────────────────────────────────
+
+function assistantToolCall(approval: ToolApprovalRequestPayload): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: [{ id: approval.toolCallId, name: approval.name, args: approval.input ?? {}, type: 'tool_call' }],
+  });
+}
+
+function toContent(output: unknown): string {
+  return typeof output === 'string' ? output : JSON.stringify(output);
+}
+
+function executedToolResult(result: ToolResultPayload): ToolMessage {
+  return new ToolMessage({
+    content: toContent(result.output),
+    tool_call_id: result.toolCallId,
+    name: result.toolName ?? 'tool',
+  });
+}
+
+function executionDeniedResult(approval: ToolApprovalRequestPayload): ToolMessage {
+  return new ToolMessage({
+    content: EXECUTION_DENIED,
+    tool_call_id: approval.toolCallId,
+    name: approval.name,
+    status: 'error',
+  });
+}
+
+// ─── Ledger entry mapper ──────────────────────────────────────────────────────
+
+export function mapApprovalRequest(entry: AgentHistoryEntry, index: ApprovalIndex): BaseMessage[] {
+  const approval = approvalOf(entry);
+  if (!approval) {
+    return [];
+  }
+
+  const state = cycleState(approval, index);
+
+  switch (state) {
+    case 'denied':
+      return [assistantToolCall(approval), executionDeniedResult(approval)];
+    case 'resolved': {
+      const result = index.toolResults.get(approval.toolCallId);
+      if (!result) {
+        return [];
+      }
+
+      return [assistantToolCall(approval), executedToolResult(result)];
+    }
+    case 'in-flight':
+      // Still pending (no decision/result yet): drop to avoid a dangling tool_call.
+      // The normal pause/resume flow never maps history in this state.
+      return [];
+    default: {
+      const unreachable: never = state;
+
+      return unreachable;
+    }
+  }
+}
+
+// ─── Resume helpers ───────────────────────────────────────────────────────────
+
+export interface ApprovedToolCall {
+  toolCallId: string;
+  toolName: string;
+  input?: Record<string, unknown>;
+}
+
+/**
+ * Gated tool calls that were approved but have not executed yet (no `tool_result` row).
+ * The adapter runs these on resume, records the outcome, and continues the graph.
+ */
+export function findApprovedUnexecuted(history: AgentHistoryEntry[]): ApprovedToolCall[] {
+  const approvedApprovalIds = new Set<string>();
+  const executedToolCallIds = new Set<string>();
+  const requests: Array<{ approvalId: string; toolCallId: string; toolName: string; input?: Record<string, unknown> }> =
+    [];
+
+  for (const entry of history) {
+    if (entry.type === TYPE_TOOL_APPROVAL_REQUEST) {
+      const approval = approvalOf(entry);
+      if (approval) {
+        requests.push({
+          approvalId: approval.approvalId,
+          toolCallId: approval.toolCallId,
+          toolName: approval.name,
+          input: approval.input,
+        });
+      }
+    } else if (entry.type === TYPE_TOOL_APPROVAL_DECISION) {
+      const decision = decisionOf(entry);
+      if (decision?.approved) {
+        approvedApprovalIds.add(decision.approvalId);
+      }
+    } else if (entry.type === TYPE_TOOL_RESULT) {
+      const result = toolResultOf(entry);
+      if (result) {
+        executedToolCallIds.add(result.toolCallId);
+      }
+    }
+  }
+
+  return requests
+    .filter((request) => approvedApprovalIds.has(request.approvalId) && !executedToolCallIds.has(request.toolCallId))
+    .map(({ toolCallId, toolName, input }) => ({ toolCallId, toolName, input }));
+}

--- a/packages/framework/src/langchain/history-mapper/history-mapper.test.ts
+++ b/packages/framework/src/langchain/history-mapper/history-mapper.test.ts
@@ -1,0 +1,295 @@
+import {
+  type BaseMessage,
+  isAIMessage,
+  isHumanMessage,
+  isSystemMessage,
+  isToolMessage,
+} from '@langchain/core/messages';
+import { describe, expect, it } from 'vitest';
+import type { AgentHistoryEntry } from '../../resources/agent/agent.types';
+import type { ToolResultPayload } from './approval-cycles';
+import { toLangChainMessages } from './index';
+
+// ─── Ledger fixtures (rows as Novu persists them; `createdAt` controls order) ───
+
+type EntryOverrides = Partial<AgentHistoryEntry> & Pick<AgentHistoryEntry, 'type' | 'role'>;
+
+let seq = 0;
+function entry(overrides: EntryOverrides): AgentHistoryEntry {
+  seq += 1;
+
+  return { content: '', createdAt: String(seq), ...overrides };
+}
+
+function userMessage(content: string): AgentHistoryEntry {
+  return entry({ role: 'subscriber', type: 'message', content });
+}
+
+function agentMessage(content: string): AgentHistoryEntry {
+  return entry({ role: 'agent', type: 'message', content });
+}
+
+function approvalRequest(params: {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  input?: Record<string, unknown>;
+}): AgentHistoryEntry {
+  return entry({
+    role: 'agent',
+    type: 'tool_approval_request',
+    content: 'Tool approval required',
+    richContent: { card: { type: 'card' } },
+    toolData: {
+      approvalId: params.approvalId,
+      toolCallId: params.toolCallId,
+      toolName: params.toolName,
+      input: params.input,
+    },
+  });
+}
+
+function approvalDecision(params: { approvalId: string; approved: boolean }): AgentHistoryEntry {
+  return entry({
+    role: 'system',
+    type: 'tool_approval_decision',
+    content: params.approved ? 'Approved' : 'Denied',
+    toolData: { approvalId: params.approvalId, approved: params.approved },
+  });
+}
+
+function toolResult(params: { toolCallId: string; toolName: string; output: unknown }): AgentHistoryEntry {
+  return entry({ role: 'system', type: 'tool_result', content: 'Tool result', toolData: params });
+}
+
+function freshResults(...results: ToolResultPayload[]): Map<string, ToolResultPayload> {
+  return new Map(results.map((result) => [result.toolCallId, result]));
+}
+
+// ─── Assertion helper: reduce a LangChain message to a comparable shape ─────────
+
+type MessageShape =
+  | { role: 'system' | 'user' | 'assistant'; content: unknown }
+  | { role: 'assistant'; content: unknown; tool_calls: Array<{ id?: string; name: string; args: unknown }> }
+  | { role: 'tool'; tool_call_id: string; name?: string; content: unknown; status?: string };
+
+function shape(message: BaseMessage): MessageShape {
+  if (isSystemMessage(message)) {
+    return { role: 'system', content: message.content };
+  }
+  if (isHumanMessage(message)) {
+    return { role: 'user', content: message.content };
+  }
+  if (isAIMessage(message)) {
+    if (message.tool_calls && message.tool_calls.length > 0) {
+      return {
+        role: 'assistant',
+        content: message.content,
+        tool_calls: message.tool_calls.map((call) => ({ id: call.id, name: call.name, args: call.args })),
+      };
+    }
+
+    return { role: 'assistant', content: message.content };
+  }
+  if (isToolMessage(message)) {
+    return {
+      role: 'tool',
+      tool_call_id: message.tool_call_id,
+      name: message.name,
+      content: message.content,
+      status: message.status,
+    };
+  }
+
+  throw new Error(`unexpected message type: ${message.getType()}`);
+}
+
+function shapes(messages: BaseMessage[]): MessageShape[] {
+  return messages.map(shape);
+}
+
+function aiToolCall(id: string, name: string, args: Record<string, unknown> = {}) {
+  return { role: 'assistant' as const, content: '', tool_calls: [{ id, name, args }] };
+}
+
+function toolMessage(toolCallId: string, name: string, output: unknown) {
+  const content = typeof output === 'string' ? output : JSON.stringify(output);
+
+  return { role: 'tool' as const, tool_call_id: toolCallId, name, content, status: undefined };
+}
+
+function executionDenied(toolCallId: string, name: string) {
+  return {
+    role: 'tool' as const,
+    tool_call_id: toolCallId,
+    name,
+    content: '{"type":"execution-denied"}',
+    status: 'error',
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('toLangChainMessages', () => {
+  describe('plain messages', () => {
+    it('maps roles to user/assistant and preserves order', () => {
+      const result = toLangChainMessages([userMessage('hi'), agentMessage('hello!')]);
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello!' },
+      ]);
+    });
+
+    it('maps bridge subscriber role to user', () => {
+      const result = toLangChainMessages([
+        entry({ role: 'subscriber', type: 'message', content: 'hi' }),
+        agentMessage('hello!'),
+      ]);
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello!' },
+      ]);
+    });
+
+    it('skips signals, edits, and empty content', () => {
+      const result = toLangChainMessages([
+        entry({ role: 'system', type: 'signal', content: 'Conversation resolved' }),
+        userMessage('   '),
+        userMessage('real question'),
+        entry({ role: 'agent', type: 'edit', content: 'Approved' }),
+      ]);
+
+      expect(shapes(result)).toEqual([{ role: 'user', content: 'real question' }]);
+    });
+
+    it('prefixes sender name when multiple humans participate', () => {
+      const result = toLangChainMessages([
+        entry({ role: 'user', type: 'message', content: 'one', senderName: 'Alice' }),
+        entry({ role: 'user', type: 'message', content: 'two', senderName: 'Bob' }),
+      ]);
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'Alice: one' },
+        { role: 'user', content: 'Bob: two' },
+      ]);
+    });
+
+    it('prepends system prompt when provided', () => {
+      expect(shape(toLangChainMessages([], 'You are support.')[0])).toEqual({
+        role: 'system',
+        content: 'You are support.',
+      });
+    });
+  });
+
+  describe('tool approval cycles', () => {
+    it('in-flight without a fresh result: drops the dangling call (pause has no transcript)', () => {
+      const result = toLangChainMessages([
+        userMessage('refund my order'),
+        approvalRequest({ approvalId: 'a_1', toolCallId: 'tc_1', toolName: 'issueRefund', input: { amount: 250 } }),
+        approvalDecision({ approvalId: 'a_1', approved: true }),
+      ]);
+
+      expect(shapes(result)).toEqual([{ role: 'user', content: 'refund my order' }]);
+    });
+
+    it('in-flight with a fresh result: replays as a resolved call+result pair on resume', () => {
+      const result = toLangChainMessages(
+        [
+          userMessage('refund my order'),
+          approvalRequest({ approvalId: 'a_1', toolCallId: 'tc_1', toolName: 'issueRefund', input: { amount: 250 } }),
+          approvalDecision({ approvalId: 'a_1', approved: true }),
+        ],
+        undefined,
+        freshResults({ toolCallId: 'tc_1', toolName: 'issueRefund', output: { ok: true } })
+      );
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'refund my order' },
+        aiToolCall('tc_1', 'issueRefund', { amount: 250 }),
+        toolMessage('tc_1', 'issueRefund', { ok: true }),
+      ]);
+    });
+
+    it('resolved: tool ran → replay as call+result pair', () => {
+      const result = toLangChainMessages([
+        userMessage('refund $50'),
+        approvalRequest({ approvalId: 'a_1', toolCallId: 'toolu_1', toolName: 'issueRefund', input: { amount: 50 } }),
+        approvalDecision({ approvalId: 'a_1', approved: true }),
+        toolResult({ toolCallId: 'toolu_1', toolName: 'issueRefund', output: { ok: true } }),
+        agentMessage('Refund issued.'),
+      ]);
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'refund $50' },
+        aiToolCall('toolu_1', 'issueRefund', { amount: 50 }),
+        toolMessage('toolu_1', 'issueRefund', { ok: true }),
+        { role: 'assistant', content: 'Refund issued.' },
+      ]);
+    });
+
+    it('denied: user rejected → replay as call + execution-denied', () => {
+      const result = toLangChainMessages([
+        userMessage('refund $50'),
+        approvalRequest({ approvalId: 'a_1', toolCallId: 'toolu_1', toolName: 'issueRefund', input: { amount: 50 } }),
+        approvalDecision({ approvalId: 'a_1', approved: false }),
+      ]);
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'refund $50' },
+        aiToolCall('toolu_1', 'issueRefund', { amount: 50 }),
+        executionDenied('toolu_1', 'issueRefund'),
+      ]);
+    });
+
+    it('resolved + interleaved onToolApproval reply: call+result stay adjacent', () => {
+      const result = toLangChainMessages([
+        userMessage('refund $170'),
+        approvalRequest({ approvalId: 'a_1', toolCallId: 'toolu_1', toolName: 'issueRefund', input: { amount: 170 } }),
+        approvalDecision({ approvalId: 'a_1', approved: true }),
+        agentMessage('Tool approved test123'),
+        toolResult({ toolCallId: 'toolu_1', toolName: 'issueRefund', output: { ok: true } }),
+        agentMessage('Refund issued.'),
+      ]);
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'refund $170' },
+        aiToolCall('toolu_1', 'issueRefund', { amount: 170 }),
+        toolMessage('toolu_1', 'issueRefund', { ok: true }),
+        { role: 'assistant', content: 'Tool approved test123' },
+        { role: 'assistant', content: 'Refund issued.' },
+      ]);
+    });
+
+    it('multi-tool: one approved + one denied → every call paired with an outcome', () => {
+      const result = toLangChainMessages([
+        userMessage('refund 150 for order C and cancel subscription B'),
+        approvalRequest({
+          approvalId: 'a_refund',
+          toolCallId: 'toolu_refund',
+          toolName: 'issueRefund',
+          input: { orderId: 'C', amount: 150 },
+        }),
+        approvalDecision({ approvalId: 'a_refund', approved: true }),
+        toolResult({ toolCallId: 'toolu_refund', toolName: 'issueRefund', output: { ok: true } }),
+        approvalRequest({
+          approvalId: 'a_cancel',
+          toolCallId: 'toolu_cancel',
+          toolName: 'cancelSubscription',
+          input: { subId: 'B' },
+        }),
+        approvalDecision({ approvalId: 'a_cancel', approved: false }),
+      ]);
+
+      expect(shapes(result)).toEqual([
+        { role: 'user', content: 'refund 150 for order C and cancel subscription B' },
+        aiToolCall('toolu_refund', 'issueRefund', { orderId: 'C', amount: 150 }),
+        toolMessage('toolu_refund', 'issueRefund', { ok: true }),
+        aiToolCall('toolu_cancel', 'cancelSubscription', { subId: 'B' }),
+        executionDenied('toolu_cancel', 'cancelSubscription'),
+      ]);
+    });
+  });
+});

--- a/packages/framework/src/langchain/history-mapper/index.ts
+++ b/packages/framework/src/langchain/history-mapper/index.ts
@@ -1,0 +1,86 @@
+import { AIMessage, type BaseMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
+import type { AgentHistoryEntry } from '../../resources/agent/agent.types';
+import { type ApprovalIndex, buildApprovalIndex, mapApprovalRequest, type ToolResultPayload } from './approval-cycles';
+
+/**
+ * Maps Novu conversation ledger entries to LangChain `BaseMessage[]`.
+ *
+ * Plain messages (user/agent text, role normalization) are handled here.
+ * Tool approval cycles are delegated to `./approval-cycles`.
+ */
+
+const TYPE_MESSAGE = 'message';
+const TYPE_TOOL_APPROVAL_REQUEST = 'tool_approval_request';
+
+function isAssistantRole(role: string): boolean {
+  return role === 'agent' || role === 'assistant';
+}
+
+function distinctHumanSenders(history: AgentHistoryEntry[]): number {
+  const names = new Set<string>();
+  for (const entry of history) {
+    if (!isAssistantRole(entry.role) && entry.role !== 'system' && entry.senderName) {
+      names.add(entry.senderName);
+    }
+  }
+
+  return names.size;
+}
+
+function mapTextMessage(entry: AgentHistoryEntry, multiSender: boolean): BaseMessage | undefined {
+  if (!entry.content.trim()) {
+    return undefined;
+  }
+
+  const isAssistant = isAssistantRole(entry.role);
+  if (isAssistant) {
+    return new AIMessage(entry.content);
+  }
+
+  const text = multiSender && entry.senderName ? `${entry.senderName}: ${entry.content}` : entry.content;
+
+  return new HumanMessage(text);
+}
+
+function mapHistoryEntry(entry: AgentHistoryEntry, multiSender: boolean, index: ApprovalIndex): BaseMessage[] {
+  switch (entry.type) {
+    case TYPE_MESSAGE: {
+      const message = mapTextMessage(entry, multiSender);
+
+      return message ? [message] : [];
+    }
+    case TYPE_TOOL_APPROVAL_REQUEST:
+      return mapApprovalRequest(entry, index);
+    default:
+      // `tool_approval_decision`, `tool_result`, `edit`, `signal`, and unknown types are
+      // UI/runtime artifacts or already replayed at the request entry — not model transcript.
+      return [];
+  }
+}
+
+/**
+ * Convert `ctx.history` into LangChain `BaseMessage[]` for `createAgent().invoke(...)`.
+ *
+ * History already includes the current incoming message — do not append the handler's
+ * `message` argument on top of it.
+ *
+ * @param system - Optional system prompt prepended as a `SystemMessage`. Omit it when the
+ *   agent already receives a prompt (e.g. via `createAgent({ prompt })`) to avoid duplication.
+ * @param freshResults - Tool outputs the adapter executed this turn (approve-resume). Cycles
+ *   with a fresh result are replayed as resolved call+result pairs.
+ */
+export function toLangChainMessages(
+  history: AgentHistoryEntry[],
+  system?: string,
+  freshResults?: Map<string, ToolResultPayload>
+): BaseMessage[] {
+  const multiSender = distinctHumanSenders(history) > 1;
+  const index = buildApprovalIndex(history, freshResults);
+  const fromHistory = history.flatMap((entry) => mapHistoryEntry(entry, multiSender, index));
+
+  if (!system) {
+    return fromHistory;
+  }
+
+  return [new SystemMessage(system), ...fromHistory];
+}

--- a/packages/framework/src/langchain/index.ts
+++ b/packages/framework/src/langchain/index.ts
@@ -1,0 +1,10 @@
+export { toLangChainMessages } from './history-mapper';
+export { agent } from './langchain-agent';
+export { NovuToolApprovalRequired } from './tool-approval';
+export type {
+  LangChainAgentConfig,
+  LangChainAgentHandlers,
+  LangChainInvokeResult,
+  LangChainResult,
+  LangChainToolCall,
+} from './types';

--- a/packages/framework/src/langchain/langchain-agent.test.ts
+++ b/packages/framework/src/langchain/langchain-agent.test.ts
@@ -1,0 +1,210 @@
+import { AIMessage, type BaseMessage } from '@langchain/core/messages';
+import { describe, expect, it, vi } from 'vitest';
+import { type AgentRuntimeContext, RUNTIME_CONTEXT_BRAND } from '../resources/agent/agent.runtime';
+import type {
+  Agent,
+  AgentActionContext,
+  AgentHistoryEntry,
+  AgentMessageContext,
+  ToolApprovalDecision,
+} from '../resources/agent/agent.types';
+import { agent } from './langchain-agent';
+import type { LangChainInvokeResult } from './types';
+
+function fakeRuntimeCtx(overrides: Partial<{ history: AgentHistoryEntry[] }> = {}) {
+  const reply = vi.fn().mockResolvedValue({ messageId: 'm', platformThreadId: 'p' });
+  const history = overrides.history ?? [];
+  const ctx = {
+    [RUNTIME_CONTEXT_BRAND]: true as const,
+    reply,
+    history,
+    emitToolResult: vi.fn(),
+    emitToolApprovalRequest: vi.fn(),
+    typing: { stop: vi.fn() },
+    asMessageContext: () => ctx as unknown as AgentMessageContext,
+  };
+
+  return ctx as unknown as AgentRuntimeContext & { reply: ReturnType<typeof vi.fn>; history: AgentHistoryEntry[] };
+}
+
+function fakeMessageCtx(overrides: Partial<{ history: AgentHistoryEntry[] }> = {}) {
+  return fakeRuntimeCtx(overrides) as unknown as AgentMessageContext & {
+    reply: ReturnType<typeof vi.fn>;
+    history: AgentHistoryEntry[];
+  };
+}
+
+function fakeActionCtx(overrides: Partial<{ history: AgentHistoryEntry[] }> = {}) {
+  return fakeRuntimeCtx(overrides) as unknown as AgentActionContext & {
+    reply: ReturnType<typeof vi.fn>;
+    history: AgentHistoryEntry[];
+  };
+}
+
+/** A pre-invoked LangChain result (skips the agent graph, so no model is needed). */
+function invokeResult(text: string): LangChainInvokeResult {
+  return { messages: [new AIMessage(text)] as BaseMessage[] };
+}
+
+function approvedCycleHistory(): AgentHistoryEntry[] {
+  return [
+    {
+      role: 'agent',
+      type: 'tool_approval_request',
+      content: '',
+      toolData: { approvalId: 'tc_1', toolCallId: 'tc_1', toolName: 'issueRefund', input: { amount: 300 } },
+      createdAt: '1',
+    },
+    {
+      role: 'system',
+      type: 'tool_approval_decision',
+      content: 'Approved issueRefund',
+      toolData: { approvalId: 'tc_1', approved: true },
+      createdAt: '2',
+    },
+  ];
+}
+
+function approvalClick(overrides: Partial<ToolApprovalDecision> = {}): ToolApprovalDecision {
+  return {
+    toolCall: { id: 'tc_1', name: 'issueRefund', input: { amount: 1 } },
+    approved: true,
+    approvalMessage: { editedByHandler: false } as never,
+    ...overrides,
+  };
+}
+
+async function invokeToolApproval(
+  supportAgent: Agent,
+  ctx: AgentActionContext,
+  decision: ToolApprovalDecision = approvalClick()
+) {
+  expect(supportAgent.handlers.onToolApproval).toBeTypeOf('function');
+
+  await supportAgent.handlers.onToolApproval!(decision, ctx);
+}
+
+describe('langchain agent adapter', () => {
+  describe('registration', () => {
+    it('accepts a bare function as onMessage', () => {
+      const supportAgent = agent('support', async () => 'hi');
+
+      expect(supportAgent.id).toBe('support');
+      expect(typeof supportAgent.handlers.onMessage).toBe('function');
+    });
+
+    it('accepts an object of handlers and passes optional handlers through', () => {
+      const supportAgent = agent('support', {
+        onMessage: async () => undefined,
+        onAction: async () => undefined,
+      });
+
+      expect(typeof supportAgent.handlers.onMessage).toBe('function');
+      expect(typeof supportAgent.handlers.onAction).toBe('function');
+    });
+
+    it('throws when onMessage is missing', () => {
+      // @ts-expect-error intentionally invalid
+      expect(() => agent('support', {})).toThrow(/onMessage/);
+    });
+  });
+
+  describe('onMessage', () => {
+    it('passes string returns through for runtime replyIfPresent', async () => {
+      const supportAgent = agent('support', async () => 'hello');
+      const ctx = fakeMessageCtx();
+
+      const result = await supportAgent.handlers.onMessage({} as never, ctx);
+
+      expect(result).toBe('hello');
+      expect(ctx.reply).not.toHaveBeenCalled();
+    });
+
+    it('auto-delivers pre-invoked results and returns void', async () => {
+      const supportAgent = agent('support', async () => invokeResult('model reply'));
+      const ctx = fakeMessageCtx();
+
+      const result = await supportAgent.handlers.onMessage({} as never, ctx);
+
+      expect(result).toBeUndefined();
+      expect(ctx.reply).toHaveBeenCalledWith('model reply');
+    });
+
+    it('auto-delivers a bare AIMessage', async () => {
+      const supportAgent = agent('support', async () => new AIMessage('done'));
+      const ctx = fakeMessageCtx();
+
+      await supportAgent.handlers.onMessage({} as never, ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('done');
+    });
+  });
+
+  describe('onToolApproval', () => {
+    it('auto-resumes via onMessage after approve (decision already in persisted history)', async () => {
+      const history = approvedCycleHistory();
+      const historySnapshots: AgentHistoryEntry[][] = [];
+
+      const billingAgent = agent('billing', async (_m, ctx) => {
+        historySnapshots.push([...ctx.history]);
+
+        return invokeResult('done');
+      });
+
+      const ctx = fakeActionCtx({ history });
+
+      await invokeToolApproval(billingAgent, ctx);
+
+      expect(historySnapshots.at(-1)).toEqual(history);
+      expect(ctx.reply).toHaveBeenCalledWith('done');
+    });
+
+    it('posts string returns from onToolApproval, then auto-resumes', async () => {
+      const billingAgent = agent('billing', {
+        onMessage: async () => invokeResult('done'),
+        onToolApproval: async (decision) => {
+          if (decision.approved) {
+            return 'test123';
+          }
+        },
+      });
+
+      const ctx = fakeActionCtx({ history: approvedCycleHistory() });
+
+      await invokeToolApproval(billingAgent, ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('test123');
+      expect(ctx.reply).toHaveBeenCalledWith('done');
+    });
+
+    it('does not double-reply when handler returns ctx.reply() (ReplyHandle)', async () => {
+      const billingAgent = agent('billing', {
+        onMessage: async () => invokeResult('done'),
+        onToolApproval: async (_decision, ctx) => ctx.reply('already posted'),
+      });
+
+      const ctx = fakeActionCtx({ history: approvedCycleHistory() });
+
+      await invokeToolApproval(billingAgent, ctx);
+
+      expect(ctx.reply).toHaveBeenCalledTimes(2);
+      expect(ctx.reply).toHaveBeenNthCalledWith(1, 'already posted');
+      expect(ctx.reply).toHaveBeenNthCalledWith(2, 'done');
+    });
+
+    it('skips auto-resume when handler returns a custom result', async () => {
+      const onMessage = vi.fn(async () => invokeResult('should not run'));
+      const billingAgent = agent('billing', {
+        onMessage,
+        onToolApproval: async () => invokeResult('custom resume'),
+      });
+
+      const ctx = fakeActionCtx({ history: approvedCycleHistory() });
+
+      await invokeToolApproval(billingAgent, ctx);
+
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(ctx.reply).toHaveBeenCalledWith('custom resume');
+    });
+  });
+});

--- a/packages/framework/src/langchain/langchain-agent.ts
+++ b/packages/framework/src/langchain/langchain-agent.ts
@@ -1,0 +1,99 @@
+import { requireRuntimeContext } from '../resources/agent/agent.runtime';
+import type {
+  Agent,
+  AgentActionContext,
+  AgentHandlers,
+  AgentMessage,
+  ReplyHandle,
+} from '../resources/agent/agent.types';
+import { handleLangChainResult, isLangChainResult } from './reply-mapper';
+import type { LangChainAgentHandlers } from './types';
+
+type LangChainMessageHandler = LangChainAgentHandlers['onMessage'];
+
+/** Synthetic message for approval resume — handlers rely on `ctx.history`, not this payload. */
+const RESUME_MESSAGE: AgentMessage = {
+  text: '',
+  platformMessageId: '',
+  author: { userId: '', fullName: '', userName: '', isBot: false },
+  timestamp: '',
+};
+
+function isReplyHandle(value: unknown): value is ReplyHandle {
+  return typeof value === 'object' && value !== null && 'messageId' in value && 'platformThreadId' in value;
+}
+
+function normalize(id: string, handlers: LangChainMessageHandler | LangChainAgentHandlers): LangChainAgentHandlers {
+  const normalized = typeof handlers === 'function' ? { onMessage: handlers } : handlers;
+  if (typeof normalized.onMessage !== 'function') {
+    throw new Error(`agent('${id}') requires an onMessage handler`);
+  }
+
+  return normalized;
+}
+
+/**
+ * Wrap LangChain handlers as a Novu {@link Agent}.
+ *
+ * Return a {@link import('./types').LangChainAgentConfig} from `onMessage` to let Novu run the
+ * agent and own the tool-approval loop; gated tools pause with an approval card and resume
+ * statelessly from `ctx.history`. You may also return already-produced messages, a card, or plain
+ * text. Approvals auto-resume `onMessage` unless a custom `onToolApproval` handles them.
+ */
+export function agent(id: string, handlers: LangChainMessageHandler | LangChainAgentHandlers): Agent {
+  if (!id) {
+    throw new Error('agent() requires a non-empty agentId');
+  }
+
+  const h = normalize(id, handlers);
+  const config = h.toolApproval;
+  const userOnToolApproval = typeof h.onToolApproval === 'function';
+
+  // The decision is persisted to `ctx.history` before this turn fires, so resuming is just
+  // re-running `onMessage`: the adapter executes the approved tool, records its result, and
+  // `toLangChainMessages(ctx.history)` replays a completed cycle for the model to continue from.
+  const resume = async (ctx: AgentActionContext): Promise<void> => {
+    const runtime = requireRuntimeContext(ctx);
+    const result = await h.onMessage(RESUME_MESSAGE, runtime.asMessageContext());
+    if (isLangChainResult(result)) {
+      await handleLangChainResult(result, runtime, config);
+    }
+  };
+
+  const wrappedHandlers: AgentHandlers = {
+    onMessage: async (message, ctx) => {
+      const result = await h.onMessage(message, ctx);
+
+      if (isLangChainResult(result)) {
+        await handleLangChainResult(result, requireRuntimeContext(ctx), config);
+
+        return;
+      }
+
+      return result;
+    },
+    onToolApproval: async (decision, ctx) => {
+      const runtime = requireRuntimeContext(ctx);
+      if (h.onToolApproval) {
+        const result = await h.onToolApproval(decision, ctx);
+        if (isLangChainResult(result)) {
+          await handleLangChainResult(result, runtime, config);
+
+          return;
+        }
+
+        if (result != null && !isReplyHandle(result)) {
+          await runtime.reply(result);
+        }
+      }
+
+      await resume(ctx);
+    },
+    ...(config && { toolApproval: config }),
+    ...(h.onAction && { onAction: h.onAction }),
+    ...(h.onReaction && { onReaction: h.onReaction }),
+    ...(h.onResolve && { onResolve: h.onResolve }),
+  };
+
+  return { id, handlers: wrappedHandlers, userOnToolApproval };
+}

--- a/packages/framework/src/langchain/reply-mapper/collect-results.ts
+++ b/packages/framework/src/langchain/reply-mapper/collect-results.ts
@@ -1,0 +1,69 @@
+import { type BaseMessage, isToolMessage, type ToolMessage } from '@langchain/core/messages';
+import type { AgentRuntimeContext } from '../../resources/agent/agent.runtime';
+
+/** Tool calls that were gated behind approval — only these get persisted as ledger tool_result rows. */
+function gatedToolCallIds(ctx: AgentRuntimeContext): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of ctx.history) {
+    if (entry.type === 'tool_approval_request' && entry.toolData?.toolCallId) {
+      ids.add(entry.toolData.toolCallId);
+    }
+  }
+
+  return ids;
+}
+
+/** toolCallIds already recorded — persisted in a prior turn or executed by the adapter this turn. */
+function alreadyRecordedToolCallIds(ctx: AgentRuntimeContext, executed: Set<string>): Set<string> {
+  const ids = new Set<string>(executed);
+  for (const entry of ctx.history) {
+    if (entry.type === 'tool_result' && entry.toolData?.toolCallId) {
+      ids.add(entry.toolData.toolCallId);
+    }
+  }
+
+  return ids;
+}
+
+function toStringContent(content: ToolMessage['content']): string {
+  return typeof content === 'string' ? content : JSON.stringify(content);
+}
+
+/**
+ * Persist tool results to Novu history — but only for approval-gated tools that the graph
+ * executed and that were not already recorded (in the ledger or by the adapter this turn).
+ *
+ * In the normal flow gated tools are executed by the adapter on resume, so this is defensive:
+ * it keeps the ledger correct if a gated tool ever runs inside the graph.
+ */
+export function emitExecutedToolResults(
+  messages: BaseMessage[],
+  ctx: AgentRuntimeContext,
+  executed: Set<string> = new Set()
+): void {
+  const gated = gatedToolCallIds(ctx);
+  if (gated.size === 0) {
+    return;
+  }
+
+  const recorded = alreadyRecordedToolCallIds(ctx, executed);
+
+  for (const message of messages) {
+    if (!isToolMessage(message)) {
+      continue;
+    }
+
+    const toolCallId = message.tool_call_id;
+    if (!gated.has(toolCallId) || recorded.has(toolCallId)) {
+      continue;
+    }
+
+    recorded.add(toolCallId);
+    ctx.emitToolResult({
+      toolCallId,
+      toolName: message.name,
+      output: toStringContent(message.content),
+      preview: `Tool "${message.name ?? toolCallId}" result`,
+    });
+  }
+}

--- a/packages/framework/src/langchain/reply-mapper/index.ts
+++ b/packages/framework/src/langchain/reply-mapper/index.ts
@@ -1,0 +1,146 @@
+import { AIMessage, type BaseMessage, isAIMessage, isBaseMessage } from '@langchain/core/messages';
+import { type AgentMiddleware, createAgent } from 'langchain';
+import type { AgentRuntimeContext } from '../../resources/agent/agent.runtime';
+import type { ToolApprovalConfig } from '../../resources/agent/agent.types';
+import { isCardElement } from '../../resources/agent/guards';
+import { toLangChainMessages } from '../history-mapper';
+import {
+  createApprovalMiddleware,
+  executeApprovedTools,
+  findToolApprovalRequired,
+  postApprovalCard,
+} from '../tool-approval';
+import type { LangChainAgentConfig, LangChainInvokeResult, LangChainResult } from '../types';
+import { emitExecutedToolResults } from './collect-results';
+
+interface AgentInvokeResult {
+  messages: BaseMessage[];
+}
+
+// ─── Guards ───────────────────────────────────────────────────────────────────
+
+export function isLangChainConfig(value: unknown): value is LangChainAgentConfig {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const model = (value as LangChainAgentConfig).model;
+
+  return typeof model === 'string' || (typeof model === 'object' && model !== null);
+}
+
+export function isLangChainInvokeResult(value: unknown): value is LangChainInvokeResult {
+  return typeof value === 'object' && value !== null && Array.isArray((value as LangChainInvokeResult).messages);
+}
+
+export function isLangChainResult(value: unknown): value is LangChainResult {
+  if (typeof value !== 'object' || value === null || isCardElement(value)) {
+    return false;
+  }
+
+  return isBaseMessage(value as BaseMessage) || isLangChainConfig(value) || isLangChainInvokeResult(value);
+}
+
+// ─── Text extraction ──────────────────────────────────────────────────────────
+
+function textFromContent(content: AIMessage['content']): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  return content
+    .map((block) => {
+      const part = block as { type?: string; text?: unknown };
+
+      return part.type === 'text' && typeof part.text === 'string' ? part.text : '';
+    })
+    .join('');
+}
+
+function finalText(messages: BaseMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (isAIMessage(message)) {
+      return textFromContent(message.content).trim();
+    }
+  }
+
+  return '';
+}
+
+async function deliverText(text: string, ctx: AgentRuntimeContext): Promise<void> {
+  if (!text) {
+    await ctx.typing.stop();
+
+    return;
+  }
+
+  await ctx.reply(text);
+}
+
+// ─── Config path (Novu-managed approval loop) ───────────────────────────────────
+
+async function runAgentConfig(
+  config: LangChainAgentConfig,
+  ctx: AgentRuntimeContext,
+  approvalConfig: ToolApprovalConfig | undefined
+): Promise<void> {
+  const freshResults = await executeApprovedTools(config.tools, ctx);
+  const messages = toLangChainMessages(ctx.history, undefined, freshResults);
+
+  const middleware: AgentMiddleware[] = [];
+  if (config.needsApproval) {
+    middleware.push(createApprovalMiddleware(config.needsApproval));
+  }
+  if (config.middleware) {
+    middleware.push(...config.middleware);
+  }
+
+  const agent = createAgent({
+    model: config.model,
+    tools: config.tools ?? [],
+    ...(config.system ? { prompt: config.system } : {}),
+    ...(middleware.length > 0 ? { middleware } : {}),
+  });
+
+  let result: AgentInvokeResult;
+  try {
+    result = (await agent.invoke({ messages })) as AgentInvokeResult;
+  } catch (error) {
+    const approval = findToolApprovalRequired(error);
+    if (approval) {
+      await postApprovalCard(ctx, approval, approvalConfig);
+
+      return;
+    }
+
+    throw error;
+  }
+
+  emitExecutedToolResults(result.messages, ctx, new Set(freshResults.keys()));
+  await deliverText(finalText(result.messages), ctx);
+}
+
+// ─── Router ─────────────────────────────────────────────────────────────────────
+
+/** Route a LangChain handler result: run the config (with approval loop) or deliver messages. */
+export async function handleLangChainResult(
+  result: LangChainResult,
+  ctx: AgentRuntimeContext,
+  approvalConfig: ToolApprovalConfig | undefined
+): Promise<void> {
+  if (isLangChainConfig(result)) {
+    await runAgentConfig(result, ctx, approvalConfig);
+
+    return;
+  }
+
+  if (isBaseMessage(result as BaseMessage)) {
+    await deliverText(finalText([result as BaseMessage]), ctx);
+
+    return;
+  }
+
+  emitExecutedToolResults((result as LangChainInvokeResult).messages, ctx);
+  await deliverText(finalText((result as LangChainInvokeResult).messages), ctx);
+}

--- a/packages/framework/src/langchain/reply-mapper/reply-mapper.test.ts
+++ b/packages/framework/src/langchain/reply-mapper/reply-mapper.test.ts
@@ -1,0 +1,204 @@
+import { AIMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AgentRuntimeContext, RUNTIME_CONTEXT_BRAND } from '../../resources/agent/agent.runtime';
+import type { AgentHistoryEntry } from '../../resources/agent/agent.types';
+import { NovuToolApprovalRequired } from '../tool-approval';
+import type { LangChainAgentConfig } from '../types';
+import { handleLangChainResult, isLangChainConfig, isLangChainInvokeResult, isLangChainResult } from './index';
+
+const { createAgentMock, invokeMock } = vi.hoisted(() => ({ createAgentMock: vi.fn(), invokeMock: vi.fn() }));
+
+vi.mock('langchain', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('langchain')>();
+
+  return { ...actual, createAgent: createAgentMock };
+});
+
+function fakeRuntimeCtx(history: AgentHistoryEntry[] = []) {
+  const reply = vi.fn().mockResolvedValue({ messageId: 'm', platformThreadId: 'p' });
+  const ctx = {
+    [RUNTIME_CONTEXT_BRAND]: true as const,
+    reply,
+    history,
+    emitToolResult: vi.fn(),
+    emitToolApprovalRequest: vi.fn(),
+    typing: { stop: vi.fn() },
+  };
+
+  return ctx as unknown as AgentRuntimeContext & {
+    reply: ReturnType<typeof vi.fn>;
+    emitToolResult: ReturnType<typeof vi.fn>;
+    emitToolApprovalRequest: ReturnType<typeof vi.fn>;
+    typing: { stop: ReturnType<typeof vi.fn> };
+  };
+}
+
+function fakeTool(name: string, run: (input: unknown) => unknown): StructuredToolInterface {
+  return { name, invoke: async (input: unknown) => run(input) } as unknown as StructuredToolInterface;
+}
+
+function config(overrides: Partial<LangChainAgentConfig> = {}): LangChainAgentConfig {
+  return { model: 'openai:gpt-4o', tools: [], ...overrides };
+}
+
+function approvedCycleHistory(): AgentHistoryEntry[] {
+  return [
+    {
+      role: 'agent',
+      type: 'tool_approval_request',
+      content: '',
+      toolData: { approvalId: 'tc_1', toolCallId: 'tc_1', toolName: 'issueRefund', input: { amount: 300 } },
+      createdAt: '1',
+    },
+    {
+      role: 'system',
+      type: 'tool_approval_decision',
+      content: 'Approved',
+      toolData: { approvalId: 'tc_1', approved: true },
+      createdAt: '2',
+    },
+  ];
+}
+
+beforeEach(() => {
+  createAgentMock.mockReset();
+  invokeMock.mockReset();
+  createAgentMock.mockReturnValue({ invoke: invokeMock });
+});
+
+describe('reply-mapper guards', () => {
+  it('recognizes an agent config by its model', () => {
+    expect(isLangChainConfig({ model: 'openai:gpt-4o' })).toBe(true);
+    expect(isLangChainConfig({ model: { invoke: () => {} } })).toBe(true);
+    expect(isLangChainConfig({ tools: [] })).toBe(false);
+  });
+
+  it('recognizes an invoke result by its messages array', () => {
+    expect(isLangChainInvokeResult({ messages: [] })).toBe(true);
+    expect(isLangChainInvokeResult({ messages: 'nope' })).toBe(false);
+  });
+
+  it('treats strings and cards as plain content, not results', () => {
+    expect(isLangChainResult('hello')).toBe(false);
+    expect(isLangChainResult({ type: 'card', children: [] })).toBe(false);
+    expect(isLangChainResult(new AIMessage('hi'))).toBe(true);
+    expect(isLangChainResult(config())).toBe(true);
+  });
+});
+
+describe('handleLangChainResult', () => {
+  describe('agent config path', () => {
+    it('runs the agent and delivers the final assistant text', async () => {
+      const ctx = fakeRuntimeCtx();
+      invokeMock.mockResolvedValue({ messages: [new AIMessage('final answer')] });
+
+      await handleLangChainResult(config(), ctx, undefined);
+
+      expect(createAgentMock).toHaveBeenCalledTimes(1);
+      expect(ctx.reply).toHaveBeenCalledWith('final answer');
+    });
+
+    it('joins content-block arrays into a single reply', async () => {
+      const ctx = fakeRuntimeCtx();
+      invokeMock.mockResolvedValue({
+        messages: [
+          new AIMessage({
+            content: [
+              { type: 'text', text: 'Hello ' },
+              { type: 'text', text: 'world' },
+            ],
+          }),
+        ],
+      });
+
+      await handleLangChainResult(config(), ctx, undefined);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Hello world');
+    });
+
+    it('posts an approval card (no reply text) when a gated tool pauses the run', async () => {
+      const ctx = fakeRuntimeCtx();
+      invokeMock.mockRejectedValue(
+        new NovuToolApprovalRequired({ toolCallId: 'tc_9', toolName: 'issueRefund', input: { amount: 300 } })
+      );
+
+      await handleLangChainResult(config({ needsApproval: () => true }), ctx, undefined);
+
+      expect(ctx.emitToolApprovalRequest).toHaveBeenCalledWith({
+        approvalId: 'tc_9',
+        toolCallId: 'tc_9',
+        name: 'issueRefund',
+        input: { amount: 300 },
+      });
+      expect(ctx.reply).toHaveBeenCalledTimes(1);
+    });
+
+    it('posts the card even when LangChain/LangGraph wraps the pause error in a cause chain', async () => {
+      const ctx = fakeRuntimeCtx();
+      const inner = new NovuToolApprovalRequired({
+        toolCallId: 'call_20QYNrm8',
+        toolName: 'linear__save_comment',
+        input: { issueId: 'NV-8208', body: 'test from agent' },
+      });
+      // MiddlewareError copies name/message and nests the original under `cause`; Pregel adds pregelTaskId.
+      const wrapped = new Error(inner.message);
+      wrapped.name = inner.name;
+      (wrapped as { cause?: unknown }).cause = inner;
+      (wrapped as { pregelTaskId?: string }).pregelTaskId = 'task-1';
+      invokeMock.mockRejectedValue(wrapped);
+
+      await handleLangChainResult(config({ needsApproval: () => true }), ctx, undefined);
+
+      expect(ctx.emitToolApprovalRequest).toHaveBeenCalledWith({
+        approvalId: 'call_20QYNrm8',
+        toolCallId: 'call_20QYNrm8',
+        name: 'linear__save_comment',
+        input: { issueId: 'NV-8208', body: 'test from agent' },
+      });
+      expect(ctx.reply).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes the approved tool on resume, records it, then delivers the reply', async () => {
+      const ctx = fakeRuntimeCtx(approvedCycleHistory());
+      const tool = fakeTool('issueRefund', () => ({ ok: true }));
+      invokeMock.mockResolvedValue({ messages: [new AIMessage('Refund issued.')] });
+
+      await handleLangChainResult(config({ tools: [tool], needsApproval: () => true }), ctx, undefined);
+
+      expect(ctx.emitToolResult).toHaveBeenCalledWith(
+        expect.objectContaining({ toolCallId: 'tc_1', toolName: 'issueRefund', output: { ok: true } })
+      );
+      expect(ctx.reply).toHaveBeenCalledWith('Refund issued.');
+    });
+
+    it('stops typing when the model returns no text', async () => {
+      const ctx = fakeRuntimeCtx();
+      invokeMock.mockResolvedValue({ messages: [new AIMessage('')] });
+
+      await handleLangChainResult(config(), ctx, undefined);
+
+      expect(ctx.reply).not.toHaveBeenCalled();
+      expect(ctx.typing.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pre-invoked result paths', () => {
+    it('delivers the final assistant message of an invoke result', async () => {
+      const ctx = fakeRuntimeCtx();
+
+      await handleLangChainResult({ messages: [new AIMessage('done')] }, ctx, undefined);
+
+      expect(createAgentMock).not.toHaveBeenCalled();
+      expect(ctx.reply).toHaveBeenCalledWith('done');
+    });
+
+    it('delivers a bare AIMessage', async () => {
+      const ctx = fakeRuntimeCtx();
+
+      await handleLangChainResult(new AIMessage('hey there'), ctx, undefined);
+
+      expect(ctx.reply).toHaveBeenCalledWith('hey there');
+    });
+  });
+});

--- a/packages/framework/src/langchain/tool-approval.test.ts
+++ b/packages/framework/src/langchain/tool-approval.test.ts
@@ -1,0 +1,214 @@
+import { ToolMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { describe, expect, it, vi } from 'vitest';
+import { type AgentRuntimeContext, RUNTIME_CONTEXT_BRAND } from '../resources/agent/agent.runtime';
+import type { AgentHistoryEntry } from '../resources/agent/agent.types';
+import {
+  createApprovalMiddleware,
+  executeApprovedTools,
+  findToolApprovalRequired,
+  isToolApprovalRequired,
+  NovuToolApprovalRequired,
+  postApprovalCard,
+} from './tool-approval';
+
+/** Mimics how LangChain's MiddlewareError + LangGraph's Pregel wrap a thrown middleware error. */
+function wrapLikeLangGraph(inner: Error): Error {
+  const middlewareError = new Error(inner.message);
+  middlewareError.name = inner.name;
+  (middlewareError as { cause?: unknown }).cause = inner;
+  (middlewareError as { pregelTaskId?: string }).pregelTaskId = 'task-1';
+
+  return middlewareError;
+}
+
+function fakeRuntimeCtx(history: AgentHistoryEntry[] = []) {
+  const reply = vi.fn().mockResolvedValue({ messageId: 'm', platformThreadId: 'p' });
+  const ctx = {
+    [RUNTIME_CONTEXT_BRAND]: true as const,
+    reply,
+    history,
+    emitToolResult: vi.fn(),
+    emitToolApprovalRequest: vi.fn(),
+    typing: { stop: vi.fn() },
+  };
+
+  return ctx as unknown as AgentRuntimeContext & {
+    reply: ReturnType<typeof vi.fn>;
+    emitToolResult: ReturnType<typeof vi.fn>;
+    emitToolApprovalRequest: ReturnType<typeof vi.fn>;
+  };
+}
+
+function fakeTool(name: string, run: (input: unknown) => unknown): StructuredToolInterface {
+  return { name, invoke: async (input: unknown) => run(input) } as unknown as StructuredToolInterface;
+}
+
+function approvedCycleHistory(): AgentHistoryEntry[] {
+  return [
+    {
+      role: 'agent',
+      type: 'tool_approval_request',
+      content: '',
+      toolData: { approvalId: 'tc_1', toolCallId: 'tc_1', toolName: 'issueRefund', input: { amount: 300 } },
+      createdAt: '1',
+    },
+    {
+      role: 'system',
+      type: 'tool_approval_decision',
+      content: 'Approved issueRefund',
+      toolData: { approvalId: 'tc_1', approved: true },
+      createdAt: '2',
+    },
+  ];
+}
+
+type WrapToolCall = (request: { toolCall: { id: string; name: string; args: unknown } }, handler: unknown) => unknown;
+
+function wrapToolCallOf(middleware: unknown): WrapToolCall {
+  return (middleware as { wrapToolCall: WrapToolCall }).wrapToolCall;
+}
+
+describe('tool-approval', () => {
+  describe('NovuToolApprovalRequired', () => {
+    it('is detected by the guard and carries the tool call', () => {
+      const error = new NovuToolApprovalRequired({ toolCallId: 'tc_1', toolName: 'issueRefund', input: { amount: 5 } });
+
+      expect(isToolApprovalRequired(error)).toBe(true);
+      expect(isToolApprovalRequired(new Error('other'))).toBe(false);
+      expect(error.toolCallId).toBe('tc_1');
+      expect(error.toolName).toBe('issueRefund');
+      expect(error.input).toEqual({ amount: 5 });
+    });
+  });
+
+  describe('findToolApprovalRequired', () => {
+    it('returns the error itself when thrown directly', () => {
+      const error = new NovuToolApprovalRequired({ toolCallId: 'tc_1', toolName: 'issueRefund' });
+
+      expect(findToolApprovalRequired(error)).toBe(error);
+    });
+
+    it('unwraps the LangChain/LangGraph cause chain', () => {
+      const inner = new NovuToolApprovalRequired({ toolCallId: 'tc_1', toolName: 'linear__save_comment' });
+      const wrapped = wrapLikeLangGraph(inner);
+
+      expect(wrapped).not.toBeInstanceOf(NovuToolApprovalRequired);
+      expect(findToolApprovalRequired(wrapped)).toBe(inner);
+      expect(isToolApprovalRequired(wrapped)).toBe(true);
+    });
+
+    it('unwraps multiple nested layers', () => {
+      const inner = new NovuToolApprovalRequired({ toolCallId: 'tc_1', toolName: 'issueRefund' });
+
+      expect(findToolApprovalRequired(wrapLikeLangGraph(wrapLikeLangGraph(inner)))).toBe(inner);
+    });
+
+    it('returns undefined for unrelated errors and cycles', () => {
+      expect(findToolApprovalRequired(new Error('boom'))).toBeUndefined();
+      expect(findToolApprovalRequired(undefined)).toBeUndefined();
+
+      const cyclic = new Error('loop') as Error & { cause?: unknown };
+      cyclic.cause = cyclic;
+      expect(findToolApprovalRequired(cyclic)).toBeUndefined();
+    });
+  });
+
+  describe('createApprovalMiddleware', () => {
+    it('throws for gated tools before they run', async () => {
+      const middleware = createApprovalMiddleware((call) => call.name === 'issueRefund');
+      const handler = vi.fn();
+
+      await expect(
+        wrapToolCallOf(middleware)({ toolCall: { id: 'tc_1', name: 'issueRefund', args: { amount: 5 } } }, handler)
+      ).rejects.toBeInstanceOf(NovuToolApprovalRequired);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('executes non-gated tools via the handler', async () => {
+      const middleware = createApprovalMiddleware((call) => call.name === 'issueRefund');
+      const output = new ToolMessage({ content: 'ok', tool_call_id: 'tc_2' });
+      const handler = vi.fn().mockResolvedValue(output);
+
+      const request = { toolCall: { id: 'tc_2', name: 'lookup', args: {} } };
+      await expect(wrapToolCallOf(middleware)(request, handler)).resolves.toBe(output);
+      expect(handler).toHaveBeenCalledWith(request);
+    });
+  });
+
+  describe('executeApprovedTools', () => {
+    it('runs approved-but-unexecuted gated tools and records the result', async () => {
+      const ctx = fakeRuntimeCtx(approvedCycleHistory());
+      const tool = fakeTool('issueRefund', (input) => ({ ok: true, input }));
+
+      const results = await executeApprovedTools([tool], ctx);
+
+      expect(results.get('tc_1')).toEqual({
+        toolCallId: 'tc_1',
+        toolName: 'issueRefund',
+        output: { ok: true, input: { amount: 300 } },
+      });
+      expect(ctx.emitToolResult).toHaveBeenCalledWith({
+        toolCallId: 'tc_1',
+        toolName: 'issueRefund',
+        output: { ok: true, input: { amount: 300 } },
+        preview: 'Tool "issueRefund" result',
+      });
+    });
+
+    it('returns empty when nothing is awaiting execution', async () => {
+      const ctx = fakeRuntimeCtx([]);
+
+      const results = await executeApprovedTools([fakeTool('issueRefund', () => 'x')], ctx);
+
+      expect(results.size).toBe(0);
+      expect(ctx.emitToolResult).not.toHaveBeenCalled();
+    });
+
+    it('skips approved cycles whose tool is not registered', async () => {
+      const ctx = fakeRuntimeCtx(approvedCycleHistory());
+
+      const results = await executeApprovedTools([fakeTool('somethingElse', () => 'x')], ctx);
+
+      expect(results.size).toBe(0);
+      expect(ctx.emitToolResult).not.toHaveBeenCalled();
+    });
+
+    it('does not execute denied cycles', async () => {
+      const history = approvedCycleHistory();
+      history[1] = {
+        role: 'system',
+        type: 'tool_approval_decision',
+        content: 'Denied',
+        toolData: { approvalId: 'tc_1', approved: false },
+        createdAt: '2',
+      };
+      const ctx = fakeRuntimeCtx(history);
+
+      const results = await executeApprovedTools([fakeTool('issueRefund', () => 'x')], ctx);
+
+      expect(results.size).toBe(0);
+    });
+  });
+
+  describe('postApprovalCard', () => {
+    it('emits the approval request and posts the card', async () => {
+      const ctx = fakeRuntimeCtx();
+      const error = new NovuToolApprovalRequired({
+        toolCallId: 'tc_9',
+        toolName: 'issueRefund',
+        input: { amount: 300 },
+      });
+
+      await postApprovalCard(ctx, error, undefined);
+
+      expect(ctx.emitToolApprovalRequest).toHaveBeenCalledWith({
+        approvalId: 'tc_9',
+        toolCallId: 'tc_9',
+        name: 'issueRefund',
+        input: { amount: 300 },
+      });
+      expect(ctx.reply).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/framework/src/langchain/tool-approval.ts
+++ b/packages/framework/src/langchain/tool-approval.ts
@@ -1,0 +1,142 @@
+import { type BaseMessage, isBaseMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { type AgentMiddleware, createMiddleware } from 'langchain';
+import type { AgentRuntimeContext } from '../resources/agent/agent.runtime';
+import type { AgentToolCall, ToolApprovalConfig } from '../resources/agent/agent.types';
+import { postToolApprovalCard } from '../resources/agent/tool-approval/post-card';
+import {
+  type ApprovedToolCall,
+  findApprovedUnexecuted,
+  type ToolResultPayload,
+} from './history-mapper/approval-cycles';
+import type { LangChainToolCall } from './types';
+
+/**
+ * Thrown from the approval middleware when a gated tool is about to run. It propagates out
+ * of `agent.invoke()` so the adapter can post a Novu approval card and end the turn instead
+ * of executing the tool. The approval decision is later replayed from `ctx.history`.
+ */
+export class NovuToolApprovalRequired extends Error {
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly input?: Record<string, unknown>;
+
+  constructor(toolCall: { toolCallId: string; toolName: string; input?: Record<string, unknown> }) {
+    super(`Tool "${toolCall.toolName}" requires approval`);
+    this.name = 'NovuToolApprovalRequired';
+    this.toolCallId = toolCall.toolCallId;
+    this.toolName = toolCall.toolName;
+    this.input = toolCall.input;
+  }
+}
+
+const MAX_CAUSE_DEPTH = 10;
+
+/**
+ * Find a {@link NovuToolApprovalRequired} in an error or its `cause` chain.
+ *
+ * LangChain wraps errors thrown from middleware in a `MiddlewareError` (copying the original
+ * `name`/`message` and nesting the original under `cause`), and LangGraph may re-wrap again for
+ * subgraphs. We therefore walk the `cause` chain rather than relying on a single `instanceof`.
+ */
+export function findToolApprovalRequired(error: unknown): NovuToolApprovalRequired | undefined {
+  let current = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current != null; depth += 1) {
+    if (current instanceof NovuToolApprovalRequired) {
+      return current;
+    }
+
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return undefined;
+}
+
+export function isToolApprovalRequired(error: unknown): error is NovuToolApprovalRequired {
+  return findToolApprovalRequired(error) !== undefined;
+}
+
+/**
+ * Middleware that gates approval-required tools. When `needsApproval` returns true for a tool
+ * call, it throws {@link NovuToolApprovalRequired} before the tool executes.
+ */
+export function createApprovalMiddleware(needsApproval: (toolCall: LangChainToolCall) => boolean): AgentMiddleware {
+  return createMiddleware({
+    name: 'novu-tool-approval',
+    wrapToolCall: async (request, handler) => {
+      const { id, name, args } = request.toolCall;
+      const input = (args ?? {}) as Record<string, unknown>;
+
+      if (needsApproval({ id, name, args: input })) {
+        throw new NovuToolApprovalRequired({ toolCallId: id ?? name, toolName: name, input });
+      }
+
+      return handler(request);
+    },
+  }) as unknown as AgentMiddleware;
+}
+
+/** Post the Novu approval card for a paused gated tool call. */
+export async function postApprovalCard(
+  ctx: AgentRuntimeContext,
+  request: NovuToolApprovalRequired,
+  config: ToolApprovalConfig | undefined
+): Promise<void> {
+  const toolCall: AgentToolCall = { id: request.toolCallId, name: request.toolName, input: request.input };
+  await postToolApprovalCard(ctx, toolCall, config);
+}
+
+function unwrapToolOutput(output: unknown): unknown {
+  if (isBaseMessage(output as BaseMessage)) {
+    return (output as BaseMessage).content;
+  }
+
+  return output;
+}
+
+function toolMapByName(tools: StructuredToolInterface[] | undefined): Map<string, StructuredToolInterface> {
+  const map = new Map<string, StructuredToolInterface>();
+  for (const tool of tools ?? []) {
+    map.set(tool.name, tool);
+  }
+
+  return map;
+}
+
+/**
+ * Execute gated tool calls that the user approved but that have not run yet, record each
+ * outcome in the ledger, and return the outputs keyed by `toolCallId` so the history mapper
+ * can replay them as resolved call+result pairs on the resume turn.
+ */
+export async function executeApprovedTools(
+  tools: StructuredToolInterface[] | undefined,
+  ctx: AgentRuntimeContext
+): Promise<Map<string, ToolResultPayload>> {
+  const approved = findApprovedUnexecuted(ctx.history);
+  const results = new Map<string, ToolResultPayload>();
+  if (approved.length === 0) {
+    return results;
+  }
+
+  const byName = toolMapByName(tools);
+
+  for (const call of approved) {
+    const tool = byName.get(call.toolName);
+    if (!tool) {
+      continue;
+    }
+
+    const output = unwrapToolOutput(await tool.invoke((call.input ?? {}) as never));
+    results.set(call.toolCallId, { toolCallId: call.toolCallId, toolName: call.toolName, output });
+    ctx.emitToolResult({
+      toolCallId: call.toolCallId,
+      toolName: call.toolName,
+      output,
+      preview: `Tool "${call.toolName}" result`,
+    });
+  }
+
+  return results;
+}
+
+export type { ApprovedToolCall };

--- a/packages/framework/src/langchain/types.ts
+++ b/packages/framework/src/langchain/types.ts
@@ -1,0 +1,71 @@
+import type { LanguageModelLike } from '@langchain/core/language_models/base';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { AgentMiddleware } from 'langchain';
+import type {
+  AgentActionContext,
+  AgentHandlers,
+  AgentMessage,
+  AgentMessageContext,
+  MessageContent,
+  ReplyHandle,
+  ToolApprovalDecision,
+} from '../resources/agent/agent.types';
+import type { Awaitable } from '../types/util.types';
+
+/** A tool call surfaced to `needsApproval` before it executes. */
+export interface LangChainToolCall {
+  id?: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Declarative agent config the adapter runs on your behalf.
+ *
+ * Returning this from `onMessage` lets Novu own the tool-approval loop: gated
+ * tools pause the turn with an approval card and resume statelessly from
+ * `ctx.history` — no LangGraph checkpointer required.
+ */
+export interface LangChainAgentConfig {
+  /** Chat model instance or `"provider:model"` identifier passed to `createAgent`. */
+  model: string | LanguageModelLike;
+  /** Tools available to the agent. */
+  tools?: StructuredToolInterface[];
+  /** System prompt for the agent (forwarded to `createAgent` as `prompt`). */
+  system?: string;
+  /** Return `true` to gate a tool call behind a Novu approval card before it runs. */
+  needsApproval?: (toolCall: LangChainToolCall) => boolean;
+  /** Extra LangChain middleware, appended after Novu's approval middleware. */
+  middleware?: AgentMiddleware[];
+}
+
+/**
+ * Result of a LangChain agent/graph you invoked yourself (e.g. `await agent.invoke(...)`).
+ * Delivered as-is — tool approval is not managed by Novu on this path.
+ */
+export interface LangChainInvokeResult {
+  messages: BaseMessage[];
+}
+
+/** Anything a `@novu/framework/langchain` handler may return for automatic delivery. */
+export type LangChainResult = LangChainAgentConfig | LangChainInvokeResult | BaseMessage;
+
+/**
+ * Handlers for `@novu/framework/langchain` agents.
+ *
+ * Extends {@link AgentHandlers}: same events and config (`toolApproval`, etc.),
+ * but `onMessage` and `onToolApproval` may return a {@link LangChainResult} for
+ * automatic delivery.
+ */
+export type LangChainAgentHandlers = Omit<AgentHandlers, 'onMessage' | 'onToolApproval'> & {
+  onMessage: (message: AgentMessage, ctx: AgentMessageContext) => Awaitable<MessageContent | LangChainResult | void>;
+  /**
+   * Optional. Auto-resumes `onMessage` after approve/deny unless you return a
+   * `LangChainResult` to drive the resume yourself.
+   */
+  onToolApproval?: (
+    decision: ToolApprovalDecision,
+    ctx: AgentActionContext
+  ) => Awaitable<MessageContent | LangChainResult | ReplyHandle | void>;
+};

--- a/packages/framework/tsup.config.ts
+++ b/packages/framework/tsup.config.ts
@@ -14,6 +14,7 @@ const baseConfig: Options = {
     'src/validators.ts',
     ...frameworks.map((framework) => `src/servers/${framework}.ts`),
     'src/ai-sdk/index.ts',
+    'src/langchain/index.ts',
     'src/cards.ts',
   ],
   sourcemap: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,13 +445,13 @@ importers:
         version: 8.1.6
       '@sentry/nestjs':
         specifier: ^10.63.0
-        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@sentry/node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@sentry/profiling-node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@slack/types':
         specifier: 2.20.1
         version: 2.20.1
@@ -571,7 +571,7 @@ importers:
         version: 3.3.8
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1424,7 +1424,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1620,7 +1620,7 @@ importers:
         version: 11.5.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1814,7 +1814,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -3489,6 +3489,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
+      '@langchain/core':
+        specifier: ^1.1.44
+        version: 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0)
       '@nestjs/common':
         specifier: 11.1.27
         version: 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -3525,6 +3528,9 @@ importers:
       h3:
         specifier: ^1.15.9
         version: 1.15.9
+      langchain:
+        specifier: ^1.2.16
+        version: 1.2.16(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.21.0)(zod-to-json-schema@3.23.3(zod@3.25.20))
       madge:
         specifier: ^8.0.0
         version: 8.0.0(typescript@5.6.2)
@@ -34525,6 +34531,20 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  '@langchain/langgraph@1.1.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.23.3(zod@3.25.20))(zod@3.25.76)':
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 1.6.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@standard-schema/spec': 1.1.0
+      uuid: 11.1.1
+      zod: 3.25.76
+    optionalDependencies:
+      zod-to-json-schema: 3.23.3(zod@3.25.20)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@langchain/langgraph@1.1.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.20))(zod@3.25.20)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0)
@@ -36572,15 +36592,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.214.0
-      import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -36716,9 +36727,8 @@ snapshots:
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.39.0
-    optional: true
 
   '@opentelemetry/sdk-logs@0.201.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -36817,8 +36827,8 @@ snapshots:
   '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
@@ -40014,20 +40024,6 @@ snapshots:
     dependencies:
       '@sentry/core': 10.63.0
 
-  '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
-    dependencies:
-      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.27)(@nestjs/websockets@11.1.27)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.63.0
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
-
   '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -40042,17 +40038,17 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
       import-in-the-middle: 3.0.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
 
   '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
@@ -40076,13 +40072,13 @@ snapshots:
   '@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
       '@sentry/server-utils': 10.63.0
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
@@ -40107,7 +40103,7 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
@@ -40122,16 +40118,6 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-
-  '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
-    dependencies:
-      '@sentry/core': 10.63.0
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-      '@sentry/node-cpu-profiler': 2.4.2
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
 
   '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -51650,6 +51636,24 @@ snapshots:
 
   kysely@0.28.17: {}
 
+  langchain@1.2.16(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.21.0)(zod-to-json-schema@3.23.3(zod@3.25.20)):
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0)
+      '@langchain/langgraph': 1.1.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.23.3(zod@3.25.20))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))
+      langsmith: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0)
+      uuid: 11.1.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - ws
+      - zod-to-json-schema
+
   langchain@1.2.16(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@3.25.20)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0)
@@ -53323,25 +53327,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
-    dependencies:
-      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-      rxjs: 7.8.2
-    optionalDependencies:
-      '@nestjs/graphql': 12.0.9(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@24.0.0)
-    transitivePeerDependencies:
-      - '@apollo/subgraph'
-      - '@nestjs/core'
-      - bufferutil
-      - class-transformer
-      - class-validator
-      - graphql
-      - reflect-metadata
-      - ts-morph
-      - utf-8-validate
-
-  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))


### PR DESCRIPTION
### What changed? Why was the change needed?

Framework - support for the agents built with LangChain

### Screenshots
<img width="1729" height="1079" alt="Screenshot 2026-07-07 at 10 59 08" src="https://github.com/user-attachments/assets/621212e1-555d-4945-a3d7-cd92b7eeaa02" />

<img width="1726" height="1081" alt="Screenshot 2026-07-07 at 10 59 15" src="https://github.com/user-attachments/assets/45dfc388-522f-4cca-949d-705c4c776489" />


https://github.com/user-attachments/assets/1a831403-1ceb-4d5c-9fcc-d46677987d5c

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `@novu/framework/langchain` adapter for Novu agents. The main changes are:

- New LangChain history mapping from Novu agent ledger entries.
- Novu-managed LangChain tool approval pause and resume flow.
- Automatic delivery of LangChain agent results and final assistant text.
- New `./langchain` package export, build entry, peer dependencies, and lockfile updates.
- Unit coverage for history mapping, reply mapping, tool approval, and adapter behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are contained to a new optional LangChain adapter entrypoint and include focused tests for the changed flows. No verified functional or security issues were found in the reviewed code paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Performed the test/typecheck proof for the LangChain adapter to verify type safety.
- Executed the smoke script for the LangChain adapter to exercise core flows.
- Reviewed the smoke run output to confirm expected runtime behavior and results.

<a href="https://app.greptile.com/trex/runs/13517721/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/langchain/langchain-agent.ts | Wraps LangChain-style handlers as Novu agents and routes LangChain results through the reply mapper, including approval resume handling. |
| packages/framework/src/langchain/reply-mapper/index.ts | Adds LangChain result detection, agent invocation, approval middleware integration, result delivery, and tool-result persistence. |
| packages/framework/src/langchain/tool-approval.ts | Adds LangChain middleware and helpers for pausing gated tools, posting Novu approval cards, and executing approved tool calls on resume. |
| packages/framework/src/langchain/history-mapper/approval-cycles.ts | Adds approval-cycle reconstruction that pairs approval requests with denial or tool-result messages for LangChain replay. |
| packages/framework/package.json | Adds the `./langchain` subpath export, optional LangChain peer dependencies, and export-check handling for the optional entrypoint. |
| packages/framework/tsup.config.ts | Includes `src/langchain/index.ts` in both CJS and ESM framework builds. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Novu as Novu Agent Runtime
participant Adapter as LangChain Adapter
participant LC as LangChain Agent
participant Tool

User->>Novu: Incoming message / approval action
Novu->>Adapter: onMessage or onToolApproval with ctx.history
Adapter->>Adapter: executeApprovedTools(config.tools, ctx)
opt Approved gated tool exists
    Adapter->>Tool: invoke(approved input)
    Tool-->>Adapter: output
    Adapter->>Novu: emitToolResult(output)
end
Adapter->>Adapter: toLangChainMessages(ctx.history, freshResults)
Adapter->>LC: "createAgent(config).invoke({ messages })"
alt Tool requires approval
    LC-->>Adapter: NovuToolApprovalRequired
    Adapter->>Novu: emitToolApprovalRequest + reply(approval card)
    Novu-->>User: Approval card
else Agent completes
    Adapter->>Novu: emitExecutedToolResults + reply(final assistant text)
    Novu-->>User: Final response
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Novu as Novu Agent Runtime
participant Adapter as LangChain Adapter
participant LC as LangChain Agent
participant Tool

User->>Novu: Incoming message / approval action
Novu->>Adapter: onMessage or onToolApproval with ctx.history
Adapter->>Adapter: executeApprovedTools(config.tools, ctx)
opt Approved gated tool exists
    Adapter->>Tool: invoke(approved input)
    Tool-->>Adapter: output
    Adapter->>Novu: emitToolResult(output)
end
Adapter->>Adapter: toLangChainMessages(ctx.history, freshResults)
Adapter->>LC: "createAgent(config).invoke({ messages })"
alt Tool requires approval
    LC-->>Adapter: NovuToolApprovalRequired
    Adapter->>Novu: emitToolApprovalRequest + reply(approval card)
    Novu-->>User: Approval card
else Agent completes
    Adapter->>Novu: emitExecutedToolResults + reply(final assistant text)
    Novu-->>User: Final response
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(framework): add agent langchain ada..."](https://github.com/novuhq/novu/commit/1856e5cd05ecf1dc5637a7d8d3a89e35cd3f9e1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42310154)</sub>

<!-- /greptile_comment -->