### PR TITLE
fix(api-service): stop NovuBridgeModule from shadowing ClickHouse DI fixes NV-8217

### DIFF
--- a/apps/api/src/app/environments-v1/novu-bridge.module.ts
+++ b/apps/api/src/app/environments-v1/novu-bridge.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import {
   AnalyticsService,
-  ClickHouseService,
   CreateExecutionDetails,
   CreateVariablesObject,
   FeatureFlagsService,
@@ -10,7 +9,6 @@ import {
   GetLayoutUseCaseV0,
   InMemoryLRUCacheService,
   LayoutVariablesSchemaUseCase,
-  TraceLogRepository,
 } from '@novu/application-generic';
 import {
   CommunityOrganizationRepository,
@@ -84,8 +82,6 @@ export const featureFlagsService = {
     GetLayoutUseCase,
     JobRepository,
     ExecutionDetailsRepository,
-    TraceLogRepository,
-    ClickHouseService,
     CreateExecutionDetails,
     featureFlagsService,
     InMemoryLRUCacheService,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the community edition API e2e failure on `should emit exactly one workflow_run_status_completed trace for a multi-step workflow`.

`NovuBridgeModule` re-declared `ClickHouseService` and `TraceLogRepository` as plain class providers, which shadowed the initialized `clickHouseService` factory from `SharedModule`. When tests called `session.testServer.getService(TraceLogRepository)`, Nest resolved the bridge module's copy backed by an uninitialized `ClickHouseService`, causing `Query failed: ClickHouse client not initialized`.

## Changes

- Removed duplicate `ClickHouseService` and `TraceLogRepository` providers from `NovuBridgeModule`
- Bridge module now relies on `SharedModule` exports, which use the `clickHouseService` factory that calls `init()`

## Why this only surfaced in CE e2e

This was not a contributor-permissions issue. The CE suite (`test:e2e:novu-v2-ce`) is the only shard that includes a test querying `TraceLogRepository` via DI; the enterprise equivalent (`process-inbound-webhook.e2e.ts`) is excluded from CE runs.

## Verification

After bootstrap in CE mode (`CI_EE_TEST=false`):

**Before:**
```json
{"traceCh":false,"wfCh":true,"appCh":false,"traceIsAppCh":true,"wfIsAppCh":false}
```

**After:**
```json
{"traceCh":true,"wfCh":true,"appCh":true,"traceIsAppCh":true,"wfIsAppCh":true}
```

## Test plan

- [x] Verified `app.get(TraceLogRepository)` resolves to initialized ClickHouse client after bootstrap
- [ ] CI: community edition API e2e shard containing `trigger-event.e2e.ts` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d258ef5-d358-4c2d-9495-4c8ed54c23f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d258ef5-d358-4c2d-9495-4c8ed54c23f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes provider wiring in `NovuBridgeModule`. The main changes are:

- Removed duplicate `TraceLogRepository` registration from the bridge module.
- Removed duplicate `ClickHouseService` registration from the bridge module.
- Let the bridge module use the initialized analytics providers exported by `SharedModule`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is a small DI cleanup, and `SharedModule` exports both `TraceLogRepository` and the initialized `clickHouseService` provider used by importing modules.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The explicit CE regression command was attempted with environment variables and Mocha options, but the run exited before the target test due to a module resolution failure in a core dependency while loading the e2e setup.
- A build-and-rerun attempt was logged, reaching tsc -p tsconfig.json but not completing before the execution timeout, with the TypeScript compiler still running; the lingering process was targeted for cleanup and logged.
- A narrower Nest DI probe was written to try resolving TraceLogRepository and ClickHouseService through NovuBridgeModule, but execution failed before Nest bootstrap because reflect-metadata could not be resolved, and no ClickHouse initialization or DI evidence was produced.
- No PR behavior failure was proven, and no severity-bearing finding was reported.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/environments-v1/novu-bridge.module.ts | Removes duplicate analytics providers so `NovuBridgeModule` uses `SharedModule`'s initialized ClickHouse-backed repository setup. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Test as CE e2e / App context
participant Bridge as NovuBridgeModule
participant Shared as SharedModule
participant TraceRepo as TraceLogRepository
participant CH as clickHouseService factory

Test->>Bridge: resolve TraceLogRepository
Bridge->>Shared: use exported provider
Shared->>CH: create and init ClickHouseService
CH-->>Shared: initialized client-backed service
Shared->>TraceRepo: inject initialized ClickHouseService
TraceRepo-->>Test: repository with ready ClickHouse client
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Test as CE e2e / App context
participant Bridge as NovuBridgeModule
participant Shared as SharedModule
participant TraceRepo as TraceLogRepository
participant CH as clickHouseService factory

Test->>Bridge: resolve TraceLogRepository
Bridge->>Shared: use exported provider
Shared->>CH: create and init ClickHouseService
CH-->>Shared: initialized client-backed service
Shared->>TraceRepo: inject initialized ClickHouseService
TraceRepo-->>Test: repository with ready ClickHouse client
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): stop NovuBridgeModule ..."](https://github.com/novuhq/novu/commit/4f2b38bc7c25b02c66624842aab7ac8ead1b6b4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42315777)</sub>

<!-- /greptile_comment -->