### PR TITLE
docs(novu): update novu and framework READMEs for agent connect story fixes DOC-405

### DIFF
--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -7,14 +7,17 @@
   </a>
 </div>
 
-# Code-First Notifications Workflow SDK
+# Novu Framework
 
 [![Version](https://img.shields.io/npm/v/@novu/framework.svg)](https://www.npmjs.org/package/@novu/framework)
 [![Downloads](https://img.shields.io/npm/dm/@novu/framework.svg)](https://www.npmjs.com/package/@novu/framework)
 
-Novu Framework allows you to write notification workflows in your codebase. Workflows are functions that execute business logic and use your preferred libraries for email, SMS, and chat generation. You can use Novu Framework with [React.Email](https://react.email/), [MJML](https://mjml.io/), or any other template generator.
+`@novu/framework` is Novu's code-first SDK for two things:
 
-Learn more about the Code-First Notifications Workflow SDK in our [docs](https://docs.novu.co/framework/quickstart).
+1. **Conversational agents** — define bridge agents in your codebase and connect them to Slack, Email, Telegram, WhatsApp, and Microsoft Teams with `npx novu connect`.
+2. **Notification workflows** — write durable, multi-channel notification flows as TypeScript functions.
+
+Learn more in the [Framework docs](https://docs.novu.co/framework/quickstart) and [managed agent quickstart](https://docs.novu.co/agents/managed-agent/quickstart).
 
 ## Installation
 
@@ -22,14 +25,83 @@ Learn more about the Code-First Notifications Workflow SDK in our [docs](https:/
 npm install @novu/framework
 ```
 
-## Quickstart
+## Connect an agent to channels
+
+The fastest path is the Novu CLI — it creates the agent in Novu Cloud, provisions channel credentials, and (for bridge runtimes) wires your local app:
+
+```bash
+npx novu@latest connect
+```
+
+For a self-hosted agent in your repo, pick a bridge runtime when prompted, or pass one explicitly:
+
+```bash
+# Vercel AI SDK agent
+npx novu@latest connect --runtime ai-sdk
+
+# Chat SDK multi-channel agent
+npx novu@latest connect --runtime chat-sdk
+```
+
+Re-run `npx novu connect` to add another channel. Each run connects one channel to one agent.
+
+## Bridge agents
+
+Define agents in your codebase and serve them on a Novu bridge endpoint. Use `@novu/framework/ai-sdk` when your agent is built with the [Vercel AI SDK](https://ai-sdk.dev/):
+
+```typescript
+import { serve } from '@novu/framework/next';
+import { agent } from '@novu/framework/ai-sdk';
+import { streamText } from 'ai';
+import { anthropic } from '@ai-sdk/anthropic';
+
+const supportAgent = agent('support-bot', {
+  onMessage: async (message, ctx) => {
+    const result = streamText({
+      model: anthropic('claude-sonnet-4-20250514'),
+      messages: await ctx.toModelMessages(),
+    });
+
+    return result;
+  },
+});
+
+const { GET, POST, OPTIONS } = serve({ agents: [supportAgent] });
+```
+
+For custom handlers without the AI SDK, use the core `agent()` export:
+
+```typescript
+import { agent } from '@novu/framework';
+import { serve } from '@novu/framework/next';
+
+const supportAgent = agent('support-bot', {
+  onMessage: async (message, ctx) => {
+    await ctx.reply(`You said: ${message.text}`);
+  },
+});
+
+const { GET, POST, OPTIONS } = serve({ agents: [supportAgent] });
+```
+
+After your bridge is running, connect channels:
+
+```bash
+npx novu@latest connect --runtime ai-sdk --channel slack
+npx novu@latest sync -b https://your-app.com/api/novu -s "$NOVU_SECRET_KEY"
+```
+
+Bridge runtimes supported by `novu connect`: `ai-sdk`, `langchain`, `custom-code`, `chat-sdk`.
+
+## Notification workflows
+
+Write notification workflows as functions that execute business logic and use your preferred libraries for email, SMS, and chat generation. Use [React.Email](https://react.email/), [MJML](https://mjml.io/), or any other template generator.
 
 ```typescript
 import { workflow, CronExpression } from '@novu/framework';
 import { serve } from '@novu/framework/next';
 import { z } from 'zod';
 
-// Define your notification workflow
 const weeklyComments = workflow(
   'comment-on-post',
   async ({ payload, step }) => {
@@ -48,9 +120,7 @@ const weeklyComments = workflow(
         body: `Weekly digest: ${weeklyDigest.events.map(({ payload }) => payload.comment).join(', ')}`,
       }),
       {
-        // Skip the notification if the weekly digest is empty
         skip: () => weeklyDigest.events.length === 0,
-        // Non-technical stakeholders can modify strongly-validated copy in Novu Cloud
         controlSchema: z.object({ prefix: z.string().describe('The prefix of the subject.').default('Hi!') }),
       }
     );
@@ -58,9 +128,44 @@ const weeklyComments = workflow(
   { payloadSchema: z.object({ comment: z.string().describe('The comment on the post.') }) }
 );
 
-// Use your favorite framework to serve your workflows
 const { GET, POST, OPTIONS } = serve({ workflows: [weeklyComments] });
 
-// Trigger your notification workflow
 weeklyComments.trigger({ to: 'user:123', comment: 'This is a comment on a post' });
 ```
+
+Sync workflows with Novu Cloud:
+
+```bash
+npx novu@latest sync -b https://your-app.com/api/novu -s "$NOVU_SECRET_KEY"
+```
+
+For local workflow development with Novu Studio, see the [Novu CLI `dev` command](../novu/README.MD#local-novu-studio).
+
+## Framework adapters
+
+Serve workflows and agents from your framework of choice:
+
+| Import | Framework |
+| --- | --- |
+| `@novu/framework/next` | Next.js |
+| `@novu/framework/nest` | NestJS |
+| `@novu/framework/express` | Express |
+| `@novu/framework/h3` | H3 / Nuxt |
+| `@novu/framework/lambda` | AWS Lambda |
+| `@novu/framework/sveltekit` | SvelteKit |
+| `@novu/framework/remix` | Remix |
+
+Additional exports:
+
+| Import | Purpose |
+| --- | --- |
+| `@novu/framework/ai-sdk` | Vercel AI SDK agent helpers |
+| `@novu/framework/step-resolver` | Deploy custom step handlers |
+| `@novu/framework/validators` | Schema validation utilities |
+
+## Links
+
+- [Managed agent quickstart](https://docs.novu.co/agents/managed-agent/quickstart)
+- [Framework quickstart](https://docs.novu.co/framework/quickstart)
+- [Novu CLI](../novu/README.MD)
+- [Chat SDK adapter](https://www.npmjs.com/package/@novu/chat-sdk-adapter)

--- a/packages/novu/README.MD
+++ b/packages/novu/README.MD
@@ -7,170 +7,234 @@
   </a>
 </div>
 
-# Code-First Notifications Workflow Platform
+# Novu CLI
 
-  <p align="center">
-    <br />
-    <a href="https://docs.novu.co" rel="dofollow"><strong>Explore the docs »</strong></a>
-    <br />
+[![Version](https://img.shields.io/npm/v/novu.svg)](https://www.npmjs.org/package/novu)
+[![Downloads](https://img.shields.io/npm/dm/novu.svg)](https://www.npmjs.com/package/novu)
 
-  <br/>
-    <a href="https://github.com/novuhq/novu/issues/new?assignees=&labels=type%3A+bug&template=bug_report.yml&title=%F0%9F%90%9B+Bug+Report%3A+">Report Bug</a>
-    ·
-    <a href="https://github.com/novuhq/novu/issues/new?assignees=&labels=feature&template=feature_request.yml&title=%F0%9F%9A%80+Feature%3A+">Request Feature</a>
-    ·
-  <a href="https://discord.novu.co">Join Our Discord</a>
-    ·
-    <a href="https://roadmap.novu.co/">Roadmap</a>
-    ·
-    <a href="https://twitter.com/novuhq">X</a>
-  </p>
+The Novu CLI connects AI agents to real communication channels — Slack, Email, Telegram, WhatsApp, and Microsoft Teams — without wiring each provider yourself.
 
-## 🚀 Quickstart
+Describe what your agent should do, pick a channel, and Novu provisions credentials, identity, and delivery so your agent can message users where they already are.
+
+Learn more in the [managed agent quickstart](https://docs.novu.co/agents/managed-agent/quickstart).
+
+## Quickstart
+
+```bash
+npx novu@latest connect
+```
+
+The interactive flow:
+
+1. **Choose a runtime** — demo credentials (fastest), Claude managed agents, AWS Claude, or a self-hosted bridge (`ai-sdk`, `langchain`, `custom-code`, `chat-sdk`).
+2. **Describe your agent** — Novu generates the system prompt, tools, MCP servers, and skills from your description.
+3. **Pick a channel** — Slack, Email, Telegram, WhatsApp, Microsoft Teams, or skip for now.
+4. **Finish the handoff** — the CLI guides you through the last step (Slack OAuth, send a test email, BotFather token, etc.).
+
+When the run succeeds, your agent is live on the connected channel. Re-run `npx novu connect` to add another channel or create another agent.
+
+### Keyless try-before-sign-up
+
+Try Novu without an account:
+
+```bash
+npx novu@latest connect "A support assistant for Acme's customers that answers billing questions." \
+  --keyless \
+  --channel slack
+```
+
+Keyless creates a temporary demo agent (~5 free replies). Claim it via the in-channel sign-up link to move the agent into your workspace.
+
+### Connect a self-hosted Chat SDK agent
+
+If your agent runs in your codebase with the [Chat SDK adapter](https://www.npmjs.com/package/@novu/chat-sdk-adapter):
+
+```bash
+npx novu@latest connect --runtime chat-sdk
+```
+
+The CLI authenticates your Novu account, creates a bridge agent, writes `NOVU_SECRET_KEY` and `NOVU_AGENT_IDENTIFIER` to your env, and opens the channel picker.
+
+## Channels
+
+| Channel | What the CLI sets up |
+| --- | --- |
+| **Slack** | Creates the Slack app, stores OAuth credentials, opens the install flow |
+| **Email** | Provisions a unique inbound address (e.g. `my-agent@agentconnect.sh`) |
+| **Telegram** | Links your @BotFather bot token |
+| **WhatsApp** | Hands off to the Novu dashboard to finish provider setup |
+| **Microsoft Teams** | Hands off to the Novu dashboard to finish provider setup |
+
+One `connect` run creates one agent and connects one channel. Run it again to add more channels (each run creates a new agent unless you pick an existing one).
+
+## Authentication
+
+| Mode | When to use | How |
+| --- | --- | --- |
+| **Dashboard OAuth** (default) | You have or want a Novu account | Omit `--keyless` and `--secret-key`; approve in the browser |
+| **Keyless** | Try Novu without signing up | Pass `--keyless` |
+| **Secret key** | CI or existing automation | Pass `--secret-key` or set `NOVU_SECRET_KEY` |
+
+WhatsApp and Microsoft Teams require dashboard OAuth — they are not supported with `--keyless` in non-interactive mode.
+
+## CLI commands
+
+| Command | Description |
+| --- | --- |
+| `connect` | Create a managed or bridge agent and connect it to a channel |
+| `init` | Scaffold a new Novu app (`notifications`, `agent`, or `chat-sdk` template) |
+| `sync` | Sync bridge workflow state with Novu Cloud |
+| `dev` | Start local Novu Studio and a tunnel to your bridge app |
+| `translations pull` | Pull translation files from Novu Cloud |
+| `translations push` | Push translation files to Novu Cloud |
+| `step publish` | Bundle and deploy step handlers to Novu |
+
+Run `npx novu@latest <command> --help` for full flags and examples.
+
+### `connect`
+
+Create a managed agent and connect it to a channel.
+
+```bash
+# Interactive (recommended)
+npx novu@latest connect
+
+# Non-interactive / CI
+npx novu@latest connect "An onboarding assistant for Acme's new members." \
+  --ci \
+  --channel email
+
+# Keyless Slack
+npx novu@latest connect "A support assistant for Acme's customers." \
+  --ci \
+  --keyless \
+  --channel slack
+
+# Chat SDK bridge (no prompt required)
+npx novu@latest connect \
+  --runtime chat-sdk \
+  --secret-key "$NOVU_SECRET_KEY" \
+  --channel telegram
+```
+
+**Runtimes:** `demo` (default), `claude`, `claude-aws`, `ai-sdk`, `langchain`, `custom-code`, `chat-sdk`
+
+**Channels:** `slack`, `email`, `telegram`, `whatsapp`, `teams`, `skip`
+
+**Common flags:**
+
+| Flag | Description |
+| --- | --- |
+| `--ci` | Non-interactive mode (requires prompt and `--channel`) |
+| `--keyless` | Temporary demo agent; claim via in-channel sign-up |
+| `--secret-key <key>` | Use an existing Novu account |
+| `--region <us\|eu>` | Target Novu Cloud region (default: `us`) |
+| `--runtime <mode>` | Agent runtime or bridge mode |
+| `--channel <name>` | Channel to connect |
+| `--slack-config-token <token>` | CI escape hatch for Slack (prefer the secure setup page) |
+| `--telegram-bot-token <token>` | CI escape hatch for Telegram (prefer the secure setup page) |
+
+For the full non-interactive contract, machine-readable stdout markers, and AI-agent onboarding guide, see [`packages/shared/docs/agent-onboarding.md`](../shared/docs/agent-onboarding.md) or run `npx novu@latest connect --help`.
+
+### `init`
+
+Scaffold a new Novu application.
+
+```bash
+npx novu@latest init
+npx novu@latest init --template chat-sdk
+npx novu@latest init --template agent --agent-identifier my-agent
+```
+
+| Flag | Description |
+| --- | --- |
+| `-s, --secret-key <key>` | Novu development environment secret key |
+| `-a, --api-url <url>` | Novu Cloud API URL (default: `https://api.novu.co`) |
+| `-t, --template <name>` | Template: `notifications`, `agent`, or `chat-sdk` |
+| `--agent-identifier <id>` | Agent identifier for the scaffolded template |
+
+### `sync`
+
+Sync your bridge endpoint state with Novu Cloud.
+
+```bash
+npx novu@latest sync -b https://acme.org/api/novu -s "$NOVU_SECRET_KEY"
+npx novu@latest sync -b https://acme.org/api/novu -s "$NOVU_SECRET_KEY" -a https://eu.api.novu.co
+```
+
+| Flag | Description |
+| --- | --- |
+| `-b, --bridge-url <url>` | Bridge endpoint URL (required) |
+| `-s, --secret-key <key>` | Novu secret key (required) |
+| `-a, --api-url <url>` | Novu Cloud API URL (default: `https://api.novu.co`) |
+
+### `translations`
+
+Manage Novu translation files.
+
+```bash
+npx novu@latest translations pull -s "$NOVU_SECRET_KEY" -d ./translations
+npx novu@latest translations push -s "$NOVU_SECRET_KEY" -d ./translations
+```
+
+| Flag | Description |
+| --- | --- |
+| `-s, --secret-key <key>` | Novu secret key |
+| `-a, --api-url <url>` | Novu Cloud API URL |
+| `-d, --directory <path>` | Local translations directory (default: `./translations`) |
+
+### `step publish`
+
+Bundle and deploy step handlers to Novu.
+
+```bash
+npx novu@latest step publish -s "$NOVU_SECRET_KEY"
+npx novu@latest step publish -s "$NOVU_SECRET_KEY" --workflow my-workflow --dry-run
+```
+
+| Flag | Description |
+| --- | --- |
+| `-s, --secret-key <key>` | Novu API secret key |
+| `-a, --api-url <url>` | Novu API URL |
+| `-c, --config <path>` | Path to config file |
+| `--out <path>` | Directory containing step handlers |
+| `--workflow <id...>` | Deploy only specific workflows |
+| `--step <id...>` | Deploy only specific steps (requires `--workflow`) |
+| `--template <path>` | React Email template path |
+| `--dry-run` | Bundle without deploying |
+
+## Local Novu Studio
+
+Use `dev` when you are building code-first notification workflows with [`@novu/framework`](../framework) and want a local Studio + tunnel to your bridge app.
 
 ```bash
 npx novu@latest dev
 ```
 
-## 🔥 Flags
+| Flag | Long form | Description | Default |
+| --- | --- | --- | --- |
+| `-p` | `--port <port>` | Bridge application port | `4000` |
+| `-r` | `--route <route>` | Bridge application route | `/api/novu` |
+| `-o` | `--origin <origin>` | Bridge application origin | `http://localhost` |
+| `-d` | `--dashboard-url <url>` | Novu Cloud dashboard URL | `https://dashboard.novu.co` |
+| `-sp` | `--studio-port <port>` | Local Studio server port | `2022` |
+| `-sh` | `--studio-host <host>` | Local Studio server host | `localhost` |
+| `-t` | `--tunnel <url>` | Self-hosted tunnel URL | — |
+| `-H` | `--headless` | Run bridge in headless mode | `false` |
+| | `--no-studio` | Skip starting local Studio | — |
+| | `--run <command>` | Spawn a local app server before opening the tunnel | — |
 
-| flag | long form usage example | description                 | default value             |
-| ---- | ----------------------- | --------------------------- | ------------------------- |
-| -p   | --port <port>           | Bridge application port     | 4000                      |
-| -r   | --route <route>         | Bridge application route    | /api/novu                 |
-| -o   | --origin <origin>       | Bridge application origin   | http://localhost          |
-| -d   | --dashboard-url <url>   | Novu Cloud dashboard URL    | https://dashboard.novu.co |
-| -sp  | --studio-port <port>    | Local Studio server port    | 2022                      |
-| -sh  | --studio-host <host>    | Local Studio server host    | localhost                 |
-| -t   | --tunnel <url>          | Self hosted tunnel url      | null                      |
-| -H   | --headless              | Run bridge in headless mode | false                     |
-
-Example: If bridge application is running on port `3002` and Novu account is in `EU` region.
+Example — bridge on port `3002` with an EU dashboard:
 
 ```bash
 npx novu@latest dev --port 3002 --dashboard-url https://eu.dashboard.novu.co
 ```
 
-## ⭐️ Why
+## Links
 
-Building a notification system is hard, at first it seems like just sending an email but in reality it's just the beginning. In today's world users expect multichannel communication experience over email, sms, push, chat and more... An ever-growing list of providers are popping up each day, and notifications are spread around the code. Novu's goal is to simplify notifications and provide developers the tools to create meaningful communication between the system and its users.
-
-## ✨ Features
-
-- 🌈 Single API for all messaging provide`rs (Email, SMS, Push, Chat)
-- 💅 Easily manage notification over multiple channels
-- 🚀 Equipped with a CMS for advanced layouts and design management
-- 🛡 Built-in protection for missing variables (Coming Soon)
-- 📦 Easy to set up and integrate
-- 🛡 Debug and analyze multichannel messages in a single dashboard
-- 📦 Embeddable notification center with real-time updates
-- 👨‍💻 Community driven
-
-## 🚀 Getting Started
-
-To start using Novu, run the following command. You'll be guided through the setup process.
-
-```bash
-npx novu init
-```
-
-After setting up your account using the cloud or docker version you can trigger the API using the `@novu/api` package.
-
-```bash
-npm install @novu/api
-```
-
-```ts
-import { Novu } from '@novu/api';
-
-const novu = new Novu({ secretKey: process.env.NOVU_API_KEY });
-
-await novu.trigger('<WORKFLOW_ID>', {
-  to: {
-    subscriberId: '<SUBSCRIBER_ID>',
-    email: 'john@doemail.com',
-    firstName: 'John',
-    lastName: 'Doe',
-  },
-  payload: {
-    name: 'Hello World',
-    organization: {
-      logo: 'https://happycorp.com/logo.png',
-    },
-  },
-});
-```
-
-## Inbox
-
-Using the Novu API and admin panel you can easily add real-time notification center to your Next.js or React application without the hassle of building it yourself.
-
-<div align="center">
-<img width="762" alt="notification-center-912bb96e009fb3a69bafec23bcde00b0" src="https://github.com/iampearceman/Design-assets/blob/main/Untitled%20design%20(8).gif?raw=true">
-  
-  Read more about how to add a notification center to your app with the Novu API [here](https://docs.novu.co/platform/inbox/overview?utm_campaign=inapp-cli-readme)
-
-</div>
-
-## Providers
-
-Novu provides a single API to manage providers across multiple channels with a simple-to-use interface.
-
-#### 💌 Email
-
-- [x] [Sendgrid](https://github.com/novuhq/novu/tree/main/providers/sendgrid)
-- [x] [Netcore](https://github.com/novuhq/novu/tree/main/providers/netcore)
-- [x] [Mailgun](https://github.com/novuhq/novu/tree/main/providers/mailgun)
-- [x] [SES](https://github.com/novuhq/novu/tree/main/providers/ses)
-- [x] [Postmark](https://github.com/novuhq/novu/tree/main/providers/postmark)
-- [x] [NodeMailer](https://github.com/novuhq/novu/tree/main/providers/nodemailer)
-- [x] [Mailjet](https://github.com/novuhq/novu/tree/main/providers/mailjet)
-- [x] [Mandrill](https://github.com/novuhq/novu/tree/main/providers/mandrill)
-- [x] [SendinBlue](https://github.com/novuhq/novu/tree/main/providers/sendinblue)
-- [x] [EmailJS](https://github.com/novuhq/novu/tree/main/providers/emailjs)
-- [ ] SparkPost
-
-#### 📞 SMS
-
-- [x] [Twilio](https://github.com/novuhq/novu/tree/main/providers/twilio)
-- [x] [Plivo](https://github.com/novuhq/novu/tree/main/providers/plivo)
-- [x] [SNS](https://github.com/novuhq/novu/tree/main/providers/sns)
-- [x] [Nexmo - Vonage](https://github.com/novuhq/novu/tree/main/providers/nexmo)
-- [x] [Sms77](https://github.com/novuhq/novu/tree/main/providers/sms77)
-- [x] [Telnyx](https://github.com/novuhq/novu/tree/main/providers/telnyx)
-- [x] [Termii](https://github.com/novuhq/novu/tree/main/providers/termii)
-- [x] [Gupshup](https://github.com/novuhq/novu/tree/main/providers/gupshup)
-- [ ] Bandwidth
-- [ ] RingCentral
-
-#### 📱 Push
-
-- [x] [FCM](https://github.com/novuhq/novu/tree/main/providers/fcm)
-- [x] [Expo](https://github.com/novuhq/novu/tree/main/providers/expo)
-- [ ] [SNS](https://github.com/novuhq/novu/tree/main/providers/sns)
-- [ ] Pushwoosh
-
-#### 👇 Chat
-
-- [x] [Slack](https://github.com/novuhq/novu/tree/main/providers/slack)
-- [x] [Discord](https://github.com/novuhq/novu/tree/main/providers/discord)
-- [ ] MS Teams
-- [ ] Mattermost
-
-#### 📱 In-App
-
-- [x] [Novu](https://docs.novu.co/notification-center/introduction?utm_campaign=inapp-cli-readme)
-
-#### Other (Coming Soon...)
-
-- [ ] PagerDuty
-
-## 💻 Need Help?
-
-We are more than happy to help you. Don't worry if you are getting some errors or problems while working with the project. Or just want to discuss something related to the project.
-
-Just <a href="https://discord.novu.co">Join Our Discord</a> server and ask for help.
-
-## 🔗 Links
-
-- [Home page](https://novu.co/)
+- [Managed agent docs](https://docs.novu.co/agents/managed-agent/quickstart)
+- [Agent onboarding guide for AI assistants](../shared/docs/agent-onboarding.md)
+- [Novu documentation](https://docs.novu.co)
+- [Discord community](https://discord.novu.co)
+- [Report a bug](https://github.com/novuhq/novu/issues/new?assignees=&labels=type%3A+bug&template=bug_report.yml&title=%F0%9F%90%9B+Bug+Report%3A+)
+- [Request a feature](https://github.com/novuhq/novu/issues/new?assignees=&labels=feature&template=feature_request.yml&title=%F0%9F%9A%80+Feature%3A+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `novu` and `@novu/framework` package READMEs to reflect the current agent connectivity story.

- **`packages/novu/README.MD`**: Centers on `npx novu connect` as the primary quickstart, documents channel connectivity (Slack, Email, Telegram, WhatsApp, Teams), auth modes, and all current CLI commands (`connect`, `init`, `sync`, `translations`, `step publish`). Moves local Novu Studio (`novu dev`) to the bottom of the page.
- **`packages/framework/README.md`**: Adds bridge agent and `novu connect` guidance alongside the existing notification workflow quickstart.

## Why

The published READMEs still led with `novu dev` and legacy notification/inbox content. The CLI's primary user-facing flow is now agent onboarding via `novu connect`, and the docs should match.

## Test plan

- [x] Verified CLI help output matches documented commands and flags
- [x] Reviewed README structure: connect-first, Studio last
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97fcd03e-de16-4380-954d-99b3d145495c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97fcd03e-de16-4380-954d-99b3d145495c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `novu` and `@novu/framework` package READMEs for the current agent connection flow. The main changes are:

- `packages/novu/README.MD` now leads with `npx novu connect` and documents channels, auth modes, and CLI commands.
- `packages/framework/README.md` now explains bridge agents alongside notification workflows.
- Local Novu Studio guidance is moved lower in the CLI README.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changed README command names and examples match the reviewed CLI registration and framework exports.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the CLI docs build and the initial run failed due to a missing @novu/shared type/module, signaling a sandbox/build prerequisite blocker.
- After adding/building the @novu/shared dependency, the CLI docs build completed successfully and all requested help commands ran with exit code 0.
- The generated comparison log shows the documented flags and commands mostly matched, with a single overly strict description regex for top-level connect; the captured help shows connect \[options\] \[prompt\] Create a managed agent and connect it to a channel, aligning with the README intent, and Markdownlint exited 0.

<a href="https://app.greptile.com/trex/runs/13522843/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/README.md | Reframes the framework README around agent bridge setup and notification workflows. |
| packages/novu/README.MD | Rewrites the CLI README to lead with `novu connect` and document current CLI usage. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant CLI as Novu CLI README
participant Connect as npx novu connect
participant Cloud as Novu Cloud
participant Channel as Slack/Email/Telegram/WhatsApp/Teams
participant Bridge as Framework bridge app

User->>CLI: Follow connect-first quickstart
CLI->>Connect: Run connect command
Connect->>Cloud: Create or select agent and auth mode
Connect->>Channel: Provision or hand off channel setup
alt Self-hosted bridge runtime
    User->>Bridge: "Define agent with @novu/framework"
    User->>Connect: Sync bridge endpoint
    Connect->>Cloud: Register bridge agent state
end
Channel-->>User: Agent is live on selected channel
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant CLI as Novu CLI README
participant Connect as npx novu connect
participant Cloud as Novu Cloud
participant Channel as Slack/Email/Telegram/WhatsApp/Teams
participant Bridge as Framework bridge app

User->>CLI: Follow connect-first quickstart
CLI->>Connect: Run connect command
Connect->>Cloud: Create or select agent and auth mode
Connect->>Channel: Provision or hand off channel setup
alt Self-hosted bridge runtime
    User->>Bridge: "Define agent with @novu/framework"
    User->>Connect: Sync bridge endpoint
    Connect->>Cloud: Register bridge agent state
end
Channel-->>User: Agent is live on selected channel
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(novu): update novu and framework RE..."](https://github.com/novuhq/novu/commit/6ab7ae213fa89f4bedc694947b44112aa3bcfcf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42320002)</sub>

<!-- /greptile_comment -->