### PR TITLE
fix(webhook): verify provider webhook signatures before processing fixes NV-8185

### DIFF
--- a/apps/webhook/src/bootstrap.ts
+++ b/apps/webhook/src/bootstrap.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { getErrorInterceptor, Logger } from '@novu/application-generic';
-import { json } from 'express';
+import { json, urlencoded } from 'express';
 import type { IncomingMessage } from 'node:http';
 
 import { AppModule } from './app.module';
@@ -13,6 +13,18 @@ const WEBHOOK_ROUTE_PATTERN =
 
 function isWebhookRoute(path: string, method: string): boolean {
   return method === 'POST' && WEBHOOK_ROUTE_PATTERN.test(path);
+}
+
+function getContentType(req: IncomingMessage): string {
+  const contentType = req.headers['content-type'];
+
+  if (!contentType) {
+    return '';
+  }
+
+  const value = Array.isArray(contentType) ? contentType[0] : contentType;
+
+  return value.split(';')[0]?.trim().toLowerCase() ?? '';
 }
 
 const captureRawBody = (req: IncomingMessage, _res: unknown, buffer: Buffer): void => {
@@ -25,11 +37,31 @@ export async function bootstrap(): Promise<INestApplication> {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true, bodyParser: false });
 
   app.use((req, res, next) => {
+    if (!isWebhookRoute(req.path, req.method)) {
+      return next();
+    }
+
+    if (getContentType(req) === 'application/x-www-form-urlencoded') {
+      return urlencoded({ extended: true, verify: captureRawBody })(req, res, next);
+    }
+
+    return json({ verify: captureRawBody })(req, res, next);
+  });
+
+  app.use((req, res, next) => {
     if (isWebhookRoute(req.path, req.method)) {
-      return json({ verify: captureRawBody })(req, res, next);
+      return next();
     }
 
     return json()(req, res, next);
+  });
+
+  app.use((req, res, next) => {
+    if (isWebhookRoute(req.path, req.method)) {
+      return next();
+    }
+
+    return urlencoded({ extended: true })(req, res, next);
   });
 
   app.useLogger(app.get(Logger));

--- a/apps/webhook/src/bootstrap.ts
+++ b/apps/webhook/src/bootstrap.ts
@@ -1,12 +1,13 @@
 import './instrument';
 import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { getErrorInterceptor, Logger } from '@novu/application-generic';
 
 import { AppModule } from './app.module';
 
 export async function bootstrap(): Promise<INestApplication> {
-  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true, rawBody: true });
 
   app.useLogger(app.get(Logger));
   app.flushLogs();

--- a/apps/webhook/src/bootstrap.ts
+++ b/apps/webhook/src/bootstrap.ts
@@ -3,11 +3,34 @@ import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { getErrorInterceptor, Logger } from '@novu/application-generic';
+import { json } from 'express';
+import type { IncomingMessage } from 'node:http';
 
 import { AppModule } from './app.module';
 
+const WEBHOOK_ROUTE_PATTERN =
+  /^\/webhooks\/organizations\/[^/]+\/environments\/[^/]+\/(email|sms)\/[^/]+$/;
+
+function isWebhookRoute(path: string, method: string): boolean {
+  return method === 'POST' && WEBHOOK_ROUTE_PATTERN.test(path);
+}
+
+const captureRawBody = (req: IncomingMessage, _res: unknown, buffer: Buffer): void => {
+  if (buffer?.length) {
+    (req as IncomingMessage & { rawBody?: Buffer }).rawBody = Buffer.from(buffer);
+  }
+};
+
 export async function bootstrap(): Promise<INestApplication> {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true, rawBody: true });
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true, bodyParser: false });
+
+  app.use((req, res, next) => {
+    if (isWebhookRoute(req.path, req.method)) {
+      return json({ verify: captureRawBody })(req, res, next);
+    }
+
+    return json()(req, res, next);
+  });
 
   app.useLogger(app.get(Logger));
   app.flushLogs();

--- a/apps/webhook/src/webhooks/helpers/normalize-headers.ts
+++ b/apps/webhook/src/webhooks/helpers/normalize-headers.ts
@@ -1,0 +1,5 @@
+export function normalizeHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value.join(', ') : (value ?? '')])
+  );
+}

--- a/apps/webhook/src/webhooks/usecases/webhook/webhook.command.ts
+++ b/apps/webhook/src/webhooks/usecases/webhook/webhook.command.ts
@@ -11,5 +11,10 @@ export class WebhookCommand extends EnvironmentCommand {
   body: any;
 
   @IsDefined()
+  headers: Record<string, string>;
+
+  rawBody: Buffer | undefined;
+
+  @IsDefined()
   type: WebhookTypes;
 }

--- a/apps/webhook/src/webhooks/usecases/webhook/webhook.usecase.ts
+++ b/apps/webhook/src/webhooks/usecases/webhook/webhook.usecase.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, Injectable, Logger, NotFoundException, Scope } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  Scope,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { AnalyticsService, IMailHandler, ISmsHandler, MailFactory, SmsFactory } from '@novu/application-generic';
 import { IntegrationEntity, IntegrationQuery, IntegrationRepository, MessageRepository } from '@novu/dal';
 import { ChannelTypeEnum, providers } from '@novu/shared';
@@ -12,6 +19,7 @@ import { WebhookCommand } from './webhook.command';
 export class Webhook {
   public readonly mailFactory = new MailFactory();
   public readonly smsFactory = new SmsFactory();
+  private handler: IMailHandler | ISmsHandler;
   private provider: IEmailProvider | ISmsProvider;
 
   constructor(
@@ -56,6 +64,8 @@ export class Webhook {
     if (!this.provider.getMessageId || !this.provider.parseEventBody) {
       throw new NotFoundException(`Provider with ${integration.providerId} can not handle webhooks`);
     }
+
+    await this.authenticate(command);
 
     const events = await this.parseEvents(command, integration.providerId, channel);
 
@@ -146,6 +156,18 @@ export class Webhook {
     return parsedEvent;
   }
 
+  private async authenticate(command: WebhookCommand): Promise<void> {
+    const verificationResult = await this.handler.verifySignature({
+      body: command.body,
+      headers: command.headers,
+      rawBody: command.rawBody,
+    });
+
+    if (!verificationResult.success) {
+      throw new UnauthorizedException(`Invalid signature: ${verificationResult.message}`);
+    }
+  }
+
   private getHandler(integration: IntegrationEntity, type: WebhookTypes): ISmsHandler | IMailHandler | null {
     switch (type) {
       case 'sms':
@@ -162,6 +184,7 @@ export class Webhook {
     }
     handler.buildProvider(integration.credentials);
 
+    this.handler = handler;
     this.provider = handler.getProvider();
   }
 }

--- a/apps/webhook/src/webhooks/webhooks.controller.ts
+++ b/apps/webhook/src/webhooks/webhooks.controller.ts
@@ -1,6 +1,17 @@
-import { Body, ClassSerializerInterceptor, Controller, Param, Post, UseInterceptors } from '@nestjs/common';
+import {
+  Body,
+  ClassSerializerInterceptor,
+  Controller,
+  Headers,
+  Param,
+  Post,
+  RawBodyRequest,
+  Req,
+  UseInterceptors,
+} from '@nestjs/common';
 
 import { IWebhookResult } from './dtos/webhooks-response.dto';
+import { normalizeHeaders } from './helpers/normalize-headers';
 import { WebhookCommand } from './usecases/webhook/webhook.command';
 import { Webhook } from './usecases/webhook/webhook.usecase';
 
@@ -14,7 +25,9 @@ export class WebhooksController {
     @Param('organizationId') organizationId: string,
     @Param('environmentId') environmentId: string,
     @Param('providerOrIntegrationId') providerOrIntegrationId: string,
-    @Body() body: any
+    @Body() body: any,
+    @Headers() headers: Record<string, string | string[] | undefined>,
+    @Req() request: RawBodyRequest<Request>
   ): Promise<IWebhookResult[]> {
     return this.webhookUsecase.execute(
       WebhookCommand.create({
@@ -22,6 +35,8 @@ export class WebhooksController {
         organizationId,
         providerOrIntegrationId,
         body,
+        headers: normalizeHeaders(headers),
+        rawBody: request.rawBody,
         type: 'email',
       })
     );
@@ -32,7 +47,9 @@ export class WebhooksController {
     @Param('organizationId') organizationId: string,
     @Param('environmentId') environmentId: string,
     @Param('providerOrIntegrationId') providerOrIntegrationId: string,
-    @Body() body: any
+    @Body() body: any,
+    @Headers() headers: Record<string, string | string[] | undefined>,
+    @Req() request: RawBodyRequest<Request>
   ): Promise<IWebhookResult[]> {
     return this.webhookUsecase.execute(
       WebhookCommand.create({
@@ -40,6 +57,8 @@ export class WebhooksController {
         organizationId,
         providerOrIntegrationId,
         body,
+        headers: normalizeHeaders(headers),
+        rawBody: request.rawBody,
         type: 'sms',
       })
     );


### PR DESCRIPTION
## Summary

Closes a P1 security gap where inbound provider webhooks in `apps/webhook` accepted forged delivery/bounce/click events without signature verification.

## What changed

* Added `rawBody` and normalized `headers` to `WebhookCommand`
* Updated `WebhooksController` to capture request headers and raw body from incoming webhook POSTs
* Enabled `rawBody: true` in webhook app bootstrap so signature verification providers (SendGrid, Resend) receive the original request bytes
* Added `authenticate()` in `Webhook.execute()` that calls the provider handler's `verifySignature()` before parsing events or writing execution details
* Rejects requests with invalid signatures via `401 Unauthorized`

## Why

The webhook controller previously passed only `@Body()` into the use case, making it impossible to verify provider signatures. Attackers could forge delivery events for guessable tenant + message IDs. Providers already implement `verifySignature` (SendGrid, Mailgun, SES, Resend) — this wires them into the webhook processing path.

## Flow

```mermaid
sequenceDiagram
    participant Provider
    participant Controller
    participant UseCase
    participant Handler

    Provider->>Controller: POST webhook (body + headers)
    Controller->>UseCase: WebhookCommand(body, headers, rawBody)
    UseCase->>Handler: verifySignature(rawBody, headers, body)
    alt invalid signature
        Handler-->>UseCase: success: false
        UseCase-->>Provider: 401 Unauthorized
    else valid signature
        Handler-->>UseCase: success: true
        UseCase->>UseCase: parse events + write execution details
        UseCase-->>Provider: 200 OK
    end
```

## Test plan

- [X] `pnpm build` in `apps/webhook` — compiles cleanly
- [X] `pnpm test:e2e` in `apps/webhook` — 3/5 pass (2 pre-existing failures on `event.row` assertion, confirmed on base branch)
- [X] Signature verification is skipped when provider has no signing key configured (backward compatible for existing integrations)
- [X] Signature verification enforced when provider sends signature headers and signing key is configured

Linear Issue: [NV-8185](https://linear.app/novu/issue/NV-8185/securityp1-inbound-provider-webhooks-are-not-signature-verified)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

### Greptile Summary

This PR adds provider signature verification to inbound webhook handling. The main changes are:

* Captures raw webhook bodies and request headers in the webhook app.
* Normalizes headers before passing them into provider signature verifiers.
* Calls provider `verifySignature()` before parsing webhook events or writing execution details.
* Rejects invalid signatures with `401 Unauthorized`.

### Confidence Score: 4/5

This PR has one contained provider compatibility issue to fix before merging.

The signature verification flow is integrated for parsed JSON and form webhook requests. Default SES/SNS notifications are not parsed or captured because they arrive as `text/plain`, so that supported webhook path rejects valid provider callbacks.

`apps/webhook/src/bootstrap.ts`

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* Attempted runtime verification of SNS body parsing; the session was stopped before execution, and only minimal source context from apps/webhook/src/bootstrap.ts was inspected.
* Observed the request handling transition in the signed-request flow: before artifact the system showed HTTP 200 with parsing and persistence enabled, and after artifact it produced HTTP 401 with an invalid signature, with verifyCalled now true and both parseCalled and persistenceCalled false, while the raw body remained available and the bad signature header was present.

![View all artifacts](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<img src="https://camo.githubusercontent.com/223063a8acd7e71fd1deaaa741d9d06948338e590a1cc633c9305234794edec8/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f56696577416c6c4172746966616374732e7376673f763d34 " alt="T-Rex" height="14" /> Ran code and verified through T-Rex

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/webhook/src/bootstrap.ts | Adds route-specific parsers and raw body capture, but default AWS SNS `text/plain` webhooks are not parsed or captured. |
| apps/webhook/src/webhooks/usecases/webhook/webhook.usecase.ts | Authenticates provider webhook signatures before parsing and recording events. |
| apps/webhook/src/webhooks/webhooks.controller.ts | Passes request headers and captured raw body into the webhook command for email and SMS routes. |
| apps/webhook/src/webhooks/usecases/webhook/webhook.command.ts | Extends the webhook command with normalized headers and optional raw body for signature verification. |
| apps/webhook/src/webhooks/helpers/normalize-headers.ts | Adds header normalization from Nest header values to a string map for provider verifiers. |

</details>

### Sequence Diagram

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Provider
participant Bootstrap as Express parser
participant Controller
participant UseCase
participant Handler

Provider->>Bootstrap: POST webhook body + headers
Bootstrap->>Bootstrap: Select parser by webhook route/content-type
Bootstrap->>Controller: body, headers, rawBody
Controller->>UseCase: WebhookCommand
UseCase->>Handler: verifySignature(rawBody, headers, body)
alt invalid signature
    Handler-->>UseCase: "success=false"
    UseCase-->>Provider: 401 Unauthorized
else valid signature
    Handler-->>UseCase: "success=true"
    UseCase->>UseCase: parseEvents + createExecutionDetails
    UseCase-->>Provider: 200 OK
end
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Provider
participant Bootstrap as Express parser
participant Controller
participant UseCase
participant Handler

Provider->>Bootstrap: POST webhook body + headers
Bootstrap->>Bootstrap: Select parser by webhook route/content-type
Bootstrap->>Controller: body, headers, rawBody
Controller->>UseCase: WebhookCommand
UseCase->>Handler: verifySignature(rawBody, headers, body)
alt invalid signature
    Handler-->>UseCase: "success=false"
    UseCase-->>Provider: 401 Unauthorized
else valid signature
    Handler-->>UseCase: "success=true"
    UseCase->>UseCase: parseEvents + createExecutionDetails
    UseCase-->>Provider: 200 OK
end
```

![Fix All in Cursor](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/webhook/src/bootstrap.ts:48
**SNS bodies skip parsing**
SES/SNS webhooks default to `Content-Type: text/plain; charset=UTF-8`, so this branch runs `json({ verify })` on a request that Express will not parse or pass to `captureRawBody`. The controller then sends `body === undefined` and no `rawBody` into `SESProvider.verifySignature()`, which rejects every default SNS notification before `parseEvents()`. Handle `text/plain` webhook bodies by capturing the bytes and JSON-parsing them for SES/SNS instead of relying on `express.json()`.
```

</details>

Reviews (3): Last reviewed commit: ["fix(webhook): support urlencoded body pa..."](<https://github.com/novuhq/novu/commit/9ebf8402c40865f59c4b53b8b71a59ac04f87a97>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=42324189>)

> Greptile also left **1 inline comment** on this PR.