### PR TITLE
chore(ci): bump sticky-pull-request-comment to v3.0.5 fixes NV-8218

### DIFF
--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: Comment on PR - Success
         if: needs.contributor-install-build-lint.result == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: contributor-checks
           message: |
@@ -126,7 +126,7 @@ jobs:
 
       - name: Comment on PR - Failure
         if: needs.contributor-install-build-lint.result == 'failure'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: contributor-checks
           message: |

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -150,7 +150,7 @@ jobs:
           scopes: |
             ${{ env.SCOPES }}
 
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         # Show success message when PR title was auto-fixed
         if: steps.auto_fix_linear_ticket.outputs.needs_update == 'true'
         with:
@@ -162,7 +162,7 @@ jobs:
 
             **Updated title:** `${{ steps.auto_fix_linear_ticket.outputs.updated_title }}`
 
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         # Show error if either conventional commit validation fails OR Linear ticket validation fails (for team members)
         if: always() && (steps.lint_pr_title.outputs.error_message != null || (steps.check_team_member.outputs.is_team_member == 'true' && steps.auto_fix_linear_ticket.outputs.linear_ticket_valid != 'true' && steps.validate_linear_ticket.outputs.linear_ticket_valid != 'true'))
         with:
@@ -186,14 +186,14 @@ jobs:
 
       # Delete previous comments when all issues have been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null && (steps.check_team_member.outputs.is_team_member != 'true' || steps.auto_fix_linear_ticket.outputs.linear_ticket_valid == 'true' || steps.validate_linear_ticket.outputs.linear_ticket_valid == 'true') }}
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-title-lint-error
           delete: true
 
       # Delete auto-fix comment after a while (on subsequent updates)
       - if: ${{ steps.auto_fix_linear_ticket.outputs.needs_update != 'true' }}
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-title-auto-fixed
           delete: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades `marocchino/sticky-pull-request-comment` from **v2** (`node20`) to **v3.0.5** (`node24`) in workflows that post sticky PR comments.

This removes the Node 20 deprecation warning on GitHub Actions runners:
> "Node 20 is being deprecated. This workflow is running with Node 24 by default."

## Changes

- `.github/workflows/contributor-checks.yml` — 2 action references updated
- `.github/workflows/conventional-commit.yml` — 4 action references updated

Pinned to commit `5770ad5eb8f42dd2c4f34da00c94c5381e49af88` (v3.0.5).

## Note

This does **not** fix the `Resource not accessible by integration` error on fork PRs — that is a separate `GITHUB_TOKEN` permissions limitation for `pull_request` events from forks. The Node deprecation warning was coming from the action's internal `node20` runtime, not our `setup-node` step.

## Test plan

- [ ] Contributor Checks workflow runs without Node 20 deprecation warning
- [ ] Conventional commit workflow sticky comments still work on non-fork PRs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ab337f3-3267-4e78-9b2a-0e2a97a888ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ab337f3-3267-4e78-9b2a-0e2a97a888ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates sticky PR comment actions in GitHub workflows. The main changes are:

- Bumps `marocchino/sticky-pull-request-comment` from v2 to pinned v3.0.5.
- Updates contributor check success and failure comment steps.
- Updates PR title lint comment and delete steps.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The diff is limited to pinned GitHub Action version updates, and the existing `header`, `message`, and `delete` inputs are supported by the upgraded action.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification for the pull request as specified.
- The verification completed but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/contributor-checks.yml | Updates both contributor-check sticky PR comment steps to the pinned v3.0.5 action commit. |
| .github/workflows/conventional-commit.yml | Updates four conventional-commit sticky PR comment and delete steps to the pinned v3.0.5 action commit. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): bump sticky-pull-request-comm..."](https://github.com/novuhq/novu/commit/b78bcd89257b7891807a16eeebf42910ffc22758) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42325206)</sub>

<!-- /greptile_comment -->