### PR TITLE
fix(api-service): prevent secrets to  callers fixes NV-8191

### DIFF
--- a/apps/api/src/app/environment-variables/e2e/update-environment-variable.e2e.ts
+++ b/apps/api/src/app/environment-variables/e2e/update-environment-variable.e2e.ts
@@ -141,4 +141,37 @@ describe('Update Environment Variable - /environment-variables/:variableKey (PAT
     expect(error).to.exist;
     expect(error?.name).to.equal('ErrorDto');
   });
+
+  it('rejects flipping a secret variable to public without replacing values', async () => {
+    const variableKey = 'SECRET_TO_PUBLIC_TEST';
+
+    await novuClient.environmentVariables.create({
+      key: variableKey,
+      isSecret: true,
+      values: [
+        { environmentId: devEnvironmentId, value: 'dev-secret' },
+        { environmentId: prodEnvironmentId, value: 'prod-secret' },
+      ],
+    });
+
+    const { error: flipWithoutValuesError } = await expectSdkExceptionGeneric(() =>
+      novuClient.environmentVariables.update({ isSecret: false }, variableKey)
+    );
+
+    expect(flipWithoutValuesError).to.exist;
+    expect(flipWithoutValuesError?.name).to.equal('ErrorDto');
+
+    const { error: partialValuesError } = await expectSdkExceptionGeneric(() =>
+      novuClient.environmentVariables.update(
+        {
+          isSecret: false,
+          values: [{ environmentId: devEnvironmentId, value: 'new-dev-value' }],
+        },
+        variableKey
+      )
+    );
+
+    expect(partialValuesError).to.exist;
+    expect(partialValuesError?.name).to.equal('ErrorDto');
+  });
 });

--- a/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
@@ -43,6 +43,25 @@ export class UpdateEnvironmentVariable {
       updateBody.type = command.type;
     }
     if (command.isSecret !== undefined) {
+      if (existing.isSecret && command.isSecret === false) {
+        if (!command.values?.length) {
+          throw new BadRequestException(
+            'Cannot mark a secret variable as public without providing new plaintext values for each environment.'
+          );
+        }
+
+        const existingEnvIds = new Set(existing.values.map((v) => v._environmentId));
+        const providedEnvIds = new Set(command.values.map((v) => v._environmentId));
+
+        for (const envId of existingEnvIds) {
+          if (!providedEnvIds.has(envId)) {
+            throw new BadRequestException(
+              'When marking a secret variable as public, provide new plaintext values for every environment.'
+            );
+          }
+        }
+      }
+
       updateBody.isSecret = command.isSecret;
     }
 

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -28,7 +28,7 @@ import {
   PinoLogger,
   RequirePermissions,
 } from '@novu/application-generic';
-import { CommunityOrganizationRepository, IntegrationRepository } from '@novu/dal';
+import { CommunityOrganizationRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import {
   ApiAuthSchemeEnum,
   ApiServiceLevelEnum,
@@ -390,7 +390,7 @@ export class IntegrationsController {
 
     return {
       ...result,
-      integration: toIntegrationResponseDto(result.integration, canAccessCredentials),
+      integration: toIntegrationResponseDto(result.integration as IntegrationEntity, canAccessCredentials),
     };
   }
 

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -119,6 +119,7 @@ import { UpdateIntegrationCommand } from './usecases/update-integration/update-i
 import { UpdateIntegration } from './usecases/update-integration/update-integration.usecase';
 import { WhatsAppValidateTokenCommand } from './usecases/whatsapp/whatsapp-validate-token.command';
 import { WhatsAppValidateToken } from './usecases/whatsapp/whatsapp-validate-token.usecase';
+import { toIntegrationResponseDto } from './utils/sanitize-integration-response';
 
 @ApiCommonResponses()
 @Controller('/integrations')
@@ -372,6 +373,7 @@ export class IntegrationsController {
     @UserSession() user: UserSessionData,
     @Param('integrationId') integrationId: string
   ): Promise<AutoConfigureIntegrationResponseDto> {
+    const canAccessCredentials = await this.canUserAccessCredentials(user);
     const result = await this.autoConfigureIntegrationUsecase.execute(
       AutoConfigureIntegrationCommand.create({
         userId: user._id,
@@ -382,7 +384,14 @@ export class IntegrationsController {
       })
     );
 
-    return result;
+    if (!result.integration) {
+      return result;
+    }
+
+    return {
+      ...result,
+      integration: toIntegrationResponseDto(result.integration, canAccessCredentials),
+    };
   }
 
   @Post('/:integrationId/set-primary')

--- a/apps/api/src/app/integrations/utils/sanitize-integration-response.spec.ts
+++ b/apps/api/src/app/integrations/utils/sanitize-integration-response.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+
+import { stripSensitiveConfigurations } from './sanitize-integration-response';
+
+describe('sanitize-integration-response', () => {
+  describe('stripSensitiveConfigurations', () => {
+    it('removes inbound webhook signing keys from configurations', () => {
+      const configurations = {
+        inboundWebhookEnabled: 'true',
+        inboundWebhookSigningKey: 'super-secret-signing-key',
+      };
+
+      const sanitized = stripSensitiveConfigurations(configurations);
+
+      expect(sanitized).to.deep.equal({
+        inboundWebhookEnabled: 'true',
+      });
+    });
+
+    it('returns undefined when configurations are undefined', () => {
+      expect(stripSensitiveConfigurations(undefined)).to.be.undefined;
+    });
+  });
+});

--- a/apps/api/src/app/integrations/utils/sanitize-integration-response.ts
+++ b/apps/api/src/app/integrations/utils/sanitize-integration-response.ts
@@ -1,0 +1,30 @@
+import { GetDecryptedIntegrations, IntegrationResponseDto } from '@novu/application-generic';
+import { ICredentialsEntity, IntegrationEntity } from '@novu/dal';
+import { IConfigurations } from '@novu/shared';
+
+export function stripSensitiveConfigurations(configurations?: IConfigurations): IConfigurations | undefined {
+  if (!configurations) {
+    return configurations;
+  }
+
+  const { inboundWebhookSigningKey: _removed, ...safeConfigurations } = configurations;
+
+  return safeConfigurations;
+}
+
+export function toIntegrationResponseDto(
+  integration: IntegrationEntity,
+  canAccessCredentials: boolean
+): IntegrationResponseDto {
+  if (canAccessCredentials) {
+    return GetDecryptedIntegrations.getDecryptedCredentials(integration);
+  }
+
+  const { credentials: _credentials, configurations, ...integrationWithoutCredentials } = integration;
+
+  return {
+    ...integrationWithoutCredentials,
+    credentials: {} as ICredentialsEntity,
+    configurations: stripSensitiveConfigurations(configurations),
+  } as unknown as IntegrationResponseDto;
+}

--- a/apps/api/src/app/layouts-v2/usecases/preview-layout/preview-layout.usecase.ts
+++ b/apps/api/src/app/layouts-v2/usecases/preview-layout/preview-layout.usecase.ts
@@ -15,7 +15,7 @@ import {
   PreviewPayloadProcessorService,
   PreviewStep,
   PreviewStepCommand,
-  resolveEnvironmentVariables,
+  resolveEnvironmentVariablesForPreview,
 } from '@novu/application-generic';
 import { EnvironmentRepository, EnvironmentVariableRepository, JsonSchemaTypeEnum } from '@novu/dal';
 import { ContextResolved } from '@novu/framework/internal';
@@ -105,7 +105,7 @@ export class PreviewLayoutUsecase {
       };
 
       const envVars = {
-        ...resolveEnvironmentVariables(rawEnvVars),
+        ...resolveEnvironmentVariablesForPreview(rawEnvVars),
         ...environmentSystemVars,
       };
 

--- a/libs/application-generic/src/encryption/encrypt-environment-variable.spec.ts
+++ b/libs/application-generic/src/encryption/encrypt-environment-variable.spec.ts
@@ -1,0 +1,40 @@
+import { SECRET_MASK } from '@novu/shared';
+import { expect } from 'chai';
+
+import {
+  decryptEnvironmentVariableValue,
+  resolveEnvironmentVariables,
+  resolveEnvironmentVariablesForPreview,
+} from './encrypt-environment-variable';
+
+describe('encrypt-environment-variable', () => {
+  describe('resolveEnvironmentVariablesForPreview', () => {
+    it('masks secret variables instead of decrypting them', () => {
+      const variables = [
+        { key: 'PUBLIC_URL', value: 'https://example.com', isSecret: false },
+        { key: 'API_KEY', value: 'nvsk.encrypted-value', isSecret: true },
+      ];
+
+      const resolved = resolveEnvironmentVariablesForPreview(variables);
+
+      expect(resolved.PUBLIC_URL).to.equal('https://example.com');
+      expect(resolved.API_KEY).to.equal(SECRET_MASK);
+    });
+
+    it('does not expose decrypted secret values that resolveEnvironmentVariables would return', () => {
+      const variables = [{ key: 'API_KEY', value: 'plain-secret', isSecret: true }];
+
+      const previewResolved = resolveEnvironmentVariablesForPreview(variables);
+      const fullResolved = resolveEnvironmentVariables(variables);
+
+      expect(previewResolved.API_KEY).to.equal(SECRET_MASK);
+      expect(fullResolved.API_KEY).to.equal('plain-secret');
+    });
+  });
+
+  describe('decryptEnvironmentVariableValue', () => {
+    it('returns plaintext values unchanged', () => {
+      expect(decryptEnvironmentVariableValue('hello')).to.equal('hello');
+    });
+  });
+});

--- a/libs/application-generic/src/encryption/encrypt-environment-variable.ts
+++ b/libs/application-generic/src/encryption/encrypt-environment-variable.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { EnvironmentVariableForTemplate } from '@novu/dal';
-import { NOVU_ENCRYPTION_SUB_MASK } from '@novu/shared';
+import { NOVU_ENCRYPTION_SUB_MASK, SECRET_MASK } from '@novu/shared';
 
 import { decryptSecret } from './encrypt-provider';
 
@@ -25,6 +25,20 @@ export function resolveEnvironmentVariables(variables: EnvironmentVariableForTem
 
   for (const variable of variables) {
     resolved[variable.key] = decryptEnvironmentVariableValue(variable.value);
+  }
+
+  return resolved;
+}
+
+export function resolveEnvironmentVariablesForPreview(
+  variables: EnvironmentVariableForTemplate[]
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+
+  for (const variable of variables) {
+    resolved[variable.key] = variable.isSecret
+      ? SECRET_MASK
+      : decryptEnvironmentVariableValue(variable.value);
   }
 
   return resolved;

--- a/libs/application-generic/src/usecases/preview/preview.usecase.ts
+++ b/libs/application-generic/src/usecases/preview/preview.usecase.ts
@@ -7,17 +7,16 @@ import { PinoLogger } from 'nestjs-pino';
 import { GeneratePreviewResponseDto } from '../../dtos/workflow/generate-preview-response.dto';
 import { PreviewPayloadDto } from '../../dtos/workflow/preview-payload.dto';
 import { StepResponseDto } from '../../dtos/workflow/step.response.dto';
-import { resolveEnvironmentVariables } from '../../encryption/encrypt-environment-variable';
+import { resolveEnvironmentVariablesForPreview } from '../../encryption/encrypt-environment-variable';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
 import { ControlValueSanitizerService } from '../../services/control-value-sanitizer.service';
 import { resolveHttpRequestBody, shouldIncludeBody } from '../../services/http-client/http-request.utils';
 import { buildVariables } from '../../utils/build-variables';
-import { buildNovuSignatureHeader } from '../../utils/hmac';
+import { buildPreviewNovuSignatureHeader } from '../../utils/hmac';
 import { isStepResolverActive } from '../../utils/step-resolver-control-state';
 import { BuildStepDataUsecase } from '../build-step-data';
 import { CreateVariablesObjectCommand } from '../create-variables-object/create-variables-object.command';
 import { CreateVariablesObject } from '../create-variables-object/create-variables-object.usecase';
-import { GetDecryptedSecretKey, GetDecryptedSecretKeyCommand } from '../get-decrypted-secret-key';
 import { PreviewStep, PreviewStepCommand } from '../preview-step';
 import { GetWorkflowByIdsCommand, GetWorkflowByIdsUseCase } from '../workflow';
 import { PreviewCommand } from './preview.command';
@@ -36,7 +35,6 @@ export class PreviewUsecase {
     private readonly payloadMerger: PayloadMergerService,
     private readonly payloadProcessor: PreviewPayloadProcessorService,
     private readonly errorHandler: PreviewErrorHandler,
-    private readonly getDecryptedSecretKey: GetDecryptedSecretKey,
     private readonly logger: PinoLogger,
     private readonly environmentVariableRepository: EnvironmentVariableRepository,
     private readonly environmentRepository: EnvironmentRepository
@@ -96,7 +94,7 @@ export class PreviewUsecase {
         );
 
         const novuSignature = isHttpRequestStep
-          ? await this.buildNovuSignatureSample(command.user.environmentId, executeOutput.outputs)
+          ? this.buildNovuSignatureSample(executeOutput.outputs)
           : undefined;
 
         return {
@@ -115,9 +113,7 @@ export class PreviewUsecase {
          * For step resolver steps, surface a structured error so the dashboard can
          * render a channel-agnostic error UI regardless of step type.
          */
-        const novuSignature = isHttpRequestStep
-          ? await this.buildNovuSignatureSample(command.user.environmentId)
-          : undefined;
+        const novuSignature = isHttpRequestStep ? this.buildNovuSignatureSample() : undefined;
 
         if (isStepResolver) {
           return {
@@ -237,7 +233,7 @@ export class PreviewUsecase {
       };
 
       envVars = {
-        ...resolveEnvironmentVariables(rawEnvVars),
+        ...resolveEnvironmentVariablesForPreview(rawEnvVars),
         ...environmentSystemVars,
       };
     } catch (error) {
@@ -271,24 +267,13 @@ export class PreviewUsecase {
     });
   }
 
-  private async buildNovuSignatureSample(
-    environmentId: string,
-    resolvedOutputs?: Record<string, unknown>
-  ): Promise<string | undefined> {
-    try {
-      const secretKey = await this.getDecryptedSecretKey.execute(
-        GetDecryptedSecretKeyCommand.create({ environmentId })
-      );
+  private buildNovuSignatureSample(resolvedOutputs?: Record<string, unknown>): string {
+    const body = resolvedOutputs?.body as string | Array<{ key: string; value: string }> | undefined;
+    const method = (resolvedOutputs?.method as string) ?? 'GET';
+    const bodyRecord = resolveHttpRequestBody(body);
+    const payload = shouldIncludeBody(bodyRecord, method) ? bodyRecord : {};
 
-      const body = resolvedOutputs?.body as string | Array<{ key: string; value: string }> | undefined;
-      const method = (resolvedOutputs?.method as string) ?? 'GET';
-      const bodyRecord = resolveHttpRequestBody(body);
-      const payload = shouldIncludeBody(bodyRecord, method) ? bodyRecord : {};
-
-      return buildNovuSignatureHeader(secretKey, payload);
-    } catch {
-      return undefined;
-    }
+    return buildPreviewNovuSignatureHeader(payload);
   }
 
   @Instrument()

--- a/libs/application-generic/src/utils/hmac.ts
+++ b/libs/application-generic/src/utils/hmac.ts
@@ -3,12 +3,18 @@ import { ContextPayload } from '@novu/shared';
 import { canonicalize } from '@tufjs/canonical-json';
 import { createHmac } from 'crypto';
 
+const PREVIEW_NOVU_SIGNATURE_SECRET = 'preview-placeholder-do-not-use-for-auth';
+
 export function buildNovuSignatureHeader(secretKey: string, payload: unknown): string {
   const timestamp = Date.now();
   const publicKey = `${timestamp}.${JSON.stringify(payload)}`;
   const hmac = createHmac('sha256', secretKey).update(publicKey).digest('hex');
 
   return `t=${timestamp},v1=${hmac}`;
+}
+
+export function buildPreviewNovuSignatureHeader(payload: unknown): string {
+  return buildNovuSignatureHeader(PREVIEW_NOVU_SIGNATURE_SECRET, payload);
 }
 
 export function createHash(key: string, valueToHash: string): string | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses four P1 security findings where decrypted secrets were returned to lower-privilege (`WORKFLOW_READ`) or API-key callers.

## Changes

### 1. Preview `novuSignature` (workflow HTTP request steps)
- `PreviewUsecase` no longer derives HMAC signatures from the environment secret key.
- Preview responses now return a placeholder signature via `buildPreviewNovuSignatureHeader`, sufficient for curl/UI display without leaking a verifiable secret.

### 2. Secret env vars in preview rendering
- Added `resolveEnvironmentVariablesForPreview` to mask `isSecret` variables with `SECRET_MASK` instead of decrypting them.
- Applied in workflow preview (`PreviewUsecase`) and layout preview (`PreviewLayoutUsecase`).

### 3. Environment variable `isSecret` flip
- `UpdateEnvironmentVariable` now rejects changing a secret variable to public unless new plaintext values are provided for **every** environment.
- Prevents toggling `isSecret: false` and then reading decrypted values via GET.

### 4. Auto-configure integration response
- Auto-configure endpoint now sanitizes integration responses for API-key/OAuth/keyless callers using existing `canUserAccessCredentials` gating.
- Strips `configurations.inboundWebhookSigningKey` from responses when credentials access is denied.

## Testing

- `encrypt-environment-variable.spec.ts` — preview env var masking
- `sanitize-integration-response.spec.ts` — signing key stripping
- `update-environment-variable.e2e.ts` — secret→public flip rejection (4/4 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8191](https://linear.app/novu/issue/NV-8191/securityp1-decrypted-secrets-leaked-to-workflow-read-callers-via)

<div><a href="https://cursor.com/agents/bc-c578baf7-3e92-4cd8-8b37-8fcbe440aef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c578baf7-3e92-4cd8-8b37-8fcbe440aef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes several paths where decrypted secrets could be returned to lower-privilege callers. The main changes are:

- Mask secret environment variables during workflow and layout previews.
- Replace preview `novuSignature` generation with a placeholder HMAC secret.
- Reject secret-to-public environment variable flips unless all environment values are replaced.
- Sanitize auto-configure integration responses when credential access is denied.
- Add focused tests for preview masking, integration response sanitization, and secret-to-public update rejection.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to secret redaction and response sanitization. Existing authorization checks are reused where applicable. Targeted tests cover the security-sensitive paths changed in this PR. No blocking correctness or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- From the general contract validation, the blocker is due to a missing target configuration for @novu/application-generic rather than a typo, as shown by the related logs.

<a href="https://app.greptile.com/trex/runs/13528698/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts | Adds validation that requires replacement plaintext values before marking a secret variable public. |
| apps/api/src/app/integrations/integrations.controller.ts | Routes auto-configure integration responses through credential-access checks before returning integration metadata. |
| apps/api/src/app/integrations/utils/sanitize-integration-response.ts | Adds response sanitization that removes credentials and inbound webhook signing keys when access is denied. |
| apps/api/src/app/layouts-v2/usecases/preview-layout/preview-layout.usecase.ts | Uses preview-safe environment variable resolution for layout preview rendering. |
| libs/application-generic/src/encryption/encrypt-environment-variable.ts | Adds preview-specific environment variable resolution that masks secret variables. |
| libs/application-generic/src/usecases/preview/preview.usecase.ts | Uses masked preview environment variables and placeholder signatures for workflow previews. |
| libs/application-generic/src/utils/hmac.ts | Adds a preview-only HMAC helper backed by a fixed placeholder secret. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller
participant API as API Controllers
participant Preview as Preview/Layout Usecases
participant Env as Environment Variables
participant Integrations as Integration Sanitizer

Caller->>API: Request workflow/layout preview or integration auto-configure
alt Preview request
    API->>Preview: Execute preview
    Preview->>Env: Load environment variables
    Env-->>Preview: Raw values with isSecret metadata
    Preview->>Preview: Mask secrets via resolveEnvironmentVariablesForPreview
    Preview->>Preview: Build placeholder novuSignature for HTTP steps
    Preview-->>Caller: Preview output with masked env secrets
else Auto-configure integration
    API->>API: Check canUserAccessCredentials(user)
    API->>Integrations: toIntegrationResponseDto(integration, canAccessCredentials)
    Integrations->>Integrations: Strip credentials and inboundWebhookSigningKey when denied
    Integrations-->>Caller: Sanitized integration response
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller
participant API as API Controllers
participant Preview as Preview/Layout Usecases
participant Env as Environment Variables
participant Integrations as Integration Sanitizer

Caller->>API: Request workflow/layout preview or integration auto-configure
alt Preview request
    API->>Preview: Execute preview
    Preview->>Env: Load environment variables
    Env-->>Preview: Raw values with isSecret metadata
    Preview->>Preview: Mask secrets via resolveEnvironmentVariablesForPreview
    Preview->>Preview: Build placeholder novuSignature for HTTP steps
    Preview-->>Caller: Preview output with masked env secrets
else Auto-configure integration
    API->>API: Check canUserAccessCredentials(user)
    API->>Integrations: toIntegrationResponseDto(integration, canAccessCredentials)
    Integrations->>Integrations: Strip credentials and inboundWebhookSigningKey when denied
    Integrations-->>Caller: Sanitized integration response
end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): cast auto-configure in..."](https://github.com/novuhq/novu/commit/7ca28dc3bdfb3fb3b37793448cd2712e6bac48e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42333596)</sub>

<!-- /greptile_comment -->