### PR TITLE
feat(shared): migrate Slack agent manifest to agent_view fixes NV-8220

### DIFF
--- a/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
@@ -1,7 +1,12 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { encryptCredentials, PinoLogger } from '@novu/application-generic';
 import { AgentIntegrationRepository, IntegrationRepository } from '@novu/dal';
-import { ChatProviderIdEnum, SLACK_AGENT_OAUTH_SCOPES } from '@novu/shared';
+import {
+  ChatProviderIdEnum,
+  SLACK_AGENT_BOT_EVENTS,
+  SLACK_AGENT_DEFAULT_DESCRIPTION,
+  SLACK_AGENT_OAUTH_SCOPES,
+} from '@novu/shared';
 import axios, { AxiosError } from 'axios';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../generate-chat-oath-url/chat-oauth.constants';
 import { SlackQuickSetupCommand } from './slack-quick-setup.command';
@@ -153,7 +158,7 @@ export class SlackQuickSetup {
     return {
       display_information: {
         name: displayName,
-        description: 'Agent built with Novu',
+        description: SLACK_AGENT_DEFAULT_DESCRIPTION,
       },
       features: {
         app_home: {
@@ -161,8 +166,8 @@ export class SlackQuickSetup {
           messages_tab_enabled: true,
           messages_tab_read_only_enabled: false,
         },
-        assistant_view: {
-          assistant_description: 'Agent built with Novu',
+        agent_view: {
+          agent_description: SLACK_AGENT_DEFAULT_DESCRIPTION,
         },
         bot_user: {
           display_name: displayName,
@@ -178,18 +183,7 @@ export class SlackQuickSetup {
       settings: {
         event_subscriptions: {
           request_url: webhookUrl,
-          bot_events: [
-            'app_mention',
-            'message.channels',
-            'message.groups',
-            'message.im',
-            'message.mpim',
-            'member_joined_channel',
-            'assistant_thread_started',
-            'assistant_thread_context_changed',
-            'reaction_added',
-            'reaction_removed',
-          ],
+          bot_events: [...SLACK_AGENT_BOT_EVENTS],
         },
         interactivity: {
           is_enabled: true,

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -1,5 +1,11 @@
 import { SlackConnectButton } from '@novu/react';
-import { ChatProviderIdEnum, FeatureFlagsKeysEnum, SLACK_AGENT_OAUTH_SCOPES } from '@novu/shared';
+import {
+  ChatProviderIdEnum,
+  FeatureFlagsKeysEnum,
+  SLACK_AGENT_BOT_EVENTS,
+  SLACK_AGENT_DEFAULT_DESCRIPTION,
+  SLACK_AGENT_OAUTH_SCOPES,
+} from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -73,10 +79,11 @@ function sanitizeBotDisplayName(name: string): string {
 
 function buildSlackManifestYaml(agent: AgentResponse, webhookHandlerUrl: string, chatOAuthCallbackUrl: string): string {
   const botName = escapeYamlDoubleQuoted(sanitizeBotDisplayName(agent.name));
-  const displayDescription = escapeYamlDoubleQuoted(agent.description?.trim() || 'Agent built with Novu');
+  const displayDescription = escapeYamlDoubleQuoted(agent.description?.trim() || SLACK_AGENT_DEFAULT_DESCRIPTION);
   const oauthCallbackQuoted = escapeYamlDoubleQuoted(chatOAuthCallbackUrl);
   const webhookHandlerUrlQuoted = escapeYamlDoubleQuoted(webhookHandlerUrl);
   const botScopesYaml = SLACK_AGENT_OAUTH_SCOPES.map((scope) => `      - ${scope}`).join('\n');
+  const botEventsYaml = SLACK_AGENT_BOT_EVENTS.map((event) => `      - ${event}`).join('\n');
 
   return `display_information:
   name: "${botName}"
@@ -87,8 +94,8 @@ features:
     home_tab_enabled: false
     messages_tab_enabled: true
     messages_tab_read_only_enabled: false
-  assistant_view:
-    assistant_description: "${displayDescription}"
+  agent_view:
+    agent_description: "${displayDescription}"
     suggested_prompts:
       - title: "Say hello"
         message: "Hello!"
@@ -107,16 +114,7 @@ settings:
   event_subscriptions:
     request_url: "${webhookHandlerUrlQuoted}"
     bot_events:
-      - app_mention
-      - message.channels
-      - message.groups
-      - message.im
-      - message.mpim
-      - member_joined_channel
-      - assistant_thread_started
-      - assistant_thread_context_changed
-      - reaction_added
-      - reaction_removed
+${botEventsYaml}
   interactivity:
     is_enabled: true
     request_url: "${webhookHandlerUrlQuoted}"

--- a/packages/shared/src/consts/index.ts
+++ b/packages/shared/src/consts/index.ts
@@ -14,6 +14,7 @@ export * from './providers';
 export * from './rate-limiting';
 export * from './severity';
 export * from './sinch-sms-regions';
+export * from './slack-agent-manifest';
 export * from './slack-agent-oauth-scopes';
 export * from './slug-identifier';
 export * from './template-store';

--- a/packages/shared/src/consts/slack-agent-manifest.ts
+++ b/packages/shared/src/consts/slack-agent-manifest.ts
@@ -1,0 +1,22 @@
+/**
+ * Slack agent app manifest defaults for Novu agents (dashboard YAML + API quick-setup).
+ * Uses the Agent messaging experience (`agent_view`); see Slack docs on migrating from `assistant_view`.
+ */
+export const SLACK_AGENT_DEFAULT_DESCRIPTION = 'Agent built with Novu';
+
+/**
+ * Bot Events API subscriptions for Slack agent apps.
+ * Agent messaging experience: `app_home_opened` + `app_context_changed` replace assistant thread events.
+ */
+export const SLACK_AGENT_BOT_EVENTS = [
+  'app_mention',
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+  'member_joined_channel',
+  'app_home_opened',
+  'app_context_changed',
+  'reaction_added',
+  'reaction_removed',
+] as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates Novu's Slack agent app manifest from the deprecated **Assistant messaging experience** (`assistant_view`) to the **Agent messaging experience** (`agent_view`), per [Slack's migration guide](https://docs.slack.dev/ai/developing-agents/#migrating).

## Changes

- **`features.assistant_view` → `features.agent_view`**
  - `assistant_description` → `agent_description`
- **Bot events updated for agent messaging:**
  - Removed: `assistant_thread_started`, `assistant_thread_context_changed`
  - Added: `app_home_opened`, `app_context_changed`
- **Centralized manifest defaults** in `packages/shared/src/consts/slack-agent-manifest.ts` (alongside existing `SLACK_AGENT_OAUTH_SCOPES`)

## Affected surfaces

| Surface | File |
|---------|------|
| API quick-setup (manifest create) | `slack-quick-setup.usecase.ts` |
| Dashboard manual setup guide | `slack-setup-guide.tsx` |

## Notes

- New Slack apps created via Novu will use the Messages tab experience (threads in timeline above composer).
- Existing deployed Slack apps are **not** auto-updated — customers need to update their app manifest in Slack App Settings (or recreate via quick-setup).
- Runtime webhook handling already relies on `message.im`; no handler changes required for this manifest-only update.

## Test plan

- [x] `pnpm --filter @novu/shared build`
- [x] `pnpm --filter @novu/api-service build`
- [ ] Manual: create Slack app via dashboard manifest link and confirm Slack accepts the YAML
- [ ] Manual: run Slack quick-setup and confirm `apps.manifest.create` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1783423822039279?thread_ts=1783423822.039279&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-eddcfbcd-169e-5a92-b36c-149cc10819d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eddcfbcd-169e-5a92-b36c-149cc10819d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the Slack agent app manifest to Slack's Agent messaging experience. The main changes are:

- Replaces `assistant_view` with `agent_view` in API quick-setup and dashboard manifest YAML.
- Centralizes the default Slack agent description and bot event list in shared constants.
- Updates bot event subscriptions to use `app_home_opened` and `app_context_changed` for agent messaging.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are limited to manifest generation constants and both generated JSON/YAML paths use the same shared event list. Slack documentation confirms `agent_view` with `app_home_opened`, `app_context_changed`, and `message.im` for the agent messaging experience.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The TypeScript build and circular dependency check completed successfully for the shared manifest build.
- The Slack agent manifest was validated, with the specified features passing and deprecated tokens absent.
- The manifest alignment was verified by inspecting static references to the key constants and ensuring no deprecated tokens are present.

<a href="https://app.greptile.com/trex/runs/13531052/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts | Quick-setup manifest now uses shared Slack agent defaults, `agent_view`, and updated agent bot events. |
| apps/dashboard/src/components/agents/slack-setup-guide.tsx | Manual Slack manifest YAML now mirrors the agent-view schema and shared bot event list. |
| packages/shared/src/consts/slack-agent-manifest.ts | Adds shared Slack agent manifest defaults for description and bot event subscriptions. |
| packages/shared/src/consts/index.ts | Exports the new Slack agent manifest constants from the shared constants barrel. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User as Dashboard/API user
participant Novu as Novu manifest builder
participant Shared as Shared Slack agent constants
participant Slack as Slack apps.manifest/create UI

User->>Novu: Create Slack agent app or copy manifest YAML
Novu->>Shared: Read default description, OAuth scopes, bot events
Shared-->>Novu: agent_view defaults + agent bot events
Novu->>Slack: Submit/copy manifest with agent_view
Slack-->>User: Slack app uses Agent messaging experience
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User as Dashboard/API user
participant Novu as Novu manifest builder
participant Shared as Shared Slack agent constants
participant Slack as Slack apps.manifest/create UI

User->>Novu: Create Slack agent app or copy manifest YAML
Novu->>Shared: Read default description, OAuth scopes, bot events
Shared-->>Novu: agent_view defaults + agent bot events
Novu->>Slack: Submit/copy manifest with agent_view
Slack-->>User: Slack app uses Agent messaging experience
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(shared): migrate Slack agent manife..."](https://github.com/novuhq/novu/commit/451a814fa2b60029019fe9c647f39c70536fa6ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42339580)</sub>

<!-- /greptile_comment -->