### PR TITLE
ci(root): add configurable runner option for GitHub Actions deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,14 @@ on:
         required: true
         type: boolean
         default: false
+      runner:
+        description: "Build runner"
+        required: true
+        type: choice
+        default: blacksmith
+        options:
+          - blacksmith
+          - github
 
 jobs:
   prepare-matrix:
@@ -340,7 +348,7 @@ jobs:
   build:
     needs: [prepare-matrix, run-clickhouse-migrations]
     timeout-minutes: 60
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ github.event.inputs.runner == 'github' && 'ubuntu-latest' || 'blacksmith-8vcpu-ubuntu-2404' }}
     environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}
     permissions:
       contents: read
@@ -373,8 +381,13 @@ jobs:
         shell: bash
         run: pnpm ci
 
-      - name: Set Up Docker Buildx
+      - name: Set Up Docker Buildx (Blacksmith)
+        if: github.event.inputs.runner != 'github'
         uses: useblacksmith/setup-docker-builder@a592b831ebb20e68f7cf47329cf2c3c67b8a7655 # v1
+
+      - name: Set Up Docker Buildx (GitHub)
+        if: github.event.inputs.runner == 'github'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Prepare Variables
         run: echo "BULL_MQ_PRO_NPM_TOKEN=${{ secrets.BULL_MQ_PRO_NPM_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,14 @@ on:
           - production-kr
           - production-us-and-eu
           - production-sg-au-uk-jp-kr
+      runner:
+        description: "Build runner"
+        required: true
+        type: choice
+        default: blacksmith
+        options:
+          - blacksmith
+          - github
 
       deploy_api:
         description: "Deploy API"
@@ -66,14 +74,6 @@ on:
         required: true
         type: boolean
         default: false
-      runner:
-        description: "Build runner"
-        required: true
-        type: choice
-        default: blacksmith
-        options:
-          - blacksmith
-          - github
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/on-push-trigger.yml
+++ b/.github/workflows/on-push-trigger.yml
@@ -133,6 +133,7 @@ jobs:
           gh workflow run "deploy.yml" \
             --ref next \
             -f environment=staging \
+            -f runner=github \
             -f deploy_api=${{ steps.determine-services.outputs.deploy_api }} \
             -f deploy_worker=${{ steps.determine-services.outputs.deploy_worker }} \
             -f deploy_ws=${{ steps.determine-services.outputs.deploy_ws }} \


### PR DESCRIPTION
### What changed? Why was the change needed?
1. If and when Blacksmith is down, team can deploy uninterrupted with this change
2. Blacksmith runners are costly, Automatic Staging deployment happens frequently. We can use github runner in that and you can always use Blacksmith for staging when required

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the deployment workflow runner configurable. The main changes are:

- Adds a `runner` workflow dispatch input with `blacksmith` and `github` options.
- Selects `ubuntu-latest` or the Blacksmith runner for the build job based on that input.
- Uses the matching Docker Buildx setup action for the chosen runner.
- Sends automatic staging deployments through the GitHub-hosted runner path.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow and keeps the existing Blacksmith path as the manual default while wiring the automatic trigger to the new required input.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the posted P1 finding proof and its review comment to confirm that a proof was produced for that finding.
- Validated the workflow runner contract validation, including parsing of the runner contract, runs-on expressions, conditional setup steps, and trigger dispatch proof, and noted an actionlint result that flagged a top-level description in deploy.yml.

<a href="https://app.greptile.com/trex/runs/13540596/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.yml | Adds a `runner` workflow dispatch choice and switches the build runner and Buildx setup between Blacksmith and GitHub-hosted runners. |
| .github/workflows/on-push-trigger.yml | Passes `runner=github` when automatic staging deployments trigger the deployment workflow from pushes to `next`. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Push as Push to next
participant Trigger as on-push-trigger.yml
participant Deploy as deploy.yml
participant Build as build job
participant ECR as Amazon ECR

Push->>Trigger: Run staging trigger workflow
Trigger->>Deploy: "gh workflow run with environment=staging and runner=github"
Deploy->>Build: Evaluate runner input
alt "runner == github"
    Build->>Build: runs-on ubuntu-latest
    Build->>Build: docker/setup-buildx-action
else "runner == blacksmith"
    Build->>Build: runs-on blacksmith-8vcpu-ubuntu-2404
    Build->>Build: useblacksmith/setup-docker-builder
end
Build->>ECR: Build, tag, and push service image
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Push as Push to next
participant Trigger as on-push-trigger.yml
participant Deploy as deploy.yml
participant Build as build job
participant ECR as Amazon ECR

Push->>Trigger: Run staging trigger workflow
Trigger->>Deploy: "gh workflow run with environment=staging and runner=github"
Deploy->>Build: Evaluate runner input
alt "runner == github"
    Build->>Build: runs-on ubuntu-latest
    Build->>Build: docker/setup-buildx-action
else "runner == blacksmith"
    Build->>Build: runs-on blacksmith-8vcpu-ubuntu-2404
    Build->>Build: useblacksmith/setup-docker-builder
end
Build->>ECR: Build, tag, and push service image
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **deploy.yml contains invalid top-level GitHub Actions key description**

   - **Bug**
     - Static workflow validation with actionlint fails on `.github/workflows/deploy.yml` because the workflow has a top-level `description:` field. GitHub Actions workflow syntax only permits known top-level keys such as `name`, `run-name`, `on`, `env`, `permissions`, `concurrency`, `defaults`, and `jobs`; actionlint rejects `description` as unexpected. This failure is in a changed workflow file and can block reliable workflow validation or execution.
   - **Cause**
     - The workflow metadata text was placed under a top-level `description:` key, which is not part of the GitHub Actions workflow schema.
   - **Fix**
     - Remove the top-level `description:` block or convert it to YAML comments near the top of `.github/workflows/deploy.yml`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(ci): update deployment workflows to..."](https://github.com/novuhq/novu/commit/4146b0d6da8ae0aab2fdb858c8ab71d64ac5b076) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42363506)</sub>

<!-- /greptile_comment -->