### PR TITLE
chore(docs): sync local and self-host setup with codebase

### DIFF
--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -22,13 +22,7 @@ From the repo root:
 docker compose -f docker/local/docker-compose.yml up -d
 ```
 
-This starts MongoDB, Redis, ClickHouse, and LocalStack.
-
-Apply ClickHouse migrations:
-
-```sh
-pnpm --filter @novu/api-service clickhouse:migrate:local
-```
+This starts MongoDB, Redis, and LocalStack.
 
 ### 2. Install and run Novu from source
 
@@ -54,7 +48,7 @@ docker compose -f docker/local/docker-compose.yml up -d
 If you only need specific services (for example, to avoid port conflicts):
 
 ```sh
-docker compose -f docker/local/docker-compose.yml up -d clickhouse
+docker compose -f docker/local/docker-compose.yml up -d redis
 ```
 
 ### Securing your setup

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,69 +1,76 @@
-Docker is the easiest way to get started with self-hosted Novu,
-however if you want to set up the system on docker for local development look [here](local/Readme.md)
-or if you want to deploy Novu to Kubernetes using Helm check [here](kubernetes/helm/Readme.md) or using Kustomize check [here](kubernetes/helm/Readme.md).
+Docker is the easiest way to get started with self-hosted Novu.
+For production-style self-hosting, see [Deploy with Docker](/community/self-hosting-novu/deploy-with-docker).
+For Kubernetes deployments, see [Helm](kubernetes/helm/Readme.md) or [Kustomize](kubernetes/helm/Readme.md).
+
+The `docker/local/` compose file is for **local development dependencies only** — it does not start the Novu API, Worker, WebSocket, or Dashboard services.
 
 ## Before you begin
 
 You need the following installed in your system:
 
-- [Docker](https://docs.docker.com/engine/install/) and [docker-compose](https://docs.docker.com/compose/install/)
+- [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
 - [Git](https://git-scm.com/downloads)
+- Node.js v22.22.1 and pnpm 11.x (to run Novu application services from source)
 
-## Quick Start
+## Quick Start (local development)
 
-### Get the code
+### 1. Start dependency services
 
-Clone the Novu repo and enter the docker directory locally:
+From the repo root:
 
 ```sh
-# Get the code
-git clone https://github.com/novuhq/novu
-
-# Go to the docker folder
-cd novu/docker
-
-# Copy the example env file
-cp .env.example ./local/.env
-
-# Start Novu
-docker-compose -f ./local/docker-compose.yml up
+docker compose -f docker/local/docker-compose.yml up -d
 ```
 
-Now visit [http://127.0.0.1:4200](http://127.0.0.1:4200) to start using Novu.
+This starts MongoDB, Redis, ClickHouse, and LocalStack.
+
+Apply ClickHouse migrations:
+
+```sh
+pnpm --filter @novu/api-service clickhouse:migrate:local
+```
+
+### 2. Install and run Novu from source
+
+Follow the [Run Novu in local machine](https://docs.novu.co/community/run-in-local-machine) guide:
+
+```sh
+npm run setup:project
+pnpm dev:portless
+```
+
+The Dashboard dev server runs at [http://127.0.0.1:4201](http://127.0.0.1:4201) by default.
 
 ### Managing services
 
-#### Running all services
-
-For local development, you'll typically need to run all dependency services:
+#### Running all dependency services
 
 ```sh
-# Start all dependency services (recommended)
-docker-compose -f docker/local/docker-compose.yml up -d
+docker compose -f docker/local/docker-compose.yml up -d
 ```
 
 #### Running specific services
 
-If you only need specific services running (for development or resource management), you can start individual services by specifying their names. This is particularly useful when you already have some services running locally on your system and want to avoid port conflicts or resource duplication:
+If you only need specific services (for example, to avoid port conflicts):
 
 ```sh
-# Run only ClickHouse
-docker-compose -f docker/local/docker-compose.yml up -d clickhouse
+docker compose -f docker/local/docker-compose.yml up -d clickhouse
 ```
 
 ### Securing your setup
 
-While we provide you with some example secrets for getting started, you should NEVER deploy your Novu setup using the defaults provided.
+While we provide example secrets for getting started, you should NEVER deploy your Novu setup using the defaults provided.
 
 ### Update Secrets
 
-Update the `.env` file with your own secrets. In particular, these are required:
+Update the `.env` files under `apps/` with your own secrets. In particular, these are required:
 
 - `JWT_SECRET`: used by the API to generate JWT keys
+- `STORE_ENCRYPTION_KEY`: used to encrypt/decrypt provider credentials (32 characters)
 
 ### Redis config
 
-Redis TLS can be configured by adding the following variables to the `.env` file and specifying the necessary properties inside:
+Redis TLS can be configured by adding the following variables to the `.env` file:
 
 - `REDIS_TLS={"servername":"localhost"}`
 - `REDIS_CACHE_SERVICE_TLS={"servername":"localhost"}`
@@ -72,11 +79,13 @@ Redis TLS can be configured by adding the following variables to the `.env` file
 
 To keep the setup simple, we made some choices that may not be optimal for production:
 
-- the database is in the same machine as the servers
-- the storage uses the filesystem backend instead of S3
+- the database is on the same machine as the servers
+- the storage uses LocalStack or the filesystem backend instead of S3
 
 We strongly recommend that you decouple your database before deploying.
 
 ## Next steps
 
+- Full local development guide: [docs.novu.co/community/run-in-local-machine](https://docs.novu.co/community/run-in-local-machine)
+- Self-hosted Docker deployment: [docs.novu.co/community/self-hosting-novu/deploy-with-docker](https://docs.novu.co/community/self-hosting-novu/deploy-with-docker)
 - Got a question? [Ask here](https://discord.gg/novu).

--- a/docs/community/run-in-local-machine.mdx
+++ b/docs/community/run-in-local-machine.mdx
@@ -8,20 +8,22 @@ description: 'Prerequisites and steps to run Novu in local machine. Learn how to
 
 ## Requirements
 
-- Node.js version v20.8.1
+- Node.js v22.22.1 (LTS). The repo requires Node `>=22 <23` and pnpm `^11`.
+- pnpm 11.x (required — the repo enforces pnpm via `preinstall`)
 - MongoDB
 - Redis
-- **(Optional)** pnpm - Needed if you want to install new packages
-- **(Optional)** localstack (required only in S3 related modules)
+- ClickHouse (required for activity feed, analytics, and traces)
+- Docker (recommended for running MongoDB, Redis, ClickHouse, and LocalStack together)
+- **(Optional)** LocalStack (required only for S3-related modules)
 
 <Note>
   We recommend having at least 8GB of RAM to run Novu on a local machine as Novu has multiple
-  services running together with external services like redis, mongodb etc.
+  services running together with external services like Redis, MongoDB, ClickHouse, and more.
 </Note>
 
 ## Setup the project
 
-After installing the required services on your machine, you can clone and set up your forked version of the project:
+After installing Node.js and pnpm, clone and set up your forked version of the project:
 
 <Steps>
   <Step title="Clone the repository">
@@ -29,11 +31,13 @@ After installing the required services on your machine, you can clone and set up
       <Tab title="Novu Org">
     ```shell
     git clone https://github.com/novuhq/novu.git
+    cd novu
     ```
       </Tab>
       <Tab title="Forked Repo">
     ```shell
     git clone https://github.com/{YOUR_GITHUB_USER_NAME}/novu.git
+    cd novu
     ```
       </Tab>
     </Tabs>
@@ -41,237 +45,194 @@ After installing the required services on your machine, you can clone and set up
 
   <Step title="Install all dependencies">
     ```shell
-    cd novu && npm run setup:project
+    npm run setup:project
+    ```
+
+    This installs dependencies with pnpm, creates default `.env` files from `.example.env`, and builds the monorepo.
+  </Step>
+
+  <Step title="Start infrastructure services">
+    Start MongoDB, Redis, ClickHouse, and LocalStack with Docker Compose:
+
+    ```shell
+    docker compose -f docker/local/docker-compose.yml up -d
+    ```
+
+    Apply ClickHouse migrations:
+
+    ```shell
+    pnpm --filter @novu/api-service clickhouse:migrate:local
     ```
   </Step>
 
   <Step title="Run the project">
+    **Recommended:** use the mprocs dev runner (API, Dashboard, and shared packages):
+
+    ```shell
+    pnpm dev:portless
+    ```
+
+    **Alternative:** use the Jarvis CLI menu:
+
     ```shell
     npm run start
     ```
+
+    On first run, Jarvis can also install OS dependencies via **Development environment setup**.
   </Step>
 </Steps>
 
-The `npm run start` will start the Jarvis CLI tool which allows you to run the whole project with ease. If you only want to run parts of the platform, you can use the following run commands from the root project:
+The recommended `pnpm dev:portless` command starts the Dashboard, API, Worker, and shared packages through [Portless](https://github.com/vercel-labs/portless) proxies. If you only want to run parts of the platform, use these commands from the repo root:
 
-- **start:dev** - Synonym to `npm run start`
-- **start:dashboard** - Only starts the dashboard management platform
-- **start:ws** - Only starts the WebSocket service for notification center updates
-- **start:widget** - Starts the widget wrapper project that hosts the notification center inside an iframe
-- **start:api** - Runs the API in watch mode
-- **start:worker** - Runs the worker application in watch mode
-- **start:dal** - Runs the Data Access Layer package in watch mode
-- **start:shared** - Starts the watch mode for the shared client and API library
-- **start:notification-center** - Runs and builds the React package for the Novu notification center
+- **start** / **jarvis** — Interactive CLI to run the full stack or test suites
+- **dev:portless** — Recommended local dev runner (Dashboard, API, Worker, shared packages)
+- **start:dashboard** — Dashboard only (Vite on port 4201 by default)
+- **start:api:dev** — API in watch mode
+- **start:ws** — WebSocket service for real-time Inbox updates
+- **start:worker** — Worker application
+- **start:webhook** — Webhook service
+- **start:dal** — Data Access Layer package in watch mode
+- **start:shared** — Shared client and API library in watch mode
+
+<Note>
+  The legacy Widget and `@novu/notification-center` apps have been removed. Use the [Inbox component](/platform/inbox) (`@novu/react`) instead.
+</Note>
 
 ## Set up your environment variables
 
-If you have used Jarvis CLI tool from the previous step you don't need to setup the env variables as Jarvis will do that on the first run if setup wasn't done before.
-
-The command `npm run setup:project` creates default environment variables that are required to run Novu in a development environment. However, if you want to test certain parts of Novu or run it in production mode, you need to change some of them. These are all the available environment variables:
+If you used `npm run setup:project` or Jarvis, default `.env` files are created automatically. To test certain parts of Novu or run it in production mode, you may need to change some values. These are the main environment variables:
 
 <AccordionGroup>
   <Accordion title="API Backend">
-    - `NODE_ENV` (default: local)The environment of the app. Possible values are: dev, test, production, ci, local
-    - `S3_LOCAL_STACK`The AWS endpoint for the S3 Bucket required for storing various media
-    - `S3_BUCKET_NAME`The name of the S3 Bucket
-    - `S3_REGION`The AWS region of the S3 Bucket
-    - `PORT`The port on which the API backend should listen on
-    - `FRONT_BASE_URL`The base url on which your frontend is accessible for the user. (e.g. dashboard.novu.co)
-    - `DISABLE_USER_REGISTRATION` (default: false)If users should not be able to create new accounts. Possible values are: true, false
-    - `REDIS_HOST`The domain / IP of your redis instance
-    - `REDIS_PORT`The port of your redis instance
-    - `REDIS_PASSWORD`Optional password of your redis instance
-    - `REDIS_DB_INDEX`The Redis database index
-    - `REDIS_CACHE_SERVICE_HOST`The domain / IP of your redis instance for caching
-    - `REDIS_CACHE_SERVICE_PORT`The port of your redis instance for caching
-    - `REDIS_CACHE_DB_INDEX`The Redis cache database index
-    - `REDIS_CACHE_TTL`The Redis cache ttl
-    - `REDIS_CACHE_PASSWORD`The Redis cache password
-    - `REDIS_CACHE_CONNECTION_TIMEOUT`The Redis cache connection timeout
-    - `REDIS_CACHE_KEEP_ALIVE`The Redis cache TCP keep alive on the socket timeout
-    - `REDIS_CACHE_FAMILY`The Redis cache IP stack version
-    - `REDIS_CACHE_KEY_PREFIX`The Redis cache prefix prepend to all keys
-    - `REDIS_CACHE_SERVICE_TLS`The Redis cache TLS connection support
-    - `IN_MEMORY_CLUSTER_MODE_ENABLED`The flag that enables the cluster mode. It might be Redis or ElastiCache cluster, depending on the env variables set for either service.
-    - `ELASTICACHE_CLUSTER_SERVICE_HOST`ElastiCache cluster host
-    - `ELASTICACHE_CLUSTER_SERVICE_PORT`ElastiCache cluster port
-    - `REDIS_CLUSTER_SERVICE_HOST`Redis cluster host
-    - `REDIS_CLUSTER_SERVICE_PORTS`Redis cluster ports
-    - `REDIS_CLUSTER_DB_INDEX`Redis cluster database index
-    - `REDIS_CLUSTER_TTL`Redis cluster ttl
-    - `REDIS_CLUSTER_PASSWORD`Redis cluster password
-    - `REDIS_CLUSTER_CONNECTION_TIMEOUT`Redis cluster connection timeout
-    - `REDIS_CLUSTER_KEEP_ALIVE`Redis cluster TCP keep alive on the socket timeout
-    - `REDIS_CLUSTER_FAMILY`Redis cluster IP stack version
-    - `REDIS_CLUSTER_KEY_PREFIX`Redis cluster prefix prepend to all keys
-    - `JWT_SECRET`The secret keybase which is used to encrypt / verify the tokens issued for authentication
-    - `SENDGRID_API_KEY`The api key of the Sendgrid account used to send various emails
-    - `MONGO_URL`The URL of your MongoDB instance
-    - `MONGO_MAX_POOL_SIZE`The max pool size of the MongoDB connection
-    - `NOVU_SECRET_KEY`The api key of dashboard.novu.co used to send various emails
-    - `SENTRY_DSN`The DSN of sentry.io used to report errors happening in production
+    - `NODE_ENV` (default: local) — The environment of the app. Possible values are: dev, test, production, ci, local
+    - `PORT` — The port on which the API backend listens (default: 3000)
+    - `API_ROOT_URL` — Public base URL for the API
+    - `FRONT_BASE_URL` / `DASHBOARD_URL` — Dashboard URL (default local dev: `http://127.0.0.1:4201`)
+    - `DISABLE_USER_REGISTRATION` (default: false) — If users should not be able to create new accounts
+    - `MONGO_URL` — MongoDB connection string
+    - `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB_INDEX` — Redis queue connection
+    - `REDIS_CACHE_SERVICE_HOST`, `REDIS_CACHE_SERVICE_PORT` — Optional Redis cache instance
+    - `IS_IN_MEMORY_CLUSTER_MODE_ENABLED` — Enables Redis or ElastiCache cluster mode
+    - `JWT_SECRET` — Secret used to sign authentication tokens
+    - `STORE_ENCRYPTION_KEY` — Encrypts provider credentials (must be 32 characters)
+    - `NOVU_SECRET_KEY` — Server-side API secret key
+    - `S3_LOCAL_STACK`, `S3_BUCKET_NAME`, `S3_REGION` — LocalStack/S3 storage settings
+    - `CLICK_HOUSE_URL`, `CLICK_HOUSE_DATABASE`, `CLICK_HOUSE_USER`, `CLICK_HOUSE_PASSWORD` — ClickHouse connection for analytics and activity feed
+    - `SENTRY_DSN` — Optional Sentry DSN for error reporting
   </Accordion>
 
-<Accordion title="Worker">
-    - `NODE_ENV` (default: local) - The environment of the app. Possible values are: dev, test, production, ci, local
-    - `PORT` - The port on which the Worker app should listen on
-    - `STORE_ENCRYPTION_KEY` - The encryption key used to encrypt/decrypt provider credentials
-    - `MAX_NOVU_INTEGRATION_MAIL_REQUESTS` - The number of free emails that can be sent with the Novu email provider
-    - `NOVU_EMAIL_INTEGRATION_API_KEY` - The Novu email provider Sentry API key
-    - `STORAGE_SERVICE` - The storage service name: AWS, GCS, or AZURE
-    - `S3_LOCAL_STACK` - The LocalStack service URL
-    - `S3_BUCKET_NAME` - The name of the S3 Bucket
-    - `S3_REGION` - The AWS region of the S3 Bucket
-    - `GCS_BUCKET_NAME` - The name of the GCS Bucket
-    - `AZURE_ACCOUNT_NAME` - The name of the Azure account
-    - `AZURE_ACCOUNT_KEY` - The Azure account key
-    - `AZURE_HOST_NAME` - The Azure host name
-    - `AZURE_CONTAINER_NAME` - The Azure container name
-    - `AWS_ACCESS_KEY_ID` - The AWS access key
-    - `AWS_SECRET_ACCESS_KEY` - The AWS secret access key
-    - `REDIS_HOST` - The domain / IP of your redis instance
-    - `REDIS_PORT` - The port of your redis instance
-    - `REDIS_PASSWORD` - Optional password of your redis instance
-    - `REDIS_DB_INDEX` - The Redis database index
-    - `REDIS_CACHE_SERVICE_HOST` - The domain / IP of your redis instance for caching
-    - `REDIS_CACHE_SERVICE_PORT` - The port of your redis instance for caching
-    - `REDIS_CACHE_DB_INDEX` - The Redis cache database index
-    - `REDIS_CACHE_TTL` - The Redis cache ttl
-    - `REDIS_CACHE_PASSWORD` - The Redis cache password
-    - `REDIS_CACHE_CONNECTION_TIMEOUT` - The Redis cache connection timeout
-    - `REDIS_CACHE_KEEP_ALIVE` - The Redis cache TCP keep alive on the socket timeout
-    - `REDIS_CACHE_FAMILY` - The Redis cache IP stack version
-    - `REDIS_CACHE_KEY_PREFIX` - The Redis cache prefix prepend to all keys
-    - `REDIS_CACHE_SERVICE_TLS` - The Redis cache TLS connection support
-    - `IN_MEMORY_CLUSTER_MODE_ENABLED` - The flag that enables the cluster mode. It might be Redis or ElastiCache cluster, depending on the env variables set for either service.
-    - `ELASTICACHE_CLUSTER_SERVICE_HOST` - ElastiCache cluster host
-    - `ELASTICACHE_CLUSTER_SERVICE_PORT` - ElastiCache cluster port
-    - `REDIS_CLUSTER_SERVICE_HOST` - Redis cluster host
-    - `REDIS_CLUSTER_SERVICE_PORTS` - Redis cluster ports
-    - `REDIS_CLUSTER_DB_INDEX` - Redis cluster database index
-    - `REDIS_CLUSTER_TTL` - Redis cluster ttl
-    - `REDIS_CLUSTER_PASSWORD` - Redis cluster password
-    - `REDIS_CLUSTER_CONNECTION_TIMEOUT` - Redis cluster connection timeout
-    - `REDIS_CLUSTER_KEEP_ALIVE` - Redis cluster TCP keep alive on the socket timeout
-    - `REDIS_CLUSTER_FAMILY` - Redis cluster IP stack version
-    - `REDIS_CLUSTER_KEY_PREFIX` - Redis cluster prefix prepend to all keys
-    - `MONGO_URL` - The URL of your MongoDB instance
-    - `MONGO_MAX_POOL_SIZE` - The max pool size of the MongoDB connection
-    - `NEW_RELIC_APP_NAME` - The New Relic app name
-    - `NEW_RELIC_LICENSE_KEY` - The New Relic license key
-    - `SEGMENT_TOKEN` - The Segment Analytics token
+  <Accordion title="Worker">
+    - `NODE_ENV` (default: local)
+    - `PORT` — Worker health-check port (default: 3004)
+    - `STORE_ENCRYPTION_KEY` — Must match the API value
+    - `MONGO_URL`, `REDIS_HOST`, `REDIS_PORT` — Same infrastructure as the API
+    - `STORAGE_SERVICE` — Storage backend: AWS, GCS, or AZURE
+    - `S3_LOCAL_STACK`, `S3_BUCKET_NAME`, `S3_REGION` — Object storage settings
+    - `NEW_RELIC_ENABLED`, `NEW_RELIC_APP_NAME`, `NEW_RELIC_LICENSE_KEY` — Optional New Relic settings
   </Accordion>
 
-  <Accordion title="Web Client">
-    - `REACT_APP_ENVIRONMENT` The environment of the app. Possible values are: dev, test, production, ci, local
-    - `REACT_APP_API_URL` The base url on which your API backend would be accessible
-    - `REACT_APP_WS_URL` The base url on which your WebSocket service would be accessible
-    - `SKIP_PREFLIGHT_CHECK` (default: true)Solves a problem with React App dependency tree.
+  <Accordion title="Dashboard">
+    - `VITE_API_HOSTNAME` — API base URL (default: `http://localhost:3000`)
+    - `VITE_WEBSOCKET_HOSTNAME` — WebSocket base URL (default: `http://localhost:3002`)
+    - `VITE_DASHBOARD_URL` — Dashboard URL (default local dev: `http://localhost:4201`)
+    - `VITE_SELF_HOSTED` — Set when running a self-hosted deployment
+    - `VITE_SENTRY_DSN`, `VITE_LAUNCH_DARKLY_CLIENT_SIDE_ID` — Optional telemetry and feature-flag settings
 
-    <Warning>
-      When configuring different than default values for the API and WebSocket URLs, in order for the Web app to apply the changes done to the `./env` file, it is needed to run the script `pnpm envsetup`. This will generate a file called `env-config.js` that will be copied inside of the `public` folder of the application. Its purpose is to inject in the `window._env_`object the chosen environment variables that manage the URLs the Web client will call to access to the API backend and the WebSocket service.
-    </Warning>
-
+    <Note>
+      When using `pnpm dev:portless`, `scripts/portless-dev-env.mjs` resolves API, WebSocket, and Dashboard URLs at runtime. Run `PORTLESS=0 pnpm start:dashboard` to bypass Portless and use the values in your `.env` file directly.
+    </Note>
   </Accordion>
 
-  <Accordion title="Web Socket">
-    - `NODE_ENV` (default: local)The environment of the app. Possible values are: dev, test, production, ci, local
-    - `SENTRY_DSN`The DSN of sentry.io used to report errors happening in production
-    - `REDIS_HOST`The domain / IP of your redis instance
-    - `REDIS_PORT`The port of your redis instance
-    - `REDIS_DB_INDEX`The database index of your redis instance
-    - `REDIS_PASSWORD`Optional password of your redis instance
-    - `JWT_SECRET`The secret keybase which is used to encrypt / verify the tokens issued for authentication
-    - `MONGO_URL`The URL of your MongoDB instance
-    - `MONGO_MAX_POOL_SIZE`The max pool size of the MongoDB connection
-    - `PORT`The port on which the WebSocket service should listen on
+  <Accordion title="WebSocket">
+    - `NODE_ENV` (default: local)
+    - `PORT` — WebSocket service port (default: 3002)
+    - `JWT_SECRET` — Must match the API value
+    - `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB_INDEX`, `REDIS_PASSWORD`
+    - `MONGO_URL`
+    - `SENTRY_DSN` — Optional Sentry DSN
   </Accordion>
 </AccordionGroup>
 
 ## Running tests
 
-After making changes, you can run the tests for the respective package using the appropriate CLI commands:
+After making changes, run tests for the respective package using the appropriate commands.
 
-## API
+### API
 
-To run the API tests, run the following command:
+To run API E2E tests through Jarvis, choose **Test the project → API tests → API E2E tests**.
+
+You can also run them directly:
 
 ```shell
 npm run start:worker:test
-npm run start:e2e:api
+pnpm --filter @novu/api-service test:e2e:novu-v2
 ```
 
-The tests create a new instance of Novu and a test db and run the tests against it. The test db is removed after all tests have finished running.
+The tests create a new instance of Novu and a test database, then remove the test database when finished.
 
-## Dashboard
+### Dashboard
 
-To run the front end tests for the dashboard project using cypress you need to install localstack. The cypress tests perform E2E tests. To be able to perform E2E tests, you need to run the API service in the appropriate test environment.
-
-Run the services in test env with the following commands:
+Dashboard E2E tests use Playwright. Start the API, Worker, and WebSocket services in test mode, then run Playwright:
 
 ```shell
-npm run start:dashboard
 npm run start:api:test
 npm run start:worker:test
 npm run start:ws:test
+cd apps/dashboard && pnpm test:e2e
 ```
 
-Run the cypress test suite with the following command:
+To open the Playwright UI for debugging:
 
 ```shell
-cd apps/dashboard && npm run cypress:run
-```
-
-To open the cypress management window to debug tests, run the following commands:
-
-```shell
-cd apps/dashboard && npm run cypress:open
+cd apps/dashboard && pnpm test:e2e:ui
 ```
 
 ## Different ports used by the services
 
-- **3000** - API
-- **3002** - WebSocket Service
-- **3003** - Webhook Service
-- **3004** - Worker Service
-- **4200** - Dashboard Management UI
-- **4701** - Iframe embed for notification center
-- **4500** - Widget Service
+| Port | Service |
+| --- | --- |
+| 3000 | API |
+| 3002 | WebSocket |
+| 3003 | Webhook |
+| 3004 | Worker |
+| 4201 | Dashboard (local Vite dev server) |
+| 8123 | ClickHouse HTTP |
+| 4566 | LocalStack (S3) |
+
+<Note>
+  The community Docker self-hosted Dashboard runs on port **4000**. That is different from the local Vite dev server on **4201**.
+</Note>
 
 ## Testing providers
 
-To run tests against the providers' folder, you can use the `npm run test:providers` command.
+To run tests against the providers folder:
+
+```shell
+npm run test:providers
+```
 
 ## Local environment setup script (beta)
 
-As an option in our script runner `Jarvis` we have made available an option to run [this script](https://github.com/novuhq/novu/blob/2f2abdcaaad8a7735e0a2d488607c3276c8975fd/scripts/dev-environment-setup.sh) that will automatically try to install all the dependencies needed to be able to run Novu locally, as the previous step of installing the project dependencies through `pnpm install`. When executing it inside `Jarvis`, you will need to have previously installed by yourself `git` and `node`, as we mentioned earlier on this page.
+Jarvis includes a **Development environment setup** option that runs [this script](https://github.com/novuhq/novu/blob/next/scripts/dev-environment-setup.sh). It tries to install OS dependencies needed to run Novu locally before `npm run setup:project`. You still need `git` and Node.js installed beforehand.
 
-The script can be run on its own without any previous dependency installed, as it is prepared to execute the following tasks:
+The script can also be run directly:
 
-- Check the running OS in the local machine (currently only MacOSx and [GNU Linux](https://en.wikipedia.org/wiki/GNU/Linux_naming_controversy)supported)
-- Install of OS dependencies (currently only MacOSx supported) -- MacOSx: It will execute the following tasks --- Will try to install or update [XCode](https://developer.apple.com/xcode/) (skippable step; though XCode installs `[git](https://git-scm.com/)` that is a required dependency for later) --- Will install [Rosetta](https://support.apple.com/en-gb/HT211861) for Apple CPUs --- Will set up some opinionated OS settings
-- Will check if `[git](https://git-scm.com/)` is installed and if not will abort the operation
-- Will make [ZSH](https://en.wikipedia.org/wiki/Z_shell) the default shell to be able to execute the next task
-- Will (opinionatedly) install [Oh My Zsh!](https://ohmyz.sh/) (skippable task)
-- Will (opinionatedly) install the [Homebrew](https://brew.sh/) package manager and will set up your local environment to execute it besides adding some casks
-- Will (opinionatedly) install [NVM](https://github.com/nvm-sh/nvm) as a Node.js version manager
-- Will install the required [Node.js](https://nodejs.org/en/) version to be able to [run Novu](https://github.com/novuhq/novu/blob/2f2abdcaaad8a7735e0a2d488607c3276c8975fd/package.json#L180)
-- Will install [PNPM](https://pnpm.io/) as a package manager, required dependency for some of the tasks inside Novu's scripts
-- Will install [Docker](https://www.docker.com/) as containerized application development tool
-- Will install required databases [MongoDB](https://www.mongodb.com/) (Community version) and [Redis](https://redis.io/) through Homebrew
-- Will install the [AWS CLI](https://aws.amazon.com/cli/) tool (not required to run Novu; it is a core maintainer used tool)
-- Will create a local development domain `local.novu.co` in your local machine
-- Will clone the Novu repository in your local machine (skippable step) to a selected folder `$HOME/Dev`
+```shell
+npm run dev-environment-setup
+```
+
+On supported platforms it can:
+
+- Detect macOS or GNU/Linux
+- Install or update common OS dependencies (macOS only for some steps)
+- Install NVM, Node.js v22.22.1, pnpm, and Docker
+- Install MongoDB and Redis (macOS via Homebrew)
+- Optionally clone the Novu repository
 
 <Warning>
-  This script has only been thoroughly tested in MacOSx. Little testing has been run in GNU Linux.
+  This script has been tested most thoroughly on macOS. Linux support is limited.
 </Warning>
 
 <Note>
-  This script is not bullet-proof and some of the tasks have intertwined dependencies with each
-  other. We have tried to make it as idempotent as possible but some loose knots will probably show
-  because of conflicts between versions of the different dependencies. Please report to us any
-  problem found and we will try to fix or assist though we do not have the resources to make it
-  idempotent in every potential system and potential combinations
+  This script is not bullet-proof. Some tasks have intertwined dependencies. Report problems on GitHub and we will try to help, but we cannot guarantee idempotency on every system.
 </Note>

--- a/docs/community/run-in-local-machine.mdx
+++ b/docs/community/run-in-local-machine.mdx
@@ -12,13 +12,12 @@ description: 'Prerequisites and steps to run Novu in local machine. Learn how to
 - pnpm 11.x (required — the repo enforces pnpm via `preinstall`)
 - MongoDB
 - Redis
-- ClickHouse (required for activity feed, analytics, and traces)
-- Docker (recommended for running MongoDB, Redis, ClickHouse, and LocalStack together)
+- Docker (recommended for running MongoDB, Redis, and LocalStack together)
 - **(Optional)** LocalStack (required only for S3-related modules)
 
 <Note>
   We recommend having at least 8GB of RAM to run Novu on a local machine as Novu has multiple
-  services running together with external services like Redis, MongoDB, ClickHouse, and more.
+  services running together with external services like Redis, MongoDB, and more.
 </Note>
 
 ## Setup the project
@@ -52,16 +51,10 @@ After installing Node.js and pnpm, clone and set up your forked version of the p
   </Step>
 
   <Step title="Start infrastructure services">
-    Start MongoDB, Redis, ClickHouse, and LocalStack with Docker Compose:
+    Start MongoDB, Redis, and LocalStack with Docker Compose:
 
     ```shell
     docker compose -f docker/local/docker-compose.yml up -d
-    ```
-
-    Apply ClickHouse migrations:
-
-    ```shell
-    pnpm --filter @novu/api-service clickhouse:migrate:local
     ```
   </Step>
 
@@ -117,7 +110,6 @@ If you used `npm run setup:project` or Jarvis, default `.env` files are created 
     - `STORE_ENCRYPTION_KEY` — Encrypts provider credentials (must be 32 characters)
     - `NOVU_SECRET_KEY` — Server-side API secret key
     - `S3_LOCAL_STACK`, `S3_BUCKET_NAME`, `S3_REGION` — LocalStack/S3 storage settings
-    - `CLICK_HOUSE_URL`, `CLICK_HOUSE_DATABASE`, `CLICK_HOUSE_USER`, `CLICK_HOUSE_PASSWORD` — ClickHouse connection for analytics and activity feed
     - `SENTRY_DSN` — Optional Sentry DSN for error reporting
   </Accordion>
 
@@ -196,7 +188,6 @@ cd apps/dashboard && pnpm test:e2e:ui
 | 3003 | Webhook |
 | 3004 | Worker |
 | 4201 | Dashboard (local Vite dev server) |
-| 8123 | ClickHouse HTTP |
 | 4566 | LocalStack (S3) |
 
 <Note>

--- a/docs/community/self-hosted-and-novu-cloud.mdx
+++ b/docs/community/self-hosted-and-novu-cloud.mdx
@@ -58,7 +58,7 @@ Below you will find a table that outlines the best available Novu Cloud Tier, co
 ### Account Administration and Security
 | Features | Community Self-Hosted | Novu Cloud |
 | ---------- | ---------- | ----------------------- |
-| Built-In authentication | ❌ | ✅ |
+| Email/password authentication | ✅ | ✅ |
 | Custom SAML SSO, OIDC providers | ❌ | ✅ |
 | Max team members | 1 | Custom |
 | Multi-Factor Authentication (MFA) | ❌ | ✅ |

--- a/docs/community/self-hosting-novu/data-migrations.mdx
+++ b/docs/community/self-hosting-novu/data-migrations.mdx
@@ -89,9 +89,8 @@ closest following release tag.
 
 ### Runtime prerequisites
 
-* `node`
-* `npm`
-* `pnpm`
+* Node.js v22.22.1 (see root `package.json` `engines`)
+* pnpm 11.x
 * `npx`
 * MacOS (or linux)
 * tunnel (optional `ssh`)

--- a/docs/community/self-hosting-novu/deploy-with-docker.mdx
+++ b/docs/community/self-hosting-novu/deploy-with-docker.mdx
@@ -91,7 +91,7 @@ npm install @novu/react react-router-dom
 
 ### Create the Inbox component
 
-Create a component file (e.g., `notification-center.tsx`) in your project:
+Create a component file (e.g., `inbox.tsx`) in your project:
 
 ```tsx
 import React from 'react';
@@ -123,7 +123,7 @@ Once your application is running, you should see the bell icon in your navbar. C
 
 To test notifications, create and trigger a workflow from your self-hosted Novu dashboard, selecting In-App as the channel.
 
-For more information on customizing the Inbox component, refer to the [Inbox documentation](/inbox/overview).
+For more information on customizing the Inbox component, refer to the [Inbox documentation](/platform/inbox).
 
 ## Initializing the Server SDK
 
@@ -335,7 +335,7 @@ curl -X POST 'http://<your-docker-host>:3000/v1/events/trigger' \
   </Tab>
 </Tabs>
 
-For more information on using the Node SDK, refer to the [Server-Side SDKs documentation](/sdks/overview).
+For more information on using the server SDKs, refer to the [Server-Side SDKs documentation](/platform/sdks).
 
 ### Setting Up local studio and bridge application
 
@@ -352,11 +352,15 @@ npx novu@latest init \
 # Install dependencies
 npm install
 
-# Start the bridge application
-npm run dev
+# Start the bridge application on a port that does not conflict with the Dashboard (4000)
+npm run dev -- --port 4005
 ```
 
-Nextjs based bridge application having one test workflow written using `@novu/framework` will be running on `http://localhost:4000`, Go to http://localhost:4000/api/novu to see status.
+A Next.js bridge application with a sample `@novu/framework` workflow runs on the port you choose (for example `http://localhost:4005`). Visit `http://localhost:4005/api/novu` to verify the bridge endpoint.
+
+<Warning>
+  The self-hosted Dashboard also runs on port **4000**. Use a different port (such as **4005**) for your bridge application to avoid a conflict.
+</Warning>
 
 #### Setting Up Novu Studio
 
@@ -368,7 +372,7 @@ Nextjs based bridge application having one test workflow written using `@novu/fr
 if novu is run using above docker compose command in local machine, use below commmand
 
 ```bash
-npx novu@latest dev -d http://localhost:4000 -p <bridge_application_port>
+npx novu@latest dev -d http://localhost:4000 -p 4005
 ```
 
 Following actions will occur:
@@ -382,10 +386,7 @@ Following actions will occur:
 To use bridge application url as bridge url, use below command:
 
 ```bash
-npx novu@latest dev -d http://localhost:4000 -p <bridge_application_port> -t http://host.docker.internal:<bridge_application_port>
-
-# example:
-npx novu@latest dev -d http://localhost:4000 -p 4000 -t http://host.docker.internal:4000
+npx novu@latest dev -d http://localhost:4000 -p 4005 -t http://host.docker.internal:4005
 ```
 
 <Warning>
@@ -567,23 +568,24 @@ We are introducing the first stage of caching in our system to improve performan
 - REDIS_CACHE_SERVICE_HOST
 - REDIS_CACHE_SERVICE_PORT
 
-Currently, we are caching data in the most heavily loaded areas of the system: the widget requests such as feed and unseen count, as well as common DAL requests during the execution of trigger event flow. These are the most heavily used areas of our system, and we hope that by implementing caching in these areas, we can improve performance in the near future.
+Currently, caching is applied in the most heavily loaded areas of the system: Inbox feed and unseen-count requests, as well as common DAL requests during the trigger-event flow.
 
 ### Reverse-Proxy / Load Balancers
 
 To implement a reverse-proxy or load balancer in front of Novu, you need to set the GLOBAL_CONTEXT_PATH for the base path of the application. This is the path that the application will be served from after the domain. For example: - company.com/novu This is used to set the base path for the application, and is used to set the base path for the API, Dashboard, and WebSocket connections.
 
-The following environment variables are used to set the context path for each public service that Novu provides: API_CONTEXT_PATH WIDGET_CONTEXT_PATH WS_CONTEXT_PATH DASHBOARD_CONTEXT_PATH
+The following environment variables set the context path for each public service: `API_CONTEXT_PATH`, `WS_CONTEXT_PATH`, `WEBHOOK_CONTEXT_PATH`, and `FRONT_BASE_CONTEXT_PATH`.
 
-These allow you to set the context path for each service independently or dependently of the GLOBAL_CONTEXT_PATH.
+These can be set independently or together with `GLOBAL_CONTEXT_PATH`.
 
-For example, if I was using a reverse proxy to serve Novu from company.com/novu, I would set the GLOBAL_CONTEXT_PATH to novu, and then set the API_CONTEXT_PATH to api, the WIDGET_CONTEXT_PATH to widget, the WS_CONTEXT_PATH to ws, and the DASHBOARD_CONTEXT_PATH to Dashboard.
+For example, to serve Novu from `company.com/novu`, set `GLOBAL_CONTEXT_PATH=novu`, then set `API_CONTEXT_PATH=api` and `WS_CONTEXT_PATH=ws`. That produces:
 
-This would produce the following urls: - API: company.com/novu/api - WIDGET: company.com/novu/widget - WS: company.com/novu/ws - DASHBOARD: company.com/novu/dashboard
+- API: `company.com/novu/api`
+- WS: `company.com/novu/ws`
 
-However the Service context path can be used entirely independently of the GLOBAL_CONTEXT_PATH.
+You can also set a service context path without `GLOBAL_CONTEXT_PATH`. For example, `API_CONTEXT_PATH=novu-api` exposes the API at `company.com/novu-api`.
 
-For example, if I wanted to expose the api as novu-api, I would set the API_CONTEXT_PATH to novu-api without setting the GLOBAL_CONTEXT_PATH. This would producte the following url: - API: company.com/novu-api
+The Dashboard container is served separately on its configured port (default **4000**) and is not controlled by these API/WS context-path variables.
 
 <Note>
   These env variables should be present on all services novu provides due to tight coupling.

--- a/docs/community/self-hosting-novu/overview.mdx
+++ b/docs/community/self-hosting-novu/overview.mdx
@@ -23,6 +23,7 @@ For optimal performance, host Novu's core services across multiple virtual machi
 | Dashboard | 1 VM | 2 vCPUs, 4 GB RAM |
 | Redis | 2 clusters (one for queues with AOF enabled) | 8 GB RAM per cluster |
 | MongoDB | 1 cluster | M20 or higher (MongoDB Atlas) |
+| ClickHouse | 1 cluster | 8 GB RAM (activity feed and analytics) |
 | S3 storage | — | 10 GB minimum |
 
 ### Single-VM deployment
@@ -34,6 +35,7 @@ If resources are limited or simplicity is a priority, all services can run on a 
 | All Novu services (API, Worker, WS, Dashboard) | 4 vCPUs, 8 GB RAM |
 | MongoDB | 2 GB RAM, 20 GB disk |
 | Redis | 2 GB RAM, AOF enabled |
+| ClickHouse | 2 GB RAM (for activity feed and analytics) |
 | S3 storage | 10 GB minimum |
 
 ### Infrastructure details

--- a/docs/community/self-hosting-novu/overview.mdx
+++ b/docs/community/self-hosting-novu/overview.mdx
@@ -23,7 +23,6 @@ For optimal performance, host Novu's core services across multiple virtual machi
 | Dashboard | 1 VM | 2 vCPUs, 4 GB RAM |
 | Redis | 2 clusters (one for queues with AOF enabled) | 8 GB RAM per cluster |
 | MongoDB | 1 cluster | M20 or higher (MongoDB Atlas) |
-| ClickHouse | 1 cluster | 8 GB RAM (activity feed and analytics) |
 | S3 storage | — | 10 GB minimum |
 
 ### Single-VM deployment
@@ -35,7 +34,6 @@ If resources are limited or simplicity is a priority, all services can run on a 
 | All Novu services (API, Worker, WS, Dashboard) | 4 vCPUs, 8 GB RAM |
 | MongoDB | 2 GB RAM, 20 GB disk |
 | Redis | 2 GB RAM, AOF enabled |
-| ClickHouse | 2 GB RAM (for activity feed and analytics) |
 | S3 storage | 10 GB minimum |
 
 ### Infrastructure details


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Community documentation for running Novu locally and self-hosting had drifted from the current monorepo setup. This PR aligns the docs with the codebase.

## Changes

### `docs/community/run-in-local-machine.mdx`
- Node.js **v22.22.1** and **pnpm 11** (required), replacing outdated v20.8.1 and optional pnpm
- Added Docker Compose infrastructure steps for MongoDB, Redis, and LocalStack
- Documented **`pnpm dev:portless`** as the recommended dev workflow
- Removed obsolete Widget / `@novu/notification-center` scripts
- Updated env vars from `REACT_APP_*` to **`VITE_*`** Dashboard variables
- Replaced Cypress with **Playwright** E2E instructions
- Corrected ports (Dashboard dev server on **4201**, not 4200)

### `docs/community/self-hosting-novu/deploy-with-docker.mdx`
- Fixed broken doc links (`/platform/inbox`, `/platform/sdks`)
- Documented bridge app **port conflict** with Dashboard on 4000 (use 4005)
- Updated caching/reverse-proxy sections to remove legacy Widget terminology
- Corrected context-path env var names

### `docs/community/self-hosted-and-novu-cloud.mdx`
- Clarified self-hosted supports email/password auth (social SSO remains Cloud-only)

### `docker/Readme.md`
- Clarified `docker/local/` starts **dependencies only**, not Novu services
- Removed misleading “visit :4200 after compose” step
- Pointed to docs for full local and self-hosted setup

### `docs/community/self-hosting-novu/data-migrations.mdx`
- Updated runtime prerequisites to Node 22 / pnpm 11

## Why

Developers following the old docs would hit wrong Node versions, missing infrastructure setup, removed scripts, and incorrect ports/env var names.

## Testing

Documentation-only change; no runtime tests required.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b665ca3f-3d57-4e2c-aeff-3d84e1a2bfc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b665ca3f-3d57-4e2c-aeff-3d84e1a2bfc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates community docs for local development and self-hosted Novu setup. The main changes are:

- Node.js and pnpm prerequisites now match the root package engines.
- Local setup docs now point to `pnpm dev:portless`, Vite dashboard port `4201`, Playwright tests, and current Dashboard env vars.
- Docker docs now clarify that `docker/local/` starts dependencies only.
- Self-hosting docs now update Inbox and SDK links, bridge port guidance, caching wording, and context-path variables.
- The Cloud comparison and migration docs now reflect current self-hosted auth and runtime requirements.

<h3>Confidence Score: 4/5</h3>

Documentation-only changes are safe to merge after the minor wording fix.

The remaining issue is a non-blocking documentation accuracy problem. The updated commands and environment names align with the inspected package scripts and config.

`docs/community/run-in-local-machine.mdx` and `docker/Readme.md` should mention ClickHouse in the local dependency service list.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding, linked to the review comment that contains the finding details.
- T-Rex performed the docs integrity validation workflow, generating a navigation/internal-link validation script and running the final validation, which reported passes for navigation references but exposed two broken links and missing Kubernetes/Helm documentation paths.

<a href="https://app.greptile.com/trex/runs/13541953/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docker/Readme.md | Clarifies that local Docker Compose starts dependencies only, but still omits ClickHouse from the listed services. |
| docs/community/run-in-local-machine.mdx | Updates local setup requirements, commands, env vars, ports, and tests; one infrastructure description omits ClickHouse. |
| docs/community/self-hosted-and-novu-cloud.mdx | Corrects the self-hosted authentication capability matrix to distinguish email/password auth from Cloud-only SSO/social auth. |
| docs/community/self-hosting-novu/data-migrations.mdx | Updates migration runtime prerequisites to match the root Node and pnpm engine requirements. |
| docs/community/self-hosting-novu/deploy-with-docker.mdx | Refreshes self-hosted Docker guidance around Inbox links, SDK docs, bridge port conflicts, caching terminology, and context-path variables. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Dev as Developer
participant Compose as docker/local compose
participant Infra as MongoDB/Redis/ClickHouse/LocalStack
participant Setup as npm run setup:project
participant DevRunner as pnpm dev:portless
participant Novu as API/Worker/WebSocket/Dashboard

Dev->>Compose: docker compose -f docker/local/docker-compose.yml up -d
Compose->>Infra: Start local dependency services
Dev->>Setup: Install dependencies and create env files
Setup-->>Dev: Monorepo ready
Dev->>DevRunner: pnpm dev:portless
DevRunner->>Novu: Run app services from source
Novu->>Infra: Connect to local dependencies
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Dev as Developer
participant Compose as docker/local compose
participant Infra as MongoDB/Redis/ClickHouse/LocalStack
participant Setup as npm run setup:project
participant DevRunner as pnpm dev:portless
participant Novu as API/Worker/WebSocket/Dashboard

Dev->>Compose: docker compose -f docker/local/docker-compose.yml up -d
Compose->>Infra: Start local dependency services
Dev->>Setup: Install dependencies and create env files
Setup-->>Dev: Monorepo ready
Dev->>DevRunner: pnpm dev:portless
DevRunner->>Novu: Run app services from source
Novu->>Infra: Connect to local dependencies
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Broken Kubernetes documentation links in docker/Readme.md**

   - **Bug**
     - `docker/Readme.md` links both `Helm` and `Kustomize` to `kubernetes/helm/Readme.md`, but that repository-relative target does not exist from `docker/Readme.md` or elsewhere in the checked path search. Users following the updated Docker README will hit broken links for Kubernetes deployment documentation.
   - **Cause**
     - The changed README introduced or retained relative links to `kubernetes/helm/Readme.md` without a matching file/path in the repository; the Kustomize link also points to the same Helm README target.
   - **Fix**
     - Update the Helm and Kustomize links to existing documentation routes/files, or add the referenced Kubernetes documentation files. If these docs are external, use the correct external URLs.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fcommunity%2Frun-in-local-machine.mdx%3A54%0A**Include%20ClickHouse%20service**%0AThis%20setup%20step%20says%20the%20local%20compose%20stack%20starts%20only%20%60MongoDB%60%2C%20%60Redis%60%2C%20and%20%60LocalStack%60%2C%20but%20%60docker%2Flocal%2Fdocker-compose.yml%60%20also%20starts%20%60clickhouse%60.%20Readers%20following%20the%20updated%20requirements%20will%20not%20know%20the%20required%20ClickHouse%20dependency%20is%20provided%20by%20this%20command%3B%20the%20same%20omission%20appears%20in%20%60docker%2FReadme.md%60%20line%2025.%0A%0A&pr=11838&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/community/run-in-local-machine.mdx:54
**Include ClickHouse service**
This setup step says the local compose stack starts only `MongoDB`, `Redis`, and `LocalStack`, but `docker/local/docker-compose.yml` also starts `clickhouse`. Readers following the updated requirements will not know the required ClickHouse dependency is provided by this command; the same omission appears in `docker/Readme.md` line 25.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(community): remove ClickHouse from ..."](https://github.com/novuhq/novu/commit/73bd814076b32b63503bbafd04bf7d251b8319f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42365821)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->