### PR TITLE
chore(api-service): improve inbound email DKIM/SPF debug logging fixes NV-8225

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -313,6 +313,9 @@ export class AgentInboundHandler implements OnModuleInit {
             dkim: emailAuthRaw?.dkim,
             spf: emailAuthRaw?.spf,
             messageId: message.id,
+            subscriberAccess: config.subscriberAccess,
+            isKeyless: config.isKeyless,
+            canAutoProvision,
           },
           'Inbound email sender failed DKIM/SPF verification — skipping subscriber resolution so a spoofed From cannot assume an existing identity.'
         );

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -515,6 +515,29 @@ class Mailin extends events.EventEmitter {
       parsedEmail.language = language;
 
       /*
+       * One searchable line per email with the final sender-auth verdicts and
+       * the exact inputs the SPF check used. Downstream (agent runtime) fails
+       * closed on anything but pass/pass, so this is the primary breadcrumb
+       * when inbound agent mail bounces with "couldn't verify your email".
+       */
+      logger.info(
+        {
+          context: LOG_CONTEXT,
+          connectionId: connection.id,
+          messageId: parsedEmail.messageId,
+          from: connection.envelope?.mailFrom?.address,
+          remoteAddress: connection.remoteAddress,
+          clientHostname: connection.clientHostname,
+          dkim: parsedEmail.dkim,
+          spf: parsedEmail.spf,
+          spamScore,
+          dkimCheckDisabled: configuration.disableDkim,
+          spfCheckDisabled: configuration.disableSpf,
+        },
+        `${connection.id} Inbound mail sender authentication verdict: dkim=${parsedEmail.dkim} spf=${parsedEmail.spf}`
+      );
+
+      /*
        * Make fields exist, even if empty. That will make
        * json easier to use on the webhook receiver side.
        */

--- a/apps/inbound-mail/src/server/mailUtilities.ts
+++ b/apps/inbound-mail/src/server/mailUtilities.ts
@@ -11,7 +11,15 @@ const spamc = new Spamc();
 /* Verify Python availability. */
 const isPythonAvailable = shell.which('python');
 if (!isPythonAvailable) {
-  logger.warn({ context: LOG_CONTEXT }, 'Python is not available. Dkim and spf checking is disabled.');
+  logger.warn(
+    { context: LOG_CONTEXT, path: process.env.PATH },
+    'Python is not available. Dkim and spf checking is disabled — every inbound email will carry dkim/spf "failed" verdicts.'
+  );
+} else {
+  logger.info(
+    { context: LOG_CONTEXT, pythonPath: isPythonAvailable.toString() },
+    'Python found — dkim and spf checking is enabled.'
+  );
 }
 
 /* Verify spamc/spamassassin availability. */
@@ -38,12 +46,34 @@ module.exports = {
     const verifyDkimPath = path.join(__dirname, '../python/verifydkim.py');
     const verifyDkim = child_process.spawn('python', [verifyDkimPath]);
 
+    let stdout = '';
+    let stderr = '';
+
     verifyDkim.stdout.on('data', (data) => {
+      stdout += data.toString();
       logger.verbose({ context: LOG_CONTEXT }, data.toString());
     });
 
+    verifyDkim.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
     verifyDkim.on('close', (code) => {
-      logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);
+      if (code) {
+        /*
+         * Exit 11 is the script's "signature did not verify" code; anything
+         * else (tracebacks, missing modules, spawn issues) means the check
+         * itself is broken and every email would be stamped as failed.
+         */
+        logger.warn(
+          { context: LOG_CONTEXT, exitCode: code, stdout: stdout.trim(), stderr: stderr.trim() },
+          code === 11
+            ? 'DKIM verification failed: signature did not verify.'
+            : 'DKIM verification errored: verifier script did not run cleanly — treating dkim as failed.'
+        );
+      } else {
+        logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);
+      }
 
       /* Convert return code to appropriate boolean. */
       return callback(null, !code);
@@ -62,14 +92,37 @@ module.exports = {
     const cmd = 'python ';
     const args = [verifySpfPath, ip, address, host];
 
-    child_process.execFile(cmd, args, (err, stdout) => {
+    child_process.execFile(cmd, args, (err, stdout, stderr) => {
       logger.verbose({ context: LOG_CONTEXT }, stdout);
       let code = 0;
       if (err) {
         code = err.code;
       }
 
-      logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);
+      if (code) {
+        /*
+         * Exit 11 is the script's "spf did not pass" code; any other code —
+         * including string codes like ENOENT when the python binary cannot be
+         * spawned — means the check itself is broken, not the sender.
+         */
+        logger.warn(
+          {
+            context: LOG_CONTEXT,
+            err,
+            exitCode: code,
+            ip,
+            address,
+            host,
+            stdout: typeof stdout === 'string' ? stdout.trim() : stdout,
+            stderr: typeof stderr === 'string' ? stderr.trim() : stderr,
+          },
+          code === 11
+            ? 'SPF verification failed: sender IP is not authorized for the domain.'
+            : 'SPF verification errored: verifier did not run cleanly — treating spf as failed.'
+        );
+      } else {
+        logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);
+      }
 
       /* Convert return code to appropriate boolean. */
       return callback(null, !code);

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
@@ -139,7 +139,10 @@ export class DomainRouteStrategy {
         this.failDelivery(resolved, err);
       }
 
-      this.logger.info({ toAddress, domain: domain.name }, 'Fired email.received agent event');
+      this.logger.info(
+        { toAddress, domain: domain.name, messageId: command.messageId, dkim: command.dkim, spf: command.spf },
+        'Fired email.received agent event'
+      );
 
       return { ...resolved, status: 200 };
     }
@@ -314,7 +317,10 @@ export class DomainRouteStrategy {
         mail: this.commandToMail(command),
         toAddress,
       });
-      this.logger.info({ toAddress, agentId: agent._id }, 'Forwarded shared-domain inbound email to agent webhook');
+      this.logger.info(
+        { toAddress, agentId: agent._id, messageId: command.messageId, dkim: command.dkim, spf: command.spf },
+        'Forwarded shared-domain inbound email to agent webhook'
+      );
 
       return { ...resolved, status: 200 };
     } catch (err) {


### PR DESCRIPTION
### What changed? Why was the change needed?

Agent runtime fails closed when inbound email lacks both `dkim=pass` and `spf=pass`, skipping subscriber resolution and replying with "We couldn't verify your email". Staging failures were hard to diagnose because auth verdicts and SPF inputs were not logged consistently across the inbound pipeline.

This PR adds structured logging at each hop so we can trace a rejected email back to the exact DKIM/SPF verdict and the inputs used.

**Changes:**
- **inbound-mail**: log final sender-auth verdicts (`dkim`, `spf`), SPF inputs (`remoteAddress`, `clientHostname`, envelope `from`), and whether checks are disabled
- **inbound-mail**: distinguish verifier script errors from genuine auth failures in DKIM/SPF Python checks; warn when Python is missing (all emails get `failed` verdicts)
- **worker**: include `dkim`/`spf`/`messageId` when forwarding agent inbound events
- **api-service**: enrich the agent inbound handler warning with `subscriberAccess`, `isKeyless`, and `canAutoProvision` context

```mermaid
sequenceDiagram
    participant Sender
    participant InboundMail as inbound-mail
    participant Worker
    participant API as agent runtime

    Sender->>InboundMail: SMTP + raw MIME
    InboundMail->>InboundMail: validateDkim / validateSpf
    Note over InboundMail: info log: dkim/spf verdict + SPF inputs
    InboundMail->>Worker: parse queue (dkim, spf on payload)
    Note over Worker: info log: dkim/spf when firing agent event
    Worker->>API: email.received webhook
    alt dkim != pass OR spf != pass
        Note over API: warn log + skip subscriber resolution
        API-->>Sender: "couldn't verify your email" reply
    else both pass
        API->>API: resolve / provision subscriber
    end
```

Linear: [NV-8225](https://linear.app/novu/issue/NV-8225/improve-inbound-email-dkimspf-debug-logging)

### Test plan

- [ ] Send an inbound email to a staging agent inbox
- [ ] Confirm inbound-mail logs `Inbound mail sender authentication verdict: dkim=... spf=...` with `remoteAddress` and `clientHostname`
- [ ] Confirm worker logs include `dkim`/`spf` when forwarding to agent webhook
- [ ] Confirm API logs the enriched warning when auth fails, including `subscriberAccess` context
- [ ] Verify no behavior change beyond logging (auth gate unchanged)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structured diagnostic logging across the inbound email pipeline — at the SMTP edge (`inbound-mail`), queue forwarding (`worker`), and agent runtime (`api-service`) — to make DKIM/SPF rejection failures traceable end-to-end. No auth logic is changed; every diff is purely additive logging.

- **inbound-mail**: emits a single info log per email with DKIM/SPF verdicts and SPF inputs (`remoteAddress`, `clientHostname`, envelope `from`); differentiates verifier script errors from genuine auth failures in the DKIM/SPF Python child-process handlers and warns when Python is missing.
- **worker** (`DomainRouteStrategy`): enriches two existing info logs with `messageId`, `dkim`, and `spf` from the parse command, which already carries those fields.
- **api-service** (`AgentInboundHandler`): adds `subscriberAccess`, `isKeyless`, and `canAutoProvision` to the DKIM/SPF rejection warn log so the context needed to diagnose silent drops is co-located with the warning.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are additive logging with no auth or delivery logic touched.

Every changed line is a log statement or log field addition. The one minor concern is that the SPF warn log serializes the raw ExecFileException object, which embeds err.cmd containing the full command string including the already-logged sender IP, address, and hostname. No crashes, no auth bypass, and no data loss are possible from these changes.

apps/inbound-mail/src/server/mailUtilities.ts — the SPF warn log includes the raw err object; the other three files are straightforward.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/server/mailUtilities.ts | Adds stderr accumulation and differentiated warn/verbose logging for DKIM and SPF checks. Logs the raw `err` ExecFileException object in the SPF warn context, which contains `err.cmd` duplicating the IP/address/host PII already logged as explicit fields. |
| apps/inbound-mail/src/server/index.ts | Adds a structured info log with DKIM/SPF verdicts, SPF inputs, and disable flags after each email is finalized. No behavioral changes; log fields look correct including proper optional chaining for `mailFrom?.address`. |
| apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts | Enriches two info-level log calls with `messageId`, `dkim`, and `spf` from the command. All three fields exist on `InboundEmailParseCommand`; no behavior change. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Adds `subscriberAccess`, `isKeyless`, and `canAutoProvision` to the existing DKIM/SPF failure warn log. Variables are in scope and correctly reference already-computed values. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Sender
    participant InboundMail as inbound-mail
    participant Worker
    participant API as agent runtime

    Sender->>InboundMail: SMTP + raw MIME
    InboundMail->>InboundMail: validateDkim (Python child process)
    InboundMail->>InboundMail: validateSpf (Python execFile)
    Note over InboundMail: NEW info log: dkim/spf verdict<br/>remoteAddress, clientHostname,<br/>envelope from, disable flags
    InboundMail->>Worker: parse queue payload (dkim, spf, messageId)
    Worker->>Worker: DomainRouteStrategy.execute()
    Note over Worker: NEW: messageId, dkim, spf added<br/>to Fired agent event info log
    Worker->>API: email.received agent event
    alt "dkim != pass OR spf != pass"
        Note over API: NEW warn fields: subscriberAccess,<br/>isKeyless, canAutoProvision
        API-->>Sender: could not verify your email
    else both pass
        API->>API: resolveOrProvision subscriber
        API-->>Sender: normal reply
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Sender
    participant InboundMail as inbound-mail
    participant Worker
    participant API as agent runtime

    Sender->>InboundMail: SMTP + raw MIME
    InboundMail->>InboundMail: validateDkim (Python child process)
    InboundMail->>InboundMail: validateSpf (Python execFile)
    Note over InboundMail: NEW info log: dkim/spf verdict<br/>remoteAddress, clientHostname,<br/>envelope from, disable flags
    InboundMail->>Worker: parse queue payload (dkim, spf, messageId)
    Worker->>Worker: DomainRouteStrategy.execute()
    Note over Worker: NEW: messageId, dkim, spf added<br/>to Fired agent event info log
    Worker->>API: email.received agent event
    alt "dkim != pass OR spf != pass"
        Note over API: NEW warn fields: subscriberAccess,<br/>isKeyless, canAutoProvision
        API-->>Sender: could not verify your email
    else both pass
        API->>API: resolveOrProvision subscriber
        API-->>Sender: normal reply
    end
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Finbound-mail%2Fsrc%2Fserver%2FmailUtilities.ts%3A108-118%0A**Raw%20%60err%60%20object%20duplicates%20PII%20already%20logged%20explicitly**%0A%0A%60ExecFileException%60%20carries%20an%20%60err.cmd%60%20property%20containing%20the%20full%20executed%20command%20string%20%E2%80%94%20%60'python%20%20%2Fpath%2Fto%2Fverifyspf.py%20%3Cip%3E%20%3Caddress%3E%20%3Chost%3E'%60.%20Because%20%60ip%60%2C%20%60address%60%2C%20and%20%60host%60%20are%20already%20spread%20into%20the%20log%20record%20as%20top-level%20fields%2C%20the%20raw%20error%20object%20double-embeds%20the%20sender's%20email%20and%20IP%20inside%20%60err.cmd%60.%20For%20log%20aggregators%20that%20index%20every%20key%2C%20this%20creates%20a%20second%2C%20harder-to-discover%20copy%20of%20those%20values.%20Consider%20replacing%20%60err%60%20with%20%60%7B%20message%3A%20err.message%2C%20code%3A%20err.code%20%7D%60%20to%20keep%20the%20log%20shape%20predictable%20and%20avoid%20the%20duplication.%0A%0A&pr=11840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/inbound-mail/src/server/mailUtilities.ts:108-118
**Raw `err` object duplicates PII already logged explicitly**

`ExecFileException` carries an `err.cmd` property containing the full executed command string — `'python  /path/to/verifyspf.py <ip> <address> <host>'`. Because `ip`, `address`, and `host` are already spread into the log record as top-level fields, the raw error object double-embeds the sender's email and IP inside `err.cmd`. For log aggregators that index every key, this creates a second, harder-to-discover copy of those values. Consider replacing `err` with `{ message: err.message, code: err.code }` to keep the log shape predictable and avoid the duplication.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(api-service): improve inbound emai..."](https://github.com/novuhq/novu/commit/8550fcdb26cc3777b290d1e0edb8a587915dfc30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42415643)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->