### PR TITLE
feat(api-service): set Slack suggested prompts after welcome DM fixes NV-8226

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -16,8 +16,10 @@ import { FileMaterializer } from './file-materializer.service';
 import { resolvePlanDeliveryMode } from './plan-live-delivery';
 import { renderPlanModelAsMarkdown } from './plan-model-to-markdown';
 import type { PlanPhase } from './plan-phase';
+import type { SlackAgentSuggestedPrompt } from '@novu/shared';
 import {
   editSlackNativeBlocks,
+  decodeSlackPlatformThreadId,
   getSlackApiErrorCode,
   postSlackNativeBlocks,
   type SlackNativeDelivery,
@@ -316,6 +318,48 @@ export class OutboundGateway {
     const platformThreadId = sent.threadId.endsWith(':') ? `${sent.threadId}${sent.id}` : sent.threadId;
 
     return { messageId: sent.id, platformThreadId };
+  }
+
+  async setSlackSuggestedPrompts(
+    agentId: string,
+    integrationIdentifier: string,
+    platformThreadId: string,
+    prompts: SlackAgentSuggestedPrompt[],
+    title?: string
+  ): Promise<void> {
+    const { channel, threadTs } = decodeSlackPlatformThreadId(platformThreadId);
+    const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
+    const instanceKey = `${agentId}:${integrationIdentifier}`;
+    const chat = await this.registry.getOrCreate(instanceKey, agentId, config.platform, config);
+    const adapter = chat.getAdapter(AgentPlatformEnum.SLACK) as {
+      setSuggestedPrompts?: (
+        channelId: string,
+        threadTs: string,
+        promptList: SlackAgentSuggestedPrompt[],
+        promptTitle?: string
+      ) => Promise<void>;
+    };
+
+    if (typeof adapter.setSuggestedPrompts !== 'function') {
+      return;
+    }
+
+    const resolvedThreadTs = threadTs ?? platformThreadId.split(':').slice(2).join(':');
+    if (!resolvedThreadTs) {
+      this.logger.warn(
+        { platformThreadId, agentId, integrationIdentifier },
+        'Skipping Slack suggested prompts because thread timestamp is missing'
+      );
+
+      return;
+    }
+
+    await adapter.setSuggestedPrompts(channel, resolvedThreadTs, prompts, title).catch((err) => {
+        this.logger.warn(
+          { err, platformThreadId, agentId, integrationIdentifier },
+          'Failed to set Slack suggested prompts'
+        );
+      });
   }
 
   async editInConversation(

--- a/apps/api/src/app/agents/conversation-runtime/egress/slack-native-delivery.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/slack-native-delivery.ts
@@ -9,7 +9,7 @@ import type {
 
 export type SlackNativeDelivery = Required<Omit<ChannelAndBlocks, 'channel'>>;
 
-function decodeSlackPlatformThreadId(platformThreadId: string): { channel: string; threadTs?: string } {
+export function decodeSlackPlatformThreadId(platformThreadId: string): { channel: string; threadTs?: string } {
   const parts = platformThreadId.split(':');
   if (parts[0] !== 'slack' || !parts[1]) {
     throw new Error(`Invalid Slack platform thread id: ${platformThreadId}`);

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.spec.ts
@@ -1,4 +1,4 @@
-import { EmailProviderIdEnum } from '@novu/shared';
+import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon, { restore, stub } from 'sinon';
 
@@ -35,7 +35,10 @@ describe('SendAgentWelcomeMessage usecase', () => {
     persistAgentMessage: sinon.SinonStub;
   };
   let analyticsService: { track: sinon.SinonStub };
-  let outboundGateway: { sendDirectMessage: sinon.SinonStub };
+  let outboundGateway: {
+    sendDirectMessage: sinon.SinonStub;
+    setSlackSuggestedPrompts: sinon.SinonStub;
+  };
   let connectClaimTokenService: { issueOrGetForEnvironment: sinon.SinonStub };
   let logger: { setContext: sinon.SinonStub; warn: sinon.SinonStub };
 
@@ -86,6 +89,7 @@ describe('SendAgentWelcomeMessage usecase', () => {
     };
     outboundGateway = {
       sendDirectMessage: stub().resolves({ messageId: 'msg-1', platformThreadId: 'email:user@example.com:hash' }),
+      setSlackSuggestedPrompts: stub().resolves(undefined),
     };
     connectClaimTokenService = {
       issueOrGetForEnvironment: stub().resolves({ token: 'claim-token' }),
@@ -103,7 +107,7 @@ describe('SendAgentWelcomeMessage usecase', () => {
   it('sends a welcome email to the connect subscriber address', async () => {
     const result = await buildUsecase().execute(buildCommand());
 
-    expect(result).to.deep.equal({ sent: true, conversationId: 'conversation-id' });
+    expect(result).to.deep.equal({ sent: true, conversationId: 'conversation-id', claimToken: undefined });
     expect(subscriberRepository.findBySubscriberId.calledOnceWith(ENV_ID, `connect:${USER_ID}`)).to.equal(true);
     expect(channelEndpointRepository.findOne.called).to.equal(false);
     expect(
@@ -135,6 +139,45 @@ describe('SendAgentWelcomeMessage usecase', () => {
     ).to.equal(true);
     expect(outboundGateway.sendDirectMessage.called).to.equal(false);
     expect(conversationService.createOrGetConversation.called).to.equal(false);
+    expect(outboundGateway.setSlackSuggestedPrompts.called).to.equal(false);
+  });
+
+  it('sets Slack suggested prompts after sending a Slack welcome message', async () => {
+    integrationRepository.findOne.resolves({
+      _id: 'integration-id',
+      providerId: ChatProviderIdEnum.Slack,
+    });
+    channelEndpointRepository.findOne.resolves({
+      endpoint: { userId: 'U123456' },
+    });
+    conversationService.createOrGetConversation.resolves({
+      _id: 'conversation-id',
+      channels: [{ platform: AgentPlatformEnum.SLACK, platformThreadId: 'slack:D123:msg-1' }],
+    });
+    conversationService.getPrimaryChannel.returns({
+      platform: AgentPlatformEnum.SLACK,
+      platformThreadId: 'slack:D123:msg-1',
+    });
+    outboundGateway.sendDirectMessage.resolves({
+      messageId: 'msg-1',
+      platformThreadId: 'slack:D123:msg-1',
+    });
+
+    const result = await buildUsecase().execute(
+      buildCommand({ integrationIdentifier: 'slack-integration' })
+    );
+
+    expect(result).to.deep.equal({ sent: true, conversationId: 'conversation-id', claimToken: undefined });
+    expect(outboundGateway.setSlackSuggestedPrompts.calledOnce).to.equal(true);
+    expect(
+      outboundGateway.setSlackSuggestedPrompts.calledOnceWith(
+        AGENT_ID,
+        'slack-integration',
+        'slack:D123:msg-1',
+        sinon.match.array,
+        sinon.match.string
+      )
+    ).to.equal(true);
   });
 
   it('returns sent:false when the connect subscriber has no email', async () => {

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
@@ -7,7 +7,11 @@ import {
   IntegrationRepository,
   SubscriberRepository,
 } from '@novu/dal';
-import { buildConnectSubscriberId } from '@novu/shared';
+import {
+  buildConnectSubscriberId,
+  SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS,
+  SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS_TITLE,
+} from '@novu/shared';
 import type { CardElement } from 'chat';
 import { ConnectClaimTokenService } from '../../../../connect/services/connect-claim-token.service';
 import { isKeylessOrganization } from '../../../../keyless/keyless-organization.helpers';
@@ -136,6 +140,16 @@ export class SendAgentWelcomeMessage {
         environmentId: command.environmentId,
         organizationId: command.organizationId,
       });
+
+      if (platform === AgentPlatformEnum.SLACK) {
+        await this.outboundGateway.setSlackSuggestedPrompts(
+          agent._id,
+          command.integrationIdentifier,
+          platformThreadId,
+          SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS,
+          SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS_TITLE
+        );
+      }
 
       this.analyticsService.track(`Agent Welcome Message Sent - [Agents]`, command.userId, {
         _organization: command.organizationId,

--- a/packages/shared/src/consts/index.ts
+++ b/packages/shared/src/consts/index.ts
@@ -16,6 +16,7 @@ export * from './severity';
 export * from './sinch-sms-regions';
 export * from './slack-agent-manifest';
 export * from './slack-agent-oauth-scopes';
+export * from './slack-agent-welcome-suggested-prompts';
 export * from './slug-identifier';
 export * from './template-store';
 export * from './topic-subscription';

--- a/packages/shared/src/consts/slack-agent-welcome-suggested-prompts.ts
+++ b/packages/shared/src/consts/slack-agent-welcome-suggested-prompts.ts
@@ -1,0 +1,21 @@
+export type SlackAgentSuggestedPrompt = {
+  title: string;
+  message: string;
+};
+
+export const SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS_TITLE = 'Try asking';
+
+export const SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS: SlackAgentSuggestedPrompt[] = [
+  {
+    title: 'Say hello',
+    message: 'Hello!',
+  },
+  {
+    title: 'What can you do?',
+    message: 'What can you help me with?',
+  },
+  {
+    title: 'Get started',
+    message: 'How do I get started with this agent?',
+  },
+];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the post-install Slack welcome DM is sent, Novu now calls Slack's `assistant.threads.setSuggestedPrompts` API so users see starter prompts in the Agent messaging experience.

## What changed

- Added shared defaults for welcome suggested prompts (`SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS`, title `Try asking`)
- Added `OutboundGateway.setSlackSuggestedPrompts()` using the existing `@chat-adapter/slack` wrapper
- Wired the call from `SendAgentWelcomeMessage` for Slack-only welcome flows (fail-soft on API errors)
- Added unit test coverage for the Slack welcome path

## Why

The welcome DM already nudges users to try the agent, but Slack's Agent UI supports pinned suggested prompts at the top of the Messages tab. Setting them at welcome time gives users one-click starters without requiring a manifest reinstall.

## Test plan

- [x] `pnpm --filter @novu/shared build`
- [x] `cd apps/api && pnpm test -- --grep "SendAgentWelcomeMessage"` (5 passing)
- [ ] Manual: connect a Slack agent, confirm welcome DM + suggested prompts appear in the bot DM

## Notes

- Uses existing `assistant:write` scope
- Errors are logged and do not block welcome delivery
- Slack e2e emulator still lacks `assistant.threads.*` endpoints (same limitation as `setStatus`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83494f75-29bc-42f5-b3c7-2600694508db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83494f75-29bc-42f5-b3c7-2600694508db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Slack suggested prompts after the agent welcome DM is sent. The main changes are:

- Shared Slack welcome prompt defaults and title.
- New outbound gateway helper for Slack suggested prompts.
- Welcome-message flow now calls the helper for Slack only.
- Unit coverage for the Slack welcome path.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to Slack welcome-message follow-up behavior, and suggested-prompt failures are handled without blocking welcome delivery. Tests cover the new Slack path and existing non-Slack behavior. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The shared build for the @novu/shared package completed successfully with exit code 0 and reported that no circular dependencies were found.
- A test run for the SendAgentWelcomeMessage case failed during pretest: build:metadata due to a TypeScript TS2307 error about missing workspace modules before any matching tests could run.
- A targeted multi-package build of @novu/dal, @novu/framework, @novu/notifications, and @novu/application-generic ended with exit code 137, and the @novu/framework step was killed after the JavaScript bundle output prevented completion.

<a href="https://app.greptile.com/trex/runs/13562951/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts | Adds `setSlackSuggestedPrompts` to decode Slack thread IDs, resolve the Slack adapter, and log API failures without blocking welcome delivery. |
| apps/api/src/app/agents/conversation-runtime/egress/slack-native-delivery.ts | Exports the existing Slack platform thread ID decoder for reuse by the outbound suggested-prompts path. |
| apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts | Wires Slack welcome sends to set shared suggested prompts after the welcome DM is persisted. |
| apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.spec.ts | Extends welcome-message tests to cover Slack suggested prompt invocation and preserve non-Slack behavior. |
| packages/shared/src/consts/slack-agent-welcome-suggested-prompts.ts | Defines the shared suggested prompt title and starter prompt list used by Slack welcome DMs. |
| packages/shared/src/consts/index.ts | Exports the Slack welcome suggested prompt constants from the shared consts barrel. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Usecase as SendAgentWelcomeMessage
participant Gateway as OutboundGateway
participant Conv as AgentConversationService
participant Slack as Slack Adapter

Usecase->>Gateway: sendDirectMessage(agentId, integration, platformUserId, welcomeContent)
Gateway-->>Usecase: messageId, platformThreadId
Usecase->>Conv: createOrGetConversation(platformThreadId)
Conv-->>Usecase: conversation
Usecase->>Conv: persistAgentMessage(messageId, welcomeText)
alt Slack welcome flow
    Usecase->>Gateway: setSlackSuggestedPrompts(platformThreadId, prompts, title)
    Gateway->>Gateway: decodeSlackPlatformThreadId(platformThreadId)
    Gateway->>Slack: setSuggestedPrompts(channel, threadTs, prompts, title)
    Slack-->>Gateway: success or error
    Gateway-->>Usecase: logs errors without throwing
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Usecase as SendAgentWelcomeMessage
participant Gateway as OutboundGateway
participant Conv as AgentConversationService
participant Slack as Slack Adapter

Usecase->>Gateway: sendDirectMessage(agentId, integration, platformUserId, welcomeContent)
Gateway-->>Usecase: messageId, platformThreadId
Usecase->>Conv: createOrGetConversation(platformThreadId)
Conv-->>Usecase: conversation
Usecase->>Conv: persistAgentMessage(messageId, welcomeText)
alt Slack welcome flow
    Usecase->>Gateway: setSlackSuggestedPrompts(platformThreadId, prompts, title)
    Gateway->>Gateway: decodeSlackPlatformThreadId(platformThreadId)
    Gateway->>Slack: setSuggestedPrompts(channel, threadTs, prompts, title)
    Slack-->>Gateway: success or error
    Gateway-->>Usecase: logs errors without throwing
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(api-service): set Slack suggested p..."](https://github.com/novuhq/novu/commit/b1adb27f990c8253f043188fbbb332f64c49d48c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42415718)</sub>

<!-- /greptile_comment -->