### PR TITLE
fix(root): copy inbound-mail python verifiers to dist/src/python fixes NV-8227

### DIFF
--- a/apps/inbound-mail/Dockerfile
+++ b/apps/inbound-mail/Dockerfile
@@ -37,7 +37,7 @@ RUN cp src/dotenvcreate.mjs dist/dotenvcreate.mjs
 RUN cp src/.env.development dist/src/.env.development
 RUN cp src/.env.production dist/src/.env.production
 
-RUN cp -r src/python dist/python
+RUN cp -r src/python dist/src/python
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Staging inbound agent emails were rejected with "We couldn't verify your email" even for known subscribers because every message carried `dkim=failed spf=failed`.

Logs showed the root cause:

```
python: can't open file '/usr/src/app/apps/inbound-mail/dist/src/python/verifydkim.py': [Errno 2] No such file or directory
```

The Docker build copied verifier scripts to `dist/python`, but compiled `mailUtilities.js` resolves them from `dist/src/server/../python` → `dist/src/python`.

**Fix:** copy `src/python` to `dist/src/python` in the inbound-mail Dockerfile.

```mermaid
flowchart LR
    A["Docker build: cp src/python"] --> B["Before: dist/python ❌"]
    A --> C["After: dist/src/python ✅"]
    D["mailUtilities.js __dirname"] --> E["dist/src/server/../python"]
    E --> C
    B -.->|ENOENT| F["dkim=failed spf=failed"]
    C --> G["DKIM/SPF checks run"]
```

Related: [NV-8225](https://linear.app/novu/issue/NV-8225/improve-inbound-email-dkimspf-debug-logging) (logging that surfaced this)

Linear: [NV-8227](https://linear.app/novu/issue/NV-8227/fix-inbound-mail-docker-python-verifier-script-path)

### Test plan

- [ ] Merge and let staging deploy `@novu/inbound-mail` (label auto-applied)
- [ ] Send test email to staging agent inbox from `george@novu.co`
- [ ] Confirm inbound-mail log no longer shows `verifydkim.py: No such file or directory`
- [ ] Confirm verdict log shows `dkim=pass` (SPF may still fail behind LB — separate follow-up if needed)
- [ ] Confirm agent processes the email instead of bouncing with verification reply

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes where inbound-mail verifier scripts are copied in the Docker image. The main change is:

- Copies `src/python` to `dist/src/python` so compiled DKIM/SPF verifier lookups resolve at runtime.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Single Dockerfile path correction that matches the compiled runtime verifier path.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the pre-change layout in inbound-mail-dockerfile-layout-01-before.log, showing the previous Dockerfile content and the intended runtime verifier paths not existing.
- T-Rex prepared and used the generated harness inbound\_mail\_layout\_check.py to run a clean layout simulation and path checks.
- T-Rex captured the post-change layout in inbound-mail-dockerfile-layout-02-after.log, showing the HEAD Dockerfile line that copies src/python to dist/src/python and that the runtime verifier files exist with sizes.
- T-Rex linked the validation artifacts (the before log, the after log, and the harness) to support reviewer inspection of the layout validation results.

<a href="https://app.greptile.com/trex/runs/13568718/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/Dockerfile | Updates the Docker build to copy inbound-mail Python verifier scripts into `dist/src/python`, matching the runtime path resolved by `mailUtilities.ts`. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Build as Docker build
participant Image as inbound-mail image
participant Runtime as mailUtilities.js
participant Py as Python verifiers

Build->>Image: Copy src/python to dist/src/python
Runtime->>Image: Resolve __dirname ../python/verifydkim.py and verifyspf.py
Image-->>Runtime: Return verifier script paths
Runtime->>Py: Execute DKIM/SPF checks with python
Py-->>Runtime: Return pass/fail verdicts
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Build as Docker build
participant Image as inbound-mail image
participant Runtime as mailUtilities.js
participant Py as Python verifiers

Build->>Image: Copy src/python to dist/src/python
Runtime->>Image: Resolve __dirname ../python/verifydkim.py and verifyspf.py
Image-->>Runtime: Return verifier script paths
Runtime->>Py: Execute DKIM/SPF checks with python
Py-->>Runtime: Return pass/fail verdicts
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(root): copy inbound-mail python veri..."](https://github.com/novuhq/novu/commit/76088d8c9fd5520a53a531e38748d7cf82f7f30d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42429640)</sub>

<!-- /greptile_comment -->