### PR TITLE
fix(root): read raw bytes in verifydkim for Python 3 compatibility fixes NV-8228

### DIFF
--- a/apps/inbound-mail/src/python/verifydkim.py
+++ b/apps/inbound-mail/src/python/verifydkim.py
@@ -9,8 +9,9 @@ import os
 import sys
 
 def main():
-    msg = sys.stdin.read()
-    res = None
+    # DKIM operates on the raw message bytes; sys.stdin.read() would decode to
+    # str, which the bytes-oriented dkim library rejects with a TypeError.
+    msg = sys.stdin.buffer.read()
     res = dkim.verify(msg)
 
     print('[' + os.path.basename(__file__) + '] isDkimValid = ' + str(res))


### PR DESCRIPTION
### What changed? Why was the change needed?

The inbound-mail DKIM verifier (`verifydkim.py`) was crashing on every email in Python 3 with:

```
TypeError: cannot use a bytes pattern on a string-like object
```

`sys.stdin.read()` returns a decoded `str` in Python 3, but the vendored `dkim` library parses the message with byte-oriented regex (`re.split(b"\r?\n", message)`). This caused the verifier to exit with code 1, and every inbound email was stamped with a failed DKIM verdict.

**Fix:** read raw message bytes via `sys.stdin.buffer.read()` before passing to `dkim.verify()`.

Related: [NV-8228](https://linear.app/novu/issue/NV-8228/fix-inbound-mail-dkim-verifier-python-3-bytes-typeerror) (follow-up to NV-8227)

```mermaid
sequenceDiagram
    participant Node as mailUtilities.ts
    participant Py as verifydkim.py
    participant DKIM as dkim library

    Node->>Py: spawn + write rawEmail (string) to stdin
    Py->>Py: sys.stdin.buffer.read() → bytes
    Py->>DKIM: dkim.verify(msg)
    alt valid signature
        DKIM-->>Py: True
        Py-->>Node: exit 0
    else invalid / missing signature
        DKIM-->>Py: False
        Py-->>Node: exit 11
    end
```

### Screenshots

N/A — backend Python script fix.

## Test plan

- [x] Piped a sample raw email into `verifydkim.py`; script runs without traceback and exits 11 (no DKIM signature on test message)
- [ ] Deploy inbound-mail image to DEV and confirm DKIM checks no longer log "verifier script did not run cleanly"
- [ ] Verify a signed inbound email returns exit 0 and `isDkimValid = True`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Python 3 DKIM verification for inbound mail. The main changes are:

- Reads the raw email from `sys.stdin.buffer` instead of decoded `stdin` text.
- Passes bytes into `dkim.verify` to match the DKIM library contract.
- Keeps the existing valid-signature and failed-signature exit behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to the Python DKIM verifier and preserves the existing output and exit-code behavior used by the Node caller.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the DKIM unsigned test before proof and confirmed the run crashed with a TypeError and exit status 1.
- Ran the DKIM unsigned test after proof and confirmed the run reported isDkimValid = False, exit status 11, with the harness assertion passing and no traceback or TypeError.
- Archived the fixture, harness, and Python compile results used for this verification.

<a href="https://app.greptile.com/trex/runs/13571883/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/python/verifydkim.py | Reads raw stdin bytes before calling the byte-oriented DKIM verifier, resolving the Python 3 string/bytes crash without changing exit-code semantics. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Node as mailUtilities.ts
participant Py as verifydkim.py
participant DKIM as dkim library

Node->>Py: spawn python verifier
Node->>Py: write rawEmail to stdin
Py->>Py: sys.stdin.buffer.read()
Py->>DKIM: dkim.verify(bytes)
DKIM-->>Py: boolean result
alt valid DKIM signature
    Py-->>Node: exit 0
else invalid or missing signature
    Py-->>Node: exit 11
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Node as mailUtilities.ts
participant Py as verifydkim.py
participant DKIM as dkim library

Node->>Py: spawn python verifier
Node->>Py: write rawEmail to stdin
Py->>Py: sys.stdin.buffer.read()
Py->>DKIM: dkim.verify(bytes)
DKIM-->>Py: boolean result
alt valid DKIM signature
    Py-->>Node: exit 0
else invalid or missing signature
    Py-->>Node: exit 11
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(root): read raw bytes in verifydkim ..."](https://github.com/novuhq/novu/commit/661f10df33b8111d87a425c95ea9f8a8249ac936) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42438000)</sub>

<!-- /greptile_comment -->