### PR TITLE
fix(root): resolve python interpreter for inbound-mail SPF/DKIM fixes NV-8229

### DIFF
--- a/apps/inbound-mail/src/server/mailUtilities.ts
+++ b/apps/inbound-mail/src/server/mailUtilities.ts
@@ -8,18 +8,20 @@ const LOG_CONTEXT = 'MailUtilities';
 
 const spamc = new Spamc();
 
-/* Verify Python availability. */
-const isPythonAvailable = shell.which('python');
-if (!isPythonAvailable) {
+/*
+ * Resolve the Python interpreter once. Alpine images ship `python3` (via
+ * py3-pip) without a `python` alias, so prefer python3 and keep the absolute
+ * path to avoid any PATH/spawn ambiguity at request time.
+ */
+const resolvedPython = shell.which('python3') || shell.which('python');
+const pythonBin = resolvedPython ? resolvedPython.toString() : null;
+if (!pythonBin) {
   logger.warn(
     { context: LOG_CONTEXT, path: process.env.PATH },
     'Python is not available. Dkim and spf checking is disabled — every inbound email will carry dkim/spf "failed" verdicts.'
   );
 } else {
-  logger.info(
-    { context: LOG_CONTEXT, pythonPath: isPythonAvailable.toString() },
-    'Python found — dkim and spf checking is enabled.'
-  );
+  logger.info({ context: LOG_CONTEXT, pythonPath: pythonBin }, 'Python found — dkim and spf checking is enabled.');
 }
 
 /* Verify spamc/spamassassin availability. */
@@ -39,12 +41,12 @@ if (!shell.which('spamassassin') || !shell.which('spamc')) {
 module.exports = {
   /* @param rawEmail is the full raw mime email as a string. */
   validateDkim(rawEmail, callback) {
-    if (!isPythonAvailable) {
+    if (!pythonBin) {
       return callback(null, false);
     }
 
     const verifyDkimPath = path.join(__dirname, '../python/verifydkim.py');
-    const verifyDkim = child_process.spawn('python', [verifyDkimPath]);
+    const verifyDkim = child_process.spawn(pythonBin, [verifyDkimPath]);
 
     let stdout = '';
     let stderr = '';
@@ -84,15 +86,14 @@ module.exports = {
   },
 
   validateSpf(ip, address, host, callback) {
-    if (!isPythonAvailable) {
+    if (!pythonBin) {
       return callback(null, false);
     }
 
     const verifySpfPath = path.join(__dirname, '../python/verifyspf.py');
-    const cmd = 'python ';
     const args = [verifySpfPath, ip, address, host];
 
-    child_process.execFile(cmd, args, (err, stdout, stderr) => {
+    child_process.execFile(pythonBin, args, (err, stdout, stderr) => {
       logger.verbose({ context: LOG_CONTEXT }, stdout);
       let code = 0;
       if (err) {


### PR DESCRIPTION
### What changed? Why was the change needed?

SPF verification in `@novu/inbound-mail` was failing in production with:

```
Error: spawn python  ENOENT
SPF verification errored: verifier did not run cleanly — treating spf as failed.
```

Two issues caused this:

1. `validateSpf` passed `'python '` (with a trailing space) to `execFile`, so Node tried to spawn a binary literally named `python `.
2. Alpine images ship `python3` via `py3-pip` without a `python` alias, so hardcoded `'python'` lookups can fail even when Python is installed.

**Fix:** Resolve the Python interpreter once at startup (`python3` then `python` fallback), store the absolute path in `pythonBin`, and use it for both DKIM (`spawn`) and SPF (`execFile`).

Related: [NV-8229](https://linear.app/novu/issue/NV-8229/fix-inbound-mail-spf-verifier-spawn-python-enoent) (follow-up to [NV-8228](https://linear.app/novu/issue/NV-8228) / [NV-8227](https://linear.app/novu/issue/NV-8227))

```mermaid
sequenceDiagram
    participant Node as mailUtilities.ts
    participant Shell as shell.which
    participant Py as verifyspf.py / verifydkim.py

    Note over Node: startup
    Node->>Shell: which python3 || which python
    Shell-->>Node: absolute path (pythonBin)

    Note over Node: per inbound email
    alt SPF check
        Node->>Py: execFile(pythonBin, [verifyspf.py, ip, address, host])
    else DKIM check
        Node->>Py: spawn(pythonBin, [verifydkim.py]) + write rawEmail
    end
    alt verifier runs cleanly
        Py-->>Node: exit 0 (pass) or 11 (fail)
    else spawn/runtime error
        Py-->>Node: ENOENT / traceback → log + treat as failed
    end
```

### Breaking changes

None.

### Screenshots

N/A — backend mail utility fix.

## Test plan

- [x] Confirmed `validateSpf` no longer passes `'python '` to `execFile`
- [x] Interpreter resolution prefers `python3` with `python` fallback
- [ ] Deploy inbound-mail image to DEV and confirm SPF checks no longer log `spawn python  ENOENT`
- [ ] Verify startup log shows resolved `pythonPath` (e.g. `/usr/bin/python3`)
- [ ] Confirm SPF returns real pass/fail verdicts (exit 0 / 11) instead of infrastructure errors

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Python interpreter resolution for inbound mail SPF and DKIM checks. The main changes are:

- Resolves `python3` first, with `python` as a fallback, during module startup.
- Stores the resolved interpreter path in `pythonBin` for later verifier calls.
- Uses `pythonBin` for DKIM `spawn` and SPF `execFile`.
- Removes the trailing-space SPF command that caused `execFile` to spawn an invalid binary.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow and directly addresses the reported ENOENT failure. Existing behavior is preserved when Python is unavailable, and the resolved interpreter path is used consistently for both SPF and DKIM checks.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated the runtime harness for the mailutilities Python resolution test.
- Executed the test using the harness, capturing the command, logger calls, SPF callback outcomes, and fallback resolution.
- Verified the run completed with exit code 0 and ALL ASSERTIONS PASSED as reported in the log.

<a href="https://app.greptile.com/trex/runs/13575852/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/server/mailUtilities.ts | Resolves the Python interpreter once at startup and reuses the absolute path for DKIM `spawn` and SPF `execFile`; no issues found. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Startup as Module startup
participant Shell as shell.which
participant Mail as mailUtilities.ts
participant SPF as verifyspf.py
participant DKIM as verifydkim.py

Startup->>Shell: "which('python3') || which('python')"
Shell-->>Startup: resolved absolute pythonBin or null
alt pythonBin missing
    Mail-->>Mail: SPF/DKIM callbacks return failed verdicts
else pythonBin resolved
    alt SPF validation
        Mail->>SPF: execFile(pythonBin, [verifyspf.py, ip, address, host])
        SPF-->>Mail: exit 0 pass / 11 fail / other error
    else DKIM validation
        Mail->>DKIM: spawn(pythonBin, [verifydkim.py])
        Mail->>DKIM: write rawEmail to stdin
        DKIM-->>Mail: exit 0 pass / 11 fail / other error
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Startup as Module startup
participant Shell as shell.which
participant Mail as mailUtilities.ts
participant SPF as verifyspf.py
participant DKIM as verifydkim.py

Startup->>Shell: "which('python3') || which('python')"
Shell-->>Startup: resolved absolute pythonBin or null
alt pythonBin missing
    Mail-->>Mail: SPF/DKIM callbacks return failed verdicts
else pythonBin resolved
    alt SPF validation
        Mail->>SPF: execFile(pythonBin, [verifyspf.py, ip, address, host])
        SPF-->>Mail: exit 0 pass / 11 fail / other error
    else DKIM validation
        Mail->>DKIM: spawn(pythonBin, [verifydkim.py])
        Mail->>DKIM: write rawEmail to stdin
        DKIM-->>Mail: exit 0 pass / 11 fail / other error
    end
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(root): resolve python interpreter fo..."](https://github.com/novuhq/novu/commit/c8147d3b8b2ab302b6f45cf7d680d3d2460c77f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42446957)</sub>

<!-- /greptile_comment -->