### PR TITLE
refactor(dashboard): improve agents gating on CE fixes NV-8231

### DIFF
--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlagsKeysEnum, type IEnvironment } from '@novu/shared';
+import type { IEnvironment } from '@novu/shared';
 import { useEffect, useState } from 'react';
 import {
   RiAddBoxLine,
@@ -13,8 +13,8 @@ import {
   RiRouteFill,
 } from 'react-icons/ri';
 import type { IResourceDependency, IResourceDiffResult, ResourceToPublish } from '@/api/environments';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useDiffEnvironments } from '@/hooks/use-environments';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useResourceDependencies } from '@/hooks/use-resource-dependencies';
 import { formatDateSimple } from '@/utils/format-date';
 import { Badge, BadgeIcon } from '../primitives/badge';
@@ -63,7 +63,7 @@ export function PublishModal({
     enabled: isOpen,
   });
 
-  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const areAgentsAvailable = useAreConversationalAgentsAvailable();
 
   const { workflows, layouts, agents, dependencyMap, calculateDependencyState } = useResourceDependencies(diffData);
 
@@ -219,7 +219,7 @@ export function PublishModal({
             </ResourceGroupCompact>
           )}
 
-          {isAgentsEnabled && agents.length > 0 && (
+          {areAgentsAvailable && agents.length > 0 && (
             <ResourceGroupCompact
               title="Agents"
               count={agents.length}
@@ -247,7 +247,7 @@ export function PublishModal({
           )}
         </div>
 
-        {isAgentsEnabled && newSelectedAgentCount > 0 && <AgentInactiveWarning count={newSelectedAgentCount} />}
+        {areAgentsAvailable && newSelectedAgentCount > 0 && <AgentInactiveWarning count={newSelectedAgentCount} />}
 
         <PublishModalActions
           environment={environment}

--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -74,6 +74,10 @@ export function PublishModal({
     const initialSelection: ResourceSelection = {};
 
     diffData.resources.forEach((resource) => {
+      if (!areAgentsAvailable && resource.resourceType === 'agent') {
+        return;
+      }
+
       const resourceId = resource.sourceResource?.id || resource.targetResource?.id;
 
       if (resourceId) {
@@ -88,7 +92,7 @@ export function PublishModal({
     // Apply dependency rules to the initial selection
     const selectionWithDependencies = calculateDependencyState(initialSelection);
     setResourceSelection(selectionWithDependencies);
-  }, [diffData, calculateDependencyState]);
+  }, [diffData, calculateDependencyState, areAgentsAvailable]);
 
   const handleResourceToggle = (resourceId: string) => {
     setResourceSelection((prev) => {

--- a/apps/dashboard/src/components/inbox-button.tsx
+++ b/apps/dashboard/src/components/inbox-button.tsx
@@ -109,24 +109,23 @@ export const InboxButton = ({
   const isNovuStagingEnvironment = apiHostnameManager.getHostname() === 'https://api.novu-staging.co';
   const shouldUseProductionApi = (isNovuProductionDashboard || isNovuStagingEnvironment) && !isTestPage;
 
-  const subscriber = useMemo(() => {
-    const email = user?.primaryEmailAddress?.emailAddress || user?.emailAddresses?.[0]?.emailAddress || '';
-
-    return {
+  const subscriber = useMemo(
+    () => ({
       subscriberId: isTestPage ? (user?.externalId ?? '') : `org_${currentOrganization?._id}:user_${user?.externalId}`,
-      ...(email ? { email } : {}),
+      email: user?.primaryEmailAddress?.emailAddress ?? user?.emailAddresses?.[0]?.emailAddress ?? '',
       firstName: user?.firstName ?? '',
       lastName: user?.lastName ?? '',
-    };
-  }, [
-    isTestPage,
-    user?.externalId,
-    user?.primaryEmailAddress?.emailAddress,
-    user?.emailAddresses,
-    user?.firstName,
-    user?.lastName,
-    currentOrganization?._id,
-  ]);
+    }),
+    [
+      isTestPage,
+      user?.externalId,
+      user?.primaryEmailAddress?.emailAddress,
+      user?.emailAddresses,
+      user?.firstName,
+      user?.lastName,
+      currentOrganization?._id,
+    ]
+  );
 
   const localization = useMemo(
     () => ({

--- a/apps/dashboard/src/components/inbox-button.tsx
+++ b/apps/dashboard/src/components/inbox-button.tsx
@@ -109,22 +109,24 @@ export const InboxButton = ({
   const isNovuStagingEnvironment = apiHostnameManager.getHostname() === 'https://api.novu-staging.co';
   const shouldUseProductionApi = (isNovuProductionDashboard || isNovuStagingEnvironment) && !isTestPage;
 
-  const subscriber = useMemo(
-    () => ({
+  const subscriber = useMemo(() => {
+    const email = user?.primaryEmailAddress?.emailAddress || user?.emailAddresses?.[0]?.emailAddress || '';
+
+    return {
       subscriberId: isTestPage ? (user?.externalId ?? '') : `org_${currentOrganization?._id}:user_${user?.externalId}`,
-      email: user?.primaryEmailAddress?.emailAddress ?? '',
+      ...(email ? { email } : {}),
       firstName: user?.firstName ?? '',
       lastName: user?.lastName ?? '',
-    }),
-    [
-      isTestPage,
-      user?.externalId,
-      user?.primaryEmailAddress?.emailAddress,
-      user?.firstName,
-      user?.lastName,
-      currentOrganization?._id,
-    ]
-  );
+    };
+  }, [
+    isTestPage,
+    user?.externalId,
+    user?.primaryEmailAddress?.emailAddress,
+    user?.emailAddresses,
+    user?.firstName,
+    user?.lastName,
+    currentOrganization?._id,
+  ]);
 
   const localization = useMemo(
     () => ({

--- a/apps/dashboard/src/components/side-navigation/side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/side-navigation.tsx
@@ -20,10 +20,11 @@ import {
 } from 'react-icons/ri';
 import { SidebarContent } from '@/components/side-navigation/sidebar';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { Protect } from '@/utils/protect';
 import { buildRoute, ROUTES } from '@/utils/routes';
-import { IS_ENTERPRISE, IS_EU, IS_SELF_HOSTED } from '../../config';
+import { IS_ENTERPRISE, IS_SELF_HOSTED } from '../../config';
 import { useFetchSubscription } from '../../hooks/use-fetch-subscription';
 import { ChangelogStack } from './changelog-cards';
 import { EnvironmentDropdown } from './environment-dropdown';
@@ -92,9 +93,7 @@ export const LegacySideNavigation = () => {
   const isDomainsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_DOMAINS_PAGE_ENABLED);
   const isHttpLogsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTTP_LOGS_PAGE_ENABLED, false);
   const isAnalyticsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_ANALYTICS_PAGE_ENABLED, false);
-  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
-  // Agents are hard-disabled in the EU region regardless of the rollout flag.
-  const showAgents = !IS_EU && isAgentsEnabled;
+  const showAgents = useAreConversationalAgentsAvailable();
 
   const { currentEnvironment, environments, switchEnvironment } = useEnvironment();
 

--- a/apps/dashboard/src/components/welcome/home/use-welcome-setup.ts
+++ b/apps/dashboard/src/components/welcome/home/use-welcome-setup.ts
@@ -2,7 +2,6 @@ import { useOrganization } from '@clerk/react';
 import {
   ChannelTypeEnum,
   DirectionEnum,
-  FeatureFlagsKeysEnum,
   type IIntegration,
   ProductUseCasesEnum,
 } from '@novu/shared';
@@ -18,10 +17,10 @@ import {
   listAgents,
 } from '@/api/agents';
 import { docsUrl } from '@/components/header-navigation/support-drawer-constants';
-import { IS_EU, IS_SELF_HOSTED, ONBOARDING_DEMO_WORKFLOW_ID } from '@/config';
+import { IS_SELF_HOSTED, ONBOARDING_DEMO_WORKFLOW_ID } from '@/config';
 import { useAuth } from '@/context/auth/hooks';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useFetchWorkflows } from '@/hooks/use-fetch-workflows';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -65,8 +64,7 @@ export function useWelcomeSetup(): UseWelcomeSetupResult {
   const { currentOrganization } = useAuth();
   const { organization } = useOrganization();
 
-  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
-  const agentsAvailable = isAgentsEnabled && !IS_EU;
+  const agentsAvailable = useAreConversationalAgentsAvailable();
   const pickedAgents = Boolean(currentOrganization?.productUseCases?.[ProductUseCasesEnum.AGENTS]);
   const variant: WelcomeVariant = pickedAgents && agentsAvailable ? 'agents' : 'standard';
 

--- a/apps/dashboard/src/hooks/use-are-conversational-agents-available.ts
+++ b/apps/dashboard/src/hooks/use-are-conversational-agents-available.ts
@@ -1,0 +1,13 @@
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { IS_EU, IS_SELF_HOSTED_CE } from '@/config';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+
+export function areConversationalAgentsAvailable(isAgentsEnabled: boolean): boolean {
+  return isAgentsEnabled && !IS_EU && !IS_SELF_HOSTED_CE;
+}
+
+export function useAreConversationalAgentsAvailable(): boolean {
+  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+
+  return areConversationalAgentsAvailable(isAgentsEnabled);
+}

--- a/apps/dashboard/src/hooks/use-are-conversational-agents-available.ts
+++ b/apps/dashboard/src/hooks/use-are-conversational-agents-available.ts
@@ -2,12 +2,8 @@ import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { IS_EU, IS_SELF_HOSTED_CE } from '@/config';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 
-export function areConversationalAgentsAvailable(isAgentsEnabled: boolean): boolean {
-  return isAgentsEnabled && !IS_EU && !IS_SELF_HOSTED_CE;
-}
-
 export function useAreConversationalAgentsAvailable(): boolean {
   const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
 
-  return areConversationalAgentsAvailable(isAgentsEnabled);
+  return isAgentsEnabled && !IS_EU && !IS_SELF_HOSTED_CE;
 }

--- a/apps/dashboard/src/pages/activity-feed.tsx
+++ b/apps/dashboard/src/pages/activity-feed.tsx
@@ -6,6 +6,7 @@ import { ConversationsContent } from '@/components/conversations/conversations-c
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -15,7 +16,7 @@ import { PageMeta } from '../components/page-meta';
 
 export function ActivityFeed() {
   const isHttpLogsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTTP_LOGS_PAGE_ENABLED, false);
-  const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const areAgentsAvailable = useAreConversationalAgentsAvailable();
   const { currentEnvironment } = useEnvironment();
   const location = useLocation();
   const navigate = useNavigate();
@@ -23,7 +24,7 @@ export function ActivityFeed() {
 
   const getCurrentTab = () => {
     if (location.pathname.includes('/activity/conversations')) {
-      if (!isConversationalAgentsEnabled) {
+      if (!areAgentsAvailable) {
         return 'workflow-runs';
       }
 
@@ -70,14 +71,14 @@ export function ActivityFeed() {
 
   useEffect(() => {
     if (
-      !isConversationalAgentsEnabled &&
+      !areAgentsAvailable &&
       location.pathname.includes('/activity/conversations') &&
       currentEnvironment?.slug
     ) {
       const fallbackPath = buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug });
       navigate(`${fallbackPath}${location.search}`, { replace: true });
     }
-  }, [isConversationalAgentsEnabled, location.pathname, location.search, currentEnvironment?.slug, navigate]);
+  }, [areAgentsAvailable, location.pathname, location.search, currentEnvironment?.slug, navigate]);
 
   useEffect(() => {
     if (!isHttpLogsPageEnabled && location.pathname.includes('/activity/requests') && currentEnvironment?.slug) {
@@ -107,7 +108,7 @@ export function ActivityFeed() {
             <TabsTrigger value="workflow-runs" variant="regular" size="lg">
               Workflow Runs
             </TabsTrigger>
-            {isConversationalAgentsEnabled && (
+            {areAgentsAvailable && (
               <TabsTrigger value="conversations" variant="regular" size="lg">
                 Agent conversations
               </TabsTrigger>
@@ -121,7 +122,7 @@ export function ActivityFeed() {
           <TabsContent value="workflow-runs">
             <ActivityFeedContent contentHeight="h-[calc(100vh-170px)]" />
           </TabsContent>
-          {isConversationalAgentsEnabled && (
+          {areAgentsAvailable && (
             <TabsContent value="conversations">
               <ConversationsContent contentHeight="h-[calc(100vh-170px)]" />
             </TabsContent>

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowLeftSLine, RiRobot2Line } from 'react-icons/ri';
@@ -35,10 +34,9 @@ import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import TruncatedText from '@/components/truncated-text';
-import { IS_EU } from '@/config';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import {
   AGENT_DETAILS_DEFAULT_TAB,
@@ -92,7 +90,7 @@ export function AgentDetailsPage() {
   const location = useLocation();
   const queryClient = useQueryClient();
   const { currentEnvironment, readOnly } = useEnvironment();
-  const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const areAgentsAvailable = useAreConversationalAgentsAvailable();
   const agentRoutes = useAgentRoutes();
   const [agentToDelete, setAgentToDelete] = useState<AgentResponse | null>(null);
   const [setupModalDismissed, setSetupModalDismissed] = useState(false);
@@ -106,7 +104,7 @@ export function AgentDetailsPage() {
   const agentQuery = useQuery({
     queryKey: getAgentDetailQueryKey(currentEnvironment?._id, agentIdentifier),
     queryFn: () => getAgent(requireEnvironment(currentEnvironment, 'No environment selected'), agentIdentifier),
-    enabled: Boolean(currentEnvironment && agentIdentifier && isConversationalAgentsEnabled),
+    enabled: Boolean(currentEnvironment && agentIdentifier && areAgentsAvailable),
   });
 
   const deleteMutation = useMutation({
@@ -143,7 +141,7 @@ export function AgentDetailsPage() {
         agentIdentifier,
         limit: 100,
       }),
-    enabled: Boolean(currentEnvironment && agentIdentifier && isConversationalAgentsEnabled),
+    enabled: Boolean(currentEnvironment && agentIdentifier && areAgentsAvailable),
   });
 
   const hasConnectedIntegration = useMemo(() => {
@@ -167,7 +165,7 @@ export function AgentDetailsPage() {
   const currentTab = integrationIdentifier ? 'integrations' : parseAgentDetailsTab(agentTabParam);
 
   useEffect(() => {
-    if (!isConversationalAgentsEnabled || !agentIdentifier || !agentQuery.data) {
+    if (!areAgentsAvailable || !agentIdentifier || !agentQuery.data) {
       return;
     }
 
@@ -190,9 +188,9 @@ export function AgentDetailsPage() {
         integrationIdentifier,
       });
     }
-  }, [agentIdentifier, agentQuery.data, currentTab, integrationIdentifier, isConversationalAgentsEnabled, track]);
+  }, [agentIdentifier, agentQuery.data, currentTab, integrationIdentifier, areAgentsAvailable, track]);
 
-  if (IS_EU || !isConversationalAgentsEnabled) {
+  if (!areAgentsAvailable) {
     return <Navigate to={agentsListPath} replace />;
   }
 

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -157,7 +157,6 @@ export function AgentsSetupPage() {
 
   // When the user arrives here via `?product_type=agents` (the usecase picker is skipped), persist the
   // agents usecase on the org once it's resolved. Runs once; the usecase picker path persists itself.
-  // Skipped when agents are unavailable (EU, Community self-hosted, or flag off) since the page redirects to the inbox path.
   useEffect(() => {
     if (productUseCasesPersistedRef.current || !areAgentsAvailable || !currentOrganization?._id) {
       return;

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -157,7 +157,7 @@ export function AgentsSetupPage() {
 
   // When the user arrives here via `?product_type=agents` (the usecase picker is skipped), persist the
   // agents usecase on the org once it's resolved. Runs once; the usecase picker path persists itself.
-  // Skipped when agents are unavailable (EU/flag off) since the page redirects to the inbox path.
+  // Skipped when agents are unavailable (EU, Community self-hosted, or flag off) since the page redirects to the inbox path.
   useEffect(() => {
     if (productUseCasesPersistedRef.current || !areAgentsAvailable || !currentOrganization?._id) {
       return;

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlagsKeysEnum, ProductUseCasesEnum } from '@novu/shared';
+import { ProductUseCasesEnum } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -16,12 +16,11 @@ import { OnboardingLoader } from '@/components/onboarding/onboarding-loader';
 import { OnboardingShell } from '@/components/onboarding/onboarding-shell';
 import { PageMeta } from '@/components/page-meta';
 import { Button } from '@/components/primitives/button';
-import { IS_EU } from '@/config';
 import { useAuth } from '@/context/auth/hooks';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useAgentCliConnectionPoll } from '@/hooks/use-agent-cli-connection-poll';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useOnboardingProvisioningActive, useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { useUpdateProductUseCases } from '@/hooks/use-update-product-use-cases';
@@ -125,7 +124,7 @@ function StepHeader({ current, onBack }: StepHeaderProps) {
 }
 
 export function AgentsSetupPage() {
-  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const areAgentsAvailable = useAreConversationalAgentsAvailable();
   const navigate = useNavigate();
   const telemetry = useTelemetry();
   const { currentOrganization } = useAuth();
@@ -160,7 +159,7 @@ export function AgentsSetupPage() {
   // agents usecase on the org once it's resolved. Runs once; the usecase picker path persists itself.
   // Skipped when agents are unavailable (EU/flag off) since the page redirects to the inbox path.
   useEffect(() => {
-    if (productUseCasesPersistedRef.current || IS_EU || !isAgentsEnabled || !currentOrganization?._id) {
+    if (productUseCasesPersistedRef.current || !areAgentsAvailable || !currentOrganization?._id) {
       return;
     }
 
@@ -171,7 +170,7 @@ export function AgentsSetupPage() {
     productUseCasesPersistedRef.current = true;
     updateProductUseCases.mutate({ [ProductUseCasesEnum.AGENTS]: true });
     clearPendingProductType();
-  }, [currentOrganization?._id, isAgentsEnabled, updateProductUseCases]);
+  }, [areAgentsAvailable, currentOrganization?._id, updateProductUseCases]);
 
   const [createdAgent, setCreatedAgent] = useState<AgentResponse | null>(null);
   const [connectSummary, setConnectSummary] = useState<ConnectSummary | null>(null);
@@ -302,8 +301,7 @@ export function AgentsSetupPage() {
     void navigate(ROUTES.USECASE_SELECT);
   }, [navigate]);
 
-  // Agents are not available in the EU region.
-  if (IS_EU || !isAgentsEnabled) {
+  if (!areAgentsAvailable) {
     return <Navigate to={ROUTES.INBOX_USECASE} replace />;
   }
 

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -1,9 +1,16 @@
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { CaretSortIcon } from '@radix-ui/react-icons';
 import { useMutation } from '@tanstack/react-query';
 import type { FormEvent, ReactElement } from 'react';
 import { useCallback, useEffect, useId, useMemo, useState } from 'react';
-import { RiArrowRightSLine, RiCheckLine, RiCloseLine, RiMailLine, RiMessage3Line, RiMoreLine } from 'react-icons/ri';
+import {
+  RiArrowRightSLine,
+  RiCheckLine,
+  RiCloseLine,
+  RiMailLine,
+  RiMessage3Line,
+  RiMoreLine,
+  RiSparkling2Line,
+} from 'react-icons/ri';
 import {
   SiGithub,
   SiGooglechat,
@@ -18,9 +25,10 @@ import { Navigate } from 'react-router-dom';
 import { NovuApiError, post } from '@/api/api.client';
 import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsList } from '@/components/agents/agents-list';
+import { UPGRADE_CTA_LABEL, usePlanUpgradeClick } from '@/components/billing/use-plan-upgrade-click';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
-import { IS_EU } from '@/config';
+import { IS_EU, IS_SELF_HOSTED_CE } from '@/config';
 import { Badge } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
@@ -31,7 +39,7 @@ import { Separator } from '@/components/primitives/separator';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { DismissButton, Icon as TagIcon, Root as TagRoot } from '@/components/primitives/tag';
 import { Textarea } from '@/components/primitives/textarea';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -406,8 +414,9 @@ function AgentsEarlyAccessDialog({ open, onOpenChange }: AgentsEarlyAccessDialog
 
 export function AgentsPage() {
   const [earlyAccessOpen, setEarlyAccessOpen] = useState(false);
-  const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const areAgentsAvailable = useAreConversationalAgentsAvailable();
   const track = useTelemetry();
+  const handleUpgradeClick = usePlanUpgradeClick('agents-page', 'agents');
 
   useEffect(() => {
     track(TelemetryEvent.AGENTS_PAGE_VISITED);
@@ -418,10 +427,50 @@ export function AgentsPage() {
     return <Navigate to={ROUTES.ROOT} replace />;
   }
 
+  let agentsContent: ReactElement;
+
+  if (IS_SELF_HOSTED_CE) {
+    agentsContent = (
+      <AgentsEmptyTeaser
+        cta={
+          <Button
+            variant="primary"
+            mode="gradient"
+            size="xs"
+            leadingIcon={RiSparkling2Line}
+            type="button"
+            onClick={handleUpgradeClick}
+          >
+            {UPGRADE_CTA_LABEL}
+          </Button>
+        }
+      />
+    );
+  } else if (areAgentsAvailable) {
+    agentsContent = <AgentsList />;
+  } else {
+    agentsContent = (
+      <AgentsEmptyTeaser
+        cta={
+          <Button
+            variant="secondary"
+            mode="gradient"
+            size="xs"
+            trailingIcon={RiArrowRightSLine}
+            type="button"
+            onClick={() => setEarlyAccessOpen(true)}
+          >
+            Request early access
+          </Button>
+        }
+      />
+    );
+  }
+
   return (
     <>
       <PageMeta title="Agents" />
-      {!isConversationalAgentsEnabled ? (
+      {!areAgentsAvailable && !IS_SELF_HOSTED_CE ? (
         <AgentsEarlyAccessDialog open={earlyAccessOpen} onOpenChange={setEarlyAccessOpen} />
       ) : null}
       <DashboardLayout
@@ -434,24 +483,7 @@ export function AgentsPage() {
           </h1>
         }
       >
-        {isConversationalAgentsEnabled ? (
-          <AgentsList />
-        ) : (
-          <AgentsEmptyTeaser
-            cta={
-              <Button
-                variant="secondary"
-                mode="gradient"
-                size="xs"
-                trailingIcon={RiArrowRightSLine}
-                type="button"
-                onClick={() => setEarlyAccessOpen(true)}
-              >
-                Request early access
-              </Button>
-            }
-          />
-        )}
+        {agentsContent}
       </DashboardLayout>
     </>
   );

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -427,47 +427,6 @@ export function AgentsPage() {
     return <Navigate to={ROUTES.ROOT} replace />;
   }
 
-  let agentsContent: ReactElement;
-
-  if (areAgentsAvailable) {
-    agentsContent = <AgentsList />;
-  } else if (IS_SELF_HOSTED) {
-    // Self-hosted has no early-access flow, so surface the Contact Sales upgrade path instead.
-    agentsContent = (
-      <AgentsEmptyTeaser
-        cta={
-          <Button
-            variant="primary"
-            mode="gradient"
-            size="xs"
-            leadingIcon={RiSparkling2Line}
-            type="button"
-            onClick={handleUpgradeClick}
-          >
-            {UPGRADE_CTA_LABEL}
-          </Button>
-        }
-      />
-    );
-  } else {
-    agentsContent = (
-      <AgentsEmptyTeaser
-        cta={
-          <Button
-            variant="secondary"
-            mode="gradient"
-            size="xs"
-            trailingIcon={RiArrowRightSLine}
-            type="button"
-            onClick={() => setEarlyAccessOpen(true)}
-          >
-            Request early access
-          </Button>
-        }
-      />
-    );
-  }
-
   return (
     <>
       <PageMeta title="Agents" />
@@ -484,7 +443,37 @@ export function AgentsPage() {
           </h1>
         }
       >
-        {agentsContent}
+        {areAgentsAvailable ? (
+          <AgentsList />
+        ) : (
+          <AgentsEmptyTeaser
+            cta={
+              IS_SELF_HOSTED ? (
+                <Button
+                  variant="primary"
+                  mode="gradient"
+                  size="xs"
+                  leadingIcon={RiSparkling2Line}
+                  type="button"
+                  onClick={handleUpgradeClick}
+                >
+                  {UPGRADE_CTA_LABEL}
+                </Button>
+              ) : (
+                <Button
+                  variant="secondary"
+                  mode="gradient"
+                  size="xs"
+                  trailingIcon={RiArrowRightSLine}
+                  type="button"
+                  onClick={() => setEarlyAccessOpen(true)}
+                >
+                  Request early access
+                </Button>
+              )
+            }
+          />
+        )}
       </DashboardLayout>
     </>
   );

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -28,7 +28,7 @@ import { AgentsList } from '@/components/agents/agents-list';
 import { UPGRADE_CTA_LABEL, usePlanUpgradeClick } from '@/components/billing/use-plan-upgrade-click';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
-import { IS_EU, IS_SELF_HOSTED_CE } from '@/config';
+import { IS_EU, IS_SELF_HOSTED } from '@/config';
 import { Badge } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
@@ -429,7 +429,10 @@ export function AgentsPage() {
 
   let agentsContent: ReactElement;
 
-  if (IS_SELF_HOSTED_CE) {
+  if (areAgentsAvailable) {
+    agentsContent = <AgentsList />;
+  } else if (IS_SELF_HOSTED) {
+    // Self-hosted has no early-access flow, so surface the Contact Sales upgrade path instead.
     agentsContent = (
       <AgentsEmptyTeaser
         cta={
@@ -446,8 +449,6 @@ export function AgentsPage() {
         }
       />
     );
-  } else if (areAgentsAvailable) {
-    agentsContent = <AgentsList />;
   } else {
     agentsContent = (
       <AgentsEmptyTeaser
@@ -470,7 +471,7 @@ export function AgentsPage() {
   return (
     <>
       <PageMeta title="Agents" />
-      {!areAgentsAvailable && !IS_SELF_HOSTED_CE ? (
+      {!areAgentsAvailable && !IS_SELF_HOSTED ? (
         <AgentsEarlyAccessDialog open={earlyAccessOpen} onOpenChange={setEarlyAccessOpen} />
       ) : null}
       <DashboardLayout

--- a/apps/dashboard/src/pages/usecase-select-page.tsx
+++ b/apps/dashboard/src/pages/usecase-select-page.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlagsKeysEnum, ProductUseCasesEnum } from '@novu/shared';
+import { ProductUseCasesEnum } from '@novu/shared';
 import {
   Bot,
   CalendarDays,
@@ -22,8 +22,7 @@ import { Notification5Fill } from '@/components/icons/notification-5-fill';
 import { AgentUsecasePreviewIllustration } from '@/components/onboarding/agent-usecase-preview-illustration';
 import { OnboardingShell } from '@/components/onboarding/onboarding-shell';
 import { PageMeta } from '@/components/page-meta';
-import { IS_EU } from '@/config';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversational-agents-available';
 import { useOnboardingProvisioningActive, useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { useUpdateProductUseCases } from '@/hooks/use-update-product-use-cases';
@@ -413,7 +412,7 @@ function UsecaseSelector({ selected, onSelect }: { selected: UsecaseId; onSelect
 }
 
 export function UsecaseSelectPage() {
-  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const areAgentsAvailable = useAreConversationalAgentsAvailable();
   const telemetry = useTelemetry();
   const [selected, setSelected] = useState<UsecaseId>('inbox');
   const provisioningActive = useOnboardingProvisioningActive();
@@ -431,8 +430,7 @@ export function UsecaseSelectPage() {
     return null;
   }
 
-  // Agents are hard-disabled in the EU region; skip the usecase picker entirely there.
-  if (IS_EU || !isAgentsEnabled) {
+  if (!areAgentsAvailable) {
     return <Navigate to={ROUTES.INBOX_USECASE} replace />;
   }
 

--- a/apps/dashboard/src/utils/self-hosted/organization.resource.tsx
+++ b/apps/dashboard/src/utils/self-hosted/organization.resource.tsx
@@ -34,6 +34,8 @@ export function OrganizationContextProvider({ children }: any) {
             externalOrgId: organization._id,
           },
           _id: organization._id,
+          update: async () => null,
+          reload: async () => null,
         }
       : undefined,
     isLoaded: hasToken ? !isLoading : true,

--- a/apps/dashboard/src/utils/self-hosted/user.types.ts
+++ b/apps/dashboard/src/utils/self-hosted/user.types.ts
@@ -7,6 +7,7 @@ export interface SelfHostedUser {
   firstName?: string;
   lastName?: string;
   emailAddresses: Array<{ emailAddress?: string }>;
+  primaryEmailAddress?: { emailAddress?: string };
   createdAt: Date;
   publicMetadata: { newDashboardOptInStatus: string };
   unsafeMetadata: { newDashboardOptInStatus: string };
@@ -26,6 +27,7 @@ export function createUserFromJwt(decodedJwt: DecodedJwt | null): SelfHostedUser
     firstName: decodedJwt.firstName,
     lastName: decodedJwt.lastName,
     emailAddresses: [{ emailAddress: decodedJwt.email }],
+    primaryEmailAddress: decodedJwt.email ? { emailAddress: decodedJwt.email } : undefined,
     createdAt: new Date(),
     publicMetadata: { newDashboardOptInStatus: 'opted_in' },
     unsafeMetadata: { newDashboardOptInStatus: 'opted_in' },

--- a/apps/dashboard/src/utils/self-hosted/user.types.ts
+++ b/apps/dashboard/src/utils/self-hosted/user.types.ts
@@ -27,7 +27,7 @@ export function createUserFromJwt(decodedJwt: DecodedJwt | null): SelfHostedUser
     firstName: decodedJwt.firstName,
     lastName: decodedJwt.lastName,
     emailAddresses: [{ emailAddress: decodedJwt.email }],
-    primaryEmailAddress: decodedJwt.email ? { emailAddress: decodedJwt.email } : undefined,
+    primaryEmailAddress: { emailAddress: decodedJwt.email },
     createdAt: new Date(),
     publicMetadata: { newDashboardOptInStatus: 'opted_in' },
     unsafeMetadata: { newDashboardOptInStatus: 'opted_in' },


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes conversational agents availability checks across the dashboard. The main changes are:

- Adds `useAreConversationalAgentsAvailable` for feature flag, EU, and self-hosted CE gating.
- Applies the shared gating hook to agents navigation, setup, details, activity conversations, welcome setup, and publish modal flows.
- Adds self-hosted compatibility fields for Clerk-like user and organization objects.
- Adds a self-hosted upgrade CTA on the agents page when agents are unavailable.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are a consistent gating refactor plus small self-hosted compatibility additions, and no verified functional or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the successful maily-core build log to confirm the core build completed for this PR.
- Captured the exact Playwright harness used to run the tests to support reproducibility.
- Inspected the dashboard Vite log to confirm the dependency resolution blocker involving @novu/js.
- Analyzed the run log and the incomplete @novu/js build log to map the execution path and partial build state, and noted that a zero-byte video was produced and intentionally not listed as UI proof.

<a href="https://app.greptile.com/trex/runs/13591209/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/hooks/use-are-conversational-agents-available.ts | Adds a shared availability hook combining the rollout flag with EU and self-hosted CE restrictions. |
| apps/dashboard/src/pages/agents.tsx | Uses centralized availability for the agents page and adds self-hosted upgrade CTA behavior. |
| apps/dashboard/src/pages/agents-setup-page.tsx | Applies centralized availability to onboarding persistence and setup-page redirects. |
| apps/dashboard/src/pages/activity-feed.tsx | Applies centralized agents availability to hide and redirect the conversations tab when unavailable. |
| apps/dashboard/src/components/header-navigation/publish-modal.tsx | Uses the centralized agents availability hook and omits agent resources from publish selection when unavailable. |
| apps/dashboard/src/utils/self-hosted/user.types.ts | Adds a Clerk-compatible primaryEmailAddress field to self-hosted users. |
| apps/dashboard/src/utils/self-hosted/organization.resource.tsx | Adds Clerk-compatible no-op organization update/reload methods for self-hosted context. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Dashboard renders agents-related UI] --> B[useAreConversationalAgentsAvailable]
  B --> C{Feature flag enabled?}
  C -- No --> X[Agents unavailable]
  C -- Yes --> D{EU region?}
  D -- Yes --> X
  D -- No --> E{Self-hosted CE?}
  E -- Yes --> X
  E -- No --> Y[Agents available]
  Y --> L[Show agents nav/list/setup/conversations/publish resources]
  X --> R[Hide or redirect agents-only routes; show teaser/upgrade where applicable]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Dashboard renders agents-related UI] --> B[useAreConversationalAgentsAvailable]
  B --> C{Feature flag enabled?}
  C -- No --> X[Agents unavailable]
  C -- Yes --> D{EU region?}
  D -- Yes --> X
  D -- No --> E{Self-hosted CE?}
  E -- Yes --> X
  E -- No --> Y[Agents available]
  Y --> L[Show agents nav/list/setup/conversations/publish resources]
  X --> R[Hide or redirect agents-only routes; show teaser/upgrade where applicable]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/components/header-navigation/publish-modal.tsx`, line 145-151 ([link](https://github.com/novuhq/novu/blob/c0222f309dd1b369883425d270febeee89b950cd/apps/dashboard/src/components/header-navigation/publish-modal.tsx#L145-L151)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Hidden agents still publish**
   When agents are unavailable, the modal hides the `Agents` group but `resourceSelection` is still initialized with every diff resource selected. `handleConfirm` then submits those hidden selected `agent` entries, so CE/self-hosted users can publish agent resources without seeing or deselecting them.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/components/header-navigation/publish-modal.tsx
   Line: 145-151

   Comment:
   **Hidden agents still publish**
   When agents are unavailable, the modal hides the `Agents` group but `resourceSelection` is still initialized with every diff resource selected. `handleConfirm` then submits those hidden selected `agent` entries, so CE/self-hosted users can publish agent resources without seeing or deselecting them.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fcomponents%2Fheader-navigation%2Fpublish-modal.tsx%0ALine%3A%20145-151%0A%0AComment%3A%0A**Hidden%20agents%20still%20publish**%0AWhen%20agents%20are%20unavailable%2C%20the%20modal%20hides%20the%20%60Agents%60%20group%20but%20%60resourceSelection%60%20is%20still%20initialized%20with%20every%20diff%20resource%20selected.%20%60handleConfirm%60%20then%20submits%20those%20hidden%20selected%20%60agent%60%20entries%2C%20so%20CE%2Fself-hosted%20users%20can%20publish%20agent%20resources%20without%20seeing%20or%20deselecting%20them.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11845&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(dashboard): streamline agent av..."](https://github.com/novuhq/novu/commit/6cd0c594ef9100f09a3217f380d0da6e5eef3d2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42473253)</sub>

<!-- /greptile_comment -->