### PR TITLE
fix(api-service): re-dispatch Telegram bot commands dropped by chat SDK slash-command routing fixes NV-8235

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
-import type { Chat, Message, ReactionEvent, Thread } from 'chat';
+import type { Chat, Message, ReactionEvent, SlashCommandEvent, Thread } from 'chat';
 import { LRUCache } from 'lru-cache';
 import { AgentConfigResolver, ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import { AgentEmailActionTokenService } from '../../email/agent-email-action-token.service';
@@ -403,6 +403,20 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
       }
     });
 
+    cached.chat.onSlashCommand(async (event: SlashCommandEvent) => {
+      try {
+        await this.redispatchTelegramCommandAsMessage(cached, event);
+      } catch (err) {
+        this.logger.error(err, `[agent:${agentId}] Error handling slash command ${event.command}`);
+        captureAgentException(err, {
+          component: 'chat-instance-registry',
+          operation: 'on-slash-command',
+          agentId,
+          extra: { command: event.command },
+        });
+      }
+    });
+
     cached.chat.onAction(async (event) => {
       try {
         if (!event.thread) {
@@ -458,6 +472,65 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
         this.logger.error(err, `[agent:${agentId}] Error handling reaction`);
         captureAgentException(err, { component: 'chat-instance-registry', operation: 'on-reaction', agentId });
       }
+    });
+  }
+
+  /**
+   * chat SDK ≥ 4.31 routes Telegram bot commands (any inbound message whose
+   * text starts with a `bot_command` entity) to slash-command handlers and no
+   * longer delivers them through the regular message pipeline. Novu consumes
+   * those commands as ordinary inbound messages — most importantly the
+   * `/start <code>` deep-link payload that drives the Telegram subscriber-link
+   * flow in `AgentInboundHandler` — so without this re-dispatch the command is
+   * silently dropped and the subscriber's channel endpoint is never created.
+   * Re-entering `chat.processMessage` restores the pre-4.31 behavior,
+   * including dedupe, thread locking, and DM/mention routing.
+   */
+  private async redispatchTelegramCommandAsMessage(cached: CachedChat, event: SlashCommandEvent): Promise<void> {
+    if (cached.config.platform !== AgentPlatformEnum.TELEGRAM) {
+      return;
+    }
+
+    const threadId = event.channel.id;
+    const message = await this.resolveTelegramCommandMessage(event, threadId);
+
+    await cached.chat.processMessage(event.adapter, threadId, message);
+  }
+
+  /**
+   * The Telegram adapter parses and caches the inbound message before emitting
+   * the slash-command event, so the cached copy (with formatting, author flags,
+   * and attachments intact) is preferred. Falls back to rebuilding the message
+   * from the event payload when the in-process cache no longer holds it.
+   */
+  private async resolveTelegramCommandMessage(event: SlashCommandEvent, threadId: string): Promise<Message> {
+    const raw = event.raw as { message_id?: number; chat?: { id?: number | string }; date?: number } | undefined;
+    const chatId = raw?.chat?.id;
+    const rawMessageId = raw?.message_id;
+    const hasPlatformIds = chatId !== undefined && rawMessageId !== undefined;
+    // Mirrors the Telegram adapter's `encodeMessageId` composite format so the
+    // chat SDK dedupe key matches the one a regular-message delivery would use.
+    const messageId = hasPlatformIds ? `${chatId}:${rawMessageId}` : `telegram-command:${threadId}:${Date.now()}`;
+
+    if (hasPlatformIds && event.adapter.fetchMessage) {
+      const cachedMessage = await event.adapter.fetchMessage(threadId, messageId);
+      if (cachedMessage) {
+        return cachedMessage;
+      }
+    }
+
+    const { Message: MessageCtor, parseMarkdown } = await esmImport('chat');
+    const text = event.text ? `${event.command} ${event.text}` : event.command;
+
+    return new MessageCtor({
+      id: messageId,
+      threadId,
+      text,
+      formatted: parseMarkdown(text),
+      raw: event.raw,
+      author: event.user,
+      metadata: { dateSent: raw?.date !== undefined ? new Date(raw.date * 1000) : new Date() },
+      attachments: [],
     });
   }
 }

--- a/apps/api/src/app/agents/e2e/helpers/telegram-api-stub.ts
+++ b/apps/api/src/app/agents/e2e/helpers/telegram-api-stub.ts
@@ -1,0 +1,113 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface RecordedTelegramCall {
+  method: string;
+  payload: Record<string, unknown>;
+}
+
+export interface TelegramApiStub {
+  url: string;
+  calls: RecordedTelegramCall[];
+  reset(): void;
+  close(): Promise<void>;
+}
+
+let stub: TelegramApiStub | undefined;
+
+const TELEGRAM_METHOD_PATTERN = /^\/bot[^/]+\/(\w+)$/;
+
+function buildResponse(method: string, payload: Record<string, unknown>): Record<string, unknown> {
+  switch (method) {
+    case 'getMe':
+      return {
+        ok: true,
+        result: { id: 999_000_001, is_bot: true, first_name: 'E2E Bot', username: 'novu_e2e_bot' },
+      };
+    case 'sendMessage':
+      return {
+        ok: true,
+        result: {
+          message_id: Math.floor(Math.random() * 1_000_000) + 1,
+          chat: { id: payload.chat_id, type: 'private' },
+          date: Math.floor(Date.now() / 1000),
+          text: payload.text ?? '',
+        },
+      };
+    case 'getWebhookInfo':
+      return { ok: true, result: { url: 'https://stub.invalid/webhook' } };
+    default:
+      return { ok: true, result: {} };
+  }
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (!raw) return {};
+
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Boots a minimal in-process Telegram Bot API stub and publishes its base URL
+ * via `process.env.TELEGRAM_API_BASE_URL`, which `@chat-adapter/telegram`
+ * reads at adapter construction. This lets e2e tests drive the production
+ * Telegram adapter (webhook parsing, `/start` command routing, replies via
+ * `sendMessage`) without the real Telegram API.
+ */
+export async function startTelegramApiStub(): Promise<TelegramApiStub> {
+  if (stub) return stub;
+
+  const calls: RecordedTelegramCall[] = [];
+
+  const server: Server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const match = TELEGRAM_METHOD_PATTERN.exec(req.url ?? '');
+    if (!match) {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, description: `Unknown path ${req.url}` }));
+
+      return;
+    }
+
+    const method = match[1];
+    const payload = await readJsonBody(req);
+    calls.push({ method, payload });
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(buildResponse(method, payload)));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const { port } = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${port}`;
+  process.env.TELEGRAM_API_BASE_URL = url;
+
+  stub = {
+    url,
+    calls,
+    reset: () => {
+      calls.length = 0;
+    },
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+      stub = undefined;
+      delete process.env.TELEGRAM_API_BASE_URL;
+    },
+  };
+
+  return stub;
+}

--- a/apps/api/src/app/agents/e2e/telegram-subscriber-link.e2e.ts
+++ b/apps/api/src/app/agents/e2e/telegram-subscriber-link.e2e.ts
@@ -11,14 +11,40 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { TelegramStartCodeService } from '../../telegram-linking/telegram-start-code.service';
 import { AgentConfigResolver } from '../channels/agent-config-resolver.service';
+import { ChatInstanceRegistry } from '../conversation-runtime/ingress/chat-instance.registry';
 import { AgentInboundHandler } from '../conversation-runtime/ingress/inbound-turn.handler';
 import { AgentEventEnum } from '../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
+import { startTelegramApiStub, type TelegramApiStub } from './helpers/telegram-api-stub';
 
 const integrationRepository = new IntegrationRepository();
 const agentIntegrationRepository = new AgentIntegrationRepository();
 const subscriberRepository = new SubscriberRepository();
 const channelEndpointRepository = new ChannelEndpointRepository();
+
+const TELEGRAM_WEBHOOK_SECRET = 'e2e-telegram-secret-token';
+
+const POLL_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 50;
+
+async function pollFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = POLL_TIMEOUT_MS): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await fn();
+      if (result) return result;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  throw new Error(
+    `pollFor timed out after ${timeoutMs}ms${lastError ? `; last error: ${(lastError as Error).message}` : ''}`
+  );
+}
 
 describe('Telegram subscriber start link (cache + inbound) #novu-v2', () => {
   let session: UserSession;
@@ -27,9 +53,11 @@ describe('Telegram subscriber start link (cache + inbound) #novu-v2', () => {
   let integrationId: string;
   let integrationIdentifier: string;
   let subscriberId: string;
+  let telegramApiStub: TelegramApiStub;
 
-  before(() => {
+  before(async () => {
     process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
+    telegramApiStub = await startTelegramApiStub();
   });
 
   beforeEach(async () => {
@@ -50,7 +78,7 @@ describe('Telegram subscriber start link (cache + inbound) #novu-v2', () => {
       channel: ChannelTypeEnum.CHAT,
       credentials: encryptCredentials({
         apiToken: '12345678:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-        token: 'e2e-telegram-secret-token',
+        token: TELEGRAM_WEBHOOK_SECRET,
       }),
       active: true,
       identifier: `telegram-sub-e2e-${Date.now()}`,
@@ -158,5 +186,90 @@ describe('Telegram subscriber start link (cache + inbound) #novu-v2', () => {
 
     expect((thread.post as sinon.SinonStub).calledOnce).to.equal(true);
     expect(String((thread.post as sinon.SinonStub).firstCall.args[0])).to.match(/expired|valid/i);
+  });
+
+  describe('inbound webhook /start delivery (full chat SDK path)', () => {
+    const TELEGRAM_CHAT_ID = 777_042;
+
+    afterEach(async () => {
+      // Drop cached Chat instances so each test builds a fresh Telegram adapter
+      // (and re-reads TELEGRAM_API_BASE_URL) for its own integration.
+      const registry = testServer.getService(ChatInstanceRegistry);
+      await registry.onModuleDestroy();
+      telegramApiStub.reset();
+    });
+
+    function buildStartUpdate(text: string) {
+      return {
+        update_id: Date.now(),
+        message: {
+          message_id: Math.floor(Math.random() * 1_000_000) + 1,
+          date: Math.floor(Date.now() / 1000),
+          chat: { id: TELEGRAM_CHAT_ID, type: 'private', first_name: 'TG' },
+          from: { id: TELEGRAM_CHAT_ID, is_bot: false, first_name: 'TG', username: 'tguser' },
+          text,
+          entities: [{ type: 'bot_command', offset: 0, length: '/start'.length }],
+        },
+      };
+    }
+
+    async function postTelegramWebhook(update: Record<string, unknown>) {
+      const res = await session.testAgent
+        .post(`/v1/agents/${agentId}/webhook/${integrationIdentifier}`)
+        .set('x-telegram-bot-api-secret-token', TELEGRAM_WEBHOOK_SECRET)
+        .set('content-type', 'application/json')
+        .send(update);
+
+      expect(res.status).to.equal(200);
+    }
+
+    it('creates the telegram_chat endpoint when /start <code> arrives as a real Telegram webhook update', async () => {
+      // Regression: chat SDK >= 4.31 routes Telegram bot commands to
+      // slash-command handlers instead of the message pipeline, which used to
+      // silently drop `/start <code>` so no channel endpoint was ever created.
+      const startCodeService = testServer.getService(TelegramStartCodeService);
+      const { code } = await startCodeService.issue({
+        environmentId: session.environment._id,
+        organizationId: session.organization._id,
+        agentIdentifier,
+        integrationId,
+        subscriberId,
+      });
+
+      await postTelegramWebhook(buildStartUpdate(`/start ${code}`));
+
+      const created = await pollFor(() =>
+        channelEndpointRepository.findByPlatformIdentity({
+          _environmentId: session.environment._id,
+          _organizationId: session.organization._id,
+          integrationIdentifier,
+          type: ENDPOINT_TYPES.TELEGRAM_CHAT,
+          endpointField: 'chatId',
+          endpointValue: String(TELEGRAM_CHAT_ID),
+        })
+      );
+
+      expect(created.subscriberId).to.equal(subscriberId);
+
+      const confirmation = await pollFor(async () =>
+        telegramApiStub.calls.find(
+          (call) => call.method === 'sendMessage' && String(call.payload.chat_id) === String(TELEGRAM_CHAT_ID)
+        )
+      );
+
+      expect(String(confirmation.payload.text)).to.match(/connected/i);
+    });
+
+    it('replies with an expired-style message when the /start code is unknown', async () => {
+      await postTelegramWebhook(buildStartUpdate('/start boguscodeboguscodeboguscodebogus'));
+
+      const reply = await pollFor(async () =>
+        telegramApiStub.calls.find(
+          (call) => call.method === 'sendMessage' && String(call.payload.chat_id) === String(TELEGRAM_CHAT_ID)
+        )
+      );
+
+      expect(String(reply.payload.text)).to.match(/expired|valid/i);
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What changed? Why was the change needed?

Fixes the broken Telegram connect flow in the quickstart (NV-8235): after clicking the Connect Telegram deep link (`t.me/<bot>?start=<code>`), no `telegram_chat` channel endpoint was created, so subsequent messages to the bot failed with *"You don't have access to message this agent. Connect your account through your application to continue."*

## Root cause

The chat SDK bump to 4.31.0 (#11721) introduced slash-command interception in `@chat-adapter/telegram`: any inbound message whose text starts with a `bot_command` entity (like `/start <code>`) is now routed to `chat.processSlashCommand` and is **no longer delivered through the regular message pipeline** (in 4.30.0 it flowed through `chat.processMessage`). Novu registers no slash-command handlers, so the `/start <code>` control message was silently dropped — `AgentInboundHandler.consumeTelegramStartLink` never ran, the start code expired unused, and no `ChannelEndpoint` was created.

The existing e2e coverage called `AgentInboundHandler.handle` directly with a synthetic message, bypassing the chat SDK routing, which is why the regression escaped.

```mermaid
sequenceDiagram
    participant TG as Telegram webhook
    participant AD as @chat-adapter/telegram (>=4.31)
    participant REG as ChatInstanceRegistry
    participant IH as AgentInboundHandler

    TG->>AD: update: "/start <code>" (bot_command entity)
    AD->>REG: chat.processSlashCommand (NOT processMessage)
    Note over REG: Before: no handler registered - dropped
    REG->>REG: onSlashCommand (new): rebuild Message
    REG->>AD: chat.processMessage (dedupe, lock, DM routing)
    AD->>REG: onNewMention -> thread.subscribe + onMessage
    REG->>IH: handle() -> consumeTelegramStartLink
    IH->>IH: consume start code, create telegram_chat endpoint
    IH->>TG: "You're connected." reply
```

## Fix

- `ChatInstanceRegistry` now registers an `onSlashCommand` handler that, for the Telegram platform, re-dispatches the bot command as an ordinary inbound message via `chat.processMessage`, restoring the pre-4.31 behavior (dedupe, thread locking, DM/mention routing). The parsed message is recovered from the adapter's in-process cache (`fetchMessage`) and rebuilt from the event payload as a fallback.

## Tests

- New e2e coverage in `telegram-subscriber-link.e2e.ts` posts a **real Telegram webhook update** (with `bot_command` entity and secret-token header) through the full production chat SDK path, backed by a new in-process Telegram Bot API stub (`telegram-api-stub.ts`, wired via `TELEGRAM_API_BASE_URL`). Asserts the `telegram_chat` endpoint is created for the subscriber and the "You're connected" confirmation is sent; a second test covers the expired/unknown-code reply.
- Verified the new tests fail (poll timeout, endpoint never created) without the registry fix and pass with it.
- Existing Slack `agent-webhook.e2e.ts` suite (20 tests) and inbound-handler/telegram-linking unit specs (47 tests) still pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52fec352-8077-4e38-987f-ffcf034d5f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52fec352-8077-4e38-987f-ffcf034d5f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores Telegram subscriber linking after chat SDK slash-command routing changes. The main changes are:

- Re-dispatches Telegram slash-command events through `chat.processMessage`.
- Rebuilds Telegram command messages from cached adapter data or webhook payloads.
- Adds webhook-level e2e coverage with an in-process Telegram Bot API stub.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after the test stub lifecycle is fixed.

The production change is narrow and covered by webhook-path tests. One contained test infrastructure bug remains: the suite starts a real HTTP server and does not close it.

`apps/api/src/app/agents/e2e/telegram-subscriber-link.e2e.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced that the Telegram API stub remains open after the e2e suite, and verified cleanup after manually closing the stub.
- The initial Telegram e2e run failed due to TypeScript module-resolution errors in e2e/setup.ts.
- The prebuild step completed successfully with exit code 0.
- The post-prebuild retry failed identically before executing Telegram tests.
- A blocker environment snapshot captured Node version and pnpm version with linked dependencies for context.

<a href="https://app.greptile.com/trex/runs/13648352/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts | Registers Telegram slash-command re-dispatch through the normal message pipeline and reconstructs cached or fallback message data. |
| apps/api/src/app/agents/e2e/helpers/telegram-api-stub.ts | Adds an in-process Telegram Bot API stub with recorded calls and environment override support for e2e tests. |
| apps/api/src/app/agents/e2e/telegram-subscriber-link.e2e.ts | Extends Telegram subscriber-link coverage through the full webhook path, but the started Telegram API stub is not closed after the suite. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant TG as Telegram webhook
participant AD as Telegram adapter
participant REG as ChatInstanceRegistry
participant SDK as chat.processMessage
participant IH as AgentInboundHandler
TG->>AD: "/start <code> update with bot_command entity"
AD->>REG: onSlashCommand(event)
REG->>AD: fetchMessage(threadId, messageId)
alt cached message found
    AD-->>REG: Message
else cache miss
    REG->>REG: rebuild Message from event payload
end
REG->>SDK: processMessage(adapter, threadId, message)
SDK->>IH: onNewMention/onMessage
IH->>IH: consumeTelegramStartLink
IH-->>TG: send confirmation or expired reply
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant TG as Telegram webhook
participant AD as Telegram adapter
participant REG as ChatInstanceRegistry
participant SDK as chat.processMessage
participant IH as AgentInboundHandler
TG->>AD: "/start <code> update with bot_command entity"
AD->>REG: onSlashCommand(event)
REG->>AD: fetchMessage(threadId, messageId)
alt cached message found
    AD-->>REG: Message
else cache miss
    REG->>REG: rebuild Message from event payload
end
REG->>SDK: processMessage(adapter, threadId, message)
SDK->>IH: onNewMention/onMessage
IH->>IH: consumeTelegramStartLink
IH-->>TG: send confirmation or expired reply
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fe2e%2Ftelegram-subscriber-link.e2e.ts%3A58-61%0A**Close%20the%20stub**%0A%60startTelegramApiStub%28%29%60%20creates%20a%20real%20%60node%3Ahttp%60%20server%20and%20stores%20a%20%60close%28%29%60%20method%2C%20but%20this%20suite%20never%20calls%20it.%20After%20these%20tests%20finish%2C%20the%20listening%20server%20and%20%60TELEGRAM_API_BASE_URL%60%20remain%20active%2C%20which%20leaves%20an%20open%20handle%20and%20can%20make%20the%20e2e%20worker%20hang%20or%20contaminate%20later%20Telegram%20adapter%20tests.%20Add%20an%20%60after%60%20hook%20that%20awaits%20%60telegramApiStub.close%28%29%60.%0A%0A&pr=11849&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/e2e/telegram-subscriber-link.e2e.ts:58-61
**Close the stub**
`startTelegramApiStub()` creates a real `node:http` server and stores a `close()` method, but this suite never calls it. After these tests finish, the listening server and `TELEGRAM_API_BASE_URL` remain active, which leaves an open handle and can make the e2e worker hang or contaminate later Telegram adapter tests. Add an `after` hook that awaits `telegramApiStub.close()`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): re-dispatch Telegram b..."](https://github.com/novuhq/novu/commit/01a5c865fbdefb1b2b2021843f63d8b2ca7281ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42615955)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->