### PR TITLE
fix(inbound-mail): evaluate SPF against MAIL FROM sender fixes NV-8236

### DIFF
--- a/apps/inbound-mail/.gitignore
+++ b/apps/inbound-mail/.gitignore
@@ -36,4 +36,8 @@ yarn-error.log*
 # tmp mails
 .tmp
 
+# Python bytecode (generated when verifyspf.py / spf.py run locally)
+__pycache__/
+*.py[cod]
+
 dist

--- a/apps/inbound-mail/src/python/verifyspf.py
+++ b/apps/inbound-mail/src/python/verifyspf.py
@@ -3,12 +3,31 @@
 Given a the smtp server ip address, the sender email address and the domain
 name, check if the smtp server is an authorized sender for the domain.
 Usage: python verifyspf.py '180.73.166.174' 'someone@gmail.com' 'gmail.com'
+
+Exit codes (consumed by mailUtilities.ts — keep in sync):
+  0  pass       sender IP is authorized
+  11 fail       sender IP is explicitly not authorized (fail/softfail)
+  12 no verdict domain publishes no applicable SPF record (none/neutral)
+  13 temperror  transient DNS failure while evaluating SPF
+  14 permerror  the domain's SPF record is invalid
+  64 usage      invalid arguments
 """
 
 
 import os
 import spf
 import sys
+
+# RFC 7208 result -> exit code. Anything unexpected is treated as fail (11).
+RESULT_EXIT_CODES = {
+    'pass': 0,
+    'fail': 11,
+    'softfail': 11,
+    'none': 12,
+    'neutral': 12,
+    'temperror': 13,
+    'permerror': 14,
+}
 
 def main():
     if len(sys.argv) != 4:
@@ -18,11 +37,7 @@ def main():
     result, explanation = spf.check2(sys.argv[1], sys.argv[2], sys.argv[3])
     print('[' + os.path.basename(__file__) + '] (' + result + ', ' + explanation + ')')
 
-    if result == 'pass':
-        sys.exit(0)
-    else:
-        # Invalid spf, exit with code 11.
-        sys.exit(11)
+    sys.exit(RESULT_EXIT_CODES.get(result, 11))
 
 if __name__ == '__main__':
     main()

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -404,9 +404,16 @@ class Mailin extends events.EventEmitter {
 
         logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating spf.`);
 
-        /* Get ip and host. */
+        /*
+         * smtp-server sessions carry the sender under envelope.mailFrom (false
+         * until MAIL FROM is received), not `.from` — the old mailin field.
+         * Passing the wrong field made pyspf fall back to the HELO identity,
+         * so SPF was never evaluated against the actual sender domain.
+         */
+        const envelopeFrom = connection.envelope?.mailFrom?.address || '';
+
         return mailUtilities
-          .validateSpfAsync(connection.remoteAddress, connection.from, connection.clientHostname)
+          .validateSpfAsync(connection.remoteAddress, envelopeFrom, connection.clientHostname)
           .catch((err) => {
             logger.error(
               { err, context: LOG_CONTEXT, connectionId: connection.id },

--- a/apps/inbound-mail/src/server/mail-utilities.spec.ts
+++ b/apps/inbound-mail/src/server/mail-utilities.spec.ts
@@ -1,0 +1,60 @@
+import child_process from 'node:child_process';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+const mailUtilities = require('./mailUtilities');
+
+/**
+ * verifyspf.py communicates its verdict through exit codes
+ * (0 pass, 11 fail/softfail, 12 none/neutral, 13 temperror, 14 permerror).
+ * These tests pin the Node-side contract: only exit 0 yields spf=pass, and
+ * undefined args are sanitized so execFile never stringifies them to
+ * "undefined".
+ */
+describe('mailUtilities.validateSpf', () => {
+  let execFileStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    execFileStub = sinon.stub(child_process, 'execFile');
+  });
+
+  afterEach(() => {
+    execFileStub.restore();
+  });
+
+  function stubSpfExit(code: number) {
+    execFileStub.callsFake((_bin, _args, callback: (err, stdout, stderr) => void) => {
+      const err = code === 0 ? null : Object.assign(new Error(`Command failed`), { code });
+      callback(err, '[verifyspf.py] (stubbed, )', '');
+    });
+  }
+
+  function validateSpf(ip, address, host): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      mailUtilities.validateSpf(ip, address, host, (err, isValid) => (err ? reject(err) : resolve(isValid)));
+    });
+  }
+
+  it('should resolve spf=pass only for exit code 0', async () => {
+    stubSpfExit(0);
+
+    expect(await validateSpf('209.85.220.41', 'someone@gmail.com', 'mail-sor-f41.google.com')).to.equal(true);
+  });
+
+  [11, 12, 13, 14, 64, 1].forEach((exitCode) => {
+    it(`should resolve spf=failed for exit code ${exitCode}`, async () => {
+      stubSpfExit(exitCode);
+
+      expect(await validateSpf('8.8.8.8', 'someone@gmail.com', 'gmail.com')).to.equal(false);
+    });
+  });
+
+  it('should pass empty strings instead of undefined args so python never receives the literal "undefined"', async () => {
+    stubSpfExit(12);
+
+    await validateSpf('10.0.10.137', undefined, undefined);
+
+    const [, args] = execFileStub.firstCall.args;
+    expect(args.slice(1)).to.deep.equal(['10.0.10.137', '', '']);
+  });
+});

--- a/apps/inbound-mail/src/server/mailUtilities.ts
+++ b/apps/inbound-mail/src/server/mailUtilities.ts
@@ -91,7 +91,13 @@ module.exports = {
     }
 
     const verifySpfPath = path.join(__dirname, '../python/verifyspf.py');
-    const args = [verifySpfPath, ip, address, host];
+    /*
+     * execFile stringifies non-string args, so an undefined sender would reach
+     * the script as the literal "undefined". Empty strings are fine: pyspf
+     * falls back to the HELO identity for an empty MAIL FROM (null sender,
+     * e.g. bounces), per RFC 7208 §2.4.
+     */
+    const args = [verifySpfPath, ip ?? '', address ?? '', host ?? ''];
 
     child_process.execFile(pythonBin, args, (err, stdout, stderr) => {
       logger.verbose({ context: LOG_CONTEXT }, stdout);
@@ -102,25 +108,51 @@ module.exports = {
 
       if (code) {
         /*
-         * Exit 11 is the script's "spf did not pass" code; any other code —
-         * including string codes like ENOENT when the python binary cannot be
-         * spawned — means the check itself is broken, not the sender.
+         * For known verdict exit codes (11-14) the err object is just
+         * "Command failed" + exit code — attaching it makes an expected
+         * verdict read like a crash. Only the default branch (spawn/runtime
+         * breakage) includes it.
          */
-        logger.warn(
-          {
-            context: LOG_CONTEXT,
-            err,
-            exitCode: code,
-            ip,
-            address,
-            host,
-            stdout: typeof stdout === 'string' ? stdout.trim() : stdout,
-            stderr: typeof stderr === 'string' ? stderr.trim() : stderr,
-          },
-          code === 11
-            ? 'SPF verification failed: sender IP is not authorized for the domain.'
-            : 'SPF verification errored: verifier did not run cleanly — treating spf as failed.'
-        );
+        const logPayload = {
+          context: LOG_CONTEXT,
+          exitCode: code,
+          ip,
+          address,
+          host,
+          stdout: typeof stdout === 'string' ? stdout.trim() : stdout,
+          stderr: typeof stderr === 'string' ? stderr.trim() : stderr,
+        };
+
+        /*
+         * Exit codes are defined in verifyspf.py — keep in sync:
+         * 11 fail/softfail, 12 none/neutral, 13 temperror, 14 permerror.
+         * Any other code — including string codes like ENOENT when the python
+         * binary cannot be spawned — means the check itself is broken, not the
+         * sender. Everything except exit 0 resolves to spf=failed; the split
+         * here is purely for accurate log levels and messages.
+         */
+        switch (code) {
+          case 11:
+            logger.warn(logPayload, 'SPF verification failed: sender IP is not authorized for the domain.');
+            break;
+          case 12:
+            logger.info(
+              logPayload,
+              'SPF verification returned no verdict: sender domain publishes no applicable SPF record.'
+            );
+            break;
+          case 13:
+            logger.warn(logPayload, 'SPF verification hit a transient DNS error — treating spf as failed.');
+            break;
+          case 14:
+            logger.warn(logPayload, 'SPF verification found an invalid SPF record — treating spf as failed.');
+            break;
+          default:
+            logger.warn(
+              { ...logPayload, err },
+              'SPF verification errored: verifier did not run cleanly — treating spf as failed.'
+            );
+        }
       } else {
         logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);
       }

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -6,6 +6,9 @@ procs:
   worker:
     shell: pnpm --filter @novu/worker start:portless
     autostart: false
+  inbound-mail:
+    shell: pnpm --filter @novu/inbound-mail start:dev
+    autostart: false
 
   shared:
     shell: pnpm --filter @novu/shared start


### PR DESCRIPTION
## Summary

- Fix SPF validation to read the sender from `connection.envelope.mailFrom.address` instead of the legacy `connection.from` field, so pyspf evaluates the actual MAIL FROM domain rather than falling back to the HELO identity.
- Map pyspf verdicts to distinct exit codes (11 fail/softfail, 12 none/neutral, 13 temperror, 14 permerror) and log each with an appropriate level; only runtime/spawn failures attach the `err` object.
- Sanitize undefined `execFile` args to empty strings so Python never receives the literal `"undefined"`.
- Add unit tests for the Node-side SPF contract and ignore Python `__pycache__` artifacts.
- Add `inbound-mail` to mprocs for local development.

## Why

After the recent inbound-mail verifier fixes (NV-8229, NV-8233), SPF checks still failed for legitimate senders because the wrong session field was passed to `verifyspf.py`. The smtp-server library stores the sender under `envelope.mailFrom`, not `.from`.

```mermaid
sequenceDiagram
    participant Client
    participant Mailin as inbound-mail (Mailin)
    participant PySPF as verifyspf.py

    Client->>Mailin: MAIL FROM:<sender@domain.com>
    Note over Mailin: envelope.mailFrom.address = sender@domain.com
    Mailin->>PySPF: validateSpf(ip, envelopeFrom, helo)
    PySPF->>PySPF: spf.check2(ip, sender, domain)
    PySPF-->>Mailin: exit 0 (pass) or 11–14 (verdict)
```

## Test plan

- [x] `cd apps/inbound-mail && pnpm test -- --grep "mailUtilities.validateSpf"` — 8 passing
- [ ] Send a test inbound email locally and confirm SPF logs show the correct sender domain
- [ ] Verify staging inbound emails from authorized senders now get `spf=pass`

## Linear

https://linear.app/novu/issue/NV-8236/fix-inbound-mail-spf-validation-using-wrong-sender-field

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes SPF validation for inbound mail. The main changes are:

- Reads the sender from `connection.envelope.mailFrom.address` before calling the SPF verifier.
- Maps `verifyspf.py` results to distinct exit codes for pass, fail, no verdict, transient error, and permanent error.
- Sanitizes undefined SPF verifier arguments to empty strings before calling Python.
- Adds unit tests for the Node-side SPF contract.
- Ignores local Python bytecode artifacts and adds `inbound-mail` to `mprocs.yaml`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The change is narrowly scoped to SPF sender selection and verdict handling. Tests cover the Node-side exit-code contract and undefined argument sanitization. No correctness or security issues were found in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification for the pull request.
- T-Rex attempted to upload local artifact references, but they were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/.gitignore | Adds Python bytecode ignore patterns for local SPF verifier runs; no issues found. |
| apps/inbound-mail/src/python/verifyspf.py | Maps pyspf SPF results to distinct exit codes consumed by the Node verifier; no issues found. |
| apps/inbound-mail/src/server/index.ts | Switches SPF validation to pass the SMTP envelope MAIL FROM address instead of the legacy connection field; no issues found. |
| apps/inbound-mail/src/server/mail-utilities.spec.ts | Adds unit coverage for SPF exit-code handling and undefined argument sanitization; no issues found. |
| apps/inbound-mail/src/server/mailUtilities.ts | Sanitizes SPF verifier args and logs distinct pyspf verdict exit codes without treating expected verdicts as runtime errors; no issues found. |
| mprocs.yaml | Adds inbound-mail as an optional local development process; no issues found. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant Mailin as inbound-mail server
participant Utils as mailUtilities.validateSpf
participant PySPF as verifyspf.py / pyspf

Client->>Mailin: SMTP MAIL FROM sender
Mailin->>Mailin: Read connection.envelope.mailFrom.address
Mailin->>Utils: validateSpfAsync(remoteAddress, envelopeFrom, clientHostname)
Utils->>PySPF: execFile(python, verifyspf.py, ip, sender, helo)
PySPF-->>Utils: exit 0 pass or 11-14 SPF verdict
Utils-->>Mailin: boolean spf result and verdict logs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant Mailin as inbound-mail server
participant Utils as mailUtilities.validateSpf
participant PySPF as verifyspf.py / pyspf

Client->>Mailin: SMTP MAIL FROM sender
Mailin->>Mailin: Read connection.envelope.mailFrom.address
Mailin->>Utils: validateSpfAsync(remoteAddress, envelopeFrom, clientHostname)
Utils->>PySPF: execFile(python, verifyspf.py, ip, sender, helo)
PySPF-->>Utils: exit 0 pass or 11-14 SPF verdict
Utils-->>Mailin: boolean spf result and verdict logs
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(inbound-mail): evaluate SPF against ..."](https://github.com/novuhq/novu/commit/57be1e0646ad42c1732789748aecf422c6d385cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42620998)</sub>

<!-- /greptile_comment -->