### PR TITLE
refactor(inbound-mail): collapse SPF verdict switch into lookup table fixes NV-8236

### DIFF
--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -405,12 +405,11 @@ class Mailin extends events.EventEmitter {
         logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating spf.`);
 
         /*
-         * smtp-server sessions carry the sender under envelope.mailFrom (false
-         * until MAIL FROM is received), not `.from` — the old mailin field.
-         * Passing the wrong field made pyspf fall back to the HELO identity,
-         * so SPF was never evaluated against the actual sender domain.
+         * smtp-server sessions carry the sender under envelope.mailFrom, not
+         * `.from` (the old mailin field). Passing the wrong field made pyspf
+         * fall back to the HELO identity instead of the actual sender domain.
          */
-        const envelopeFrom = connection.envelope?.mailFrom?.address || '';
+        const envelopeFrom = connection.envelope?.mailFrom?.address;
 
         return mailUtilities
           .validateSpfAsync(connection.remoteAddress, envelopeFrom, connection.clientHostname)

--- a/apps/inbound-mail/src/server/mail-utilities.spec.ts
+++ b/apps/inbound-mail/src/server/mail-utilities.spec.ts
@@ -22,16 +22,18 @@ describe('mailUtilities.validateSpf', () => {
     execFileStub.restore();
   });
 
-  function stubSpfExit(code: number) {
-    execFileStub.callsFake((_bin, _args, callback: (err, stdout, stderr) => void) => {
-      const err = code === 0 ? null : Object.assign(new Error(`Command failed`), { code });
+  function stubSpfExit(code: number | string) {
+    execFileStub.callsFake((_bin, _args, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const err = code === 0 ? null : Object.assign(new Error('Command failed'), { code });
       callback(err, '[verifyspf.py] (stubbed, )', '');
     });
   }
 
-  function validateSpf(ip, address, host): Promise<boolean> {
+  function validateSpf(ip?: string, address?: string, host?: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      mailUtilities.validateSpf(ip, address, host, (err, isValid) => (err ? reject(err) : resolve(isValid)));
+      mailUtilities.validateSpf(ip, address, host, (err: Error | null, isValid: boolean) =>
+        err ? reject(err) : resolve(isValid)
+      );
     });
   }
 
@@ -47,6 +49,12 @@ describe('mailUtilities.validateSpf', () => {
 
       expect(await validateSpf('8.8.8.8', 'someone@gmail.com', 'gmail.com')).to.equal(false);
     });
+  });
+
+  it('should resolve spf=failed for string spawn error codes like ENOENT', async () => {
+    stubSpfExit('ENOENT');
+
+    expect(await validateSpf('8.8.8.8', 'someone@gmail.com', 'gmail.com')).to.equal(false);
   });
 
   it('should pass empty strings instead of undefined args so python never receives the literal "undefined"', async () => {

--- a/apps/inbound-mail/src/server/mailUtilities.ts
+++ b/apps/inbound-mail/src/server/mailUtilities.ts
@@ -6,6 +6,22 @@ import logger from './logger';
 
 const LOG_CONTEXT = 'MailUtilities';
 
+/*
+ * Verdict exit codes defined in verifyspf.py — keep in sync. Everything except
+ * exit 0 resolves to spf=failed; this map only picks log levels and messages.
+ * Codes outside the map — including string codes like ENOENT when the python
+ * binary cannot be spawned — mean the check itself is broken, not the sender.
+ */
+const SPF_VERDICT_LOGS: Record<number, { level: 'warn' | 'info'; message: string }> = {
+  11: { level: 'warn', message: 'SPF verification failed: sender IP is not authorized for the domain.' },
+  12: {
+    level: 'info',
+    message: 'SPF verification returned no verdict: sender domain publishes no applicable SPF record.',
+  },
+  13: { level: 'warn', message: 'SPF verification hit a transient DNS error — treating spf as failed.' },
+  14: { level: 'warn', message: 'SPF verification found an invalid SPF record — treating spf as failed.' },
+};
+
 const spamc = new Spamc();
 
 /*
@@ -94,8 +110,7 @@ module.exports = {
     /*
      * execFile stringifies non-string args, so an undefined sender would reach
      * the script as the literal "undefined". Empty strings are fine: pyspf
-     * falls back to the HELO identity for an empty MAIL FROM (null sender,
-     * e.g. bounces), per RFC 7208 §2.4.
+     * falls back to the HELO identity for an empty MAIL FROM (RFC 7208 §2.4).
      */
     const args = [verifySpfPath, ip ?? '', address ?? '', host ?? ''];
 
@@ -107,12 +122,6 @@ module.exports = {
       }
 
       if (code) {
-        /*
-         * For known verdict exit codes (11-14) the err object is just
-         * "Command failed" + exit code — attaching it makes an expected
-         * verdict read like a crash. Only the default branch (spawn/runtime
-         * breakage) includes it.
-         */
         const logPayload = {
           context: LOG_CONTEXT,
           exitCode: code,
@@ -123,35 +132,19 @@ module.exports = {
           stderr: typeof stderr === 'string' ? stderr.trim() : stderr,
         };
 
-        /*
-         * Exit codes are defined in verifyspf.py — keep in sync:
-         * 11 fail/softfail, 12 none/neutral, 13 temperror, 14 permerror.
-         * Any other code — including string codes like ENOENT when the python
-         * binary cannot be spawned — means the check itself is broken, not the
-         * sender. Everything except exit 0 resolves to spf=failed; the split
-         * here is purely for accurate log levels and messages.
-         */
-        switch (code) {
-          case 11:
-            logger.warn(logPayload, 'SPF verification failed: sender IP is not authorized for the domain.');
-            break;
-          case 12:
-            logger.info(
-              logPayload,
-              'SPF verification returned no verdict: sender domain publishes no applicable SPF record.'
-            );
-            break;
-          case 13:
-            logger.warn(logPayload, 'SPF verification hit a transient DNS error — treating spf as failed.');
-            break;
-          case 14:
-            logger.warn(logPayload, 'SPF verification found an invalid SPF record — treating spf as failed.');
-            break;
-          default:
-            logger.warn(
-              { ...logPayload, err },
-              'SPF verification errored: verifier did not run cleanly — treating spf as failed.'
-            );
+        const verdict = SPF_VERDICT_LOGS[code];
+        if (verdict) {
+          logger[verdict.level](logPayload, verdict.message);
+        } else {
+          /*
+           * Spawn/runtime breakage rather than an SPF verdict — this is the
+           * only branch where the err object adds signal; for verdict codes it
+           * is just "Command failed" + exit code and reads like a crash.
+           */
+          logger.warn(
+            { ...logPayload, err },
+            'SPF verification errored: verifier did not run cleanly — treating spf as failed.'
+          );
         }
       } else {
         logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);


### PR DESCRIPTION
## Summary

Follow-up cleanup to #11850 (merged before the quality pass landed):

- Replace the four-branch SPF exit-code `switch` in `mailUtilities.ts` with a `SPF_VERDICT_LOGS` lookup table that mirrors the Python-side `RESULT_EXIT_CODES` map.
- Trim comment noise introduced in #11850 and drop the redundant `|| ''` sender fallback in `index.ts` (args are already sanitized in `validateSpf`).
- Type the test helpers and add coverage for string spawn error codes (`ENOENT`).

No behavior change: every non-zero exit code still resolves to spf=failed; the map only selects log levels and messages.

## Test plan

- [x] `cd apps/inbound-mail && pnpm test -- --grep "mailUtilities.validateSpf"` — 9 passing
- [x] `pnpm build` (tsc) — clean

## Linear

https://linear.app/novu/issue/NV-8236/fix-inbound-mail-spf-validation-using-wrong-sender-field

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors SPF validation logging while keeping the existing pass/fail behavior. The main changes are:

- Replaces the SPF exit-code `switch` with an `SPF_VERDICT_LOGS` lookup table.
- Keeps empty-string argument sanitization inside `validateSpf` instead of the SMTP connection path.
- Adds test coverage for string-valued spawn errors such as `ENOENT`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changed SPF path preserves the existing boolean contract: only exit code `0` returns `true`, and every non-zero numeric or string code returns `false`. The lookup table matches the Python verifier exit-code map for the known SPF verdicts, and the removed sender fallback is still covered by argument sanitization in `validateSpf`.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the SPF targeted validation results and confirmed all tests passed, including the test should resolve spf=failed for string spawn error codes like ENOENT.
- Observed the SPF build attempt started and progressed to dependent Nx build tasks before the runner timed out.
- Verified a follow-up process check showed the build was still running after the timeout.
- Noted the cleanup command invocation following the timeout as part of the workflow.

<a href="https://app.greptile.com/trex/runs/13651398/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/server/index.ts | Drops the redundant SPF sender fallback while still passing the envelope sender through `validateSpf`. |
| apps/inbound-mail/src/server/mailUtilities.ts | Replaces the SPF exit-code switch with a lookup table that preserves non-zero-code failure behavior. |
| apps/inbound-mail/src/server/mail-utilities.spec.ts | Adds typed test helpers and coverage for string-valued SPF spawn errors. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant SMTP as SMTP connection
participant Mailin as Mailin.validateSpf
participant Utilities as mailUtilities.validateSpf
participant Python as verifyspf.py
participant Logger as logger

SMTP->>Mailin: remoteAddress, envelope.mailFrom.address, clientHostname
Mailin->>Utilities: validateSpfAsync(ip, envelopeFrom, host)
Utilities->>Utilities: sanitize undefined args to empty strings
Utilities->>Python: execFile(pythonBin, verifyspf.py, ip, address, host)
Python-->>Utilities: exit code 0, 11-14, or runtime/spawn code
alt exit code 0
    Utilities->>Logger: verbose success
    Utilities-->>Mailin: "spf=true"
else known SPF verdict code
    Utilities->>Logger: lookup log level/message in SPF_VERDICT_LOGS
    Utilities-->>Mailin: "spf=false"
else runtime/spawn error code
    Utilities->>Logger: warn with error payload
    Utilities-->>Mailin: "spf=false"
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant SMTP as SMTP connection
participant Mailin as Mailin.validateSpf
participant Utilities as mailUtilities.validateSpf
participant Python as verifyspf.py
participant Logger as logger

SMTP->>Mailin: remoteAddress, envelope.mailFrom.address, clientHostname
Mailin->>Utilities: validateSpfAsync(ip, envelopeFrom, host)
Utilities->>Utilities: sanitize undefined args to empty strings
Utilities->>Python: execFile(pythonBin, verifyspf.py, ip, address, host)
Python-->>Utilities: exit code 0, 11-14, or runtime/spawn code
alt exit code 0
    Utilities->>Logger: verbose success
    Utilities-->>Mailin: "spf=true"
else known SPF verdict code
    Utilities->>Logger: lookup log level/message in SPF_VERDICT_LOGS
    Utilities-->>Mailin: "spf=false"
else runtime/spawn error code
    Utilities->>Logger: warn with error payload
    Utilities-->>Mailin: "spf=false"
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(inbound-mail): collapse SPF ver..."](https://github.com/novuhq/novu/commit/11dd74720a95172d3d5ca342d12f4664c63cb76f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42622282)</sub>

<!-- /greptile_comment -->