### PR TITLE
fix(api-service): discriminate unresolved subscriber resolution outcomes fixes NV-8238

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
@@ -373,6 +373,75 @@ describe('AgentSubscriberResolver', () => {
     });
   });
 
+  describe('resolveSubscriber — discriminated outcomes', () => {
+    it('returns resolved with the subscriberId on an email hit', async () => {
+      const { resolver } = makeResolver({
+        findByEmail: sinon.stub().resolves([{ subscriberId: 'sub-email' }]),
+      });
+
+      const result = await resolver.resolveSubscriber({
+        ...baseLookupParams,
+        platform: AgentPlatformEnum.EMAIL,
+        platformUserId: 'user@example.com',
+      });
+
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-email' });
+    });
+
+    it('returns not_found when the email lookup ran cleanly but matched nothing', async () => {
+      const { resolver } = makeResolver({ findByEmail: sinon.stub().resolves([]) });
+
+      const result = await resolver.resolveSubscriber({
+        ...baseLookupParams,
+        platform: AgentPlatformEnum.EMAIL,
+        platformUserId: 'unknown@example.com',
+      });
+
+      expect(result).to.deep.equal({ outcome: 'not_found' });
+    });
+
+    it('returns invalid_identity for an unusable email address without a DB call', async () => {
+      const { resolver, subscriberRepository } = makeResolver();
+
+      const result = await resolver.resolveSubscriber({
+        ...baseLookupParams,
+        platform: AgentPlatformEnum.EMAIL,
+        platformUserId: 'not-an-email',
+      });
+
+      expect(result).to.deep.equal({ outcome: 'invalid_identity' });
+      expect(subscriberRepository.findByEmail.called).to.equal(false);
+    });
+
+    it('returns invalid_identity for an empty platformUserId', async () => {
+      const { resolver } = makeResolver();
+
+      const result = await resolver.resolveSubscriber({
+        ...baseLookupParams,
+        platform: AgentPlatformEnum.SLACK,
+        platformUserId: '   ',
+      });
+
+      expect(result).to.deep.equal({ outcome: 'invalid_identity' });
+    });
+
+    it('propagates lookup errors instead of flattening them to a miss', async () => {
+      const lookupError = new Error('mongo timeout');
+      const { resolver } = makeResolver({ findByEmail: sinon.stub().rejects(lookupError) });
+
+      try {
+        await resolver.resolveSubscriber({
+          ...baseLookupParams,
+          platform: AgentPlatformEnum.EMAIL,
+          platformUserId: 'user@example.com',
+        });
+        expect.fail('Expected the lookup error to propagate');
+      } catch (err) {
+        expect(err).to.equal(lookupError);
+      }
+    });
+  });
+
   describe('resolveOnly — channel endpoint resolution', () => {
     it('resolves Slack via channel endpoints', async () => {
       const { resolver, channelEndpointRepository } = makeResolver({

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.spec.ts
@@ -85,35 +85,35 @@ describe('AgentSubscriberResolver', () => {
     };
   }
 
-  describe('resolveOnly — WhatsApp phone resolution', () => {
+  describe('resolveSubscriber — WhatsApp phone resolution', () => {
     it('resolves when inbound phone has no + and subscriber has +', async () => {
       const { resolver, subscriberRepository, channelEndpointRepository } = makeResolver({
         findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-1' }]),
       });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.WHATSAPP,
         platformUserId: '972541111111',
       });
 
-      expect(result).to.equal('sub-1');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-1' });
       expect(
         subscriberRepository.findByPhone.calledOnceWith('env-1', 'org-1', ['+972541111111', '972541111111'])
       ).to.equal(true);
       expect(channelEndpointRepository.findByPlatformIdentity.called).to.equal(false);
     });
 
-    it('returns null when no subscriber matches', async () => {
+    it('returns not_found when no subscriber matches', async () => {
       const { resolver } = makeResolver({ findByPhone: sinon.stub().resolves([]) });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.WHATSAPP,
         platformUserId: '972541111111',
       });
 
-      expect(result).to.equal(null);
+      expect(result).to.deep.equal({ outcome: 'not_found' });
     });
 
     it('warns and returns first match when multiple subscribers share the phone', async () => {
@@ -121,74 +121,90 @@ describe('AgentSubscriberResolver', () => {
         findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-1' }, { subscriberId: 'sub-2' }]),
       });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.WHATSAPP,
         platformUserId: '972541111111',
       });
 
-      expect(result).to.equal('sub-1');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-1' });
       expect(logger.warn.calledOnce).to.equal(true);
     });
 
-    it('returns null for empty platformUserId without DB call', async () => {
+    it('returns invalid_identity for empty platformUserId without DB call', async () => {
       const { resolver, subscriberRepository, channelEndpointRepository } = makeResolver();
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.WHATSAPP,
         platformUserId: '   ',
       });
 
-      expect(result).to.equal(null);
+      expect(result).to.deep.equal({ outcome: 'invalid_identity' });
       expect(subscriberRepository.findByPhone.called).to.equal(false);
       expect(channelEndpointRepository.findByPlatformIdentity.called).to.equal(false);
     });
   });
 
-  describe('resolveOnly — Email resolution', () => {
+  describe('resolveSubscriber — Email resolution', () => {
     it('resolves when subscriber.email matches inbound address (lowercased)', async () => {
       const { resolver, subscriberRepository } = makeResolver({
         findByEmail: sinon.stub().resolves([{ subscriberId: 'sub-email' }]),
       });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.EMAIL,
         platformUserId: 'User@Example.com',
       });
 
-      expect(result).to.equal('sub-email');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-email' });
       expect(subscriberRepository.findByEmail.calledOnceWith('env-1', 'org-1', 'user@example.com')).to.equal(true);
     });
 
-    it('returns null when no subscriber matches', async () => {
+    it('returns not_found when no subscriber matches', async () => {
       const { resolver } = makeResolver({ findByEmail: sinon.stub().resolves([]) });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.EMAIL,
         platformUserId: 'unknown@example.com',
       });
 
-      expect(result).to.equal(null);
+      expect(result).to.deep.equal({ outcome: 'not_found' });
     });
 
-    it('returns null for invalid email without DB call', async () => {
+    it('returns invalid_identity for invalid email without DB call', async () => {
       const { resolver, subscriberRepository } = makeResolver();
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.EMAIL,
         platformUserId: 'not-an-email',
       });
 
-      expect(result).to.equal(null);
+      expect(result).to.deep.equal({ outcome: 'invalid_identity' });
       expect(subscriberRepository.findByEmail.called).to.equal(false);
+    });
+
+    it('propagates lookup errors instead of flattening them to a miss', async () => {
+      const lookupError = new Error('mongo timeout');
+      const { resolver } = makeResolver({ findByEmail: sinon.stub().rejects(lookupError) });
+
+      try {
+        await resolver.resolveSubscriber({
+          ...baseLookupParams,
+          platform: AgentPlatformEnum.EMAIL,
+          platformUserId: 'user@example.com',
+        });
+        expect.fail('Expected the lookup error to propagate');
+      } catch (err) {
+        expect(err).to.equal(lookupError);
+      }
     });
   });
 
-  describe('resolveOnly — Email adoption / prefer customer-created', () => {
+  describe('resolveSubscriber — Email adoption / prefer customer-created', () => {
     const realMatch = { _id: 'mongo-real', subscriberId: 'sub-real', email: 'user@example.com', data: {} };
     const phantomMatch = {
       _id: 'mongo-phantom',
@@ -204,13 +220,13 @@ describe('AgentSubscriberResolver', () => {
         adoptPhantomsInto,
       });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.EMAIL,
         platformUserId: 'user@example.com',
       });
 
-      expect(result).to.equal('sub-real');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-real' });
       expect(adoptPhantomsInto.calledOnce).to.equal(true);
       const arg = adoptPhantomsInto.firstCall.args[0];
       expect(arg.real).to.deep.equal({ _id: 'mongo-real', subscriberId: 'sub-real' });
@@ -224,13 +240,13 @@ describe('AgentSubscriberResolver', () => {
         adoptPhantomsInto,
       });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.EMAIL,
         platformUserId: 'user@example.com',
       });
 
-      expect(result).to.equal('sub-phantom');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-phantom' });
       expect(adoptPhantomsInto.called).to.equal(false);
     });
 
@@ -241,13 +257,13 @@ describe('AgentSubscriberResolver', () => {
         adoptPhantomsInto,
       });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.EMAIL,
         platformUserId: 'user@example.com',
       });
 
-      expect(result).to.equal('sub-real');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-real' });
       expect(adoptPhantomsInto.called).to.equal(false);
     });
   });
@@ -373,88 +389,19 @@ describe('AgentSubscriberResolver', () => {
     });
   });
 
-  describe('resolveSubscriber — discriminated outcomes', () => {
-    it('returns resolved with the subscriberId on an email hit', async () => {
-      const { resolver } = makeResolver({
-        findByEmail: sinon.stub().resolves([{ subscriberId: 'sub-email' }]),
-      });
-
-      const result = await resolver.resolveSubscriber({
-        ...baseLookupParams,
-        platform: AgentPlatformEnum.EMAIL,
-        platformUserId: 'user@example.com',
-      });
-
-      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-email' });
-    });
-
-    it('returns not_found when the email lookup ran cleanly but matched nothing', async () => {
-      const { resolver } = makeResolver({ findByEmail: sinon.stub().resolves([]) });
-
-      const result = await resolver.resolveSubscriber({
-        ...baseLookupParams,
-        platform: AgentPlatformEnum.EMAIL,
-        platformUserId: 'unknown@example.com',
-      });
-
-      expect(result).to.deep.equal({ outcome: 'not_found' });
-    });
-
-    it('returns invalid_identity for an unusable email address without a DB call', async () => {
-      const { resolver, subscriberRepository } = makeResolver();
-
-      const result = await resolver.resolveSubscriber({
-        ...baseLookupParams,
-        platform: AgentPlatformEnum.EMAIL,
-        platformUserId: 'not-an-email',
-      });
-
-      expect(result).to.deep.equal({ outcome: 'invalid_identity' });
-      expect(subscriberRepository.findByEmail.called).to.equal(false);
-    });
-
-    it('returns invalid_identity for an empty platformUserId', async () => {
-      const { resolver } = makeResolver();
-
-      const result = await resolver.resolveSubscriber({
-        ...baseLookupParams,
-        platform: AgentPlatformEnum.SLACK,
-        platformUserId: '   ',
-      });
-
-      expect(result).to.deep.equal({ outcome: 'invalid_identity' });
-    });
-
-    it('propagates lookup errors instead of flattening them to a miss', async () => {
-      const lookupError = new Error('mongo timeout');
-      const { resolver } = makeResolver({ findByEmail: sinon.stub().rejects(lookupError) });
-
-      try {
-        await resolver.resolveSubscriber({
-          ...baseLookupParams,
-          platform: AgentPlatformEnum.EMAIL,
-          platformUserId: 'user@example.com',
-        });
-        expect.fail('Expected the lookup error to propagate');
-      } catch (err) {
-        expect(err).to.equal(lookupError);
-      }
-    });
-  });
-
-  describe('resolveOnly — channel endpoint resolution', () => {
+  describe('resolveSubscriber — channel endpoint resolution', () => {
     it('resolves Slack via channel endpoints', async () => {
       const { resolver, channelEndpointRepository } = makeResolver({
         findByPlatformIdentity: sinon.stub().resolves({ subscriberId: 'sub-slack' }),
       });
 
-      const result = await resolver.resolveOnly({
+      const result = await resolver.resolveSubscriber({
         ...baseLookupParams,
         platform: AgentPlatformEnum.SLACK,
         platformUserId: 'U_LINKED',
       });
 
-      expect(result).to.equal('sub-slack');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-slack' });
       expect(channelEndpointRepository.findByPlatformIdentity.calledOnce).to.equal(true);
     });
   });
@@ -471,7 +418,7 @@ describe('AgentSubscriberResolver', () => {
         platformUserId: 'U_EXISTING',
       });
 
-      expect(result).to.equal('sub-existing');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-existing' });
       expect(createOrUpdateSubscriber.execute.called).to.equal(false);
       expect(createChannelEndpoint.execute.called).to.equal(false);
       expect(analyticsService.track.called).to.equal(false);
@@ -486,10 +433,12 @@ describe('AgentSubscriberResolver', () => {
         platformUserId: 'U_NEW',
       });
 
-      expect(result).to.match(/^sub_/);
+      expect(result.outcome).to.equal('resolved');
+      const subscriberId = result.outcome === 'resolved' ? result.subscriberId : '';
+      expect(subscriberId).to.match(/^sub_/);
       expect(createOrUpdateSubscriber.execute.calledOnce).to.equal(true);
       const subscriberCommand = createOrUpdateSubscriber.execute.firstCall.args[0];
-      expect(subscriberCommand.subscriberId).to.equal(result);
+      expect(subscriberCommand.subscriberId).to.equal(subscriberId);
       expect(subscriberCommand.firstName).to.equal('Alice Smith');
       expect(subscriberCommand.data).to.deep.include({
         [AGENT_PROVISION_DATA_KEYS.source]: AGENT_PLATFORM_PROVISION_SOURCE,
@@ -501,7 +450,7 @@ describe('AgentSubscriberResolver', () => {
 
       expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
       const endpointCommand = createChannelEndpoint.execute.firstCall.args[0];
-      expect(endpointCommand.subscriberId).to.equal(result);
+      expect(endpointCommand.subscriberId).to.equal(subscriberId);
       expect(endpointCommand.type).to.equal('slack_user');
       expect(endpointCommand.endpoint).to.deep.equal({ userId: 'U_NEW' });
 
@@ -524,7 +473,7 @@ describe('AgentSubscriberResolver', () => {
         platformUserId: 'U_DETERMINISTIC',
       });
 
-      expect(first).to.equal(second);
+      expect(first).to.deep.equal(second);
       expect(u1.execute.firstCall.args[0].subscriberId).to.equal(u2.execute.firstCall.args[0].subscriberId);
     });
 
@@ -626,7 +575,7 @@ describe('AgentSubscriberResolver', () => {
       // would have generated locally, so returning the winner's row
       // converges every racer on a single `Subscriber` without leaving
       // orphan rows behind to log or clean up.
-      expect(result).to.equal('sub-winner');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-winner' });
       expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
       expect(findByPlatformIdentity.callCount).to.equal(2);
 
@@ -693,7 +642,7 @@ describe('AgentSubscriberResolver', () => {
         platformUserId: 'known@example.com',
       });
 
-      expect(result).to.equal('sub-known');
+      expect(result).to.deep.equal({ outcome: 'resolved', subscriberId: 'sub-known' });
       expect(createOrUpdateSubscriber.execute.called).to.equal(false);
     });
 
@@ -711,15 +660,17 @@ describe('AgentSubscriberResolver', () => {
         platformUserId: 'newcomer@example.com',
       });
 
-      expect(result).to.be.a('string').and.to.match(/^sub_/);
+      expect(result.outcome).to.equal('resolved');
+      expect(result.outcome === 'resolved' ? result.subscriberId : '').to.match(/^sub_/);
       expect(createOrUpdateSubscriberExecute.calledOnce).to.equal(true);
     });
 
-    it('soft-fails to null when provisioning throws', async () => {
+    it('soft-fails to an error outcome when provisioning throws', async () => {
+      const provisionError = new Error('mongo down');
       const { resolver, logger } = makeResolver({
         findByEmail: sinon.stub().resolves([]),
         find: sinon.stub().resolves([]),
-        createOrUpdateSubscriberExecute: sinon.stub().rejects(new Error('mongo down')),
+        createOrUpdateSubscriberExecute: sinon.stub().rejects(provisionError),
       });
 
       const result = await resolver.resolveOrProvision({
@@ -728,8 +679,22 @@ describe('AgentSubscriberResolver', () => {
         platformUserId: 'fail@example.com',
       });
 
-      expect(result).to.equal(null);
+      expect(result).to.deep.equal({ outcome: 'error', err: provisionError });
       expect(logger.warn.called).to.equal(true);
+    });
+
+    it('returns invalid_identity for an unusable address without provisioning', async () => {
+      const createOrUpdateSubscriberExecute = sinon.stub().resolves(undefined);
+      const { resolver } = makeResolver({ createOrUpdateSubscriberExecute });
+
+      const result = await resolver.resolveOrProvision({
+        ...baseProvisionParams,
+        platform: AgentPlatformEnum.EMAIL,
+        platformUserId: 'not-an-email',
+      });
+
+      expect(result).to.deep.equal({ outcome: 'invalid_identity' });
+      expect(createOrUpdateSubscriberExecute.called).to.equal(false);
     });
   });
 

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
@@ -12,6 +12,7 @@ import { CreateChannelEndpointCommand } from '../../../channel-endpoints/usecase
 import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
+import type { SubscriberResolution } from '../../shared/types/subscriber-resolution';
 import { isValidEmailForLookup, normalizeEmailForLookup } from '../../shared/util/email-normalization';
 import { getPhoneLookupCandidates } from '../../shared/util/phone-normalization';
 import { AUTO_PROVISION_PLATFORMS, PLATFORM_ENDPOINT_CONFIG } from '../../shared/util/platform-endpoint-config';
@@ -88,15 +89,17 @@ export class AgentSubscriberResolver {
   }
 
   /**
-   * Pure platform-identity lookup. Returns the linked subscriberId or `null`
-   * when no link exists. Safe for read-only callers (reactions, actions, and
-   * platforms outside the auto-provision scope).
+   * Pure platform-identity lookup returning a discriminated outcome, so callers
+   * can tell a genuine miss (`not_found`) apart from an unusable identity
+   * (`invalid_identity`). Never returns the `error` outcome — lookup failures
+   * propagate as rejections for the caller to classify. Safe for read-only
+   * callers (reactions, actions, and platforms outside the auto-provision scope).
    */
-  async resolveOnly(params: ResolveSubscriberParams): Promise<string | null> {
+  async resolveSubscriber(params: ResolveSubscriberParams): Promise<SubscriberResolution> {
     const { environmentId, organizationId, platform, platformUserId, integrationIdentifier } = params;
 
     if (!platformUserId.trim()) {
-      return null;
+      return { outcome: 'invalid_identity' };
     }
 
     if (platform === AgentPlatformEnum.WHATSAPP) {
@@ -122,7 +125,7 @@ export class AgentSubscriberResolver {
         `No endpoint config for platform ${platform} — subscriber resolution skipped (integration: ${integrationIdentifier})`
       );
 
-      return null;
+      return { outcome: 'not_found' };
     }
 
     const endpoint = await this.channelEndpointRepository.findByPlatformIdentity({
@@ -137,14 +140,25 @@ export class AgentSubscriberResolver {
     if (endpoint) {
       this.logger.debug(`Resolved platform user ${platform}:${platformUserId} → subscriber ${endpoint.subscriberId}`);
 
-      return endpoint.subscriberId;
+      return { outcome: 'resolved', subscriberId: endpoint.subscriberId };
     }
 
     this.logger.debug(
       `No subscriber linked for platform user ${platform}:${platformUserId} (integration: ${integrationIdentifier})`
     );
 
-    return null;
+    return { outcome: 'not_found' };
+  }
+
+  /**
+   * Legacy convenience view over `resolveSubscriber` that flattens the outcome
+   * back to `subscriberId | null` for callers that only care about the happy
+   * path (e.g. the `resolveOrProvision` pre-check).
+   */
+  async resolveOnly(params: ResolveSubscriberParams): Promise<string | null> {
+    const resolution = await this.resolveSubscriber(params);
+
+    return resolution.outcome === 'resolved' ? resolution.subscriberId : null;
   }
 
   /**
@@ -312,7 +326,7 @@ export class AgentSubscriberResolver {
     environmentId: string;
     organizationId: string;
     platformUserId: string;
-  }): Promise<string | null> {
+  }): Promise<SubscriberResolution> {
     const { environmentId, organizationId, platformUserId } = params;
     const phoneCandidates = getPhoneLookupCandidates(platformUserId);
     const matches = await this.subscriberRepository.findByPhone(environmentId, organizationId, phoneCandidates);
@@ -328,12 +342,12 @@ export class AgentSubscriberResolver {
     if (subscriber) {
       this.logger.debug(`Resolved WhatsApp phone ${platformUserId} → subscriber ${subscriber.subscriberId}`);
 
-      return subscriber.subscriberId;
+      return { outcome: 'resolved', subscriberId: subscriber.subscriberId };
     }
 
     this.logger.debug(`No subscriber found for WhatsApp phone ${platformUserId}`);
 
-    return null;
+    return { outcome: 'not_found' };
   }
 
   private async resolveAgentProvisionedEmailSubscriber(params: {
@@ -377,14 +391,14 @@ export class AgentSubscriberResolver {
     environmentId: string;
     organizationId: string;
     platformUserId: string;
-  }): Promise<string | null> {
+  }): Promise<SubscriberResolution> {
     const { environmentId, organizationId, platformUserId } = params;
     const email = normalizeEmailForLookup(platformUserId);
 
     if (!isValidEmailForLookup(email)) {
       this.logger.debug(`Skipping email subscriber lookup for invalid address "${platformUserId}"`);
 
-      return null;
+      return { outcome: 'invalid_identity' };
     }
 
     const matches = await this.subscriberRepository.findByEmail(environmentId, organizationId, email);
@@ -392,7 +406,7 @@ export class AgentSubscriberResolver {
     if (matches.length === 0) {
       this.logger.debug(`No subscriber found for email ${email}`);
 
-      return null;
+      return { outcome: 'not_found' };
     }
 
     // Partition matches into real (customer-created) vs auto-provisioned
@@ -426,7 +440,7 @@ export class AgentSubscriberResolver {
 
       this.logger.debug(`Resolved email ${email} → subscriber ${real.subscriberId}`);
 
-      return real.subscriberId;
+      return { outcome: 'resolved', subscriberId: real.subscriberId };
     }
 
     // Only phantom(s) exist — no customer-created subscriber yet. Resolve to the
@@ -440,7 +454,7 @@ export class AgentSubscriberResolver {
     const phantom = phantoms[0];
     this.logger.debug(`Resolved email ${email} → auto-provisioned subscriber ${phantom.subscriberId}`);
 
-    return phantom.subscriberId;
+    return { outcome: 'resolved', subscriberId: phantom.subscriberId };
   }
 
   private async provisionSubscriberAndEndpoint(params: ResolveOrProvisionParams): Promise<string> {

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
@@ -151,17 +151,6 @@ export class AgentSubscriberResolver {
   }
 
   /**
-   * Legacy convenience view over `resolveSubscriber` that flattens the outcome
-   * back to `subscriberId | null` for callers that only care about the happy
-   * path (e.g. the `resolveOrProvision` pre-check).
-   */
-  async resolveOnly(params: ResolveSubscriberParams): Promise<string | null> {
-    const resolution = await this.resolveSubscriber(params);
-
-    return resolution.outcome === 'resolved' ? resolution.subscriberId : null;
-  }
-
-  /**
    * Lookup-or-provision for inbound text messages on platforms where the agent
    * may create the subscriber itself: Slack/Teams (always) and email when the
    * caller has established open access (`subscriberAccess === 'open'`, never
@@ -180,16 +169,17 @@ export class AgentSubscriberResolver {
    *     binding; email identity lives on `Subscriber.email` alone.
    *
    * Slack/Teams throw on provisioning failure (dispatch stays off); the email
-   * branch soft-fails to `null` so a provisioning hiccup never crashes the
-   * inbound webhook. Throws for non-provisionable platforms; callers MUST
-   * route reactions, actions, and other inbound through `resolveOnly`.
+   * branch soft-fails to an `error` outcome so a provisioning hiccup never
+   * crashes the inbound webhook. Throws for non-provisionable platforms;
+   * callers MUST route reactions, actions, and other inbound through
+   * `resolveSubscriber`.
    */
-  async resolveOrProvision(params: ResolveOrProvisionParams): Promise<string | null> {
+  async resolveOrProvision(params: ResolveOrProvisionParams): Promise<SubscriberResolution> {
     const isOpenAccessEmail = params.platform === AgentPlatformEnum.EMAIL;
 
     if (!AUTO_PROVISION_PLATFORMS.has(params.platform) && !isOpenAccessEmail) {
       throw new Error(
-        `resolveOrProvision called for unsupported platform "${params.platform}". Route through resolveOnly instead.`
+        `resolveOrProvision called for unsupported platform "${params.platform}". Route through resolveSubscriber instead.`
       );
     }
 
@@ -207,34 +197,40 @@ export class AgentSubscriberResolver {
       return this.resolveOrProvisionEmail(params);
     }
 
-    const existing = await this.resolveOnly(params);
-    if (existing) {
+    const existing = await this.resolveSubscriber(params);
+    if (existing.outcome === 'resolved') {
       return existing;
     }
 
-    return this.provisionSubscriberAndEndpoint(params);
+    return { outcome: 'resolved', subscriberId: await this.provisionSubscriberAndEndpoint(params) };
   }
 
   /**
    * Email flavor of lookup-or-provision, used for open-access agents. Fully
-   * soft-fail: a lookup or provisioning error is logged and swallowed so the
-   * inbound webhook keeps flowing — the turn then continues unresolved and the
-   * managed subscriber gate replies instead.
+   * soft-fail: a lookup or provisioning error is logged and mapped to an
+   * `error` outcome so the inbound webhook keeps flowing — the turn then
+   * continues unresolved and the managed subscriber gate replies instead.
    */
-  private async resolveOrProvisionEmail(params: ResolveOrProvisionParams): Promise<string | null> {
+  private async resolveOrProvisionEmail(params: ResolveOrProvisionParams): Promise<SubscriberResolution> {
     try {
-      const existing = await this.resolveOnly(params);
-      if (existing) {
+      const existing = await this.resolveSubscriber(params);
+      if (existing.outcome !== 'not_found') {
         return existing;
       }
 
-      return await this.provisionEmailSubscriber({
+      const provisionedSubscriberId = await this.provisionEmailSubscriber({
         environmentId: params.environmentId,
         organizationId: params.organizationId,
         integrationIdentifier: params.integrationIdentifier,
         agentIdentifier: params.agentIdentifier,
         email: params.platformUserId,
       });
+
+      // `provisionEmailSubscriber` only returns null for an unusable address,
+      // which the lookup above would already have classified — kept for safety.
+      return provisionedSubscriberId
+        ? { outcome: 'resolved', subscriberId: provisionedSubscriberId }
+        : { outcome: 'invalid_identity' };
     } catch (err) {
       this.logger.warn(
         err,
@@ -247,7 +243,7 @@ export class AgentSubscriberResolver {
         integrationIdentifier: params.integrationIdentifier,
       });
 
-      return null;
+      return { outcome: 'error', err };
     }
   }
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -4,7 +4,10 @@ import sinon from 'sinon';
 import { ManagedRuntime } from '../../managed-runtime/managed.runtime';
 import { AgentEventEnum } from '../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
-import { UNRESOLVED_SUBSCRIBER_ACCESS_REPLY } from '../../shared/util/agent-inbound-replies';
+import {
+  UNRESOLVED_SUBSCRIBER_ACCESS_REPLY,
+  UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY,
+} from '../../shared/util/agent-inbound-replies';
 import { BridgeRuntime } from '../runtime/bridge.runtime';
 import { NoBridgeUrlError } from '../runtime/bridge-executor.service';
 import { AgentInboundHandler } from './inbound-turn.handler';
@@ -50,11 +53,20 @@ describe('AgentInboundHandler', () => {
     } = {}
   ) {
     const logger = makeLogger();
+    // Legacy overrides stub the resolver with `subscriberId | null` (or a rejection);
+    // adapt them to the discriminated `SubscriberResolution` contract of `resolveSubscriber`.
+    const legacySubscriberResolve = overrides.subscriberResolve;
     const subscriberResolver = {
-      resolveOnly: overrides.subscriberResolve ?? sinon.stub().resolves(null),
+      resolveSubscriber: legacySubscriberResolve
+        ? sinon.stub().callsFake(async (...args: unknown[]) => {
+            const subscriberId = await legacySubscriberResolve(...args);
+
+            return subscriberId ? { outcome: 'resolved', subscriberId } : { outcome: 'not_found' };
+          })
+        : sinon.stub().resolves({ outcome: 'not_found' }),
       resolveOrProvision:
         overrides.subscriberResolveOrProvision ??
-        overrides.subscriberResolve ??
+        legacySubscriberResolve ??
         sinon.stub().resolves(`sub_${Math.random().toString(36).slice(2, 14)}`),
     };
     const conversationService = {
@@ -186,6 +198,7 @@ describe('AgentInboundHandler', () => {
 
     return {
       handler,
+      logger,
       attachmentStorage,
       bridgeExecutor,
       conversationService,
@@ -446,6 +459,44 @@ describe('AgentInboundHandler', () => {
       expect(outboundGateway.replyOnThread.firstCall.args[1].markdown).to.include('Novu account');
     });
 
+    it('should reply with transient copy and log a structured warn when subscriber resolution errors (email)', async () => {
+      const emailConfig = {
+        ...config,
+        platform: AgentPlatformEnum.EMAIL,
+        integrationIdentifier: 'email-main',
+      };
+      const senderEmail = 'known@example.com';
+      const { handler, logger, managedAgentService, outboundGateway } = makeHandler({
+        subscriberResolve: sinon.stub().rejects(new Error('mongo timeout')),
+        subscriberFindById: sinon.stub().resolves(null),
+        agentFindOne: sinon.stub().resolves(makeManagedAgentStub()),
+      });
+      const thread = makeEmailDmThread();
+      const message = makeEmailDmMessage(senderEmail);
+
+      await handler.handle('agent1', emailConfig as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(managedAgentService.dispatch.called).to.equal(false);
+      expect(outboundGateway.replyOnThread.calledOnce).to.equal(true);
+      // A broken lookup must not blame the sender's address.
+      expect(outboundGateway.replyOnThread.firstCall.args[1].markdown).to.equal(UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY);
+      expect(outboundGateway.replyOnThread.firstCall.args[1].markdown).to.not.include(senderEmail);
+
+      const gateWarn = logger.warn
+        .getCalls()
+        .find((call) => typeof call.args[0] === 'object' && call.args[0]?.resolutionOutcome);
+      if (!gateWarn) {
+        expect.fail('expected a structured unresolved-subscriber warn');
+      }
+      expect(gateWarn.args[0]).to.include({
+        environmentId: 'env1',
+        organizationId: 'org1',
+        platform: AgentPlatformEnum.EMAIL,
+        senderPlatformUserId: senderEmail,
+        resolutionOutcome: 'error',
+      });
+    });
+
     it('should dispatch keyless managed agent even when subscriber is unresolved (email)', async () => {
       const emailConfig = {
         ...config,
@@ -606,7 +657,7 @@ describe('AgentInboundHandler', () => {
       await handler.handle('agent1', emailConfig as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
 
       expect(subscriberResolver.resolveOrProvision.called).to.equal(false);
-      expect(subscriberResolver.resolveOnly.called).to.equal(false);
+      expect(subscriberResolver.resolveSubscriber.called).to.equal(false);
       // No identity resolved → managed subscriber gate blocks dispatch.
       expect(managedAgentService.dispatch.called).to.equal(false);
       expect(outboundGateway.replyOnThread.calledOnce).to.equal(true);
@@ -634,7 +685,7 @@ describe('AgentInboundHandler', () => {
 
       await handler.handle('agent1', emailConfig as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
 
-      expect(subscriberResolver.resolveOnly.called).to.equal(false);
+      expect(subscriberResolver.resolveSubscriber.called).to.equal(false);
       expect(subscriberRepository.findBySubscriberId.called).to.equal(false);
       expect(managedAgentService.dispatch.called).to.equal(false);
       expect(outboundGateway.replyOnThread.calledOnce).to.equal(true);
@@ -660,7 +711,7 @@ describe('AgentInboundHandler', () => {
 
       await handler.handle('agent1', emailConfig as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
 
-      expect(subscriberResolver.resolveOnly.calledOnce).to.equal(true);
+      expect(subscriberResolver.resolveSubscriber.calledOnce).to.equal(true);
       expect(managedAgentService.dispatch.calledOnce).to.equal(true);
       expect(outboundGateway.replyOnThread.called).to.equal(false);
     });

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -54,20 +54,25 @@ describe('AgentInboundHandler', () => {
   ) {
     const logger = makeLogger();
     // Legacy overrides stub the resolver with `subscriberId | null` (or a rejection);
-    // adapt them to the discriminated `SubscriberResolution` contract of `resolveSubscriber`.
+    // adapt them to the discriminated `SubscriberResolution` contract.
     const legacySubscriberResolve = overrides.subscriberResolve;
+    const toResolution = async (...args: unknown[]) => {
+      const subscriberId = await legacySubscriberResolve?.(...args);
+
+      return subscriberId ? { outcome: 'resolved', subscriberId } : { outcome: 'not_found' };
+    };
     const subscriberResolver = {
       resolveSubscriber: legacySubscriberResolve
-        ? sinon.stub().callsFake(async (...args: unknown[]) => {
-            const subscriberId = await legacySubscriberResolve(...args);
-
-            return subscriberId ? { outcome: 'resolved', subscriberId } : { outcome: 'not_found' };
-          })
+        ? sinon.stub().callsFake(toResolution)
         : sinon.stub().resolves({ outcome: 'not_found' }),
       resolveOrProvision:
         overrides.subscriberResolveOrProvision ??
-        legacySubscriberResolve ??
-        sinon.stub().resolves(`sub_${Math.random().toString(36).slice(2, 14)}`),
+        (legacySubscriberResolve
+          ? sinon.stub().callsFake(toResolution)
+          : sinon.stub().resolves({
+              outcome: 'resolved',
+              subscriberId: `sub_${Math.random().toString(36).slice(2, 14)}`,
+            })),
     };
     const conversationService = {
       createOrGetConversation: sinon.stub().resolves(conversation),
@@ -497,6 +502,28 @@ describe('AgentInboundHandler', () => {
       });
     });
 
+    it('should reclassify a resolved id whose subscriber record cannot be loaded as a transient error', async () => {
+      const emailConfig = {
+        ...config,
+        platform: AgentPlatformEnum.EMAIL,
+        integrationIdentifier: 'email-main',
+      };
+      const { handler, managedAgentService, outboundGateway } = makeHandler({
+        subscriberResolve: sinon.stub().resolves('ghost-subscriber'),
+        subscriberFindById: sinon.stub().resolves(null),
+        agentFindOne: sinon.stub().resolves(makeManagedAgentStub()),
+      });
+      const thread = makeEmailDmThread();
+      const message = makeEmailDmMessage('known@example.com');
+
+      await handler.handle('agent1', emailConfig as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(managedAgentService.dispatch.called).to.equal(false);
+      // Internal inconsistency, not a sender problem — must not blame the address.
+      expect(outboundGateway.replyOnThread.calledOnce).to.equal(true);
+      expect(outboundGateway.replyOnThread.firstCall.args[1].markdown).to.equal(UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY);
+    });
+
     it('should dispatch keyless managed agent even when subscriber is unresolved (email)', async () => {
       const emailConfig = {
         ...config,
@@ -559,7 +586,7 @@ describe('AgentInboundHandler', () => {
         subscriberAccess: AgentSubscriberAccessEnum.OPEN,
       };
       const senderEmail = 'newcomer@example.com';
-      const resolveOrProvision = sinon.stub().resolves('sub-provisioned');
+      const resolveOrProvision = sinon.stub().resolves({ outcome: 'resolved', subscriberId: 'sub-provisioned' });
       const { handler, managedAgentService, outboundGateway } = makeHandler({
         subscriberResolveOrProvision: resolveOrProvision,
         subscriberFindById: sinon.stub().resolves({ _id: 'sub-mongo', subscriberId: 'sub-provisioned' }),
@@ -588,7 +615,7 @@ describe('AgentInboundHandler', () => {
         subscriberAccess: AgentSubscriberAccessEnum.RESTRICTED,
       };
       const senderEmail = 'stranger@example.com';
-      const resolveOrProvision = sinon.stub().resolves('sub-provisioned');
+      const resolveOrProvision = sinon.stub().resolves({ outcome: 'resolved', subscriberId: 'sub-provisioned' });
       const { handler, managedAgentService, outboundGateway } = makeHandler({
         subscriberResolve: sinon.stub().resolves(null),
         subscriberResolveOrProvision: resolveOrProvision,
@@ -615,7 +642,7 @@ describe('AgentInboundHandler', () => {
         isManaged: true,
         subscriberAccess: AgentSubscriberAccessEnum.OPEN,
       };
-      const resolveOrProvision = sinon.stub().resolves('sub-provisioned');
+      const resolveOrProvision = sinon.stub().resolves({ outcome: 'resolved', subscriberId: 'sub-provisioned' });
       const { handler, managedAgentService } = makeHandler({
         subscriberResolve: sinon.stub().resolves(null),
         subscriberResolveOrProvision: resolveOrProvision,
@@ -642,7 +669,7 @@ describe('AgentInboundHandler', () => {
       };
       // On unpatched code the open-access path provisions/looks up the forged
       // address, handing the attacker a subscriber identity.
-      const resolveOrProvision = sinon.stub().resolves('sub-provisioned');
+      const resolveOrProvision = sinon.stub().resolves({ outcome: 'resolved', subscriberId: 'sub-provisioned' });
       const resolveOnly = sinon.stub().resolves('victim-subscriber');
       const { handler, subscriberResolver, managedAgentService, outboundGateway } = makeHandler({
         subscriberResolve: resolveOnly,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -32,6 +32,7 @@ import { AgentEventEnum } from '../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { parseToolApprovalActionId } from '../../shared/tool-approval/action-id';
+import type { SubscriberResolution } from '../../shared/types/subscriber-resolution';
 import { agentLinkAwaitingInboundConnectionFilter } from '../../shared/util/agent-inbound-connection';
 import { extractMsTeamsTenantId } from '../../shared/util/msteams-activity';
 import { type AutoProvisionPlatform, isAutoProvisionPlatform } from '../../shared/util/platform-endpoint-config';
@@ -301,7 +302,7 @@ export class AgentInboundHandler implements OnModuleInit {
         config.subscriberAccess === AgentSubscriberAccessEnum.OPEN &&
         !config.isKeyless);
 
-    let subscriberId: string | null;
+    let resolution: SubscriberResolution;
     try {
       if (!isVerifiedEmailSender) {
         this.logger.warn(
@@ -319,26 +320,29 @@ export class AgentInboundHandler implements OnModuleInit {
           },
           'Inbound email sender failed DKIM/SPF verification — skipping subscriber resolution so a spoofed From cannot assume an existing identity.'
         );
-        subscriberId = null;
+        resolution = { outcome: 'not_found' };
+      } else if (canAutoProvision) {
+        const provisionedSubscriberId = await this.subscriberResolver.resolveOrProvision({
+          environmentId: config.environmentId,
+          organizationId: config.organizationId,
+          platform: config.platform,
+          platformUserId: message.author.userId,
+          integrationIdentifier: config.integrationIdentifier,
+          agentIdentifier: config.agentIdentifier,
+          authorFullName: message.author.fullName,
+          authorUserName: message.author.userName,
+          // chat-sdk types isBot as `boolean | "unknown"`; treat anything except `true` as a non-bot author.
+          authorIsBot: message.author.isBot === true,
+          // Teams multi-tenant: capture the user's tenant from the inbound activity so the endpoint
+          // records which (possibly external customer) tenant the user belongs to.
+          platformTenantId:
+            config.platform === AgentPlatformEnum.TEAMS ? extractMsTeamsTenantId(message.raw) : undefined,
+        });
+        resolution = provisionedSubscriberId
+          ? { outcome: 'resolved', subscriberId: provisionedSubscriberId }
+          : { outcome: 'not_found' };
       } else {
-        subscriberId = canAutoProvision
-          ? await this.subscriberResolver.resolveOrProvision({
-              environmentId: config.environmentId,
-              organizationId: config.organizationId,
-              platform: config.platform,
-              platformUserId: message.author.userId,
-              integrationIdentifier: config.integrationIdentifier,
-              agentIdentifier: config.agentIdentifier,
-              authorFullName: message.author.fullName,
-              authorUserName: message.author.userName,
-              // chat-sdk types isBot as `boolean | "unknown"`; treat anything except `true` as a non-bot author.
-              authorIsBot: message.author.isBot === true,
-              // Teams multi-tenant: capture the user's tenant from the inbound activity so the endpoint
-              // records which (possibly external customer) tenant the user belongs to.
-              platformTenantId:
-                config.platform === AgentPlatformEnum.TEAMS ? extractMsTeamsTenantId(message.raw) : undefined,
-            })
-          : await this.resolveSubscriberId(agentId, config, message.author.userId, 'resolve-subscriber');
+        resolution = await this.resolveSubscriber(agentId, config, message.author.userId, 'resolve-subscriber');
       }
     } catch (err) {
       if (err instanceof BotAuthorSkippedError) {
@@ -360,18 +364,20 @@ export class AgentInboundHandler implements OnModuleInit {
       }
 
       /**
-       * Only `resolveOrProvision` on SLACK / TEAMS can reach here — the
-       * `resolveSubscriberId` read path and the resolver's open-access email
-       * branch both soft-fail to `null` internally. For auto-provision
-       * platforms an unknown error means we don't know the subscriber state,
-       * so we keep dispatch off and surface the failure rather than silently
-       * degrading to a PLATFORM_USER participant the removed-anonymous-state
-       * contract was meant to eliminate.
+       * Only `resolveOrProvision` on Slack / Teams / open-access email can reach
+       * here — the `resolveSubscriber` read path maps its own failures to an
+       * `error` outcome internally and never throws. For auto-provision platforms
+       * an unknown error means we don't know the subscriber state, so we keep
+       * dispatch off and surface the failure rather than silently degrading to
+       * a PLATFORM_USER participant the removed-anonymous-state contract was
+       * meant to eliminate.
        */
       captureAgentWarning(err, { component: 'agent-inbound-handler', operation: 'resolve-subscriber', agentId });
 
       throw err;
     }
+
+    const subscriberId = resolution.outcome === 'resolved' ? resolution.subscriberId : null;
 
     // A genuine, non-bot user has messaged the agent (bot-authored echoes threw
     // `BotAuthorSkippedError` above). This — not the raw webhook POST — is what
@@ -471,6 +477,7 @@ export class AgentInboundHandler implements OnModuleInit {
       config,
       conversation,
       subscriber,
+      subscriberResolution: resolution,
       message,
       event,
       thread,
@@ -679,26 +686,31 @@ export class AgentInboundHandler implements OnModuleInit {
     }
   }
 
-  private async resolveSubscriberId(
+  /**
+   * Read-path resolution that never throws: lookup failures are mapped to an
+   * `error` outcome instead of being flattened to `null`, so downstream gates
+   * (and their logs) can tell "no such subscriber" apart from "resolution broke".
+   */
+  private async resolveSubscriber(
     agentId: string,
     config: ResolvedAgentConfig,
     platformUserId: string,
     operation: string
-  ): Promise<string | null> {
-    return this.subscriberResolver
-      .resolveOnly({
+  ): Promise<SubscriberResolution> {
+    try {
+      return await this.subscriberResolver.resolveSubscriber({
         environmentId: config.environmentId,
         organizationId: config.organizationId,
         platform: config.platform,
         platformUserId,
         integrationIdentifier: config.integrationIdentifier,
-      })
-      .catch((err) => {
-        this.logger.warn(err, `[agent:${agentId}] Subscriber resolution failed (${operation}), continuing without it`);
-        captureAgentWarning(err, { component: 'agent-inbound-handler', operation, agentId });
-
-        return null;
       });
+    } catch (err) {
+      this.logger.warn(err, `[agent:${agentId}] Subscriber resolution failed (${operation}), continuing without it`);
+      captureAgentWarning(err, { component: 'agent-inbound-handler', operation, agentId });
+
+      return { outcome: 'error', err };
+    }
   }
 
   /**
@@ -909,9 +921,10 @@ export class AgentInboundHandler implements OnModuleInit {
 
     const platformUserId = event.user?.userId;
 
-    const subscriberId = platformUserId
-      ? await this.resolveSubscriberId(agentId, config, platformUserId, 'resolve-subscriber-reaction')
-      : null;
+    const reactionResolution = platformUserId
+      ? await this.resolveSubscriber(agentId, config, platformUserId, 'resolve-subscriber-reaction')
+      : undefined;
+    const subscriberId = reactionResolution?.outcome === 'resolved' ? reactionResolution.subscriberId : null;
 
     const [subscriber, sourceActivity] = await Promise.all([
       subscriberId
@@ -949,6 +962,7 @@ export class AgentInboundHandler implements OnModuleInit {
       config,
       conversation,
       subscriber,
+      subscriberResolution: reactionResolution,
       message: null,
       event: AgentEventEnum.ON_REACTION,
       thread: event.thread ?? ({ id: threadId, channelId: '', isDM: false } as Thread),
@@ -972,7 +986,8 @@ export class AgentInboundHandler implements OnModuleInit {
       return;
     }
 
-    const subscriberId = await this.resolveSubscriberId(agentId, config, userId, 'resolve-subscriber-action');
+    const actionResolution = await this.resolveSubscriber(agentId, config, userId, 'resolve-subscriber-action');
+    const subscriberId = actionResolution.outcome === 'resolved' ? actionResolution.subscriberId : null;
 
     const participantId = subscriberId ?? `${config.platform}:${userId}`;
     const participantType = subscriberId
@@ -1036,6 +1051,7 @@ export class AgentInboundHandler implements OnModuleInit {
       config,
       conversation,
       subscriber,
+      subscriberResolution: actionResolution,
       message: null,
       event: AgentEventEnum.ON_ACTION,
       thread,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -32,7 +32,7 @@ import { AgentEventEnum } from '../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { parseToolApprovalActionId } from '../../shared/tool-approval/action-id';
-import type { SubscriberResolution } from '../../shared/types/subscriber-resolution';
+import { getResolvedSubscriberId, type SubscriberResolution } from '../../shared/types/subscriber-resolution';
 import { agentLinkAwaitingInboundConnectionFilter } from '../../shared/util/agent-inbound-connection';
 import { extractMsTeamsTenantId } from '../../shared/util/msteams-activity';
 import { type AutoProvisionPlatform, isAutoProvisionPlatform } from '../../shared/util/platform-endpoint-config';
@@ -322,7 +322,7 @@ export class AgentInboundHandler implements OnModuleInit {
         );
         resolution = { outcome: 'not_found' };
       } else if (canAutoProvision) {
-        const provisionedSubscriberId = await this.subscriberResolver.resolveOrProvision({
+        resolution = await this.subscriberResolver.resolveOrProvision({
           environmentId: config.environmentId,
           organizationId: config.organizationId,
           platform: config.platform,
@@ -338,9 +338,6 @@ export class AgentInboundHandler implements OnModuleInit {
           platformTenantId:
             config.platform === AgentPlatformEnum.TEAMS ? extractMsTeamsTenantId(message.raw) : undefined,
         });
-        resolution = provisionedSubscriberId
-          ? { outcome: 'resolved', subscriberId: provisionedSubscriberId }
-          : { outcome: 'not_found' };
       } else {
         resolution = await this.resolveSubscriber(agentId, config, message.author.userId, 'resolve-subscriber');
       }
@@ -377,7 +374,7 @@ export class AgentInboundHandler implements OnModuleInit {
       throw err;
     }
 
-    const subscriberId = resolution.outcome === 'resolved' ? resolution.subscriberId : null;
+    const subscriberId = getResolvedSubscriberId(resolution);
 
     // A genuine, non-bot user has messaged the agent (bot-authored echoes threw
     // `BotAuthorSkippedError` above). This — not the raw webhook POST — is what
@@ -459,6 +456,16 @@ export class AgentInboundHandler implements OnModuleInit {
         'managedRuntime',
       ]),
     ]);
+
+    // An id that resolved but whose Subscriber record cannot be loaded is an
+    // internal inconsistency, not a sender problem — reclassify so downstream
+    // gates reply with the transient copy instead of rejecting the sender.
+    if (resolution.outcome === 'resolved' && !subscriber) {
+      resolution = {
+        outcome: 'error',
+        err: new Error(`Subscriber record ${resolution.subscriberId} not found after resolution`),
+      };
+    }
 
     if (!config.isManaged) {
       await this.inboundAck.showWorkingSignal({
@@ -924,7 +931,7 @@ export class AgentInboundHandler implements OnModuleInit {
     const reactionResolution = platformUserId
       ? await this.resolveSubscriber(agentId, config, platformUserId, 'resolve-subscriber-reaction')
       : undefined;
-    const subscriberId = reactionResolution?.outcome === 'resolved' ? reactionResolution.subscriberId : null;
+    const subscriberId = getResolvedSubscriberId(reactionResolution);
 
     const [subscriber, sourceActivity] = await Promise.all([
       subscriberId
@@ -987,7 +994,7 @@ export class AgentInboundHandler implements OnModuleInit {
     }
 
     const actionResolution = await this.resolveSubscriber(agentId, config, userId, 'resolve-subscriber-action');
-    const subscriberId = actionResolution.outcome === 'resolved' ? actionResolution.subscriberId : null;
+    const subscriberId = getResolvedSubscriberId(actionResolution);
 
     const participantId = subscriberId ?? `${config.platform}:${userId}`;
     const participantType = subscriberId

--- a/apps/api/src/app/agents/conversation-runtime/runtime/conversation-turn.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/conversation-turn.ts
@@ -3,6 +3,7 @@ import type { AgentAction } from '@novu/framework';
 import type { Message, Thread } from 'chat';
 import type { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
 import type { AgentEventEnum } from '../../shared/enums/agent-event.enum';
+import type { SubscriberResolution } from '../../shared/types/subscriber-resolution';
 import type { StoredAttachment } from '../conversation/agent-attachment-storage.service';
 import type { BridgeReaction } from './bridge-executor.service';
 
@@ -12,6 +13,12 @@ export interface ConversationTurn {
   config: ResolvedAgentConfig;
   conversation: ConversationEntity;
   subscriber: SubscriberEntity | null;
+  /**
+   * How `subscriber` was (or wasn't) resolved. Lets the unresolved-subscriber
+   * gate distinguish a genuine unknown sender from a resolution failure and
+   * log/reply accordingly.
+   */
+  subscriberResolution?: SubscriberResolution;
   message: Message | null;
   event: AgentEventEnum;
   thread: Thread;

--- a/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
@@ -141,9 +141,36 @@ export class ManagedRuntime implements AgentRuntime {
   }
 
   private async replyUnresolvedSubscriberAccess(turn: ConversationTurn): Promise<void> {
+    const resolution = turn.subscriberResolution;
+
+    /*
+     * The only place the access-denied / verify-your-email reply is produced.
+     * This warn is deliberately structured to make the distinct causes
+     * separable in log search without debug logging: `resolutionOutcome`
+     * distinguishes a genuine miss from a broken lookup, `environmentId`
+     * exposes environment mismatches, and a `resolved` outcome paired with a
+     * null `turn.subscriber` flags a subscriber record that failed to load.
+     */
+    this.logger.warn(
+      {
+        agentId: turn.agentId,
+        environmentId: turn.config.environmentId,
+        organizationId: turn.config.organizationId,
+        platform: turn.config.platform,
+        integrationIdentifier: turn.config.integrationIdentifier,
+        conversationId: turn.conversation._id,
+        senderPlatformUserId: turn.message?.author?.userId,
+        resolutionOutcome: resolution?.outcome,
+        resolvedSubscriberId: resolution?.outcome === 'resolved' ? resolution.subscriberId : undefined,
+        err: resolution?.outcome === 'error' ? resolution.err : undefined,
+      },
+      'Unresolved subscriber — replying with access message instead of dispatching'
+    );
+
     const reply = buildUnresolvedSubscriberAccessReply({
       platform: turn.config.platform,
       senderEmail: turn.message?.author?.userId,
+      resolutionOutcome: resolution?.outcome,
     });
 
     applyPlatformThreadIdToThread(turn.thread, turn.platformThreadId);

--- a/apps/api/src/app/agents/shared/types/subscriber-resolution.ts
+++ b/apps/api/src/app/agents/shared/types/subscriber-resolution.ts
@@ -32,3 +32,7 @@ export type SubscriberResolution =
   | SubscriberResolutionError;
 
 export type SubscriberResolutionOutcome = SubscriberResolution['outcome'];
+
+export function getResolvedSubscriberId(resolution: SubscriberResolution | undefined): string | null {
+  return resolution?.outcome === 'resolved' ? resolution.subscriberId : null;
+}

--- a/apps/api/src/app/agents/shared/types/subscriber-resolution.ts
+++ b/apps/api/src/app/agents/shared/types/subscriber-resolution.ts
@@ -1,0 +1,34 @@
+/**
+ * Discriminated result of mapping an inbound platform identity to a Novu
+ * subscriber. Exists so "no subscriber exists" is never conflated with
+ * "resolution broke": the gate that replies to unresolved senders logs the
+ * outcome and picks its user-facing copy from it.
+ */
+export interface SubscriberResolutionResolved {
+  outcome: 'resolved';
+  subscriberId: string;
+}
+
+/** Lookup ran cleanly and no subscriber matched the platform identity. */
+export interface SubscriberResolutionNotFound {
+  outcome: 'not_found';
+}
+
+/** The platform identity is unusable for lookup (empty, or not a valid email address). */
+export interface SubscriberResolutionInvalidIdentity {
+  outcome: 'invalid_identity';
+}
+
+/** Resolution itself failed (DB error, timeout) — subscriber state is unknown, not absent. */
+export interface SubscriberResolutionError {
+  outcome: 'error';
+  err: unknown;
+}
+
+export type SubscriberResolution =
+  | SubscriberResolutionResolved
+  | SubscriberResolutionNotFound
+  | SubscriberResolutionInvalidIdentity
+  | SubscriberResolutionError;
+
+export type SubscriberResolutionOutcome = SubscriberResolution['outcome'];

--- a/apps/api/src/app/agents/shared/util/agent-inbound-replies.spec.ts
+++ b/apps/api/src/app/agents/shared/util/agent-inbound-replies.spec.ts
@@ -40,14 +40,14 @@ describe('buildUnresolvedSubscriberAccessReply', () => {
     expect(reply).to.not.include('known@example.com');
   });
 
-  it('returns transient copy when the id resolved but the subscriber record failed to load', () => {
+  it('does not treat a resolved outcome as transient — the handler reclassifies unloadable records as error', () => {
     const reply = buildUnresolvedSubscriberAccessReply({
       platform: AgentPlatformEnum.EMAIL,
       senderEmail: 'known@example.com',
       resolutionOutcome: 'resolved',
     });
 
-    expect(reply).to.equal(UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY);
+    expect(reply).to.not.equal(UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY);
   });
 
   it('returns generic access copy for invalid_identity', () => {

--- a/apps/api/src/app/agents/shared/util/agent-inbound-replies.spec.ts
+++ b/apps/api/src/app/agents/shared/util/agent-inbound-replies.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import { AgentPlatformEnum } from '../enums/agent-platform.enum';
-import { buildUnresolvedSubscriberAccessReply, UNRESOLVED_SUBSCRIBER_ACCESS_REPLY } from './agent-inbound-replies';
+import {
+  buildUnresolvedSubscriberAccessReply,
+  UNRESOLVED_SUBSCRIBER_ACCESS_REPLY,
+  UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY,
+} from './agent-inbound-replies';
 
 describe('buildUnresolvedSubscriberAccessReply', () => {
   it('returns email-specific copy when platform is email and sender is known', () => {
@@ -12,6 +16,47 @@ describe('buildUnresolvedSubscriberAccessReply', () => {
     expect(reply).to.include('unknown@example.com');
     expect(reply).to.include('Novu account');
     expect(reply).to.not.equal(UNRESOLVED_SUBSCRIBER_ACCESS_REPLY);
+  });
+
+  it('keeps email-specific copy for a genuine not_found outcome', () => {
+    const reply = buildUnresolvedSubscriberAccessReply({
+      platform: AgentPlatformEnum.EMAIL,
+      senderEmail: 'unknown@example.com',
+      resolutionOutcome: 'not_found',
+    });
+
+    expect(reply).to.include('unknown@example.com');
+    expect(reply).to.not.equal(UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY);
+  });
+
+  it('returns transient copy when resolution errored — the sender address was never rejected', () => {
+    const reply = buildUnresolvedSubscriberAccessReply({
+      platform: AgentPlatformEnum.EMAIL,
+      senderEmail: 'known@example.com',
+      resolutionOutcome: 'error',
+    });
+
+    expect(reply).to.equal(UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY);
+    expect(reply).to.not.include('known@example.com');
+  });
+
+  it('returns transient copy when the id resolved but the subscriber record failed to load', () => {
+    const reply = buildUnresolvedSubscriberAccessReply({
+      platform: AgentPlatformEnum.EMAIL,
+      senderEmail: 'known@example.com',
+      resolutionOutcome: 'resolved',
+    });
+
+    expect(reply).to.equal(UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY);
+  });
+
+  it('returns generic access copy for invalid_identity', () => {
+    const reply = buildUnresolvedSubscriberAccessReply({
+      platform: AgentPlatformEnum.SLACK,
+      resolutionOutcome: 'invalid_identity',
+    });
+
+    expect(reply).to.equal(UNRESOLVED_SUBSCRIBER_ACCESS_REPLY);
   });
 
   it('returns generic copy when platform is email but sender is missing', () => {

--- a/apps/api/src/app/agents/shared/util/agent-inbound-replies.ts
+++ b/apps/api/src/app/agents/shared/util/agent-inbound-replies.ts
@@ -1,13 +1,26 @@
 import { AgentPlatformEnum } from '../enums/agent-platform.enum';
+import type { SubscriberResolutionOutcome } from '../types/subscriber-resolution';
 
 /** Shown when an inbound turn cannot be mapped to a Novu subscriber (e.g. unknown chat sender). */
 export const UNRESOLVED_SUBSCRIBER_ACCESS_REPLY =
   "You don't have access to message this agent. Connect your account through your application to continue.";
 
+/**
+ * Shown when resolution itself broke rather than the sender being unknown —
+ * blaming the sender's identity for an internal failure would be misleading.
+ */
+export const UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY =
+  "We couldn't process your message because of a temporary issue on our side. Please try again in a few minutes.";
+
 export function buildUnresolvedSubscriberAccessReply(params: {
   platform: AgentPlatformEnum;
   senderEmail?: string;
+  resolutionOutcome?: SubscriberResolutionOutcome;
 }): string {
+  if (isTransientResolutionOutcome(params.resolutionOutcome)) {
+    return UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY;
+  }
+
   const sender = params.senderEmail?.trim();
 
   if (params.platform === AgentPlatformEnum.EMAIL && sender) {
@@ -18,4 +31,27 @@ export function buildUnresolvedSubscriberAccessReply(params: {
   }
 
   return UNRESOLVED_SUBSCRIBER_ACCESS_REPLY;
+}
+
+/**
+ * `error` means the lookup failed outright. `resolved` reaching the unresolved
+ * gate means the id resolved but the Subscriber record could not be loaded
+ * afterwards. In both cases the sender's identity was never actually rejected,
+ * so the access-denied copy would be wrong.
+ */
+function isTransientResolutionOutcome(outcome: SubscriberResolutionOutcome | undefined): boolean {
+  switch (outcome) {
+    case 'error':
+    case 'resolved':
+      return true;
+    case 'not_found':
+    case 'invalid_identity':
+    case undefined:
+      return false;
+    default: {
+      const exhaustiveCheck: never = outcome;
+
+      throw new Error(`Unhandled subscriber resolution outcome: ${exhaustiveCheck as string}`);
+    }
+  }
 }

--- a/apps/api/src/app/agents/shared/util/agent-inbound-replies.ts
+++ b/apps/api/src/app/agents/shared/util/agent-inbound-replies.ts
@@ -17,7 +17,11 @@ export function buildUnresolvedSubscriberAccessReply(params: {
   senderEmail?: string;
   resolutionOutcome?: SubscriberResolutionOutcome;
 }): string {
-  if (isTransientResolutionOutcome(params.resolutionOutcome)) {
+  // On `error` the sender's identity was never actually rejected, so the
+  // access-denied copy would be wrong. (`resolved` never reaches this gate —
+  // the inbound handler reclassifies resolved-but-unloadable records as
+  // `error` before dispatch.)
+  if (params.resolutionOutcome === 'error') {
     return UNRESOLVED_SUBSCRIBER_TRANSIENT_REPLY;
   }
 
@@ -31,27 +35,4 @@ export function buildUnresolvedSubscriberAccessReply(params: {
   }
 
   return UNRESOLVED_SUBSCRIBER_ACCESS_REPLY;
-}
-
-/**
- * `error` means the lookup failed outright. `resolved` reaching the unresolved
- * gate means the id resolved but the Subscriber record could not be loaded
- * afterwards. In both cases the sender's identity was never actually rejected,
- * so the access-denied copy would be wrong.
- */
-function isTransientResolutionOutcome(outcome: SubscriberResolutionOutcome | undefined): boolean {
-  switch (outcome) {
-    case 'error':
-    case 'resolved':
-      return true;
-    case 'not_found':
-    case 'invalid_identity':
-    case undefined:
-      return false;
-    default: {
-      const exhaustiveCheck: never = outcome;
-
-      throw new Error(`Unhandled subscriber resolution outcome: ${exhaustiveCheck as string}`);
-    }
-  }
 }

--- a/apps/api/src/app/agents/shared/util/platform-endpoint-config.ts
+++ b/apps/api/src/app/agents/shared/util/platform-endpoint-config.ts
@@ -28,7 +28,7 @@ export const PLATFORM_ENDPOINT_CONFIG: Partial<Record<AgentPlatformEnum, Platfor
  * Platforms whose inbound message path auto-provisions a Subscriber +
  * ChannelEndpoint on first mention. Single source of truth shared by the
  * resolver (`resolveOrProvision`) and the inbound handler (branching between
- * `resolveOrProvision` and `resolveOnly`). Other platforms keep their existing
+ * `resolveOrProvision` and `resolveSubscriber`). Other platforms keep their existing
  * lookup-only semantics: WhatsApp by phone, Email by address, Telegram via
  * `/start` deep-link.
  */


### PR DESCRIPTION
## Summary

- Replace the ambiguous `subscriberId | null` subscriber-resolution contract with a discriminated `SubscriberResolution` outcome (`resolved`, `not_found`, `invalid_identity`, `error`) across the full inbound path — including `resolveOrProvision`, so open-access email soft-fails surface as `error` instead of masquerading as an unknown sender.
- Thread the outcome through `AgentInboundHandler` into `ConversationTurn`, preserving upstream email DKIM/SPF gating; the handler also reclassifies a resolved id whose Subscriber record cannot be loaded as an internal `error`.
- Emit one structured warn at the managed-runtime unresolved-subscriber gate (`resolutionOutcome`, `environmentId`, sender identity) and split user-facing replies: internal failures get a retry message instead of blaming the sender's email. The unused `resolveOnly` wrapper is removed.

```mermaid
flowchart TD
  A[Inbound message] --> B{DKIM/SPF pass?}
  B -- no --> C[not_found]
  B -- yes --> D{canAutoProvision?}
  D -- yes --> E[resolveOrProvision → outcome<br/>email soft-fail → error]
  D -- no --> F[resolveSubscriber → outcome<br/>throws → error]
  E --> G{outcome resolved?}
  F --> G
  G -- yes --> H[load Subscriber record]
  H -- loaded --> N[dispatch agent]
  H -- missing --> L[reclassified as error]
  G -- no --> O[structured warn + outcome-specific reply]
  C --> O
  L --> O
```

## Why

Staging was replying with "We couldn't verify your email" even when the subscriber existed, because every failure path — genuine miss, Mongo error, env mismatch, DKIM/SPF softfail — collapsed to the same `null` and the same user copy. This makes the next incident diagnosable from one warn log line, and stops blaming senders for internal failures.

## Test plan

- [x] `agent-inbound-replies.spec.ts` — outcome-specific reply copy (`not_found` vs `error`)
- [x] `agent-subscriber-resolver.service.spec.ts` — discriminated outcomes across lookup, adoption, and open-access provisioning (incl. soft-fail → `error`, unusable address → `invalid_identity`)
- [x] `inbound-turn.handler.spec.ts` — structured warn on resolution error, resolved-but-unloadable reclassification, DKIM/SPF spoof blocking, verified restricted email dispatch
- [ ] Deploy to staging and confirm the next unresolved-subscriber warn includes `resolutionOutcome` and `environmentId`

Linear: https://linear.app/novu/issue/NV-8238/discriminate-unresolved-subscriber-resolution-outcomes-in-agent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes subscriber resolution from nullable ids to explicit outcomes. The main changes are:

- Adds `SubscriberResolution` outcomes for resolved, not found, invalid identity, and error states.
- Threads the outcome through inbound message, reaction, and action turns.
- Adds structured unresolved-subscriber logging in managed runtime.
- Splits unresolved-subscriber reply copy between genuine access misses and transient internal failures.

<h3>Confidence Score: 4/5</h3>

Mostly safe after fixing the auto-provision identity handling.

The resolution outcome flow is coherent and covered by tests, but one contained bug can create subscriber records for invalid Slack/Teams identities.

`apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The verification step for honoring invalid identities was blocked after reaching the step limit, and no runtime proof was captured; only static code context was read.
- An environment resolution attempt failed with module-resolution errors and a suggested bootstrap remedy command, as shown in related API agent specs and build logs.
- The feasible reply utility spec subset passed all 7 tests, with a clean exit.

<a href="https://app.greptile.com/trex/runs/13657423/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts | Replaces nullable subscriber lookup results with discriminated outcomes; invalid auto-provision identities can still fall through to provisioning. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Threads subscriber resolution outcomes through inbound message, reaction, and action turns while mapping lookup failures to error outcomes. |
| apps/api/src/app/agents/managed-runtime/managed.runtime.ts | Logs structured unresolved-subscriber context and selects reply copy from the resolution outcome. |
| apps/api/src/app/agents/shared/types/subscriber-resolution.ts | Introduces the `SubscriberResolution` discriminated union and resolved-id helper. |
| apps/api/src/app/agents/shared/util/agent-inbound-replies.ts | Adds transient internal-failure copy while preserving access-denied copy for genuine misses. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Inbound as AgentInboundHandler
participant Resolver as AgentSubscriberResolver
participant Repo as Subscriber/Endpoint Repos
participant Runtime as ManagedRuntime
participant Gateway as OutboundGateway

Inbound->>Inbound: Verify DKIM/SPF for email
alt Unverified email sender
    Inbound->>Runtime: "ConversationTurn(subscriber=null, outcome=not_found)"
else Auto-provision path
    Inbound->>Resolver: resolveOrProvision(platform identity)
    Resolver->>Repo: lookup subscriber/endpoint
    alt resolved
        Resolver-->>Inbound: "{ outcome: resolved, subscriberId }"
    else invalid identity
        Resolver-->>Inbound: "{ outcome: invalid_identity }"
    else lookup/provision error
        Resolver-->>Inbound: "{ outcome: error, err }"
    else miss
        Resolver->>Repo: provision subscriber/endpoint when allowed
        Resolver-->>Inbound: "{ outcome: resolved, subscriberId }"
    end
else Lookup-only path
    Inbound->>Resolver: resolveSubscriber(platform identity)
    Resolver->>Repo: lookup subscriber/endpoint
    Resolver-->>Inbound: SubscriberResolution
end

Inbound->>Repo: load Subscriber when resolved
opt resolved id cannot load
    Inbound->>Inbound: reclassify outcome as error
end
Inbound->>Runtime: dispatch ConversationTurn with subscriberResolution
alt managed and subscriber missing
    Runtime->>Runtime: structured warn(resolutionOutcome, environmentId)
    Runtime->>Gateway: reply access or transient copy
else subscriber present/keyless demo
    Runtime->>Runtime: dispatch managed agent
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Inbound as AgentInboundHandler
participant Resolver as AgentSubscriberResolver
participant Repo as Subscriber/Endpoint Repos
participant Runtime as ManagedRuntime
participant Gateway as OutboundGateway

Inbound->>Inbound: Verify DKIM/SPF for email
alt Unverified email sender
    Inbound->>Runtime: "ConversationTurn(subscriber=null, outcome=not_found)"
else Auto-provision path
    Inbound->>Resolver: resolveOrProvision(platform identity)
    Resolver->>Repo: lookup subscriber/endpoint
    alt resolved
        Resolver-->>Inbound: "{ outcome: resolved, subscriberId }"
    else invalid identity
        Resolver-->>Inbound: "{ outcome: invalid_identity }"
    else lookup/provision error
        Resolver-->>Inbound: "{ outcome: error, err }"
    else miss
        Resolver->>Repo: provision subscriber/endpoint when allowed
        Resolver-->>Inbound: "{ outcome: resolved, subscriberId }"
    end
else Lookup-only path
    Inbound->>Resolver: resolveSubscriber(platform identity)
    Resolver->>Repo: lookup subscriber/endpoint
    Resolver-->>Inbound: SubscriberResolution
end

Inbound->>Repo: load Subscriber when resolved
opt resolved id cannot load
    Inbound->>Inbound: reclassify outcome as error
end
Inbound->>Runtime: dispatch ConversationTurn with subscriberResolution
alt managed and subscriber missing
    Runtime->>Runtime: structured warn(resolutionOutcome, environmentId)
    Runtime->>Gateway: reply access or transient copy
else subscriber present/keyless demo
    Runtime->>Runtime: dispatch managed agent
end
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Fconversation%2Fagent-subscriber-resolver.service.ts%3A200-205%0A**Honor%20invalid%20identities**%0A%60resolveSubscriber%60%20now%20classifies%20empty%20%60platformUserId%60%20as%20%60invalid_identity%60%2C%20but%20the%20Slack%2FTeams%20auto-provision%20path%20only%20stops%20on%20%60resolved%60.%20A%20malformed%20inbound%20message%20with%20a%20blank%20user%20id%20therefore%20falls%20through%20into%20%60provisionSubscriberAndEndpoint%60%2C%20creating%20a%20deterministic%20subscriber%20and%20endpoint%20for%20an%20unusable%20identity%20instead%20of%20staying%20unresolved.%0A%0A&pr=11855&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts:200-205
**Honor invalid identities**
`resolveSubscriber` now classifies empty `platformUserId` as `invalid_identity`, but the Slack/Teams auto-provision path only stops on `resolved`. A malformed inbound message with a blank user id therefore falls through into `provisionSubscriberAndEndpoint`, creating a deterministic subscriber and endpoint for an unusable identity instead of staying unresolved.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): extend resolution outc..."](https://github.com/novuhq/novu/commit/5012800a7adbc0b383eca43739dd4d34738c4a38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42634753)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->