### PR TITLE
feat(inbound-mail): add client IP source debug logging fixes NV-8239

### DIFF
--- a/apps/inbound-mail/src/server/client-ip-sources.spec.ts
+++ b/apps/inbound-mail/src/server/client-ip-sources.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+
+import { collectClientIpSources } from './client-ip-sources';
+
+describe('collectClientIpSources', () => {
+  it('orders SMTP session fields before email headers and Received chain', () => {
+    const debug = collectClientIpSources(
+      {
+        remoteAddress: '10.0.45.33',
+        clientHostname: 'ip-10-0-45-33.eu-west-2.compute.internal',
+        xForward: new Map([['ADDR', '203.0.113.10']]),
+        xClient: new Map([
+          ['ADDR', '203.0.113.10'],
+          ['ADDR:DEFAULT', '10.0.45.33'],
+        ]),
+      },
+      {
+        'x-forwarded-for': '198.51.100.20, 10.0.0.1',
+        received: ['from mail.google.com (mail.google.com [209.85.128.123]) by mx.example.com'],
+      }
+    );
+
+    expect(debug.spfEvaluatedWith).to.deep.equal({
+      ip: '10.0.45.33',
+      helo: 'ip-10-0-45-33.eu-west-2.compute.internal',
+      property: 'session.remoteAddress',
+    });
+
+    expect(debug.orderedCandidates[0]).to.include({
+      property: 'session.xForward.ADDR',
+      value: '203.0.113.10',
+      isPrivate: false,
+    });
+
+    const headerCandidate = debug.orderedCandidates.find(
+      (candidate) => candidate.property === 'headers.x-forwarded-for'
+    );
+    expect(headerCandidate?.value).to.equal('198.51.100.20');
+
+    const receivedCandidate = debug.orderedCandidates.find((candidate) =>
+      candidate.property.startsWith('headers.received[0]')
+    );
+    expect(receivedCandidate?.value).to.equal('209.85.128.123');
+
+    expect(debug.firstPublicCandidate?.property).to.equal('session.xForward.ADDR');
+  });
+
+  it('extracts the first IP from Forwarded headers', () => {
+    const debug = collectClientIpSources(
+      {
+        remoteAddress: '10.0.0.5',
+        clientHostname: 'proxy.internal',
+      },
+      {
+        forwarded: 'for=203.0.113.60;proto=smtp;by=203.0.113.1',
+      }
+    );
+
+    const forwardedCandidate = debug.orderedCandidates.find((candidate) => candidate.property === 'headers.forwarded');
+
+    expect(forwardedCandidate?.value).to.equal('203.0.113.60');
+  });
+});

--- a/apps/inbound-mail/src/server/client-ip-sources.ts
+++ b/apps/inbound-mail/src/server/client-ip-sources.ts
@@ -1,0 +1,318 @@
+import { isPrivateIp, normalizeHostnameForLookup } from '@novu/shared/utils/private-ip-classification';
+
+export interface ClientIpSourceCandidate {
+  rank: number;
+  category: 'smtp-session' | 'email-header' | 'received';
+  property: string;
+  value: string | null;
+  isPrivate: boolean | null;
+  raw?: string;
+}
+
+export interface ClientIpSourceDebug {
+  spfEvaluatedWith: {
+    ip: string;
+    helo: string;
+    property: 'session.remoteAddress' | 'session.clientHostname';
+  };
+  orderedCandidates: ClientIpSourceCandidate[];
+  firstPublicCandidate: ClientIpSourceCandidate | null;
+  receivedHeaders: string[];
+}
+
+interface HeaderLookup {
+  get(name: string): string | string[] | undefined;
+}
+
+/*
+ * Mirrors the precedence documented by @supercharge/request-ip for HTTP
+ * requests. SMTP has no Express req object, so the first block maps the
+ * closest session/socket equivalents; the second block reads the same proxy
+ * headers if an upstream MTA or gateway injected them into the message.
+ */
+const EMAIL_HEADER_IP_KEYS = [
+  'x-forwarded-for',
+  'x-forwarded',
+  'forwarded',
+  'forwarded-for',
+  'x-client-ip',
+  'x-real-ip',
+  'cf-connecting-ip',
+  'fastly-client-ip',
+  'true-client-ip',
+  'x-cluster-client-ip',
+] as const;
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+function classifyIp(value: string | null): boolean | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = normalizeHostnameForLookup(value);
+
+  try {
+    return isPrivateIp(normalized);
+  } catch {
+    return null;
+  }
+}
+
+function readMapLikeValue(mapLike: unknown, key: string): string | null {
+  if (mapLike instanceof Map) {
+    return asString(mapLike.get(key));
+  }
+
+  if (mapLike && typeof mapLike === 'object') {
+    return asString((mapLike as Record<string, unknown>)[key]);
+  }
+
+  return null;
+}
+
+function readNestedRemoteAddress(source: unknown, path: string[]): string | null {
+  let current: unknown = source;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object') {
+      return null;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return asString(current);
+}
+
+function extractFirstIpFromForwardedHeader(value: string): string | null {
+  const forMatch = /(?:^|;|\s)for=(?:"\[([^"\]]+)\]"|\[([^\]]+)\]|"([^";]+)"|([^;\s]+))/i.exec(value);
+
+  if (forMatch) {
+    const candidate = forMatch[1] ?? forMatch[2] ?? forMatch[3] ?? forMatch[4] ?? null;
+
+    return candidate ? normalizeHostnameForLookup(candidate) : null;
+  }
+
+  return extractFirstIpFromList(value);
+}
+
+function extractFirstIpFromList(value: string): string | null {
+  const firstSegment = value.split(',')[0]?.trim();
+
+  if (!firstSegment) {
+    return null;
+  }
+
+  const bracketMatch = /\[([0-9a-f.:]+)\]/i.exec(firstSegment);
+  if (bracketMatch?.[1]) {
+    return normalizeHostnameForLookup(bracketMatch[1]);
+  }
+
+  const ipv4Match = /\b(\d{1,3}(?:\.\d{1,3}){3})\b/.exec(firstSegment);
+  if (ipv4Match?.[1]) {
+    return ipv4Match[1];
+  }
+
+  return normalizeHostnameForLookup(firstSegment.replace(/^::ffff:/i, ''));
+}
+
+function extractIpsFromReceivedHeader(value: string): string[] {
+  const matches = value.matchAll(/\[([0-9a-f.:]+)\]/gi);
+  const ips: string[] = [];
+
+  for (const match of matches) {
+    const ip = asString(match[1]);
+
+    if (ip) {
+      ips.push(normalizeHostnameForLookup(ip.replace(/^::ffff:/i, '')));
+    }
+  }
+
+  return ips;
+}
+
+function toHeaderLookup(headers: unknown): HeaderLookup | null {
+  if (!headers) {
+    return null;
+  }
+
+  if (headers instanceof Map) {
+    return {
+      get(name: string) {
+        const direct = headers.get(name) ?? headers.get(name.toLowerCase());
+
+        return direct as string | string[] | undefined;
+      },
+    };
+  }
+
+  if (typeof headers === 'object') {
+    const record = headers as Record<string, unknown>;
+
+    return {
+      get(name: string) {
+        const value = record[name] ?? record[name.toLowerCase()];
+
+        return value as string | string[] | undefined;
+      },
+    };
+  }
+
+  return null;
+}
+
+function readHeaderValues(lookup: HeaderLookup, name: string): string[] {
+  const raw = lookup.get(name);
+
+  if (Array.isArray(raw)) {
+    return raw.flatMap((entry) => (typeof entry === 'string' ? [entry] : []));
+  }
+
+  if (typeof raw === 'string') {
+    return [raw];
+  }
+
+  return [];
+}
+
+function pushCandidate(
+  candidates: ClientIpSourceCandidate[],
+  rank: number,
+  category: ClientIpSourceCandidate['category'],
+  property: string,
+  value: string | null,
+  raw?: string
+): number {
+  candidates.push({
+    rank,
+    category,
+    property,
+    value,
+    isPrivate: classifyIp(value),
+    raw,
+  });
+
+  return rank + 1;
+}
+
+function readHeaderCandidate(
+  lookup: HeaderLookup,
+  headerName: (typeof EMAIL_HEADER_IP_KEYS)[number]
+): { property: string; value: string | null; raw?: string } | null {
+  const values = readHeaderValues(lookup, headerName);
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  const raw = values[0];
+  const value =
+    headerName === 'forwarded' || headerName === 'x-forwarded'
+      ? extractFirstIpFromForwardedHeader(raw)
+      : extractFirstIpFromList(raw);
+
+  return {
+    property: `headers.${headerName}`,
+    value,
+    raw,
+  };
+}
+
+export function collectClientIpSources(
+  connection: Record<string, unknown>,
+  parsedEmailHeaders: unknown
+): ClientIpSourceDebug {
+  const candidates: ClientIpSourceCandidate[] = [];
+  let rank = 1;
+
+  const smtpSessionChecks: Array<{ property: string; value: string | null }> = [
+    { property: 'session.xForward.ADDR', value: readMapLikeValue(connection.xForward, 'ADDR') },
+    { property: 'session.xClient.ADDR', value: readMapLikeValue(connection.xClient, 'ADDR') },
+    { property: 'session.xClient.ADDR:DEFAULT', value: readMapLikeValue(connection.xClient, 'ADDR:DEFAULT') },
+    { property: 'session.remoteAddress', value: asString(connection.remoteAddress) },
+    { property: 'session.remotePort', value: asString(connection.remotePort) },
+    { property: 'session.localAddress', value: asString(connection.localAddress) },
+    { property: 'session.localPort', value: asString(connection.localPort) },
+    { property: 'session.clientHostname', value: asString(connection.clientHostname) },
+    { property: 'session.hostNameAppearsAs', value: asString(connection.hostNameAppearsAs) },
+    {
+      property: 'session.socket.remoteAddress',
+      value: readNestedRemoteAddress(connection.socket, ['remoteAddress']),
+    },
+    {
+      property: 'session.connection.remoteAddress',
+      value: readNestedRemoteAddress(connection.connection, ['remoteAddress']),
+    },
+    {
+      property: 'session.connection.socket.remoteAddress',
+      value: readNestedRemoteAddress(connection.connection, ['socket', 'remoteAddress']),
+    },
+  ];
+
+  for (const check of smtpSessionChecks) {
+    rank = pushCandidate(candidates, rank, 'smtp-session', check.property, check.value);
+  }
+
+  const headerLookup = toHeaderLookup(parsedEmailHeaders);
+  const receivedHeaders = headerLookup ? readHeaderValues(headerLookup, 'received') : [];
+
+  if (headerLookup) {
+    for (const headerName of EMAIL_HEADER_IP_KEYS) {
+      const headerCandidate = readHeaderCandidate(headerLookup, headerName);
+
+      if (!headerCandidate) {
+        continue;
+      }
+
+      rank = pushCandidate(
+        candidates,
+        rank,
+        'email-header',
+        headerCandidate.property,
+        headerCandidate.value,
+        headerCandidate.raw
+      );
+    }
+  }
+
+  for (const [index, receivedHeader] of receivedHeaders.entries()) {
+    const ips = extractIpsFromReceivedHeader(receivedHeader);
+
+    for (const [ipIndex, ip] of ips.entries()) {
+      rank = pushCandidate(
+        candidates,
+        rank,
+        'received',
+        `headers.received[${index}].ip[${ipIndex}]`,
+        ip,
+        receivedHeader
+      );
+    }
+  }
+
+  const firstPublicCandidate = candidates.find((candidate) => candidate.value && candidate.isPrivate === false) ?? null;
+
+  return {
+    spfEvaluatedWith: {
+      ip: asString(connection.remoteAddress) ?? '',
+      helo: asString(connection.clientHostname) ?? '',
+      property: 'session.remoteAddress',
+    },
+    orderedCandidates: candidates,
+    firstPublicCandidate,
+    receivedHeaders,
+  };
+}

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -15,6 +15,7 @@ import util from 'util';
 import { v4 as uuidv4 } from 'uuid';
 
 import { uploadAttachmentsToS3 } from './attachment-uploader';
+import { collectClientIpSources } from './client-ip-sources';
 import { InboundMailService } from './inbound-mail.service';
 import logger from './logger';
 
@@ -542,6 +543,46 @@ class Mailin extends events.EventEmitter {
         },
         `${connection.id} Inbound mail sender authentication verdict: dkim=${parsedEmail.dkim} spf=${parsedEmail.spf}`
       );
+
+      if (process.env.INBOUND_MAIL_DEBUG_CLIENT_IP === 'true') {
+        /*
+         * Structured client-IP source dump for debugging sender-auth issues in
+         * cloud envs: mirrors @supercharge/request-ip precedence (proxy headers
+         * first, then socket/connection fallbacks) adapted for SMTP session
+         * fields plus Received-chain IPs. Shows which property SPF currently
+         * uses vs the first public candidate elsewhere in the chain. Verbose and
+         * may include attacker-controlled header values.
+         */
+        const clientIpSources = collectClientIpSources(connection, parsedEmail.headers);
+
+        logger.info(
+          {
+            context: LOG_CONTEXT,
+            connectionId: connection.id,
+            envelopeFrom: connection.envelope?.mailFrom?.address,
+            clientIpSources,
+          },
+          `${connection.id} Inbound mail client IP source dump`
+        );
+      }
+
+      if (process.env.INBOUND_MAIL_DEBUG_HEADERS === 'true') {
+        /*
+         * Full header dump when you need every raw header value beyond the
+         * structured IP-source view above.
+         */
+        logger.info(
+          {
+            context: LOG_CONTEXT,
+            connectionId: connection.id,
+            remoteAddress: connection.remoteAddress,
+            clientHostname: connection.clientHostname,
+            envelopeFrom: connection.envelope?.mailFrom?.address,
+            headers: parsedEmail.headers,
+          },
+          `${connection.id} Inbound mail header dump`
+        );
+      }
 
       /*
        * Make fields exist, even if empty. That will make


### PR DESCRIPTION
## Summary

- Add `collectClientIpSources()` to gather SMTP session fields, proxy headers, and Received-chain IPs in `@supercharge/request-ip` precedence order
- Log which IP/helo SPF currently evaluates against vs the first public candidate elsewhere in the chain
- Gate verbose dumps behind `INBOUND_MAIL_DEBUG_CLIENT_IP=true` and `INBOUND_MAIL_DEBUG_HEADERS=true` so production logs stay lean by default

## Why

Inbound mail SPF checks use `connection.remoteAddress`, which is often a private/proxy IP in cloud deployments. When sender auth fails unexpectedly, we need a structured view of every IP source (session, headers, Received chain) without manually parsing raw logs.

```mermaid
flowchart TD
  A[Inbound SMTP connection] --> B[Sender auth verdict log]
  B --> C{INBOUND_MAIL_DEBUG_CLIENT_IP?}
  C -->|yes| D[collectClientIpSources]
  D --> E[Log spfEvaluatedWith + orderedCandidates + firstPublicCandidate]
  C -->|no| F[Skip IP source dump]
  B --> G{INBOUND_MAIL_DEBUG_HEADERS?}
  G -->|yes| H[Log full parsed headers]
  G -->|no| I[Skip header dump]
```

## Test plan

- [x] `pnpm exec cross-env NODE_ENV=test mocha --require tsx/cjs src/server/client-ip-sources.spec.ts` — 2 passing
- [ ] Enable `INBOUND_MAIL_DEBUG_CLIENT_IP=true` in a cloud/staging env and confirm structured IP source dump appears after an inbound message
- [ ] Confirm logs are absent when debug flags are unset

### What changed? Why was the change needed?

Adds opt-in debug instrumentation for diagnosing SPF/sender-auth issues when inbound-mail runs behind load balancers or MTA gateways. Linear: [NV-8239](https://linear.app/novu/issue/NV-8239/add-debug-logging-for-inbound-mail-client-ip-sources)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in inbound-mail debug logging for SPF client IP source diagnostics. The main changes are:

- Collect SMTP session fields, proxy-style headers, and Received-chain IPs into ordered debug candidates.
- Log SPF inputs alongside the first public client IP candidate when `INBOUND_MAIL_DEBUG_CLIENT_IP` is enabled.
- Log full parsed headers only when `INBOUND_MAIL_DEBUG_HEADERS` is enabled.
- Add unit tests for source ordering and `Forwarded` header parsing.

<h3>Confidence Score: 4/5</h3>

Safe to merge after the debug-output accuracy issue is addressed.

The change is gated behind debug flags and does not change SPF validation behavior. The remaining issue affects diagnostic accuracy, not the inbound mail delivery path.

`apps/inbound-mail/src/server/client-ip-sources.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A test run was executed in the inbound-mail working directory to validate client IP source collection.
- Mocha reported 2 passing tests for collectClientIpSources in 7ms, with exit code 0.
- A Node engine warning about v24.18.0 vs repo preference \>=22 \<23 appeared during the run, but it did not block the focused test.

<a href="https://app.greptile.com/trex/runs/13664965/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/server/client-ip-sources.ts | Adds client IP source collection and parsing; first public candidate selection can misclassify ports or hostnames as public IPs in debug output. |
| apps/inbound-mail/src/server/index.ts | Adds opt-in sender-auth debug logging for client IP source dumps and parsed headers behind environment flags. |
| apps/inbound-mail/src/server/client-ip-sources.spec.ts | Adds focused unit coverage for precedence ordering and Forwarded header parsing. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant SMTP as Inbound SMTP session
  participant Mailin as Mailin.finalizeMessage
  participant AuthLog as Sender-auth verdict log
  participant Collector as collectClientIpSources
  participant Logger as Logger

  SMTP->>Mailin: Parsed email + connection
  Mailin->>AuthLog: Log DKIM/SPF verdict inputs
  alt INBOUND_MAIL_DEBUG_CLIENT_IP enabled
    Mailin->>Collector: connection, parsedEmail.headers
    Collector-->>Mailin: SPF input, ordered candidates, first public candidate
    Mailin->>Logger: Structured client IP source dump
  end
  alt INBOUND_MAIL_DEBUG_HEADERS enabled
    Mailin->>Logger: Full parsed header dump
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant SMTP as Inbound SMTP session
  participant Mailin as Mailin.finalizeMessage
  participant AuthLog as Sender-auth verdict log
  participant Collector as collectClientIpSources
  participant Logger as Logger

  SMTP->>Mailin: Parsed email + connection
  Mailin->>AuthLog: Log DKIM/SPF verdict inputs
  alt INBOUND_MAIL_DEBUG_CLIENT_IP enabled
    Mailin->>Collector: connection, parsedEmail.headers
    Collector-->>Mailin: SPF input, ordered candidates, first public candidate
    Mailin->>Logger: Structured client IP source dump
  end
  alt INBOUND_MAIL_DEBUG_HEADERS enabled
    Mailin->>Logger: Full parsed header dump
  end
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Finbound-mail%2Fsrc%2Fserver%2Fclient-ip-sources.ts%3A306%0A**Filter%20non-IP%20candidates**%0A%60firstPublicCandidate%60%20treats%20any%20non-private%20classification%20as%20public%2C%20but%20%60classifyIp%28%29%60%20returns%20%60false%60%20for%20values%20that%20are%20not%20IP%20addresses%2C%20including%20%60session.remotePort%60%2C%20%60session.localPort%60%2C%20and%20hostnames%20like%20%60mail.example.com%60.%20With%20a%20private%20%60remoteAddress%60%20and%20no%20proxy%20IPs%2C%20the%20debug%20dump%20reports%20the%20port%20as%20the%20first%20public%20candidate%2C%20which%20defeats%20the%20diagnostic%20this%20helper%20is%20meant%20to%20provide.%20Please%20only%20consider%20syntactically%20valid%20IP%20candidates%20when%20selecting%20%60firstPublicCandidate%60.%0A%0A&pr=11857&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/inbound-mail/src/server/client-ip-sources.ts:306
**Filter non-IP candidates**
`firstPublicCandidate` treats any non-private classification as public, but `classifyIp()` returns `false` for values that are not IP addresses, including `session.remotePort`, `session.localPort`, and hostnames like `mail.example.com`. With a private `remoteAddress` and no proxy IPs, the debug dump reports the port as the first public candidate, which defeats the diagnostic this helper is meant to provide. Please only consider syntactically valid IP candidates when selecting `firstPublicCandidate`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(inbound-mail): add client IP source..."](https://github.com/novuhq/novu/commit/8c07cb99f1d979dd63a00e8c7fd690be02713d73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42653714)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->