### PR TITLE
refactor(dashboard): consolidate edition flags onto IS_CLOUD / IS_SELF_HOSTED_CE / IS_SELF_HOSTED_EE

### DIFF
--- a/apps/dashboard/src/components/activity/activity-filters.tsx
+++ b/apps/dashboard/src/components/activity/activity-filters.tsx
@@ -14,7 +14,7 @@ import { buildActivityDateFilters } from '@/utils/activityFilters';
 import { ROUTES } from '@/utils/routes';
 import { capitalize } from '@/utils/string';
 import { cn } from '@/utils/ui';
-import { IS_SELF_HOSTED } from '../../config';
+import { IS_CLOUD } from '../../config';
 import { useFetchWorkflows } from '../../hooks/use-fetch-workflows';
 import { ContextFilter } from '../contexts/context-filter';
 import { Button } from '../primitives/button';
@@ -89,7 +89,7 @@ export function ActivityFilters({
   useDebouncedForm(watch, onFiltersChange, 400);
 
   const maxActivityFeedRetentionOptions = useMemo(() => {
-    const missingSubscription = !subscription && !IS_SELF_HOSTED;
+    const missingSubscription = !subscription && IS_CLOUD;
 
     if (!organization || missingSubscription) {
       return [];

--- a/apps/dashboard/src/components/agents/agent-integration-guides/whats-next/agent-channel-whats-next-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/whats-next/agent-channel-whats-next-guide.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
 import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
 import { ConnectionConfetti } from '@/components/agents/connection-confetti';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useChannelFirstConnectedEndpoint } from '@/hooks/use-channel-first-connected-endpoint';
 import { useInSessionMilestone } from '@/hooks/use-in-session-milestone';
@@ -26,7 +26,7 @@ type AgentChannelWhatsNextGuideProps = {
   justConnected?: boolean;
 };
 
-const CONVERSATIONS_AVAILABLE = !IS_SELF_HOSTED || IS_ENTERPRISE;
+const CONVERSATIONS_AVAILABLE = !IS_SELF_HOSTED_CE;
 
 function ConnectedBadge() {
   return (

--- a/apps/dashboard/src/components/agents/recent-conversations-section.tsx
+++ b/apps/dashboard/src/components/agents/recent-conversations-section.tsx
@@ -8,7 +8,7 @@ import { ConversationStatusBadge } from '@/components/conversations/conversation
 import { ConversationsUpgradeCta } from '@/components/conversations/conversations-upgrade-cta';
 import { SubscriberFallbackAvatar } from '@/components/conversations/subscriber-fallback-avatar';
 import { Skeleton } from '@/components/primitives/skeleton';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD, IS_SELF_HOSTED_CE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchConversations } from '@/hooks/use-fetch-conversations';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -34,7 +34,7 @@ export function RecentConversationsSection({ agent }: RecentConversationsSection
         <span className="text-text-soft font-code text-[11px] font-medium uppercase leading-4 tracking-wider">
           Recent conversations
         </span>
-        {!IS_SELF_HOSTED && conversationsPath ? (
+        {IS_CLOUD && conversationsPath ? (
           <Link
             to={conversationsPath}
             className="text-text-sub hover:text-text-strong text-label-xs flex items-center gap-0.5 rounded-lg p-0 font-medium transition-colors"
@@ -46,7 +46,7 @@ export function RecentConversationsSection({ agent }: RecentConversationsSection
       </div>
 
       <div className="bg-bg-white flex h-[300px] flex-col overflow-hidden rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
-        {!IS_SELF_HOSTED || IS_ENTERPRISE ? (
+        {!IS_SELF_HOSTED_CE ? (
           <RecentConversationsContent agent={agent} onSelectConversation={setActiveConversationId} />
         ) : (
           <ConversationsUpgradeCta source="agent-overview" variant="compact" />

--- a/apps/dashboard/src/components/analytics/hooks/use-analytics-page-date-filter.ts
+++ b/apps/dashboard/src/components/analytics/hooks/use-analytics-page-date-filter.ts
@@ -6,7 +6,7 @@ import {
   getFeatureForTierAsNumber,
 } from '@novu/shared';
 import { useEffect, useMemo, useState } from 'react';
-import { IS_SELF_HOSTED } from '../../../config';
+import { IS_CLOUD, IS_SELF_HOSTED } from '../../../config';
 import { useNumericFeatureFlag } from '../../../hooks/use-feature-flag';
 
 type OrganizationLike = { createdAt: Date };
@@ -145,7 +145,7 @@ export function useHomepageDateFilter({ organization, subscription, upgradeCtaIc
   }, [defaultDateRange]);
 
   const dateFilterOptions = useMemo(() => {
-    const missingSubscription = !subscription && !IS_SELF_HOSTED;
+    const missingSubscription = !subscription && IS_CLOUD;
 
     if (!organization || missingSubscription) {
       return [];

--- a/apps/dashboard/src/components/auth/auth-side-banner.tsx
+++ b/apps/dashboard/src/components/auth/auth-side-banner.tsx
@@ -4,7 +4,7 @@ import { RiCheckLine } from 'react-icons/ri';
 import { Button } from '@/components/primitives/button';
 import { readProductTypeParam } from '@/utils/product-type-pending';
 import { openInNewTab } from '@/utils/url';
-import { IS_ENTERPRISE, IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '../../config';
+import { IS_SELF_HOSTED, IS_SELF_HOSTED_CE, IS_SELF_HOSTED_EE, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '../../config';
 import { Battery } from '../icons/battery';
 import { CircleCheck } from '../icons/circle-check';
 import { Plug } from '../icons/plug';
@@ -39,10 +39,10 @@ export function AuthSideBanner({ variant }: AuthSideBannerProps) {
           <div className="flex hidden flex-col items-start justify-start gap-4 md:block">
             <div className="flex flex-col items-start justify-start gap-1.5 self-stretch">
               <div className="text-2xl font-medium leading-8 text-neutral-950">
-                {IS_ENTERPRISE ? 'Welcome to Novu Enterprise' : 'Welcome to Novu Self-Hosted!'}
+                {IS_SELF_HOSTED_EE ? 'Welcome to Novu Enterprise' : 'Welcome to Novu Self-Hosted!'}
               </div>
               <div className="text-sm leading-snug text-neutral-500">
-                {IS_ENTERPRISE
+                {IS_SELF_HOSTED_EE
                   ? 'Enterprise-grade notification infrastructure with premium support and advanced features.'
                   : 'Full control over your notification infrastructure. Backed by a vibrant community.'}
               </div>
@@ -70,19 +70,21 @@ export function AuthSideBanner({ variant }: AuthSideBannerProps) {
           <AuthFeatureRow
             icon={<Plug className="h-6 w-6 text-[#DD2450]" />}
             title={
-              IS_ENTERPRISE ? 'Enterprise Data Sovereignty & Compliance' : 'Full Data Control & Unlimited Customization'
+              IS_SELF_HOSTED_EE
+                ? 'Enterprise Data Sovereignty & Compliance'
+                : 'Full Data Control & Unlimited Customization'
             }
             description={
-              IS_ENTERPRISE
+              IS_SELF_HOSTED_EE
                 ? 'Complete data residency control with enterprise-grade security, compliance certifications, and audit trails.'
                 : 'Host Novu on your own infrastructure, tailor it to your exact needs, and own your data.'
             }
           />
           <AuthFeatureRow
             icon={<Sparkling className="h-6 w-6" />}
-            title={IS_ENTERPRISE ? 'Premium Support & Professional Services' : 'Community-Driven & Transparent'}
+            title={IS_SELF_HOSTED_EE ? 'Premium Support & Professional Services' : 'Community-Driven & Transparent'}
             description={
-              IS_ENTERPRISE
+              IS_SELF_HOSTED_EE
                 ? 'Dedicated account management, priority support, and professional services for seamless deployment and optimization.'
                 : 'Leverage the power of open-source. Contribute, inspect the code, and be part of our active community.'
             }
@@ -90,10 +92,10 @@ export function AuthSideBanner({ variant }: AuthSideBannerProps) {
           <AuthFeatureRow
             icon={<ShieldZap className="h-6 w-6" />}
             title={
-              IS_ENTERPRISE ? 'Enterprise-Grade Performance & Reliability' : 'Scalable, Secure, and Enterprise-Ready'
+              IS_SELF_HOSTED_EE ? 'Enterprise-Grade Performance & Reliability' : 'Scalable, Secure, and Enterprise-Ready'
             }
             description={
-              IS_ENTERPRISE
+              IS_SELF_HOSTED_EE
                 ? 'Mission-critical SLAs, advanced monitoring, and enterprise integrations built for large-scale operations.'
                 : 'Built to handle any volume, ensuring reliable delivery for your mission-critical notifications.'
             }
@@ -118,7 +120,7 @@ export function AuthSideBanner({ variant }: AuthSideBannerProps) {
           />
         </div>
       )}
-      {IS_SELF_HOSTED && !IS_ENTERPRISE && (
+      {IS_SELF_HOSTED_CE && (
         <div className="border-stroke-soft rounded-8 hidden flex-col items-start justify-start gap-3 self-stretch border from-blue-50/80 to-transparent p-6 shadow-md md:flex">
           <h3 className="text-lg font-semibold text-neutral-900">Looking for a Managed Solution?</h3>
           <p className="text-sm text-neutral-600">

--- a/apps/dashboard/src/components/command-palette/commands/navigation-commands.tsx
+++ b/apps/dashboard/src/components/command-palette/commands/navigation-commands.tsx
@@ -13,7 +13,7 @@ import {
   RiTranslate2,
 } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { Command, CommandExecutionContext } from '../command-types';
@@ -23,7 +23,7 @@ export function useNavigationCommands(context: CommandExecutionContext): Command
   const hasPermission = useHasPermission();
   const hasWorkflowPermission = hasPermission({ permission: PermissionsEnum.WORKFLOW_READ });
   const hasSubscriberPermission = hasPermission({ permission: PermissionsEnum.SUBSCRIBER_READ });
-  const isEnterprise = !IS_SELF_HOSTED || IS_ENTERPRISE;
+  const areTranslationsAvailable = !IS_SELF_HOSTED_CE;
 
   const createNavigationCommand = useCallback(
     (id: string, label: string, route: string, icon: React.ReactNode, permission?: () => boolean) => ({
@@ -97,14 +97,14 @@ export function useNavigationCommands(context: CommandExecutionContext): Command
   // Layouts
   commands.push(createNavigationCommand('nav-layouts', 'Email Layouts', ROUTES.LAYOUTS, <RiLayout5Line />));
 
-  if (isEnterprise) {
+  if (areTranslationsAvailable) {
     commands.push(
       createNavigationCommand(
         'nav-translations',
         'Translations',
         ROUTES.TRANSLATIONS,
         <RiTranslate2 />,
-        () => isEnterprise
+        () => areTranslationsAvailable
       )
     );
   }

--- a/apps/dashboard/src/components/command-palette/commands/settings-commands.tsx
+++ b/apps/dashboard/src/components/command-palette/commands/settings-commands.tsx
@@ -1,7 +1,7 @@
 import { PermissionsEnum } from '@novu/shared';
 import { RiDatabase2Line, RiMoneyDollarCircleLine, RiSettings4Line, RiUserAddLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { ROUTES } from '@/utils/routes';
 import { Command, CommandExecutionContext } from '../command-types';
@@ -10,7 +10,7 @@ export function useSettingsCommands(_context: CommandExecutionContext): Command[
   const navigate = useNavigate();
   const hasPermission = useHasPermission();
   const hasBillingPermission = hasPermission({ permission: PermissionsEnum.BILLING_WRITE });
-  const canShowBilling = !IS_SELF_HOSTED && hasBillingPermission;
+  const canShowBilling = IS_CLOUD && hasBillingPermission;
 
   const commands: Command[] = [
     {

--- a/apps/dashboard/src/components/conversations/conversations-content.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-content.tsx
@@ -9,7 +9,7 @@ import { ConversationsTable } from '@/components/conversations/conversations-tab
 import { ConversationsUpgradeCta } from '@/components/conversations/conversations-upgrade-cta';
 import { ResizablePanel, ResizablePanelGroup } from '@/components/primitives/resizable';
 import { UpdatedAgo } from '@/components/updated-ago';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useConversationUrlState } from '@/hooks/use-conversation-url-state';
 import { cn } from '@/utils/ui';
@@ -29,7 +29,7 @@ export function ConversationsContent({
   contentHeight = 'h-[calc(100vh-140px)]',
   redirectConversationSelectionTo,
 }: ConversationsContentProps) {
-  if (IS_SELF_HOSTED && !IS_ENTERPRISE) {
+  if (IS_SELF_HOSTED_CE) {
     return (
       <div className={cn('p-2.5', className)}>
         <div className={cn('flex', contentHeight)}>

--- a/apps/dashboard/src/components/conversations/conversations-filters.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-filters.tsx
@@ -12,7 +12,7 @@ import { useHasPermission } from '@/hooks/use-has-permission';
 import { ConversationFiltersData } from '@/types/conversation';
 import { buildActivityDateFilters } from '@/utils/activityFilters';
 import { cn } from '@/utils/ui';
-import { IS_SELF_HOSTED } from '../../config';
+import { IS_CLOUD } from '../../config';
 import { Button } from '../primitives/button';
 import { FacetedFormFilter } from '../primitives/form/faceted-filter/facated-form-filter';
 import { Form, FormField, FormItem, FormRoot } from '../primitives/form/form';
@@ -51,7 +51,7 @@ export function ConversationFilters({
   useDebouncedForm(watch, onFiltersChange, 400);
 
   const dateFilterOptions = useMemo(() => {
-    const missingSubscription = !subscription && !IS_SELF_HOSTED;
+    const missingSubscription = !subscription && IS_CLOUD;
 
     if (!organization || missingSubscription) {
       return [];

--- a/apps/dashboard/src/components/header-navigation/customer-support-button.tsx
+++ b/apps/dashboard/src/components/header-navigation/customer-support-button.tsx
@@ -2,7 +2,7 @@ import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { RiQuestionFill } from 'react-icons/ri';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { usePlainChat } from '@/hooks/use-plain-chat';
-import { IS_SELF_HOSTED } from '../../config';
+import { IS_SELF_HOSTED_CE } from '../../config';
 import { openInNewTab } from '../../utils/url';
 import { HeaderButton } from './header-button';
 import { SupportDrawer } from './support-drawer';
@@ -11,7 +11,9 @@ export const CustomerSupportButton = () => {
   const { showPlainLiveChat } = usePlainChat();
   const isContextualHelpEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONTEXTUAL_HELP_DRAWER_ENABLED);
 
-  if (IS_SELF_HOSTED) {
+  // On CE the help icon deep-links to the hosted-upgrade page; EE renders no button at all
+  // (the parent header gates on `!IS_SELF_HOSTED_EE`), and Cloud gets the support drawer/chat.
+  if (IS_SELF_HOSTED_CE) {
     return (
       <button
         tabIndex={-1}

--- a/apps/dashboard/src/components/header-navigation/header-navigation.tsx
+++ b/apps/dashboard/src/components/header-navigation/header-navigation.tsx
@@ -7,7 +7,7 @@ import { MobileSideNavigation } from '@/components/side-navigation/mobile-side-n
 import { UserProfile } from '@/components/user-profile';
 import { RegionSelector } from '@/context/region';
 import { cn } from '@/utils/ui';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '../../config';
+import { IS_SELF_HOSTED_EE } from '../../config';
 import { useEnvironment } from '../../context/environment/hooks';
 import { useHasPermission } from '../../hooks/use-has-permission';
 import { Button } from '../primitives/button';
@@ -78,7 +78,7 @@ export const HeaderNavigation = (props: HeaderNavigationProps) => {
         {!hideRestItems && (
           <>
             <div className="flex items-center gap-2">
-              {!(IS_SELF_HOSTED && IS_ENTERPRISE) && <CustomerSupportButton />}
+              {!IS_SELF_HOSTED_EE && <CustomerSupportButton />}
               <InboxButton />
               <div className="hidden h-4 w-px bg-neutral-200 md:block" />
               <span className="hidden md:inline-flex">

--- a/apps/dashboard/src/components/http-logs/logs-filters.tsx
+++ b/apps/dashboard/src/components/http-logs/logs-filters.tsx
@@ -10,7 +10,7 @@ import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import type { LogsFilters } from '@/hooks/use-logs-url-state';
 import { buildLogsDateFilters } from '@/utils/logs-filters.utils';
 import { ROUTES } from '@/utils/routes';
-import { IS_SELF_HOSTED } from '../../config';
+import { IS_CLOUD } from '../../config';
 
 interface RequestsFiltersProps {
   filters: LogsFilters;
@@ -85,7 +85,7 @@ export function RequestsFilters({
   }, [filters, form]);
 
   const maxLogsRetentionOptions = useMemo(() => {
-    const missingSubscription = !subscription && !IS_SELF_HOSTED;
+    const missingSubscription = !subscription && IS_CLOUD;
 
     if (!organization || missingSubscription) {
       return [];

--- a/apps/dashboard/src/components/layouts/create-layout-btn.tsx
+++ b/apps/dashboard/src/components/layouts/create-layout-btn.tsx
@@ -4,7 +4,7 @@ import { RiAddCircleLine } from 'react-icons/ri';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { PermissionButton } from '@/components/primitives/permission-button';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
@@ -44,7 +44,7 @@ export const CreateLayoutButton = ({
     navigate(`${buildRoute(ROUTES.LAYOUTS_CREATE, { environmentSlug: currentEnvironment?.slug ?? '' })}${search}`);
   };
 
-  if (!IS_SELF_HOSTED && tier === ApiServiceLevelEnum.FREE && data?.layouts && data?.layouts?.length >= 1) {
+  if (IS_CLOUD && tier === ApiServiceLevelEnum.FREE && data?.layouts && data?.layouts?.length >= 1) {
     return (
       <Tooltip>
         <TooltipTrigger className="cursor-not-allowed">

--- a/apps/dashboard/src/components/layouts/layout-list-blank.tsx
+++ b/apps/dashboard/src/components/layouts/layout-list-blank.tsx
@@ -1,7 +1,7 @@
 import { ApiServiceLevelEnum } from '@novu/shared';
 import { RiAddCircleLine, RiInformation2Line } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { ROUTES } from '@/utils/routes';
 import { CreateLayoutButton } from './create-layout-btn';
@@ -36,7 +36,7 @@ export const LayoutListBlank = () => {
 
       <div className="flex flex-col items-center gap-1">
         <CreateLayoutButton text="Create your first layout" icon={RiAddCircleLine} />
-        {!IS_SELF_HOSTED && tier === ApiServiceLevelEnum.FREE && (
+        {IS_CLOUD && tier === ApiServiceLevelEnum.FREE && (
           <p className="text-text-soft text-paragraph-xs mt-2 flex items-center gap-1">
             <RiInformation2Line />
             One layout is included in your plan,{' '}

--- a/apps/dashboard/src/components/layouts/layout-list.tsx
+++ b/apps/dashboard/src/components/layouts/layout-list.tsx
@@ -24,7 +24,7 @@ import {
   TableRow,
 } from '@/components/primitives/table';
 import { TablePaginationFooter } from '@/components/primitives/table-pagination-footer';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { cn } from '@/utils/ui';
@@ -193,7 +193,7 @@ export const LayoutList = (props: LayoutListProps) => {
     );
   }
 
-  if (!IS_SELF_HOSTED && tier === ApiServiceLevelEnum.FREE && data?.layouts.length === 1) {
+  if (IS_CLOUD && tier === ApiServiceLevelEnum.FREE && data?.layouts.length === 1) {
     return <LayoutsListUpgradeCta />;
   }
 

--- a/apps/dashboard/src/components/settings/settings-tabs.tsx
+++ b/apps/dashboard/src/components/settings/settings-tabs.tsx
@@ -16,7 +16,7 @@ import { Card } from '@/components/primitives/card';
 import { InlineToast } from '@/components/primitives/inline-toast';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { OrganizationSettings } from '@/components/settings/organization-settings';
-import { EE_AUTH_PROVIDER, IS_SELF_HOSTED } from '@/config';
+import { EE_AUTH_PROVIDER, IS_CLOUD } from '@/config';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { useHasPermission } from '@/hooks/use-has-permission';
@@ -129,7 +129,7 @@ export function SettingsTabs({ routes, rootRoute }: SettingsTabsProps) {
   const clerkAppearance = useMemo(() => getClerkComponentAppearance(isRbacEnabled), [isRbacEnabled]);
   const UserProfile = EE_AUTH_PROVIDER === 'clerk' ? ClerkUserProfile : BetterAuthUserProfile;
 
-  const canShowBilling = !IS_SELF_HOSTED && hasBillingPermission;
+  const canShowBilling = IS_CLOUD && hasBillingPermission;
 
   const currentTab = resolveCurrentTab(location.pathname, routes, rootRoute);
 

--- a/apps/dashboard/src/components/side-navigation/side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/side-navigation.tsx
@@ -24,7 +24,7 @@ import { useAreConversationalAgentsAvailable } from '@/hooks/use-are-conversatio
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { Protect } from '@/utils/protect';
 import { buildRoute, ROUTES } from '@/utils/routes';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '../../config';
+import { IS_SELF_HOSTED, IS_SELF_HOSTED_CE } from '../../config';
 import { useFetchSubscription } from '../../hooks/use-fetch-subscription';
 import { ChangelogStack } from './changelog-cards';
 import { EnvironmentDropdown } from './environment-dropdown';
@@ -283,7 +283,7 @@ export const LegacySideNavigation = () => {
                     </NavigationLink>
                   </Protect>
                 )}
-                {isDomainsPageEnabled && (!IS_SELF_HOSTED || IS_ENTERPRISE) && (
+                {isDomainsPageEnabled && !IS_SELF_HOSTED_CE && (
                   <NavigationLink
                     to={
                       currentEnvironment?.slug
@@ -318,9 +318,7 @@ export const LegacySideNavigation = () => {
               </NavigationGroup>
             </Protect>
             <Protect
-              condition={(has) =>
-                has({ permission: PermissionsEnum.INTEGRATION_READ }) || !IS_SELF_HOSTED || IS_ENTERPRISE
-              }
+              condition={(has) => has({ permission: PermissionsEnum.INTEGRATION_READ }) || !IS_SELF_HOSTED_CE}
             >
               <NavigationGroup label="Platform">
                 <Protect permission={PermissionsEnum.INTEGRATION_READ}>
@@ -335,7 +333,7 @@ export const LegacySideNavigation = () => {
                     <span>Integration Store</span>
                   </NavigationLink>
                 </Protect>
-                {(!IS_SELF_HOSTED || IS_ENTERPRISE) && (
+                {!IS_SELF_HOSTED_CE && (
                   <NavigationLink to={ROUTES.SETTINGS}>
                     <RiSettings4Line className="size-4" />
                     <span>Settings</span>

--- a/apps/dashboard/src/components/translations/translation-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-list.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/primitives/table';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
@@ -193,7 +193,7 @@ export function TranslationList(props: TranslationListProps) {
       FeatureNameEnum.AUTO_TRANSLATIONS,
       subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE
     ) &&
-    (!IS_SELF_HOSTED || IS_ENTERPRISE);
+    !IS_SELF_HOSTED_CE;
 
   // Only make API call if user has proper tier
   const { filterValues, handleFiltersChange, resetFilters, data, isPending, isFetching, areFiltersApplied } =

--- a/apps/dashboard/src/components/translations/translation-switch.tsx
+++ b/apps/dashboard/src/components/translations/translation-switch.tsx
@@ -1,7 +1,7 @@
 import { ApiServiceLevelEnum, FeatureNameEnum, getFeatureForTierAsBoolean, PermissionsEnum } from '@novu/shared';
 import { Switch } from '@/components/primitives/switch';
 import { UpgradeCTATooltip } from '@/components/upgrade-cta-tooltip';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { PermissionSwitch } from '../primitives/permission-switch';
 
@@ -20,7 +20,7 @@ export function TranslationSwitch({ id, value, onChange, isReadOnly }: Translati
       FeatureNameEnum.AUTO_TRANSLATIONS,
       subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE
     ) &&
-    (!IS_SELF_HOSTED || IS_ENTERPRISE);
+    !IS_SELF_HOSTED_CE;
 
   const isFeatureUnavailable = !canUseTranslationFeature || isLoading;
   const disabled = isFeatureUnavailable || isReadOnly;

--- a/apps/dashboard/src/components/variables/variable-list.tsx
+++ b/apps/dashboard/src/components/variables/variable-list.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { FacetedFormFilter } from '@/components/primitives/form/faceted-filter/facated-form-filter';
 import { PermissionButton } from '@/components/primitives/permission-button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/primitives/table';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchEnvironmentVariables } from '@/hooks/use-fetch-environment-variables';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
@@ -27,7 +27,7 @@ export const VariableList = () => {
       FeatureNameEnum.ENVIRONMENT_VARIABLES,
       subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE
     ) &&
-    (!IS_SELF_HOSTED || IS_ENTERPRISE);
+    !IS_SELF_HOSTED_CE;
 
   useEffect(() => {
     const timeout = setTimeout(() => {

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -49,7 +49,7 @@ import { SkipConditionsButton } from '@/components/workflow-editor/steps/skip-co
 import { ConfigureSmsStepPreview } from '@/components/workflow-editor/steps/sms/configure-sms-step-preview';
 import { ThrottleControlValues } from '@/components/workflow-editor/steps/throttle/throttle-control-values';
 import { UpdateWorkflowFn } from '@/components/workflow-editor/workflow-provider';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { useFormAutosave } from '@/hooks/use-form-autosave';
@@ -147,7 +147,7 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
   const isUnlimited = codeStepLimit >= UNLIMITED_VALUE;
   const stepResolversCount = stepResolversCountData?.count;
   const isAtCodeStepLimit =
-    !IS_SELF_HOSTED &&
+    IS_CLOUD &&
     !isSubscriptionLoading &&
     !isCountLoading &&
     !isUnlimited &&

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
@@ -14,7 +14,7 @@ import { Switch } from '@/components/primitives/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { UpgradeCTATooltip } from '@/components/upgrade-cta-tooltip';
 import { useStepEditor } from '@/components/workflow-editor/steps/context/step-editor-context';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useDisconnectStepResolver } from '@/hooks/use-disconnect-step-resolver';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
@@ -49,7 +49,7 @@ export function StepEditorModeToggle() {
   const isUnlimited = codeStepLimit >= UNLIMITED_VALUE;
   const stepResolversCount = stepResolversCountData?.count;
   const isAtCodeStepLimit =
-    !IS_SELF_HOSTED &&
+    IS_CLOUD &&
     !isSubscriptionLoading &&
     !isCountLoading &&
     !isUnlimited &&

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -57,21 +57,39 @@ export const PLAIN_SUPPORT_CHAT_APP_ID = import.meta.env.VITE_PLAIN_SUPPORT_CHAT
 
 export const ONBOARDING_DEMO_WORKFLOW_ID = 'onboarding-demo-workflow';
 
+/**
+ * Deployment-mode flags. There are exactly three modes, baked at build time by the
+ * release workflows (see prepare-cloud-release / prepare-self-hosted-release /
+ * prepare-enterprise-self-hosted-release):
+ *
+ * - Cloud: neither VITE_SELF_HOSTED nor VITE_NOVU_ENTERPRISE is set -> `IS_CLOUD`
+ * - Community Edition (CE): VITE_SELF_HOSTED=true only -> `IS_SELF_HOSTED_CE`
+ * - Enterprise Edition (EE): VITE_SELF_HOSTED=true + VITE_NOVU_ENTERPRISE=true -> `IS_SELF_HOSTED_EE`
+ *
+ * Canonical gating patterns — prefer these over hand-written combos of the raw flags:
+ * - Feature not available in CE (available on Cloud + EE): `!IS_SELF_HOSTED_CE`
+ * - Feature behaves differently on EE than on Cloud: `IS_SELF_HOSTED_EE`
+ * - Feature is cloud-only regardless of edition: `IS_CLOUD`
+ * - Behavior common to any self-hosted deployment (CE or EE): `IS_SELF_HOSTED`
+ */
 export const IS_SELF_HOSTED = import.meta.env.VITE_SELF_HOSTED === 'true';
 
 export const IS_ENTERPRISE = import.meta.env.VITE_NOVU_ENTERPRISE === 'true';
+
+export const IS_CLOUD = !IS_SELF_HOSTED;
 
 export const IS_SELF_HOSTED_EE = IS_SELF_HOSTED && IS_ENTERPRISE;
 
 export const IS_SELF_HOSTED_CE = IS_SELF_HOSTED && !IS_ENTERPRISE;
 
-export const IS_AI_FEATURES_ENABLED = !(IS_SELF_HOSTED && IS_ENTERPRISE);
+// AI features call Novu-hosted services and are cloud-only: disabled on both CE and EE.
+export const IS_AI_FEATURES_ENABLED = IS_CLOUD;
 
-if (!IS_SELF_HOSTED && EE_AUTH_PROVIDER === 'clerk' && !CLERK_PUBLISHABLE_KEY) {
+if (IS_CLOUD && EE_AUTH_PROVIDER === 'clerk' && !CLERK_PUBLISHABLE_KEY) {
   throw new Error('Missing Clerk Publishable Key');
 }
 
-if (!IS_SELF_HOSTED && EE_AUTH_PROVIDER === 'better-auth' && !BETTER_AUTH_BASE_URL) {
+if (IS_CLOUD && EE_AUTH_PROVIDER === 'better-auth' && !BETTER_AUTH_BASE_URL) {
   throw new Error('Missing Better Auth Base URL');
 }
 

--- a/apps/dashboard/src/context/ee-auth-provider.tsx
+++ b/apps/dashboard/src/context/ee-auth-provider.tsx
@@ -2,7 +2,7 @@ import { ClerkProvider as _ClerkProvider } from '@clerk/react';
 import { PropsWithChildren } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { buttonVariants } from '@/components/primitives/button';
-import { CLERK_PUBLISHABLE_KEY, EE_AUTH_PROVIDER, IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { CLERK_PUBLISHABLE_KEY, EE_AUTH_PROVIDER, IS_SELF_HOSTED_CE } from '@/config';
 import { isAbsoluteUrl } from '@/utils/apps';
 import { buildClerkAllowedRedirectOrigins } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
@@ -13,7 +13,7 @@ export const EEAuthProvider = (props: EEAuthProviderProps) => {
   const navigate = useNavigate();
   const { children } = props;
 
-  if (IS_SELF_HOSTED && !IS_ENTERPRISE) {
+  if (IS_SELF_HOSTED_CE) {
     // @ts-expect-error - Self-hosted ClerkProvider has simpler props
     return <_ClerkProvider>{children}</_ClerkProvider>;
   }

--- a/apps/dashboard/src/context/feature-flags-provider.tsx
+++ b/apps/dashboard/src/context/feature-flags-provider.tsx
@@ -1,6 +1,6 @@
 import { AsyncProviderConfig, asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
 import { lazy, Suspense } from 'react';
-import { IS_ENTERPRISE, IS_SELF_HOSTED, LAUNCH_DARKLY_CLIENT_SIDE_ID } from '@/config';
+import { LAUNCH_DARKLY_CLIENT_SIDE_ID } from '@/config';
 import { detectRegionFromURL, getRegionConfig } from '@/context/region';
 
 function getAwsRegion(): string {

--- a/apps/dashboard/src/hooks/use-agent-channels-rollout-status.ts
+++ b/apps/dashboard/src/hooks/use-agent-channels-rollout-status.ts
@@ -4,14 +4,14 @@ import { useMemo } from 'react';
 import type { AgentIntegrationLink } from '@/api/agents';
 import { type ChannelEndpointsListResponse, listChannelEndpoints } from '@/api/channel-endpoints';
 import { providerHasWhatsNextPhase } from '@/components/agents/agent-integration-guides/whats-next/whats-next-config';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { findFirstGenuineConnectedEndpoint } from '@/hooks/use-channel-first-connected-endpoint';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 
 const POLL_INTERVAL_MS = 3000;
-const CONVERSATIONS_AVAILABLE = !IS_SELF_HOSTED || IS_ENTERPRISE;
+const CONVERSATIONS_AVAILABLE = !IS_SELF_HOSTED_CE;
 
 type RolloutStatus = {
   allRolledOut: boolean;

--- a/apps/dashboard/src/hooks/use-feature-flag.tsx
+++ b/apps/dashboard/src/hooks/use-feature-flag.tsx
@@ -1,13 +1,13 @@
 import { FeatureFlagsKeysEnum, prepareBooleanStringFeatureFlag } from '@novu/shared';
 import { useFlags } from 'launchdarkly-react-client-sdk';
-import { IS_ENTERPRISE, IS_SELF_HOSTED, LAUNCH_DARKLY_CLIENT_SIDE_ID } from '../config';
+import { IS_SELF_HOSTED_EE, LAUNCH_DARKLY_CLIENT_SIDE_ID } from '../config';
 
 function isLaunchDarklyEnabled() {
-  if (!!LAUNCH_DARKLY_CLIENT_SIDE_ID && IS_ENTERPRISE) {
+  if (!!LAUNCH_DARKLY_CLIENT_SIDE_ID && IS_SELF_HOSTED_EE) {
     return true;
   }
 
-  return !!LAUNCH_DARKLY_CLIENT_SIDE_ID && !(IS_SELF_HOSTED && IS_ENTERPRISE);
+  return !!LAUNCH_DARKLY_CLIENT_SIDE_ID && !IS_SELF_HOSTED_EE;
 }
 
 export const useFeatureFlag = (key: FeatureFlagsKeysEnum, defaultValue = false): boolean => {

--- a/apps/dashboard/src/hooks/use-fetch-organization-settings.ts
+++ b/apps/dashboard/src/hooks/use-fetch-organization-settings.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { QueryKeys } from '@/utils/query-keys';
 import { GetOrganizationSettingsDto, getOrganizationSettings } from '../api/organization';
@@ -10,7 +10,7 @@ export const useFetchOrganizationSettings = () => {
   const query = useQuery<{ data: GetOrganizationSettingsDto }>({
     queryKey: [QueryKeys.organizationSettings, currentEnvironment?._id],
     queryFn: async () => await getOrganizationSettings({ environment: currentEnvironment! }),
-    enabled: !!currentEnvironment?._id && !IS_SELF_HOSTED,
+    enabled: !!currentEnvironment?._id && IS_CLOUD,
     refetchOnMount: false,
   });
 

--- a/apps/dashboard/src/hooks/use-fetch-subscription.ts
+++ b/apps/dashboard/src/hooks/use-fetch-subscription.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { differenceInDays, isSameDay } from 'date-fns';
 import { useMemo } from 'react';
 import { getSubscription } from '@/api/billing';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useAuth } from '@/context/auth/hooks';
 import { useEnvironment } from '@/context/environment/hooks';
 import { QueryKeys } from '@/utils/query-keys';
@@ -19,7 +19,7 @@ export const useFetchSubscription = () => {
   const { data: subscription, isLoading: isLoadingSubscription } = useQuery<GetSubscriptionDto>({
     queryKey: [QueryKeys.billingSubscription, currentOrganization?._id],
     queryFn: () => getSubscription({ environment: currentEnvironment! }),
-    enabled: !!currentOrganization && (IS_ENTERPRISE || !IS_SELF_HOSTED),
+    enabled: !!currentOrganization && !IS_SELF_HOSTED_CE,
     meta: {
       showError: false,
     },

--- a/apps/dashboard/src/hooks/use-is-translation-enabled.ts
+++ b/apps/dashboard/src/hooks/use-is-translation-enabled.ts
@@ -1,5 +1,5 @@
 import { ApiServiceLevelEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 
 export const useIsTranslationEnabled = ({
@@ -14,7 +14,7 @@ export const useIsTranslationEnabled = ({
       FeatureNameEnum.AUTO_TRANSLATIONS,
       subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE
     ) &&
-    (!IS_SELF_HOSTED || IS_ENTERPRISE);
+    !IS_SELF_HOSTED_CE;
 
   const isTranslationEnabled = isTranslationEnabledOnResource && canUseTranslationFeature;
 

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -40,7 +40,7 @@ import { ConnectSubscriberProvider } from './components/connect/connect-subscrib
 import { CreateIntegrationSidebar } from './components/integrations/components/create-integration-sidebar';
 import { UpdateIntegrationSidebar } from './components/integrations/components/update-integration-sidebar';
 import { ChannelPreferences } from './components/workflow-editor/channel-preferences';
-import { EE_AUTH_PROVIDER, IS_ENTERPRISE, IS_SELF_HOSTED } from './config';
+import { EE_AUTH_PROVIDER, IS_CLOUD, IS_SELF_HOSTED, IS_SELF_HOSTED_CE } from './config';
 import { FeatureFlagsProvider } from './context/feature-flags-provider';
 import { AgentDetailsPage } from './pages/agent-details';
 import { AgentSlackSetupPage } from './pages/agent-slack-setup-page';
@@ -440,12 +440,11 @@ const router = createBrowserRouter([
               },
               {
                 path: ROUTES.DOMAINS,
-                element: !IS_SELF_HOSTED || IS_ENTERPRISE ? <DomainsPage /> : <Navigate to={ROUTES.ROOT} replace />,
+                element: !IS_SELF_HOSTED_CE ? <DomainsPage /> : <Navigate to={ROUTES.ROOT} replace />,
               },
               {
                 path: ROUTES.DOMAIN_DETAIL,
-                element:
-                  !IS_SELF_HOSTED || IS_ENTERPRISE ? <DomainDetailPage /> : <Navigate to={ROUTES.ROOT} replace />,
+                element: !IS_SELF_HOSTED_CE ? <DomainDetailPage /> : <Navigate to={ROUTES.ROOT} replace />,
               },
               {
                 path: ROUTES.API_KEYS,
@@ -682,7 +681,7 @@ const router = createBrowserRouter([
           {
             path: ROUTES.PARTNER_INTEGRATIONS_VERCEL,
             element:
-              EE_AUTH_PROVIDER === 'clerk' && !IS_SELF_HOSTED ? (
+              EE_AUTH_PROVIDER === 'clerk' && IS_CLOUD ? (
                 <ProtectedRoute permission={PermissionsEnum.PARTNER_INTEGRATION_READ}>
                   <VercelIntegrationPage />
                 </ProtectedRoute>
@@ -692,19 +691,19 @@ const router = createBrowserRouter([
           },
           {
             path: ROUTES.SETTINGS,
-            element: IS_SELF_HOSTED && !IS_ENTERPRISE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
+            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
           },
           {
             path: ROUTES.SETTINGS_ACCOUNT,
-            element: IS_SELF_HOSTED && !IS_ENTERPRISE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
+            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
           },
           {
             path: ROUTES.SETTINGS_ORGANIZATION,
-            element: IS_SELF_HOSTED && !IS_ENTERPRISE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
+            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
           },
           {
             path: ROUTES.SETTINGS_TEAM,
-            element: IS_SELF_HOSTED && !IS_ENTERPRISE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
+            element: IS_SELF_HOSTED_CE ? <Navigate to={ROUTES.ROOT} /> : <SettingsPage />,
           },
           {
             path: ROUTES.SETTINGS_BILLING,

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -28,7 +28,7 @@ import { AgentsList } from '@/components/agents/agents-list';
 import { UPGRADE_CTA_LABEL, usePlanUpgradeClick } from '@/components/billing/use-plan-upgrade-click';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
-import { IS_EU, IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD, IS_EU, IS_SELF_HOSTED } from '@/config';
 import { Badge } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
@@ -430,7 +430,7 @@ export function AgentsPage() {
   return (
     <>
       <PageMeta title="Agents" />
-      {!areAgentsAvailable && !IS_SELF_HOSTED ? (
+      {!areAgentsAvailable && IS_CLOUD ? (
         <AgentsEarlyAccessDialog open={earlyAccessOpen} onOpenChange={setEarlyAccessOpen} />
       ) : null}
       <DashboardLayout

--- a/apps/dashboard/src/pages/environments.tsx
+++ b/apps/dashboard/src/pages/environments.tsx
@@ -5,7 +5,7 @@ import { DashboardLayout } from '../components/dashboard-layout';
 import { CreateEnvironmentButton } from '../components/environments/create-environment-button';
 import { FreeTierState } from '../components/environments/environments-free-state';
 import { EnvironmentsList } from '../components/environments/environments-list';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '../config';
+import { IS_SELF_HOSTED_CE } from '../config';
 import { useAuth } from '../context/auth/hooks';
 import { useFetchEnvironments } from '../context/environment/hooks';
 import { useFetchSubscription } from '../hooks/use-fetch-subscription';
@@ -27,7 +27,7 @@ export function EnvironmentsPage() {
   const isTrialActive = subscription?.trial?.isActive;
   const allowedToAccessEnvironments =
     areEnvironmentsInitialLoading || !subscription || (isTierEligibleForCustomEnvironments && !isTrialActive);
-  const canAccessEnvironments = allowedToAccessEnvironments && (!IS_SELF_HOSTED || IS_ENTERPRISE);
+  const canAccessEnvironments = allowedToAccessEnvironments && !IS_SELF_HOSTED_CE;
 
   useEffect(() => {
     track(TelemetryEvent.ENVIRONMENTS_PAGE_VIEWED);

--- a/apps/dashboard/src/pages/landing-1-signup.tsx
+++ b/apps/dashboard/src/pages/landing-1-signup.tsx
@@ -5,7 +5,7 @@ import { RegionPicker } from '@/components/auth/region-picker';
 import { PageMeta } from '@/components/page-meta';
 import { clerkLandingSignupAppearance } from '@/utils/clerk-appearance';
 import { ROUTES } from '@/utils/routes';
-import { IS_SELF_HOSTED } from '../config';
+import { IS_CLOUD } from '../config';
 import { useSegment } from '../context/segment';
 import { TelemetryEvent } from '../utils/telemetry';
 import { getReferrer, getUtmParams } from '../utils/tracking';
@@ -194,7 +194,7 @@ function RightPanel() {
             appearance={clerkLandingSignupAppearance}
             forceRedirectUrl={ROUTES.SIGNUP_ORGANIZATION_LIST}
           />
-          {!IS_SELF_HOSTED && (
+          {IS_CLOUD && (
             <div className="**:border-white/15! [&_.text-neutral-400]:text-white/45! [&_.text-foreground-300]:text-white/30! [&_button]:bg-transparent! [&_button]:text-white/60!">
               <RegionPicker />
             </div>

--- a/apps/dashboard/src/pages/organization-list.tsx
+++ b/apps/dashboard/src/pages/organization-list.tsx
@@ -2,13 +2,13 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import OrganizationCreate from '@/components/auth/create-organization';
 import { PageMeta } from '@/components/page-meta';
-import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { IS_SELF_HOSTED_CE } from '@/config';
 
 export const OrganizationListPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (IS_SELF_HOSTED && !IS_ENTERPRISE) {
+    if (IS_SELF_HOSTED_CE) {
       void navigate('/');
     }
   }, [navigate]);

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { AuthSideBanner } from '@/components/auth/auth-side-banner';
 import { RegionPicker } from '@/components/auth/region-picker';
 import { PageMeta } from '@/components/page-meta';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useSegment } from '@/context/segment';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import {
@@ -119,7 +119,7 @@ export const SignInPage = () => {
             appearance={clerkSignupAppearance}
             forceRedirectUrl={cliAuthReturnUrl ?? connectClaimReturnUrl ?? undefined}
           />
-          {!IS_SELF_HOSTED && <RegionPicker />}
+          {IS_CLOUD && <RegionPicker />}
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { AuthSideBanner } from '@/components/auth/auth-side-banner';
 import { RegionPicker } from '@/components/auth/region-picker';
 import { PageMeta } from '@/components/page-meta';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useSegment } from '@/context/segment';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { appendRedirectUrlParam, readCliAuthReturnUrl } from '@/utils/cli-auth-pending';
@@ -68,7 +68,7 @@ export const SignUpPage = () => {
             appearance={clerkSignupAppearance}
             forceRedirectUrl={ROUTES.SIGNUP_ORGANIZATION_LIST}
           />
-          {!IS_SELF_HOSTED && <RegionPicker />}
+          {IS_CLOUD && <RegionPicker />}
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/pages/webhooks-page.tsx
+++ b/apps/dashboard/src/pages/webhooks-page.tsx
@@ -13,7 +13,7 @@ import { createWebhookPortalToken, getWebhookPortalToken } from '@/api/webhooks'
 import { Button } from '@/components/primitives/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { EmptyStateSvg, WebhooksPaywallState } from '@/components/webhooks/webhooks-paywall-state';
-import { IS_SELF_HOSTED } from '@/config';
+import { IS_CLOUD } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
@@ -82,7 +82,7 @@ export function WebhooksPage() {
         throw new Error('Environment is not available for enabling webhooks.') as CustomError;
       }
 
-      if (!isTierEligibleForWebhooks && !IS_SELF_HOSTED) {
+      if (!isTierEligibleForWebhooks && IS_CLOUD) {
         throw new Error('Current tier is not eligible for webhooks.') as CustomError;
       }
 
@@ -131,7 +131,7 @@ export function WebhooksPage() {
     return <Navigate to={buildRoute(activeTabDefinition.routePath, { environmentSlug })} replace />;
   }
 
-  if (!IS_SELF_HOSTED && !isTierEligibleForWebhooks && !isLoadingEligibility) {
+  if (IS_CLOUD && !isTierEligibleForWebhooks && !isLoadingEligibility) {
     return (
       <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Webhooks</h1>}>
         <WebhooksPaywallState />

--- a/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
-import { IS_ENTERPRISE } from '@/config';
+import { IS_SELF_HOSTED_EE } from '@/config';
 import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
@@ -186,7 +186,7 @@ export function SignIn() {
           </span>
         </p>
       </form>
-      {IS_ENTERPRISE && (
+      {IS_SELF_HOSTED_EE && (
         <>
           <div className="relative my-6">
             <div className="absolute inset-0 flex items-center">

--- a/apps/dashboard/src/utils/better-auth/index.tsx
+++ b/apps/dashboard/src/utils/better-auth/index.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import { useNavigate } from 'react-router-dom';
 import { appendRedirectUrlParam } from '@/utils/cli-auth-pending';
 import { ROUTES } from '@/utils/routes';
-import { EE_AUTH_PROVIDER, IS_SELF_HOSTED } from '../../config';
+import { EE_AUTH_PROVIDER } from '../../config';
 import { AuthContext, type BetterAuthOrganization, type BetterAuthUser } from './auth-context';
 import { authClient } from './client';
 import {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The dashboard gated deployment-mode behavior using many different hand-written boolean combos of the raw `IS_SELF_HOSTED` / `IS_ENTERPRISE` flags (e.g. `!IS_SELF_HOSTED || IS_ENTERPRISE`, `IS_SELF_HOSTED && !IS_ENTERPRISE`, `!(IS_SELF_HOSTED && IS_ENTERPRISE)`). These are hard to grep for and easy to get the polarity wrong. This PR standardizes on three positively-named, canonical mode flags and fixes one confirmed bug found during the audit.

There are exactly three deployment modes, baked at build time by the release workflows (verified against `prepare-cloud-release`, `prepare-self-hosted-release`, `prepare-enterprise-self-hosted-release`):
- Cloud → neither `VITE_SELF_HOSTED` nor `VITE_NOVU_ENTERPRISE` set → `IS_CLOUD`
- Community Edition (CE) → `VITE_SELF_HOSTED=true` only → `IS_SELF_HOSTED_CE`
- Enterprise Edition (EE) → both set → `IS_SELF_HOSTED_EE`

Canonical gating patterns now used throughout the dashboard:
- Feature not available in CE (Cloud + EE): `!IS_SELF_HOSTED_CE`
- Feature differs/hidden vs Cloud on EE: `IS_SELF_HOSTED_EE`
- Feature is cloud-only regardless of edition: `IS_CLOUD`
- Behavior common to any self-hosted deployment: `IS_SELF_HOSTED` (kept for positive checks)

**Changes**
- `config/index.ts`: add `IS_CLOUD = !IS_SELF_HOSTED`; document the canonical patterns.
- **Bug fix (only intentional behavior change):** `IS_AI_FEATURES_ENABLED` was `!(IS_SELF_HOSTED && IS_ENTERPRISE)`, which evaluated to `true` on CE — enabling AI features on CE. It is now `IS_CLOUD`, so AI features are disabled on both CE and EE (they are cloud-only). Cloud and EE behavior is unchanged; ~15 AI-gated surfaces (AI drawer, workflow AI generation, command-palette Novu AI, Inkeep support, agent suggestions, etc.) now correctly turn off on CE.
- Normalize `!IS_SELF_HOSTED || IS_ENTERPRISE` → `!IS_SELF_HOSTED_CE`.
- Normalize `IS_SELF_HOSTED && !IS_ENTERPRISE` → `IS_SELF_HOSTED_CE`.
- Normalize `!(IS_SELF_HOSTED && IS_ENTERPRISE)` → `!IS_SELF_HOSTED_EE`.
- Normalize standalone `!IS_SELF_HOSTED` → `IS_CLOUD`.
- Normalize standalone `IS_ENTERPRISE` → `IS_SELF_HOSTED_EE` (Cloud never sets `VITE_NOVU_ENTERPRISE`, so these are runtime-equivalent).
- Consolidate `customer-support-button` gating onto `IS_SELF_HOSTED_CE`, keeping the parent `!IS_SELF_HOSTED_EE` gate so EE still shows no help button (behavior preserved).
- Rename the misleading local `isEnterprise` in `navigation-commands.tsx` (it was true on Cloud) to `areTranslationsAvailable`.

Every change other than the `IS_AI_FEATURES_ENABLED` fix is boolean-equivalent to the previous behavior.

### Screenshots

Manually verified the app in EE mode (self-hosted Enterprise): auto/manual sign-in works; side nav shows Settings/Environments/Variables; Settings loads with Account/Organization/Team tabs and no Billing tab; header shows no help icon; Create-workflow dialog shows the manual form only (no AI/guided tab).

![EE Settings page: Account/Organization/Team tabs, no Billing](https://cursor.com/artifacts/c/art-53a4c726-0417-4ac1-a38c-0158dbb0dc57)
![EE Create workflow dialog: manual form only, no AI/guided tab](https://cursor.com/artifacts/c/art-17ec9c01-9e69-4687-89c5-a45754da4b6d)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Testing: `tsc -b` passes and Biome lint is clean on the changed files. EE mode was verified end-to-end in the browser (screenshots above). CE mode was verified at the API level (community login + `/v1/organizations/me` + `/v1/environments` all return 200 after seeding a community member record locally); the CE UI walkthrough was not captured to keep scope contained and can be picked up separately.
- No changes outside `apps/dashboard/src`. The raw `IS_SELF_HOSTED` / `IS_ENTERPRISE` exports remain as private building blocks in `config/index.ts`.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0eb543a9-a91b-44fc-acdc-d455cf6d8cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0eb543a9-a91b-44fc-acdc-d455cf6d8cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes dashboard deployment-mode checks around canonical Cloud, self-hosted CE, and self-hosted EE flags. The main changes are:

- Adds `IS_CLOUD`, `IS_SELF_HOSTED_CE`, and `IS_SELF_HOSTED_EE` as the preferred mode flags.
- Makes AI features cloud-only by setting `IS_AI_FEATURES_ENABLED` to `IS_CLOUD`.
- Replaces hand-written boolean combinations across routes, hooks, and UI gates with the new canonical flags.
- Preserves Cloud, CE, and EE behavior for billing, settings, translations, conversations, webhooks, support, and auth surfaces.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are mostly mechanical boolean refactors. The new canonical flags match the three stated deployment modes. Reviewed route, feature, subscription, support, and auth gates preserve prior behavior aside from the documented AI cloud-only fix.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex confirmed that the libs/internal-sdk build completed successfully.
- T-Rex observed the EE-dashboard dev-server entering an EE-mode retry and failing due to dependency-resolution errors that blocked rendering.
- T-Rex verified via Playwright that navigating real routes produced HTTP 404/500 failures with empty bodies.
- T-Rex captured the browser flow with a Playwright recording and screenshots showing a blank rendered state caused by module-load failures.

<a href="https://app.greptile.com/trex/runs/13671777/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/config/index.ts | Adds canonical deployment-mode flags and makes AI features cloud-only. |
| apps/dashboard/src/main.tsx | Updates route guards for CE, Cloud, and EE deployment modes using canonical flags. |
| apps/dashboard/src/hooks/use-fetch-subscription.ts | Allows subscription fetches for Cloud and EE while excluding CE through `!IS_SELF_HOSTED_CE`. |
| apps/dashboard/src/hooks/use-feature-flag.tsx | Simplifies LaunchDarkly enablement to the equivalent non-EE condition. |
| apps/dashboard/src/components/header-navigation/customer-support-button.tsx | Consolidates CE support-button deep-link gating while preserving parent EE suppression. |
| apps/dashboard/src/utils/better-auth/components/sign-in.tsx | Shows the SSO sign-in option only for self-hosted EE using `IS_SELF_HOSTED_EE`. |
| apps/dashboard/src/pages/webhooks-page.tsx | Keeps webhooks tier paywall and mutation restriction cloud-only through `IS_CLOUD`. |
| apps/dashboard/src/components/side-navigation/side-navigation.tsx | Replaces Cloud/EE navigation visibility expressions with `!IS_SELF_HOSTED_CE`. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Build as Release build env
participant Config as apps/dashboard/src/config/index.ts
participant UI as Dashboard routes/components/hooks

Build->>Config: VITE_SELF_HOSTED / VITE_NOVU_ENTERPRISE
alt Cloud
    Config-->>UI: "IS_CLOUD=true, IS_SELF_HOSTED_CE=false, IS_SELF_HOSTED_EE=false"
    UI->>UI: show cloud-only billing, AI, region, hosted support gates
else Self-hosted CE
    Config-->>UI: "IS_CLOUD=false, IS_SELF_HOSTED_CE=true, IS_SELF_HOSTED_EE=false"
    UI->>UI: hide CE-unavailable Cloud/EE features and AI surfaces
else Self-hosted EE
    Config-->>UI: "IS_CLOUD=false, IS_SELF_HOSTED_CE=false, IS_SELF_HOSTED_EE=true"
    UI->>UI: enable EE-available features and suppress CE/cloud-only surfaces
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Build as Release build env
participant Config as apps/dashboard/src/config/index.ts
participant UI as Dashboard routes/components/hooks

Build->>Config: VITE_SELF_HOSTED / VITE_NOVU_ENTERPRISE
alt Cloud
    Config-->>UI: "IS_CLOUD=true, IS_SELF_HOSTED_CE=false, IS_SELF_HOSTED_EE=false"
    UI->>UI: show cloud-only billing, AI, region, hosted support gates
else Self-hosted CE
    Config-->>UI: "IS_CLOUD=false, IS_SELF_HOSTED_CE=true, IS_SELF_HOSTED_EE=false"
    UI->>UI: hide CE-unavailable Cloud/EE features and AI surfaces
else Self-hosted EE
    Config-->>UI: "IS_CLOUD=false, IS_SELF_HOSTED_CE=false, IS_SELF_HOSTED_EE=true"
    UI->>UI: enable EE-available features and suppress CE/cloud-only surfaces
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(dashboard): consolidate edition..."](https://github.com/novuhq/novu/commit/4f520d7b1e83a22d6fa2452d71c30c973eb4881e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42664305)</sub>

<!-- /greptile_comment -->