### PR TITLE
fix(inbound-mail): import private-ip helpers from application-generic fixes NV-8239

### DIFF
--- a/apps/inbound-mail/src/server/client-ip-sources.ts
+++ b/apps/inbound-mail/src/server/client-ip-sources.ts
@@ -1,14 +1,4 @@
-/*
- * inbound-mail compiles with node10 module resolution, which cannot resolve
- * the `@novu/shared/utils/private-ip-classification` exports subpath, so we
- * go through the @novu/application-generic re-export instead. Deep build-path
- * import (same pattern as instrument.ts) to avoid pulling the full barrel
- * (mongoose, newrelic, clickhouse) into this pure utility module.
- */
-import {
-  isPrivateIp,
-  normalizeHostnameForLookup,
-} from '@novu/application-generic/build/main/utils/ssrf-url-validation';
+import { isPrivateIp, normalizeHostnameForLookup } from '@novu/application-generic';
 
 export interface ClientIpSourceCandidate {
   rank: number;

--- a/apps/inbound-mail/src/server/client-ip-sources.ts
+++ b/apps/inbound-mail/src/server/client-ip-sources.ts
@@ -1,4 +1,14 @@
-import { isPrivateIp, normalizeHostnameForLookup } from '@novu/shared/utils/private-ip-classification';
+/*
+ * inbound-mail compiles with node10 module resolution, which cannot resolve
+ * the `@novu/shared/utils/private-ip-classification` exports subpath, so we
+ * go through the @novu/application-generic re-export instead. Deep build-path
+ * import (same pattern as instrument.ts) to avoid pulling the full barrel
+ * (mongoose, newrelic, clickhouse) into this pure utility module.
+ */
+import {
+  isPrivateIp,
+  normalizeHostnameForLookup,
+} from '@novu/application-generic/build/main/utils/ssrf-url-validation';
 
 export interface ClientIpSourceCandidate {
   rank: number;


### PR DESCRIPTION
### What changed? Why was the change needed?

Follow-up to #11857 (already merged), which broke the inbound-mail Docker build in CI:

```
src/server/client-ip-sources.ts(1,57): error TS2307: Cannot find module '@novu/shared/utils/private-ip-classification' or its corresponding type declarations.
```

inbound-mail compiles with `tsc` using the root tsconfig's `moduleResolution: "node"` (node10), which does not honour the `exports` subpath map that `@novu/shared` uses to publish `utils/private-ip-classification`. The import resolved in local dev/test (tsx uses modern resolution) but failed under the CI `tsc` build.

Fix: import `isPrivateIp` / `normalizeHostnameForLookup` from the public `@novu/application-generic` entry point, which already re-exports them through its utils barrel and is an existing dependency of inbound-mail.

Failed run: https://github.com/novuhq/novu/actions/runs/28931014338/job/85830267189

Linear: [NV-8239](https://linear.app/novu/issue/NV-8239/add-debug-logging-for-inbound-mail-client-ip-sources)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

Verified locally: `pnpm build` in `apps/inbound-mail` passes (previously reproduced the TS2307 with the subpath import), and `client-ip-sources.spec.ts` still passes (2 passing).

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates inbound-mail client IP classification imports. The main change is:

- Switches private-IP helper imports away from the shared package subpath so the `tsc` build no longer depends on subpath export resolution.

<h3>Confidence Score: 4/5</h3>

Likely safe to merge with one non-blocking import-path concern.

The change is small and uses existing re-exported utilities, but it imports from the application-generic barrel rather than the deep build path described for this build fix.

`apps/inbound-mail/src/server/client-ip-sources.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- An initial shell-wrapper attempt produced the inbound mail build result but failed with /bin/sh: Bad substitution after the build completed.
- The build was re-run using bash -lc to overwrite the artifact with a clean capture showing tsc -p tsconfig.json in the inbound mail workspace and an exit code of 0.
- The unit test proof shows execution through client-ip-sources.ts with Mocha reporting 2 passing tests and an exit code of 0.

<a href="https://app.greptile.com/trex/runs/13672906/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/server/client-ip-sources.ts | Swaps private IP helpers to application-generic; one P2 notes the import uses the barrel instead of the intended deep build utility path. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant InboundMail as inbound-mail client-ip-sources
participant AppGeneric as @novu/application-generic
participant Ssrf as ssrf-url-validation utils
participant Shared as @novu/shared private-ip-classification

InboundMail->>AppGeneric: import isPrivateIp / normalizeHostnameForLookup
AppGeneric->>Ssrf: barrel re-export through utils
Ssrf->>Shared: require private-ip-classification
Shared-->>InboundMail: normalize/classify IP candidates
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant InboundMail as inbound-mail client-ip-sources
participant AppGeneric as @novu/application-generic
participant Ssrf as ssrf-url-validation utils
participant Shared as @novu/shared private-ip-classification

InboundMail->>AppGeneric: import isPrivateIp / normalizeHostnameForLookup
AppGeneric->>Ssrf: barrel re-export through utils
Ssrf->>Shared: require private-ip-classification
Shared-->>InboundMail: normalize/classify IP candidates
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Finbound-mail%2Fsrc%2Fserver%2Fclient-ip-sources.ts%3A1%0A**Use%20intended%20deep%20import**%0AThe%20changed%20import%20uses%20the%20%60%40novu%2Fapplication-generic%60%20barrel%2C%20but%20the%20PR%20description%20says%20this%20file%20should%20avoid%20that%20barrel%20because%20it%20transitively%20pulls%20in%20heavier%20backend%20modules.%20This%20makes%20the%20pure%20IP%20utility%20depend%20on%20the%20full%20application-generic%20surface%20instead%20of%20the%20already-built%20SSRF%20utility%20path.%0A%0A&pr=11859&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/inbound-mail/src/server/client-ip-sources.ts:1
**Use intended deep import**
The changed import uses the `@novu/application-generic` barrel, but the PR description says this file should avoid that barrel because it transitively pulls in heavier backend modules. This makes the pure IP utility depend on the full application-generic surface instead of the already-built SSRF utility path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(inbound-mail): import private-ip hel..."](https://github.com/novuhq/novu/commit/97e61b9ec58bff150daab1cb185b7ddfcd8a58b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42670451)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->