### PR TITLE
fix(inbound-mail): always emit client IP source debug logs fixes NV-8239

### DIFF
--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -544,45 +544,41 @@ class Mailin extends events.EventEmitter {
         `${connection.id} Inbound mail sender authentication verdict: dkim=${parsedEmail.dkim} spf=${parsedEmail.spf}`
       );
 
-      if (process.env.INBOUND_MAIL_DEBUG_CLIENT_IP === 'true') {
-        /*
-         * Structured client-IP source dump for debugging sender-auth issues in
-         * cloud envs: mirrors @supercharge/request-ip precedence (proxy headers
-         * first, then socket/connection fallbacks) adapted for SMTP session
-         * fields plus Received-chain IPs. Shows which property SPF currently
-         * uses vs the first public candidate elsewhere in the chain. Verbose and
-         * may include attacker-controlled header values.
-         */
-        const clientIpSources = collectClientIpSources(connection, parsedEmail.headers);
+      /*
+       * Structured client-IP source dump for debugging sender-auth issues in
+       * cloud envs: mirrors @supercharge/request-ip precedence (proxy headers
+       * first, then socket/connection fallbacks) adapted for SMTP session
+       * fields plus Received-chain IPs. Shows which property SPF currently
+       * uses vs the first public candidate elsewhere in the chain. Verbose and
+       * may include attacker-controlled header values.
+       */
+      const clientIpSources = collectClientIpSources(connection, parsedEmail.headers);
 
-        logger.info(
-          {
-            context: LOG_CONTEXT,
-            connectionId: connection.id,
-            envelopeFrom: connection.envelope?.mailFrom?.address,
-            clientIpSources,
-          },
-          `${connection.id} Inbound mail client IP source dump`
-        );
-      }
+      logger.info(
+        {
+          context: LOG_CONTEXT,
+          connectionId: connection.id,
+          envelopeFrom: connection.envelope?.mailFrom?.address,
+          clientIpSources,
+        },
+        `${connection.id} Inbound mail client IP source dump`
+      );
 
-      if (process.env.INBOUND_MAIL_DEBUG_HEADERS === 'true') {
-        /*
-         * Full header dump when you need every raw header value beyond the
-         * structured IP-source view above.
-         */
-        logger.info(
-          {
-            context: LOG_CONTEXT,
-            connectionId: connection.id,
-            remoteAddress: connection.remoteAddress,
-            clientHostname: connection.clientHostname,
-            envelopeFrom: connection.envelope?.mailFrom?.address,
-            headers: parsedEmail.headers,
-          },
-          `${connection.id} Inbound mail header dump`
-        );
-      }
+      /*
+       * Full header dump when you need every raw header value beyond the
+       * structured IP-source view above.
+       */
+      logger.info(
+        {
+          context: LOG_CONTEXT,
+          connectionId: connection.id,
+          remoteAddress: connection.remoteAddress,
+          clientHostname: connection.clientHostname,
+          envelopeFrom: connection.envelope?.mailFrom?.address,
+          headers: parsedEmail.headers,
+        },
+        `${connection.id} Inbound mail header dump`
+      );
 
       /*
        * Make fields exist, even if empty. That will make


### PR DESCRIPTION
## Summary

- Remove `INBOUND_MAIL_DEBUG_CLIENT_IP` and `INBOUND_MAIL_DEBUG_HEADERS` env gates so structured IP source and header dumps are emitted on every processed inbound message
- Keeps the existing `collectClientIpSources()` instrumentation from #11857 — only changes when it is logged

## Why

The debug logging from NV-8239 was deployed but logs were missing in New Relic because the ECS task definition did not set `INBOUND_MAIL_DEBUG_CLIENT_IP=true`. For short-lived cloud diagnostics we need these dumps without a separate env rollout.

```mermaid
flowchart TD
  A[Inbound SMTP connection] --> B[Sender auth verdict log]
  B --> C[collectClientIpSources]
  C --> D[Log client IP source dump]
  B --> E[Log full parsed headers]
```

## Test plan

- [x] `pnpm exec cross-env NODE_ENV=test mocha --require tsx/cjs src/server/client-ip-sources.spec.ts` — 2 passing
- [ ] Deploy to staging and confirm `Inbound mail client IP source dump` appears per message without setting debug env vars
- [ ] Confirm `spfEvaluatedWith` vs `firstPublicCandidate` in `clientIpSources` payload for a real inbound email
- [ ] Revert or re-gate behind a flag once the correct SPF IP source is identified

### What changed? Why was the change needed?

Follow-up to [NV-8239](https://linear.app/novu/issue/NV-8239/add-debug-logging-for-inbound-mail-client-ip-sources) / #11857. Makes client-IP debug instrumentation always-on so we can diagnose SPF failures behind proxies without coordinating a separate env-var change in ECS.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes inbound-mail diagnostics always emit during message finalization. The main changes are:

- Removes the `INBOUND_MAIL_DEBUG_CLIENT_IP` gate around the client IP source dump.
- Removes the `INBOUND_MAIL_DEBUG_HEADERS` gate around the parsed header dump.
- Keeps the existing sender-auth verdict and `collectClientIpSources()` instrumentation flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge with the documented diagnostic logging trade-off.

The change is narrowly scoped to removing two environment gates around existing logging. The always-on behavior matches the PR description and no functional regressions were found in the changed path.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/inbound-mail/src/server/index.ts | Removes debug env gates so inbound mail client IP source and parsed header dumps are logged for every finalized message. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant SMTP as Inbound SMTP connection
participant Mailin as Mailin.finalizeMessage
participant Sources as collectClientIpSources
participant Logger as logger.info

SMTP->>Mailin: Message finalized with parsed email/session
Mailin->>Logger: Sender auth verdict
Mailin->>Sources: collectClientIpSources(connection, headers)
Sources-->>Mailin: clientIpSources debug payload
Mailin->>Logger: Client IP source dump
Mailin->>Logger: Full parsed header dump
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant SMTP as Inbound SMTP connection
participant Mailin as Mailin.finalizeMessage
participant Sources as collectClientIpSources
participant Logger as logger.info

SMTP->>Mailin: Message finalized with parsed email/session
Mailin->>Logger: Sender auth verdict
Mailin->>Sources: collectClientIpSources(connection, headers)
Sources-->>Mailin: clientIpSources debug payload
Mailin->>Logger: Client IP source dump
Mailin->>Logger: Full parsed header dump
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(inbound-mail): always emit client IP..."](https://github.com/novuhq/novu/commit/b22990d868b6f0fa05e500ea64d9f22f9ba455ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42679107)</sub>

<!-- /greptile_comment -->