### PR TITLE
chore(root): update package versions to 3.18.0 for api-service, dashboard, inbound-mail, webhook, worker, and ws

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/api-service",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@novu/dashboard",
   "private": true,
-  "version": "3.17.5",
+  "version": "3.18.0",
   "type": "module",
   "portless": {
     "name": "dashboard.novu"

--- a/apps/inbound-mail/package.json
+++ b/apps/inbound-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/inbound-mail",
-  "version": "2.1.10",
+  "version": "3.18.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/webhook/package.json
+++ b/apps/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/webhook",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/worker",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/ws",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates version metadata for several deployable apps. The main changes are:

- `@novu/api-service` moves from `3.17.1` to `3.18.0`.
- `@novu/dashboard` moves from `3.17.5` to `3.18.0`.
- `@novu/inbound-mail` moves from `2.1.10` to `3.18.0`.
- `@novu/webhook`, `@novu/worker`, and `@novu/ws` move from `3.17.1` to `3.18.0`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The diff only changes package version fields and does not modify dependencies, scripts, or runtime code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the affected-project command and confirmed it exited with code 0 and reported six affected packages.
- Validated that six workspace version checks also exited 0 and printed version 3.18.0 with VERSION\_OK for each.
- Examined the concise summary artifact and confirmed it states the expected count was 6, the actual count was 6, and the VERSION\_OK count was 6.

<a href="https://app.greptile.com/trex/runs/13680672/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/package.json | Updates `@novu/api-service` package version from `3.17.1` to `3.18.0`. |
| apps/dashboard/package.json | Updates `@novu/dashboard` package version from `3.17.5` to `3.18.0`. |
| apps/inbound-mail/package.json | Updates `@novu/inbound-mail` package version from `2.1.10` to `3.18.0`. |
| apps/webhook/package.json | Updates `@novu/webhook` package version from `3.17.1` to `3.18.0`. |
| apps/worker/package.json | Updates `@novu/worker` package version from `3.17.1` to `3.18.0`. |
| apps/ws/package.json | Updates `@novu/ws` package version from `3.17.1` to `3.18.0`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(root): update package versions to ..."](https://github.com/novuhq/novu/commit/0bd879c0d8761ac72d4848d5e2155909df84fae4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42688671)</sub>

<!-- /greptile_comment -->