### PR TITLE
chore(root): update service images to version 3.18.0 for api, worker, ws, and dashboard

### DIFF
--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       start_period: 20s
 
   api:
-    image: "ghcr.io/novuhq/novu/api:3.17.0"
+    image: "ghcr.io/novuhq/novu/api:3.18.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -109,7 +109,7 @@ services:
       start_period: 40s
 
   worker:
-    image: "ghcr.io/novuhq/novu/worker:3.17.0"
+    image: "ghcr.io/novuhq/novu/worker:3.18.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -162,7 +162,7 @@ services:
       start_period: 20s
 
   ws:
-    image: "ghcr.io/novuhq/novu/ws:3.17.0"
+    image: "ghcr.io/novuhq/novu/ws:3.18.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -203,7 +203,7 @@ services:
       start_period: 40s
 
   dashboard:
-    image: "ghcr.io/novuhq/novu/dashboard:3.17.0"
+    image: "ghcr.io/novuhq/novu/dashboard:3.18.0"
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
… 

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the community Docker Compose stack to use Novu `3.18.0` images. The main changes are:

- `api` image updated from `3.17.0` to `3.18.0`.
- `worker` image updated from `3.17.0` to `3.18.0`.
- `ws` image updated from `3.17.0` to `3.18.0`.
- `dashboard` image updated from `3.17.0` to `3.18.0`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The PR only changes coordinated image tags in one Docker Compose file. Service dependencies, health checks, ports, and environment wiring are unchanged.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated the image-tag validation script and used it to perform the executed image-tag contract check.
- Read the compose file from the repository, parsed it, and verified that all four target image tags passed the contract.
- Ran Docker and Compose availability checks and observed the config-render blocker status during the run.

<a href="https://app.greptile.com/trex/runs/13681878/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/community/docker-compose.yml | Updates the community Docker Compose images for `api`, `worker`, `ws`, and `dashboard` from `3.17.0` to `3.18.0`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(root): update service images to ve..."](https://github.com/novuhq/novu/commit/1081dbc56a1dc29fca94dbf769a307c629607e07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42691088)</sub>

<!-- /greptile_comment -->