### PR TITLE
feat(docs): add Microsoft Teams connect button and linking components to documentation fixes DOC-408

### DIFF
--- a/docs/agents/custom-code-agent/setup-your-agent/connect-components.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/connect-components.mdx
@@ -62,22 +62,22 @@ Optional reference: https://docs.novu.co/agents/custom-code-agent/setup-your-age
 
 `SlackConnectButton` accepts the following props to customize the UI and behavior:
 
-<Fields>
-  <Field name="integrationIdentifier" type="string" />
-  <Field name="connectionIdentifier" type="string" />
-  <Field name="subscriberId" type="string" />
-  <Field name="context" type="Partial<Record<string, ContextValue>>" />
-  <Field name="scope" type="string[]" />
-  <Field name="connectionMode" type="ConnectionMode" />
-  <Field name="onConnectSuccess" type="(connectionIdentifier: string) => void" />
-  <Field name="onConnectError" type="(error: unknown) => void" />
-  <Field name="onDisconnectSuccess" type="() => void" />
-  <Field name="onDisconnectError" type="(error: unknown) => void" />
-  <Field name="connectLabel" type="string" />
-  <Field name="connectedLabel" type="string" />
-  <Field name="appearance" type="ReactInboxAppearance | ReactSubscriptionAppearance | ReactAllAppearance" />
-  <Field name="container" type="any" />
-</Fields>
+| Property | Type | Description |
+| --- | --- | --- |
+| `integrationIdentifier` | `string` | Required. Identifier of the Slack integration to connect against. |
+| `connectionIdentifier` | `string` | Optional. Unique identifier for the connection. Auto-generated per subscriber when omitted. |
+| `subscriberId` | `string` | Optional. Subscriber to connect. Defaults to the `NovuProvider` subscriber. |
+| `context` | `Partial<Record<string, ContextValue>>` | Optional. Contextual attributes used to scope the connection. Required when `connectionMode` is `shared`. |
+| `scope` | `string[]` | Optional. OAuth scopes requested during connect. |
+| `connectionMode` | `ConnectionMode` | Optional. `subscriber` (default) or `shared`. |
+| `onConnectSuccess` | `(connectionIdentifier: string) => void` | Called once the connection is established. |
+| `onConnectError` | `(error: unknown) => void` | Called when the connect flow fails or times out. |
+| `onDisconnectSuccess` | `() => void` | Called after the connection is removed. |
+| `onDisconnectError` | `(error: unknown) => void` | Called when disconnecting fails. |
+| `connectLabel` | `string` | Label shown when disconnected. |
+| `connectedLabel` | `string` | Label shown when connected. |
+| `appearance` | `ReactInboxAppearance \| ReactSubscriptionAppearance \| ReactAllAppearance` | Style overrides reusing the shared `channelConnectButton*` keys. |
+| `container` | `HTMLElement` | Optional element to render the component into. |
 
 ## Microsoft Teams connect button
 
@@ -138,23 +138,23 @@ Optional reference: https://docs.novu.co/agents/custom-code-agent/setup-your-age
 
 `MsTeamsConnectButton` accepts the following props to customize the UI and behavior:
 
-<Fields>
-  <Field name="integrationIdentifier" type="string" />
-  <Field name="connectionIdentifier" type="string" />
-  <Field name="subscriberId" type="string" />
-  <Field name="context" type="Partial<Record<string, ContextValue>>" />
-  <Field name="scope" type="string[]" />
-  <Field name="connectionMode" type="ConnectionMode" />
-  <Field name="autoLinkUser" type="boolean" />
-  <Field name="onConnectSuccess" type="(connectionIdentifier: string) => void" />
-  <Field name="onConnectError" type="(error: unknown) => void" />
-  <Field name="onDisconnectSuccess" type="() => void" />
-  <Field name="onDisconnectError" type="(error: unknown) => void" />
-  <Field name="connectLabel" type="string" />
-  <Field name="connectedLabel" type="string" />
-  <Field name="appearance" type="ReactInboxAppearance | ReactSubscriptionAppearance | ReactAllAppearance" />
-  <Field name="container" type="any" />
-</Fields>
+| Property | Type | Description |
+| --- | --- | --- |
+| `integrationIdentifier` | `string` | Required. Identifier of the Microsoft Teams integration to connect against. |
+| `connectionIdentifier` | `string` | Optional. Unique identifier for the connection. Auto-generated per subscriber when omitted. |
+| `subscriberId` | `string` | Optional. Subscriber to connect. Defaults to the `NovuProvider` subscriber. |
+| `context` | `Partial<Record<string, ContextValue>>` | Optional. Contextual attributes used to scope the connection. Required when `connectionMode` is `shared`. |
+| `scope` | `string[]` | Optional. OAuth scopes requested during connect. |
+| `connectionMode` | `ConnectionMode` | Optional. `subscriber` (default) or `shared`. |
+| `autoLinkUser` | `boolean` | Optional. When `true` (default in subscriber mode), chains into the delegated user-linking flow after admin consent. Set `false` for tenant-only admin consent. |
+| `onConnectSuccess` | `(connectionIdentifier: string) => void` | Called once the connection is established. |
+| `onConnectError` | `(error: unknown) => void` | Called when the connect flow fails or times out. |
+| `onDisconnectSuccess` | `() => void` | Called after the connection is removed. |
+| `onDisconnectError` | `(error: unknown) => void` | Called when disconnecting fails. |
+| `connectLabel` | `string` | Label shown when disconnected. Defaults to `Connect MS Teams`. |
+| `connectedLabel` | `string` | Label shown when connected. Defaults to `Connected`. |
+| `appearance` | `ReactInboxAppearance \| ReactSubscriptionAppearance \| ReactAllAppearance` | Style overrides reusing the shared `channelConnectButton*` keys. |
+| `container` | `HTMLElement` | Optional element to render the component into. |
 
 ### Link a subscriber for direct messages
 
@@ -194,19 +194,19 @@ export default MsTeamsLinkUserComponent;
 
 `MsTeamsLinkUser` accepts the following props to customize the UI and behavior:
 
-<Fields>
-  <Field name="integrationIdentifier" type="string" />
-  <Field name="connectionIdentifier" type="string" />
-  <Field name="context" type="Partial<Record<string, ContextValue>>" />
-  <Field name="onLinkSuccess" type="(endpoint: { identifier: string }) => void" />
-  <Field name="onLinkError" type="(error: unknown) => void" />
-  <Field name="onUnlinkSuccess" type="() => void" />
-  <Field name="onUnlinkError" type="(error: unknown) => void" />
-  <Field name="linkLabel" type="string" />
-  <Field name="unlinkLabel" type="string" />
-  <Field name="appearance" type="ReactInboxAppearance | ReactSubscriptionAppearance | ReactAllAppearance" />
-  <Field name="container" type="any" />
-</Fields>
+| Property | Type | Description |
+| --- | --- | --- |
+| `integrationIdentifier` | `string` | Required. Identifier of the Microsoft Teams integration to link against. |
+| `connectionIdentifier` | `string` | Optional. Unique identifier for the connection. Auto-generated per subscriber when omitted. |
+| `context` | `Partial<Record<string, ContextValue>>` | Optional. Contextual attributes used to scope the endpoint. |
+| `onLinkSuccess` | `(endpoint: { identifier: string }) => void` | Called once the `ms_teams_user` endpoint is created. |
+| `onLinkError` | `(error: unknown) => void` | Called when linking fails or polling times out. |
+| `onUnlinkSuccess` | `() => void` | Called after the endpoint is removed. |
+| `onUnlinkError` | `(error: unknown) => void` | Called when unlinking fails. |
+| `linkLabel` | `string` | Label shown when not linked. |
+| `unlinkLabel` | `string` | Label shown when linked. |
+| `appearance` | `ReactInboxAppearance \| ReactSubscriptionAppearance \| ReactAllAppearance` | Style overrides reusing the shared `channelConnectButton*` keys. |
+| `container` | `HTMLElement` | Optional element to render the component into. |
 
 ## Telegram connect button
 

--- a/docs/agents/custom-code-agent/setup-your-agent/connect-components.mdx
+++ b/docs/agents/custom-code-agent/setup-your-agent/connect-components.mdx
@@ -81,9 +81,132 @@ Optional reference: https://docs.novu.co/agents/custom-code-agent/setup-your-age
 
 ## Microsoft Teams connect button
 
+`MsTeamsConnectButton` is a pre-built UI component in the `@novu/react` SDK that connects your agent to a customer's Microsoft Teams tenant. When clicked, it opens Microsoft's admin consent flow in a new tab and polls until the tenant administrator grants consent, then stores a `ChannelConnection` for that tenant.
+
+In `subscriber` mode, `autoLinkUser` defaults to `true`, so the same flow also links the subscriber who clicked **Connect** as a personal Teams endpoint for direct messages. Set `autoLinkUser={false}` to perform only the tenant-level admin consent.
+
+```tsx
+import { NovuProvider, MsTeamsConnectButton } from '@novu/react';
+
+const MsTeamsConnectButtonComponent = () => {
+  const subscriberId = 'subscriber-id';
+  const integrationIdentifier = 'msteams-integration-identifier';
+
+  return (
+    <NovuProvider subscriberId={subscriberId} applicationIdentifier="application-identifier">
+      <MsTeamsConnectButton
+        integrationIdentifier={integrationIdentifier}
+        connectLabel="Connect MS Teams"
+        connectedLabel="Connected to MS Teams"
+        onConnectSuccess={(connectionIdentifier) => {
+          console.log('Connected', connectionIdentifier);
+        }}
+        onConnectError={(error: unknown) => {
+          console.error(error);
+        }}
+        onDisconnectSuccess={() => {
+          // Handle disconnect
+        }}
+      />
+    </NovuProvider>
+  );
+};
+
+export default MsTeamsConnectButtonComponent;
+```
+
 <Note>
-  Novu is working on adding a Microsoft Teams connect button to the `@novu/react` SDK. Reach out to support at support@novu.co to get access to a pre-release version.
+  Admin consent connects the customer's Microsoft 365 tenant. It is required for both channel messages and direct messages. Linking a subscriber for direct messages is a separate step handled by `autoLinkUser` or the `MsTeamsLinkUser` component below. Sending to a specific channel additionally requires registering an `ms_teams_channel` [channel endpoint](/platform/integrations/chat/ms-teams#sending-message-to-channels) after consent.
 </Note>
+
+<Prompt description="Add MsTeamsConnectButton to my app" icon="plug" actions={["copy", "cursor"]}>
+Add the Novu MsTeamsConnectButton from @novu/react to my app so each of my end users can connect "YOUR_AGENT_NAME" to their own Microsoft Teams tenant.
+
+Context: The Microsoft Teams integration already exists in Novu. This is purely a frontend code integration — do NOT run the Novu CLI or the agent-onboarding flow.
+
+Requirements:
+- Install @novu/react with my project's package manager.
+- Render `<MsTeamsConnectButton />` inside a `<NovuProvider>` configured for the currently signed-in end user.
+- Use applicationIdentifier="YOUR_APPLICATION_IDENTIFIER" and integrationIdentifier="YOUR_INTEGRATION_IDENTIFIER". Store applicationIdentifier in an environment variable rather than hardcoding it.
+- Pass the authenticated user's id as subscriberId — source it from my app's existing auth, don't hardcode it.
+- Follow my app's existing framework, routing, styling, and TypeScript conventions, place the button in a sensible spot in the UI, and add no unnecessary wrappers.
+
+Optional reference: https://docs.novu.co/agents/custom-code-agent/setup-your-agent/connect-components
+</Prompt>
+
+### API reference
+
+`MsTeamsConnectButton` accepts the following props to customize the UI and behavior:
+
+<Fields>
+  <Field name="integrationIdentifier" type="string" />
+  <Field name="connectionIdentifier" type="string" />
+  <Field name="subscriberId" type="string" />
+  <Field name="context" type="Partial<Record<string, ContextValue>>" />
+  <Field name="scope" type="string[]" />
+  <Field name="connectionMode" type="ConnectionMode" />
+  <Field name="autoLinkUser" type="boolean" />
+  <Field name="onConnectSuccess" type="(connectionIdentifier: string) => void" />
+  <Field name="onConnectError" type="(error: unknown) => void" />
+  <Field name="onDisconnectSuccess" type="() => void" />
+  <Field name="onDisconnectError" type="(error: unknown) => void" />
+  <Field name="connectLabel" type="string" />
+  <Field name="connectedLabel" type="string" />
+  <Field name="appearance" type="ReactInboxAppearance | ReactSubscriptionAppearance | ReactAllAppearance" />
+  <Field name="container" type="any" />
+</Fields>
+
+### Link a subscriber for direct messages
+
+`MsTeamsLinkUser` links an individual subscriber's Teams identity so your agent can send them direct messages. It runs a delegated Microsoft OAuth flow (`User.Read` scope), resolves the subscriber's AAD Object ID, and creates a `ChannelEndpoint` of type `ms_teams_user`. Admin consent from `MsTeamsConnectButton` must be completed first.
+
+Use this component when you set `autoLinkUser={false}` on the connect button, or when you want to link users in a separate step.
+
+```tsx
+import { NovuProvider, MsTeamsLinkUser } from '@novu/react';
+
+const MsTeamsLinkUserComponent = () => {
+  const subscriberId = 'subscriber-id';
+  const integrationIdentifier = 'msteams-integration-identifier';
+
+  return (
+    <NovuProvider subscriberId={subscriberId} applicationIdentifier="application-identifier">
+      <MsTeamsLinkUser
+        integrationIdentifier={integrationIdentifier}
+        linkLabel="Link Microsoft Teams"
+        unlinkLabel="Linked to Microsoft Teams"
+        onLinkSuccess={(endpoint) => {
+          console.log('Linked', endpoint.identifier);
+        }}
+        onLinkError={(error: unknown) => {
+          console.error(error);
+        }}
+        onUnlinkSuccess={() => {
+          // Handle unlink
+        }}
+      />
+    </NovuProvider>
+  );
+};
+
+export default MsTeamsLinkUserComponent;
+```
+
+`MsTeamsLinkUser` accepts the following props to customize the UI and behavior:
+
+<Fields>
+  <Field name="integrationIdentifier" type="string" />
+  <Field name="connectionIdentifier" type="string" />
+  <Field name="context" type="Partial<Record<string, ContextValue>>" />
+  <Field name="onLinkSuccess" type="(endpoint: { identifier: string }) => void" />
+  <Field name="onLinkError" type="(error: unknown) => void" />
+  <Field name="onUnlinkSuccess" type="() => void" />
+  <Field name="onUnlinkError" type="(error: unknown) => void" />
+  <Field name="linkLabel" type="string" />
+  <Field name="unlinkLabel" type="string" />
+  <Field name="appearance" type="ReactInboxAppearance | ReactSubscriptionAppearance | ReactAllAppearance" />
+  <Field name="container" type="any" />
+</Fields>
 
 ## Telegram connect button
 

--- a/docs/api-reference/topics/create-topic-subscriptions.mdx
+++ b/docs/api-reference/topics/create-topic-subscriptions.mdx
@@ -1,4 +1,11 @@
 ---
 title: "Create topic subscriptions"
+description: "Subscribe one or more subscribers to a topic and optionally set per-subscription preferences."
 openapi: "POST /v2/topics/{topicKey}/subscriptions"
 ---
+
+Subscribe one or more subscribers to a topic. Pass `subscriptions` as subscriber IDs, or as objects with `identifier` and `subscriberId` when you need a custom subscription key.
+
+<Note>
+  When you provide a custom `identifier` for a subscription, it must be **512 characters or fewer**. Requests with longer identifiers are rejected.
+</Note>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates docs for Microsoft Teams connect components and topic subscriptions. The main changes are:

- Adds `MsTeamsConnectButton` setup guidance, examples, prompt text, and prop reference.
- Adds `MsTeamsLinkUser` guidance for linking subscribers to Microsoft Teams direct messages.
- Replaces the Slack prop list with a table format.
- Adds a topic subscriptions API description, intro text, and custom identifier length note.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge with minimal risk.

The changes are limited to MDX documentation and align with the nearby component APIs and repository documentation conventions. No functional or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to generate a real Mintlify preview, but the command failed because the Mintlify CLI was not found.
- T-Rex ran the Mintlify validation step and it also failed due to the same missing Mintlify CLI blocker.
- T-Rex ran markdownlint on the changed MDX files, and the results showed MD034 bare URL warnings in prompt reference lines along with Node engine and deprecation warnings.

<a href="https://app.greptile.com/trex/runs/13686983/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/agents/custom-code-agent/setup-your-agent/connect-components.mdx | Adds Microsoft Teams connect and link-user documentation with examples, prompt guidance, and prop references; no blocking issues found. |
| docs/api-reference/topics/create-topic-subscriptions.mdx | Adds API description, intro text, and identifier length note for topic subscriptions; no issues found. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Subscriber
participant App as App with NovuProvider
participant Button as MsTeamsConnectButton
participant Microsoft as Microsoft admin consent
participant Novu as Novu ChannelConnection
participant LinkUser as MsTeamsLinkUser

Subscriber->>App: Open agent setup UI
App->>Button: Render with subscriberId and integrationIdentifier
Subscriber->>Button: Click Connect
Button->>Microsoft: Open admin consent flow
Microsoft-->>Novu: Consent completed
Button->>Novu: Poll for ChannelConnection
Novu-->>Button: Return tenant connection
alt autoLinkUser false or separate linking
    Subscriber->>LinkUser: Link Microsoft Teams identity
    LinkUser->>Microsoft: Open delegated User.Read OAuth
    Microsoft-->>Novu: User identity resolved
    LinkUser->>Novu: Poll for ms_teams_user endpoint
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Subscriber
participant App as App with NovuProvider
participant Button as MsTeamsConnectButton
participant Microsoft as Microsoft admin consent
participant Novu as Novu ChannelConnection
participant LinkUser as MsTeamsLinkUser

Subscriber->>App: Open agent setup UI
App->>Button: Render with subscriberId and integrationIdentifier
Subscriber->>Button: Click Connect
Button->>Microsoft: Open admin consent flow
Microsoft-->>Novu: Consent completed
Button->>Novu: Poll for ChannelConnection
Novu-->>Button: Return tenant connection
alt autoLinkUser false or separate linking
    Subscriber->>LinkUser: Link Microsoft Teams identity
    LinkUser->>Microsoft: Open delegated User.Read OAuth
    Microsoft-->>Novu: User identity resolved
    LinkUser->>Novu: Poll for ms_teams_user endpoint
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: update Slack and Microsoft Teams c..."](https://github.com/novuhq/novu/commit/9c7058bb26e9b32a14e9664c8a36dc01a606503a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42701714)</sub>

<!-- /greptile_comment -->