### PR TITLE
feat(docs): add FAQs for contexts, subscribers, environments, and Slack integration to improve user guidance

### DIFF
--- a/docs/platform/concepts/contexts.mdx
+++ b/docs/platform/concepts/contexts.mdx
@@ -305,3 +305,25 @@ curl -L -g -X POST 'https://api.novu.co/v1/events/trigger' \
     Filter the Inbox by context and secure it with `contextHash`.
   </Card>
 </CardGroup>
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="Should I create and update contexts ahead of time or pass context data on every trigger?">
+    Create and update contexts ahead of time. Novu auto-creates a context the first time it sees a new key, but it does **not** update existing context `data` when you pass new values on a trigger.
+
+    Recommended approach:
+
+    1. [Create the context](/api-reference/contexts/create-a-context) with initial `data` before you need it.
+    2. [Update context data](/api-reference/contexts/update-a-context) through the API or SDK when metadata changes (for example, tenant name or plan).
+    3. When [triggering](/platform/concepts/trigger) workflows, pass only the context key and `id` not the full `data` object.
+
+    This keeps tenant branding and metadata accurate in templates and the Inbox without relying on trigger-time overwrites.
+  </Accordion>
+
+  <Accordion title="Why are notifications sent but not showing in the Inbox after I added context?">
+    Inbox notifications are scoped per context. If you trigger a workflow with `context` but initialize `<Inbox />` without the same context (or vice versa), the notification will not appear in that Inbox session—even though the in-app job may report success.
+
+    Pass the same context to both your workflow trigger and the Inbox `context` prop. See [Inbox with context](/platform/inbox/configuration/inbox-with-context) for the matching rules and troubleshooting steps.
+  </Accordion>
+</AccordionGroup>

--- a/docs/platform/concepts/subscribers.mdx
+++ b/docs/platform/concepts/subscribers.mdx
@@ -701,4 +701,10 @@ These are some of the most frequently asked questions about subscribers in Novu.
   <Accordion title="Can subscriber credentials for chat and push channels be added when creating a new subscriber?">
     Subscriber credentials for Push and Chat channel providers can be added while creating a new subscriber using the `channels` field in the [create subscriber](/api-reference/subscribers/create-a-subscriber) request payload.
   </Accordion>
+
+  <Accordion title="Should I create subscribers ahead of time or rely on just-in-time creation on trigger?">
+    For most apps, rely on **just-in-time (JIT) creation** when you trigger workflows. Novu upserts subscriber details on every trigger, so passing `to: { subscriberId, email, firstName, locale, timezone }` keeps profiles up to date without separate create or update calls.
+
+    Create subscribers ahead of time when you need to manage preferences, enrich profiles, or inspect delivery readiness before any notification is sent—for example during onboarding or bulk migration. See [Just in time](/platform/concepts/subscribers#just-in-time) and [Ahead of trigger](/platform/concepts/subscribers#ahead-of-trigger) for both patterns.
+  </Accordion>
 </AccordionGroup>

--- a/docs/platform/developer/environments.mdx
+++ b/docs/platform/developer/environments.mdx
@@ -85,3 +85,17 @@ You can promote changes to other environments by following these steps:
 4. Select the checkboxes next to the workflows that you want to publish. A menu appears, showing all the available workflows.
    ![Publish changes](/images/developer-tools/publish-changes-modal.png)
 5. Click the publish button to publish the selected workflows to the selected environment.
+
+## Frequently asked questions
+
+Frequently asked questions related to managing environments:
+
+<AccordionGroup>
+  <Accordion title="Why don't I see the Publish changes button?">
+    The **Publish changes** button only appears when you are in the **Development** environment. If you are already in Development and still do not see it, your organization role may not include permission to publish.
+
+    Publishing requires the **Admin** or **Owner** role. Members with the **Author** or **Viewer** role can create and edit workflows in Development, but they cannot publish those changes to Production or other environments.
+
+    Ask your organization owner or an admin to update your role from the [Team settings](https://dashboard.novu.co/settings/team) page. See [Roles and permissions](/platform/account/roles-and-permissions) for the full permissions matrix.
+  </Accordion>
+</AccordionGroup>

--- a/docs/platform/inbox/configuration/inbox-with-context.mdx
+++ b/docs/platform/inbox/configuration/inbox-with-context.mdx
@@ -9,6 +9,10 @@ _Contexts_ let you scope each `<Inbox />` instance to a specific environment, te
   If you’re new to contexts, start from [Contexts](/platform/concepts/contexts) to understand how contexts are created, managed in Novu, and used in workflows.
 </Note>
 
+<Warning>
+  **Context on triggers must match context on `<Inbox />`.** By default, an Inbox initialized without a `context` prop only shows notifications triggered **without** context. If you add `context` to workflow triggers but do not pass the same context to `<Inbox />`, in-app jobs can still report success while notifications never appear in that Inbox session.
+</Warning>
+
 ## How context works in `<Inbox/>`
 
 The [`<Inbox />`](/platform/inbox/configuration/inbox-with-context) uses exact-match context filtering to determine which notifications to display. This means the context provided to the [`<Inbox />`](/platform/inbox/configuration/inbox-with-context) must match all the key-value pairs of the context used when the workflow was triggered.
@@ -135,3 +139,22 @@ const context = {
 <Note>
   Learn how to secure your [`<Inbox />`](/platform/inbox/configuration/inbox-with-context) with HMAC encryption, refer to the [Prepare for Production](/platform/inbox/prepare-for-production) documentation.
 </Note>
+
+## Frequently asked questions
+
+Frequently asked questions related to context in the Inbox component.
+<AccordionGroup>
+  <Accordion title="Why are in-app notifications sent successfully but not showing in the Inbox?">
+    The Inbox uses **exact-match** context filtering. The `context` prop on `<Inbox />` must match the context used when the workflow was triggered, key for key and value for value.
+
+    A common cause: you started passing `context` on workflow triggers but did not update `<Inbox />` to use the same context. The in-app channel job can still complete with status "Success" in the activity feed, but the notification is scoped to a different context and will not appear in an Inbox session that does not match.
+
+    Check that:
+
+    1. If you trigger **with** context, initialize `<Inbox />` with the **same** context.
+    2. If you trigger **without** context, do not pass a `context` prop to `<Inbox />`.
+    3. When a user switches tenants or orgs in your app, re-render `<Inbox />` with the updated context.
+
+    See the context matching table above for all combinations.
+  </Accordion>
+</AccordionGroup>

--- a/docs/platform/integrations/chat/slack.mdx
+++ b/docs/platform/integrations/chat/slack.mdx
@@ -35,6 +35,11 @@ This guide walks you through setting up Slack chat, connect workspaces, and deli
 
 Before integrating Slack chat with Novu, you must create and configure a Slack app. The Slack app manages the OAuth permissions, bot token scopes, and redirect URLs needed for Novu to connect to your users' workspaces securely.
 
+<Warning>
+  **Token rotation is not supported.** Novu does not currently support Slack apps with **token rotation** enabled. If token rotation is turned on in your Slack app settings, bot tokens expire after about 12 hours and message delivery fails with errors such as `token_revoked` or `invalid_auth` until the workspace is manually reconnected.
+  Keep token rotation **disabled** on your Slack app until this is supported. Reach out to support@novu.co if this is a blocker for your usecase.
+</Warning>
+
 ### Create a Slack app
 First, you need to create a Slack app. This provides you with the credential you need to create a Slack integration in Novu.
 

--- a/docs/platform/sdks/react-native.mdx
+++ b/docs/platform/sdks/react-native.mdx
@@ -7,8 +7,7 @@ description: 'Learn how to add Novu powered Inbox to your React Native app'
 You can build your own Inbox UI with Novu's React Native hooks SDK. Novu will take care of data fetching will help you build a fully custom notification-center UI.
 
 <Note>
-  View our [React Native Expo Template](https://github.com/novuhq/novu-expo) for a live example of
-  the inbox in action.
+  Novu provides hooks to build a custom Inbox UI for react-native applications. Pre built `Inbox` component for react-native is currently not available. View our [React Native Expo Template](https://github.com/novuhq/novu-expo) for a live example on how to use hooks exposed by `@novu/react-native` SDK to build your own Inbox UI.
 </Note>
 
 <Steps>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds documentation guidance for common Novu setup questions. The main changes are:

- New context FAQs about trigger-time data, context updates, and Inbox visibility.
- New subscriber FAQ comparing just-in-time creation with ahead-of-trigger creation.
- New environments FAQ explaining when **Publish changes** appears and which roles can publish.
- New Inbox context warning and FAQ for exact-match context filtering.
- New Slack warning that token rotation is not currently supported.
- Updated React Native SDK note clarifying that it provides hooks, not a prebuilt Inbox component.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changes are scoped to explanatory MDX content and align with the surrounding documentation and referenced concepts.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the corresponding review comment.
- T-Rex performed docs validation by running markdownlint and Mintlify checks, captured blockers to preview, and verified with git status that no MDX files were modified.

<a href="https://app.greptile.com/trex/runs/13816893/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/platform/concepts/contexts.mdx | Adds context FAQs clarifying trigger-time context data behavior and Inbox context matching. |
| docs/platform/concepts/subscribers.mdx | Adds a subscriber FAQ explaining just-in-time creation versus creating subscribers ahead of trigger. |
| docs/platform/developer/environments.mdx | Adds an environments FAQ about Publish changes visibility and required Admin or Owner permissions. |
| docs/platform/inbox/configuration/inbox-with-context.mdx | Adds a warning and FAQ reinforcing exact-match context behavior for Inbox notification visibility. |
| docs/platform/integrations/chat/slack.mdx | Adds a Slack integration warning that token rotation is unsupported and causes token-expiry delivery failures. |
| docs/platform/sdks/react-native.mdx | Updates the React Native note to clarify that the SDK exposes hooks and does not provide a prebuilt Inbox component. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Dev as Developer
participant Docs as Novu docs
participant API as Novu API
participant Inbox as Inbox
participant Slack as Slack integration

Dev->>Docs: Read new FAQs and warnings
Docs-->>Dev: Explain subscriber JIT, contexts, environments, Slack, React Native
Dev->>API: Trigger workflow with subscriber/context guidance
API-->>Inbox: Deliver notifications matching Inbox context
Dev->>Slack: Configure Slack app without token rotation
Slack-->>API: Stable bot token delivery path
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Dev as Developer
participant Docs as Novu docs
participant API as Novu API
participant Inbox as Inbox
participant Slack as Slack integration

Dev->>Docs: Read new FAQs and warnings
Docs-->>Dev: Explain subscriber JIT, contexts, environments, Slack, React Native
Dev->>API: Trigger workflow with subscriber/context guidance
API-->>Inbox: Deliver notifications matching Inbox context
Dev->>Slack: Configure Slack app without token rotation
Slack-->>API: Stable bot token delivery path
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Changed FAQ MDX fails the requested markdownlint validation**

   - **Bug**
     - The exact requested markdownlint command exits 1 on the six changed documentation files. Some failures are pre-existing style issues in these files, but the changed FAQ content also introduces or leaves lint violations in the newly added FAQ sections: `docs/platform/concepts/subscribers.mdx:681` lacks the required blank line after the `## Frequently asked questions` heading, `docs/platform/concepts/subscribers.mdx:708` is reported as an indented code-block style violation inside the new FAQ accordion, and `docs/platform/integrations/chat/slack.mdx:1565` reports `MD044/proper-names` because the new agent content uses lowercase `markdown` instead of `Markdown`.
   - **Cause**
     - The added FAQ/content sections were not formatted to satisfy the repository's markdownlint rules, and the requested docs lint check is enforced against the changed MDX files.
   - **Fix**
     - Update the changed MDX so new FAQ/content additions satisfy markdownlint: add a blank line after `## Frequently asked questions` in `subscribers.mdx`, adjust the multiline FAQ accordion content around line 708 so markdownlint no longer treats it as an indented code block, and capitalize `Markdown` in `slack.mdx` line 1565. Then rerun the exact markdownlint command and address remaining violations or explicitly scope/waive pre-existing unrelated lint debt.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(docs): add FAQs for contexts, subsc..."](https://github.com/novuhq/novu/commit/27299c63261225af00ef16dc2675f29e6640b708) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42966617)</sub>

<!-- /greptile_comment -->