### PR TITLE
docs(docs): add Postman collection references to SDK and API pages fixes DOC-412

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -12,7 +12,7 @@ The Novu REST API lets you manage subscribers, trigger workflows, configure inte
 - [Create a workflow](/api-reference/workflows/create-a-workflow) — define a notification workflow programmatically
 - [Authentication](/api-reference/authentication) — authenticate requests with your secret API key
 
-Use the API directly with HTTP requests, or through one of our [server-side SDKs](/platform/sdks#server-side-sdks).
+Use the API directly with HTTP requests, through one of our [server-side SDKs](/platform/sdks#server-side-sdks), or with our official [Postman collection](https://github.com/novuhq/novu-postman).
 
 <Note>
   The REST API and server-side SDKs are intended for server-side applications only. Using them in client-side code causes Cross-Origin Resource Sharing (CORS) errors and exposes your secret key.
@@ -78,8 +78,8 @@ Use these resources to explore, test, and integrate with the API:
   <Card title="OpenAPI specification" icon="file-json" href="https://api.novu.co/openapi.json">
     Machine-readable API schema for code generation, validation, and tooling.
   </Card>
-  <Card title="Postman collection" icon="send" href="https://github.com/novuhq/novu-postman/blob/main/postman/novu_api_postman_collection.json">
-    Pre-built requests to test endpoints in Postman or compatible tools.
+  <Card title="Postman collection" icon="send" href="https://github.com/novuhq/novu-postman">
+    Official Postman collection with pre-built requests for every endpoint.
   </Card>
   <Card title="Server-side SDKs" icon="code" href="/platform/sdks#server-side-sdks">
     Official SDKs for TypeScript, Python, Go, PHP, .NET, and Java.
@@ -97,9 +97,13 @@ Use these resources to explore, test, and integrate with the API:
 
 ### Import the Postman collection
 
-1. Clone or download the [novu-postman](https://github.com/novuhq/novu-postman) repository.
-2. Import `postman/novu_api_postman_collection.json` into Postman.
+The [novu-postman](https://github.com/novuhq/novu-postman) repository contains the official Novu API Postman collection, kept in sync with the REST API.
+
+1. Clone or download the repository from [github.com/novuhq/novu-postman](https://github.com/novuhq/novu-postman).
+2. Import `postman/novu_api_postman_collection.json` into Postman (or any compatible client).
 3. Set the `secretKey` collection variable to your environment's secret key from the [API Keys](https://dashboard.novu.co/api-keys) page.
+
+You can also import the collection directly from the raw JSON file: [novu_api_postman_collection.json](https://github.com/novuhq/novu-postman/blob/main/postman/novu_api_postman_collection.json).
 
 ## Getting started
 
@@ -108,7 +112,7 @@ Use these resources to explore, test, and integrate with the API:
     Copy your environment's secret key from the [Novu Dashboard](https://dashboard.novu.co/api-keys). See [Authentication](/api-reference/authentication) for details on credential types and security.
   </Step>
   <Step title="Make your first request">
-    Trigger a workflow or create a subscriber using the REST API or an SDK. Start with [Trigger event](/api-reference/events/trigger-event) or [Create a subscriber](/api-reference/subscribers/create-a-subscriber).
+    Trigger a workflow or create a subscriber using the REST API, a [server-side SDK](/platform/sdks#server-side-sdks), or the [Postman collection](https://github.com/novuhq/novu-postman). Start with [Trigger event](/api-reference/events/trigger-event) or [Create a subscriber](/api-reference/subscribers/create-a-subscriber).
   </Step>
   <Step title="Review API policies">
     Understand [Errors](/api-reference/errors), [Pagination](/api-reference/pagination), [Rate limiting](/api-reference/rate-limiting), [Idempotency](/api-reference/idempotency), and [Payload limits](/api-reference/payload-limits) before building production integrations.

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -103,7 +103,7 @@ The [novu-postman](https://github.com/novuhq/novu-postman) repository contains t
 2. Import `postman/novu_api_postman_collection.json` into Postman (or any compatible client).
 3. Set the `secretKey` collection variable to your environment's secret key from the [API Keys](https://dashboard.novu.co/api-keys) page.
 
-You can also import the collection directly from the raw JSON file: [novu_api_postman_collection.json](https://github.com/novuhq/novu-postman/blob/main/postman/novu_api_postman_collection.json).
+You can also import the collection directly from the raw JSON file: [novu_api_postman_collection.json](https://raw.githubusercontent.com/novuhq/novu-postman/refs/heads/main/postman/novu_api_postman_collection.json).
 
 ## Getting started
 

--- a/docs/api-reference/authentication.mdx
+++ b/docs/api-reference/authentication.mdx
@@ -40,6 +40,10 @@ const novu = new Novu({
   Do not hardcode credentials in source code. Store your secret key in environment variables or a secrets manager.
 </Warning>
 
+### Test with Postman
+
+To send authenticated requests in Postman, import the [official Postman collection](https://github.com/novuhq/novu-postman) and set the `secretKey` collection variable to your environment's secret key. See [Import the Postman collection](/api-reference#import-the-postman-collection) for setup steps.
+
 ## Credential types
 
 Each Novu environment has two credentials. Use the right one for the context:

--- a/docs/platform/sdks.mdx
+++ b/docs/platform/sdks.mdx
@@ -10,6 +10,10 @@ description: "Browse Novu's official and community SDKs for Node, Python, Go, PH
 
 Novu's server-side SDKs simplify the integration with Novu's REST API.
 
+<Note>
+  Prefer to explore the API before installing an SDK? Import the official [Postman collection](https://github.com/novuhq/novu-postman) to test endpoints interactively. See [Import the Postman collection](/api-reference#import-the-postman-collection) in the API reference.
+</Note>
+
 #### Offical SDKs maintained by Novu:
 
 <Columns cols={2}>

--- a/docs/platform/sdks/server.mdx
+++ b/docs/platform/sdks/server.mdx
@@ -8,6 +8,10 @@ description: "Explore Novu's comprehensive collection of server-side SDKs for se
 
 Novu's server-side SDKs simplify the integration with Novu's REST API.
 
+<Note>
+  Prefer to explore the API before installing an SDK? Import the official [Postman collection](https://github.com/novuhq/novu-postman) to test endpoints interactively. See [Import the Postman collection](/api-reference#import-the-postman-collection) in the API reference.
+</Note>
+
 ### Offical SDKs maintained by Novu:
 
 <Columns cols={2}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added references to the official [novu-postman](https://github.com/novuhq/novu-postman) repository so users can easily find and import the Postman collection when exploring the REST API.

**Pages updated:**
- **SDK overview** (`/platform/sdks`) — Note linking to the Postman collection before the server SDK list
- **Server SDK overview** (`/platform/sdks/server`) — Same Note for server-side SDK users
- **API reference overview** (`/api-reference`) — Mention in intro, updated developer resources card to link to the GitHub repo, expanded import instructions, and Postman option in getting started steps
- **Authentication** (`/api-reference/authentication`) — New "Test with Postman" section with setup pointer

### Screenshots

N/A — documentation-only change.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1783589395805819?thread_ts=1783589395.805819&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-a71af7c5-5e0c-5535-80be-326db2fcb130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a71af7c5-5e0c-5535-80be-326db2fcb130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds official Postman collection references to Novu API and SDK documentation. The main changes are:

- Added Postman collection links to the API reference overview.
- Expanded the Postman import instructions with the corrected raw JSON URL.
- Added a Postman authentication setup note.
- Added Postman discovery notes to the SDK overview pages.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The changes are documentation-only, use valid MDX patterns, and the previously reported raw URL issue is fixed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the before-state proof captured in the before log to confirm there were no Postman or novu-postman references in the base HEAD.
- Validated the after-state proof captured in the after log showing that the four changed files now include the required guidance and official links.
- Audited the direct grep/diff evidence in the direct checks log to confirm the exact changes are present as intended.
- Reviewed the preview and markdown lint results to ensure the preview could proceed and the Markdown guidance passes lint.

<a href="https://app.greptile.com/trex/runs/13823075/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/api-reference.mdx | Adds Postman collection references, import guidance, and getting-started options using the corrected raw JSON URL. |
| docs/api-reference/authentication.mdx | Adds a short Postman authentication setup section that points to the shared import instructions. |
| docs/platform/sdks.mdx | Adds a note directing SDK overview readers to the official Postman collection before installing SDKs. |
| docs/platform/sdks/server.mdx | Adds the same Postman discovery note to the server-side SDK overview. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(docs): use raw URL for Postman coll..."](https://github.com/novuhq/novu/commit/386cff47f3a02ca03968f0efd9f8461f9ccdbc1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42968994)</sub>

<!-- /greptile_comment -->