### PR TITLE
refactor(api-service): consolidate tool trust to agent_tool_trust fixes NV-8247

### DIFF
--- a/apps/api/src/app/agents/managed-runtime/tool-approval/tool-trust.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/tool-trust.service.ts
@@ -1,17 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { type PendingToolApproval, PinoLogger } from '@novu/application-generic';
+import { type PendingToolApproval } from '@novu/application-generic';
 import {
-  AgentMcpServerRepository,
   AgentRepository,
   AgentToolTrustRepository,
   type AgentToolTrustState,
   DEFAULT_TOOL_TRUST_POLICY,
-  McpConnectionRepository,
   SubscriberRepository,
   type ToolTrust,
   type ToolTrustPolicy,
 } from '@novu/dal';
-import { resolveMcpCatalogIdByName } from '@novu/shared';
 import type { ToolTrustTarget } from '../../shared/tool-approval/action-id';
 
 @Injectable()
@@ -19,13 +16,8 @@ export class ToolTrustService {
   constructor(
     private readonly agentToolTrustRepository: AgentToolTrustRepository,
     private readonly agentRepository: AgentRepository,
-    private readonly subscriberRepository: SubscriberRepository,
-    private readonly agentMcpServerRepository: AgentMcpServerRepository,
-    private readonly mcpConnectionRepository: McpConnectionRepository,
-    private readonly logger: PinoLogger
-  ) {
-    this.logger.setContext(this.constructor.name);
-  }
+    private readonly subscriberRepository: SubscriberRepository
+  ) {}
 
   /**
    * Split a batch of pending tool approvals for one `(agent, subscriber)` into
@@ -55,41 +47,12 @@ export class ToolTrustService {
       subscriberId: subscriberMongoId,
     });
 
-    // Working copy of the stored trust. The legacy backfill below may hydrate it
-    // in-memory so every tool in this batch resolves through the unified path.
     const trust: AgentToolTrustState = row?.trust ?? {};
 
     const autoApprovedTools: PendingToolApproval[] = [];
     const pendingApprovalTools: PendingToolApproval[] = [];
-    const legacyMigratedServers = new Set<string>();
 
     for (const tool of params.tools) {
-      const mcpServerName = tool.mcpServerName;
-
-      // First touch of an MCP server with no unified entry: pull its trust over
-      // from the legacy store once, then resolve the whole batch against it.
-      if (mcpServerName && !trust.mcp?.[mcpServerName] && !legacyMigratedServers.has(mcpServerName)) {
-        legacyMigratedServers.add(mcpServerName);
-
-        // Best-effort: a failed backfill must never block delivery of the
-        // approval card, so on any error we just leave the tool pending.
-        try {
-          const bucket = await this.backfillLegacyMcpTrust({
-            environmentId: params.environmentId,
-            organizationId: params.organizationId,
-            agentId: agentMongoId,
-            subscriberId: subscriberMongoId,
-            mcpServerName,
-          });
-
-          if (bucket) {
-            trust.mcp = { ...(trust.mcp ?? {}), [mcpServerName]: bucket };
-          }
-        } catch (error) {
-          this.logger.warn(error, 'Legacy MCP tool trust backfill failed; leaving tool pending approval');
-        }
-      }
-
       if (this.isToolTrusted(trust, tool)) {
         autoApprovedTools.push(tool);
       } else {
@@ -98,81 +61,6 @@ export class ToolTrustService {
     }
 
     return { autoApprovedTools, pendingApprovalTools };
-  }
-
-  /**
-   * TEMPORARY pre-migration backfill: the first time we see an MCP server with
-   * no entry in the unified `agent_tool_trust` store, copy its trust bucket over
-   * from the legacy `mcp_connection.toolTrust` store (verbatim) and return it so
-   * the caller can resolve the current batch against it. After this copy the
-   * unified store owns the data, so legacy is read at most once per server.
-   *
-   * Remove this method (and the two MCP repositories it uses) once the legacy
-   * `mcp_connection.toolTrust` data has been fully backfilled and the field has
-   * been dropped from the schema.
-   */
-  private async backfillLegacyMcpTrust(params: {
-    environmentId: string;
-    organizationId: string;
-    agentId: string;
-    subscriberId: string;
-    mcpServerName: string;
-  }): Promise<ToolTrust | undefined> {
-    const enablement = await this.findLegacyEnablement(params);
-    if (!enablement) {
-      return undefined;
-    }
-
-    const connection = await this.mcpConnectionRepository.findSubscriberConnection({
-      organizationId: params.organizationId,
-      environmentId: params.environmentId,
-      agentMcpServerId: enablement._id,
-      subscriberId: params.subscriberId,
-    });
-
-    const legacyBucket = connection?.toolTrust;
-    if (!legacyBucket || (legacyBucket.serverDefault === undefined && !legacyBucket.tools)) {
-      return undefined;
-    }
-
-    const bucket: ToolTrust = { serverDefault: legacyBucket.serverDefault, tools: legacyBucket.tools };
-
-    // Single atomic write so a multi-tool bucket can never be left partially copied.
-    await this.agentToolTrustRepository.setMcpServerTrust({
-      environmentId: params.environmentId,
-      organizationId: params.organizationId,
-      agentId: params.agentId,
-      subscriberId: params.subscriberId,
-      mcpServerName: params.mcpServerName,
-      bucket,
-    });
-
-    return bucket;
-  }
-
-  /**
-   * Match an enabled MCP row for the pending server name. Mirrors the legacy
-   * resolver: prefer the provider-projected name, then fall back to the catalog
-   * name — so renamed/projected servers still migrate their trust.
-   */
-  private async findLegacyEnablement(params: {
-    environmentId: string;
-    organizationId: string;
-    agentId: string;
-    mcpServerName: string;
-  }) {
-    const enablements = await this.agentMcpServerRepository.findOAuthEnablementsForAgent({
-      organizationId: params.organizationId,
-      environmentId: params.environmentId,
-      agentId: params.agentId,
-    });
-    const catalogId = resolveMcpCatalogIdByName(params.mcpServerName);
-
-    return enablements.find(
-      (row) =>
-        row.externalProjection?.mcpServerName === params.mcpServerName ||
-        (catalogId !== undefined && row.mcpId === catalogId)
-    );
   }
 
   /**

--- a/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.ts
+++ b/apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.ts
@@ -25,7 +25,7 @@ export interface McpOAuthState {
   userId?: string;
   /** Where the OAuth URL was generated — round-trips for consistent callback attribution. */
   source?: 'api' | 'user_chat';
-  /** When set, persist server-wide tool auto-approve on the connection after OAuth succeeds. */
+  /** When set, persist server-wide tool auto-approve in `agent_tool_trust` after OAuth succeeds. */
   trustToolsOnConnect?: boolean;
 
   // ── Session resume fields (source: 'user_chat') ──────────────────────

--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
@@ -14,6 +14,7 @@ import {
 import {
   AgentMcpServerRepository,
   AgentRepository,
+  AgentToolTrustRepository,
   EnvironmentRepository,
   IntegrationRepository,
   McpConnectionEntity,
@@ -88,6 +89,7 @@ export class McpOAuthCallback {
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly mcpConnectionRepository: McpConnectionRepository,
+    private readonly agentToolTrustRepository: AgentToolTrustRepository,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly discoveryService: McpOAuthDiscoveryService,
     private readonly mcpConnectionVaultService: McpConnectionVaultService,
@@ -330,10 +332,6 @@ export class McpOAuthCallback {
       connectedAt: new Date(),
     };
 
-    if (stateData.trustToolsOnConnect) {
-      $set['toolTrust.serverDefault'] = 'always_allow';
-    }
-
     await this.mcpConnectionRepository.update(
       {
         _id: claimed._id,
@@ -345,6 +343,38 @@ export class McpOAuthCallback {
         $unset: { oauthState: 1, lastError: 1 },
       }
     );
+
+    if (stateData.trustToolsOnConnect) {
+      await this.persistToolTrustOnConnect(stateData);
+    }
+  }
+
+  private async persistToolTrustOnConnect(stateData: McpOAuthState): Promise<void> {
+    const catalog = MCP_SERVERS.find((entry) => entry.id === stateData.mcpId);
+    if (!catalog?.name) {
+      this.logger.warn(
+        { mcpId: stateData.mcpId, agentId: stateData.agentId, subscriberId: stateData.subscriberId },
+        'Connect & auto-approve skipped: MCP catalog name not found'
+      );
+
+      return;
+    }
+
+    try {
+      await this.agentToolTrustRepository.setMcpServerTrust({
+        environmentId: stateData.environmentId,
+        organizationId: stateData.organizationId,
+        agentId: stateData.agentId,
+        subscriberId: stateData.subscriberId,
+        mcpServerName: catalog.name,
+        bucket: { serverDefault: 'always_allow' },
+      });
+    } catch (err) {
+      this.logger.warn(
+        err,
+        'Failed to persist server-wide tool trust after Connect & auto-approve; OAuth connect still succeeded'
+      );
+    }
   }
 
   private async runPostConnectSafe(

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
@@ -158,17 +158,6 @@ export interface McpConnectionLastError {
   at: Date;
 }
 
-export type McpToolTrustPolicy = 'always_ask' | 'always_allow';
-
-export const DEFAULT_MCP_TOOL_TRUST_POLICY: McpToolTrustPolicy = 'always_ask';
-
-export type McpToolTrust = {
-  /** Applies to all tools from this MCP server for this subscriber. */
-  serverDefault?: McpToolTrustPolicy;
-  /** Per-tool overrides keyed by MCP tool name (e.g. "list_issues"). */
-  tools?: Record<string, McpToolTrustPolicy>;
-};
-
 /**
  * OAuth state for a (scope, mcp, owner) tuple.
  *
@@ -223,9 +212,6 @@ export class McpConnectionEntity {
   oauthClient?: McpConnectionOAuthClient;
 
   lastError?: McpConnectionLastError;
-
-  /** Subscriber-scoped auto-approve prefs for MCP tool calls. */
-  toolTrust?: McpToolTrust;
 
   connectedAt?: string;
 

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
@@ -3,7 +3,7 @@ import { FilterQuery } from 'mongoose';
 
 import type { EnforceEnvOrOrgIds } from '../../types';
 import { BaseRepositoryV2 } from '../base-repository-v2';
-import { McpConnectionDBModel, McpConnectionEntity, McpToolTrust } from './mcp-connection.entity';
+import { McpConnectionDBModel, McpConnectionEntity } from './mcp-connection.entity';
 import { McpConnection } from './mcp-connection.schema';
 
 export class McpConnectionRepository extends BaseRepositoryV2<
@@ -204,39 +204,6 @@ export class McpConnectionRepository extends BaseRepositoryV2<
     return result.modified > 0;
   }
 
-  async mergeToolTrust(params: {
-    connectionId: string;
-    environmentId: string;
-    organizationId: string;
-    patch: Partial<McpToolTrust>;
-  }): Promise<void> {
-    const $set: Record<string, unknown> = {};
-
-    if (params.patch.serverDefault !== undefined) {
-      $set['toolTrust.serverDefault'] = params.patch.serverDefault;
-    }
-
-    if (params.patch.tools) {
-      for (const [toolName, policy] of Object.entries(params.patch.tools)) {
-        assertSafeMcpToolTrustKeySegment(toolName);
-        $set[`toolTrust.tools.${toolName}`] = policy;
-      }
-    }
-
-    if (Object.keys($set).length === 0) {
-      return;
-    }
-
-    await this.update(
-      {
-        _id: params.connectionId,
-        _environmentId: params.environmentId,
-        _organizationId: params.organizationId,
-      },
-      { $set }
-    );
-  }
-
   /**
    * Repoint every subscriber-scoped connection from `fromSubscriberId` to
    * `toSubscriberId` (both Mongo `Subscriber._id`s). Used by the email adoption
@@ -309,12 +276,5 @@ export class McpConnectionRepository extends BaseRepositoryV2<
     }
 
     return { moved: movedIds.length, dropped: droppedIds.length };
-  }
-}
-
-function assertSafeMcpToolTrustKeySegment(name: string): void {
-  // Stored as toolTrust.tools.{name}; `.` and `$` would corrupt the Mongo update path.
-  if (name.includes('.') || name.includes('$') || name.includes('\0')) {
-    throw new Error(`Invalid MCP tool name for trust persistence: ${name}`);
   }
 }

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
@@ -157,25 +157,6 @@ const oauthClientSchema = new Schema(
   { _id: false }
 );
 
-const toolTrustSchema = new Schema(
-  {
-    serverDefault: {
-      type: Schema.Types.String,
-      required: false,
-      enum: ['always_ask', 'always_allow'],
-    },
-    tools: {
-      type: Schema.Types.Map,
-      of: {
-        type: Schema.Types.String,
-        enum: ['always_ask', 'always_allow'],
-      },
-      required: false,
-    },
-  },
-  { _id: false }
-);
-
 const lastErrorSchema = new Schema(
   {
     code: {
@@ -274,10 +255,6 @@ const mcpConnectionSchema = new Schema<McpConnectionDBModel>(
     },
     lastError: {
       type: lastErrorSchema,
-      required: false,
-    },
-    toolTrust: {
-      type: toolTrustSchema,
       required: false,
     },
     connectedAt: {


### PR DESCRIPTION
## Summary

- Remove legacy `mcp_connection.toolTrust` field, types, and dead `mergeToolTrust` repository helper
- Drop lazy `backfillLegacyMcpTrust` bridge — `ToolTrustService` now reads only `agent_tool_trust`
- Redirect **Connect & auto-approve** OAuth (`trustToolsOnConnect`) to write `trust.mcp.{serverName}.serverDefault = always_allow` into `agent_tool_trust`

## Why

Approval-card persistence already writes to `agent_tool_trust`. The only remaining legacy write was OAuth connect auto-approve storing trust on `mcp_connection`. This completes the migration to a single source of truth keyed by `(agent, subscriber)`.

```mermaid
flowchart LR
  A[Approval card always allow] --> T[agent_tool_trust]
  B[Connect & auto-approve OAuth] --> T
  T --> R[partitionByTrust reads]
  M[mcp_connection] -->|auth tokens only| OAuth
```

## Impact

Subscribers with trust stored only on legacy `mcp_connection.toolTrust` (never backfilled) will be re-prompted on the approval card. Low expected volume.

## Test plan

- [x] `@novu/dal` builds cleanly
- [ ] Connect MCP via **Connect & auto-approve** → first tool call auto-approves without card
- [ ] Approve tool with **Always allow this tool** → subsequent calls skip card
- [ ] Approve tool with **Always allow {server}** → all tools from that MCP skip card
- [ ] Plain **Approve** (no persist) → card reappears on next call

Linear: https://linear.app/novu/issue/NV-8247

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the move to unified MCP tool trust storage. The main changes are:

- Removes legacy `mcp_connection.toolTrust` types, schema fields, and repository helpers.
- Stops lazy backfilling trust from `mcp_connection` during approval partitioning.
- Stores Connect and auto-approve OAuth grants in `agent_tool_trust` with a server-wide `always_allow` policy.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are focused on removing the legacy trust path and writing Connect and auto-approve grants through the existing unified trust repository.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the required shared and DAL build completed successfully with exit code 0.
- Generated a focused Mocha spec for Connect and auto-approve persistence using repository stubs.
- Encountered a blocker during the API harness run due to a missing module, which prevented the test body from executing (Cannot find module ... @novu/framework/dist/cjs/internal/index.cjs) and left the harness exit code at 1.

<a href="https://app.greptile.com/trex/runs/13825404/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/managed-runtime/tool-approval/tool-trust.service.ts | Removes legacy `mcp_connection.toolTrust` backfill and resolves approvals only from `agent_tool_trust`. |
| apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts | Redirects Connect and auto-approve persistence to `AgentToolTrustRepository.setMcpServerTrust`. |
| apps/api/src/app/agents/mcp/oauth/generate-mcp-oauth-url/mcp-oauth-state.ts | Updates the OAuth state comment to describe `agent_tool_trust` persistence. |
| libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts | Removes legacy MCP tool trust types and the entity field. |
| libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts | Drops the legacy `mergeToolTrust` helper and its local path-key validation. |
| libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts | Removes the `toolTrust` sub-schema from MCP connection documents. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant OAuth as MCP OAuth Callback
  participant Conn as mcp_connection
  participant Trust as agent_tool_trust
  participant Approval as ToolTrustService

  User->>OAuth: Complete Connect and auto approve OAuth
  OAuth->>Conn: Persist connected auth tokens
  alt trustToolsOnConnect
    OAuth->>Trust: Set MCP server default to always_allow
  end
  Approval->>Trust: Load agent subscriber trust row
  Approval-->>User: Auto approve trusted tools or show card
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant OAuth as MCP OAuth Callback
  participant Conn as mcp_connection
  participant Trust as agent_tool_trust
  participant Approval as ToolTrustService

  User->>OAuth: Complete Connect and auto approve OAuth
  OAuth->>Conn: Persist connected auth tokens
  alt trustToolsOnConnect
    OAuth->>Trust: Set MCP server default to always_allow
  end
  Approval->>Trust: Load agent subscriber trust row
  Approval-->>User: Auto approve trusted tools or show card
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(api-service): consolidate tool ..."](https://github.com/novuhq/novu/commit/7e4574d6708f7a76ba0939aaef4bb50f1d55c273) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42983176)</sub>

<!-- /greptile_comment -->