### PR TITLE
fix(dashboard): show subscriber email unmasked and scope credentials integrations fixes NV-8256

### DIFF
--- a/apps/dashboard/src/components/subscribers/credentials/credential-row.tsx
+++ b/apps/dashboard/src/components/subscribers/credentials/credential-row.tsx
@@ -53,10 +53,12 @@ function ReadonlyCard({
   onEditInOverview: (field: OverviewField) => void;
 }) {
   const [valuesVisible, setValuesVisible] = useState(false);
-  const emptyLabel = row.overviewField === 'email' ? 'Email address not set' : 'Phone number not set';
+  const isEmail = row.overviewField === 'email';
+  const emptyLabel = isEmail ? 'Email address not set' : 'Phone number not set';
   const fieldLabel = getOverviewFieldLabel(row.overviewField);
-  const displayValue = valuesVisible || !row.value ? row.value : maskCredentialValue(row.value);
-  const actionPaddingClass = row.hideProviderHeader ? 'pr-16' : 'pr-7';
+  const displayValue = isEmail || valuesVisible || !row.value ? row.value : maskCredentialValue(row.value);
+  const showVisibilityToggle = !isEmail && !!row.value;
+  const actionPaddingClass = row.hideProviderHeader ? (showVisibilityToggle ? 'pr-16' : 'pr-12') : 'pr-7';
 
   return (
     <div className="bg-bg-weak flex w-full flex-col gap-1.5 rounded-lg p-1.5">
@@ -64,7 +66,7 @@ function ReadonlyCard({
         <div className="flex min-h-7 items-center gap-1.5 px-0.5">
           <ProviderIcon providerId={row.providerId} providerDisplayName={row.displayName} className="size-5 shrink-0" />
           <span className="text-label-xs truncate font-medium text-text-strong">{row.displayName}</span>
-          {row.value && (
+          {showVisibilityToggle && (
             <div className="ml-auto flex shrink-0 items-center gap-1">
               <CredentialVisibilityToggle
                 visible={valuesVisible}
@@ -88,7 +90,7 @@ function ReadonlyCard({
                   CREDENTIAL_HOVER_ACTIONS_CLASS
                 )}
               >
-                {row.hideProviderHeader && (
+                {row.hideProviderHeader && showVisibilityToggle && (
                   <CredentialVisibilityToggle
                     visible={valuesVisible}
                     ariaLabel={`${row.displayName} credentials`}

--- a/apps/dashboard/src/components/subscribers/credentials/subscriber-credentials.tsx
+++ b/apps/dashboard/src/components/subscribers/credentials/subscriber-credentials.tsx
@@ -1,6 +1,7 @@
 import type { ChannelEndpointType } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/shared';
 import { formatDistanceToNow } from 'date-fns';
+import { useEnvironment } from '@/context/environment/hooks';
 import { useMemo, useState } from 'react';
 import { ExternalToast } from 'sonner';
 import type { ChannelEndpointPayload } from '@/api/channel-endpoints';
@@ -66,6 +67,7 @@ export function SubscriberCredentials({
   readOnly = false,
   onEditInOverview,
 }: SubscriberCredentialsProps) {
+  const { currentEnvironment } = useEnvironment();
   const { data: subscriber, isPending: isSubscriberPending } = useFetchSubscriber({ subscriberId });
   const { integrations, isPending: isIntegrationsPending } = useFetchIntegrations();
   const { channelEndpoints, isPending: isEndpointsPending } = useFetchChannelEndpoints({
@@ -85,6 +87,14 @@ export function SubscriberCredentials({
   const { deleteChannelEndpoint, isPending: isEndpointDeletePending } = useDeleteChannelEndpoint();
   const { updateSubscriberCredentials, isPending: isCredentialsUpdatePending } = useUpdateSubscriberCredentials();
 
+  const environmentIntegrations = useMemo(() => {
+    if (!integrations || !currentEnvironment?._id) {
+      return [];
+    }
+
+    return integrations.filter((integration) => integration._environmentId === currentEnvironment._id);
+  }, [integrations, currentEnvironment?._id]);
+
   const groups = useMemo(() => {
     if (!subscriber) {
       return [];
@@ -92,11 +102,11 @@ export function SubscriberCredentials({
 
     return buildCredentialGroups({
       subscriber,
-      integrations: integrations ?? [],
+      integrations: environmentIntegrations,
       channelEndpoints,
       channelConnections,
     });
-  }, [subscriber, integrations, channelEndpoints, channelConnections]);
+  }, [subscriber, environmentIntegrations, channelEndpoints, channelConnections]);
 
   if (isSubscriberPending || isIntegrationsPending || isEndpointsPending || isConnectionsPending) {
     return <CredentialsSkeleton />;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two issues on the subscriber **Credentials** tab:

1. **Email always visible** — Subscriber email is no longer masked behind the eye toggle. It is shown in full at all times (phone numbers still support show/hide).
2. **Environment-scoped integrations** — Integration rows are filtered to the current environment only. The integrations API can return org-wide integrations across environments, which caused duplicate cards (e.g. two Firebase Cloud Messaging entries from dev + prod).

## Changes

- `credential-row.tsx`: Skip masking and visibility toggle for email readonly rows.
- `subscriber-credentials.tsx`: Filter `useFetchIntegrations()` results by `integration._environmentId === currentEnvironment._id` before building credential groups.

## Test plan

- [ ] Open a subscriber with an email set on the Credentials tab — email should be fully visible with no eye icon.
- [ ] Phone number on Credentials tab should still support show/hide masking.
- [ ] With push integrations in multiple environments, only the current environment's integration(s) should appear (no duplicates).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-229c0eab-b355-42a6-b097-e2088c8ee6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-229c0eab-b355-42a6-b097-e2088c8ee6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the subscriber Credentials tab behavior. The main changes are:

- Email readonly credential rows now show the full email without an eye toggle.
- Phone readonly credential rows keep their existing show and hide behavior.
- Subscriber credential groups now use integrations scoped to the current environment.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are small and localized to credential row rendering and integration filtering. No issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the Subscriber Credentials UI components and confirmed how email and phone rows render and toggle visibility, including environment-based filtering of integrations.
- Created harness artifacts for the credentials row UI and attempted to run a focused Vite-based test harness, addressing path and alias issues to enable a UI capture flow.
- Ran Playwright UI capture against the harness URL; the latest attempt reached the harness page but timed out waiting for the credentials harness element to appear, so no complete UI capture was produced.
- Documented remaining tasks and recommended next steps to run the dashboard test server with a route-mocking Playwright harness and save logs and screenshots in the artifacts collection.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/subscribers/credentials/credential-row.tsx | Updates readonly credential rendering so email values bypass masking and the visibility toggle while phone values retain hide/show behavior. |
| apps/dashboard/src/components/subscribers/credentials/subscriber-credentials.tsx | Filters fetched integrations to the current environment before building subscriber credential groups. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant UI as Subscriber Credentials tab
participant Env as Environment Context
participant Integrations as useFetchIntegrations
participant Builder as buildCredentialGroups
participant Rows as Credential Rows

UI->>Env: read current environment id
UI->>Integrations: fetch integrations
Integrations-->>UI: integrations list
UI->>UI: filter integrations by environment id
UI->>Builder: build groups with filtered integrations
Builder-->>Rows: credential groups
Rows-->>UI: render email unmasked and phone toggleable
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant UI as Subscriber Credentials tab
participant Env as Environment Context
participant Integrations as useFetchIntegrations
participant Builder as buildCredentialGroups
participant Rows as Credential Rows

UI->>Env: read current environment id
UI->>Integrations: fetch integrations
Integrations-->>UI: integrations list
UI->>UI: filter integrations by environment id
UI->>Builder: build groups with filtered integrations
Builder-->>Rows: credential groups
Rows-->>UI: render email unmasked and phone toggleable
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): show subscriber email un..."](https://github.com/novuhq/novu/commit/e533329f97d9811ebcc71d45c098ac4c3208faa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43005604)</sub>

<!-- /greptile_comment -->