### PR TITLE
chore(root): bump @novu/framework to 2.11.2-alpha.0 and novu CLI to 2.19.0-rc.1 fixes NV-8257

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.11.1",
+  "version": "2.11.2-alpha.0",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",
@@ -244,7 +244,7 @@
     "@nestjs/common": ">=10.0.0",
     "@sveltejs/kit": ">=1.27.3",
     "@vercel/node": ">=2.15.9",
-    "ai": "^7.0.0",
+    "ai": ">=7.0.0",
     "aws-lambda": ">=1.0.7",
     "express": ">=4.19.2",
     "h3": ">=1.8.1",

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.19.0-rc.0",
+  "version": "2.19.0-rc.1",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {


### PR DESCRIPTION
### What changed? Why was the change needed?

Version bump for two published packages:

- **`@novu/framework`**: `2.11.1` → `2.11.2-alpha.0`, and broadened the `ai` peer dependency range from `^7.0.0` to `>=7.0.0` (consistent with the other optional peers).
- **`novu` (CLI)**: `2.19.0-rc.0` → `2.19.0-rc.1`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates published package metadata for the framework and CLI packages. The main changes are:

- `@novu/framework` version moves from `2.11.1` to `2.11.2-alpha.0`.
- The optional `ai` peer dependency range changes from `^7.0.0` to `>=7.0.0`.
- The `novu` CLI version moves from `2.19.0-rc.0` to `2.19.0-rc.1`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are limited to package metadata version bumps and one intentional optional peer dependency range update.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the package manifest assertions to verify the COMMAND, CWD, and EXIT\_CODE reported for the manifest, confirming EXIT\_CODE: 0.
- Reviewed the manifest assertion script to confirm the executed checks align with the observed manifest results.
- Validated the frozen install by confirming pnpm install --frozen-lockfile completed with EXIT\_CODE: 0 and did not require a lockfile update.

<a href="https://app.greptile.com/trex/runs/13841516/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/package.json | Bumps `@novu/framework` to `2.11.2-alpha.0` and broadens the optional `ai` peer range; no issues found. |
| packages/novu/package.json | Bumps the `novu` CLI package version to `2.19.0-rc.1`; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump @novu/framework to ..."](https://github.com/novuhq/novu/commit/997387d706e92fb300710287477c66321971e799) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43016553)</sub>

<!-- /greptile_comment -->