### PR TITLE
fix(framework): use error.issues in ZodValidator for zod v4 compatibility

### DIFF
--- a/packages/framework/src/validators/validator.test.ts
+++ b/packages/framework/src/validators/validator.test.ts
@@ -331,6 +331,23 @@ describe('validators', () => {
       // @ts-expect-error - we are testing the type guard
       await expect(validateData(schema, {})).rejects.toThrow('Invalid schema');
     });
+
+    it('should return errors for a Zod v4 schema, whose error exposes only `issues`', async () => {
+      // Zod v4 removed the `error.errors` alias, leaving `error.issues` as the only array of issues.
+      const zodV4Schema = {
+        safeParseAsync: async () => ({
+          success: false,
+          error: { issues: [{ path: ['name'], message: 'Invalid input' }] },
+        }),
+      } as unknown as ZodSchema;
+
+      const result = await validateData(zodV4Schema, { name: 123 });
+
+      expect(result).toEqual({
+        success: false,
+        errors: [{ message: 'Invalid input', path: '/name' }],
+      });
+    });
   });
 
   describe('transformSchema', () => {

--- a/packages/framework/src/validators/zod.validator.ts
+++ b/packages/framework/src/validators/zod.validator.ts
@@ -45,7 +45,7 @@ export class ZodValidator implements Validator<ZodSchema> {
     } else {
       return {
         success: false,
-        errors: result.error.errors.map((err) => ({
+        errors: result.error.issues.map((err) => ({
           path: `/${err.path.join('/')}`,
           message: err.message,
         })),


### PR DESCRIPTION
## What changed? Why was the change needed?

Fixes #11758

`ZodValidator.validate` reads `result.error.errors` when validation fails. Zod v4 removed the `errors` alias from `ZodError` (only `issues` exists now), and since the framework's peer dependency range is `zod >=3.0.0`, any app on zod 4 crashes with `TypeError: Cannot read properties of undefined (reading 'map')` inside the validator — but only when schema validation actually fails, which is why it looked so sporadic in the issue. The stack trace in #11758 points exactly at this `.map` call, and the zod-4 users in #9416 hit the same thing.

The fix is to read `result.error.issues` instead. `issues` is the canonical array in zod v3 as well (`errors` was just a getter alias for it), so nothing changes for v3 users — the whole existing validator suite still passes.

Added a regression test with a zod-v4-shaped error object (only `issues`, no `errors`). It throws the reported TypeError on current `next` and passes with this change.

Note this is complementary to #11527, which updates the type imports for zod v4 but keeps the crashing `.errors` access at runtime.

## Screenshots

n/a

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Zod validation errors for Zod v4 users. The main changes are:

- `ZodValidator` now reads failed parse issues from `result.error.issues`.
- The framework still returns validation failures under its existing `errors` result field.
- A regression test covers a Zod v4-style error object with only `issues`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the zod validator regression test and saved a general-contract-validation-proof log that includes the command, working directory, timestamps, test output, and exit code.
- The focused validator test file for the zod-v4-shaped error-object regression completed successfully.

<a href="https://app.greptile.com/trex/runs/14084742/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/validators/zod.validator.ts | Updates the failed Zod parse branch to use the canonical `issues` array while preserving the framework error result shape. |
| packages/framework/src/validators/validator.test.ts | Adds test coverage for a Zod v4-shaped validation failure object that exposes `issues` without `errors`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(framework): use error.issues in ZodV..."](https://github.com/novuhq/novu/commit/7fe61e1e1016bff511f961ed88c44c12a4d6a0c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43498003)</sub>

<!-- /greptile_comment -->