### PR TITLE
docs(docs): add Nuxt Inbox quickstart with ClientOnly wrapper fixes DOC-414

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -66,6 +66,7 @@
                   "platform/quickstart/remix",
                   "platform/quickstart/angular",
                   "platform/quickstart/vue",
+                  "platform/quickstart/nuxt",
                   "platform/quickstart/vanilla-js"
                 ]
               }

--- a/docs/platform/quickstart/nuxt.mdx
+++ b/docs/platform/quickstart/nuxt.mdx
@@ -1,22 +1,22 @@
 ---
-title: 'Vue In-App Notifications Quickstart — Novu Inbox'
-description: "Create a Novu account and integrate the Novu Inbox component into your Vue application to display real-time in-app notifications for your subscribers."
-sidebarTitle: 'Vue'
+title: 'Nuxt In-App Notifications Quickstart — Novu Inbox'
+description: "Create a Novu account and integrate the Novu Inbox component into your Nuxt application to display real-time in-app notifications for your subscribers."
+sidebarTitle: 'Nuxt'
 ---
 
 
-Add real-time in-app notifications to Vue using the Novu Inbox component and the `@novu/js` SDK.
+Add real-time in-app notifications to Nuxt using the Novu Inbox component and the `@novu/js` SDK.
 
 <Note>
-  This guide uses @novu/js javascript sdk to build the Inbox component in Vue. Novu currently does not support native Vue Inbox component. For Nuxt applications, see the [Nuxt quickstart](/platform/quickstart/nuxt).
+  This guide uses the `@novu/js` JavaScript SDK to build the Inbox component in Nuxt. Novu currently does not support a native Nuxt Inbox component.
 </Note>
 
-<Prompt description="Add Novu Inbox to my Vue app" icon="sparkles" actions={["copy", "cursor"]}>
-# Add Novu Inbox to Vue App
+<Prompt description="Add Novu Inbox to my Nuxt app" icon="sparkles" actions={["copy", "cursor"]}>
+# Add Novu Inbox to Nuxt App
 
-Install `@novu/js`. Mount the Inbox in your header, navbar, or sidebar.
+Install `@novu/js`. Mount the Inbox in your header, navbar, or sidebar. Wrap the Inbox in `<ClientOnly>` because Nuxt renders with SSR by default and the Inbox is client-only.
 
-Latest docs: https://docs.novu.co/platform/quickstart/vue
+Latest docs: https://docs.novu.co/platform/quickstart/nuxt
 
 ## Install
 
@@ -26,21 +26,53 @@ npm install @novu/js
 
 ## Component
 
-```ts
+```vue
+<template>
+  <div ref="novuInbox"></div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
 import { NovuUI } from '@novu/js/ui';
 
-const novu = new NovuUI({
-  options: {
-    applicationIdentifier: 'YOUR_APPLICATION_IDENTIFIER',
-    subscriber: 'YOUR_SUBSCRIBER_ID',
-  },
+const novuInbox = ref<HTMLElement | null>(null);
+let novuInstance: NovuUI | null = null;
+
+onMounted(() => {
+  if (!novuInbox.value) return;
+
+  const novu = new NovuUI({
+    options: {
+      applicationIdentifier: 'YOUR_APPLICATION_IDENTIFIER',
+      subscriber: 'YOUR_SUBSCRIBER_ID',
+    },
+  });
+
+  novu.mountComponent({
+    name: 'Inbox',
+    props: {},
+    element: novuInbox.value,
+  });
+
+  novuInstance = novu;
 });
 
-novu.mountComponent({
-  name: 'Inbox',
-  props: {},
-  element: document.getElementById('notification-inbox'),
+onUnmounted(() => {
+  if (novuInstance && novuInbox.value) {
+    novuInstance.unmountComponent(novuInbox.value);
+  }
 });
+</script>
+```
+
+## Usage in Nuxt
+
+```vue
+<template>
+  <ClientOnly>
+    <NovuInbox />
+  </ClientOnly>
+</template>
 ```
 
 ## Subscriber ID
@@ -56,12 +88,14 @@ Extract design tokens from the host app and apply via the appearance configurati
 ALWAYS:
 
 - Detect the project's package manager and use it for installation
+- Wrap the Inbox in `<ClientOnly>` because Nuxt uses SSR by default
 - Mount the Inbox inline in existing UI — no new pages or wrappers
-- Follow Vue conventions (Composition API, existing project patterns)
+- Follow Nuxt conventions (Composition API, existing project patterns)
 - Use the existing auth system to source subscriberId when available
 
 NEVER:
 
+- Render the Inbox during server-side rendering
 - Create wrapper components or new pages just for the inbox
 - Add code comments
 - Introduce styles not in the host app
@@ -69,8 +103,9 @@ NEVER:
 ## Verify Before Responding
 
 1. Is `@novu/js` installed with the project's package manager?
-2. Is the Inbox mounted inline in existing UI?
-3. Is subscriberId sourced from the auth system when available?
+2. Is the Inbox wrapped in `<ClientOnly>`?
+3. Is the Inbox mounted inline in existing UI?
+4. Is subscriberId sourced from the auth system when available?
 
 If any fails, revise.
 </Prompt>
@@ -81,12 +116,12 @@ If any fails, revise.
     [Create a Novu account](https://dashboard.novu.co/auth/sign-up) or [sign in](https://dashboard.novu.co/auth/sign-in) to access the Novu dashboard.
   </Step>
 
-    <Step>
-  ### Create a Vue application
-    Run the following command to create a new Vue app:
+  <Step>
+  ### Create a Nuxt application
+    Run the following command to create a new Nuxt app:
 
     ```package-install
-    npm create vue@latest novu-inbox-vue
+    npx nuxi@latest init novu-inbox-nuxt
     ```
   </Step>
 
@@ -103,10 +138,51 @@ If any fails, revise.
 
   <Step>
   ### Add the Inbox component
-  Create the `src/components/NovuInbox.vue` file to add the Inbox component passing <Tooltip tip="The application identifier is a unique identifier for your application. You can find it in the Novu Dashboard under the API keys page.">applicationIdentifier</Tooltip> and <Tooltip tip="The subscriber ID is the unique identifier for the user in your application, typically the user's id in your database.">subscriberId</Tooltip>:
+  Create the `app/components/NovuInbox.vue` file to add the Inbox component passing <Tooltip tip="The application identifier is a unique identifier for your application. You can find it in the Novu Dashboard under the API keys page.">applicationIdentifier</Tooltip> and <Tooltip tip="The subscriber ID is the unique identifier for the user in your application, typically the user's id in your database.">subscriberId</Tooltip>:
+
+  ```vue title="app/components/NovuInbox.vue"
+  <template>
+    <div ref="novuInbox"></div>
+  </template>
+
+  <script setup lang="ts">
+  import { ref, onMounted, onUnmounted } from 'vue';
+  import { NovuUI } from '@novu/js/ui';
+
+  const novuInbox = ref<HTMLElement | null>(null);
+  let novuInstance: NovuUI | null = null;
+
+  onMounted(() => {
+    if (!novuInbox.value) {
+      return;
+    }
+
+    const novu = new NovuUI({
+      options: {
+        applicationIdentifier: 'YOUR_APPLICATION_IDENTIFIER',
+        subscriber: 'YOUR_SUBSCRIBER_ID',
+      },
+    });
+
+    novu.mountComponent({
+      name: 'Inbox',
+      props: {},
+      element: novuInbox.value,
+    });
+
+    novuInstance = novu;
+  });
+
+  onUnmounted(() => {
+    if (novuInstance && novuInbox.value) {
+      novuInstance.unmountComponent(novuInbox.value);
+    }
+  });
+  </script>
+  ```
 
   <Note>
-  Explore the full `vue-inbox` example in the [Novu examples repository](https://github.com/novuhq/novu).
+  Explore the full `nuxt-inbox` example in the [Novu examples repository](https://github.com/jainpawan21/novu-inbox-nuxt).
 </Note>
 
      If you're signed in to your Novu account, then the <Tooltip tip="The application identifier is a unique identifier for your application. You can find it in the Novu Dashboard under the API keys page.">applicationIdentifier</Tooltip> and <Tooltip tip="The subscriber ID is the unique identifier for the user in your application, typically the user's id in your database.">subscriberId</Tooltip> are automatically entered in the code sample above. Otherwise, you can manually retrieve them:
@@ -121,25 +197,33 @@ If any fails, revise.
 
   <Step>
   ### Add the Inbox component to your application
-  Import and use the `NovuInbox` component in `src/App.vue` file:
+  Import and use the `NovuInbox` component in `app/app.vue`. Wrap it with `<ClientOnly>` so the Inbox renders only in the browser. Nuxt enables SSR by default, and the Inbox does not support server-side rendering.
 
-  ```vue title="src/App.vue"
+  <Note>
+    This is similar to using `'use client'` in Next.js. Without `<ClientOnly>`, you may see errors such as `The requested module 'solid-js/web' does not provide an export named 'use'`.
+  </Note>
+
+  ```vue title="app/app.vue"
   <script setup lang="ts">
-
+  import NovuInbox from './components/NovuInbox.vue';
   </script>
 
   <template>
-    <NovuInbox />
+    <div>
+      <ClientOnly>
+        <NovuInbox />
+      </ClientOnly>
+    </div>
   </template>
   ```
   </Step>
 
   <Step>
-  ### Run Your Application
+  ### Run your application
   Start your development server:
 
   ```package-install
-  npm run start
+  npm run dev
   ```
   Once the application is running, a bell icon will appear on the top left side of the screen. Clicking it opens the notification inbox UI.
 
@@ -169,8 +253,8 @@ If any fails, revise.
   </Step>
 
   <Step>
-  ###  View the notification in your app
-  Go back to your Vue app, then click the bell icon.
+  ### View the notification in your app
+  Go back to your Nuxt app, then click the bell icon.
 
   You should see the notification you just sent from Novu! 🎉
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Adds a dedicated Nuxt Inbox quickstart that documents wrapping the `@novu/js` Inbox in Nuxt's `<ClientOnly>` component.

Nuxt enables SSR by default, but the Novu Inbox is client-only (similar to Next.js `'use client'`). Without `<ClientOnly>`, Nuxt users hit errors such as `The requested module 'solid-js/web' does not provide an export named 'use'` when following the Vue quickstart.

**Changes:**
- Added `docs/platform/quickstart/nuxt.mdx` with full setup steps, `NovuInbox.vue` example, and `app/app.vue` wrapped in `<ClientOnly>`
- Added the page to the Quickstart sidebar in `docs.json`
- Linked Nuxt users from the Vue quickstart to the new guide

**Context:** Support thread in #eng-and-support — customer could not use `@novu/js` in Nuxt until the Inbox was wrapped in `<ClientOnly>`.

### Screenshots

N/A — documentation-only change.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1759862746554409?thread_ts=1759862746.554409&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-5302ee55-8486-56b2-90f9-e7ed384c7342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5302ee55-8486-56b2-90f9-e7ed384c7342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Nuxt-specific Inbox quickstart for client-only rendering.

- Adds a new Nuxt quickstart page for `@novu/js` Inbox setup.
- Registers the Nuxt page in the quickstart sidebar.
- Links Nuxt users from the Vue quickstart note.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The preview proof of the docs UI rendering was reviewed, showing an ERR\_MODULE\_NOT\_FOUND error during the Mintlify dev attempt.
- The before-proof state was inspected, confirming that docs/platform/quickstart/nuxt.mdx was missing and the Vue quickstart lacked the Nuxt guide link.
- The after-proof and static validation results were inspected and confirmed the Nuxt sidebar entry, Vue link, and Nuxt ClientOnly/app.vue guidance were added.
- Artifacts documenting these states were uploaded and linked to the proof for reviewer access.

<a href="https://app.greptile.com/trex/runs/14138063/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Adds the Nuxt quickstart route to the existing quickstart navigation list. |
| docs/platform/quickstart/nuxt.mdx | Adds the Nuxt Inbox quickstart with installation, component setup, client-only usage, and notification trigger steps. |
| docs/platform/quickstart/vue.mdx | Adds a note that points Nuxt users to the new Nuxt quickstart. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docs): add Nuxt Inbox quickstart wi..."](https://github.com/novuhq/novu/commit/50fc5daedd8335b0bd52046e7c8c7a8ab4997ed4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43609403)</sub>

<!-- /greptile_comment -->