### PR TITLE
fix(api-service): scope env variable delete and reads to API key environment fixes NV-7642

### DIFF
--- a/apps/api/src/app/environment-variables/e2e/api-key-environment-scope.e2e.ts
+++ b/apps/api/src/app/environment-variables/e2e/api-key-environment-scope.e2e.ts
@@ -145,5 +145,123 @@ describe('Environment Variables API key environment scope - /environment-variabl
       expect(updated.values.some((value: { _environmentId: string }) => value._environmentId === prodEnvironmentId)).to
         .be.true;
     });
+
+    it('should filter list values to the API key environment', async () => {
+      await session.testAgent.post('/v1/environment-variables').send({
+        key: 'CROSS_ENV_READ_LIST',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-secret-ish' },
+        ],
+      });
+
+      const {
+        body: { data },
+      } = await session.testAgent
+        .get('/v1/environment-variables')
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      const variable = data.find((item: { key: string }) => item.key === 'CROSS_ENV_READ_LIST');
+
+      expect(variable).to.exist;
+      expect(variable.values).to.have.length(1);
+      expect(variable.values[0]._environmentId).to.equal(devEnvironmentId);
+      expect(variable.values[0].value).to.equal('dev-value');
+    });
+
+    it('should filter retrieve values to the API key environment', async () => {
+      await session.testAgent.post('/v1/environment-variables').send({
+        key: 'CROSS_ENV_READ_ONE',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-value' },
+        ],
+      });
+
+      const {
+        body: { data },
+      } = await session.testAgent
+        .get('/v1/environment-variables/CROSS_ENV_READ_ONE')
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      expect(data.values).to.have.length(1);
+      expect(data.values[0]._environmentId).to.equal(devEnvironmentId);
+      expect(data.values[0].value).to.equal('dev-value');
+    });
+
+    it('should allow bearer auth to read values across environments', async () => {
+      await session.testAgent.post('/v1/environment-variables').send({
+        key: 'BEARER_CROSS_ENV_READ',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-value' },
+        ],
+      });
+
+      const {
+        body: { data },
+      } = await session.testAgent.get('/v1/environment-variables/BEARER_CROSS_ENV_READ');
+
+      expect(data.values).to.have.length(2);
+    });
+
+    it('should delete only the API key environment value and preserve sibling values', async () => {
+      await session.testAgent.post('/v1/environment-variables').send({
+        key: 'CROSS_ENV_DELETE',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-value' },
+        ],
+      });
+
+      const deleteResponse = await session.testAgent
+        .delete('/v1/environment-variables/CROSS_ENV_DELETE')
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      expect(deleteResponse.status).to.equal(204);
+
+      const {
+        body: { data },
+      } = await session.testAgent.get('/v1/environment-variables/CROSS_ENV_DELETE');
+
+      expect(data.values).to.have.length(1);
+      expect(data.values[0]._environmentId).to.equal(prodEnvironmentId);
+      expect(data.values[0].value).to.equal('prod-value');
+    });
+
+    it('should fully remove the variable when API key deletes the last environment value', async () => {
+      await session.testAgent.post('/v1/environment-variables').send({
+        key: 'LAST_ENV_DELETE',
+        values: [{ _environmentId: devEnvironmentId, value: 'dev-only-value' }],
+      });
+
+      const deleteResponse = await session.testAgent
+        .delete('/v1/environment-variables/LAST_ENV_DELETE')
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      expect(deleteResponse.status).to.equal(204);
+
+      const { body } = await session.testAgent.get('/v1/environment-variables/LAST_ENV_DELETE');
+
+      expect(body.statusCode).to.equal(404);
+    });
+
+    it('should allow bearer auth to delete the entire variable across environments', async () => {
+      await session.testAgent.post('/v1/environment-variables').send({
+        key: 'BEARER_FULL_DELETE',
+        values: [
+          { _environmentId: devEnvironmentId, value: 'dev-value' },
+          { _environmentId: prodEnvironmentId, value: 'prod-value' },
+        ],
+      });
+
+      const deleteResponse = await session.testAgent.delete('/v1/environment-variables/BEARER_FULL_DELETE');
+
+      expect(deleteResponse.status).to.equal(204);
+
+      const { body } = await session.testAgent.get('/v1/environment-variables/BEARER_FULL_DELETE');
+
+      expect(body.statusCode).to.equal(404);
+    });
   });
 });

--- a/apps/api/src/app/environment-variables/environment-variables.controller.ts
+++ b/apps/api/src/app/environment-variables/environment-variables.controller.ts
@@ -82,8 +82,10 @@ export class EnvironmentVariablesController {
     return this.getEnvironmentVariablesUsecase.execute(
       GetEnvironmentVariablesCommand.create({
         organizationId: user.organizationId,
+        environmentId: user.environmentId,
         userId: user._id,
         search: query.search,
+        scopeToEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
   }
@@ -141,8 +143,10 @@ export class EnvironmentVariablesController {
     return this.getEnvironmentVariableUsecase.execute(
       GetEnvironmentVariableCommand.create({
         organizationId: user.organizationId,
+        environmentId: user.environmentId,
         userId: user._id,
         variableKey,
+        scopeToEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
   }
@@ -247,8 +251,10 @@ export class EnvironmentVariablesController {
     return this.deleteEnvironmentVariableUsecase.execute(
       DeleteEnvironmentVariableCommand.create({
         organizationId: user.organizationId,
+        environmentId: user.environmentId,
         userId: user._id,
         variableKey,
+        restrictToUserEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );
   }

--- a/apps/api/src/app/environment-variables/usecases/delete-environment-variable/delete-environment-variable.command.ts
+++ b/apps/api/src/app/environment-variables/usecases/delete-environment-variable/delete-environment-variable.command.ts
@@ -1,8 +1,12 @@
 import { OrganizationLevelWithUserCommand } from '@novu/application-generic';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class DeleteEnvironmentVariableCommand extends OrganizationLevelWithUserCommand {
   @IsString()
   @IsNotEmpty()
   variableKey: string;
+
+  @IsBoolean()
+  @IsOptional()
+  restrictToUserEnvironment?: boolean;
 }

--- a/apps/api/src/app/environment-variables/usecases/delete-environment-variable/delete-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/delete-environment-variable/delete-environment-variable.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { EnvironmentVariableRepository } from '@novu/dal';
 import { DeleteEnvironmentVariableCommand } from './delete-environment-variable.command';
 
@@ -9,16 +9,57 @@ export class DeleteEnvironmentVariable {
   async execute(command: DeleteEnvironmentVariableCommand): Promise<void> {
     const existing = await this.environmentVariableRepository.findOne(
       { key: command.variableKey, _organizationId: command.organizationId },
-      ['_id']
+      ['_id', 'values']
     );
 
     if (!existing) {
       throw new NotFoundException(`Environment variable with key "${command.variableKey}" not found`);
     }
 
+    if (command.restrictToUserEnvironment) {
+      await this.deleteScopedEnvironmentValue(command, existing._id, existing.values);
+
+      return;
+    }
+
     await this.environmentVariableRepository.delete({
       _id: existing._id,
       _organizationId: command.organizationId,
+    });
+  }
+
+  private async deleteScopedEnvironmentValue(
+    command: DeleteEnvironmentVariableCommand,
+    variableId: string,
+    values: Array<{ _environmentId: string }>
+  ): Promise<void> {
+    const callerEnvironmentId = command.environmentId;
+
+    if (!callerEnvironmentId) {
+      throw new ForbiddenException(
+        'This authentication scheme is scoped to a single environment and cannot delete a shared environment variable without an authenticated environment.'
+      );
+    }
+
+    const hasCallerValue = values.some((value) => value._environmentId === callerEnvironmentId);
+
+    if (!hasCallerValue) {
+      throw new NotFoundException(
+        `Environment variable with key "${command.variableKey}" has no value for the authenticated environment`
+      );
+    }
+
+    await this.environmentVariableRepository.update(
+      { _id: variableId, _organizationId: command.organizationId },
+      { $pull: { values: { _environmentId: callerEnvironmentId } } }
+    );
+
+    // Remove the org-level record when no per-environment values remain.
+    // Scoped to empty values so a concurrent sibling-env write cannot be wiped.
+    await this.environmentVariableRepository.delete({
+      _id: variableId,
+      _organizationId: command.organizationId,
+      values: { $size: 0 },
     });
   }
 }

--- a/apps/api/src/app/environment-variables/usecases/get-environment-variable/get-environment-variable.command.ts
+++ b/apps/api/src/app/environment-variables/usecases/get-environment-variable/get-environment-variable.command.ts
@@ -1,8 +1,12 @@
 import { OrganizationLevelWithUserCommand } from '@novu/application-generic';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class GetEnvironmentVariableCommand extends OrganizationLevelWithUserCommand {
   @IsString()
   @IsNotEmpty()
   variableKey: string;
+
+  @IsBoolean()
+  @IsOptional()
+  scopeToEnvironment?: boolean;
 }

--- a/apps/api/src/app/environment-variables/usecases/get-environment-variable/get-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/get-environment-variable/get-environment-variable.usecase.ts
@@ -18,6 +18,8 @@ export class GetEnvironmentVariable {
       throw new NotFoundException(`Environment variable with key "${command.variableKey}" not found`);
     }
 
-    return toEnvironmentVariableResponseDto(variable);
+    return toEnvironmentVariableResponseDto(variable, {
+      scopeToEnvironmentId: command.scopeToEnvironment ? command.environmentId : undefined,
+    });
   }
 }

--- a/apps/api/src/app/environment-variables/usecases/get-environment-variables/get-environment-variables.command.ts
+++ b/apps/api/src/app/environment-variables/usecases/get-environment-variables/get-environment-variables.command.ts
@@ -1,8 +1,12 @@
 import { OrganizationLevelWithUserCommand } from '@novu/application-generic';
-import { IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class GetEnvironmentVariablesCommand extends OrganizationLevelWithUserCommand {
   @IsString()
   @IsOptional()
   search?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  scopeToEnvironment?: boolean;
 }

--- a/apps/api/src/app/environment-variables/usecases/get-environment-variables/get-environment-variables.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/get-environment-variables/get-environment-variables.usecase.ts
@@ -21,19 +21,31 @@ export class GetEnvironmentVariables {
     }
 
     const variables = await this.environmentVariableRepository.find(query, '*', { sort: { createdAt: -1 } });
+    const scopeToEnvironmentId = command.scopeToEnvironment ? command.environmentId : undefined;
 
-    return variables.map((variable) => toEnvironmentVariableResponseDto(variable));
+    return variables.map((variable) => toEnvironmentVariableResponseDto(variable, { scopeToEnvironmentId }));
   }
 }
 
-export function toEnvironmentVariableResponseDto(variable: EnvironmentVariableEntity): EnvironmentVariableResponseDto {
+type ToEnvironmentVariableResponseOptions = {
+  scopeToEnvironmentId?: string;
+};
+
+export function toEnvironmentVariableResponseDto(
+  variable: EnvironmentVariableEntity,
+  options?: ToEnvironmentVariableResponseOptions
+): EnvironmentVariableResponseDto {
+  const values = options?.scopeToEnvironmentId
+    ? variable.values.filter((value) => value._environmentId === options.scopeToEnvironmentId)
+    : variable.values;
+
   return {
     _id: variable._id,
     _organizationId: variable._organizationId,
     key: variable.key,
     type: variable.type ?? EnvironmentVariableType.STRING,
     isSecret: variable.isSecret,
-    values: variable.values.map((v) => ({
+    values: values.map((v) => ({
       _environmentId: v._environmentId,
       value: variable.isSecret ? SECRET_MASK : decryptEnvironmentVariableValue(v.value),
     })),

--- a/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
+++ b/apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts
@@ -110,6 +110,8 @@ export class UpdateEnvironmentVariable {
       throw new NotFoundException(`Environment variable with key "${updatedKey}" not found`);
     }
 
-    return toEnvironmentVariableResponseDto(updated);
+    return toEnvironmentVariableResponseDto(updated, {
+      scopeToEnvironmentId: command.restrictToUserEnvironment ? command.environmentId : undefined,
+    });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified follow-up security finding on environment-variables CRUD after NV-8182: create/update were guarded, but **DELETE** and **GET** still ran org-wide for env-scoped API keys.

**DELETE** was the real integrity bug — a Development API key could wipe the entire org-level variable document (including Production values). **GET** leaked non-secret sibling-env values (secrets already masked).

Implements the remaining NV-7642 acceptance criteria using the same `restrictToUserEnvironment` / `scopeToEnvironment` patterns as create/update and integrations.

## Changes

- **DELETE** (API key / keyless): `$pull` only the caller's env entry from `values[]`; delete the org document only when `values` is empty
- **DELETE** (JWT/session): unchanged full-document delete
- **GET list / retrieve** (API key / keyless): filter response `values[]` to the authenticated environment
- **PATCH response**: also filters `values[]` for scoped callers (avoids leaking sibling values via write response)
- E2E coverage for read filter, per-env delete, last-value full removal, and bearer full delete

## Behavior note (API-key DELETE)

Previously one API-key DELETE removed the whole org variable. It now removes only that key's value for the caller's environment. JWT/dashboard delete is unchanged.

```mermaid
flowchart TD
  A[DELETE /environment-variables/:key] --> B{Env-scoped auth?}
  B -->|No JWT| C[Delete entire org document]
  B -->|Yes API key| D[$pull caller env from values]
  D --> E{values empty?}
  E -->|Yes| F[Delete org document]
  E -->|No| G[Keep document with sibling values]
```

## Test plan

- [x] E2E: API key list/retrieve only return caller-env values
- [x] E2E: API key DELETE preserves Production value
- [x] E2E: API key DELETE of last env value removes the document
- [x] E2E: Bearer DELETE still removes the full variable
- [x] Ran `api-key-environment-scope.e2e.ts` — **12 passing**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2374fba0-179f-4e23-8c2a-868336030b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2374fba0-179f-4e23-8c2a-868336030b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes environment-variable reads and deletes for environment-scoped auth. The main changes are:

- API-key and keyless list/retrieve responses filter `values[]` to the caller environment.
- API-key and keyless delete now pulls only the caller environment value.
- Bearer delete continues to remove the full variable document.
- Update responses are filtered for environment-scoped callers.
- E2E coverage was added for scoped reads and deletes.

<h3>Confidence Score: 4/5</h3>

The scoped read paths need a metadata filtering fix before merging.

Scoped list can return Production-only variable keys to a Development API key with an empty `values[]`. Scoped retrieve can return success for a key that has no value in the authenticated environment. Scoped delete now follows the intended per-environment delete behavior.

apps/api/src/app/environment-variables/usecases/get-environment-variables/get-environment-variables.usecase.ts; apps/api/src/app/environment-variables/usecases/get-environment-variable/get-environment-variable.usecase.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Blocked by step-limit: The empty-values contract-validation run could not reach a runtime harness or endpoint request.
- Blocked by step-limit: The scoped retrieve verification could not reach a runtime reproduction harness or command artifact.
- Artifacts from the API-key env scope tests include logs of the initial command attempt, baseline deletion behavior, a subsequent after-state capture, and a generated harness used to invoke the repository usecase.

<a href="https://app.greptile.com/trex/runs/14139025/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/environment-variables/environment-variables.controller.ts | Passes environment ids and scoped-auth flags into list, retrieve, and delete commands. |
| apps/api/src/app/environment-variables/usecases/get-environment-variables/get-environment-variables.usecase.ts | Adds response-level value filtering, but scoped list still returns metadata for variables outside the caller environment. |
| apps/api/src/app/environment-variables/usecases/get-environment-variable/get-environment-variable.usecase.ts | Adds response-level value filtering, but scoped retrieve still succeeds for keys with no caller-environment value. |
| apps/api/src/app/environment-variables/usecases/delete-environment-variable/delete-environment-variable.usecase.ts | Adds scoped deletion by pulling the caller environment value and deleting the document only when no values remain. |
| apps/api/src/app/environment-variables/usecases/update-environment-variable/update-environment-variable.usecase.ts | Filters update responses for environment-scoped callers. |
| apps/api/src/app/environment-variables/e2e/api-key-environment-scope.e2e.ts | Adds tests for scoped reads, scoped deletes, last-value deletion, and bearer full deletion. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
A[Scoped API-key GET/list] --> B[Query by organization/key]
B --> C[Return org-level variable document]
C --> D[Filter values to caller environment]
D --> E{Any matching values?}
E -->|Yes| F[Return scoped value]
E -->|No| G[Return key metadata with empty values]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
A[Scoped API-key GET/list] --> B[Query by organization/key]
B --> C[Return org-level variable document]
C --> D[Filter values to caller environment]
D --> E{Any matching values?}
E -->|Yes| F[Return scoped value]
E -->|No| G[Return key metadata with empty values]
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fenvironment-variables%2Fusecases%2Fget-environment-variables%2Fget-environment-variables.usecase.ts%3A39-41%0A**Empty%20Values%20Leak%20Keys**%0A%0AWhen%20an%20API-key%20or%20keyless%20caller%20lists%20variables%2C%20the%20query%20still%20returns%20every%20org-level%20variable%20and%20only%20filters%20%60values%5B%5D%60%20afterward.%20A%20Development-scoped%20caller%20can%20still%20see%20that%20a%20Production-only%20key%20exists%2C%20along%20with%20its%20type%20and%20secret%20flag%2C%20because%20the%20response%20includes%20the%20document%20with%20%60values%3A%20%5B%5D%60%20instead%20of%20excluding%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fenvironment-variables%2Fusecases%2Fget-environment-variable%2Fget-environment-variable.usecase.ts%3A21-23%0A**Scoped%20Retrieve%20Returns%20Sibling%20Metadata**%0A%0AWhen%20an%20API-key%20or%20keyless%20caller%20retrieves%20a%20key%20that%20exists%20only%20in%20another%20environment%2C%20this%20path%20returns%20the%20variable%20document%20with%20an%20empty%20%60values%5B%5D%60%20instead%20of%20treating%20it%20as%20not%20found%20for%20the%20authenticated%20environment.%20That%20leaks%20sibling-environment%20key%20metadata%20and%20makes%20callers%20see%20a%20successful%20lookup%20for%20a%20variable%20they%20cannot%20actually%20read.%0A%0A&pr=11894&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/environment-variables/usecases/get-environment-variables/get-environment-variables.usecase.ts:39-41
**Empty Values Leak Keys**

When an API-key or keyless caller lists variables, the query still returns every org-level variable and only filters `values[]` afterward. A Development-scoped caller can still see that a Production-only key exists, along with its type and secret flag, because the response includes the document with `values: []` instead of excluding it.

### Issue 2 of 2
apps/api/src/app/environment-variables/usecases/get-environment-variable/get-environment-variable.usecase.ts:21-23
**Scoped Retrieve Returns Sibling Metadata**

When an API-key or keyless caller retrieves a key that exists only in another environment, this path returns the variable document with an empty `values[]` instead of treating it as not found for the authenticated environment. That leaks sibling-environment key metadata and makes callers see a successful lookup for a variable they cannot actually read.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): scope env variable del..."](https://github.com/novuhq/novu/commit/fe1dcd003520b412ba84d0b18ee56a9d8617e00e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43611152)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->