### PR TITLE
feat(dashboard): show all changelog items with text fallback fixes NV-8269

### DIFF
--- a/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
+++ b/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
@@ -1,6 +1,7 @@
 import { useUser } from '@clerk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
+import { useState } from 'react';
 import { RiCloseLine } from 'react-icons/ri';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { fetchSanity, SANITY_CDN_URL } from '@/utils/sanity';
@@ -22,6 +23,7 @@ type SanityChangelogPost = {
     current: string;
   };
   publishedAt: string;
+  description?: string;
   cover?: {
     _type: 'image';
     asset: SanityAsset;
@@ -34,6 +36,7 @@ type Changelog = {
   title: string;
   version: number;
   imageUrl?: string;
+  description?: string;
   published: boolean;
   slug: string;
 };
@@ -106,15 +109,15 @@ export function ChangelogStack() {
       title: post.title,
       version: index + 1, // Since Sanity doesn't have version numbers, we'll use index
       imageUrl: getImageUrl(post.cover?.asset),
+      description: post.description?.trim() || undefined,
       published: !!post.publishedAt && new Date(post.publishedAt) <= now,
       slug: post.slug?.current || '',
     }));
   };
 
   const fetchChangelogs = async (): Promise<Changelog[]> => {
-    // Get published changelog posts with covers, sorted by publishedAt.
     const query = `
-      *[_type == "changelogPost" && defined(cover.asset)] | order(publishedAt desc, _createdAt desc) [0...10] {
+      *[_type == "changelogPost"] | order(publishedAt desc, _createdAt desc) [0...10] {
         _id,
         _createdAt,
         _updatedAt,
@@ -122,6 +125,11 @@ export function ChangelogStack() {
         title,
         slug,
         publishedAt,
+        "description": coalesce(
+          description,
+          pt::text(content[_type == "block" && style == "normal"][0..0]),
+          pt::text(content[_type == "block"][0..0])
+        ),
         cover {
           _type,
           asset {
@@ -188,7 +196,7 @@ function filterChangelogs(changelogs: Changelog[], dismissedIds: string[]): Chan
   return changelogs
     .filter((item) => {
       const changelogDate = new Date(item.date);
-      return item.published && item.imageUrl && changelogDate >= cutoffDate;
+      return item.published && changelogDate >= cutoffDate;
     })
     .slice(0, CONSTANTS.NUMBER_OF_CARDS)
     .filter((item) => !dismissedIds.includes(item.id));
@@ -207,10 +215,14 @@ function ChangelogCard({
   onDismiss: (e: React.MouseEvent, changelog: Changelog) => void;
   onClick: (changelog: Changelog) => void;
 }) {
+  const [hasImageError, setHasImageError] = useState(false);
+  const showImage = Boolean(changelog.imageUrl) && !hasImageError;
+  const showDescription = !showImage && Boolean(changelog.description);
+
   return (
     <motion.div
       key={changelog.id}
-      className="border-stroke-soft rounded-8 group absolute flex h-[175px] w-full cursor-pointer flex-col justify-between overflow-hidden border bg-white p-3 shadow-xl shadow-black/10 transition-[height] duration-200 dark:border-white/10 dark:bg-black dark:shadow-white/5"
+      className="border-stroke-soft rounded-8 group absolute flex h-[175px] w-full cursor-pointer flex-col overflow-hidden border bg-white p-3 shadow-xl shadow-black/10 transition-[height] duration-200 dark:border-white/10 dark:bg-black dark:shadow-white/5"
       style={{ transformOrigin: 'top center' }}
       animate={{
         top: index * -CONSTANTS.CARD_OFFSET,
@@ -224,31 +236,30 @@ function ChangelogCard({
       }}
       onClick={() => onClick(changelog)}
     >
-      <div>
-        <div className="relative">
-          <div className="text-text-soft text-subheading-2xs">WHAT'S NEW</div>
-          <button
-            onClick={(e) => onDismiss(e, changelog)}
-            className="absolute right-[-8px] top-[-8px] p-1 text-neutral-500 opacity-0 transition-opacity duration-200 hover:text-neutral-900 group-hover:opacity-100 dark:hover:text-white"
-          >
-            <RiCloseLine size={16} />
-          </button>
-          <div className="mb-2 flex items-center justify-between">
-            <h5 className="text-label-sm text-text-strong mt-0 line-clamp-1 dark:text-white">{changelog.title}</h5>
-          </div>
-          {changelog.imageUrl && (
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <div className="text-text-soft text-subheading-2xs">WHAT'S NEW</div>
+        <button
+          onClick={(e) => onDismiss(e, changelog)}
+          className="absolute right-[-8px] top-[-8px] p-1 text-neutral-500 opacity-0 transition-opacity duration-200 hover:text-neutral-900 group-hover:opacity-100 dark:hover:text-white"
+        >
+          <RiCloseLine size={16} />
+        </button>
+        <h5 className="text-label-sm text-text-strong mt-0 line-clamp-1 dark:text-white">{changelog.title}</h5>
+        <div className="mt-2 min-h-0 flex-1">
+          {showImage ? (
             <div className="relative h-[110px] w-full">
               <img
                 src={changelog.imageUrl}
                 alt={changelog.title}
                 className="h-full w-full rounded-[6px] object-cover object-top"
-                onError={(e) => {
-                  // Hide image if it fails to load
-                  e.currentTarget.style.display = 'none';
-                }}
+                onError={() => setHasImageError(true)}
               />
             </div>
-          )}
+          ) : showDescription ? (
+            <div className="bg-bg-weak rounded-6 border-stroke-soft flex h-[110px] flex-col overflow-hidden border px-2.5 py-2 dark:bg-white/5">
+              <p className="text-paragraph-xs text-text-soft line-clamp-5 leading-relaxed">{changelog.description}</p>
+            </div>
+          ) : null}
         </div>
       </div>
     </motion.div>

--- a/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
+++ b/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
@@ -23,7 +23,7 @@ type SanityChangelogPost = {
     current: string;
   };
   publishedAt: string;
-  description?: string;
+  caption?: string;
   cover?: {
     _type: 'image';
     asset: SanityAsset;
@@ -36,7 +36,7 @@ type Changelog = {
   title: string;
   version: number;
   imageUrl?: string;
-  description?: string;
+  caption?: string;
   published: boolean;
   slug: string;
 };
@@ -109,7 +109,7 @@ export function ChangelogStack() {
       title: post.title,
       version: index + 1, // Since Sanity doesn't have version numbers, we'll use index
       imageUrl: getImageUrl(post.cover?.asset),
-      description: post.description?.trim() || undefined,
+      caption: post.caption?.trim() || undefined,
       published: !!post.publishedAt && new Date(post.publishedAt) <= now,
       slug: post.slug?.current || '',
     }));
@@ -125,8 +125,9 @@ export function ChangelogStack() {
         title,
         slug,
         publishedAt,
-        "description": coalesce(
-          description,
+        "caption": coalesce(
+          caption,
+          seo.description,
           pt::text(content[_type == "block" && style == "normal"][0..0]),
           pt::text(content[_type == "block"][0..0])
         ),
@@ -217,7 +218,7 @@ function ChangelogCard({
 }) {
   const [hasImageError, setHasImageError] = useState(false);
   const showImage = Boolean(changelog.imageUrl) && !hasImageError;
-  const showDescription = !showImage && Boolean(changelog.description);
+  const showCaption = !showImage && Boolean(changelog.caption);
 
   return (
     <motion.div
@@ -244,24 +245,58 @@ function ChangelogCard({
         >
           <RiCloseLine size={16} />
         </button>
-        <h5 className="text-label-sm text-text-strong mt-0 line-clamp-1 dark:text-white">{changelog.title}</h5>
-        <div className="mt-2 min-h-0 flex-1">
-          {showImage ? (
-            <div className="relative h-[110px] w-full">
-              <img
-                src={changelog.imageUrl}
-                alt={changelog.title}
-                className="h-full w-full rounded-[6px] object-cover object-top"
-                onError={() => setHasImageError(true)}
-              />
-            </div>
-          ) : showDescription ? (
-            <div className="bg-bg-weak rounded-6 border-stroke-soft flex h-[110px] flex-col overflow-hidden border px-2.5 py-2 dark:bg-white/5">
-              <p className="text-paragraph-xs text-text-soft line-clamp-5 leading-relaxed">{changelog.description}</p>
-            </div>
-          ) : null}
-        </div>
+
+        {showImage ? (
+          <ChangelogImageContent
+            title={changelog.title}
+            imageUrl={changelog.imageUrl!}
+            onImageError={() => setHasImageError(true)}
+          />
+        ) : showCaption ? (
+          <ChangelogTextContent title={changelog.title} caption={changelog.caption!} />
+        ) : (
+          <h5 className="text-label-sm text-text-strong mt-0 line-clamp-2 dark:text-white">{changelog.title}</h5>
+        )}
       </div>
     </motion.div>
+  );
+}
+
+function ChangelogImageContent({
+  title,
+  imageUrl,
+  onImageError,
+}: {
+  title: string;
+  imageUrl: string;
+  onImageError: () => void;
+}) {
+  return (
+    <>
+      <h5 className="text-label-sm text-text-strong mt-0 line-clamp-1 dark:text-white">{title}</h5>
+      <div className="relative mt-2 h-[110px] w-full">
+        <img
+          src={imageUrl}
+          alt={title}
+          className="h-full w-full rounded-[6px] object-cover object-top"
+          onError={onImageError}
+        />
+      </div>
+    </>
+  );
+}
+
+function ChangelogTextContent({ title, caption }: { title: string; caption: string }) {
+  return (
+    <div className="mt-1 flex min-h-0 flex-1 flex-col gap-1.5">
+      <h5 className="text-label-sm text-text-strong line-clamp-2 dark:text-white">{title}</h5>
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <p className="text-paragraph-xs text-text-soft line-clamp-4 leading-5">{caption}</p>
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-5 bg-gradient-to-t from-white to-transparent dark:from-black"
+        />
+      </div>
+    </div>
   );
 }

--- a/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
+++ b/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
@@ -1,7 +1,7 @@
 import { useUser } from '@clerk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { RiCloseLine } from 'react-icons/ri';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { fetchSanity, SANITY_CDN_URL } from '@/utils/sanity';
@@ -197,7 +197,9 @@ function filterChangelogs(changelogs: Changelog[], dismissedIds: string[]): Chan
   return changelogs
     .filter((item) => {
       const changelogDate = new Date(item.date);
-      return item.published && changelogDate >= cutoffDate;
+      const hasRenderableContent = Boolean(item.imageUrl || item.caption);
+
+      return item.published && changelogDate >= cutoffDate && hasRenderableContent;
     })
     .slice(0, CONSTANTS.NUMBER_OF_CARDS)
     .filter((item) => !dismissedIds.includes(item.id));
@@ -217,6 +219,11 @@ function ChangelogCard({
   onClick: (changelog: Changelog) => void;
 }) {
   const [hasImageError, setHasImageError] = useState(false);
+
+  useEffect(() => {
+    setHasImageError(false);
+  }, [changelog.imageUrl]);
+
   const showImage = Boolean(changelog.imageUrl) && !hasImageError;
   const showCaption = !showImage && Boolean(changelog.caption);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The sidebar "What's New" changelog stack previously only fetched and displayed changelog posts that had a cover image. This change shows all published changelog items and adds a cleaner text-only card layout when no cover image is available.

## Changes

- **Sanity query**: Removed the `defined(cover.asset)` filter; fetches all `changelogPost` documents
- **Caption field**: Uses the dedicated `caption` field from Sanity (with fallbacks to `seo.description` and first content paragraph)
- **Text-only card design**: Editorial layout without the bordered box — title (`line-clamp-2`) + caption (`line-clamp-4`) with a subtle bottom fade for overflow
- **Image cards**: Unchanged — title + cover image
- **Image error fallback**: Falls back to caption text layout if cover fails to load

## Card variants

| Variant | Layout |
|---------|--------|
| With cover | WHAT'S NEW + title + image |
| Text-only | WHAT'S NEW + title (2 lines) + caption (4 lines, faded overflow) |
| Image error | Same as text-only |

## Test plan

- [ ] Verify sidebar shows changelog cards for posts without cover images
- [ ] Verify caption text matches Sanity `caption` field (e.g. Novu Chat SDK Adapter)
- [ ] Verify posts with cover images still render the image layout
- [ ] Verify long captions truncate cleanly with fade + ellipsis
- [ ] Verify image load failure falls back to caption layout
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c87744a-8dec-4d99-b6c1-09cb4a7fc453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c87744a-8dec-4d99-b6c1-09cb4a7fc453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the sidebar changelog cards to show text-only entries as well as image cards.

- Fetches all changelog posts instead of only posts with cover images.
- Adds caption data with Sanity fallbacks.
- Filters cards to entries with an image or caption.
- Adds text-only rendering and image-error fallback behavior.

<h3>Confidence Score: 4/5</h3>

The image-error recovery path can keep showing the fallback after the image becomes available.

Caption filtering and text-only rendering cover the empty-card path, but the image error state only resets when the URL string changes.

apps/dashboard/src/components/side-navigation/changelog-cards.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I created a narrow React/Playwright harness under trex-artifacts that copies the ChangelogCard state, effect, and render branching from the reviewed code.
- I attempted to run the harness with Playwright and Vite, but the page did not mount the React harness before the step limit was reached.
- Earlier server logs documented initial sandbox/harness dependency resolution failures before moving the harness under apps/dashboard.
- Server logs show Vite started but failed during esbuild processing of motion, and the subsequent capture logs show Playwright getting ERR\_CONNECTION\_REFUSED after the server exited.

<a href="https://app.greptile.com/trex/runs/14144810/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/side-navigation/changelog-cards.tsx | Adds caption-based changelog rendering and image fallback handling; same-URL image recovery still needs attention. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fside-navigation%2Fchangelog-cards.tsx%3A225%0A**Same-Url%20Error%20Stays%20Sticky**%0A%0AWhen%20an%20image%20fails%20once%20and%20the%20changelog%20refetches%20with%20the%20same%20%60imageUrl%60%2C%20this%20effect%20does%20not%20run%20because%20the%20dependency%20value%20is%20unchanged.%20The%20card%20keeps%20%60hasImageError%60%20set%20to%20%60true%60%2C%20so%20users%20continue%20to%20see%20the%20text%20fallback%20even%20after%20the%20image%20becomes%20reachable%20again.%0A%0A&pr=11896&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/side-navigation/changelog-cards.tsx:225
**Same-Url Error Stays Sticky**

When an image fails once and the changelog refetches with the same `imageUrl`, this effect does not run because the dependency value is unchanged. The card keeps `hasImageError` set to `true`, so users continue to see the text fallback even after the image becomes reachable again.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): reset image error state ..."](https://github.com/novuhq/novu/commit/1e02cda0b782588677a9ffaf70b3d5bd1c8aac33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43617616)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->