### PR TITLE
fix(worker): await cron job registration

### DIFF
--- a/libs/application-generic/src/services/cron/cron.service.spec.ts
+++ b/libs/application-generic/src/services/cron/cron.service.spec.ts
@@ -1,0 +1,90 @@
+import { JobCronNameEnum } from '@novu/shared';
+import { MetricsService } from '../metrics';
+import { CronService } from './cron.service';
+import { CronJobProcessor, CronMetrics, CronMetricsEventEnum, CronOptions } from './cron.types';
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
+class TestCronService extends CronService {
+  protected cronServiceName = 'TestCronService';
+  public addJobMock = jest.fn<Promise<void>, [JobCronNameEnum, CronJobProcessor<unknown>, string, CronOptions]>();
+
+  protected async addJob<TData = unknown>(
+    jobName: JobCronNameEnum,
+    processor: CronJobProcessor<TData>,
+    interval: string,
+    options: CronOptions
+  ): Promise<void> {
+    await this.addJobMock(jobName, processor as CronJobProcessor<unknown>, interval, options);
+  }
+
+  protected async removeJob(): Promise<void> {}
+
+  protected async getMetrics(): Promise<CronMetrics> {
+    return {} as CronMetrics;
+  }
+
+  protected async initialize(): Promise<void> {}
+
+  protected async shutdown(): Promise<void> {}
+}
+
+describe('CronService', () => {
+  const jobName = JobCronNameEnum.SEND_CRON_METRICS;
+  const processor = jest.fn();
+  const interval = '* * * * *';
+  const metricsService = {
+    recordMetric: jest.fn(),
+  } as unknown as MetricsService;
+  let service: TestCronService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new TestCronService(metricsService, [jobName]);
+  });
+
+  it('should wait for job registration before reporting success', async () => {
+    let resolveRegistration = () => {};
+    const registration = new Promise<void>((resolve) => {
+      resolveRegistration = resolve;
+    });
+    service.addJobMock.mockReturnValueOnce(registration);
+
+    const addPromise = service.add(jobName, processor, interval, {});
+
+    expect(metricsService.recordMetric).toHaveBeenCalledWith(
+      `Cron/default/${jobName}/${CronMetricsEventEnum.CREATE_STARTED}`,
+      1
+    );
+    expect(metricsService.recordMetric).not.toHaveBeenCalledWith(
+      `Cron/default/${jobName}/${CronMetricsEventEnum.CREATE_COMPLETED}`,
+      1
+    );
+
+    resolveRegistration();
+    await addPromise;
+
+    expect(metricsService.recordMetric).toHaveBeenCalledWith(
+      `Cron/default/${jobName}/${CronMetricsEventEnum.CREATE_COMPLETED}`,
+      1
+    );
+  });
+
+  it('should report and rethrow job registration errors', async () => {
+    const error = new Error('Failed to register job');
+    service.addJobMock.mockRejectedValueOnce(error);
+
+    await expect(service.add(jobName, processor, interval, {})).rejects.toThrow(error);
+
+    expect(metricsService.recordMetric).toHaveBeenCalledWith(
+      `Cron/default/${jobName}/${CronMetricsEventEnum.CREATE_FAILED}`,
+      1
+    );
+    expect(metricsService.recordMetric).not.toHaveBeenCalledWith(
+      `Cron/default/${jobName}/${CronMetricsEventEnum.CREATE_COMPLETED}`,
+      1
+    );
+  });
+});

--- a/libs/application-generic/src/services/cron/cron.service.ts
+++ b/libs/application-generic/src/services/cron/cron.service.ts
@@ -151,7 +151,7 @@ export abstract class CronService implements OnApplicationBootstrap, OnApplicati
     this.handleJobOutcome(jobName, CronMetricsEventEnum.CREATE_STARTED);
     try {
       const _this = this;
-      this.addJob(
+      await this.addJob(
         jobName,
         async function runCronJob(job) {
           nr.startBackgroundTransaction(


### PR DESCRIPTION
## What changed

  - Await cron job registration before reporting it as successfully created.
  - Route scheduler registration failures through the existing failure metric and
  error-handling path.
  - Add regression coverage for both pending and failed registration.

  ## Why

  `CronService.add()` previously returned before the underlying Pulse scheduler
  finished registering the job.

  That created two misleading behaviors:

  - `CREATE_COMPLETED` could be emitted before the job actually existed.
  - A registration rejection could occur after the surrounding `try/catch` had
  completed, bypassing the existing `CREATE_FAILED` handling.

  Awaiting `addJob()` makes the method’s completion and failure behavior match its
  contract.

  ## Testing

  - Focused cron service tests: 2 passed
  - Full repository build/type-check: passed
  - Repository lint across all 28 configured projects: passed
  - Changed-file Biome check: passed

  I also attempted the broader `application-generic` test suite. It currently
  encounters unrelated environment and suite issues, including unavailable Redis,
  missing encryption configuration, and existing Jest/ESM dependency
  incompatibilities.

  ## Review note

  This PR intentionally preserves the current bootstrap policy: registration
  failures are retried and logged rather than terminating the process.

  Do reviewers agree that this remains the desired startup behavior, or should
  fail-fast startup semantics be considered in a follow-up?

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes cron job creation wait for scheduler registration. The main changes are:

- Awaiting `addJob()` before emitting `CREATE_COMPLETED`.
- Routing registration rejections through `CREATE_FAILED`.
- Adding tests for delayed success metrics and rejected registration handling.

<h3>Confidence Score: 4/5</h3>

The cron startup path can hang during metrics job registration.

Rejected registrations now flow through the intended failure metric, but a stalled scheduler registration call is awaited without the startup timeout or retry guard.

libs/application-generic/src/services/cron/cron.service.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced an unbounded CronService bootstrap hang in a standalone Node harness when enabling SEND\_CRON\_METRICS, with initialize() resolving quickly but addJob() never settling.
- The harness log shows initialize() resolving at 2ms, addJob() being attempted at 2ms, and the startup guard timing out at 3103ms, exceeding the 2000ms deadline.
- I reviewed Jest-related proofs and confirmed an environment blocker prevents cron-service tests from running due to a TypeError: Cannot read properties of undefined (reading 'testEnvironmentOptions').
- I inspected the uploaded artifacts to verify the failure modes, including the bootstrap hang repro and related logs.

<a href="https://app.greptile.com/trex/runs/14179480/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/cron/cron.service.ts | Awaits scheduler registration before reporting cron job creation success. |
| libs/application-generic/src/services/cron/cron.service.spec.ts | Adds tests for delayed success metrics and rejected registration handling. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Fapplication-generic%2Fsrc%2Fservices%2Fcron%2Fcron.service.ts%3A151%0A**Unbounded%20Registration%20Blocks%20Bootstrap**%0A%0AWhen%20%60PulseCronService.addJob%28%29%60%20waits%20on%20%60pulse.every%28...%29%60%2C%20this%20new%20await%20runs%20after%20the%20existing%20startup%20timeout%20and%20retry%20loop%20has%20finished.%20If%20Pulse%20or%20Mongo%20stalls%20during%20metrics%20job%20registration%2C%20%60onApplicationBootstrap%28%29%60%20can%20wait%20forever%20instead%20of%20timing%20out%2C%20retrying%2C%20or%20finishing%20startup%20with%20the%20existing%20logged%20failure%20path.%0A%0A&pr=11898&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
libs/application-generic/src/services/cron/cron.service.ts:151
**Unbounded Registration Blocks Bootstrap**

When `PulseCronService.addJob()` waits on `pulse.every(...)`, this new await runs after the existing startup timeout and retry loop has finished. If Pulse or Mongo stalls during metrics job registration, `onApplicationBootstrap()` can wait forever instead of timing out, retrying, or finishing startup with the existing logged failure path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): await cron job registration"](https://github.com/novuhq/novu/commit/67029c8cfbcd9ead6888fdc9e3b2fe104e68d519) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43697553)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->