### PR TITLE
fix(api-service): make layout mutations atomic

### DIFF
--- a/apps/api/src/app/layouts-v1/usecases/create-default-layout-change/create-default-layout-change.usecase.ts
+++ b/apps/api/src/app/layouts-v1/usecases/create-default-layout-change/create-default-layout-change.usecase.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { CreateChange, CreateChangeCommand, LayoutDtoV0 } from '@novu/application-generic';
-import { ChangeRepository, LayoutEntity, LayoutRepository } from '@novu/dal';
+import { ChangeRepository, ClientSession, LayoutEntity, LayoutRepository } from '@novu/dal';
 import { ChangeEntityTypeEnum } from '@novu/shared';
 import { FindDeletedLayoutCommand, FindDeletedLayoutUseCase } from '../find-deleted-layout';
 import { CreateDefaultLayoutChangeCommand } from './create-default-layout-change.command';
@@ -19,14 +19,18 @@ export class CreateDefaultLayoutChangeUseCase {
     private changeRepository: ChangeRepository
   ) {}
 
-  async execute(command: CreateDefaultLayoutChangeCommand): Promise<void> {
-    let item: LayoutEntity | LayoutDtoV0 | null = await this.layoutRepository.findOne({
-      _id: command.layoutId,
-      _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
-    });
+  async execute(command: CreateDefaultLayoutChangeCommand, session?: ClientSession | null): Promise<void> {
+    let item: LayoutEntity | LayoutDtoV0 | null = await this.layoutRepository.findOne(
+      {
+        _id: command.layoutId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      undefined,
+      { session }
+    );
 
-    const changeId = command.changeId || (await this.getChangeId(command));
+    const changeId = command.changeId || (await this.getChangeId(command, session));
 
     if (!item) {
       item = await this.findDeletedLayout.execute(FindDeletedLayoutCommand.create(command));
@@ -42,16 +46,18 @@ export class CreateDefaultLayoutChangeUseCase {
           parentChangeId: command.parentChangeId,
           changeId,
           item,
-        })
+        }),
+        session
       );
     }
   }
 
-  private async getChangeId(command: GetChangeId) {
+  private async getChangeId(command: GetChangeId, session?: ClientSession | null) {
     return await this.changeRepository.getChangeId(
       command.environmentId,
       ChangeEntityTypeEnum.DEFAULT_LAYOUT,
-      command.layoutId
+      command.layoutId,
+      session
     );
   }
 }

--- a/apps/api/src/app/layouts-v1/usecases/set-default-layout/set-default-layout.use-case.spec.ts
+++ b/apps/api/src/app/layouts-v1/usecases/set-default-layout/set-default-layout.use-case.spec.ts
@@ -1,0 +1,112 @@
+import { AnalyticsService, GetLayoutUseCaseV0, PinoLogger } from '@novu/application-generic';
+import { ChangeRepository, LayoutRepository } from '@novu/dal';
+import { ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { CreateDefaultLayoutChangeUseCase } from '../create-default-layout-change/create-default-layout-change.usecase';
+import { SetDefaultLayoutCommand } from './set-default-layout.command';
+import { SetDefaultLayoutUseCase } from './set-default-layout.use-case';
+
+describe('SetDefaultLayoutUseCase', () => {
+  let getLayoutUseCaseMock: sinon.SinonStubbedInstance<GetLayoutUseCaseV0>;
+  let createDefaultLayoutChangeMock: sinon.SinonStubbedInstance<CreateDefaultLayoutChangeUseCase>;
+  let layoutRepositoryMock: sinon.SinonStubbedInstance<LayoutRepository>;
+  let changeRepositoryMock: sinon.SinonStubbedInstance<ChangeRepository>;
+  let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
+  let pinoLoggerMock: sinon.SinonStubbedInstance<PinoLogger>;
+  let setDefaultLayoutUseCase: SetDefaultLayoutUseCase;
+
+  const mockSession = { id: 'session_id' };
+  const command = SetDefaultLayoutCommand.create({
+    layoutId: 'new_layout_id',
+    userId: 'user_id',
+    environmentId: 'environment_id',
+    organizationId: 'organization_id',
+  });
+
+  beforeEach(() => {
+    getLayoutUseCaseMock = sinon.createStubInstance(GetLayoutUseCaseV0);
+    createDefaultLayoutChangeMock = sinon.createStubInstance(CreateDefaultLayoutChangeUseCase);
+    layoutRepositoryMock = sinon.createStubInstance(LayoutRepository);
+    changeRepositoryMock = sinon.createStubInstance(ChangeRepository);
+    analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
+    pinoLoggerMock = sinon.createStubInstance(PinoLogger);
+
+    setDefaultLayoutUseCase = new SetDefaultLayoutUseCase(
+      getLayoutUseCaseMock as any,
+      createDefaultLayoutChangeMock as any,
+      layoutRepositoryMock as any,
+      changeRepositoryMock as any,
+      analyticsServiceMock as any,
+      pinoLoggerMock as any
+    );
+
+    getLayoutUseCaseMock.execute.resolves({ _id: 'new_layout_id' } as any);
+    layoutRepositoryMock.findOne.resolves({ _id: 'previous_layout_id' } as any);
+    layoutRepositoryMock.updateIsDefault.resolves();
+    layoutRepositoryMock.withTransaction.callsFake(async (callback: any) => await callback(mockSession));
+    changeRepositoryMock.getParentId.resolves(null);
+    changeRepositoryMock.getChangeId.resolves('previous_change_id');
+    createDefaultLayoutChangeMock.execute.resolves();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should update default flags and change records in one transaction', async () => {
+    await setDefaultLayoutUseCase.execute(command);
+
+    expect(layoutRepositoryMock.withTransaction.calledOnce).to.be.true;
+    expect(layoutRepositoryMock.updateIsDefault.firstCall.args).to.deep.equal([
+      'previous_layout_id',
+      'environment_id',
+      'organization_id',
+      false,
+      { session: mockSession },
+    ]);
+    expect(layoutRepositoryMock.updateIsDefault.secondCall.args).to.deep.equal([
+      'new_layout_id',
+      'environment_id',
+      'organization_id',
+      true,
+      { session: mockSession },
+    ]);
+    expect(createDefaultLayoutChangeMock.execute.callCount).to.equal(2);
+    expect(createDefaultLayoutChangeMock.execute.firstCall.args[1]).to.equal(mockSession);
+    expect(createDefaultLayoutChangeMock.execute.secondCall.args[1]).to.equal(mockSession);
+    expect(analyticsServiceMock.track.calledOnce).to.be.true;
+  });
+
+  it('should propagate a change-record failure and not report success', async () => {
+    const error = new Error('Failed to create change record');
+    createDefaultLayoutChangeMock.execute.onSecondCall().rejects(error);
+
+    try {
+      await setDefaultLayoutUseCase.execute(command);
+      expect.fail('Should have thrown an error');
+    } catch (thrownError) {
+      expect(thrownError).to.equal(error);
+      expect(analyticsServiceMock.track.called).to.be.false;
+    }
+  });
+
+  it('should set a v2 layout as default without creating legacy change records', async () => {
+    const v2Command = SetDefaultLayoutCommand.create({
+      ...command,
+      type: ResourceTypeEnum.BRIDGE,
+      origin: ResourceOriginEnum.NOVU_CLOUD,
+    });
+
+    await setDefaultLayoutUseCase.execute(v2Command);
+
+    expect(layoutRepositoryMock.updateIsDefault.secondCall.args).to.deep.equal([
+      'new_layout_id',
+      'environment_id',
+      'organization_id',
+      true,
+      { session: mockSession },
+    ]);
+    expect(createDefaultLayoutChangeMock.execute.called).to.be.false;
+  });
+});

--- a/apps/api/src/app/layouts-v1/usecases/set-default-layout/set-default-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v1/usecases/set-default-layout/set-default-layout.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { AnalyticsService, GetLayoutUseCaseV0, PinoLogger } from '@novu/application-generic';
-import { ChangeRepository, LayoutRepository } from '@novu/dal';
+import { ChangeRepository, ClientSession, LayoutRepository } from '@novu/dal';
 import { ChangeEntityTypeEnum, ResourceOriginEnum } from '@novu/shared';
 
 import { EnvironmentId, LayoutId, OrganizationId } from '../../types';
@@ -33,75 +33,102 @@ export class SetDefaultLayoutUseCase {
       origin: command.origin,
     });
 
-    const existingDefaultLayoutId = await this.findExistingDefaultLayoutId(layout._id as string, command, isV2Layout);
+    let existingDefaultLayoutId: LayoutId | undefined;
+    await this.layoutRepository.withTransaction(async (session) => {
+      existingDefaultLayoutId = await this.findExistingDefaultLayoutId(
+        layout._id as string,
+        command,
+        isV2Layout,
+        session
+      );
 
-    if (!existingDefaultLayoutId) {
-      await this.createDefaultChange(command, isV2Layout);
+      if (existingDefaultLayoutId) {
+        await this.setIsDefaultForLayout(
+          existingDefaultLayoutId,
+          command.environmentId,
+          command.organizationId,
+          false,
+          session
+        );
+      }
 
-      return;
-    }
+      await this.setIsDefaultForLayout(
+        layout._id as string,
+        command.environmentId,
+        command.organizationId,
+        true,
+        session
+      );
 
-    try {
-      await this.setIsDefaultForLayout(existingDefaultLayoutId, command.environmentId, command.organizationId, false);
-
-      if (!isV2Layout) {
-        const existingParentChangeId = await this.getParentChangeId(command.environmentId, existingDefaultLayoutId);
+      if (!isV2Layout && existingDefaultLayoutId) {
+        const existingParentChangeId = await this.getParentChangeId(
+          command.environmentId,
+          existingDefaultLayoutId,
+          session
+        );
         const previousDefaultLayoutChangeId = await this.changeRepository.getChangeId(
           command.environmentId,
           ChangeEntityTypeEnum.DEFAULT_LAYOUT,
-          existingDefaultLayoutId
+          existingDefaultLayoutId,
+          session
         );
 
         await this.createLayoutChangeForPreviousDefault(
           command,
           existingDefaultLayoutId,
           previousDefaultLayoutChangeId,
-          isV2Layout
+          isV2Layout,
+          session
         );
 
-        await this.setIsDefaultForLayout(layout._id as string, command.environmentId, command.organizationId, true);
         await this.createDefaultChange(
           {
             ...command,
             parentChangeId: existingParentChangeId || previousDefaultLayoutChangeId,
           },
-          isV2Layout
+          isV2Layout,
+          session
         );
+      } else {
+        await this.createDefaultChange(command, isV2Layout, session);
       }
+    });
 
-      this.analyticsService.track('[Layout] - Set default layout', command.userId, {
-        _organizationId: command.organizationId,
-        _environmentId: command.environmentId,
-        newDefaultLayoutId: layout._id,
-        previousDefaultLayout: existingDefaultLayoutId,
-      });
-    } catch (error) {
-      this.logger.error({ err: error });
-      // TODO: Rollback through transactions
-    }
+    this.analyticsService.track('[Layout] - Set default layout', command.userId, {
+      _organizationId: command.organizationId,
+      _environmentId: command.environmentId,
+      newDefaultLayoutId: layout._id,
+      previousDefaultLayout: existingDefaultLayoutId,
+    });
   }
 
   private async createLayoutChangeForPreviousDefault(
     command: SetDefaultLayoutCommand,
     layoutId: LayoutId,
     changeId: string,
-    isV2Layout: boolean
+    isV2Layout: boolean,
+    session: ClientSession | null
   ) {
-    await this.createDefaultChange({ ...command, layoutId, changeId }, isV2Layout);
+    await this.createDefaultChange({ ...command, layoutId, changeId }, isV2Layout, session);
   }
 
   private async findExistingDefaultLayoutId(
     layoutId: LayoutId,
     command: SetDefaultLayoutCommand,
-    isV2Layout: boolean
+    isV2Layout: boolean,
+    session: ClientSession | null
   ): Promise<LayoutId | undefined> {
-    const defaultLayout = await this.layoutRepository.findOne({
-      _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
-      isDefault: true,
-      ...(isV2Layout ? { type: command.type, origin: command.origin } : {}),
-      _id: { $ne: layoutId },
-    });
+    const defaultLayout = await this.layoutRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        isDefault: true,
+        ...(isV2Layout ? { type: command.type, origin: command.origin } : {}),
+        _id: { $ne: layoutId },
+      },
+      undefined,
+      { session }
+    );
 
     if (!defaultLayout) {
       return undefined;
@@ -114,12 +141,17 @@ export class SetDefaultLayoutUseCase {
     layoutId: LayoutId,
     environmentId: EnvironmentId,
     organizationId: OrganizationId,
-    isDefault: boolean
+    isDefault: boolean,
+    session: ClientSession | null
   ): Promise<void> {
-    await this.layoutRepository.updateIsDefault(layoutId, environmentId, organizationId, isDefault);
+    await this.layoutRepository.updateIsDefault(layoutId, environmentId, organizationId, isDefault, { session });
   }
 
-  private async createDefaultChange(command: CreateDefaultLayoutChangeCommand, isV2Layout: boolean) {
+  private async createDefaultChange(
+    command: CreateDefaultLayoutChangeCommand,
+    isV2Layout: boolean,
+    session: ClientSession | null
+  ) {
     if (isV2Layout) {
       return;
     }
@@ -133,14 +165,15 @@ export class SetDefaultLayoutUseCase {
       parentChangeId: command.parentChangeId,
     });
 
-    await this.createDefaultLayoutChange.execute(createLayoutChangeCommand);
+    await this.createDefaultLayoutChange.execute(createLayoutChangeCommand, session);
   }
 
-  private async getParentChangeId(environmentId: string, layoutId: string) {
+  private async getParentChangeId(environmentId: string, layoutId: string, session: ClientSession | null) {
     const parentChangeId = await this.changeRepository.getParentId(
       environmentId,
       ChangeEntityTypeEnum.DEFAULT_LAYOUT,
-      layoutId
+      layoutId,
+      session
     );
 
     return parentChangeId;

--- a/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.spec.ts
+++ b/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { AnalyticsService, GetLayoutUseCase, PinoLogger } from '@novu/application-generic';
 import { ControlValuesRepository, LayoutRepository } from '@novu/dal';
@@ -15,7 +15,9 @@ describe('DeleteLayoutUseCase', () => {
   let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
   let moduleRefMock: sinon.SinonStubbedInstance<ModuleRef>;
   let pinoLoggerMock: sinon.SinonStubbedInstance<PinoLogger>;
+  let deleteTranslationGroupExecuteMock: sinon.SinonStub;
   let deleteLayoutUseCase: DeleteLayoutUseCase;
+  const mockSession = { id: 'session_id' };
 
   const mockUser = {
     _id: 'user_id',
@@ -44,40 +46,16 @@ describe('DeleteLayoutUseCase', () => {
     name: 'Default Layout',
   };
 
-  const mockStepControlValues = [
-    {
-      _id: 'step_control_1',
-      _environmentId: 'env_id',
-      _organizationId: 'org_id',
-      level: ControlValuesLevelEnum.STEP_CONTROLS,
-      controls: {
-        email: {
-          layoutId: 'layout_id',
-          subject: 'Test Subject',
-        },
-      },
-    },
-    {
-      _id: 'step_control_2',
-      _environmentId: 'env_id',
-      _organizationId: 'org_id',
-      level: ControlValuesLevelEnum.STEP_CONTROLS,
-      controls: {
-        email: {
-          layoutId: 'layout_id',
-          body: 'Test Body',
-        },
-      },
-    },
-  ];
-
   beforeEach(() => {
     getLayoutUseCaseMock = sinon.createStubInstance(GetLayoutUseCase);
     layoutRepositoryMock = sinon.createStubInstance(LayoutRepository);
     controlValuesRepositoryMock = sinon.createStubInstance(ControlValuesRepository);
     analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
     pinoLoggerMock = sinon.createStubInstance(PinoLogger);
-    moduleRefMock = sinon.createStubInstance(ModuleRef);
+    deleteTranslationGroupExecuteMock = sinon.stub().resolves();
+    moduleRefMock = {
+      get: sinon.stub().returns({ execute: deleteTranslationGroupExecuteMock }),
+    } as any;
 
     deleteLayoutUseCase = new DeleteLayoutUseCase(
       getLayoutUseCaseMock as any,
@@ -87,9 +65,13 @@ describe('DeleteLayoutUseCase', () => {
       moduleRefMock as any,
       pinoLoggerMock as any
     );
+    sinon.stub(deleteLayoutUseCase as any, 'getDeleteTranslationGroupUseCase').returns({
+      execute: deleteTranslationGroupExecuteMock,
+    });
 
     // Default mocks
     getLayoutUseCaseMock.execute.resolves(mockLayout as any);
+    layoutRepositoryMock.withTransaction.callsFake(async (callback: any) => await callback(mockSession));
     controlValuesRepositoryMock.update.resolves({ matched: 2, modified: 2 } as any);
     controlValuesRepositoryMock.delete.resolves({} as any);
     layoutRepositoryMock.deleteLayout.resolves();
@@ -120,7 +102,12 @@ describe('DeleteLayoutUseCase', () => {
 
       // Verify layout was deleted from repository
       expect(layoutRepositoryMock.deleteLayout.calledOnce).to.be.true;
-      expect(layoutRepositoryMock.deleteLayout.firstCall.args).to.deep.equal(['layout_id', 'env_id', 'org_id']);
+      expect(layoutRepositoryMock.deleteLayout.firstCall.args).to.deep.equal([
+        'layout_id',
+        'env_id',
+        'org_id',
+        { session: mockSession },
+      ]);
 
       // Verify control values were deleted
       expect(controlValuesRepositoryMock.delete.calledOnce).to.be.true;
@@ -130,6 +117,7 @@ describe('DeleteLayoutUseCase', () => {
         _layoutId: 'layout_id',
         level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
       });
+      expect(controlValuesRepositoryMock.delete.firstCall.args[1]).to.deep.equal({ session: mockSession });
     });
 
     it('should throw ConflictException when trying to delete default layout', async () => {
@@ -175,6 +163,7 @@ describe('DeleteLayoutUseCase', () => {
       expect(controlValuesRepositoryMock.update.firstCall.args[1]).to.deep.equal({
         $unset: { 'controls.layoutId': '' },
       });
+      expect(controlValuesRepositoryMock.update.firstCall.args[2]).to.deep.equal({ session: mockSession });
     });
 
     it('should handle case where no step controls reference the layout', async () => {
@@ -289,6 +278,78 @@ describe('DeleteLayoutUseCase', () => {
         expect.fail('Should have thrown an error');
       } catch (thrownError) {
         expect(thrownError.message).to.equal('Delete error');
+      }
+    });
+
+    it('should propagate error from layout control values cleanup', async () => {
+      const error = new Error('Control values cleanup failed');
+      controlValuesRepositoryMock.delete.rejects(error);
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        userId: mockUser._id,
+        environmentId: mockUser.environmentId,
+        organizationId: mockUser.organizationId,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError).to.equal(error);
+        expect(analyticsServiceMock.track.called).to.be.false;
+      }
+    });
+
+    it('should propagate translation deletion errors', async () => {
+      const originalNovuEnterprise = process.env.NOVU_ENTERPRISE;
+      process.env.NOVU_ENTERPRISE = 'true';
+      deleteTranslationGroupExecuteMock.rejects(new Error('Translation service unavailable'));
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        userId: mockUser._id,
+        environmentId: mockUser.environmentId,
+        organizationId: mockUser.organizationId,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error.message).to.equal('Translation service unavailable');
+        expect(layoutRepositoryMock.deleteLayout.called).to.be.false;
+        expect(deleteTranslationGroupExecuteMock.firstCall.args[0].session).to.equal(mockSession);
+      } finally {
+        if (originalNovuEnterprise === undefined) {
+          delete process.env.NOVU_ENTERPRISE;
+        } else {
+          process.env.NOVU_ENTERPRISE = originalNovuEnterprise;
+        }
+      }
+    });
+
+    it('should ignore a missing translation group', async () => {
+      const originalNovuEnterprise = process.env.NOVU_ENTERPRISE;
+      process.env.NOVU_ENTERPRISE = 'true';
+      deleteTranslationGroupExecuteMock.rejects(new NotFoundException('Translation group not found'));
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        userId: mockUser._id,
+        environmentId: mockUser.environmentId,
+        organizationId: mockUser.organizationId,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect(layoutRepositoryMock.deleteLayout.calledOnce).to.be.true;
+      } finally {
+        if (originalNovuEnterprise === undefined) {
+          delete process.env.NOVU_ENTERPRISE;
+        } else {
+          process.env.NOVU_ENTERPRISE = originalNovuEnterprise;
+        }
       }
     });
 

--- a/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import {
   AnalyticsService,
@@ -7,7 +7,7 @@ import {
   LayoutResponseDto,
   PinoLogger,
 } from '@novu/application-generic';
-import { ControlValuesRepository, LayoutRepository, LocalizationResourceEnum } from '@novu/dal';
+import { ClientSession, ControlValuesRepository, LayoutRepository, LocalizationResourceEnum } from '@novu/dal';
 import { ControlValuesLevelEnum } from '@novu/shared';
 import { DeleteLayoutCommand } from './delete-layout.command';
 
@@ -42,21 +42,29 @@ export class DeleteLayoutUseCase {
       );
     }
 
-    await this.removeLayoutReferencesFromStepControls({
-      layoutId: layout.layoutId!,
-      environmentId,
-      organizationId,
-    });
+    await this.layoutRepository.withTransaction(async (session) => {
+      await this.removeLayoutReferencesFromStepControls(
+        {
+          layoutId: layout.layoutId!,
+          environmentId,
+          organizationId,
+        },
+        session
+      );
 
-    await this.deleteTranslationGroup(layout, command);
+      await this.deleteTranslationGroup(layout, command, session);
 
-    await this.layoutRepository.deleteLayout(layout._id!, environmentId, organizationId);
+      await this.layoutRepository.deleteLayout(layout._id!, environmentId, organizationId, { session });
 
-    await this.controlValuesRepository.delete({
-      _environmentId: environmentId,
-      _organizationId: organizationId,
-      _layoutId: layout._id!,
-      level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+      await this.controlValuesRepository.delete(
+        {
+          _environmentId: environmentId,
+          _organizationId: organizationId,
+          _layoutId: layout._id!,
+          level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+        },
+        { session }
+      );
     });
 
     this.analyticsService.track('Delete layout - [Layouts]', userId, {
@@ -66,15 +74,18 @@ export class DeleteLayoutUseCase {
     });
   }
 
-  private async removeLayoutReferencesFromStepControls({
-    layoutId,
-    environmentId,
-    organizationId,
-  }: {
-    layoutId: string;
-    environmentId: string;
-    organizationId: string;
-  }): Promise<void> {
+  private async removeLayoutReferencesFromStepControls(
+    {
+      layoutId,
+      environmentId,
+      organizationId,
+    }: {
+      layoutId: string;
+      environmentId: string;
+      organizationId: string;
+    },
+    session: ClientSession | null
+  ): Promise<void> {
     await this.controlValuesRepository.update(
       {
         level: ControlValuesLevelEnum.STEP_CONTROLS,
@@ -82,11 +93,16 @@ export class DeleteLayoutUseCase {
         _organizationId: organizationId,
         'controls.layoutId': layoutId,
       },
-      { $unset: { 'controls.layoutId': '' } }
+      { $unset: { 'controls.layoutId': '' } },
+      { session }
     );
   }
 
-  private async deleteTranslationGroup(layout: LayoutResponseDto, command: DeleteLayoutCommand) {
+  private async deleteTranslationGroup(
+    layout: LayoutResponseDto,
+    command: DeleteLayoutCommand,
+    session: ClientSession | null
+  ) {
     const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
     const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
 
@@ -95,12 +111,7 @@ export class DeleteLayoutUseCase {
     }
 
     try {
-      const deleteTranslationGroupUseCase = this.moduleRef.get(
-        require('@novu/ee-translation')?.DeleteTranslationGroup,
-        {
-          strict: false,
-        }
-      );
+      const deleteTranslationGroupUseCase = this.getDeleteTranslationGroupUseCase();
 
       await deleteTranslationGroupUseCase.execute({
         resourceId: layout.layoutId,
@@ -108,15 +119,29 @@ export class DeleteLayoutUseCase {
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         userId: command.userId,
+        session,
       });
     } catch (error) {
-      this.logger.error(`Failed to delete translations for layout`, {
-        layoutId: layout.layoutId,
-        organizationId: command.organizationId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      if (error instanceof NotFoundException) {
+        return;
+      }
 
-      // translation group might not be present, so we can ignore the error
+      this.logger.error(
+        {
+          layoutId: layout.layoutId,
+          organizationId: command.organizationId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        `Failed to delete translations for layout`
+      );
+
+      throw error;
     }
+  }
+
+  private getDeleteTranslationGroupUseCase() {
+    return this.moduleRef.get(require('@novu/ee-translation')?.DeleteTranslationGroup, {
+      strict: false,
+    });
   }
 }

--- a/libs/application-generic/src/usecases/create-change/create-change.usecase.ts
+++ b/libs/application-generic/src/usecases/create-change/create-change.usecase.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { ChangeRepository } from '@novu/dal';
+import { ChangeRepository, ClientSession } from '@novu/dal';
 import { applyDiff, getDiff, rdiffResult } from 'recursive-diff';
 
 import { CreateChangeCommand } from './create-change.command';
@@ -14,13 +14,13 @@ function sanitizeDiff(diff: unknown): rdiffResult[] {
 export class CreateChange {
   constructor(private changeRepository: ChangeRepository) {}
 
-  async execute(command: CreateChangeCommand) {
+  async execute(command: CreateChangeCommand, session?: ClientSession | null) {
     const itemId = command.item._id;
     if (!itemId) {
       throw new BadRequestException('Item must have an _id to create a change');
     }
 
-    const changes = await this.changeRepository.getEntityChanges(command.organizationId, command.type, itemId);
+    const changes = await this.changeRepository.getEntityChanges(command.organizationId, command.type, itemId, session);
     const aggregatedItem = changes
       .filter((change) => change.enabled)
       .reduce((prev, change) => {
@@ -32,10 +32,14 @@ export class CreateChange {
 
     const changePayload = getDiff(aggregatedItem, command.item, true);
 
-    const change = await this.changeRepository.findOne({
-      _environmentId: command.environmentId,
-      _id: command.changeId,
-    });
+    const change = await this.changeRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _id: command.changeId,
+      },
+      undefined,
+      { session }
+    );
 
     if (change) {
       change.change = changePayload;
@@ -44,23 +48,27 @@ export class CreateChange {
         { _environmentId: command.environmentId, _id: command.changeId },
         {
           $set: change,
-        }
+        },
+        { session }
       );
 
       return change;
     }
 
-    const item = await this.changeRepository.create({
-      _organizationId: command.organizationId,
-      _environmentId: command.environmentId,
-      _creatorId: command.userId,
-      change: changePayload,
-      type: command.type,
-      _entityId: itemId,
-      enabled: false,
-      _parentId: command.parentChangeId,
-      _id: command.changeId,
-    });
+    const item = await this.changeRepository.create(
+      {
+        _organizationId: command.organizationId,
+        _environmentId: command.environmentId,
+        _creatorId: command.userId,
+        change: changePayload,
+        type: command.type,
+        _entityId: itemId,
+        enabled: false,
+        _parentId: command.parentChangeId,
+        _id: command.changeId,
+      },
+      { session }
+    );
 
     return item;
   }

--- a/libs/dal/src/repositories/change/change.repository.ts
+++ b/libs/dal/src/repositories/change/change.repository.ts
@@ -1,4 +1,5 @@
 import { ChangeEntityTypeEnum } from '@novu/shared';
+import { ClientSession } from 'mongoose';
 
 import { EnforceEnvOrOrgIds } from '../../types/enforce';
 import { BaseRepository } from '../base-repository';
@@ -15,7 +16,8 @@ export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity
   public async getEntityChanges(
     organizationId: string,
     entityType: ChangeEntityTypeEnum,
-    entityId: string
+    entityId: string,
+    session?: ClientSession | null
   ): Promise<ChangeEntity[]> {
     return await this.find(
       {
@@ -26,17 +28,27 @@ export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity
       '',
       {
         sort: { createdAt: 1 },
+        session,
       }
     );
   }
 
-  public async getChangeId(environmentId: string, entityType: ChangeEntityTypeEnum, entityId: string): Promise<string> {
-    const change = await this.findOne({
-      _environmentId: environmentId,
-      _entityId: entityId,
-      type: entityType,
-      enabled: false,
-    });
+  public async getChangeId(
+    environmentId: string,
+    entityType: ChangeEntityTypeEnum,
+    entityId: string,
+    session?: ClientSession | null
+  ): Promise<string> {
+    const change = await this.findOne(
+      {
+        _environmentId: environmentId,
+        _entityId: entityId,
+        type: entityType,
+        enabled: false,
+      },
+      undefined,
+      { session }
+    );
 
     if (change?._id) {
       return change._id;
@@ -72,7 +84,8 @@ export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity
   public async getParentId(
     environmentId: string,
     entityType: ChangeEntityTypeEnum,
-    entityId: string
+    entityId: string,
+    session?: ClientSession | null
   ): Promise<string | null> {
     const change = await this.findOne(
       {
@@ -82,7 +95,8 @@ export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity
         enabled: false,
         _parentId: { $exists: true },
       },
-      '_parentId'
+      '_parentId',
+      { session }
     );
     if (change?._parentId) {
       return change._parentId;

--- a/libs/dal/src/repositories/layout/layout.repository.ts
+++ b/libs/dal/src/repositories/layout/layout.repository.ts
@@ -93,14 +93,19 @@ export class LayoutRepository extends BaseRepository<LayoutDBModel, LayoutEntity
     });
   }
 
-  async deleteLayout(_id: LayoutId, _environmentId: EnvironmentId, _organizationId: OrganizationId): Promise<void> {
+  async deleteLayout(
+    _id: LayoutId,
+    _environmentId: EnvironmentId,
+    _organizationId: OrganizationId,
+    options: { session?: ClientSession | null } = {}
+  ): Promise<void> {
     const deleteQuery: LayoutQuery = {
       _id,
       _environmentId,
       _organizationId,
     };
 
-    const result = await this.layout.delete(deleteQuery);
+    const result = await this.layout.delete(deleteQuery, options);
 
     if (result.modifiedCount !== 1) {
       throw new DalException(
@@ -172,7 +177,8 @@ export class LayoutRepository extends BaseRepository<LayoutDBModel, LayoutEntity
     _id: LayoutId,
     _environmentId: EnvironmentId,
     _organizationId: OrganizationId,
-    isDefault: boolean
+    isDefault: boolean,
+    options: { session?: ClientSession | null } = {}
   ): Promise<void> {
     const updated = await this.update(
       {
@@ -182,10 +188,11 @@ export class LayoutRepository extends BaseRepository<LayoutDBModel, LayoutEntity
       },
       {
         isDefault,
-      }
+      },
+      options
     );
 
-    if (updated.matched === 0 || updated.modified === 0) {
+    if (updated.matched === 0) {
       throw new DalException(
         `Update of layout ${_id} in environment ${_environmentId} was not performed properly. Not able to set 'isDefault' to ${isDefault}`
       );


### PR DESCRIPTION
## What changed

  - Run default-layout flag updates and their change records in one Mongo
  transaction.
  - Run layout deletion, workflow-reference cleanup, translation deletion, and
  layout control cleanup in one transaction.
  - Propagate state-changing failures instead of logging and returning success.
  - Ignore only an explicit translation-group `404`; infrastructure and
  authorization errors now abort the operation.
  - Explicitly mark the requested v2 layout as default.
  - Add regression coverage for session propagation and failures occurring after
  earlier writes.

  ## Why

  The previous flows performed several related writes independently.

  A later failure could therefore leave:

  - default-layout flags out of sync with change records;
  - workflow layout references removed while the layout itself survived;
  - orphaned translation or control resources;
  - an API response reporting success despite an incomplete mutation.

  The v2 default path could also unset the previous default without explicitly
  setting the requested layout.

  ## Testing

  - Focused layout unit tests: 16 passing
  - Full monorepo build: passed
  - API build and type-check: passed
  - Repository lint across 28 targets: passed
  - Changed-file Biome check: passed

  The standard full API suite currently fails during global setup because the local
  enterprise submodule artifact `@novu/ee-auth/dist/index.js` is unavailable,
  before test discovery begins.

  ## Review notes

  I kept missing translation groups idempotent by ignoring only
  `NotFoundException`. All other translation failures now roll back the mutation.

  Two points I’d especially appreciate reviewer input on:

  1. Is `NotFoundException` the complete missing-group contract from the enterprise
  translation use case?
  2. This follows the repository’s existing `withTransaction` fallback for Mongo
  deployments without transaction support. Should stronger standalone compensation
  be handled in a follow-up?

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes layout mutations run through transactional paths. The main changes are:

- Session propagation for default-layout change records.
- Atomic default-layout flag updates with explicit v2 default setting.
- Transactional layout deletion and cleanup steps.
- Failure propagation for cleanup and translation deletion errors.
- Regression tests for session use and rollback-sensitive failures.

<h3>Confidence Score: 4/5</h3>

The delete-layout flow needs a fix before merging.

Translation deletion is an external side effect inside the Mongo transaction, and a later Mongo failure can leave the layout present while its translation group has already been deleted. The default-layout transaction changes look consistent with the updated repository contracts.

apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I created a focused Jest/Mocha-style TypeScript test harness under trex-artifacts that instantiates DeleteLayoutUseCase, enables enterprise mode, records DeleteTranslationGroup execution, forces layoutRepository.deleteLayout to throw, and asserts the side-effect-before-rollback ordering.
- I reviewed the environment blockers that prevented the focused repro from running, including a missing build entrypoint and timeouts in a no-config Mocha invocation.

<a href="https://app.greptile.com/trex/runs/14189264/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/layouts-v1/usecases/create-default-layout-change/create-default-layout-change.usecase.ts | Adds optional session propagation to layout lookup, change-id lookup, and change creation. |
| apps/api/src/app/layouts-v1/usecases/set-default-layout/set-default-layout.use-case.ts | Moves default flag updates and change-record writes into one transaction and tracks analytics after success. |
| apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts | Moves layout deletion cleanup into one transaction, but translation deletion can still escape rollback. |
| libs/application-generic/src/usecases/create-change/create-change.usecase.ts | Passes optional sessions through change aggregation, lookup, update, and create calls. |
| libs/dal/src/repositories/change/change.repository.ts | Adds optional sessions to change lookup helpers used by the transactional layout flow. |
| libs/dal/src/repositories/layout/layout.repository.ts | Adds optional sessions to layout delete/default updates and allows matched no-op default updates. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Flayouts-v2%2Fusecases%2Fdelete-layout%2Fdelete-layout.use-case.ts%3A55%0A**External%20Delete%20Escapes%20Rollback**%0A%0AWhen%20enterprise%20translation%20deletion%20succeeds%20but%20a%20later%20Mongo%20write%20in%20this%20transaction%20fails%2C%20the%20Mongo%20changes%20roll%20back%20while%20the%20translation%20group%20is%20already%20gone.%20The%20API%20returns%20an%20error%20and%20the%20layout%20can%20remain%20in%20Mongo%20without%20its%20translations%2C%20so%20this%20side%20effect%20is%20not%20atomic%20with%20the%20layout%20deletion.%0A%0A&pr=11899&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts:55
**External Delete Escapes Rollback**

When enterprise translation deletion succeeds but a later Mongo write in this transaction fails, the Mongo changes roll back while the translation group is already gone. The API returns an error and the layout can remain in Mongo without its translations, so this side effect is not atomic with the layout deletion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): make layout mutations ..."](https://github.com/novuhq/novu/commit/ba9019171d1db55c0f447e0d161b9d4d7f118d47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43716717)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->