### PR TITLE
fix(api-service): restore ExternalApiAccessible on agent CLI routes

### DIFF
--- a/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
+++ b/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
@@ -268,7 +268,8 @@ export class AgentIntegrationsController {
   }
 
   @Post('/:identifier/integrations/:integrationIdentifier/sendblue/configure-webhook')
-  @ApiExcludeEndpoint()
+  @KeylessAccessible()
+  @ExternalApiAccessible()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Configure the Sendblue receive webhook for an agent integration',
@@ -442,6 +443,7 @@ export class AgentIntegrationsController {
 
   @Post('/:identifier/welcome-message')
   @ApiExcludeEndpoint()
+  @ExternalApiAccessible()
   @KeylessAccessible()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
@@ -472,6 +474,7 @@ export class AgentIntegrationsController {
 
   @Post('/:identifier/integrations/:integrationId/slack/setup-link')
   @ApiExcludeEndpoint()
+  @ExternalApiAccessible()
   @KeylessAccessible()
   @HttpCode(HttpStatus.OK)
   @ApiResponse(IssueSlackSetupLinkResponseDto, 200)

--- a/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
+++ b/apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts
@@ -268,8 +268,7 @@ export class AgentIntegrationsController {
   }
 
   @Post('/:identifier/integrations/:integrationIdentifier/sendblue/configure-webhook')
-  @KeylessAccessible()
-  @ExternalApiAccessible()
+  @ApiExcludeEndpoint()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Configure the Sendblue receive webhook for an agent integration',

--- a/apps/api/src/app/agents/management/agent-runtime.controller.ts
+++ b/apps/api/src/app/agents/management/agent-runtime.controller.ts
@@ -140,6 +140,7 @@ export class AgentRuntimeController {
 
   @Post('/generate')
   @ApiExcludeEndpoint()
+  @ExternalApiAccessible()
   @KeylessAccessible()
   @ApiResponse(GenerateManagedAgentResponseDto)
   @ApiOperation({


### PR DESCRIPTION
## Summary

- Restores `@ExternalApiAccessible()` on three agent endpoints that lost it in #11871 (agent docs cleanup), which broke the `novu connect` CLI flow for users authenticated with a real secret API key (`Authorization: ApiKey ...`).
- Cleans up an unrelated, unintentional auth change on the Sendblue `configure-webhook` endpoint that had drifted from its sibling endpoints while this branch was being edited.

## Root cause

`CommunityUserAuthGuard` checks the `external_api_accessible` metadata for any request using the `ApiKey` auth scheme. #11871 swapped several agent routes from fully-hidden (`@ApiExcludeController`) to publicly documented, and in doing so dropped `@ExternalApiAccessible()` from a few of them — without it, API-key callers get `401 API endpoint not accessible`. Keyless (demo) sessions were unaffected since they use a separate `Keyless` auth scheme gated by `@KeylessAccessible()`.

```mermaid
flowchart LR
    CLI["CLI connect command<br/>Authorization: ApiKey secretKey"] --> Guard["CommunityUserAuthGuard"]
    Guard -->|"authScheme = ApiKey"| Check["reflector.get('external_api_accessible')"]
    Check -->|"true"| Allow["200 OK"]
    Check -->|"false / missing"| Deny["401 API endpoint not accessible"]
```

## Changes

Restored `@ExternalApiAccessible()` on (all still `@ApiExcludeEndpoint()` — hidden from public OpenAPI docs/SDK):
- `POST /agents/:identifier/welcome-message`
- `POST /agents/:identifier/integrations/:integrationId/slack/setup-link`
- `POST /agents/generate`

Reverted an unrelated drift on `POST /agents/:identifier/integrations/:integrationIdentifier/sendblue/configure-webhook` back to `@ApiExcludeEndpoint()` only, matching its sibling endpoints (`sendblue/remove-webhooks`, `sendblue/test-message`, `whatsapp/auto-configure`, `whatsapp/test-template`) — this endpoint is not called by the CLI and shouldn't be externally/keyless accessible.

## Test plan

- [ ] Confirm `novu connect` completes agent generation, welcome message, and Slack setup-link steps using a real API secret key (not keyless).
- [ ] Verify Sendblue `configure-webhook` still works from the dashboard (JWT auth) and remains inaccessible via API key/keyless.
- [x] Lint passes on both edited controller files (no linter errors).

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores API-key access metadata on hidden agent CLI routes. The main changes are:

- Adds `@ExternalApiAccessible()` to the agent welcome-message endpoint.
- Adds `@ExternalApiAccessible()` to the Slack setup-link endpoint.
- Adds `@ExternalApiAccessible()` to the agent generation endpoint.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. The added decorators use imports already present in both files, and the affected handlers continue to use authenticated organization and environment context.

No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the pre-change contract state where HEAD^ failed the combined contract due to Sendblue configure-webhook exposing ExternalApiAccessible and KeylessAccessible and missing ApiExcludeEndpoint.
- Validated the artifact results and confirmed that all four target route contracts pass with HTTP 200 OK; Sendblue now uses only ApiExcludeEndpoint.
- Checked the lint run and observed exit code 0 with only the expected Node engine warning.

<a href="https://app.greptile.com/trex/runs/14220258/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/channels/integrations/agent-integrations.controller.ts | Restores API-key accessibility metadata on two hidden agent integration routes. |
| apps/api/src/app/agents/management/agent-runtime.controller.ts | Restores API-key accessibility metadata on the hidden agent generation route. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): keep Sendblue configur..."](https://github.com/novuhq/novu/commit/abdca84f4157032360e020d320155ac9958ed297) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43780569)</sub>

<!-- /greptile_comment -->