### PR TITLE
fix(novu): reject agent identifiers starting with a digit

### DIFF
--- a/packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.spec.ts
@@ -9,6 +9,14 @@ describe('deriveAgentIdentifier', () => {
   it('falls back when the name is empty', () => {
     expect(deriveAgentIdentifier('   ')).toBe('my-chat-sdk-agent');
   });
+
+  it('prefixes numeric-only names so the identifier starts with a letter', () => {
+    expect(deriveAgentIdentifier('118')).toBe('agent-118');
+  });
+
+  it('prefixes names that start with a digit', () => {
+    expect(deriveAgentIdentifier('3rd bot')).toBe('agent-3rd-bot');
+  });
 });
 
 describe('defaultAgentNameFromDir', () => {

--- a/packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.ts
+++ b/packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.ts
@@ -1,10 +1,14 @@
 export function deriveAgentIdentifier(name: string): string {
-  const slug = name
+  let slug = name
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 50);
+
+  if (slug && /^[0-9]/.test(slug)) {
+    slug = `agent-${slug}`.slice(0, 50);
+  }
 
   return slug || 'my-chat-sdk-agent';
 }

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -89,9 +89,9 @@ export const installTemplate = async ({
 
   const renameAgent =
     (template === TemplateTypeEnum.APP_AGENT || template === TemplateTypeEnum.APP_AGENT_AI_SDK) && agentIdentifier;
-  if (renameAgent && !/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/.test(agentIdentifier)) {
+  if (renameAgent && !/^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$/.test(agentIdentifier)) {
     throw new Error(
-      `Invalid agent identifier: "${agentIdentifier}". Must be a lowercase slug (a-z, 0-9, hyphens, underscores).`
+      `Invalid agent identifier: "${agentIdentifier}". Must be a lowercase slug starting with a letter (a-z, 0-9, hyphens, underscores).`
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

When using `npx novu@latest init -t agent --agent-identifier 118` (or naming an agent with a number like "118" in the `connect` flow), the CLI generates invalid TypeScript:

```ts
export const 118 = agent('118', { ... })
```

JavaScript identifiers cannot start with a digit, so this produces a syntax error.

**Changes:**

1. **`packages/novu/src/commands/init/templates/index.ts`** — Tightened the agent-identifier slug regex from `/^[a-z0-9]+.../` to `/^[a-z][a-z0-9]+.../`, requiring the first character to be a letter. The error message now says "starting with a letter".

2. **`packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.ts`** — `deriveAgentIdentifier()` now auto-prefixes `agent-` when the derived slug starts with a digit (e.g. `"118"` → `"agent-118"`), so the connect flow always produces a valid JS identifier.

3. **`packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.spec.ts`** — Added test cases for numeric-only names and digit-prefixed names.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

The string passed to `agent('...')` as the Novu agent ID can remain numeric — only the generated TypeScript export variable name needs to be a valid identifier.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1783939716801209?thread_ts=1783939716.801209&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-e7e61ff2-6903-54b5-92aa-4eaa047bb615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7e61ff2-6903-54b5-92aa-4eaa047bb615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Novu agent identifier handling for digit-leading names.

- Adds `agent-` to derived connect-flow slugs that start with a digit.
- Rejects init-flow agent identifiers that do not start with a lowercase letter.
- Adds tests for numeric-only and digit-prefixed derived names.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The derive-identifier.spec.ts test suite was run and completed with 5 tests passing across 1 file.
- A local harness source was used to exercise installTemplate rejection for the numeric identifier 118.
- The harness run produced an assertion indicating numeric init agent identifier 118 was rejected with an updated message.

<a href="https://app.greptile.com/trex/runs/14224029/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.ts | Prefixes digit-leading derived agent slugs with `agent-` while keeping the empty-name fallback. |
| packages/novu/src/commands/connect/pipeline/chat-sdk/derive-identifier.spec.ts | Adds tests for numeric-only and digit-prefixed agent names. |
| packages/novu/src/commands/init/templates/index.ts | Requires init agent identifiers to start with a lowercase letter and updates the error message. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(novu): reject agent identifiers star..."](https://github.com/novuhq/novu/commit/77cc1a9bcbad4f5ee210940e4c4acc53545d8b00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43788686)</sub>

<!-- /greptile_comment -->