### PR TITLE
feat(dashboard): explain agent runtime categories fixes NV-8275

### DIFF
--- a/apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx
@@ -8,6 +8,7 @@ import {
   RiArrowRightSLine,
   RiCheckLine,
   RiExpandUpDownLine,
+  RiInformationLine,
 } from 'react-icons/ri';
 import {
   DemoCredentialBadge,
@@ -24,6 +25,7 @@ import {
   CommandSeparator,
 } from '@/components/primitives/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { useManagedAgentRuntimeEnabled } from '@/hooks/use-managed-agent-runtime-enabled';
 import { cn } from '@/utils/ui';
 import { getClaudeManagedAgentIntegrations, partitionClaudeManagedIntegrations } from './claude-managed-integrations';
@@ -39,6 +41,33 @@ const GROUP_HEADING_CLASSNAME =
   '**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1';
 
 export type ConnectorIntegrationStatus = 'idle' | 'valid' | 'missing';
+
+type ConnectorGroupHeadingProps = {
+  label: string;
+  description: string;
+};
+
+function ConnectorGroupHeading({ label, description }: ConnectorGroupHeadingProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <span>{label}</span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={`About ${label}`}
+            className="text-text-soft hover:text-text-sub inline-flex cursor-help items-center transition-colors"
+          >
+            <RiInformationLine className="size-3.5" aria-hidden />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="max-w-[260px]">
+          {description}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
 
 type ConnectorIntegrationDropdownProps = {
   selectedConnectorId?: ConnectorId;
@@ -268,11 +297,27 @@ export function ConnectorIntegrationDropdown({
 
   const connectorsView = (
     <>
-      <CommandGroup heading="Custom code" className={GROUP_HEADING_CLASSNAME}>
+      <CommandGroup
+        heading={
+          <ConnectorGroupHeading
+            label="Custom code"
+            description="Build and host the agent in your own application using your preferred framework or custom implementation."
+          />
+        }
+        className={GROUP_HEADING_CLASSNAME}
+      >
         {customOptions.map(renderConnectorItem)}
       </CommandGroup>
       {externalOptions.length > 0 ? (
-        <CommandGroup heading="Managed agent runtimes" className={GROUP_HEADING_CLASSNAME}>
+        <CommandGroup
+          heading={
+            <ConnectorGroupHeading
+              label="Managed agent runtimes"
+              description="Connect an agent running on a supported managed platform. The platform hosts and operates the agent runtime for you."
+            />
+          }
+          className={GROUP_HEADING_CLASSNAME}
+        >
           {externalOptions.map(renderConnectorItem)}
         </CommandGroup>
       ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The Add agent runtime picker showed "Custom code" and "Managed agent runtimes" without explaining what each category means. This adds an info icon beside each category heading with a tooltip that clarifies the distinction.

- **Custom code:** Build and host the agent in your own application using your preferred framework or custom implementation.
- **Managed agent runtimes:** Connect an agent running on a supported managed platform. The platform hosts and operates the agent runtime for you.

### Screenshots

<a href="https://cursor.com/agents/bc-d5466371-d44d-4e52-bdad-1c0e8a0f213e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_runtime_category_tooltips.mp4"><img src="https://cursor.com/artifacts/c/art-a57f0057-5f6e-4ac5-b7d2-15d18da12fa6" alt="agent_runtime_category_tooltips.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Change is limited to `ConnectorIntegrationDropdown`, which is shared by the Add agent dialog and onboarding setup flow.
- Linear ticket still needs to be created and linked in the PR title (`fixes NV-XXX`) — Linear MCP was not authenticated in the cloud agent environment.

</details>

### Test plan

- [x] Open Add agent dialog or onboarding agent setup
- [x] Open the agent runtime dropdown
- [x] Hover the info icon next to **Custom code** and verify tooltip copy
- [x] Hover the info icon next to **Managed agent runtimes** and verify tooltip copy
- [x] `pnpm exec biome check src/components/agents/connectors/connector-integration-dropdown.tsx`
- [x] `pnpm exec tsc -b --pretty false` (dashboard)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5466371-d44d-4e52-bdad-1c0e8a0f213e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5466371-d44d-4e52-bdad-1c0e8a0f213e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds help text to the agent runtime category headings. The main changes are:

- Adds a reusable connector group heading component.
- Adds info icons with tooltip copy for custom code runtimes.
- Adds info icons with tooltip copy for managed agent runtimes.

<h3>Confidence Score: 4/5</h3>

The dropdown help text path has a contained accessibility issue in the command heading.

The new imports match existing dashboard tooltip and icon usage. The tooltip trigger is focusable inside a command group heading rather than an item. Keyboard and assistive-technology users can reach a control that is outside the command menu selection model.

apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Prepared a temporary Vite harness importing the real ConnectorIntegrationDropdown and a Playwright script to focus the heading info button; the harness and script were saved as artifacts.
- The Playwright run did not complete due to both reaching the maximum steps and an early shell failure that prevented browser evidence capture.
- Observed a server-side failure to resolve a CSS import, blocking the app rendering during the tooltips dashboard exploration.
- Playwright route attempts were blocked by a missing agent runtime trigger selection.
- Captured a screenshot and a video illustrating the failed route state during the attempts.

<a href="https://app.greptile.com/trex/runs/14224042/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx | Adds tooltip-based help text to the connector dropdown group headings, with one accessibility issue from placing a focusable button inside the command heading slot. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Fconnectors%2Fconnector-integration-dropdown.tsx%3A55-59%0A**Focusable%20Heading%20Control**%0A%0AThe%20tooltip%20trigger%20becomes%20a%20real%20button%20inside%20the%20%60CommandGroup%60%20heading%20slot.%20That%20slot%20is%20rendered%20as%20the%20command%20menu's%20group%20label%20rather%20than%20as%20a%20command%20item%2C%20so%20keyboard%20users%20can%20tab%20into%20a%20control%20that%20is%20outside%20the%20menu's%20selection%20flow%20and%20may%20not%20get%20a%20usable%20tooltip%20or%20group%20label%20from%20assistive%20technology.%0A%0A&pr=11911&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/agents/connectors/connector-integration-dropdown.tsx:55-59
**Focusable Heading Control**

The tooltip trigger becomes a real button inside the `CommandGroup` heading slot. That slot is rendered as the command menu's group label rather than as a command item, so keyboard users can tab into a control that is outside the menu's selection flow and may not get a usable tooltip or group label from assistive technology.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): explain agent runtime c..."](https://github.com/novuhq/novu/commit/f12349b77e9cbaf35e7ae3ceab0b46e54d632b29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43788711)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->