### PR TITLE
chore(root): add sanity-changelog agent skill fixes NV-8280

### DIFF
--- a/.cursor/skills/sanity-changelog/SKILL.md
+++ b/.cursor/skills/sanity-changelog/SKILL.md
@@ -51,7 +51,7 @@ References (`authors`, `categories`, `tag`) are documents — resolve their `_id
 
 ### 5. Create
 
-Use `create_documents` with the Portable Text structure from [reference.md](reference.md#portable-text-cheat-sheet). Every block/span needs a unique `_key`. Keep `create_documents` JSON valid — brace/bracket errors are the most common failure.
+Use Sanity MCP `create_documents` (draft-only — see [reference.md](reference.md#create--patch--publish)) with the Portable Text structure from [reference.md](reference.md#portable-text-cheat-sheet). Every block/span needs a unique `_key`. Keep `create_documents` JSON valid — brace/bracket errors are the most common failure.
 
 ### 6. Images (known limitation)
 

--- a/.cursor/skills/sanity-changelog/SKILL.md
+++ b/.cursor/skills/sanity-changelog/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: sanity-changelog
+description: >-
+  Create and publish Novu changelog entries in Sanity (changelogPost documents),
+  including feature posts, "improvements & fixes" roundups built from Linear
+  releases, and the Changes (changeBlock) component. Use when asked to write a
+  changelog entry, announce a shipped feature on the changelog, roll up
+  improvements/bug fixes since the last release, or work with Sanity changelog
+  content for the Novu website.
+---
+
+# Novu Sanity Changelog
+
+Authoring workflow for Novu changelog entries. Content lives in Sanity (`changelogPost`), reviewed from Linear releases. Uses the Sanity MCP (`plugin-sanity-Sanity`) and Linear MCP (`plugin-linear-linear`).
+
+Connection constants and all templates/IDs are in [reference.md](reference.md) — read it before creating or patching documents.
+
+## Target
+
+- Sanity project **`w2rl2099`** ("Novu Website"), dataset **`production`**, workspace **`default`**.
+- Document type: **`changelogPost`**.
+- Always create as **drafts** (leave `publishedAt` unset). Never publish unless explicitly asked.
+
+## Workflow
+
+```
+- [ ] 1. Load reference.md; confirm project/dataset
+- [ ] 2. Resolve author + category (and tag) reference IDs via GROQ (don't hardcode)
+- [ ] 3. Gather source material (feature: explore codebase / screenshot; roundup: Linear releases)
+- [ ] 4. Draft content in Novu changelog voice
+- [ ] 5. create_documents (draft) — text first
+- [ ] 6. Handle images (manual Studio upload — MCP cannot upload local files)
+- [ ] 7. Report draft IDs + Studio link; publish only if asked
+```
+
+### 1–2. Setup and references
+
+References (`authors`, `categories`, `tag`) are documents — resolve their `_id`s at runtime, never assume. Run the GROQ in [reference.md](reference.md#fetch-reference-ids). Pick the author = the person shipping/announcing, plus 1–2 categories (e.g. `Dashboard` + `New Feature`, or `Improvement` + `Bug Fix`).
+
+### 3. Source material
+
+- **Feature entry**: understand the feature accurately before writing. For dashboard/SDK features, explore the relevant `apps/` or `packages/` code (or delegate to the `explore` subagent) so copy matches real behavior — don't over-promise from a mockup.
+- **Improvements & fixes roundup**: review Linear releases since the last published changelog. See [reference.md](reference.md#linear-release-review). Filter to customer-relevant items only; exclude dependency/CVE bumps, internal refactors, test/CI, and WIP scaffolding.
+
+### 4. Voice
+
+- Benefit-oriented and concrete; active voice; short paragraphs.
+- Feature posts: intro paragraph → `h2` sections → optional `codeBlock` → closing line with a docs link.
+- Roundup / change items: **bold lead-in label** (area or feature) + em dash + one clear sentence. No `NV-xxxx` IDs in public copy. Group by area.
+- Match the tone of recent posts (query the latest few — see reference).
+
+### 5. Create
+
+Use `create_documents` with the Portable Text structure from [reference.md](reference.md#portable-text-cheat-sheet). Every block/span needs a unique `_key`. Keep `create_documents` JSON valid — brace/bracket errors are the most common failure.
+
+### 6. Images (known limitation)
+
+The Sanity MCP **cannot upload a local image** — `generate_image` only creates AI images. To attach a real screenshot:
+- Have the user drop it into the **Cover Image** field (or an inline image block) in Studio, OR
+- If a Sanity write token is provided, upload via the assets HTTP API and set the `cover` / an `image` block by `asset._ref`.
+
+Studio: open the `changelogPost` in the deployed Sanity Studio for the `default` workspace.
+
+### The Changes component (`changeBlock`)
+
+For an "improvements & fixes" section — standalone or appended to a feature post — use the `changeBlock` object (`type: "improvements" | "fixes"`, `items[]` with portable-text `text` and optional `tag` reference). Template in [reference.md](reference.md#changeblock-template). Leave `tag` off unless a listed tag clearly fits.
+
+## Editing existing drafts
+
+- Patch with `patch_documents` using `insert` (`before` / `after` / `replace`) targeting array items by `_key`, e.g. `content[_key=="fd1ce739c172"]`. This preserves the user's other edits (uploaded images, author, caption, `publishedAt`).
+- Remove a redundant draft with `discard_drafts` (permanent for never-published drafts — confirm intent).
+- Publish with `publish_documents` only when explicitly requested.

--- a/.cursor/skills/sanity-changelog/reference.md
+++ b/.cursor/skills/sanity-changelog/reference.md
@@ -99,7 +99,8 @@ Append after a feature post's body, typically under an `h2` like "Also new acros
 
 ## create / patch / publish
 
-- **Create draft**: `create_documents` → `{ type: "changelogPost", content: { ...fields } }`. Omit `_id` (Sanity generates). Result id is `drafts.<uuid>`.
+- **Create draft**: use Sanity MCP `create_documents` only — it always writes to `drafts.<uuid>` (do not set `_id` in `content`, and do not pass `releaseId`). Example: `{ type: "changelogPost", content: { ...fields } }`. Verify the returned id starts with `drafts.`.
+- **Never** use raw `@sanity/client` `create()` without `_id: "drafts.<uuid>"` — omitting `_id` there creates a published document. Leaving `publishedAt` unset does not make a document a draft.
 - **Patch**: `patch_documents` → `documents: { "drafts.<id>": { patches: [ { insert: { after|before|replace: "content[_key==\"KEY\"]", items: [ ... ] } } ] } }`. Prefer targeting by `_key` to preserve concurrent edits.
 - **Discard** a never-published draft: `discard_drafts` → `{ ids: ["drafts.<id>"] }` (permanent).
 - **Publish**: `publish_documents` — only when explicitly asked.

--- a/.cursor/skills/sanity-changelog/reference.md
+++ b/.cursor/skills/sanity-changelog/reference.md
@@ -1,0 +1,124 @@
+# Sanity Changelog — Reference
+
+## Connection
+
+| Field | Value |
+|-------|-------|
+| Sanity project | `w2rl2099` ("Novu Website") |
+| Dataset | `production` |
+| Workspace | `default` |
+| Studio | Deployed Sanity Studio for the `default` workspace |
+| Sanity MCP | `plugin-sanity-Sanity` |
+| Linear MCP | `plugin-linear-linear` |
+
+Pass `resource: { projectId: "w2rl2099", dataset: "production" }` to every Sanity MCP call.
+
+## changelogPost schema
+
+Fields: `title` (string), `caption` (text), `slug` (slug, from title), `publishedAt` (datetime — leave unset for draft/unpublished), `authors` (array of refs → `author`), `categories` (array of refs → `changelogCategory`), `cover` (image + `alt`), `content` (Portable Text), `seo` (object: title/description/socialImage/noIndex).
+
+## Fetch reference IDs
+
+Reference `_id`s can change — always query, don't hardcode:
+
+```groq
+{
+  "authors": *[_type == "author"]{_id, name},
+  "categories": *[_type == "changelogCategory"]{_id, title},
+  "tags": *[_type == "tag"]{_id, title}
+}
+```
+
+Look at recent posts for voice + structure:
+
+```groq
+*[_type == "changelogPost"] | order(_createdAt desc)[0...3]{title, caption, content}
+```
+
+### Snapshot (verify before use — may drift)
+
+- Categories: `Dashboard` `c35549e4-0fa3-45ca-aa88-67bf2c93fc51`, `New Feature` `8979aa18-c496-43fd-acb8-d1f75ac80034`, `Improvement` `4dc00b28-34f9-46c5-a38e-e9f639e956a9`, `Bug Fix` `ccd3b8dd-fdce-4a49-b46d-42922e7ac2c4`, `Chat` `92f4f918-6ca0-4fc2-961f-7808fc5d4e0a`, `Email` `07ef612e-934a-4746-ab52-00d626f6df1e`, `Slack` `c2e41136-141f-4ac2-bd9f-cfd4e68ce09c`, `MCP` `7b34c994-a190-48eb-bebc-dc6f1bb45ef4`, `@novu/react` `68633a07-04e2-4cda-96be-e8777b68692c`, `@novu/js` `8056885d-2a08-4f98-8a8c-364578b87f90`.
+- `tag` documents (used by `changeBlock` items): React, Node.js, Notifications, WebSockets, Open Source, Tutorial. Broad — only apply when clearly relevant.
+
+## Portable Text cheat sheet
+
+Every block and span needs a unique `_key`.
+
+Paragraph / heading (styles: `normal`, `h2`, `h3`):
+```json
+{ "_type": "block", "_key": "k1", "style": "normal", "markDefs": [],
+  "children": [ { "_type": "span", "_key": "k1s1", "marks": [], "text": "..." } ] }
+```
+
+Bold lead-in + link (marks: `strong`, `code`, or a markDef `_key`):
+```json
+{ "_type": "block", "_key": "k2", "style": "normal",
+  "markDefs": [ { "_key": "lnk", "_type": "link", "href": "<docs-url>" } ],
+  "children": [
+    { "_type": "span", "_key": "a", "marks": ["strong"], "text": "Label — " },
+    { "_type": "span", "_key": "b", "marks": [], "text": "sentence, " },
+    { "_type": "span", "_key": "c", "marks": ["lnk"], "text": "link text" },
+    { "_type": "span", "_key": "d", "marks": [], "text": "." }
+  ] }
+```
+
+Bullet list item (`listItem: "bullet"`, `level: 1`):
+```json
+{ "_type": "block", "_key": "k3", "style": "normal", "listItem": "bullet", "level": 1,
+  "markDefs": [], "children": [ { "_type": "span", "_key": "k3s1", "marks": [], "text": "..." } ] }
+```
+
+Code block:
+```json
+{ "_type": "codeBlock", "_key": "k4", "language": "bash", "code": "npx novu dev" }
+```
+
+Image block (asset must already exist in Sanity — see image limitation):
+```json
+{ "_type": "image", "_key": "k5", "variant": "default",
+  "asset": { "_type": "reference", "_ref": "image-<hash>-<w>x<h>-png" } }
+```
+
+## changeBlock template
+
+`type` is `"improvements"` or `"fixes"`. Each item: portable-text `text` (bold lead-in + sentence) and optional `tag` ref.
+
+```json
+{ "_type": "changeBlock", "_key": "changeImprovements", "type": "improvements",
+  "items": [
+    { "_key": "imp1",
+      "text": [ { "_type": "block", "_key": "imp1b", "style": "normal", "markDefs": [],
+        "children": [
+          { "_type": "span", "_key": "imp1a", "marks": ["strong"], "text": "Area — " },
+          { "_type": "span", "_key": "imp1c", "marks": [], "text": "what changed and why it helps." }
+        ] } ] }
+  ] }
+```
+
+Append after a feature post's body, typically under an `h2` like "Also new across the platform", with an `improvements` block then a `fixes` block.
+
+## create / patch / publish
+
+- **Create draft**: `create_documents` → `{ type: "changelogPost", content: { ...fields } }`. Omit `_id` (Sanity generates). Result id is `drafts.<uuid>`.
+- **Patch**: `patch_documents` → `documents: { "drafts.<id>": { patches: [ { insert: { after|before|replace: "content[_key==\"KEY\"]", items: [ ... ] } } ] } }`. Prefer targeting by `_key` to preserve concurrent edits.
+- **Discard** a never-published draft: `discard_drafts` → `{ ids: ["drafts.<id>"] }` (permanent).
+- **Publish**: `publish_documents` — only when explicitly asked.
+
+## Linear release review
+
+For "improvements & fixes since the last release":
+
+1. `list_release_pipelines` → Cloud Production (`cloud-production`, id `c39d8470-d232-4872-b282-2f4df1dd9bc3`).
+2. `list_releases` for that pipeline. The last changelog-published release is typically marked with a 📒 emoji in its name — treat everything after it as the review window.
+3. For each newer release slug: `list_issues` with `{ release: "<slug>", limit: 100 }`. Use `get_issue` for detail on truncated descriptions.
+4. For large windows (many releases), delegate the fetch-and-filter to a `generalPurpose` subagent with the criteria below.
+
+### Include (customer-relevant)
+
+Bug fixes and UX/product improvements a customer would notice: dashboard, Inbox, workflow editor, API correctness, subscriber/preferences, delivery/providers (email/SMS/push/chat), SDKs (`@novu/react`, `@novu/js`, `@novu/api`), agents product. Customer-facing reliability/perf fixes count.
+
+### Exclude
+
+Dependency/CVE version bumps; internal security hardening not user-visible; refactors, test/eval harnesses, CI/build tooling; WIP scaffolding for unreleased features.
+
+Flag genuinely major standalone features separately — they usually deserve their own entry, not a roundup line.


### PR DESCRIPTION
## Summary

Adds a project agent skill at `.cursor/skills/sanity-changelog/` that codifies the workflow for authoring Novu changelog entries in Sanity (`changelogPost`). Docs/tooling only — no product or runtime code changes.

- **`SKILL.md`** — end-to-end flow: target project/dataset, resolve author/category/tag reference IDs at runtime, gather source material (codebase exploration for feature posts / Linear release review for roundups), Novu changelog voice, create drafts via the Sanity MCP, the local-image upload limitation, the `changeBlock` (Changes) component, and editing via patch/discard/publish.
- **`reference.md`** — connection constants, `changelogPost` schema, GROQ to fetch reference IDs, a Portable Text cheat sheet, the `changeBlock` template, mutation syntax, and Linear release-review filtering criteria.

## Why

Captures the repeatable process used to publish changelog entries so future runs are consistent and don't have to rediscover the schema, the change-block structure, or the release-review flow.

## Notes

- Internal URLs and Studio identifiers were intentionally excluded since this repo is public open source.
- `disable-model-invocation` is left off so the skill auto-triggers on changelog tasks.

## Test plan

- [ ] Skill is discovered when asked to create a Sanity changelog entry
- [ ] `SKILL.md` frontmatter is valid and reference links resolve

Linear: NV-8280

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Cursor skill for creating Novu changelog entries in Sanity.

- New `sanity-changelog` skill workflow under `.cursor/skills/`.
- Sanity project, dataset, schema, and reference lookup guidance.
- Draft creation, patching, publishing, image, and Linear release-review instructions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed docs, and the draft creation guidance keeps changelog entries in the draft path before explicit publishing.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding.
- T-Rex produced a proof for the posted P2 finding.
- T-Rex generated a contract-validation proof package for the sanity-changelog review, including a frontmatter discovery log, a generated validation script, and a markdownlint result.

<a href="https://app.greptile.com/trex/runs/14243918/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .cursor/skills/sanity-changelog/SKILL.md | Adds the changelog skill workflow and points creation through draft-only Sanity guidance. |
| .cursor/skills/sanity-changelog/reference.md | Adds Sanity reference details, content templates, and explicit draft creation guidance. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **SKILL.md contains a broken reference.md anchor link**

   - **Bug**
     - `SKILL.md` links to `reference.md#create--patch--publish`, but the target heading in `reference.md` is `## create / patch / publish`. The repository-level link checker resolved available anchors and found `create-/-patch-/-publish`, not `create--patch--publish`, so this reference link does not resolve under the anchor-generation logic used by the validation.
   - **Cause**
     - The link fragment was written as if slashes are removed/collapsed, while the target heading text includes literal `/` separators and produces a different anchor.
   - **Fix**
     - Change the link target in `SKILL.md` to the actual generated anchor, or rename the heading in `reference.md` to a slash-free form such as `## Create, patch, and publish` and update the link accordingly.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Changed SKILL.md fails markdownlint for an unlabeled fenced code block**

   - **Bug**
     - `pnpm exec markdownlint .cursor/skills/sanity-changelog/SKILL.md .cursor/skills/sanity-changelog/reference.md` exits 1 because the workflow checklist fence at `SKILL.md:26` uses bare triple backticks without a language.
   - **Cause**
     - The fenced block in `SKILL.md` does not specify a language, violating markdownlint rule MD040.
   - **Fix**
     - Add an appropriate fence language such as `markdown` or `text` to the code fence at `SKILL.md:26`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(root): clarify Sanity MCP draft-only..."](https://github.com/novuhq/novu/commit/b289f65bbcb6ee0341a2357c786e00a4f2674e25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43823566)</sub>

<!-- /greptile_comment -->