### PR TITLE
feat(framework): add Hono serve adapter fixes NV-8283

### DIFF
--- a/docs/agents/custom-code-agent/connecting-your-app.mdx
+++ b/docs/agents/custom-code-agent/connecting-your-app.mdx
@@ -47,6 +47,10 @@ Import `serve` from the adapter that matches your stack:
 | Remix | `@novu/framework/remix` |
 | SvelteKit | `@novu/framework/sveltekit` |
 | Nuxt | `@novu/framework/nuxt` |
+| Hono | `@novu/framework/hono` |
+| NestJS | `@novu/framework/nest` |
+| H3 | `@novu/framework/h3` |
+| AWS Lambda | `@novu/framework/lambda` |
 
 The first argument to `agent('support-bot', …)` must match the agent **Identifier** in the dashboard. To run multiple agents from one endpoint, add each export to the `agents` array.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -903,6 +903,7 @@
                       "framework/quickstart/svelte",
                       "framework/quickstart/nuxt",
                       "framework/quickstart/h3",
+                      "framework/quickstart/hono",
                       "framework/quickstart/lambda"
                     ]
                   }

--- a/docs/framework.mdx
+++ b/docs/framework.mdx
@@ -37,5 +37,6 @@ To get started with Novu Framework, pick your preferred technology from the list
   <Card title="Svelte" icon="/images/icons/svelte.svg" href="/framework/quickstart/svelte" />
   <Card title="Nuxt" icon="/images/icons/nuxt.svg" href="/framework/quickstart/nuxt" />
   <Card title="H3" icon="server" href="/framework/quickstart/h3" />
+  <Card title="Hono" icon="flame" href="/framework/quickstart/hono" />
   <Card title="Lambda" icon="cloud" href="/framework/quickstart/lambda" />
 </Columns>

--- a/docs/framework/endpoint.mdx
+++ b/docs/framework/endpoint.mdx
@@ -22,10 +22,13 @@ Currently, we offer `serve` functions for the following frameworks:
 
 - [Next.js](/framework/quickstart/nextjs)
 - [Express.js](/framework/quickstart/express)
+- [NestJS](/framework/quickstart/nestjs)
 - [Nuxt](/framework/quickstart/nuxt)
 - [h3](/framework/quickstart/h3)
+- [Hono](/framework/quickstart/hono)
 - [Remix](/framework/quickstart/remix)
 - [Sveltekit](/framework/quickstart/svelte)
+- [AWS Lambda](/framework/quickstart/lambda)
 
 ## Retry behavior
 

--- a/docs/framework/quickstart/hono.mdx
+++ b/docs/framework/quickstart/hono.mdx
@@ -22,13 +22,13 @@ This opens the Novu Dashboard in **Local mode** — a local environment connecte
    <Step>
          ## Install packages
 
-Install the Novu Framework package:
+Install the Novu Framework package and Hono:
 
 ```bash
-npm install @novu/framework
+npm install @novu/framework hono
 ```
 
-This package provides all the necessary tools to build and manage your notification workflows.
+`@novu/framework` provides the tools to build and manage your notification workflows. `hono` is required because it is an optional peer dependency of the Hono adapter.
 
     </Step>
    <Step>

--- a/docs/framework/quickstart/hono.mdx
+++ b/docs/framework/quickstart/hono.mdx
@@ -1,0 +1,127 @@
+---
+title: 'Hono'
+description: "Get started with Novu Framework in a Hono application by scaffolding a bridge, defining a workflow, and triggering your first notification."
+---
+
+
+In this guide, we will add a Novu [Bridge Endpoint](/framework/endpoint) to a Hono application and send our first test workflow.
+
+<Steps>
+    <Step>
+         ## Set up your local environment
+
+Start local development by running:
+
+```bash
+npx novu dev
+```
+
+This opens the Novu Dashboard in **Local mode** — a local environment connected to your running app through a tunnel — where you can preview and test the workflows running on your machine. See [Local development](/framework/studio) for details.
+
+    </Step>
+   <Step>
+         ## Install packages
+
+Install the Novu Framework package:
+
+```bash
+npm install @novu/framework
+```
+
+This package provides all the necessary tools to build and manage your notification workflows.
+
+    </Step>
+   <Step>
+         ## Add a Novu API Endpoint
+
+```typescript src/index.ts
+import { Hono } from 'hono';
+import { serve } from '@novu/framework/hono';
+import { testWorkflow } from './novu/workflows';
+
+const app = new Hono();
+
+app.on(
+  ['GET', 'POST', 'OPTIONS'],
+  '/api/novu',
+  serve({ workflows: [testWorkflow] })
+);
+
+export default app;
+```
+
+    </Step>
+    <Step>
+        ## Configure your secret key
+
+Add your Novu secret key to your environment variables:
+
+```bash .env
+NOVU_SECRET_KEY=your_secret_key
+```
+
+    </Step>
+    <Step>
+        ## Create your workflow definition
+        Add a `novu` folder in your app folder as such ```novu/workflows.ts``` that will contain your workflow definitions.
+
+```ts src/novu/workflows.ts
+import { workflow } from '@novu/framework';
+
+export const testWorkflow = workflow('test-workflow', async ({ step }) => {
+  await step.email('test-email', async () => {
+    return {
+      subject: 'Test Email',
+      body: 'This is a test email from Novu Framework!',
+    };
+  });
+});
+```
+
+    </Step>
+    <Step>
+        ## Start your application
+        Start your Hono server with the Novu Endpoint configured.
+
+        If your Hono application is running on a port other than `4000`, restart `npx novu dev` with that port:
+
+        ```tsx
+        npx novu@latest dev --port <YOUR_HONO_APPLICATION_PORT>
+        ```
+    </Step>
+    <Step>
+        ## Test your endpoint
+
+Test your workflow by triggering it from the Local environment or using the Novu API:
+
+```bash
+curl -X POST https://api.novu.co/v1/events/trigger \
+  -H 'Authorization: ApiKey YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "my-workflow",
+    "to": "subscriber-id",
+    "payload": {}
+  }'
+```
+
+You should see the notification being processed in the Local environment.
+
+    </Step>
+    <Step>
+        ## Deploy your application
+
+Deploy your application to your preferred hosting provider. Make sure the `/api/novu` endpoint is accessible from the internet.
+
+For local development and testing, you can use tools like ngrok to expose your local server to the internet.
+
+    </Step>
+
+</Steps>
+
+Now that you have your first workflow running, you can:
+
+- Learn about [Workflow Controls](/framework/controls) to expose no-code editing capabilities
+- Explore different [Channel Steps](/framework/email-channel) like Email, SMS, Push, and more
+- Set up [Action Steps](/framework/digest) like Delay and Digest
+- Check out our [React Email integration](/framework/content/react-email) for building beautiful email templates

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -151,6 +151,7 @@ Serve workflows and agents from your framework of choice:
 | `@novu/framework/nest` | NestJS |
 | `@novu/framework/express` | Express |
 | `@novu/framework/h3` | H3 / Nuxt |
+| `@novu/framework/hono` | Hono |
 | `@novu/framework/lambda` | AWS Lambda |
 | `@novu/framework/sveltekit` | SvelteKit |
 | `@novu/framework/remix` | Remix |

--- a/packages/framework/hono/package.json
+++ b/packages/framework/hono/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../dist/cjs/servers/hono.cjs"
+}

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -18,6 +18,7 @@
     "dist",
     "express",
     "h3",
+    "hono",
     "internal",
     "lambda",
     "nest",
@@ -63,6 +64,7 @@
     "next",
     "nuxt",
     "h3",
+    "hono",
     "express"
   ],
   "author": "Novu Team <engineering@novu.co>",
@@ -146,6 +148,16 @@
       "import": {
         "types": "./dist/esm/servers/h3.d.ts",
         "default": "./dist/esm/servers/h3.js"
+      }
+    },
+    "./hono": {
+      "require": {
+        "types": "./dist/cjs/servers/hono.d.cts",
+        "default": "./dist/cjs/servers/hono.cjs"
+      },
+      "import": {
+        "types": "./dist/esm/servers/hono.d.ts",
+        "default": "./dist/esm/servers/hono.js"
       }
     },
     "./lambda": {
@@ -248,6 +260,7 @@
     "aws-lambda": ">=1.0.7",
     "express": ">=4.19.2",
     "h3": ">=1.8.1",
+    "hono": ">=4.0.0",
     "langchain": ">=1.0.0",
     "next": ">=12.0.0",
     "zod": ">=3.0.0",
@@ -276,6 +289,9 @@
       "optional": true
     },
     "h3": {
+      "optional": true
+    },
+    "hono": {
       "optional": true
     },
     "aws-lambda": {
@@ -310,6 +326,7 @@
     "aws-lambda": "^1.0.7",
     "express": "^4.19.2",
     "h3": "^1.11.1",
+    "hono": "^4.12.25",
     "langchain": "^1.2.16",
     "madge": "^8.0.0",
     "next": "^16.2.1",

--- a/packages/framework/src/servers/hono.ts
+++ b/packages/framework/src/servers/hono.ts
@@ -60,7 +60,7 @@ export const serve = (options: ServeHandlerOptions): ((c: Context) => Promise<Re
             // no-op when url is relative
           }
 
-          const host = c.req.header('host') || '';
+          const host = c.req.header('host') || 'localhost';
           let protocol: 'http' | 'https' = 'https';
 
           try {

--- a/packages/framework/src/servers/hono.ts
+++ b/packages/framework/src/servers/hono.ts
@@ -61,9 +61,16 @@ export const serve = (options: ServeHandlerOptions): ((c: Context) => Promise<Re
           }
 
           const host = c.req.header('host') || '';
-          const protocol =
+          let protocol: 'http' | 'https' = 'https';
+
+          try {
             // biome-ignore lint/suspicious/noExplicitAny: Needed for some edge cases
-            process.env.NODE_ENV === 'development' || (process.env.NODE_ENV as any) === 'dev' ? 'http' : 'https';
+            if (process.env.NODE_ENV === 'development' || (process.env.NODE_ENV as any) === 'dev') {
+              protocol = 'http';
+            }
+          } catch {
+            // no-op when process is unavailable (edge runtimes)
+          }
 
           return new URL(c.req.url, `${protocol}://${host}`);
         },

--- a/packages/framework/src/servers/hono.ts
+++ b/packages/framework/src/servers/hono.ts
@@ -1,0 +1,83 @@
+import { type Context } from 'hono';
+
+import { NovuRequestHandler, type ServeHandlerOptions } from '../handler';
+import { type SupportedFrameworkName } from '../types';
+import { getResponse } from '../utils';
+
+/*
+ * Re-export all top level exports from the main package.
+ * This results in better DX reduces the chances of the dual package hazard for ESM + CJS packages.
+ *
+ * Example:
+ *
+ * import { serve, Client, type Workflow } from '@novu/framework/hono';
+ *
+ * instead of
+ *
+ * import { serve } from '@novu/framework/hono';
+ * import { Client, type Workflow } from '@novu/framework';
+ */
+export * from '../index';
+export const frameworkName: SupportedFrameworkName = 'hono';
+
+/**
+ * Using Hono, serve and register any declared workflows with Novu,
+ * making them available to be triggered by events.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from "hono";
+ * import { serve } from "@novu/framework/hono";
+ * import { myWorkflow } from "./src/novu/workflows";
+ *
+ * const app = new Hono();
+ *
+ * app.on(
+ *   ["GET", "POST", "OPTIONS"],
+ *   "/api/novu",
+ *   serve({ workflows: [myWorkflow] })
+ * );
+ *
+ * export default app;
+ * ```
+ *
+ * @public
+ */
+export const serve = (options: ServeHandlerOptions): ((c: Context) => Promise<Response>) => {
+  const handler = new NovuRequestHandler({
+    frameworkName,
+    ...options,
+    handler: (c: Context) => {
+      return {
+        body: () => c.req.json(),
+        headers: (key) => c.req.header(key),
+        method: () => c.req.method,
+        queryString: (key) => c.req.query(key),
+        url: () => {
+          try {
+            return new URL(c.req.url);
+          } catch {
+            // no-op when url is relative
+          }
+
+          const host = c.req.header('host') || '';
+          const protocol =
+            // biome-ignore lint/suspicious/noExplicitAny: Needed for some edge cases
+            process.env.NODE_ENV === 'development' || (process.env.NODE_ENV as any) === 'dev' ? 'http' : 'https';
+
+          return new URL(c.req.url, `${protocol}://${host}`);
+        },
+        transformResponse: ({ body, status, headers }): Response => {
+          const Res = getResponse();
+
+          return new Res(body, {
+            status,
+            headers,
+          });
+        },
+      };
+    },
+  });
+
+  return handler.createHandler();
+};

--- a/packages/framework/src/types/server.types.ts
+++ b/packages/framework/src/types/server.types.ts
@@ -1,1 +1,10 @@
-export type SupportedFrameworkName = 'next' | 'express' | 'nuxt' | 'h3' | 'sveltekit' | 'remix' | 'lambda' | 'nest';
+export type SupportedFrameworkName =
+  | 'next'
+  | 'express'
+  | 'nuxt'
+  | 'h3'
+  | 'hono'
+  | 'sveltekit'
+  | 'remix'
+  | 'lambda'
+  | 'nest';

--- a/packages/framework/tsup.config.ts
+++ b/packages/framework/tsup.config.ts
@@ -2,7 +2,17 @@ import { defineConfig, type Options } from 'tsup';
 import { version } from './package.json';
 import { type SupportedFrameworkName } from './src/internal';
 
-const frameworks: SupportedFrameworkName[] = ['h3', 'express', 'next', 'nuxt', 'sveltekit', 'remix', 'lambda', 'nest'];
+const frameworks: SupportedFrameworkName[] = [
+  'h3',
+  'hono',
+  'express',
+  'next',
+  'nuxt',
+  'sveltekit',
+  'remix',
+  'lambda',
+  'nest',
+];
 
 const baseConfig: Options = {
   entry: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,13 +451,13 @@ importers:
         version: 8.1.6
       '@sentry/nestjs':
         specifier: ^10.63.0
-        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@sentry/node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@sentry/profiling-node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@slack/types':
         specifier: 2.20.1
         version: 2.20.1
@@ -577,7 +577,7 @@ importers:
         version: 3.3.8
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1427,7 +1427,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1620,7 +1620,7 @@ importers:
         version: 11.5.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1811,7 +1811,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -3544,6 +3544,9 @@ importers:
       h3:
         specifier: ^1.15.9
         version: 1.15.9
+      hono:
+        specifier: ^4.12.25
+        version: 4.12.25
       langchain:
         specifier: ^1.2.16
         version: 1.2.16(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.17.0(ws@8.21.0)(zod@3.25.20))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.21.0)(zod-to-json-schema@3.23.3(zod@3.25.20))
@@ -31393,7 +31396,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       kysely: 0.28.17
       nanostores: 1.2.0
@@ -36174,15 +36177,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.214.0
-      import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -36318,9 +36312,8 @@ snapshots:
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.39.0
-    optional: true
 
   '@opentelemetry/sdk-logs@0.201.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -36419,8 +36412,8 @@ snapshots:
   '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
@@ -39616,20 +39609,6 @@ snapshots:
     dependencies:
       '@sentry/core': 10.63.0
 
-  '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
-    dependencies:
-      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.27)(@nestjs/websockets@11.1.27)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.63.0
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
-
   '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -39644,17 +39623,17 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
       import-in-the-middle: 3.0.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
 
   '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
@@ -39678,13 +39657,13 @@ snapshots:
   '@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
       '@sentry/server-utils': 10.63.0
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
@@ -39709,7 +39688,7 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
@@ -39724,16 +39703,6 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-
-  '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
-    dependencies:
-      '@sentry/core': 10.63.0
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-      '@sentry/node-cpu-profiler': 2.4.2
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
 
   '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -45014,7 +44983,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.6
       jose: 6.1.3
       kysely: 0.28.17
@@ -45032,15 +45001,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.2(zod@4.3.5):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:
@@ -52903,25 +52863,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
-    dependencies:
-      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-      rxjs: 7.8.2
-    optionalDependencies:
-      '@nestjs/graphql': 12.0.9(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@24.0.0)
-    transitivePeerDependencies:
-      - '@apollo/subgraph'
-      - '@nestjs/core'
-      - bufferutil
-      - class-transformer
-      - class-validator
-      - graphql
-      - reflect-metadata
-      - ts-morph
-      - utf-8-validate
-
-  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

Added a Hono framework adapter for `@novu/framework`, exposing `serve` via `@novu/framework/hono` using the same `NovuRequestHandler` pattern as existing adapters (express, h3, remix, etc.).

Also updated Framework and Agents docs:

- New Hono quickstart at `/framework/quickstart/hono`
- Framework overview cards, bridge endpoint `serve` list, and `docs.json` nav
- Agents "Connecting your app" adapter table

Review follow-ups:

- Edge-safe relative URL fallback (no bare `process.env` access)
- Quickstart install now includes the `hono` peer dependency

## Why?

Hono is a common Web Standards runtime (Cloudflare Workers, Bun, Node) and was already detected by the Novu CLI wizard, but the Framework SDK had no matching `serve` export or docs page.

## How to test?

1. Install / link `@novu/framework` and `hono`
2. Mount the bridge:

```ts
import { Hono } from 'hono';
import { serve } from '@novu/framework/hono';

const app = new Hono();
app.on(['GET', 'POST', 'OPTIONS'], '/api/novu', serve({ workflows: [] }));
```

3. Hit `/api/novu` and confirm a health/discovery response
4. Verified locally: package build, `attw` export checks (`@novu/framework/hono` green), CJS/ESM smoke import, and relative-URL fallback with `process` removed (returns HTTP 200)
5. Confirm docs pages render and link correctly from Framework overview / sidebar
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c463cf43-7258-4fdc-a535-473e286ab725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c463cf43-7258-4fdc-a535-473e286ab725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Hono support to the Novu Framework adapter set. The main changes are:

- New `@novu/framework/hono` server adapter and package export.
- Hono package metadata, peer dependency, and build entry wiring.
- Hono quickstart docs and navigation updates.
- Adapter tables updated across framework and agent docs.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Launched the hono-endpoint harness after setting NOVU\_SECRET\_KEY (redacted) and ran the after-change command, which completed with exit code 0.
- Queried GET /api/novu and received HTTP 200 with a discovery payload showing sdkVersion 2.12.0 and frameworkVersion 2024-06-26, along with discovered workflow/step counts of 0.
- Queried OPTIONS /api/novu and received HTTP 200 with an empty JSON body.
- Posted {} to /api/novu and received HTTP 400 with Invalid query string: action=health-check, confirming the POST route reached Novu's handler contract.
- Temporarily undefining globalThis.process, re-checking GET /api/novu still yielded HTTP 200 with the same discovery payload, indicating resilience of the route/handler under modified runtime state.

<a href="https://app.greptile.com/trex/runs/14352803/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/servers/hono.ts | Adds the Hono request handler adapter with URL, body, header, query, and response translation. |
| packages/framework/package.json | Adds the Hono subpath export, package file entry, peer dependency metadata, and development dependency. |
| packages/framework/tsup.config.ts | Includes Hono in the framework adapter build entries. |
| docs/framework/quickstart/hono.mdx | Adds a Hono quickstart that installs both Novu Framework and Hono. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(framework): use localhost host fallb..."](https://github.com/novuhq/novu/commit/a6ee86f1fee35695a933b2a9b95f5aa5bc40a52a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43868786)</sub>

<!-- /greptile_comment -->