### PR TITLE
fix(framework): remove doubled separator in digest filter 3-item branch

### DIFF
--- a/packages/framework/src/filters/digest.test.ts
+++ b/packages/framework/src/filters/digest.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { digest } from './digest';
+
+describe('digest', () => {
+  it('should return empty string for non-arrays or empty arrays', () => {
+    expect(digest(null)).toBe('');
+    expect(digest(undefined)).toBe('');
+    expect(digest([])).toBe('');
+  });
+
+  it('should return the single value for one item', () => {
+    expect(digest(['John'])).toBe('John');
+  });
+
+  it('should join two items with "and"', () => {
+    expect(digest(['John', 'Josh'])).toBe('John and Josh');
+  });
+
+  it('should show all three names without a doubled separator when maxNames >= 3', () => {
+    expect(digest(['John', 'Josh', 'Sarah'], 3)).toBe('John, Josh and Sarah');
+  });
+
+  it('should respect a custom separator when showing all three names', () => {
+    expect(digest(['John', 'Josh', 'Sarah'], 3, undefined, ' • ')).toBe('John • Josh and Sarah');
+  });
+
+  it('should use the "others" format for 4+ items', () => {
+    expect(digest(['John', 'Josh', 'Sarah', 'Mike'])).toBe('John, Josh and 2 others');
+  });
+});

--- a/packages/framework/src/filters/digest.ts
+++ b/packages/framework/src/filters/digest.ts
@@ -37,7 +37,7 @@ export function digest(array: unknown, maxNames = 2, keyPath?: string, separator
   if (values.length === 2) return `${values[0]} and ${values[1]}`;
 
   if (values.length === 3 && maxNames >= 3) {
-    return `${values[0]}, ${separator}${values[1]} and ${values[2]}`;
+    return `${values[0]}${separator}${values[1]} and ${values[2]}`;
   }
 
   // Use "others" format for 4+ items or when maxNames is less than array length


### PR DESCRIPTION
The `digest` Liquid filter's 3-item branch (`maxNames >= 3`) hardcoded a literal `, ` in addition to interpolating the `separator` argument, producing a doubled separator. Every other branch uses `separator` alone.

`digest(['John','Josh','Sarah'], 3)` rendered `"John, , Josh and Sarah"` instead of `"John, Josh and Sarah"` (the function's own documented output), and a custom separator was mixed with the stray comma.

Removes the hardcoded `, ` and adds `digest.test.ts` covering the 3-item default and custom-separator cases.

### What changed? Why was the change needed?

While rendering actor lists in my digest notifications with the `digest` Liquid filter (`{{ actors | digest }}`), a digest of exactly three actors came out with a doubled separator:

> John, , Josh and Sarah

instead of the filter's own documented output:

> John, Josh and Sarah

**Root cause** — in `packages/framework/src/filters/digest.ts`, the 3-item branch (`values.length === 3 && maxNames >= 3`) hardcodes a literal `, ` *and* also interpolates the `separator` argument, so the separator is emitted twice:

```ts
return `${values[0]}, ${separator}${values[1]} and ${values[2]}`;
```

Every other branch in the function uses `separator` on its own, and the default `separator` is already `', '`, so the extra comma is redundant. With a custom separator it's more visibly wrong: the hardcoded comma gets mixed in with the caller's separator (e.g. `John,  • Josh and Sarah`).

**The change** — drop the stray `, ` so the branch uses `separator` like every other branch:

```ts
return `${values[0]}${separator}${values[1]} and ${values[2]}`;
```

**Why it went unnoticed** — the branch only fires when `maxNames >= 3` *and* there are exactly three items. The default `maxNames` is `2`, and 4+ items take the "others" branch, so most usage never hits this line.

**Tests** — added `packages/framework/src/filters/digest.test.ts` covering the 3-item case with the default separator and with a custom separator (plus the existing 1/2/4+ item shapes as guards). The two new assertions fail on the current code and pass with the fix; the surrounding `src/filters/` suite stays green.



### Special notes for your reviewer

Narrow trigger, so it's safe: only the `maxNames >= 3` + exactly-3-items path changes. All other digest shapes (1, 2, 4+ items) are unaffected and covered by the added tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the exactly-three-item output for the `digest` filter. The main changes are:

- Removed the extra hardcoded comma before the configured separator.
- Added direct tests for default and custom separator output.
- Added guard tests for empty, one-item, two-item, and 4+ item cases.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. The behavior change is limited to the exactly-three-item branch, and the new tests match the filter signature and existing Vitest style.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the test suite and confirmed Vitest reported 1 test file passed, 6 tests passed, and no type errors.
- Validated the Biome check completed in 14 seconds with no fixes applied.
- Reviewed the coverage note to identify the real test names covering the default and the 3-item separator assertions.

<a href="https://app.greptile.com/trex/runs/14340022/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/filters/digest.ts | Updates the three-item branch to use the configured separator consistently. |
| packages/framework/src/filters/digest.test.ts | Adds focused Vitest coverage for the digest filter formatting cases. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(framework): remove doubled separator..."](https://github.com/novuhq/novu/commit/908fdcc3a0cba4670ace6238780fab3193efeb05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44030687)</sub>

<!-- /greptile_comment -->