### PR TITLE
feat(api-service): expose agent reply endpoint in OpenAPI with typed shapes fixes NV-8285

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts
@@ -1,17 +1,20 @@
 import { Body, Controller, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import type { Signal, ToolResult } from '@novu/framework/internal';
+import { ApiBody, ApiExtraModels, ApiOperation, ApiTags, getSchemaPath } from '@nestjs/swagger';
+import type { SentMessageInfo, Signal, ToolResult } from '@novu/framework/internal';
 import { UserSessionData } from '@novu/shared';
 import { RequireAuthentication } from '../../../auth/framework/auth.decorator';
 import { ExternalApiAccessible } from '../../../auth/framework/external-api.decorator';
-import { ApiCommonResponses } from '../../../shared/framework/response.decorator';
-import { SdkGroupName, SdkMethodName } from '../../../shared/framework/swagger/sdk.decorators';
+import { ApiCommonResponses, ApiResponse } from '../../../shared/framework/response.decorator';
+import { SdkApiParam, SdkGroupName, SdkMethodName, SdkUsageExample } from '../../../shared/framework/swagger/sdk.decorators';
 import { UserSession } from '../../../shared/framework/user.decorator';
+import { AGENT_REPLY_BODY_EXAMPLES } from '../../shared/dtos/agent-reply-body.examples';
 import { AgentReplyPayloadDto } from '../../shared/dtos/agent-reply-payload.dto';
+import { SentMessageInfoDto } from '../../shared/dtos/sent-message-info.dto';
 import { HandleAgentReplyCommand } from './handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from './handle-agent-reply/handle-agent-reply.usecase';
 
 @ApiCommonResponses()
+@ApiExtraModels(SentMessageInfoDto, AgentReplyPayloadDto)
 @Controller('/agents')
 @ApiTags('Agents')
 @SdkGroupName('Agents')
@@ -24,17 +27,46 @@ export class AgentReplyController {
   @ExternalApiAccessible()
   @SdkGroupName('Agents')
   @SdkMethodName('sendReply')
+  @SdkUsageExample('Send Agent Reply')
+  @SdkApiParam({
+    name: 'agentId',
+    description: 'Unique identifier of the agent that owns the conversation.',
+    example: 'support-bot',
+  })
+  @ApiBody({
+    type: AgentReplyPayloadDto,
+    description:
+      'Agent reply payload. Provide at least one action field (`reply`, `edit`, `resolve`, `signals`, ' +
+      '`toolResults`, `toolApprovalRequest`, `addReactions`, `deleteMessages`, `typing`, or `error`). ' +
+      'Only `reply` or `edit` may carry message content; `error` must be sent alone.',
+    examples: AGENT_REPLY_BODY_EXAMPLES,
+  })
+  @ApiResponse(SentMessageInfoDto, 200, false, true, {
+    description:
+      'When a message is posted or edited, returns platform message identifiers. `data` is `null` when the ' +
+      'request only performed side effects (signals, typing, reactions, deletes, tool results) without posting ' +
+      'a new message.',
+    schema: {
+      properties: {
+        data: {
+          nullable: true,
+          oneOf: [{ $ref: getSchemaPath(SentMessageInfoDto) }, { type: 'null' }],
+        },
+      },
+    },
+  })
   @ApiOperation({
     summary: 'Send an agent reply',
     description:
       'Send a reply into an existing agent conversation from server-side code. Supports plain text, markdown, ' +
-      'cards, edits, reactions, typing indicators, tool results, and conversation resolution signals.',
+      'cards, file attachments, edits, reactions, typing indicators, tool results, tool-approval cards, workflow ' +
+      'triggers, metadata updates, conversation resolution, and bridge error reporting.',
   })
   async handleAgentReplyHandler(
     @UserSession() user: UserSessionData,
     @Param('agentId') agentId: string,
     @Body() body: AgentReplyPayloadDto
-  ) {
+  ): Promise<SentMessageInfo | null> {
     return this.handleAgentReply.execute(
       HandleAgentReplyCommand.create({
         userId: user._id,

--- a/apps/api/src/app/agents/shared/dtos/agent-reply-body.examples.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-reply-body.examples.ts
@@ -1,0 +1,192 @@
+const CONVERSATION_ID = 'conv_abc123';
+const INTEGRATION_IDENTIFIER = 'slack-prod';
+
+export const AGENT_REPLY_BODY_EXAMPLES = {
+  markdownReply: {
+    summary: 'Markdown reply',
+    description: 'Send a plain markdown message into the conversation thread.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      reply: {
+        markdown: '**Report generated.** See the attached PDF.',
+      },
+    },
+  },
+  filesReply: {
+    summary: 'Markdown reply with file attachments',
+    description: 'Attach one or more files via public URL alongside markdown content.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      reply: {
+        markdown: 'Here is your report.',
+        files: [
+          {
+            filename: 'report.pdf',
+            mimeType: 'application/pdf',
+            url: 'https://cdn.example.com/report.pdf',
+          },
+        ],
+      },
+    },
+  },
+  cardReply: {
+    summary: 'Interactive card reply',
+    description: 'Send a structured card with text and action buttons.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      reply: {
+        card: {
+          type: 'card',
+          title: 'Deploy status',
+          subtitle: 'Production',
+          children: [
+            { type: 'text', content: 'The latest deploy succeeded.' },
+            {
+              type: 'button',
+              id: 'view-logs',
+              label: 'View logs',
+              style: 'primary',
+            },
+          ],
+        },
+      },
+    },
+  },
+  editMessage: {
+    summary: 'Edit a sent message',
+    description: 'Replace the content of a previously posted platform message.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      edit: {
+        messageId: 'msg_01HXYZ',
+        content: {
+          markdown: 'Updated answer after review.',
+        },
+      },
+    },
+  },
+  addReactions: {
+    summary: 'Add emoji reactions',
+    description: 'React to one or more platform messages without posting a new message.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      addReactions: [
+        { messageId: 'msg_01HXYZ', emojiName: 'thumbs_up' },
+        { messageId: 'msg_01HABC', emojiName: 'check' },
+      ],
+    },
+  },
+  deleteMessages: {
+    summary: 'Delete platform messages',
+    description: 'Remove rendered messages from the provider thread while preserving conversation history.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      deleteMessages: [{ messageId: 'msg_01HXYZ' }, { messageId: 'msg_01HABC' }],
+    },
+  },
+  typingStatus: {
+    summary: 'Set typing status',
+    description: 'Show a custom status while the agent processes the turn.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      typing: { status: 'Searching the docs…' },
+    },
+  },
+  typingStop: {
+    summary: 'Clear typing status',
+    description: 'Stop the typing indicator without sending a message.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      typing: 'stop',
+    },
+  },
+  resolveConversation: {
+    summary: 'Resolve conversation',
+    description: 'Mark the conversation resolved with an optional summary.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      resolve: { summary: 'Issue resolved — billing adjustment applied.' },
+    },
+  },
+  metadataSignal: {
+    summary: 'Metadata signal',
+    description: 'Persist key-value metadata on the conversation without messaging the user.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      signals: [{ type: 'metadata', action: 'set', key: 'sentiment', value: 'positive' }],
+    },
+  },
+  triggerSignal: {
+    summary: 'Trigger workflow signal',
+    description: 'Fire a Novu workflow from the agent turn.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      signals: [
+        {
+          type: 'trigger',
+          workflowId: 'escalation-email',
+          to: 'subscriber-123',
+          payload: { reason: 'User requested human support' },
+        },
+      ],
+    },
+  },
+  toolResults: {
+    summary: 'Report tool results',
+    description: 'Record tool execution output in the conversation history.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      toolResults: [
+        {
+          toolCallId: 'tc_456',
+          toolName: 'search_database',
+          output: { rows: 3 },
+          preview: 'Found 3 matching rows',
+        },
+      ],
+    },
+  },
+  toolApproval: {
+    summary: 'Request tool approval',
+    description: 'Post a tool-approval card and register the pending approval in the conversation ledger.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      toolApprovalRequest: {
+        approvalId: 'appr_123',
+        toolCallId: 'tc_456',
+        name: 'search_database',
+        input: { query: 'SELECT * FROM users WHERE id = 42' },
+      },
+      reply: {
+        toolApprovalCard: {
+          type: 'tool-approval-card',
+          title: 'Approve database search?',
+          subtitle: 'search_database',
+          body: 'Query: `SELECT * FROM users WHERE id = 42`',
+        },
+      },
+    },
+  },
+  errorReport: {
+    summary: 'Report turn error',
+    description: 'Deliver generic user-facing copy when the agent runtime fails. Cannot be combined with other fields.',
+    value: {
+      conversationId: CONVERSATION_ID,
+      integrationIdentifier: INTEGRATION_IDENTIFIER,
+      error: true,
+    },
+  },
+} as const;

--- a/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
@@ -1,5 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import type { FileRef } from '@novu/framework';
+import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
 import type { TriggerRecipientsPayload } from '@novu/shared';
 import { Type } from 'class-transformer';
 import {
@@ -15,6 +14,7 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
+import { FileRefDto } from './file-ref.dto';
 
 export type { FileRef } from '@novu/framework';
 
@@ -90,7 +90,7 @@ export class IsValidTriggerRecipient implements ValidatorConstraintInterface {
 
 @ValidatorConstraint({ name: 'isValidSignal', async: false })
 export class IsValidSignal implements ValidatorConstraintInterface {
-  validate(signal: SignalDto): boolean {
+  validate(signal: MetadataSignalDto | TriggerSignalDto): boolean {
     if (!signal?.type) return false;
 
     if (signal.type === 'metadata') {
@@ -170,52 +170,145 @@ export class IsValidTypingOp implements ValidatorConstraintInterface {
   }
 }
 
+export class ToolApprovalCardDto {
+  @ApiProperty({
+    enum: ['tool-approval-card'],
+    description: 'Discriminator for Novu tool-approval cards.',
+    example: 'tool-approval-card',
+  })
+  @IsString()
+  @IsIn(['tool-approval-card'])
+  type: 'tool-approval-card';
+
+  @ApiPropertyOptional({
+    description: 'Slack-only catalog icon id, `https://` URL, or omit to auto-match the tool name.',
+    example: 'stripe',
+  })
+  @IsOptional()
+  @IsString()
+  icon?: string;
+
+  @ApiPropertyOptional({
+    description: 'Card title shown on all channels.',
+    example: 'Approve database search?',
+  })
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @ApiPropertyOptional({
+    description: 'Card subtitle; auto-generated from the tool name when omitted.',
+    example: 'search_database',
+  })
+  @IsOptional()
+  @IsString()
+  subtitle?: string;
+
+  @ApiPropertyOptional({
+    description: 'Slack-only optional markdown body (for example, argument preview).',
+    example: 'Query: `SELECT * FROM users WHERE id = 42`',
+  })
+  @IsOptional()
+  @IsString()
+  body?: string;
+
+  @ApiPropertyOptional({ description: 'Approve button label.', example: 'Approve' })
+  @IsOptional()
+  @IsString()
+  approveLabel?: string;
+
+  @ApiPropertyOptional({ description: 'Deny button label.', example: 'Deny' })
+  @IsOptional()
+  @IsString()
+  denyLabel?: string;
+}
+
+@ApiExtraModels(FileRefDto, ToolApprovalCardDto)
 export class ReplyContentDto {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Plain text or markdown body for the reply.',
+    example: '**Report generated.** See the attached PDF.',
+  })
   @IsOptional()
   @IsString()
   markdown?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description:
+      'Interactive card element tree (buttons, text blocks, and other chat-sdk primitives). ' +
+      'Mutually exclusive with `markdown` and `toolApprovalCard`.',
+    example: {
+      type: 'card',
+      title: 'Deploy status',
+      subtitle: 'Production',
+      children: [{ type: 'text', content: 'The latest deploy succeeded.' }],
+    },
+  })
   @IsOptional()
   @IsObject()
   card?: Record<string, unknown>;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    type: ToolApprovalCardDto,
+    description: 'Novu tool-approval card rendered natively on supported channels.',
+  })
   @IsOptional()
-  @IsObject()
-  toolApprovalCard?: Record<string, unknown>;
+  @ValidateNested()
+  @Type(() => ToolApprovalCardDto)
+  toolApprovalCard?: ToolApprovalCardDto;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    type: [FileRefDto],
+    description:
+      'File attachments delivered alongside markdown or card content. Up to 15 files per message. ' +
+      'Each file must provide exactly one of `data` or `url`.',
+  })
   @IsOptional()
   @IsArray()
-  files?: FileRef[];
+  @ValidateNested({ each: true })
+  @Type(() => FileRefDto)
+  files?: FileRefDto[];
 }
 
 export class ToolApprovalRequestPayloadDto {
-  @ApiProperty({ description: 'Unique id for this approval request (matches the AI SDK approvalId).' })
+  @ApiProperty({
+    description: 'Unique id for this approval request (matches the AI SDK approvalId).',
+    example: 'appr_123',
+  })
   @IsString()
   @IsNotEmpty()
   approvalId: string;
 
-  @ApiProperty({ description: 'Id of the tool call awaiting approval.' })
+  @ApiProperty({
+    description: 'Id of the tool call awaiting approval.',
+    example: 'tc_456',
+  })
   @IsString()
   @IsNotEmpty()
   toolCallId: string;
 
-  @ApiProperty({ description: 'Name of the gated tool.' })
+  @ApiProperty({
+    description: 'Name of the gated tool.',
+    example: 'search_database',
+  })
   @IsString()
   @IsNotEmpty()
   name: string;
 
-  @ApiPropertyOptional({ description: 'Tool input the model proposed.' })
+  @ApiPropertyOptional({
+    description: 'Tool input the model proposed.',
+    example: { query: 'SELECT * FROM users WHERE id = 42' },
+  })
   @IsOptional()
   @IsObject()
   input?: Record<string, unknown>;
 }
 
 export class EditPayloadDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Platform message id of the message to edit.',
+    example: 'msg_01HXYZ',
+  })
   @IsString()
   @IsNotEmpty()
   messageId: string;
@@ -229,99 +322,199 @@ export class EditPayloadDto {
 }
 
 export class ResolveDto {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Optional human-readable summary stored on the resolve signal.',
+    example: 'Issue resolved — billing adjustment applied.',
+  })
   @IsOptional()
   @IsString()
   summary?: string;
 }
 
 export class AddReactionPayloadDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Platform message id to react to.',
+    example: 'msg_01HXYZ',
+  })
   @IsString()
   @IsNotEmpty()
   messageId: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Cross-platform emoji name (for example, `thumbs_up`, `check`).',
+    example: 'thumbs_up',
+  })
   @IsString()
   @IsNotEmpty()
   emojiName: string;
 }
 
 export class DeleteMessagePayloadDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Platform message id to delete from the provider thread.',
+    example: 'msg_01HXYZ',
+  })
   @IsString()
   @IsNotEmpty()
   messageId: string;
 }
 
-export class SignalDto {
-  @ApiProperty({ enum: SIGNAL_TYPES })
+export class MetadataSignalDto {
+  @ApiProperty({ enum: ['metadata'], example: 'metadata' })
   @IsString()
-  @IsIn(SIGNAL_TYPES)
-  type: (typeof SIGNAL_TYPES)[number];
+  @IsIn(['metadata'])
+  type: 'metadata';
 
-  @ApiPropertyOptional({ enum: METADATA_ACTIONS })
+  @ApiPropertyOptional({
+    enum: METADATA_ACTIONS,
+    description: 'Metadata mutation to apply. Defaults to `set`.',
+    example: 'set',
+  })
   @IsOptional()
   @IsString()
   @IsIn(METADATA_ACTIONS)
   action?: (typeof METADATA_ACTIONS)[number];
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Metadata key (1–128 chars; letters, digits, `-`, `_`, `:`). Required for `set` and `delete`.',
+    example: 'sentiment',
+  })
   @IsOptional()
   @IsString()
   key?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description: 'Value to store when `action` is `set`.',
+    example: 'positive',
+  })
   @IsOptional()
   value?: unknown;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ description: 'Not used for metadata signals.', deprecated: true })
   @IsOptional()
   @IsString()
   workflowId?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ description: 'Not used for metadata signals.', deprecated: true })
   @IsOptional()
   @Validate(IsValidTriggerRecipient)
   to?: TriggerRecipientsPayload;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ description: 'Not used for metadata signals.', deprecated: true })
   @IsOptional()
   @IsObject()
   payload?: Record<string, unknown>;
+}
+
+export class TriggerSignalDto {
+  @ApiProperty({ enum: ['trigger'], example: 'trigger' })
+  @IsString()
+  @IsIn(['trigger'])
+  type: 'trigger';
+
+  @ApiPropertyOptional({ description: 'Not used for trigger signals.', deprecated: true })
+  @IsOptional()
+  @IsString()
+  @IsIn(METADATA_ACTIONS)
+  action?: (typeof METADATA_ACTIONS)[number];
+
+  @ApiPropertyOptional({ description: 'Not used for trigger signals.', deprecated: true })
+  @IsOptional()
+  @IsString()
+  key?: string;
+
+  @ApiPropertyOptional({ description: 'Not used for trigger signals.', deprecated: true })
+  @IsOptional()
+  value?: unknown;
+
+  @ApiProperty({
+    description: 'Workflow identifier or slug to trigger.',
+    example: 'escalation-email',
+  })
+  @IsString()
+  @IsNotEmpty()
+  workflowId: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Workflow recipients — subscriber id string, `{ subscriberId }` object, topic object, or an array of those.',
+    example: 'subscriber-123',
+  })
+  @IsOptional()
+  @Validate(IsValidTriggerRecipient)
+  to?: TriggerRecipientsPayload;
+
+  @ApiPropertyOptional({
+    description: 'Workflow trigger payload.',
+    example: { reason: 'User requested human support' },
+  })
+  @IsOptional()
+  @IsObject()
+  payload?: Record<string, unknown>;
+}
+
+export type SignalDto = MetadataSignalDto | TriggerSignalDto;
+
+export class TypingStatusDto {
+  @ApiPropertyOptional({
+    description: 'Custom status text. Omit for the default "Thinking…".',
+    example: 'Searching the docs…',
+  })
+  @IsOptional()
+  @IsString()
+  status?: string;
 }
 
 /**
  * Reports the outcome of a tool call back to Novu so it's saved in the conversation history.
  */
 export class ToolResultDto {
-  @ApiProperty({ description: 'Id of the tool call this result resolves.' })
+  @ApiProperty({
+    description: 'Id of the tool call this result resolves.',
+    example: 'tc_456',
+  })
   @IsString()
   @IsNotEmpty()
   toolCallId: string;
 
-  @ApiPropertyOptional({ description: 'Name of the tool that produced this result.' })
+  @ApiPropertyOptional({
+    description: 'Name of the tool that produced this result.',
+    example: 'search_database',
+  })
   @IsOptional()
   @IsString()
   toolName?: string;
 
-  @ApiPropertyOptional({ description: 'JSON-serializable tool output (or the execution-denied marker).' })
+  @ApiPropertyOptional({
+    description: 'JSON-serializable tool output (or the execution-denied marker).',
+    example: { rows: 3 },
+  })
   @IsOptional()
   output?: unknown;
 
-  @ApiPropertyOptional({ description: 'Human-readable preview for the display timeline.' })
+  @ApiPropertyOptional({
+    description: 'Human-readable preview for the display timeline.',
+    example: 'Found 3 matching rows',
+  })
   @IsOptional()
   @IsString()
   preview?: string;
 }
 
+@ApiExtraModels(MetadataSignalDto, TriggerSignalDto, TypingStatusDto, ReplyContentDto, FileRefDto, ToolApprovalCardDto)
 export class AgentReplyPayloadDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Conversation id returned by inbound webhooks or the conversations API.',
+    example: 'conv_abc123',
+  })
   @IsString()
   @IsNotEmpty()
   conversationId: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Integration identifier for the channel connection that owns the thread.',
+    example: 'slack-prod',
+  })
   @IsString()
   @IsNotEmpty()
   integrationIdentifier: string;
@@ -357,12 +550,34 @@ export class AgentReplyPayloadDto {
   @Type(() => ResolveDto)
   resolve?: ResolveDto;
 
-  @ApiPropertyOptional({ type: [SignalDto] })
+  @ApiPropertyOptional({
+    type: 'array',
+    description: 'Side-effect signals applied during the turn (metadata updates or workflow triggers).',
+    items: {
+      oneOf: [{ $ref: getSchemaPath(MetadataSignalDto) }, { $ref: getSchemaPath(TriggerSignalDto) }],
+      discriminator: {
+        propertyName: 'type',
+        mapping: {
+          metadata: getSchemaPath(MetadataSignalDto),
+          trigger: getSchemaPath(TriggerSignalDto),
+        },
+      },
+    },
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Validate(IsValidSignal, { each: true })
-  @Type(() => SignalDto)
+  @Type(() => MetadataSignalDto, {
+    discriminator: {
+      property: 'type',
+      subTypes: [
+        { value: MetadataSignalDto, name: 'metadata' },
+        { value: TriggerSignalDto, name: 'trigger' },
+      ],
+    },
+    keepDiscriminatorProperty: true,
+  })
   signals?: SignalDto[];
 
   @ApiPropertyOptional({ type: [ToolResultDto] })
@@ -394,13 +609,18 @@ export class AgentReplyPayloadDto {
     description:
       'Per-turn typing/status control. `{ status?: string }` sets the status text ' +
       '(omit for the default "Thinking…"); `"stop"` clears it. Best-effort per platform.',
+    oneOf: [{ $ref: getSchemaPath(TypingStatusDto) }, { type: 'string', enum: ['stop'] }],
+    examples: [{ status: 'Searching the docs…' }, 'stop'],
   })
   @IsOptional()
   @Validate(IsValidTypingOp)
-  typing?: { status?: string } | 'stop';
+  typing?: TypingStatusDto | 'stop';
 
   @ApiPropertyOptional({
-    description: 'Bridge reports the turn failed on the customer runtime. Delivers generic user copy.',
+    description:
+      'Bridge reports the turn failed on the customer runtime. Delivers generic user copy. ' +
+      'Cannot be combined with any other request fields.',
+    example: true,
   })
   @IsOptional()
   @IsBoolean()

--- a/apps/api/src/app/agents/shared/dtos/file-ref.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/file-ref.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class FileRefDto {
+  @ApiProperty({
+    description: 'Filename shown to the subscriber and used when materializing the attachment.',
+    example: 'report.pdf',
+  })
+  @IsString()
+  @IsNotEmpty()
+  filename: string;
+
+  @ApiPropertyOptional({
+    description: 'MIME type hint for the attachment (for example, `application/pdf`).',
+    example: 'application/pdf',
+  })
+  @IsOptional()
+  @IsString()
+  mimeType?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Inline file data as a base64-encoded string. Use for small generated files (up to 5 MB decoded). ' +
+      'Provide exactly one of `data` or `url` per file.',
+    example: 'JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PC9UeXBlL0NhdGFsb2c+PgplbmRvYmoK',
+  })
+  @IsOptional()
+  @IsString()
+  data?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Public HTTP(S) URL Novu fetches server-side. Recommended for larger files (up to 25 MB per file). ' +
+      'Provide exactly one of `data` or `url` per file.',
+    example: 'https://cdn.example.com/report.pdf',
+  })
+  @IsOptional()
+  @IsString()
+  url?: string;
+}

--- a/apps/api/src/app/agents/shared/dtos/sent-message-info.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/sent-message-info.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+/**
+ * Identifiers for a message posted or edited on the destination platform.
+ * Returned when the reply endpoint delivers a new message or edits an existing one.
+ */
+export class SentMessageInfoDto {
+  @ApiProperty({
+    description: 'Platform-specific message identifier for the posted or edited message.',
+    example: 'msg_01HXYZ',
+  })
+  @IsString()
+  @IsNotEmpty()
+  messageId: string;
+
+  @ApiProperty({
+    description: 'Platform-specific thread identifier the message belongs to.',
+    example: 'thread_01HXYZ',
+  })
+  @IsString()
+  @IsNotEmpty()
+  platformThreadId: string;
+}

--- a/docs/api-reference/agents/send-an-agent-reply.mdx
+++ b/docs/api-reference/agents/send-an-agent-reply.mdx
@@ -1,4 +1,9 @@
 ---
 title: "Send an agent reply"
+description: "Post a reply or side-effect into an existing agent conversation from server-side code."
 openapi: "POST /v1/agents/{agentId}/reply"
 ---
+
+Use this endpoint when your agent runs outside `@novu/framework` (for example, in Python, Go, or a custom Node service) and needs to deliver messages or conversation side effects into an active thread.
+
+Each request targets one conversation via `conversationId` and the channel `integrationIdentifier`. Combine `reply` with `signals` or `resolve` in a single call when your turn both messages the user and updates conversation state. The response includes platform message ids when a new message is posted or edited; otherwise `data` is `null`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents `POST /v1/agents/{agentId}/reply` for OpenAPI and Speakeasy SDK autogeneration so non-TypeScript customers can call the endpoint with typed server-side SDKs.

## Changes

- **DTO annotations**: Added `FileRefDto`, `SentMessageInfoDto`, `ToolApprovalCardDto`, `TypingStatusDto`, and discriminated `MetadataSignalDto` / `TriggerSignalDto` with descriptions and examples on `AgentReplyPayloadDto` and nested types.
- **Controller**: Added `@ApiBody` with 14 named request examples (markdown, files, cards, edit, reactions, delete, typing, resolve, metadata/trigger signals, tool results, tool approval, error), `@ApiResponse` with nullable `SentMessageInfoDto` envelope, `@SdkApiParam`, and `@SdkUsageExample`.
- **Docs**: Expanded `send-an-agent-reply.mdx` with frontmatter description and intro prose.

## Testing

- `pnpm --filter @novu/api-service build` — pass
- `pnpm generate:swagger` — pass (verified 14 named examples and new schemas in spec)
- `agent-reply.e2e.ts` — 21 passing

## Notes

- `libs/internal-sdk` regeneration requires Speakeasy credentials in CI; OpenAPI source annotations are in place for the next SDK publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8285](https://linear.app/novu/issue/NV-8285/expose-agent-reply-endpoint-in-openapisdk-with-typed-shapes-and)

<div><a href="https://cursor.com/agents/bc-49762934-381e-4726-9c28-5d4aa5a82c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49762934-381e-4726-9c28-5d4aa5a82c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the agent reply endpoint with typed OpenAPI shapes. The main changes are:

- Adds request and response annotations for `POST /v1/agents/{agentId}/reply`.
- Adds named OpenAPI examples for reply, side-effect, and error payloads.
- Adds DTOs for file references, sent message info, signals, typing status, and tool approval cards.
- Expands the agent reply docs page with endpoint usage guidance.

<h3>Confidence Score: 4/5</h3>

The typed tool approval card path needs a compatibility fix before merging.

`toolApprovalCard` now runs nested DTO validation, and existing approval-card payloads without the discriminator can be rejected before the use case runs. The response envelope and nullable `data` behavior match the existing response wrapper.

apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reproduced the missing discriminator error when validating a payload lacking the discriminator, confirming the tool-approval-card path requires a type field.
- The same validation path passes for a control payload with type: "tool-approval-card", showing zero validation errors.
- Root command attempt and subsequent OpenAPI validation steps were documented, including blockers that prevent generating fresh OpenAPI output.
- Blocker evidence shows the dependency build path is blocked, preventing validation from confirming updated OpenAPI output.

<a href="https://app.greptile.com/trex/runs/14352323/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/reply/agent-reply.controller.ts | Adds OpenAPI and SDK decorators for the agent reply endpoint, including nullable enveloped response metadata. |
| apps/api/src/app/agents/shared/dtos/agent-reply-body.examples.ts | Adds named request examples for the documented agent reply payload variants. |
| apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts | Adds richer schema metadata and nested DTOs, with a runtime validation compatibility issue for tool approval cards. |
| apps/api/src/app/agents/shared/dtos/file-ref.dto.ts | Adds a DTO for JSON file attachment references. |
| apps/api/src/app/agents/shared/dtos/sent-message-info.dto.ts | Adds a DTO for platform message identifiers returned by the endpoint. |
| docs/api-reference/agents/send-an-agent-reply.mdx | Adds a description and short usage notes for the agent reply endpoint. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fshared%2Fdtos%2Fagent-reply-payload.dto.ts%3A258%0A**Tool%20Card%20Discriminator%20Becomes%20Required**%0A%0AWhen%20%60toolApprovalCard%60%20is%20transformed%20into%20%60ToolApprovalCardDto%60%2C%20validation%20now%20requires%20%60type%3A%20'tool-approval-card'%60.%20A%20request%20like%20%60reply%3A%20%7B%20toolApprovalCard%3A%20%7B%20title%3A%20'Approve%3F'%2C%20body%3A%20'...'%20%7D%20%7D%60%20previously%20passed%20as%20a%20plain%20object%2C%20but%20now%20fails%20validation%20before%20%60HandleAgentReply%60%20runs%2C%20so%20existing%20callers%20can%20no%20longer%20post%20approval%20cards%20unless%20they%20add%20the%20discriminator.%0A%0A&pr=11928&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts:258
**Tool Card Discriminator Becomes Required**

When `toolApprovalCard` is transformed into `ToolApprovalCardDto`, validation now requires `type: 'tool-approval-card'`. A request like `reply: { toolApprovalCard: { title: 'Approve?', body: '...' } }` previously passed as a plain object, but now fails validation before `HandleAgentReply` runs, so existing callers can no longer post approval cards unless they add the discriminator.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api-service): expose agent reply en..."](https://github.com/novuhq/novu/commit/0d5164a53219bf5513d1a21569fc6af921a818e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44054757)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->