### PR TITLE
fix(novu): respect --no-studio to skip dashboard open fixes NV-8286

### DIFF
--- a/packages/novu/README.MD
+++ b/packages/novu/README.MD
@@ -217,11 +217,11 @@ npx novu@latest dev
 | `-r` | `--route <route>` | Bridge application route | `/api/novu` |
 | `-o` | `--origin <origin>` | Bridge application origin | `http://localhost` |
 | `-d` | `--dashboard-url <url>` | Novu Cloud dashboard URL | `https://dashboard.novu.co` |
-| `-sp` | `--studio-port <port>` | Local Studio server port | `2022` |
-| `-sh` | `--studio-host <host>` | Local Studio server host | `localhost` |
+| `-sp` | `--studio-port <port>` | [deprecated] Ignored | `2022` |
+| `-sh` | `--studio-host <host>` | [deprecated] Ignored | `localhost` |
 | `-t` | `--tunnel <url>` | Self-hosted tunnel URL | — |
-| `-H` | `--headless` | Run bridge in headless mode | `false` |
-| | `--no-studio` | Skip starting local Studio | — |
+| `-H` | `--headless` | Run without opening the browser | `false` |
+| | `--no-studio` | Skip opening the dashboard Local environment (tunnel and agent sync still run) | — |
 | | `--run <command>` | Spawn a local app server before opening the tunnel | — |
 
 Example — bridge on port `3002` with an EU dashboard:

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -134,19 +134,21 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
 
   await monitorEndpointHealth(parsedOptions, NOVU_ENDPOINT_PATH);
 
-  // The legacy local studio is gone: local development happens in the cloud
-  // dashboard's "Local" environment mode, connected through the tunnel.
-  const handshakeUrl = buildDashboardHandshakeUrl(
-    parsedOptions.dashboardUrl,
-    tunnelOrigin,
-    NOVU_ENDPOINT_PATH,
-    anonymousId
-  );
-  const dashboardSpinner = ora('Opening dashboard').start();
-  dashboardSpinner.succeed(`🖥️  Dashboard → ${handshakeUrl}`);
+  // Dashboard Local environment replaces the legacy local studio. --no-studio
+  // skips opening it (used by connect/init agent flows that only need tunnel + sync).
+  if (parsedOptions.studio !== false) {
+    const handshakeUrl = buildDashboardHandshakeUrl(
+      parsedOptions.dashboardUrl,
+      tunnelOrigin,
+      NOVU_ENDPOINT_PATH,
+      anonymousId
+    );
+    const dashboardSpinner = ora('Opening dashboard').start();
+    dashboardSpinner.succeed(`🖥️  Dashboard → ${handshakeUrl}`);
 
-  if (process.env.NODE_ENV !== 'dev' && parsedOptions.headless === false) {
-    await open(handshakeUrl);
+    if (process.env.NODE_ENV !== 'dev' && parsedOptions.headless === false) {
+      await open(handshakeUrl);
+    }
   }
 
   if (!parsedOptions.tunnel) {
@@ -182,7 +184,6 @@ function warnAboutDeprecatedStudioOptions(options: DevCommandOptions) {
 
   if (options.studioPort && options.studioPort !== '2022') usedDeprecated.push('--studio-port');
   if (options.studioHost && options.studioHost !== 'localhost') usedDeprecated.push('--studio-host');
-  if (options.studio === false) usedDeprecated.push('--no-studio');
 
   if (usedDeprecated.length > 0) {
     console.log(

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -131,7 +131,10 @@ program
   )
   .option('-t, --tunnel <url>', 'Self hosted tunnel. e.g. https://my-tunnel.ngrok.app')
   .option('-H, --headless', 'Run without opening the browser', false)
-  .option('--no-studio', '[deprecated] Ignored — the local studio was replaced by the dashboard Local environment')
+  .option(
+    '--no-studio',
+    'Skip opening the dashboard Local environment (tunnel and agent sync still run)'
+  )
   .option('--run <command>', 'Spawn a local app server before opening the tunnel')
   .action(async (options: DevCommandOptions) => {
     analytics.track({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`npx novu dev --no-studio` was marked deprecated/ignored after the local studio was replaced by the dashboard Local environment, so it still opened the dashboard. Connect and init scripts still pass `--no-studio` and expect tunnel + agent sync only.

## Changes

- Honor `--no-studio`: skip building/printing/opening the dashboard Local handshake URL
- Still create the tunnel, health-check the bridge, and run agent discovery/registration
- Stop treating `--no-studio` as a deprecated ignored flag (keep `--studio-port` / `--studio-host` deprecated)
- Update CLI help and README to match

## Test plan

- [ ] `npx novu dev` still opens the dashboard Local environment (default)
- [ ] `npx novu dev --no-studio` does not open or print the dashboard URL
- [ ] With `--no-studio` and `NOVU_SECRET_KEY` set, agent sync/registration still runs after tunnel + health check
- [ ] `npx novu dev --headless` still prints the dashboard URL but does not open the browser
- [ ] Connect/init `--no-studio` scripts no longer open the dashboard unexpectedly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8969304-2853-481d-8432-78dfa7c912b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8969304-2853-481d-8432-78dfa7c912b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `--no-studio` an active Novu dev option again. The main changes are:

- Skips dashboard Local URL creation, printing, and browser opening when `--no-studio` is passed.
- Keeps tunnel setup, bridge checks, and agent registration outside that skip path.
- Removes the `--no-studio` deprecation warning.
- Updates CLI help and README option text.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. The default dev flow still opens the dashboard, and the `--no-studio` flow still reaches tunnel and agent sync code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the no-studio runtime spec with Vitest; the run exited with code 0 and reported 3 passing tests.
- Inspected the --no-studio trace and confirmed openCalls was empty, the console showed no Dashboard or /local?, and fetch calls included a health check, discover, and a PUT to api.novu.co/v1/agents/agent-alpha/bridge.
- Checked the default trace and confirmed the dashboard URL printed and openCalls contained the Local handshake URL.
- Checked the headless trace and confirmed the dashboard URL printed and openCalls remained \[\].

<a href="https://app.greptile.com/trex/runs/14356257/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/dev/dev.ts | Guards only the dashboard URL and browser-open work while leaving tunnel checks and agent registration active. |
| packages/novu/src/index.ts | Updates the `--no-studio` help text to describe the active skip behavior. |
| packages/novu/README.MD | Updates the dev command option table for the new dashboard and headless wording. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(novu): respect --no-studio to skip d..."](https://github.com/novuhq/novu/commit/1d87332bc502522ccb8b815c5271df9aeee61536) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44064186)</sub>

<!-- /greptile_comment -->