### PR TITLE
fix(api-service): seed Slack thread parent into agent history fixes NV-8287

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -40,6 +40,7 @@ import { AgentConversationService } from './conversation-runtime/conversation/ag
 import { AgentSubscriberAdoptionService } from './conversation-runtime/conversation/agent-subscriber-adoption.service';
 import { AgentSubscriberResolver } from './conversation-runtime/conversation/agent-subscriber-resolver.service';
 import { ConversationActivationService } from './conversation-runtime/conversation/conversation-activation.service';
+import { SeedSlackThreadParentService } from './conversation-runtime/conversation/seed-slack-thread-parent.service';
 import { FileMaterializer } from './conversation-runtime/egress/file-materializer.service';
 import { OutboundGateway } from './conversation-runtime/egress/outbound.gateway';
 import { AgentInboundController } from './conversation-runtime/ingress/agent-inbound.controller';
@@ -120,6 +121,7 @@ import { USE_CASES } from './usecases';
     AgentSubscriberResolver,
     AgentSubscriberAdoptionService,
     AgentConversationService,
+    SeedSlackThreadParentService,
     ConversationActivationService,
     InboundAckService,
     AgentEmailActionTokenService,

--- a/apps/api/src/app/agents/conversation-runtime/conversation/seed-slack-thread-parent.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/seed-slack-thread-parent.service.spec.ts
@@ -1,0 +1,234 @@
+import { expect } from 'chai';
+import type { Message } from 'chat';
+import sinon from 'sinon';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import {
+  extractSlackMessageText,
+  isSlackBotAuthoredMessage,
+  resolveSlackThreadParentTs,
+  SeedSlackThreadParentService,
+} from './seed-slack-thread-parent.service';
+
+function makeMessage(overrides: {
+  id?: string;
+  text?: string;
+  thread_ts?: string;
+  ts?: string;
+}): Message {
+  const ts = overrides.ts ?? overrides.id ?? '1777837477.000200';
+  const event: Record<string, unknown> = { ts, text: overrides.text ?? 'reply' };
+
+  if (overrides.thread_ts !== undefined) {
+    event.thread_ts = overrides.thread_ts;
+  }
+
+  return {
+    id: overrides.id ?? ts,
+    text: overrides.text ?? 'reply',
+    author: { userId: 'U123', isBot: false },
+    raw: { event },
+  } as Message;
+}
+
+describe('resolveSlackThreadParentTs', () => {
+  it('returns null for top-level messages without thread_ts', () => {
+    expect(resolveSlackThreadParentTs(makeMessage({ ts: '1.1' }))).to.equal(null);
+  });
+
+  it('returns null when thread_ts equals the message ts (message is the root)', () => {
+    expect(resolveSlackThreadParentTs(makeMessage({ ts: '1.1', thread_ts: '1.1' }))).to.equal(null);
+  });
+
+  it('returns the parent ts for a thread reply', () => {
+    expect(resolveSlackThreadParentTs(makeMessage({ ts: '1.2', thread_ts: '1.1' }))).to.equal('1.1');
+  });
+});
+
+describe('isSlackBotAuthoredMessage', () => {
+  it('detects bot_id, app_id, and bot_message subtype', () => {
+    expect(isSlackBotAuthoredMessage({ bot_id: 'B1' })).to.equal(true);
+    expect(isSlackBotAuthoredMessage({ app_id: 'A1' })).to.equal(true);
+    expect(isSlackBotAuthoredMessage({ subtype: 'bot_message' })).to.equal(true);
+    expect(isSlackBotAuthoredMessage({ text: 'from a human' })).to.equal(false);
+  });
+});
+
+describe('extractSlackMessageText', () => {
+  it('prefers the top-level text field', () => {
+    expect(extractSlackMessageText({ text: 'hello', blocks: [{ type: 'section', text: { text: 'ignored' } }] })).to.equal(
+      'hello'
+    );
+  });
+
+  it('falls back to block kit section and field text', () => {
+    expect(
+      extractSlackMessageText({
+        blocks: [
+          { type: 'section', text: { type: 'mrkdwn', text: 'insight' } },
+          { type: 'section', fields: [{ type: 'mrkdwn', text: 'growth' }] },
+        ],
+      })
+    ).to.equal('insight\ngrowth');
+  });
+
+  it('falls back to attachment fallback text', () => {
+    expect(extractSlackMessageText({ attachments: [{ fallback: 'digest body' }] })).to.equal('digest body');
+  });
+});
+
+describe('SeedSlackThreadParentService', () => {
+  const config = {
+    platform: AgentPlatformEnum.SLACK,
+    connectionAccessToken: 'xoxb-token',
+    environmentId: 'env1',
+    organizationId: 'org1',
+    agentIdentifier: 'revenue-agent',
+    agentName: 'Revenue Agent',
+    integrationId: 'integration1',
+  } as any;
+
+  const conversation = {
+    _id: 'conversation1',
+    channels: [{ platform: 'slack', _integrationId: 'integration1', platformThreadId: 'slack:C1:1.1' }],
+  } as any;
+
+  function makeService() {
+    const conversationService = {
+      findSourceActivity: sinon.stub().resolves(null),
+      getPrimaryChannel: sinon.stub().callsFake((conv) => conv.channels[0]),
+      persistAgentMessage: sinon.stub().resolves({ _id: 'activity-parent' }),
+    };
+    const logger = {
+      setContext: sinon.stub(),
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    const service = new SeedSlackThreadParentService(conversationService as any, logger as any);
+
+    return { service, conversationService, logger };
+  }
+
+  it('persists a bot thread parent before the inbound reply is recorded', async () => {
+    const { service, conversationService } = makeService();
+    const replies = sinon.stub().resolves({
+      ok: true,
+      messages: [{ ts: '1.1', text: 'New revenue insight found', bot_id: 'B123' }],
+    });
+    service.createClient = (() => ({ conversations: { replies } })) as any;
+
+    const parentTs = await service.maybeSeed({
+      agentId: 'agent1',
+      config,
+      conversation,
+      message: makeMessage({ ts: '1.2', thread_ts: '1.1', text: 'check latest deals' }),
+      platformThreadId: 'slack:C1:1.1',
+    });
+
+    expect(parentTs).to.equal('1.1');
+    expect(replies.calledOnce).to.equal(true);
+    expect(replies.firstCall.args[0]).to.deep.include({
+      channel: 'C1',
+      ts: '1.1',
+      latest: '1.1',
+      inclusive: true,
+      limit: 1,
+    });
+    expect(conversationService.persistAgentMessage.calledOnce).to.equal(true);
+    expect(conversationService.persistAgentMessage.firstCall.args[0]).to.include({
+      conversationId: 'conversation1',
+      platformMessageId: '1.1',
+      platformThreadId: 'slack:C1:1.1',
+      agentIdentifier: 'revenue-agent',
+      content: 'New revenue insight found',
+    });
+  });
+
+  it('is idempotent when the parent activity already exists', async () => {
+    const { service, conversationService } = makeService();
+    conversationService.findSourceActivity.resolves({ platformMessageId: '1.1' });
+    const replies = sinon.stub();
+    service.createClient = (() => ({ conversations: { replies } })) as any;
+
+    const parentTs = await service.maybeSeed({
+      agentId: 'agent1',
+      config,
+      conversation,
+      message: makeMessage({ ts: '1.2', thread_ts: '1.1' }),
+      platformThreadId: 'slack:C1:1.1',
+    });
+
+    expect(parentTs).to.equal('1.1');
+    expect(replies.called).to.equal(false);
+    expect(conversationService.persistAgentMessage.called).to.equal(false);
+  });
+
+  it('does not seed human-authored thread parents as agent messages', async () => {
+    const { service, conversationService } = makeService();
+    service.createClient = (() => ({
+      conversations: {
+        replies: sinon.stub().resolves({
+          ok: true,
+          messages: [{ ts: '1.1', text: 'started by a teammate', user: 'U999' }],
+        }),
+      },
+    })) as any;
+
+    const parentTs = await service.maybeSeed({
+      agentId: 'agent1',
+      config,
+      conversation,
+      message: makeMessage({ ts: '1.2', thread_ts: '1.1' }),
+      platformThreadId: 'slack:C1:1.1',
+    });
+
+    expect(parentTs).to.equal(null);
+    expect(conversationService.persistAgentMessage.called).to.equal(false);
+  });
+
+  it('fails soft when Slack API errors', async () => {
+    const { service, conversationService, logger } = makeService();
+    service.createClient = (() => ({
+      conversations: {
+        replies: sinon.stub().rejects(new Error('slack down')),
+      },
+    })) as any;
+
+    const parentTs = await service.maybeSeed({
+      agentId: 'agent1',
+      config,
+      conversation,
+      message: makeMessage({ ts: '1.2', thread_ts: '1.1' }),
+      platformThreadId: 'slack:C1:1.1',
+    });
+
+    expect(parentTs).to.equal(null);
+    expect(conversationService.persistAgentMessage.called).to.equal(false);
+    expect(logger.warn.calledOnce).to.equal(true);
+  });
+
+  it('skips non-Slack platforms and top-level messages', async () => {
+    const { service, conversationService } = makeService();
+
+    expect(
+      await service.maybeSeed({
+        agentId: 'agent1',
+        config: { ...config, platform: AgentPlatformEnum.TEAMS },
+        conversation,
+        message: makeMessage({ ts: '1.2', thread_ts: '1.1' }),
+        platformThreadId: 'slack:C1:1.1',
+      })
+    ).to.equal(null);
+
+    expect(
+      await service.maybeSeed({
+        agentId: 'agent1',
+        config,
+        conversation,
+        message: makeMessage({ ts: '1.1' }),
+        platformThreadId: 'slack:C1:1.1',
+      })
+    ).to.equal(null);
+
+    expect(conversationService.findSourceActivity.called).to.equal(false);
+  });
+});

--- a/apps/api/src/app/agents/conversation-runtime/conversation/seed-slack-thread-parent.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/seed-slack-thread-parent.service.ts
@@ -1,0 +1,250 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { ConversationEntity } from '@novu/dal';
+import type { Message } from 'chat';
+import type { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
+import { createSlackWebClient, decodeSlackPlatformThreadId } from '../egress/slack-native-delivery';
+import { AgentConversationService } from './agent-conversation.service';
+
+type SlackParentMessage = {
+  ts?: string;
+  text?: string;
+  bot_id?: string;
+  app_id?: string;
+  subtype?: string;
+  blocks?: unknown[];
+  attachments?: Array<{ fallback?: string; text?: string; pretext?: string }>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function getMessageRawEvent(message: Message): Record<string, unknown> | undefined {
+  const raw = asRecord(message.raw);
+
+  return asRecord(raw?.event) ?? raw;
+}
+
+/**
+ * Returns the Slack thread root `ts` when `message` is a reply in an existing
+ * thread. Top-level posts (no `thread_ts`, or `thread_ts === ts`) return null.
+ */
+export function resolveSlackThreadParentTs(message: Message): string | null {
+  const rawEvent = getMessageRawEvent(message);
+  const threadTs = rawEvent?.thread_ts;
+
+  if (typeof threadTs !== 'string' || threadTs.length === 0) {
+    return null;
+  }
+
+  const messageTs = typeof rawEvent?.ts === 'string' && rawEvent.ts.length > 0 ? rawEvent.ts : message.id;
+
+  if (messageTs && threadTs === messageTs) {
+    return null;
+  }
+
+  return threadTs;
+}
+
+export function isSlackBotAuthoredMessage(message: SlackParentMessage): boolean {
+  if (typeof message.bot_id === 'string' && message.bot_id.length > 0) {
+    return true;
+  }
+
+  if (typeof message.app_id === 'string' && message.app_id.length > 0) {
+    return true;
+  }
+
+  return message.subtype === 'bot_message';
+}
+
+function extractTextFromBlocks(blocks: unknown[] | undefined): string {
+  if (!Array.isArray(blocks)) {
+    return '';
+  }
+
+  const parts: string[] = [];
+
+  for (const block of blocks) {
+    const record = asRecord(block);
+    if (!record) {
+      continue;
+    }
+
+    const textNode = asRecord(record.text);
+    if (typeof textNode?.text === 'string' && textNode.text.trim().length > 0) {
+      parts.push(textNode.text.trim());
+      continue;
+    }
+
+    const fields = record.fields;
+    if (!Array.isArray(fields)) {
+      continue;
+    }
+
+    for (const field of fields) {
+      const fieldRecord = asRecord(field);
+      if (typeof fieldRecord?.text === 'string' && fieldRecord.text.trim().length > 0) {
+        parts.push(fieldRecord.text.trim());
+      }
+    }
+  }
+
+  return parts.join('\n');
+}
+
+export function extractSlackMessageText(message: SlackParentMessage): string {
+  const direct = message.text?.trim() ?? '';
+  if (direct.length > 0) {
+    return direct;
+  }
+
+  const fromBlocks = extractTextFromBlocks(message.blocks);
+  if (fromBlocks.length > 0) {
+    return fromBlocks;
+  }
+
+  for (const attachment of message.attachments ?? []) {
+    const fallback = attachment.fallback?.trim() || attachment.text?.trim() || attachment.pretext?.trim();
+    if (fallback) {
+      return fallback;
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Workflow (and other bot) Slack posts do not create ConversationActivity rows.
+ * When a user later replies in that thread, hydrate the thread root from Slack
+ * so the bridge history includes the original agent/workflow context.
+ */
+@Injectable()
+export class SeedSlackThreadParentService {
+  /** Overridable in unit tests so WebClient does not hit the network. */
+  createClient = createSlackWebClient;
+
+  constructor(
+    private readonly conversationService: AgentConversationService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  /**
+   * Persists the Slack thread parent as an agent activity when missing.
+   * Returns the parent platform message id when seeded or already present;
+   * null when there is nothing to seed or hydration fails (fail-soft).
+   */
+  async maybeSeed(params: {
+    agentId: string;
+    config: ResolvedAgentConfig;
+    conversation: ConversationEntity;
+    message: Message;
+    platformThreadId: string;
+  }): Promise<string | null> {
+    const { agentId, config, conversation, message, platformThreadId } = params;
+
+    if (config.platform !== AgentPlatformEnum.SLACK) {
+      return null;
+    }
+
+    const botToken = config.connectionAccessToken;
+    if (!botToken) {
+      return null;
+    }
+
+    const parentTs = resolveSlackThreadParentTs(message);
+    if (!parentTs) {
+      return null;
+    }
+
+    const existing = await this.conversationService.findSourceActivity(
+      config.environmentId,
+      conversation._id,
+      parentTs
+    );
+    if (existing) {
+      return parentTs;
+    }
+
+    try {
+      const { channel } = decodeSlackPlatformThreadId(platformThreadId);
+      const parent = await this.fetchThreadParent({ botToken, channel, parentTs });
+
+      if (!parent || !isSlackBotAuthoredMessage(parent)) {
+        return null;
+      }
+
+      const content = extractSlackMessageText(parent);
+      if (!content) {
+        this.logger.debug(
+          `[agent:${agentId}] Slack thread parent ${parentTs} has no extractable text; skipping history seed`
+        );
+
+        return null;
+      }
+
+      await this.conversationService.persistAgentMessage({
+        conversationId: conversation._id,
+        channel: this.conversationService.getPrimaryChannel(conversation),
+        platformMessageId: parentTs,
+        platformThreadId,
+        agentIdentifier: config.agentIdentifier,
+        agentName: config.agentName,
+        content,
+        environmentId: config.environmentId,
+        organizationId: config.organizationId,
+      });
+
+      this.logger.debug(`[agent:${agentId}] Seeded Slack thread parent ${parentTs} into conversation history`);
+
+      return parentTs;
+    } catch (err) {
+      this.logger.warn(
+        err,
+        `[agent:${agentId}] Failed to seed Slack thread parent into conversation history; continuing without it`
+      );
+      captureAgentWarning(err, {
+        component: 'seed-slack-thread-parent',
+        operation: 'seed-thread-parent',
+        agentId,
+      });
+
+      return null;
+    }
+  }
+
+  private async fetchThreadParent(params: {
+    botToken: string;
+    channel: string;
+    parentTs: string;
+  }): Promise<SlackParentMessage | null> {
+    const client = this.createClient(params.botToken);
+    const result = await client.conversations.replies({
+      channel: params.channel,
+      ts: params.parentTs,
+      latest: params.parentTs,
+      inclusive: true,
+      limit: 1,
+    });
+
+    if (!result.ok) {
+      throw new Error(`Slack conversations.replies failed: ${result.error ?? 'unknown_error'}`);
+    }
+
+    const parent = result.messages?.[0] as SlackParentMessage | undefined;
+    if (!parent?.ts || parent.ts !== params.parentTs) {
+      return null;
+    }
+
+    return parent;
+  }
+}

--- a/apps/api/src/app/agents/conversation-runtime/egress/slack-native-delivery.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/slack-native-delivery.ts
@@ -30,7 +30,7 @@ export function getSlackApiErrorCode(err: unknown): string | undefined {
   return typeof error === 'string' ? error : undefined;
 }
 
-function createSlackWebClient(token: string): WebClient {
+export function createSlackWebClient(token: string): WebClient {
   return new WebClient(token, {
     ...(process.env.SLACK_API_URL ? { slackApiUrl: process.env.SLACK_API_URL } : {}),
   });

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -184,6 +184,9 @@ describe('AgentInboundHandler', () => {
       tryHandleAsApprovalReply: sinon.stub().resolves(false),
       tryHandleAsApprovalReaction: sinon.stub().resolves(false),
     };
+    const seedSlackThreadParent = {
+      maybeSeed: sinon.stub().resolves(null),
+    };
     const handler = new AgentInboundHandler(
       logger as any,
       subscriberResolver as any,
@@ -203,7 +206,8 @@ describe('AgentInboundHandler', () => {
       keylessAbuseGuard as any,
       planLimitGate as any,
       inboundAck as any,
-      replyApprovalInterceptor as any
+      replyApprovalInterceptor as any,
+      seedSlackThreadParent as any
     );
 
     return {
@@ -223,6 +227,7 @@ describe('AgentInboundHandler', () => {
       subscriberRepository,
       outboundGateway,
       inboundAck,
+      seedSlackThreadParent,
     };
   }
 
@@ -376,6 +381,53 @@ describe('AgentInboundHandler', () => {
       expect(conversationService.persistInboundMessage.firstCall.args[0].platformThreadId).to.equal(expectedThreadId);
       expect(conversationService.setFirstPlatformMessageId.firstCall.args[3]).to.equal(expectedThreadId);
       expect(bridgeExecutor.execute.firstCall.args[0].platformContext.threadId).to.equal(expectedThreadId);
+    });
+
+    it('should seed the Slack thread parent before persisting the inbound user reply', async () => {
+      const { handler, conversationService, seedSlackThreadParent } = makeHandler();
+      const thread = {
+        id: 'slack:C123:1777837477.000100',
+        channelId: 'slack:C123',
+        isDM: false,
+        toJSON: () => ({ id: 'slack:C123:1777837477.000100', channelId: 'slack:C123', isDM: false }),
+        startTyping: sinon.stub().resolves(undefined),
+        post: sinon.stub().resolves({ id: '1777837479.000300', threadId: 'slack:C123:1777837477.000100' }),
+      };
+      const message = {
+        id: '1777837478.000200',
+        threadId: 'slack:C123:1777837477.000100',
+        text: 'check latest deals',
+        author: { userId: 'user1', fullName: 'User One', userName: 'userone', isBot: false },
+        raw: {
+          event: {
+            type: 'message',
+            ts: '1777837478.000200',
+            thread_ts: '1777837477.000100',
+            text: 'check latest deals',
+          },
+        },
+        attachments: [],
+      };
+      const callOrder: string[] = [];
+      seedSlackThreadParent.maybeSeed.callsFake(async () => {
+        callOrder.push('seed');
+
+        return '1777837477.000100';
+      });
+      conversationService.persistInboundMessage.callsFake(async () => {
+        callOrder.push('inbound');
+
+        return { _id: 'activity1' };
+      });
+
+      await handler.handle('agent1', config as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(seedSlackThreadParent.maybeSeed.calledOnce).to.equal(true);
+      expect(seedSlackThreadParent.maybeSeed.firstCall.args[0]).to.include({
+        agentId: 'agent1',
+        platformThreadId: 'slack:C123:1777837477.000100',
+      });
+      expect(callOrder).to.deep.equal(['seed', 'inbound']);
     });
 
     it('should post no-bridge Slack DM auto-replies with the message-rooted platform thread id', async () => {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -44,6 +44,7 @@ import {
   BotAuthorSkippedError,
   ConnectOrgSubscriberCapExceededError,
 } from '../conversation/agent-subscriber-resolver.service';
+import { SeedSlackThreadParentService } from '../conversation/seed-slack-thread-parent.service';
 import { OutboundGateway } from '../egress/outbound.gateway';
 import type { BridgeReaction } from '../runtime/bridge-executor.service';
 import type { ConversationTurn } from '../runtime/conversation-turn';
@@ -261,7 +262,8 @@ export class AgentInboundHandler implements OnModuleInit {
     private readonly keylessAbuseGuard: KeylessAbuseGuardService,
     private readonly planLimitGate: PlanLimitGateService,
     private readonly inboundAck: InboundAckService,
-    private readonly replyApprovalInterceptor: ReplyApprovalInterceptor
+    private readonly replyApprovalInterceptor: ReplyApprovalInterceptor,
+    private readonly seedSlackThreadParent: SeedSlackThreadParentService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -439,6 +441,17 @@ export class AgentInboundHandler implements OnModuleInit {
 
     const storedAttachments = await this.storeInboundAttachments(config, conversation, message);
     const isFirstMessage = !this.conversationService.getPrimaryChannel(conversation).firstPlatformMessageId;
+
+    // Workflow/bot Slack posts never create ConversationActivity rows. Seed the
+    // thread parent here (before the user reply) so bridge history includes the
+    // original notification context on the first human reply.
+    await this.seedSlackThreadParent.maybeSeed({
+      agentId,
+      config,
+      conversation,
+      message,
+      platformThreadId,
+    });
 
     await this.recordInboundMessage(agentId, config, conversation, message, {
       subscriberId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a workflow delivers a Slack message via an agent-linked integration and a user replies in that thread, the agent bridge was only receiving the user reply in `ctx.history` — missing the original workflow/bot message that started the thread.

**Root cause:** Workflow chat delivery never writes `Conversation` / `ConversationActivity`. Conversations are created lazily on the first inbound reply, which only persists that reply. Bot echoes are intentionally skipped, so the parent cannot be backfilled from inbound webhooks.

**Fix:** On Slack thread-reply inbound, hydrate the thread parent via `conversations.replies` and persist it as an agent activity *before* recording the user message / dispatching to the bridge.

```mermaid
sequenceDiagram
  participant Slack
  participant Inbound as AgentInboundHandler
  participant Seed as SeedSlackThreadParent
  participant DB as ConversationActivity
  participant Bridge

  Slack->>Inbound: user reply (thread_ts = parent)
  Inbound->>Seed: maybeSeed(parent ts)
  Seed->>Slack: conversations.replies
  Seed->>DB: persistAgentMessage(parent)
  Inbound->>DB: persistInboundMessage(user reply)
  Inbound->>Bridge: history = [parent, user reply]
```

## Changes

- New `SeedSlackThreadParentService`: fail-soft, idempotent, only seeds bot-authored parents
- Wired into `AgentInboundHandler` before inbound persistence
- Unit coverage for helpers, seed service, and inbound ordering

## Test plan

- [x] Unit tests for parent-ts resolution, bot detection, text extraction, seed service, inbound ordering
- [ ] Manual: trigger workflow chat via agent-linked Slack integration → reply in thread → confirm bridge `history[0]` is the workflow message

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4b4fdda-ce8f-459b-8300-d7489b6d22b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4b4fdda-ce8f-459b-8300-d7489b6d22b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR seeds Slack thread parents into agent conversation history. The main changes are:

- Added a Slack thread-parent seeding service.
- Wired seeding before inbound Slack reply persistence.
- Exported the Slack WebClient factory for reuse.
- Added unit coverage for helpers, seeding, and inbound ordering.

<h3>Confidence Score: 4/5</h3>

The Slack inbound path needs a small fail-soft fix before merging.

The new seeding call runs before the user reply is persisted, and a repository lookup failure can still escape the seeding service and stop the inbound turn.

apps/api/src/app/agents/conversation-runtime/conversation/seed-slack-thread-parent.service.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the seed seeding lookup fail-soft behavior by running a focused Node/ts-node harness that mocks findSourceActivity to reject for a valid Slack thread reply, which showed maybeSeed propagated the repository read failure instead of resolving null and Slack fetch was not reached.
- I captured the exact command used to run the Slack ingress unit test.
- I saved the full stdout/stderr from the Slack ingress unit run, including the command, cwd, timestamps, and exit code (1).
- I added a concise blocker note describing the setup hurdle preventing progress on the Slack ingress unit test.

<a href="https://app.greptile.com/trex/runs/14363651/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/conversation/seed-slack-thread-parent.service.ts | Adds Slack parent resolution, bot-message checks, text extraction, and parent activity persistence; the idempotency lookup can still abort inbound handling. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Calls parent seeding before recording the inbound reply so bridge history can include the original Slack thread root. |
| apps/api/src/app/agents/agents.module.ts | Registers the new seeding service with the agents module. |
| apps/api/src/app/agents/conversation-runtime/egress/slack-native-delivery.ts | Exports the existing Slack WebClient factory. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Slack
  participant Inbound as AgentInboundHandler
  participant Seed as SeedSlackThreadParentService
  participant DB as ConversationActivity
  participant Bridge

  Slack->>Inbound: Thread reply event
  Inbound->>Seed: maybeSeed(parent ts)
  Seed->>DB: find existing parent activity
  alt parent missing
    Seed->>Slack: conversations.replies(parent ts)
    Seed->>DB: persist parent agent activity
  end
  Inbound->>DB: persist inbound user reply
  Inbound->>Bridge: dispatch turn with history
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Slack
  participant Inbound as AgentInboundHandler
  participant Seed as SeedSlackThreadParentService
  participant DB as ConversationActivity
  participant Bridge

  Slack->>Inbound: Thread reply event
  Inbound->>Seed: maybeSeed(parent ts)
  Seed->>DB: find existing parent activity
  alt parent missing
    Seed->>Slack: conversations.replies(parent ts)
    Seed->>DB: persist parent agent activity
  end
  Inbound->>DB: persist inbound user reply
  Inbound->>Bridge: dispatch turn with history
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fconversation-runtime%2Fconversation%2Fseed-slack-thread-parent.service.ts%3A169-179%0A**Seeding%20Lookup%20Escapes%20Fail-Soft**%0A%0AWhen%20the%20activity%20lookup%20fails%2C%20this%20exception%20happens%20before%20the%20%60try%2Fcatch%60%2C%20so%20the%20new%20pre-persistence%20seeding%20step%20can%20abort%20%60AgentInboundHandler%60%20before%20the%20user's%20Slack%20reply%20is%20recorded%20or%20dispatched.%20Parent%20hydration%20is%20best-effort%2C%20so%20repository%20read%20failures%20in%20this%20path%20should%20fall%20through%20the%20same%20fail-soft%20handling%20as%20the%20Slack%20fetch%20and%20persist.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20const%20existing%20%3D%20await%20this.conversationService.findSourceActivity%28%0A%20%20%20%20%20%20%20%20config.environmentId%2C%0A%20%20%20%20%20%20%20%20conversation._id%2C%0A%20%20%20%20%20%20%20%20parentTs%0A%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20if%20%28existing%29%20%7B%0A%20%20%20%20%20%20%20%20return%20parentTs%3B%0A%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20const%20%7B%20channel%20%7D%20%3D%20decodeSlackPlatformThreadId%28platformThreadId%29%3B%0A%60%60%60%0A%0A&pr=11931&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/agents/conversation-runtime/conversation/seed-slack-thread-parent.service.ts:169-179
**Seeding Lookup Escapes Fail-Soft**

When the activity lookup fails, this exception happens before the `try/catch`, so the new pre-persistence seeding step can abort `AgentInboundHandler` before the user's Slack reply is recorded or dispatched. Parent hydration is best-effort, so repository read failures in this path should fall through the same fail-soft handling as the Slack fetch and persist.

```suggestion
    try {
      const existing = await this.conversationService.findSourceActivity(
        config.environmentId,
        conversation._id,
        parentTs
      );
      if (existing) {
        return parentTs;
      }

      const { channel } = decodeSlackPlatformThreadId(platformThreadId);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): seed Slack thread pare..."](https://github.com/novuhq/novu/commit/875ee2d900f5d43932932060d11c6a0e4581631a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44083589)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->