### PR TITLE
fix(api-service): handle Azure AD errors in MS Teams OAuth callback fixes NV-8291

### DIFF
--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts
@@ -384,6 +384,57 @@ describe('MsTeamsOauthCallback', () => {
       }
     });
 
+    function buildAxiosError(status: number, data: Record<string, unknown>) {
+      return Object.assign(new Error(`Request failed with status code ${status}`), {
+        isAxiosError: true,
+        response: { status, data },
+      });
+    }
+
+    it('should return an error page (not 500) when the code exchange is rejected by Azure AD', async () => {
+      axiosPost.onFirstCall().rejects(
+        buildAxiosError(400, {
+          error: 'invalid_grant',
+          error_description: 'AADSTS54005: OAuth2 Authorization code was already redeemed.',
+        })
+      );
+
+      const command = MsTeamsOauthCallbackCommand.create({
+        providerCode: 'auth-code-abc',
+        state: buildLinkUserState(),
+      });
+
+      const result = await usecase.execute(command);
+
+      // Apostrophes are HTML-escaped in the rendered page, so match the escape-free part
+      expect(result.result).to.include('set up Microsoft Teams');
+      expect(result.result).to.include('AADSTS54005');
+      expect(createChannelEndpoint.execute.called).to.be.false;
+    });
+
+    it('should return an error page (not 500) when acquiring the Graph token fails', async () => {
+      stubTokenExchange();
+      msTeamsTokenService.getGraphToken.rejects(
+        buildAxiosError(400, {
+          error: 'unauthorized_client',
+          error_description: `AADSTS700016: Application with identifier '${MOCK_CLIENT_ID}' was not found in the directory.`,
+        })
+      );
+
+      const command = MsTeamsOauthCallbackCommand.create({
+        providerCode: 'auth-code-abc',
+        state: buildLinkUserState(),
+      });
+
+      const result = await usecase.execute(command);
+
+      expect(result.result).to.include('set up Microsoft Teams');
+      expect(result.result).to.include('AADSTS700016');
+      // Propagation-delay hint for the fresh-consent case
+      expect(result.result).to.include('Azure permission changes can take up to 60 minutes');
+      expect(createChannelEndpoint.execute.called).to.be.false;
+    });
+
     it('should throw if id_token is missing from token response', async () => {
       axiosPost.onFirstCall().resolves({ data: { access_token: 'at-123' } });
 

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
@@ -56,7 +56,12 @@ export class MsTeamsOauthCallback {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
 
-        if (message.includes('MS Teams bot installation failed')) {
+        this.logger.error(
+          { err: error },
+          `MS Teams link_user callback failed: subscriberId=${stateData.subscriberId} integrationId=${integration._id}`
+        );
+
+        if (message.includes('MS Teams bot installation failed') || message.includes('MS Teams user linking failed')) {
           return { type: ResponseTypeEnum.HTML, result: this.buildErrorHtml(message) };
         }
 
@@ -169,6 +174,10 @@ export class MsTeamsOauthCallback {
     }
 
     const decrypted = decryptCredentials(credentials);
+
+    this.logger.info(
+      `MS Teams link_user: exchanging authorization code for subscriberId=${stateData.subscriberId} clientId=${decrypted.clientId}`
+    );
     const { oid, tid } = await this.exchangeCodeForUserIdentity(command.providerCode, decrypted);
 
     /*
@@ -204,11 +213,16 @@ export class MsTeamsOauthCallback {
      * App-only Graph token in the USER's tenant. For a multi-tenant Entra app this works once that
      * tenant's admin has granted consent; the app + its org catalog entry then exist in that tenant.
      */
-    const graphToken = await this.msTeamsTokenService.getGraphToken(
-      clientId as string,
-      secretKey as string,
-      userTenantId
-    );
+    let graphToken: string;
+
+    try {
+      graphToken = await this.msTeamsTokenService.getGraphToken(clientId as string, secretKey as string, userTenantId);
+    } catch (error) {
+      this.logAadFailure('graph token acquisition', error, { clientId: clientId as string, tenantId: userTenantId });
+      throw new BadRequestException(
+        `MS Teams bot installation failed while acquiring a Microsoft Graph token in tenant ${userTenantId}: ${this.describeAadError(error)}`
+      );
+    }
 
     this.logger.info(`MS Teams bot install: resolving Teams app catalog ID for clientId=${clientId}`);
     const teamsAppId = await this.resolveTeamsAppId(graphToken, clientId as string);
@@ -324,8 +338,16 @@ export class MsTeamsOauthCallback {
    * propagation hint in `footerNote`.
    */
   private buildErrorHtml(message: string): string {
+    /*
+     * AADSTS700016 / AADSTS7000229: the app's service principal does not (yet) exist in the
+     * user's tenant — right after admin consent this is usually Azure propagation delay,
+     * so it deserves the same "wait and retry" hint as the permission errors.
+     */
     const isPermissionError =
-      message.includes('TeamsAppInstallation.ReadWriteSelfForUser.All') || message.includes('AppCatalog.Read.All');
+      message.includes('TeamsAppInstallation.ReadWriteSelfForUser.All') ||
+      message.includes('AppCatalog.Read.All') ||
+      message.includes('AADSTS700016') ||
+      message.includes('AADSTS7000229');
 
     return renderConnectionResultPage({
       status: 'error',
@@ -336,6 +358,52 @@ export class MsTeamsOauthCallback {
         ? 'Azure permission changes can take up to 60 minutes to take effect. If you just granted the required permissions, wait a few minutes and try again.'
         : undefined,
     });
+  }
+
+  /**
+   * Extracts a human-readable cause from an Azure AD / Graph error. AAD token endpoints return
+   * `{ error, error_description }` where `error_description` carries the AADSTS code — the part
+   * that actually tells the user (and us) what went wrong.
+   */
+  private describeAadError(error: unknown): string {
+    if (axios.isAxiosError(error)) {
+      const data = error.response?.data as { error?: string; error_description?: string } | undefined;
+
+      if (data?.error_description) {
+        return data.error_description;
+      }
+
+      if (data?.error) {
+        return data.error;
+      }
+
+      return error.message;
+    }
+
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  /**
+   * Logs a sanitized view of an AAD failure instead of the raw AxiosError: the axios `config`
+   * carries the request body, which contains the client secret and must never reach the logs.
+   */
+  private logAadFailure(step: string, error: unknown, context: Record<string, string> = {}): void {
+    const responseStatus = axios.isAxiosError(error) ? error.response?.status : undefined;
+    const data = axios.isAxiosError(error)
+      ? (error.response?.data as { error?: string; error_description?: string } | undefined)
+      : undefined;
+
+    this.logger.error(
+      {
+        ...context,
+        responseStatus,
+        aadError: data?.error,
+        aadErrorDescription: data?.error_description,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+      `MS Teams OAuth ${step} failed`
+    );
   }
 
   /**
@@ -364,11 +432,18 @@ export class MsTeamsOauthCallback {
       scope: 'openid profile User.Read',
     });
 
-    const response = await axios.post(
-      `${this.MS_TEAMS_TOKEN_URL}/organizations/oauth2/v2.0/token`,
-      tokenParams.toString(),
-      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
-    );
+    let response: { data: { id_token?: string } };
+
+    try {
+      response = await axios.post(
+        `${this.MS_TEAMS_TOKEN_URL}/organizations/oauth2/v2.0/token`,
+        tokenParams.toString(),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+      );
+    } catch (error) {
+      this.logAadFailure('authorization code exchange', error);
+      throw new BadRequestException(`MS Teams user linking failed: ${this.describeAadError(error)}`);
+    }
 
     const { id_token: idToken } = response.data;
 

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -101,9 +101,11 @@ export class AllExceptionsFilter implements ExceptionFilter {
       /*
        * The errorId and path go into the message text so a plain-text search for the
        * errorId a customer reports finds this log — nested attributes like
-       * `error.errorId` are not reliably indexed for full-text search.
+       * `error.errorId` are not reliably indexed for full-text search. The query string
+       * is stripped from the path here because it may contain single-use secrets
+       * (OAuth codes, invite tokens); the full URL is still available on `error.path`.
        */
-      `Unhandled exception: statusCode=${errorDto.statusCode} path=${errorDto.path}${errorDto.errorId ? ` errorId=${errorDto.errorId}` : ''}`
+      `Unhandled exception: statusCode=${errorDto.statusCode} path=${stripQuery(errorDto.path)}${errorDto.errorId ? ` errorId=${errorDto.errorId}` : ''}`
     );
   }
 
@@ -240,4 +242,11 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
 function safeHasProperty(obj: unknown, property: string): boolean {
   return typeof obj === 'object' && obj !== null && property in obj;
+}
+
+function stripQuery(url: string | undefined): string {
+  if (!url) return '';
+  const questionMark = url.indexOf('?');
+
+  return questionMark === -1 ? url : url.slice(0, questionMark);
 }

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -87,16 +87,24 @@ export class AllExceptionsFilter implements ExceptionFilter {
   }
 
   private logError(errorDto: ErrorDto, exception: unknown) {
-    this.logger.error({
-      /**
-       * It's important to use `err` as the key, pino (the logger we use) will
-       * log an empty object if the key is not `err`
-       *
-       * @see https://github.com/pinojs/pino/issues/819#issuecomment-611995074
+    this.logger.error(
+      {
+        /**
+         * It's important to use `err` as the key, pino (the logger we use) will
+         * log an empty object if the key is not `err`
+         *
+         * @see https://github.com/pinojs/pino/issues/819#issuecomment-611995074
+         */
+        err: exception,
+        error: errorDto,
+      },
+      /*
+       * The errorId and path go into the message text so a plain-text search for the
+       * errorId a customer reports finds this log — nested attributes like
+       * `error.errorId` are not reliably indexed for full-text search.
        */
-      err: exception,
-      error: errorDto,
-    });
+      `Unhandled exception: statusCode=${errorDto.statusCode} path=${errorDto.path}${errorDto.errorId ? ` errorId=${errorDto.errorId}` : ''}`
+    );
   }
 
   private buildErrorDto(


### PR DESCRIPTION
## What Changed

Customers connecting Microsoft Teams were hitting an opaque generic 500 (`"Internal server error, contact support and provide them with the errorId"`) on the OAuth callback. The MS Teams connect flow is two-legged: admin consent (leg 1) succeeded, then the chained `link_user` callback (leg 2) died with an unhandled exception — and left zero logs behind.

**Root cause:** two unwrapped axios calls in `MsTeamsOauthCallback` let raw `AxiosError`s escape to the global exception filter:

1. `exchangeCodeForUserIdentity` — the authorization-code exchange against `login.microsoftonline.com`. Any AAD rejection (`AADSTS7000215` bad client secret, `AADSTS54005` code already redeemed, `AADSTS50011` redirect URI mismatch) became a 500.
2. `MsTeamsTokenService.getGraphToken()` inside `installBotForUser` — failures (e.g. `AADSTS700016` service principal not yet propagated after fresh consent) didn't match the `'MS Teams bot installation failed'` string check and rethrew as 500.

**Fix (usecase):**
- Wrap both calls: throw `BadRequestException` carrying the AAD `error_description`, and render the friendly connection-error HTML page (same card as the existing bot-install failures) instead of a 500.
- Log a **sanitized** view of the AAD failure (status, `error`, `error_description`, message, stack) — never the raw `AxiosError`, whose `config` carries the client secret in the request body.
- Log every `link_user` failure in `execute()` before handling/rethrowing.
- Add a breadcrumb log before the code exchange (previously there were zero log lines between callback entry and the exchange, which made this incident untraceable in New Relic).
- Extend the "Azure permission changes can take up to 60 minutes" footer hint to `AADSTS700016`/`AADSTS7000229` propagation errors.

**Fix (exception filter):** unhandled-5xx logs now include `statusCode`, `path`, and `errorId` in the log **message text**, so a plain-text search for the errorId a customer reports actually finds the log (previously it only existed as a nested `error.errorId` attribute, which full-text search misses).

## Flow

```mermaid
sequenceDiagram
    participant B as User browser
    participant API as Novu API callback
    participant AAD as Azure AD / Graph

    B->>API: Leg 1: ?admin_consent=True&tenant=...
    API->>API: create channel connection (works today)
    API-->>B: redirect to link_user authorize URL
    B->>API: Leg 2: ?code=...&state=...
    API->>AAD: exchange code for id_token
    alt AAD rejects (bad secret / redeemed code / redirect mismatch)
        AAD-->>API: 400 + AADSTS error
        Note over API: BEFORE: raw AxiosError → opaque 500, no logs
        API->>API: AFTER: sanitized error log + BadRequestException
        API-->>B: error page with AADSTS description
    else exchange OK
        API->>AAD: getGraphToken (user tenant)
        alt token acquisition fails (e.g. consent not propagated)
            AAD-->>API: 400 AADSTS700016
            API-->>B: AFTER: error page + "wait up to 60 minutes" hint
        else OK
            API->>AAD: install bot for user
            API-->>B: success page
        end
    end
```

## Breaking Changes

None. Expected AAD failures on this endpoint now return 400 with an HTML error page instead of a 500 JSON body.

## Testing

- Two new unit tests covering both failure paths (code exchange rejected, Graph token acquisition failed) — assert the error page renders with the AADSTS code and no endpoint is created. All 15 specs pass.
- `biome check` clean on changed files; full `nx build @novu/api-service` TSC clean.

Linear: [NV-8291](https://linear.app/novu/issue/NV-8291/ms-teams-oauth-link-user-callback-returns-opaque-500-on-azure-ad)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the Microsoft Teams OAuth callback failure path. The main changes are:

- Converts Azure AD code-exchange failures into the existing connection error page.
- Handles Graph token acquisition failures during bot installation.
- Logs sanitized Azure AD error details for the Teams callback flow.
- Adds search-friendly unhandled exception log messages.
- Adds tests for the new Teams OAuth error paths.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The contract validation proof shows that the focused spec command failed with exit code 1 due to a pre-test module resolution blocker, while the Biome fallback path ran and exited with code 0, and the runtime test was blocked before executing the OAuth callback tests.

<a href="https://app.greptile.com/trex/runs/14515891/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts | Adds handled Azure AD and Graph token failure responses for the Microsoft Teams OAuth callback. |
| apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts | Adds tests for rejected Azure AD code exchange and Graph token acquisition failure. |
| apps/api/src/exception-filter.ts | Adds status, stripped path, and errorId details to unhandled exception log messages. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): strip query string fro..."](https://github.com/novuhq/novu/commit/ed74b77f6d28189f50b7d9e53c922733d2bb1c81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44099456)</sub>

<!-- /greptile_comment -->