### PR TITLE
chore(root): restore nv-implement agent skill fixes NV-8293

### DIFF
--- a/.cursor/skills/nv-implement/SKILL.md
+++ b/.cursor/skills/nv-implement/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: nv-implement
+description: Implement planned work by fanning out parallel subagents on isolated worktrees — TDD at pre-agreed seams, per-slice nv-review-local-changes, merge back, full suite once at the end.
+disable-model-invocation: true
+---
+
+# nv-implement
+
+Implement the work described (plan file, spec, or ticket) as **vertical slices**, one subagent per slice, each on its own worktree. Use `/tdd` where possible, at pre-agreed seams. Run typechecking regularly, single test files regularly, and the full test suite once at the end.
+
+Invoking this skill authorizes the commits it produces (slice commits, review refactor commits, merge commits, and integration fixes).
+
+## Workflow
+
+```
+- [ ] 1. Cut the work into seams
+- [ ] 2. Feature branch + one worktree per seam
+- [ ] 3. Fan out subagents (TDD → commit → /nv-review-local-changes)
+- [ ] 4. Merge slices back
+- [ ] 5. Integration pass (typecheck + cross-slice fallout)
+- [ ] 6. Full suite once + teardown
+```
+
+### 1. Cut the work into seams
+
+Split the plan into slices that touch **disjoint files** — each slice independently committable and testable. Typical Novu cuts: policy/backend logic, create-path + migration, copy/DTO/docs, dashboard UI.
+
+For each seam decide upfront: is it TDD-able (public function, use case, resolver → yes) or verify-by-lint (dashboard UI with no unit harness → no)? Tell the subagent which.
+
+**Done when:** every plan item is owned by exactly one seam, and no two seams edit the same file. If two seams must touch the same file, merge them into one slice — do not parallelize a conflict.
+
+### 2. Feature branch + one worktree per seam
+
+```bash
+git fetch origin next
+git checkout -b <feature-branch> origin/next
+git worktree add -b <feature-branch>-<seam> ../wt-<seam> HEAD
+```
+
+Symlink dependencies into each worktree (no install needed):
+
+```bash
+ln -s <main-checkout>/node_modules ../wt-<seam>/node_modules
+```
+
+**Done when:** `git worktree list` shows one worktree per seam, all at the feature branch HEAD.
+
+### 3. Fan out subagents
+
+Launch all slice subagents **in one message** (parallel Task calls, `run_in_background: true`). Each prompt must carry full context — subagents see nothing of this conversation. Include:
+
+- Worktree path + branch; hard boundary: work ONLY there
+- The slice's goal and the locked product decisions it depends on
+- Exact files to change and files owned by **other** slices (do not touch)
+- `/tdd` instruction for TDD-able seams: vertical slices, one behavior at a time, with the prioritized behavior list
+- The test command (see Commands below) and instruction to run single spec files regularly
+- Closing step: commit with `type(scope): why`, then run `/nv-review-local-changes` from the worktree
+
+**Done when:** every subagent reports commits + test results + review triage. Read each summary; a subagent that skipped review or left tests red gets resumed, not merged.
+
+### 4. Merge slices back
+
+From the main checkout, on the feature branch:
+
+```bash
+git merge --no-ff <feature-branch>-<seam> -m "merge: <slice summary>"
+```
+
+Merge in dependency order (backend policy before tests that rely on it). Then remove worktrees and delete slice branches.
+
+**Done when:** all slice branches merged, `git worktree list` shows only the main checkout, slice branches deleted.
+
+### 5. Integration pass
+
+Slices were reviewed in isolation — the seams between them were not. Expect cross-slice fallout: one slice changed copy while another slice's spec asserts the old string; one slice widened a type another slice consumes.
+
+1. Typecheck: `pnpm exec nest build` in `apps/api`; `ReadLints` on dashboard files
+2. Run every spec file touched by any slice, together, from the main checkout
+3. Fix fallout as small commits on the feature branch
+
+**Done when:** typecheck is clean and all touched spec files pass in one run.
+
+### 6. Full suite once + teardown
+
+Run the full relevant suite once (e.g. all `src/app/agents/**/*.spec.ts`). Report genuinely-related failures fixed; unrelated environmental failures named as such — not silently ignored, not chased.
+
+**Done when:** suite result reported with pass/fail counts and any unrelated failures explained.
+
+## Commands (Novu)
+
+```bash
+# API typecheck (catches what TS_NODE_TRANSPILE_ONLY hides)
+cd apps/api && pnpm exec nest build
+
+# Single spec file(s) — mocha, from apps/api
+TS_NODE_PROJECT=tsconfig.spec.json TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test \
+NOVU_ENTERPRISE=true CLERK_ENABLED=true NEW_RELIC_ENABLED=false \
+NODE_OPTIONS=--no-experimental-strip-types \
+npx mocha --timeout 15000 --require ts-node/register --exit --no-config 'src/path/to/file.spec.ts'
+```
+
+Dashboard has no unit harness for most components — verify via `ReadLints`; do not invent a test harness.
+
+## Guardrails
+
+- One slice, one worktree, one branch — a subagent that edits outside its worktree corrupts a sibling slice.
+- Slice commits and review refactor commits stay separate (per `/nv-review-local-changes`); never amend or squash them during merge.
+- E2E suites that need a running API/DB are out of scope for slices — flag them for CI instead.
+- If a Linear ticket is required for the eventual PR, create it early; hand off to `/novu-prepare-pr` when implementation is done.
+
+## Related skills
+
+- `/tdd` — the red-green loop each TDD-able slice runs
+- `/nv-review-local-changes` — each slice's closing review
+- [novu-prepare-pr](../novu-prepare-pr/SKILL.md) — PR prep after implementation
+- [nv-worktree-commands](../nv-worktree-commands/SKILL.md) — worktree debugging reference


### PR DESCRIPTION
## Summary

- Restores `.cursor/skills/nv-implement/SKILL.md`, which was accidentally removed from `next` during PR #11932 prep (scoped as unrelated tooling).
- The `nv-implement` skill enables agents to fan out parallel subagents on isolated worktrees for vertical-slice implementation with TDD and per-slice review.
- Linear ticket: [NV-8293](https://linear.app/novu/issue/NV-8293/restore-nv-implement-cursor-agent-skill)

## Test plan

- [ ] Verify `.cursor/skills/nv-implement/SKILL.md` exists on the branch (116 lines, frontmatter `name: nv-implement`)
- [ ] Confirm file content matches commit `0fca2459d4` (pre-removal version)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the `nv-implement` Cursor skill. The main changes are:

- Adds the skill frontmatter and implementation workflow.
- Documents worktree-based slice execution and merge steps.
- Adds Novu-specific typecheck and test command guidance.
- Links related Cursor skills for PR prep and worktree help.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Collected the historical baseline capture as part of the contract-validation process.
- Ran the HEAD validation against the baseline and produced the comparison log.
- Generated the validation script that orchestrates the contract-validation checks.
- Captured optional Biome output as part of the validation artifacts.

<a href="https://app.greptile.com/trex/runs/14375334/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .cursor/skills/nv-implement/SKILL.md | Restores the `nv-implement` skill documentation with workflow, commands, guardrails, and related-skill references. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(root): restore nv-implement agent ..."](https://github.com/novuhq/novu/commit/f1cd36cfced9c6f21bfc427e8de266a3334d6258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44105272)</sub>

<!-- /greptile_comment -->