### PR TITLE
feat(novu): power scaffolded agents via API key or subscription fixes NV-8289

### DIFF
--- a/docs/agents/custom-code-agent/quickstart.mdx
+++ b/docs/agents/custom-code-agent/quickstart.mdx
@@ -152,10 +152,10 @@ When you're done, run `npm run dev:novu` in the project folder and message your 
 
 Paste this into Cursor or another AI tool. It uses Novu's agent setup guide and adapts it to your repo.
 
-<Prompt description="Add a Novu agent to my app" icon="plug" actions={["copy", "cursor"]}>
-Add an agent to my app following instructions from this markdown file: https://novu.co/agents.md
+<Prompt description="Add a Novu custom code agent to my app" icon="plug" actions={["copy", "cursor"]}>
+I'm signed in to the Novu dashboard, so use dashboard login (not keyless mode). Add an agent to my app following instructions from this markdown file: https://novu.co/agents.md
 
-Follow my project's existing framework, routing, styling, and TypeScript conventions.
+Use AI SDK or LangChain based on what this project already uses. Follow my project's existing framework, routing, styling, and TypeScript conventions.
 
 Reference: https://docs.novu.co/agents/custom-code-agent/quickstart
 </Prompt>

--- a/libs/agent-evals/src/suites/agent-onboarding/catalog.ts
+++ b/libs/agent-evals/src/suites/agent-onboarding/catalog.ts
@@ -194,6 +194,34 @@ export const catalog = {
     connectCommands(result).every((cmd) => !/--slack-config-token\b/.test(cmd))
       ? 'pass'
       : fail('passed --slack-config-token inline instead of the secure token path'),
+
+  usesBridgeRuntimeWhenAddingToApp: (result: RunResult): GraderOutcome | 'pass' => {
+    if (!/add an agent to my app/i.test(result.userPrompt)) {
+      return 'pass';
+    }
+
+    const commands = connectCommands(result);
+
+    if (commands.length === 0) {
+      return fail('bridge path expected a connect command with --runtime ai-sdk or langchain');
+    }
+
+    return commands.every((cmd) => /--runtime\s+(ai-sdk|langchain)\b/.test(cmd))
+      ? 'pass'
+      : fail('bridge path connect command is missing --runtime ai-sdk or langchain');
+  },
+
+  readRequirementsFile: (result: RunResult): GraderOutcome | 'pass' => {
+    if (!/add an agent to my app/i.test(result.userPrompt)) {
+      return 'pass';
+    }
+
+    const readRequirements = result.toolCalls.some(
+      (call) => call.name === 'Read' && /novu-(ai-sdk|langchain)-requirements/i.test(String(call.args.file_path ?? ''))
+    );
+
+    return readRequirements ? 'pass' : fail('never read the bridge requirements file after connect');
+  },
 };
 
 export const sharedJudgeGraders = defineGraders({

--- a/libs/agent-evals/src/suites/agent-onboarding/connect-parser.test.ts
+++ b/libs/agent-evals/src/suites/agent-onboarding/connect-parser.test.ts
@@ -46,6 +46,13 @@ describe('connectParser', () => {
 
     expect(flags.slackConfigToken).toBe('xoxe.test');
   });
+
+  it('parses --runtime for bridge connect commands', () => {
+    const flags = connectParser.parse('npx novu connect --ci --runtime ai-sdk --channel slack', {});
+
+    expect(flags.runtime).toBe('ai-sdk');
+    expect(flags.description).toBeUndefined();
+  });
 });
 
 describe('connectValidate', () => {

--- a/libs/agent-evals/src/suites/agent-onboarding/connect-parser.ts
+++ b/libs/agent-evals/src/suites/agent-onboarding/connect-parser.ts
@@ -5,6 +5,7 @@ export type ConnectFlags = {
   secretKey: boolean;
   ci: boolean;
   channel?: string;
+  runtime?: string;
   description?: string;
   slackConfigToken?: string;
 };
@@ -14,7 +15,14 @@ export function isConnectCommand(command: string): boolean {
 }
 
 /** Flags that consume the following token as their value (so it is not a positional). */
-const VALUE_FLAGS = new Set(['--channel', '--slack-config-token', '--secret-key', '--api-url', '--dashboard-url']);
+const VALUE_FLAGS = new Set([
+  '--channel',
+  '--runtime',
+  '--slack-config-token',
+  '--secret-key',
+  '--api-url',
+  '--dashboard-url',
+]);
 
 /**
  * Split a command into shell words, honoring single quotes, double quotes, and backslash
@@ -163,6 +171,7 @@ export const connectParser: CommandParser<ConnectFlags> = {
     };
 
     flags.channel = readFlagValue(tokens, '--channel');
+    flags.runtime = readFlagValue(tokens, '--runtime');
     flags.slackConfigToken = readFlagValue(tokens, '--slack-config-token');
     flags.description = resolveDescription(command, tokens, env);
 

--- a/libs/agent-evals/src/suites/agent-onboarding/index.ts
+++ b/libs/agent-evals/src/suites/agent-onboarding/index.ts
@@ -29,7 +29,8 @@ const SYSTEM_PROMPT_PREAMBLE = [
 
 export const agentOnboardingSuite: Suite<ConnectFlags> = {
   id: 'agent-onboarding',
-  description: 'Behavioral evals for the Novu agent onboarding playbook (npx novu connect).',
+  description:
+    'Behavioral evals for the Novu agent onboarding playbook (managed and custom-code bridge `npx novu connect` flows).',
   systemPrompt: { path: AGENT_ONBOARDING_DOC_PATH },
   systemPromptPreamble: SYSTEM_PROMPT_PREAMBLE,
   commandParser: connectParser,

--- a/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/graders.ts
+++ b/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/graders.ts
@@ -1,4 +1,4 @@
-import { catalog, defineGraders, labeled, sharedJudgeGraders } from '../../kit.js';
+import { catalog, defineGraders, judge, judgePrompts, labeled } from '../../kit.js';
 
 export const graders = defineGraders({
   usedDashboardOAuthWhenPrompted: labeled(
@@ -6,11 +6,22 @@ export const graders = defineGraders({
     catalog.usedDashboardOAuthWhenPrompted
   ),
   noSecretKeyFlag: labeled('does not pass --secret-key or NOVU_SECRET_KEY to connect', catalog.noSecretKeyFlag),
+  usesBridgeRuntime: labeled(
+    'runs connect with --runtime ai-sdk or langchain for the add-to-my-app bridge path',
+    catalog.usesBridgeRuntimeWhenAddingToApp
+  ),
   backgroundConnectShell: labeled(
     'runs connect in the background and polls output with BashOutput',
     catalog.backgroundConnectShell
   ),
   readAuthUrlFile: labeled('reads the auth-url file or surfaces the /oauth/device URL', catalog.readAuthUrlFile),
+  readRequirementsFile: labeled(
+    'reads the AI SDK or LangChain requirements file after connect',
+    catalog.readRequirementsFile
+  ),
   reportedSuccess: labeled('confirms the agent is live in the final report', catalog.reportedSuccess),
-  ...sharedJudgeGraders,
+  conclusionFirstReport: labeled(
+    'leads the final report with the CLI result and next action',
+    judge(judgePrompts.conclusionFirstReport, (result) => result.finalText)
+  ),
 });

--- a/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/graders.ts
+++ b/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/graders.ts
@@ -1,4 +1,4 @@
-import { catalog, defineGraders, judge, judgePrompts, labeled } from '../../kit.js';
+import { catalog, defineGraders, labeled, sharedJudgeGraders } from '../../kit.js';
 
 export const graders = defineGraders({
   usedDashboardOAuthWhenPrompted: labeled(
@@ -20,8 +20,5 @@ export const graders = defineGraders({
     catalog.readRequirementsFile
   ),
   reportedSuccess: labeled('confirms the agent is live in the final report', catalog.reportedSuccess),
-  conclusionFirstReport: labeled(
-    'leads the final report with the CLI result and next action',
-    judge(judgePrompts.conclusionFirstReport, (result) => result.finalText)
-  ),
+  ...sharedJudgeGraders,
 });

--- a/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/project/novu-ai-sdk-requirements.txt
+++ b/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/project/novu-ai-sdk-requirements.txt
@@ -1,0 +1,23 @@
+# Novu AI SDK connect requirements
+
+Project: /fixture/acme-support
+
+- [x] env: NOVU_SECRET_KEY set
+- [ ] package: Missing packages: @novu/framework, ai
+- [ ] dev-script: Add dev:novu script
+- [ ] code-wiring: Create bridge route and agent handler
+
+## Code wiring
+
+Wire your AI SDK agent into this project:
+
+1. Create app/api/novu/route.ts with serve({ agents: [...] }) from @novu/framework/next
+2. Create app/novu/agents/dash-agent-1.tsx with agent() from @novu/framework/ai-sdk
+3. In the agent handler, call generateText from `ai` to reply
+4. Run npm run dev:novu for local bridge tunnel
+
+## Agent prompt
+
+Paste the following into your coding agent to finish wiring:
+
+Wire the Novu AI SDK bridge for agent identifier `dash-agent-1`.

--- a/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/scenario.ts
+++ b/libs/agent-evals/src/suites/agent-onboarding/scenarios/dashboard-prompt-login/scenario.ts
@@ -7,13 +7,12 @@ const scenarioDir = path.dirname(fileURLToPath(import.meta.url));
 export const scenario: EvalScenario<ConnectFlags> = {
   id: 'dashboard-prompt-login',
   category: 'authenticated',
-  description: 'Dashboard prompt must use dashboard OAuth (omit --keyless) and deliver auth URL from file.',
+  description: 'Dashboard add-to-my-app prompt must use bridge runtime and read requirements file.',
   userPrompt:
     "I'm signed in to the Novu dashboard. Add an agent to my app and connect it to Slack following the onboarding instructions.",
   projectRoot: path.join(scenarioDir, 'project'),
   scriptedAnswers: [
     { questionContains: 'channel', optionId: 'slack' },
-    { questionContains: 'description', optionId: 'approve' },
     { questionContains: 'token', optionId: 'secure' },
   ],
   tape: connectTape({
@@ -26,6 +25,9 @@ export const scenario: EvalScenario<ConnectFlags> = {
       { stdout: 'NOVU_CONNECT_SLACK_SETUP_URL=https://setup.novu.test/slack/login-1' },
       { stdout: 'NOVU_CONNECT_SLACK_CONFIG_TOKEN_SAVED=1' },
       { stdout: 'NOVU_CONNECT_SLACK_AUTHORIZE_URL=https://slack.test/oauth/login-1' },
+      {
+        stdout: `NOVU_CONNECT_AI_SDK_REQUIREMENTS_FILE=${path.join(scenarioDir, 'project/novu-ai-sdk-requirements.txt')}`,
+      },
       {
         stdout: [
           '✓ Your agent is live.',

--- a/packages/novu/AGENT_ONBOARDING.md
+++ b/packages/novu/AGENT_ONBOARDING.md
@@ -2,6 +2,6 @@
 
 > **This file has moved.** The canonical agent onboarding instructions live in `@novu/shared`.
 
-See **[`packages/shared/docs/agent-onboarding.md`](../shared/docs/agent-onboarding.md)** for the full guide (keyless `novu connect` flow, channel handoffs, MCP inference rules, and CLI flag reference).
+See **[`packages/shared/docs/agent-onboarding.md`](../shared/docs/agent-onboarding.md)** for the full guide (managed and custom-code `novu connect` flows, channel handoffs, bridge wiring, and CLI flag reference).
 
 Use that document when wiring Cursor skills, Claude Code prompts, or any AI agent that helps users create a managed agent and connect a channel.

--- a/packages/novu/src/commands/connect/LLM_AUTH_IMPLEMENTATION_PLAN.md
+++ b/packages/novu/src/commands/connect/LLM_AUTH_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,29 @@
+# LLM auth during `novu connect` scaffold
+
+Implemented. See `pipeline/llm-auth/README.md` for architecture and file roles.
+
+## Scope
+
+- **In:** fresh empty-dir scaffold for `--runtime ai-sdk` and `--runtime langchain`
+- **Out:** reconciliation of existing projects, managed runtimes (`demo`, `claude`, `claude-aws`), Google/local models
+
+## Provider matrix (current)
+
+| Choice | AI SDK | LangChain | Auth | Default model |
+|--------|--------|-----------|------|---------------|
+| OpenAI API key | yes | yes | `OPENAI_API_KEY` | `gpt-4o-mini` |
+| Anthropic API key | yes | yes | `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
+| ChatGPT subscription | yes | yes | Codex CLI / langchainjs-codex-oauth OAuth | `gpt-5.4-mini` |
+| Claude subscription | yes | no | Claude Code OAuth | `haiku` |
+| Skip | yes | yes | demo echo | — |
+
+## Flags
+
+```bash
+npx novu connect --runtime ai-sdk --llm-auth openai --openai-api-key "$OPENAI_API_KEY"
+npx novu connect --runtime ai-sdk --llm-auth codex-subscription
+npx novu connect --runtime ai-sdk --llm-auth claude-subscription   # ai-sdk only
+npx novu connect --runtime langchain --llm-auth codex-subscription
+```
+
+`--llm-auth` bypasses the interactive picker without requiring `--ci`.

--- a/packages/novu/src/commands/connect/help-text.ts
+++ b/packages/novu/src/commands/connect/help-text.ts
@@ -6,6 +6,41 @@ Examples (non-interactive / agent / CI):
       --ci \\
       --channel slack
 
+  Custom code bridge — AI SDK (dashboard OAuth, no agent description):
+    npx novu connect \\
+      --ci \\
+      --runtime ai-sdk \\
+      --channel slack
+
+  Custom code bridge — LangChain:
+    npx novu connect \\
+      --ci \\
+      --runtime langchain \\
+      --channel slack
+
+  AI SDK scaffold with OpenAI API key:
+    npx novu connect \\
+      --ci \\
+      --runtime ai-sdk \\
+      --llm-auth openai \\
+      --openai-api-key "$OPENAI_API_KEY" \\
+      --channel slack
+
+  AI SDK scaffold with ChatGPT subscription (Codex CLI must be logged in):
+    npx novu connect \\
+      --ci \\
+      --runtime ai-sdk \\
+      --llm-auth codex-subscription \\
+      --channel slack
+
+  LangChain scaffold with Anthropic API key:
+    npx novu connect \\
+      --ci \\
+      --runtime langchain \\
+      --llm-auth anthropic \\
+      --anthropic-api-key "$ANTHROPIC_API_KEY" \\
+      --channel slack
+
   Dashboard OAuth Email:
     npx novu connect "An onboarding assistant for Acme's new members." \\
       --ci \\
@@ -62,8 +97,9 @@ Examples (non-interactive / agent / CI):
 Non-interactive (agent / CI) contract:
 
   Required for --ci mode:
-    - Pass the agent description as the positional <prompt> argument or --prompt.
+    - Pass the agent description as the positional <prompt> argument or --prompt (managed path only).
     - Pass --channel <slack|email|telegram|skip> (or whatsapp/teams without --keyless).
+    - Bridge path: pass --runtime ai-sdk or --runtime langchain (omit the positional description).
 
   Authentication (pick one):
     - Dashboard OAuth (default): omit --secret-key and --keyless (opens /cli/auth; user approves in the browser; agent is created in their Development environment)
@@ -79,6 +115,14 @@ Non-interactive (agent / CI) contract:
   Optional CI-only escape hatches (secrets injected via env — never paste in chat):
     - --slack-config-token "xoxe.xoxp-…"    → skip the setup page; pass token directly
     - --telegram-bot-token "123456:ABC-…"   → skip the setup page; pass token directly
+
+  LLM wiring (fresh empty-dir scaffold for --runtime ai-sdk or --runtime langchain only):
+    - --llm-auth openai --openai-api-key "$OPENAI_API_KEY"  → wire OpenAI; skips the Ink picker (no --ci required)
+    - --llm-auth anthropic --anthropic-api-key "$ANTHROPIC_API_KEY"  → wire Anthropic; skips the Ink picker
+    - --llm-auth codex-subscription  → OAuth via codex login (ai-sdk) or langchainjs-codex-oauth (langchain)
+    - --llm-auth claude-subscription  → ai-sdk only; requires prior claude auth login
+    - --llm-auth skip  → demo echo agent (default when omitted)
+    - Omitted on existing projects (reconcile path only; no LLM rewire)
 
   Defaults (do not pass unless needed):
     - Dashboard OAuth: omit --secret-key and --keyless (creates the agent in the user's Development environment)
@@ -118,6 +162,12 @@ Machine-readable stdout (plain text, no ANSI — watch these in --ci mode):
 
   Chat SDK (requirements summary):
     NOVU_CONNECT_CHAT_SDK_REQUIREMENTS_FILE=<absolute path to requirements summary file>
+
+  AI SDK bridge (requirements summary):
+    NOVU_CONNECT_AI_SDK_REQUIREMENTS_FILE=<absolute path to requirements summary file>
+
+  LangChain bridge (requirements summary):
+    NOVU_CONNECT_LANGCHAIN_REQUIREMENTS_FILE=<absolute path to requirements summary file>
 
   Success:
     ✓ Your agent is live.

--- a/packages/novu/src/commands/connect/pipeline/ai-sdk/scaffold.ts
+++ b/packages/novu/src/commands/connect/pipeline/ai-sdk/scaffold.ts
@@ -1,6 +1,7 @@
 import { TemplateTypeEnum } from '../../../init/templates';
 import { defaultCustomCodeScaffoldDirName } from '../bridge/agent-paths';
 import { type ScaffoldBridgeProjectResult, scaffoldBridgeProject } from '../bridge/scaffold-project';
+import type { LlmAuthChoice } from '../llm-auth/types';
 
 export async function scaffoldAiSdkProject(input: {
   parentDir: string;
@@ -9,6 +10,7 @@ export async function scaffoldAiSdkProject(input: {
   apiUrl: string;
   agentIdentifier: string;
   silent?: boolean;
+  llmAuth: LlmAuthChoice;
 }): Promise<ScaffoldBridgeProjectResult> {
   return scaffoldBridgeProject({
     parentDir: input.parentDir,
@@ -19,5 +21,6 @@ export async function scaffoldAiSdkProject(input: {
     apiUrl: input.apiUrl,
     agentIdentifier: input.agentIdentifier,
     silent: input.silent,
+    llmAuth: input.llmAuth,
   });
 }

--- a/packages/novu/src/commands/connect/pipeline/bridge-adapter/engine.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge-adapter/engine.ts
@@ -2,9 +2,11 @@ import type { BridgeRequirement, BridgeRequirementId } from '../../types';
 import { applyDevNovuScript, buildDevNovuScript } from '../ai-sdk/dev-script';
 import { maskSecretKey, mergeProjectEnv, readEnvSecretKey, resolveProjectEnvPaths } from '../ai-sdk/wire-env';
 import { defaultCustomCodeScaffoldDirName, resolveAgentHandlerPathIfExists } from '../bridge/agent-paths';
-import { confirmEmptyDirScaffold } from '../bridge/confirm-empty-dir-scaffold';
+import { resolveEmptyDirScaffoldTarget } from '../bridge/confirm-empty-dir-scaffold';
 import { requireConnectSecretKey } from '../bridge/require-secret-key';
 import { runScaffoldWithConsole } from '../bridge/run-scaffold-with-console';
+import { resolveLlmAuthChoice } from '../llm-auth/resolve-llm-auth';
+import type { LlmAuthChoice } from '../llm-auth/types';
 import type {
   BridgeAdapter,
   BridgeAdapterConnectOutcome,
@@ -23,7 +25,7 @@ export async function runBridgeAdapterProjectSetup(
   adapter: BridgeAdapter
 ): Promise<BridgeAdapterConnectOutcome> {
   const projectDir = input.options.projectDir?.trim() || process.cwd();
-  const decision = await confirmEmptyDirScaffold({
+  const target = resolveEmptyDirScaffoldTarget({
     projectDir,
     options: input.options,
     ui: input.ui,
@@ -32,29 +34,52 @@ export async function runBridgeAdapterProjectSetup(
     agentIdentifier: input.agent.identifier,
   });
 
-  if (decision.action === 'existing-project') {
-    return reconcileProject(input, adapter, decision.projectDir, 'project', {
-      agentFilePath: resolveAgentHandlerPathIfExists(decision.projectDir, input.agent.identifier),
+  if (target.status === 'existing-project') {
+    return reconcileProject(input, adapter, target.projectDir, 'project', {
+      agentFilePath: resolveAgentHandlerPathIfExists(target.projectDir, input.agent.identifier),
     });
   }
 
-  if (decision.action === 'skipped') {
+  if (target.status === 'skipped') {
     return {
       projectKind: 'empty',
-      projectDir: decision.projectDir,
+      projectDir: target.projectDir,
       scaffolded: false,
       coreReady: false,
     };
   }
 
-  return scaffoldThenReconcile(input, adapter, decision.projectDir, decision.appName);
+  // Empty-dir scaffold: pick LLM provider, confirm, then install template (see pipeline/llm-auth/README.md).
+  const llmAuth = await resolveLlmAuthChoice({
+    connectMode: adapter.variant,
+    options: input.options,
+    ui: input.ui,
+  });
+
+  const confirmed = await input.ui.confirmScaffold({
+    projectDir: target.projectDir,
+    appName: target.appName,
+    variant: adapter.variant,
+  });
+
+  if (!confirmed) {
+    return {
+      projectKind: 'empty',
+      projectDir: target.projectDir,
+      scaffolded: false,
+      coreReady: false,
+    };
+  }
+
+  return scaffoldThenReconcile(input, adapter, target.projectDir, target.appName, llmAuth);
 }
 
 async function scaffoldThenReconcile(
   input: BridgeAdapterSetupInput,
   adapter: BridgeAdapter,
   parentDir: string,
-  appName: string
+  appName: string,
+  llmAuth: LlmAuthChoice
 ): Promise<BridgeAdapterConnectOutcome> {
   const scaffolded = await runScaffoldWithConsole({
     ui: input.ui,
@@ -67,6 +92,7 @@ async function scaffoldThenReconcile(
         apiUrl: input.options.apiUrl,
         agentIdentifier: input.agent.identifier,
         silent: false,
+        llmAuth,
       }),
   });
 

--- a/packages/novu/src/commands/connect/pipeline/bridge-adapter/types.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge-adapter/types.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../types';
 import type { ConnectUI } from '../../ui/ui';
 import type { ScaffoldBridgeProjectResult } from '../bridge/scaffold-project';
+import type { LlmAuthChoice } from '../llm-auth/types';
 
 /**
  * Bridge-adapter connect flows (AI SDK, LangChain) share one reconcile engine.
@@ -36,6 +37,7 @@ export type BridgeAdapterScaffoldInput = {
   apiUrl: string;
   agentIdentifier: string;
   silent?: boolean;
+  llmAuth: LlmAuthChoice;
 };
 
 export type BridgeAdapterRequirementsInput = {

--- a/packages/novu/src/commands/connect/pipeline/bridge/confirm-empty-dir-scaffold.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge/confirm-empty-dir-scaffold.ts
@@ -17,27 +17,47 @@ export type EmptyDirScaffoldDecision =
   | { action: 'skipped'; projectDir: string }
   | { action: 'confirmed'; projectDir: string; appName: string };
 
-export async function confirmEmptyDirScaffold(input: ConfirmEmptyDirScaffoldInput): Promise<EmptyDirScaffoldDecision> {
+export type EmptyDirScaffoldTarget =
+  | { status: 'existing-project'; projectDir: string }
+  | { status: 'skipped'; projectDir: string }
+  | { status: 'needs-confirm'; projectDir: string; appName: string };
+
+export function resolveEmptyDirScaffoldTarget(input: ConfirmEmptyDirScaffoldInput): EmptyDirScaffoldTarget {
   const detected = detectBridgeProject(input.projectDir);
 
   if (detected.kind === 'project') {
-    return { action: 'existing-project', projectDir: detected.projectDir };
+    return { status: 'existing-project', projectDir: detected.projectDir };
   }
 
   if (input.options.noScaffold) {
-    return { action: 'skipped', projectDir: detected.projectDir };
+    return { status: 'skipped', projectDir: detected.projectDir };
   }
 
   const appName = input.options.scaffoldDir?.trim() || input.defaultAppName(input.agentIdentifier);
+
+  return { status: 'needs-confirm', projectDir: detected.projectDir, appName };
+}
+
+export async function confirmEmptyDirScaffold(input: ConfirmEmptyDirScaffoldInput): Promise<EmptyDirScaffoldDecision> {
+  const target = resolveEmptyDirScaffoldTarget(input);
+
+  if (target.status === 'existing-project') {
+    return { action: 'existing-project', projectDir: target.projectDir };
+  }
+
+  if (target.status === 'skipped') {
+    return { action: 'skipped', projectDir: target.projectDir };
+  }
+
   const confirmed = await input.ui.confirmScaffold({
-    projectDir: detected.projectDir,
-    appName,
+    projectDir: target.projectDir,
+    appName: target.appName,
     variant: input.variant,
   });
 
   if (!confirmed) {
-    return { action: 'skipped', projectDir: detected.projectDir };
+    return { action: 'skipped', projectDir: target.projectDir };
   }
 
-  return { action: 'confirmed', projectDir: detected.projectDir, appName };
+  return { action: 'confirmed', projectDir: target.projectDir, appName: target.appName };
 }

--- a/packages/novu/src/commands/connect/pipeline/bridge/scaffold-project.ts
+++ b/packages/novu/src/commands/connect/pipeline/bridge/scaffold-project.ts
@@ -4,6 +4,7 @@ import { tryGitInit } from '../../../init/helpers/git';
 import { isFolderEmpty } from '../../../init/helpers/is-folder-empty';
 import { getOnline } from '../../../init/helpers/is-online';
 import { installTemplate, TemplateTypeEnum } from '../../../init/templates';
+import type { LlmAuthChoice } from '../llm-auth/types';
 
 export type ScaffoldBridgeProjectInput = {
   parentDir: string;
@@ -18,6 +19,7 @@ export type ScaffoldBridgeProjectInput = {
   apiUrl: string;
   agentIdentifier: string;
   silent?: boolean;
+  llmAuth?: LlmAuthChoice;
 };
 
 export type ScaffoldBridgeProjectResult = {
@@ -84,6 +86,7 @@ export async function scaffoldBridgeProject(input: ScaffoldBridgeProjectInput): 
     agentIdentifier: input.agentIdentifier,
     skipInstall: skippedInstall,
     silent: input.silent,
+    llmAuth: input.llmAuth,
   });
 
   tryGitInit(root);

--- a/packages/novu/src/commands/connect/pipeline/langchain/scaffold.ts
+++ b/packages/novu/src/commands/connect/pipeline/langchain/scaffold.ts
@@ -1,6 +1,7 @@
 import { TemplateTypeEnum } from '../../../init/templates';
 import { defaultCustomCodeScaffoldDirName } from '../bridge/agent-paths';
 import { type ScaffoldBridgeProjectResult, scaffoldBridgeProject } from '../bridge/scaffold-project';
+import type { LlmAuthChoice } from '../llm-auth/types';
 
 export async function scaffoldLangChainProject(input: {
   parentDir: string;
@@ -9,6 +10,7 @@ export async function scaffoldLangChainProject(input: {
   apiUrl: string;
   agentIdentifier: string;
   silent?: boolean;
+  llmAuth: LlmAuthChoice;
 }): Promise<ScaffoldBridgeProjectResult> {
   return scaffoldBridgeProject({
     parentDir: input.parentDir,
@@ -19,5 +21,6 @@ export async function scaffoldLangChainProject(input: {
     apiUrl: input.apiUrl,
     agentIdentifier: input.agentIdentifier,
     silent: input.silent,
+    llmAuth: input.llmAuth,
   });
 }

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/README.md
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/README.md
@@ -1,0 +1,33 @@
+# LLM auth during bridge scaffold
+
+Wires an LLM provider when `novu connect` scaffolds a **new** ai-sdk or langchain agent app into an empty directory. Reconciliation of existing projects is out of scope.
+
+## Flow
+
+```
+empty dir detected
+  → resolveLlmAuthChoice()     picker or --llm-auth flags
+  → ensureSubscriptionAuth()   CLI OAuth when subscription kind (releases Ink TUI)
+  → confirmScaffold()          Ink or console prompt if terminal was released
+  → installTemplate()          registry deps/env + codegen → .env.local + agent handler
+```
+
+Entry point: `bridge-adapter/engine.ts` calls `resolveLlmAuthChoice` before scaffold confirm.
+
+## Files
+
+| File | Role |
+|------|------|
+| `types.ts` | `LlmAuthChoice` union; CLI uses short names (`openai`), internal uses precise kinds (`openai-api-key`) |
+| `resolve-llm-auth.ts` | Interactive picker vs `--llm-auth` flag resolution |
+| `ensure-subscription-auth.ts` | Codex / LangChain Codex / Claude Code login orchestration |
+| `subscription-auth.ts` | Credential detection + `runInteractiveCli` for OAuth subprocesses |
+| `registry.ts` | Per-kind npm packages and `.env.local` keys |
+| `llm-auth-options.ts` | Picker labels; Claude subscription omitted for langchain |
+| `codegen/` | Generated `support-agent.tsx` and `next.config.mjs` |
+
+## CLI flags
+
+`--llm-auth` skips the Ink picker even without `--ci`. Pair API-key kinds with `--openai-api-key` or `--anthropic-api-key` in non-interactive mode.
+
+Subscription kinds run OAuth on the local machine; tokens are not stored in Novu cloud. Warn when `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` are set in the shell (may override subscription billing).

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/README.md
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/README.md
@@ -24,6 +24,7 @@ Entry point: `bridge-adapter/engine.ts` calls `resolveLlmAuthChoice` before scaf
 | `subscription-auth.ts` | Credential detection + `runInteractiveCli` for OAuth subprocesses |
 | `registry.ts` | Per-kind npm packages and `.env.local` keys |
 | `llm-auth-options.ts` | Picker labels; Claude subscription omitted for langchain |
+| `subscription-cli-specs.ts` | Pinned `package@version` strings for `npx` OAuth fallbacks |
 | `codegen/` | Generated `support-agent.tsx` and `next.config.mjs` |
 
 ## CLI flags
@@ -31,3 +32,13 @@ Entry point: `bridge-adapter/engine.ts` calls `resolveLlmAuthChoice` before scaf
 `--llm-auth` skips the Ink picker even without `--ci`. Pair API-key kinds with `--openai-api-key` or `--anthropic-api-key` in non-interactive mode.
 
 Subscription kinds run OAuth on the local machine; tokens are not stored in Novu cloud. Warn when `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` are set in the shell (may override subscription billing).
+
+## Subscription OAuth trust boundary
+
+Subscription auth shells out to vendor CLIs (`codex`, `claude`, or pinned `npx` fallbacks in `subscription-cli-specs.ts`). That requires trusting Anthropic/OpenAI npm packages on the developer machine — the same tradeoff as running those tools directly.
+
+Hardening:
+
+- Prefer a globally installed `codex` / `claude` binary when present (no `npx` fetch).
+- `npx` fallbacks use pinned `package@version` specs, not unpinned `latest`.
+- Auth **detection** reads local credential files only; it does not run `npx` on the status-check path.

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-agent-next-config.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-agent-next-config.ts
@@ -1,0 +1,48 @@
+import type { BridgeAdapterVariant } from '../../bridge-adapter/types';
+import type { LlmAuthChoice } from '../types';
+
+export function resolveAgentServerExternalPackages(
+  runtime: BridgeAdapterVariant,
+  llmAuth: LlmAuthChoice
+): readonly string[] {
+  if (llmAuth.kind === 'codex-subscription') {
+    if (runtime === 'ai-sdk') {
+      return ['ai-sdk-provider-codex-cli', '@openai/codex'];
+    }
+
+    return ['langchainjs-codex-oauth'];
+  }
+
+  if (llmAuth.kind === 'claude-subscription') {
+    return ['ai-sdk-provider-claude-code', '@anthropic-ai/claude-agent-sdk'];
+  }
+
+  return [];
+}
+
+export function generateAgentNextConfigSource(runtime: BridgeAdapterVariant, llmAuth: LlmAuthChoice): string {
+  const serverExternalPackages = resolveAgentServerExternalPackages(runtime, llmAuth);
+  const externalPackagesBlock =
+    serverExternalPackages.length > 0
+      ? `
+  // CLI-based LLM providers spawn subprocesses; keep them out of the Next.js bundle.
+  serverExternalPackages: [
+${serverExternalPackages.map((pkg) => `    '${pkg}',`).join('\n')}
+  ],`
+      : '';
+
+  return `import path from 'path';
+import { fileURLToPath } from 'url';
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  turbopack: {
+    root: projectRoot,
+  },${externalPackagesBlock}
+};
+
+export default nextConfig;
+`;
+}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts
@@ -1,0 +1,199 @@
+import type { GenerateSupportAgentInput } from '../types';
+
+function toCamelAgentName(agentIdentifier: string): string {
+  return agentIdentifier.replace(/[-_]([a-z0-9])/g, (_, char) => char.toUpperCase());
+}
+
+function buildSharedHandlerBody(): string {
+  return `    const firstName = ctx.subscriber?.firstName;
+    const text = (message.text ?? '').toLowerCase();
+
+    const isFirstMessage = ctx.conversation.messageCount <= 1;
+
+    if (isFirstMessage) {
+      ctx.metadata.set('topic', 'unknown');
+
+      return (
+        <Card title={\`Hi\${firstName ? \`, \${firstName}\` : ''}! I'm Support Agent\`}>
+          <CardText>How can I help you today?</CardText>
+          <Actions>
+            <Button id="topic-billing" label="Billing question" value="billing" />
+            <Button id="topic-technical" label="Technical issue" value="technical" />
+            <Button id="topic-other" label="Something else" value="other" />
+          </Actions>
+        </Card>
+      );
+    }
+
+    if (text.includes('resolve') || text.includes('thanks')) {
+      ctx.resolve(\`Resolved by user: \${text}\`);
+
+      return 'Glad I could help! Marking this resolved.';
+    }
+
+    ctx.metadata.set('lastMessage', text);`;
+}
+
+function buildOnActionHandler(): string {
+  return `  onAction: async (action, ctx) => {
+    if (action.id.startsWith('topic-') && action.value) {
+      ctx.metadata.set('topic', action.value);
+
+      return \`Topic set to **\${action.value}**. Describe your issue and I'll help.\`;
+    }
+  },`;
+}
+
+function buildAiSdkOpenAiHandler(): string {
+  return `${buildSharedHandlerBody()}
+
+    return generateText({
+      model: openai('gpt-4o-mini'),
+      instructions: 'You are a helpful support agent.',
+      messages: toModelMessages(ctx.history),
+    });`;
+}
+
+function buildAiSdkAnthropicHandler(): string {
+  return `${buildSharedHandlerBody()}
+
+    return generateText({
+      model: anthropic('claude-haiku-4-5'),
+      instructions: 'You are a helpful support agent.',
+      messages: toModelMessages(ctx.history),
+    });`;
+}
+
+function buildAiSdkCodexHandler(): string {
+  return `${buildSharedHandlerBody()}
+
+    return generateText({
+      model: codexCli('gpt-5.4-mini'),
+      instructions: 'You are a helpful support agent.',
+      messages: toModelMessages(ctx.history),
+    });`;
+}
+
+function buildAiSdkClaudeSubscriptionHandler(): string {
+  return `${buildSharedHandlerBody()}
+
+    return generateText({
+      model: claudeCode('haiku'),
+      instructions: 'You are a helpful support agent.',
+      messages: toModelMessages(ctx.history),
+    });`;
+}
+
+function buildLangChainOpenAiHandler(): string {
+  return `${buildSharedHandlerBody()}
+
+    return {
+      model: 'openai:gpt-4o-mini',
+      system: 'You are a helpful support agent.',
+      tools: [],
+    };`;
+}
+
+function buildLangChainAnthropicHandler(): string {
+  return `${buildSharedHandlerBody()}
+
+    return {
+      model: 'anthropic:claude-haiku-4-5',
+      system: 'You are a helpful support agent.',
+      tools: [],
+    };`;
+}
+
+function buildLangChainCodexHandler(): string {
+  return `${buildSharedHandlerBody()}
+
+    return {
+      model: new ChatCodexOAuth({ model: 'gpt-5.4-mini' }),
+      system: 'You are a helpful support agent.',
+      tools: [],
+    };`;
+}
+
+function buildAiSdkImports(kind: GenerateSupportAgentInput['llmAuth']['kind']): string {
+  const base = `/** @jsxImportSource @novu/framework */
+import { Actions, Button, Card, CardText } from '@novu/framework';
+import { agent } from '@novu/framework/ai-sdk';
+import { generateText } from 'ai';
+import { toModelMessages } from '@novu/framework/ai-sdk';`;
+
+  if (kind === 'openai-api-key') {
+    return `${base}
+import { openai } from '@ai-sdk/openai';`;
+  }
+
+  if (kind === 'anthropic-api-key') {
+    return `${base}
+import { anthropic } from '@ai-sdk/anthropic';`;
+  }
+
+  if (kind === 'codex-subscription') {
+    return `${base}
+import { codexCli } from 'ai-sdk-provider-codex-cli';`;
+  }
+
+  if (kind === 'claude-subscription') {
+    return `${base}
+import { claudeCode } from 'ai-sdk-provider-claude-code';`;
+  }
+
+  return base;
+}
+
+function buildLangChainImports(kind: GenerateSupportAgentInput['llmAuth']['kind']): string {
+  const base = `/** @jsxImportSource @novu/framework */
+import { Actions, Button, Card, CardText } from '@novu/framework';
+import { agent } from '@novu/framework/langchain';`;
+
+  if (kind === 'codex-subscription') {
+    return `${base}
+import { ChatCodexOAuth } from 'langchainjs-codex-oauth';`;
+  }
+
+  return base;
+}
+
+function buildOnMessageBody(input: GenerateSupportAgentInput): string {
+  const { runtime, llmAuth } = input;
+
+  if (runtime === 'ai-sdk') {
+    if (llmAuth.kind === 'openai-api-key') return buildAiSdkOpenAiHandler();
+    if (llmAuth.kind === 'anthropic-api-key') return buildAiSdkAnthropicHandler();
+    if (llmAuth.kind === 'codex-subscription') return buildAiSdkCodexHandler();
+    if (llmAuth.kind === 'claude-subscription') return buildAiSdkClaudeSubscriptionHandler();
+  }
+
+  if (runtime === 'langchain') {
+    if (llmAuth.kind === 'openai-api-key') return buildLangChainOpenAiHandler();
+    if (llmAuth.kind === 'anthropic-api-key') return buildLangChainAnthropicHandler();
+    if (llmAuth.kind === 'codex-subscription') return buildLangChainCodexHandler();
+  }
+
+  throw new Error(`Unsupported LLM auth "${llmAuth.kind}" for runtime "${runtime}".`);
+}
+
+export function generateSupportAgentSource(input: GenerateSupportAgentInput): string {
+  const camelName = toCamelAgentName(input.agentIdentifier);
+  const imports =
+    input.runtime === 'ai-sdk' ? buildAiSdkImports(input.llmAuth.kind) : buildLangChainImports(input.llmAuth.kind);
+  const onMessageBody = buildOnMessageBody(input);
+
+  return `${imports}
+
+/**
+ * Novu calls these handlers whenever a user sends a message or clicks an action
+ * in a connected channel (Slack, Teams, in-app, etc.).
+ */
+export const ${camelName} = agent('${input.agentIdentifier}', {
+  onMessage: async (message, ctx) => {
+${onMessageBody}
+  },
+
+${buildOnActionHandler()}
+});
+`;
+}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts
@@ -1,7 +1,13 @@
 import type { GenerateSupportAgentInput } from '../types';
 
 function toCamelAgentName(agentIdentifier: string): string {
-  return agentIdentifier.replace(/[-_]([a-z0-9])/g, (_, char) => char.toUpperCase());
+  const camelName = agentIdentifier.replace(/[-_]([a-z0-9])/g, (_, char) => char.toUpperCase());
+
+  if (/^\d/.test(camelName)) {
+    return `agent${camelName.charAt(0).toUpperCase()}${camelName.slice(1)}`;
+  }
+
+  return camelName;
 }
 
 function buildSharedHandlerBody(): string {

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/ensure-subscription-auth.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/ensure-subscription-auth.ts
@@ -9,6 +9,7 @@ import {
   runInteractiveCli,
   warnSubscriptionEnvConflicts,
 } from './subscription-auth';
+import { npxSubscriptionCliArgs, SUBSCRIPTION_CLI_NPX_SPECS } from './subscription-cli-specs';
 
 type EnsureSubscriptionAuthInput = {
   kind: 'codex-subscription' | 'claude-subscription';
@@ -28,7 +29,7 @@ async function ensureCodexCliAuth(ui: ConnectUI, ci?: boolean): Promise<void> {
 
   if (ci) {
     throw new Error(
-      'ChatGPT subscription requires Codex CLI login. Run `codex login` (or `npx @openai/codex login`) on this machine, then re-run with --llm-auth codex-subscription.'
+      `ChatGPT subscription requires Codex CLI login. Run \`codex login\` or \`npx ${SUBSCRIPTION_CLI_NPX_SPECS.codex} login\` on this machine, then re-run with --llm-auth codex-subscription.`
     );
   }
 
@@ -38,7 +39,7 @@ async function ensureCodexCliAuth(ui: ConnectUI, ci?: boolean): Promise<void> {
   if (commandExists('codex')) {
     await runInteractiveCli('codex', ['login'], { onAuthUrl: printBrowserAuthWaitingStatus });
   } else {
-    await runInteractiveCli('npx', ['--yes', '@openai/codex', 'login'], {
+    await runInteractiveCli('npx', npxSubscriptionCliArgs(SUBSCRIPTION_CLI_NPX_SPECS.codex, ['login']), {
       onAuthUrl: printBrowserAuthWaitingStatus,
     });
   }
@@ -55,20 +56,22 @@ async function ensureLangchainCodexOauthAuth(ui: ConnectUI, ci?: boolean): Promi
 
   if (ci) {
     throw new Error(
-      'ChatGPT subscription for LangChain requires OAuth login. Run `npx langchainjs-codex-oauth auth login`, then re-run with --llm-auth codex-subscription.'
+      `ChatGPT subscription for LangChain requires OAuth login. Run \`npx ${SUBSCRIPTION_CLI_NPX_SPECS.langchainCodexOauth} auth login\`, then re-run with --llm-auth codex-subscription.`
     );
   }
 
   await ui.releaseTerminal();
   console.log('Sign in with your ChatGPT account for LangChain Codex OAuth.');
 
-  await runInteractiveCli('npx', ['--yes', 'langchainjs-codex-oauth', 'auth', 'login'], {
-    onAuthUrl: printBrowserAuthWaitingStatus,
-  });
+  await runInteractiveCli(
+    'npx',
+    npxSubscriptionCliArgs(SUBSCRIPTION_CLI_NPX_SPECS.langchainCodexOauth, ['auth', 'login']),
+    { onAuthUrl: printBrowserAuthWaitingStatus }
+  );
 
   if (!hasLangchainCodexOauthAuth()) {
     throw new Error(
-      'LangChain Codex OAuth login did not complete. Run `npx langchainjs-codex-oauth auth login` and try again.'
+      `LangChain Codex OAuth login did not complete. Run \`npx ${SUBSCRIPTION_CLI_NPX_SPECS.langchainCodexOauth} auth login\` and try again.`
     );
   }
 
@@ -82,7 +85,7 @@ async function ensureClaudeCodeAuth(ui: ConnectUI, ci?: boolean): Promise<void> 
 
   if (ci) {
     throw new Error(
-      'Claude subscription requires Claude Code login. Run `claude auth login` (or `npx @anthropic-ai/claude-code auth login`), then re-run with --llm-auth claude-subscription.'
+      `Claude subscription requires Claude Code login. Run \`claude auth login\` or \`npx ${SUBSCRIPTION_CLI_NPX_SPECS.claudeCode} auth login\`, then re-run with --llm-auth claude-subscription.`
     );
   }
 
@@ -92,7 +95,7 @@ async function ensureClaudeCodeAuth(ui: ConnectUI, ci?: boolean): Promise<void> 
   if (commandExists('claude')) {
     await runInteractiveCli('claude', ['auth', 'login'], { onAuthUrl: printBrowserAuthWaitingStatus });
   } else {
-    await runInteractiveCli('npx', ['--yes', '@anthropic-ai/claude-code', 'auth', 'login'], {
+    await runInteractiveCli('npx', npxSubscriptionCliArgs(SUBSCRIPTION_CLI_NPX_SPECS.claudeCode, ['auth', 'login']), {
       onAuthUrl: printBrowserAuthWaitingStatus,
     });
   }

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/ensure-subscription-auth.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/ensure-subscription-auth.ts
@@ -1,0 +1,121 @@
+import chalk from 'chalk';
+import type { ConnectUI } from '../../ui/ui';
+import type { BridgeAdapterVariant } from '../bridge-adapter/types';
+import {
+  commandExists,
+  hasClaudeCodeAuth,
+  hasCodexCliAuth,
+  hasLangchainCodexOauthAuth,
+  runInteractiveCli,
+  warnSubscriptionEnvConflicts,
+} from './subscription-auth';
+
+type EnsureSubscriptionAuthInput = {
+  kind: 'codex-subscription' | 'claude-subscription';
+  connectMode: BridgeAdapterVariant;
+  ui: ConnectUI;
+  ci?: boolean;
+};
+
+function printBrowserAuthWaitingStatus(): void {
+  console.log(chalk.dim('⏳ Waiting for browser authentication… Return here when it completes.'));
+}
+
+async function ensureCodexCliAuth(ui: ConnectUI, ci?: boolean): Promise<void> {
+  if (hasCodexCliAuth()) {
+    return;
+  }
+
+  if (ci) {
+    throw new Error(
+      'ChatGPT subscription requires Codex CLI login. Run `codex login` (or `npx @openai/codex login`) on this machine, then re-run with --llm-auth codex-subscription.'
+    );
+  }
+
+  await ui.releaseTerminal();
+  console.log('Sign in with your ChatGPT account to use Codex (Plus/Pro subscription).');
+
+  if (commandExists('codex')) {
+    await runInteractiveCli('codex', ['login'], { onAuthUrl: printBrowserAuthWaitingStatus });
+  } else {
+    await runInteractiveCli('npx', ['--yes', '@openai/codex', 'login'], {
+      onAuthUrl: printBrowserAuthWaitingStatus,
+    });
+  }
+
+  if (!hasCodexCliAuth()) {
+    throw new Error('Codex login did not complete. Run `codex login` and try again.');
+  }
+}
+
+async function ensureLangchainCodexOauthAuth(ui: ConnectUI, ci?: boolean): Promise<void> {
+  if (hasLangchainCodexOauthAuth()) {
+    return;
+  }
+
+  if (ci) {
+    throw new Error(
+      'ChatGPT subscription for LangChain requires OAuth login. Run `npx langchainjs-codex-oauth auth login`, then re-run with --llm-auth codex-subscription.'
+    );
+  }
+
+  await ui.releaseTerminal();
+  console.log('Sign in with your ChatGPT account for LangChain Codex OAuth.');
+
+  await runInteractiveCli('npx', ['--yes', 'langchainjs-codex-oauth', 'auth', 'login'], {
+    onAuthUrl: printBrowserAuthWaitingStatus,
+  });
+
+  if (!hasLangchainCodexOauthAuth()) {
+    throw new Error(
+      'LangChain Codex OAuth login did not complete. Run `npx langchainjs-codex-oauth auth login` and try again.'
+    );
+  }
+
+  console.log(chalk.green('✓ ChatGPT subscription connected.'));
+}
+
+async function ensureClaudeCodeAuth(ui: ConnectUI, ci?: boolean): Promise<void> {
+  if (hasClaudeCodeAuth()) {
+    return;
+  }
+
+  if (ci) {
+    throw new Error(
+      'Claude subscription requires Claude Code login. Run `claude auth login` (or `npx @anthropic-ai/claude-code auth login`), then re-run with --llm-auth claude-subscription.'
+    );
+  }
+
+  await ui.releaseTerminal();
+  console.log('Sign in with your Claude Pro or Max subscription via Claude Code.');
+
+  if (commandExists('claude')) {
+    await runInteractiveCli('claude', ['auth', 'login'], { onAuthUrl: printBrowserAuthWaitingStatus });
+  } else {
+    await runInteractiveCli('npx', ['--yes', '@anthropic-ai/claude-code', 'auth', 'login'], {
+      onAuthUrl: printBrowserAuthWaitingStatus,
+    });
+  }
+
+  if (!hasClaudeCodeAuth()) {
+    throw new Error('Claude Code login did not complete. Run `claude auth login` and try again.');
+  }
+}
+
+export async function ensureSubscriptionAuth(input: EnsureSubscriptionAuthInput): Promise<void> {
+  warnSubscriptionEnvConflicts(input.kind);
+
+  if (input.kind === 'claude-subscription') {
+    await ensureClaudeCodeAuth(input.ui, input.ci);
+
+    return;
+  }
+
+  if (input.connectMode === 'langchain') {
+    await ensureLangchainCodexOauthAuth(input.ui, input.ci);
+
+    return;
+  }
+
+  await ensureCodexCliAuth(input.ui, input.ci);
+}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth-options.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth-options.ts
@@ -1,0 +1,48 @@
+import type { BridgeAdapterVariant } from '../bridge-adapter/types';
+import type { LlmAuthPickerOption } from './types';
+
+const OPENAI_API_KEY_OPTION: LlmAuthPickerOption = {
+  kind: 'openai-api-key',
+  title: 'OpenAI API key',
+};
+
+const ANTHROPIC_API_KEY_OPTION: LlmAuthPickerOption = {
+  kind: 'anthropic-api-key',
+  title: 'Anthropic API key',
+};
+
+const CODEX_SUBSCRIPTION_OPTION: LlmAuthPickerOption = {
+  kind: 'codex-subscription',
+  title: 'ChatGPT subscription (Codex)',
+  detail: 'OAuth via Codex CLI — no API key',
+};
+
+const CLAUDE_SUBSCRIPTION_OPTION: LlmAuthPickerOption = {
+  kind: 'claude-subscription',
+  title: 'Claude subscription (Claude Code)',
+  detail: 'OAuth via claude login — no API key',
+};
+
+const SKIP_OPTION: LlmAuthPickerOption = {
+  kind: 'skip',
+  title: 'Skip for now (demo echo)',
+};
+
+export function getLlmAuthPickerOptions(connectMode: BridgeAdapterVariant): readonly LlmAuthPickerOption[] {
+  if (connectMode === 'ai-sdk') {
+    return [
+      OPENAI_API_KEY_OPTION,
+      ANTHROPIC_API_KEY_OPTION,
+      CODEX_SUBSCRIPTION_OPTION,
+      CLAUDE_SUBSCRIPTION_OPTION,
+      SKIP_OPTION,
+    ];
+  }
+
+  return [OPENAI_API_KEY_OPTION, ANTHROPIC_API_KEY_OPTION, CODEX_SUBSCRIPTION_OPTION, SKIP_OPTION];
+}
+
+export const LLM_AUTH_PICKER_TITLE = 'How do you want to power your agent?';
+
+export const LLM_AUTH_PICKER_SUBTITLE =
+  'Optional for local dev. API keys are saved to .env.local; subscriptions use CLI OAuth on your machine.';

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth-options.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth-options.ts
@@ -14,13 +14,13 @@ const ANTHROPIC_API_KEY_OPTION: LlmAuthPickerOption = {
 const CODEX_SUBSCRIPTION_OPTION: LlmAuthPickerOption = {
   kind: 'codex-subscription',
   title: 'ChatGPT subscription (Codex)',
-  detail: 'OAuth via Codex CLI — no API key',
+  detail: 'OAuth via Codex CLI',
 };
 
 const CLAUDE_SUBSCRIPTION_OPTION: LlmAuthPickerOption = {
   kind: 'claude-subscription',
   title: 'Claude subscription (Claude Code)',
-  detail: 'OAuth via claude login — no API key',
+  detail: 'OAuth via claude login',
 };
 
 const SKIP_OPTION: LlmAuthPickerOption = {

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
@@ -106,4 +106,15 @@ describe('generateSupportAgentSource', () => {
     expect(source).toContain("import { codexCli } from 'ai-sdk-provider-codex-cli'");
     expect(source).toContain("model: codexCli('gpt-5.4-mini')");
   });
+
+  it('generates a valid export name when the identifier starts with a digit', () => {
+    const source = generateSupportAgentSource({
+      runtime: 'ai-sdk',
+      agentIdentifier: '1-agent',
+      llmAuth: { kind: 'openai-api-key', apiKey: 'sk-test' },
+    });
+
+    expect(source).toContain('export const agent1Agent');
+    expect(source).not.toMatch(/export const \d/);
+  });
 });

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { generateAgentNextConfigSource } from './codegen/generate-agent-next-config';
+import { generateSupportAgentSource } from './codegen/generate-support-agent';
+import { getLlmAuthPickerOptions } from './llm-auth-options';
+import { resolveLlmAuthEnvVars, resolveLlmAuthPackageDependencies, resolveLlmAuthPackages } from './registry';
+
+describe('llm-auth registry', () => {
+  it('resolves OpenAI packages per runtime', () => {
+    expect(resolveLlmAuthPackages('ai-sdk', { kind: 'openai-api-key', apiKey: 'sk-test' })).toEqual(['@ai-sdk/openai']);
+    expect(resolveLlmAuthPackages('langchain', { kind: 'openai-api-key', apiKey: 'sk-test' })).toEqual([
+      '@langchain/openai',
+    ]);
+  });
+
+  it('writes API keys to env vars', () => {
+    expect(resolveLlmAuthEnvVars({ kind: 'openai-api-key', apiKey: 'sk-test' })).toEqual({
+      OPENAI_API_KEY: 'sk-test',
+    });
+    expect(resolveLlmAuthEnvVars({ kind: 'skip' })).toEqual({});
+  });
+
+  it('pins subscription providers to zod v4-compatible releases', () => {
+    expect(resolveLlmAuthPackageDependencies('ai-sdk', { kind: 'codex-subscription' })).toEqual({
+      'ai-sdk-provider-codex-cli': '2.1.1',
+      '@openai/codex': '^0.144.0',
+    });
+    expect(resolveLlmAuthPackageDependencies('ai-sdk', { kind: 'claude-subscription' })).toEqual({
+      'ai-sdk-provider-claude-code': '4.0.1',
+    });
+  });
+});
+
+describe('generateAgentNextConfigSource', () => {
+  it('externalizes Codex CLI packages for subscription scaffolds', () => {
+    const source = generateAgentNextConfigSource('ai-sdk', { kind: 'codex-subscription' });
+
+    expect(source).toContain('turbopack');
+    expect(source).toContain("'ai-sdk-provider-codex-cli'");
+    expect(source).toContain("'@openai/codex'");
+  });
+
+  it('omits serverExternalPackages for API key scaffolds', () => {
+    const source = generateAgentNextConfigSource('ai-sdk', { kind: 'openai-api-key', apiKey: 'sk-test' });
+
+    expect(source).toContain('turbopack');
+    expect(source).not.toContain('serverExternalPackages');
+  });
+});
+
+describe('llm-auth picker options', () => {
+  it('includes Claude subscription for ai-sdk only', () => {
+    const aiSdkKinds = getLlmAuthPickerOptions('ai-sdk').map((opt) => opt.kind);
+    const langChainKinds = getLlmAuthPickerOptions('langchain').map((opt) => opt.kind);
+
+    expect(aiSdkKinds).toContain('claude-subscription');
+    expect(langChainKinds).not.toContain('claude-subscription');
+  });
+});
+
+describe('generateSupportAgentSource', () => {
+  it('generates wired AI SDK OpenAI handler', () => {
+    const source = generateSupportAgentSource({
+      runtime: 'ai-sdk',
+      agentIdentifier: 'support-agent',
+      llmAuth: { kind: 'openai-api-key', apiKey: 'sk-test' },
+    });
+
+    expect(source).toContain("import { openai } from '@ai-sdk/openai'");
+    expect(source).toContain("model: openai('gpt-4o-mini')");
+    expect(source).not.toContain('demo agent');
+  });
+
+  it('generates wired LangChain Anthropic handler', () => {
+    const source = generateSupportAgentSource({
+      runtime: 'langchain',
+      agentIdentifier: 'my-agent',
+      llmAuth: { kind: 'anthropic-api-key', apiKey: 'sk-ant-test' },
+    });
+
+    expect(source).toContain("agent('my-agent'");
+    expect(source).toContain("model: 'anthropic:claude-haiku-4-5'");
+    expect(source).toContain('export const myAgent');
+  });
+
+  it('generates wired LangChain Codex subscription handler', () => {
+    const source = generateSupportAgentSource({
+      runtime: 'langchain',
+      agentIdentifier: 'support-agent',
+      llmAuth: { kind: 'codex-subscription' },
+    });
+
+    expect(source).toContain("import { ChatCodexOAuth } from 'langchainjs-codex-oauth'");
+    expect(source).toContain("model: new ChatCodexOAuth({ model: 'gpt-5.4-mini' })");
+  });
+
+  it('generates wired AI SDK Codex subscription handler', () => {
+    const source = generateSupportAgentSource({
+      runtime: 'ai-sdk',
+      agentIdentifier: 'support-agent',
+      llmAuth: { kind: 'codex-subscription' },
+    });
+
+    expect(source).toContain("import { codexCli } from 'ai-sdk-provider-codex-cli'");
+    expect(source).toContain("model: codexCli('gpt-5.4-mini')");
+  });
+});

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/llm-auth.spec.ts
@@ -27,6 +27,9 @@ describe('llm-auth registry', () => {
     expect(resolveLlmAuthPackageDependencies('ai-sdk', { kind: 'claude-subscription' })).toEqual({
       'ai-sdk-provider-claude-code': '4.0.1',
     });
+    expect(resolveLlmAuthPackageDependencies('langchain', { kind: 'codex-subscription' })).toEqual({
+      'langchainjs-codex-oauth': '0.1.8',
+    });
   });
 });
 

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/registry.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/registry.ts
@@ -1,0 +1,90 @@
+import type { BridgeAdapterVariant } from '../bridge-adapter/types';
+import type { LlmAuthChoice, LlmAuthKind } from './types';
+
+export type LlmPackageSpec = {
+  name: string;
+  version: string;
+};
+
+export type LlmAuthRegistryEntry = {
+  envKey?: string;
+  packages: Record<BridgeAdapterVariant, readonly LlmPackageSpec[]>;
+};
+
+const REGISTRY: Record<Exclude<LlmAuthKind, 'skip'>, LlmAuthRegistryEntry> = {
+  'openai-api-key': {
+    envKey: 'OPENAI_API_KEY',
+    packages: {
+      'ai-sdk': [{ name: '@ai-sdk/openai', version: 'latest' }],
+      langchain: [{ name: '@langchain/openai', version: 'latest' }],
+    },
+  },
+  'anthropic-api-key': {
+    envKey: 'ANTHROPIC_API_KEY',
+    packages: {
+      'ai-sdk': [{ name: '@ai-sdk/anthropic', version: 'latest' }],
+      langchain: [{ name: '@langchain/anthropic', version: 'latest' }],
+    },
+  },
+  'codex-subscription': {
+    packages: {
+      'ai-sdk': [
+        { name: 'ai-sdk-provider-codex-cli', version: '2.1.1' },
+        { name: '@openai/codex', version: '^0.144.0' },
+      ],
+      langchain: [{ name: 'langchainjs-codex-oauth', version: 'latest' }],
+    },
+  },
+  'claude-subscription': {
+    packages: {
+      'ai-sdk': [{ name: 'ai-sdk-provider-claude-code', version: '4.0.1' }],
+      langchain: [],
+    },
+  },
+};
+
+export function resolveLlmAuthPackageSpecs(
+  runtime: BridgeAdapterVariant,
+  llmAuth: LlmAuthChoice
+): readonly LlmPackageSpec[] {
+  if (llmAuth.kind === 'skip') {
+    return [];
+  }
+
+  return REGISTRY[llmAuth.kind].packages[runtime];
+}
+
+export function resolveLlmAuthPackages(runtime: BridgeAdapterVariant, llmAuth: LlmAuthChoice): string[] {
+  return resolveLlmAuthPackageSpecs(runtime, llmAuth).map((spec) => spec.name);
+}
+
+export function resolveLlmAuthPackageDependencies(
+  runtime: BridgeAdapterVariant,
+  llmAuth: LlmAuthChoice
+): Record<string, string> {
+  const dependencies: Record<string, string> = {};
+
+  for (const spec of resolveLlmAuthPackageSpecs(runtime, llmAuth)) {
+    dependencies[spec.name] = spec.version;
+  }
+
+  return dependencies;
+}
+
+export function resolveLlmAuthEnvVars(llmAuth: LlmAuthChoice): Record<string, string> {
+  if (llmAuth.kind === 'openai-api-key') {
+    return { OPENAI_API_KEY: llmAuth.apiKey };
+  }
+
+  if (llmAuth.kind === 'anthropic-api-key') {
+    return { ANTHROPIC_API_KEY: llmAuth.apiKey };
+  }
+
+  return {};
+}
+
+export function shouldWireLlmAuth(
+  llmAuth: LlmAuthChoice | undefined
+): llmAuth is Exclude<LlmAuthChoice, { kind: 'skip' }> {
+  return llmAuth !== undefined && llmAuth.kind !== 'skip';
+}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/registry.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/registry.ts
@@ -32,7 +32,7 @@ const REGISTRY: Record<Exclude<LlmAuthKind, 'skip'>, LlmAuthRegistryEntry> = {
         { name: 'ai-sdk-provider-codex-cli', version: '2.1.1' },
         { name: '@openai/codex', version: '^0.144.0' },
       ],
-      langchain: [{ name: 'langchainjs-codex-oauth', version: 'latest' }],
+      langchain: [{ name: 'langchainjs-codex-oauth', version: '0.1.8' }],
     },
   },
   'claude-subscription': {

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.spec.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CloudRegionEnum } from '../../../dev/enums';
+import type { ConnectUI } from '../../ui/ui';
+import { ensureSubscriptionAuth } from './ensure-subscription-auth';
+import { resolveLlmAuthChoice } from './resolve-llm-auth';
+import * as subscriptionAuth from './subscription-auth';
+
+function baseOptions() {
+  return {
+    region: CloudRegionEnum.US,
+    apiUrl: 'https://api.novu.co',
+    dashboardUrl: 'https://dashboard.novu.co',
+    connectDashboardUrl: 'https://dashboard.novu.co',
+  };
+}
+
+function createUi(overrides: Partial<ConnectUI> = {}): ConnectUI {
+  return {
+    interactive: true,
+    releaseTerminal: vi.fn().mockResolvedValue(undefined),
+    pickLlmAuthKind: vi.fn().mockResolvedValue('skip'),
+    promptForSecretInput: vi.fn().mockResolvedValue('sk-test'),
+    ...overrides,
+  } as ConnectUI;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveLlmAuthChoice', () => {
+  it('resolves skip from CI when llm-auth is omitted', async () => {
+    const result = await resolveLlmAuthChoice({
+      connectMode: 'ai-sdk',
+      options: { ci: true, ...baseOptions() },
+      ui: createUi(),
+    });
+
+    expect(result).toEqual({ kind: 'skip' });
+  });
+
+  it('resolves OpenAI API key from CI flags', async () => {
+    const result = await resolveLlmAuthChoice({
+      connectMode: 'ai-sdk',
+      options: {
+        ci: true,
+        llmAuth: 'openai',
+        openaiApiKey: 'sk-test',
+        ...baseOptions(),
+      },
+      ui: createUi(),
+    });
+
+    expect(result).toEqual({ kind: 'openai-api-key', apiKey: 'sk-test' });
+  });
+
+  it('rejects Claude subscription for langchain runtime', async () => {
+    await expect(
+      resolveLlmAuthChoice({
+        connectMode: 'langchain',
+        options: {
+          ci: true,
+          llmAuth: 'claude-subscription',
+          ...baseOptions(),
+        },
+        ui: createUi(),
+      })
+    ).rejects.toThrow(/only supported for --runtime ai-sdk/);
+  });
+
+  it('resolves codex subscription from CI when already authenticated', async () => {
+    vi.spyOn(subscriptionAuth, 'hasCodexCliAuth').mockReturnValue(true);
+
+    const result = await resolveLlmAuthChoice({
+      connectMode: 'ai-sdk',
+      options: {
+        ci: true,
+        llmAuth: 'codex-subscription',
+        ...baseOptions(),
+      },
+      ui: createUi(),
+    });
+
+    expect(result).toEqual({ kind: 'codex-subscription' });
+  });
+});
+
+describe('ensureSubscriptionAuth', () => {
+  it('skips login when codex auth already exists', async () => {
+    vi.spyOn(subscriptionAuth, 'hasCodexCliAuth').mockReturnValue(true);
+    const releaseTerminal = vi.fn();
+
+    await ensureSubscriptionAuth({
+      kind: 'codex-subscription',
+      connectMode: 'ai-sdk',
+      ui: createUi({ releaseTerminal }),
+    });
+
+    expect(releaseTerminal).not.toHaveBeenCalled();
+  });
+
+  it('shows a waiting status during LangChain browser OAuth', async () => {
+    vi.spyOn(subscriptionAuth, 'hasLangchainCodexOauthAuth').mockReturnValueOnce(false).mockReturnValue(true);
+    vi.spyOn(subscriptionAuth, 'runInteractiveCli').mockImplementation(async (_command, _args, options) => {
+      options?.onAuthUrl?.();
+    });
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await ensureSubscriptionAuth({
+      kind: 'codex-subscription',
+      connectMode: 'langchain',
+      ui: createUi(),
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Waiting for browser authentication'));
+  });
+});

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.ts
@@ -1,0 +1,126 @@
+import type { ConnectCommandOptions } from '../../types';
+import type { ConnectUI } from '../../ui/ui';
+import type { BridgeAdapterVariant } from '../bridge-adapter/types';
+import { ensureSubscriptionAuth } from './ensure-subscription-auth';
+import type { LlmAuthChoice, LlmAuthCliChoice, LlmAuthKind } from './types';
+
+type ResolveLlmAuthInput = {
+  connectMode: BridgeAdapterVariant;
+  options: ConnectCommandOptions;
+  ui: ConnectUI;
+};
+
+function isSubscriptionKind(kind: LlmAuthKind): kind is 'codex-subscription' | 'claude-subscription' {
+  return kind === 'codex-subscription' || kind === 'claude-subscription';
+}
+
+function mapCliChoiceToKind(choice: LlmAuthCliChoice, connectMode: BridgeAdapterVariant): LlmAuthKind {
+  switch (choice) {
+    case 'openai':
+      return 'openai-api-key';
+    case 'anthropic':
+      return 'anthropic-api-key';
+    case 'codex-subscription':
+      return 'codex-subscription';
+    case 'claude-subscription':
+      if (connectMode === 'langchain') {
+        throw new Error('Claude subscription is only supported for --runtime ai-sdk.');
+      }
+
+      return 'claude-subscription';
+    case 'skip':
+      return 'skip';
+  }
+}
+
+function resolveApiKeyFromOptions(kind: LlmAuthKind, options: ConnectCommandOptions): string | undefined {
+  if (kind === 'openai-api-key') {
+    return options.openaiApiKey?.trim();
+  }
+
+  if (kind === 'anthropic-api-key') {
+    return options.anthropicApiKey?.trim();
+  }
+
+  return undefined;
+}
+
+async function promptForApiKey(ui: ConnectUI, kind: 'openai-api-key' | 'anthropic-api-key'): Promise<string> {
+  const isOpenAi = kind === 'openai-api-key';
+
+  while (true) {
+    const value = await ui.promptForSecretInput({
+      title: isOpenAi ? 'OpenAI API key' : 'Anthropic API key',
+      placeholder: isOpenAi ? 'sk-...' : 'sk-ant-...',
+      hint: 'Saved to .env.local in your scaffolded project.',
+      secret: true,
+    });
+
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+}
+
+async function resolveFromCliFlags(input: ResolveLlmAuthInput): Promise<LlmAuthChoice> {
+  const cliChoice = input.options.llmAuth;
+  if (!cliChoice) {
+    return { kind: 'skip' };
+  }
+
+  const kind = mapCliChoiceToKind(cliChoice, input.connectMode);
+
+  if (kind === 'skip') {
+    return { kind: 'skip' };
+  }
+
+  if (isSubscriptionKind(kind)) {
+    await ensureSubscriptionAuth({ kind, connectMode: input.connectMode, ui: input.ui, ci: input.options.ci });
+
+    return { kind };
+  }
+
+  const apiKey = resolveApiKeyFromOptions(kind, input.options);
+  if (!apiKey) {
+    const flag = kind === 'openai-api-key' ? '--openai-api-key' : '--anthropic-api-key';
+
+    throw new Error(`Non-interactive mode requires ${flag} when --llm-auth is "${cliChoice}".`);
+  }
+
+  if (kind === 'openai-api-key') {
+    return { kind, apiKey };
+  }
+
+  return { kind, apiKey };
+}
+
+async function resolveInteractive(input: ResolveLlmAuthInput): Promise<LlmAuthChoice> {
+  const kind = await input.ui.pickLlmAuthKind({ connectMode: input.connectMode });
+
+  if (kind === 'skip') {
+    return { kind: 'skip' };
+  }
+
+  if (isSubscriptionKind(kind)) {
+    await ensureSubscriptionAuth({ kind, connectMode: input.connectMode, ui: input.ui, ci: input.options.ci });
+
+    return { kind };
+  }
+
+  const apiKey = await promptForApiKey(input.ui, kind);
+
+  if (kind === 'openai-api-key') {
+    return { kind, apiKey };
+  }
+
+  return { kind, apiKey };
+}
+
+export async function resolveLlmAuthChoice(input: ResolveLlmAuthInput): Promise<LlmAuthChoice> {
+  if (input.options.ci || input.options.llmAuth) {
+    return resolveFromCliFlags(input);
+  }
+
+  return resolveInteractive(input);
+}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  resolveClaudeCredentialsPath,
+  resolveCodexHome,
+  resolveLangchainCodexOauthAuthPath,
+  runInteractiveCli,
+} from './subscription-auth';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('subscription-auth paths', () => {
+  it('resolves default credential paths', () => {
+    expect(resolveCodexHome()).toContain('.codex');
+    expect(resolveClaudeCredentialsPath()).toContain('.claude');
+    expect(resolveLangchainCodexOauthAuthPath()).toContain('langchainjs-codex-oauth');
+  });
+});
+
+describe('runInteractiveCli', () => {
+  it('notifies after forwarding an OAuth URL', async () => {
+    const events: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      events.push(String(chunk));
+
+      return true;
+    });
+    const runWithAuthUrlCallback = runInteractiveCli as unknown as (
+      command: string,
+      args: string[],
+      options: { onAuthUrl: () => void }
+    ) => Promise<void>;
+
+    await runWithAuthUrlCallback(
+      process.execPath,
+      ['-e', "console.log('https://auth.openai.com/oauth/authorize?test=1')"],
+      { onAuthUrl: () => events.push('WAITING') }
+    );
+
+    const output = events.join('');
+
+    expect(output).toContain('https://auth.openai.com/oauth/authorize?test=1');
+    expect(output.indexOf('WAITING')).toBeGreaterThan(output.indexOf('https://auth.openai.com'));
+  });
+});

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.spec.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.spec.ts
@@ -5,9 +5,21 @@ import {
   resolveLangchainCodexOauthAuthPath,
   runInteractiveCli,
 } from './subscription-auth';
+import { npxSubscriptionCliArgs, SUBSCRIPTION_CLI_NPX_SPECS } from './subscription-cli-specs';
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe('subscription-cli-specs', () => {
+  it('pins npx package versions for OAuth fallbacks', () => {
+    expect(npxSubscriptionCliArgs(SUBSCRIPTION_CLI_NPX_SPECS.claudeCode, ['auth', 'login'])).toEqual([
+      '--yes',
+      '@anthropic-ai/claude-code@2.1.209',
+      'auth',
+      'login',
+    ]);
+  });
 });
 
 describe('subscription-auth paths', () => {

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.ts
@@ -125,19 +125,6 @@ export function hasClaudeCodeAuth(): boolean {
     }
   }
 
-  try {
-    const output = execSync('npx --yes @anthropic-ai/claude-code auth status', {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    if (/loggedIn":\s*true/.test(output) || /"loggedIn": true/.test(output)) {
-      return true;
-    }
-  } catch {
-    // Fall through to credentials file check.
-  }
-
   const credentials = readJsonFile(resolveClaudeCredentialsPath());
   if (!credentials) {
     return false;
@@ -147,20 +134,12 @@ export function hasClaudeCodeAuth(): boolean {
 }
 
 export function hasLangchainCodexOauthAuth(): boolean {
-  if (fs.existsSync(resolveLangchainCodexOauthAuthPath())) {
-    return true;
-  }
-
-  try {
-    execSync('npx --yes langchainjs-codex-oauth auth status', {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    return true;
-  } catch {
+  const auth = readJsonFile(resolveLangchainCodexOauthAuthPath());
+  if (!auth) {
     return false;
   }
+
+  return Object.keys(auth).length > 0;
 }
 
 export function warnSubscriptionEnvConflicts(kind: 'codex-subscription' | 'claude-subscription'): void {

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-auth.ts
@@ -1,0 +1,178 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import spawn from 'cross-spawn';
+
+type RunInteractiveCliOptions = {
+  onAuthUrl?: () => void;
+};
+
+export function commandExists(command: string): boolean {
+  try {
+    execSync(`command -v ${command}`, { stdio: 'ignore' });
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function runInteractiveCli(
+  command: string,
+  args: string[],
+  options: RunInteractiveCliOptions = {}
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['inherit', 'pipe', 'pipe'] });
+    let authUrlReported = false;
+    let outputTail = '';
+
+    const forwardOutput = (chunk: Buffer, target: NodeJS.WriteStream) => {
+      target.write(chunk);
+      outputTail = `${outputTail}${chunk.toString('utf8')}`.slice(-4096);
+
+      if (!authUrlReported && /https?:\/\/\S+/.test(outputTail)) {
+        authUrlReported = true;
+        options.onAuthUrl?.();
+      }
+    };
+
+    child.stdout?.on('data', (chunk: Buffer) => forwardOutput(chunk, process.stdout));
+    child.stderr?.on('data', (chunk: Buffer) => forwardOutput(chunk, process.stderr));
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+
+        return;
+      }
+
+      reject(new Error(`Command failed: ${command} ${args.join(' ')} (exit ${code ?? 'unknown'})`));
+    });
+  });
+}
+
+export function resolveCodexHome(): string {
+  return process.env.CODEX_HOME?.trim() || path.join(os.homedir(), '.codex');
+}
+
+export function resolveClaudeCredentialsPath(): string {
+  return path.join(os.homedir(), '.claude', '.credentials.json');
+}
+
+export function resolveLangchainCodexOauthAuthPath(): string {
+  return path.join(os.homedir(), '.langchainjs-codex-oauth', 'auth', 'openai.json');
+}
+
+function readJsonFile(filePath: string): Record<string, unknown> | null {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function hasCodexCliAuth(): boolean {
+  if (commandExists('codex')) {
+    try {
+      const output = execSync('codex login status', {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      if (/logged in/i.test(output) || /authenticated:\s*yes/i.test(output)) {
+        return true;
+      }
+    } catch {
+      // Fall through to auth.json check.
+    }
+  }
+
+  const auth = readJsonFile(path.join(resolveCodexHome(), 'auth.json'));
+  if (!auth) {
+    return false;
+  }
+
+  const tokens = auth.tokens;
+  if (!tokens || typeof tokens !== 'object') {
+    return false;
+  }
+
+  const tokenRecord = tokens as Record<string, unknown>;
+
+  return Boolean(tokenRecord.access_token || tokenRecord.refresh_token);
+}
+
+export function hasClaudeCodeAuth(): boolean {
+  if (commandExists('claude')) {
+    try {
+      const output = execSync('claude auth status', {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      if (/loggedIn":\s*true/.test(output) || /"loggedIn": true/.test(output)) {
+        return true;
+      }
+    } catch {
+      // Fall through to credentials file check.
+    }
+  }
+
+  try {
+    const output = execSync('npx --yes @anthropic-ai/claude-code auth status', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    if (/loggedIn":\s*true/.test(output) || /"loggedIn": true/.test(output)) {
+      return true;
+    }
+  } catch {
+    // Fall through to credentials file check.
+  }
+
+  const credentials = readJsonFile(resolveClaudeCredentialsPath());
+  if (!credentials) {
+    return false;
+  }
+
+  return Object.keys(credentials).length > 0;
+}
+
+export function hasLangchainCodexOauthAuth(): boolean {
+  if (fs.existsSync(resolveLangchainCodexOauthAuthPath())) {
+    return true;
+  }
+
+  try {
+    execSync('npx --yes langchainjs-codex-oauth auth status', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function warnSubscriptionEnvConflicts(kind: 'codex-subscription' | 'claude-subscription'): void {
+  if (kind === 'codex-subscription' && process.env.OPENAI_API_KEY?.trim()) {
+    console.warn(
+      'Warning: OPENAI_API_KEY is set. Codex may bill your API account instead of using your ChatGPT subscription.'
+    );
+  }
+
+  if (kind === 'claude-subscription' && process.env.ANTHROPIC_API_KEY?.trim()) {
+    console.warn(
+      'Warning: ANTHROPIC_API_KEY is set. Claude Code may bill your API account instead of using your subscription.'
+    );
+  }
+}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-cli-specs.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/subscription-cli-specs.ts
@@ -1,0 +1,13 @@
+/**
+ * Pinned npm package@version strings for subscription OAuth CLIs invoked via npx.
+ * Avoids `npx --yes <pkg>` fetching an unpinned latest from the registry.
+ */
+export const SUBSCRIPTION_CLI_NPX_SPECS = {
+  codex: '@openai/codex@0.144.0',
+  claudeCode: '@anthropic-ai/claude-code@2.1.209',
+  langchainCodexOauth: 'langchainjs-codex-oauth@0.1.8',
+} as const;
+
+export function npxSubscriptionCliArgs(spec: string, cliArgs: readonly string[]): string[] {
+  return ['--yes', spec, ...cliArgs];
+}

--- a/packages/novu/src/commands/connect/pipeline/llm-auth/types.ts
+++ b/packages/novu/src/commands/connect/pipeline/llm-auth/types.ts
@@ -1,0 +1,31 @@
+import type { BridgeAdapterVariant } from '../bridge-adapter/types';
+
+/** Internal discriminated-union tag used by registry, codegen, and scaffold wiring. */
+export type LlmAuthKind =
+  | 'openai-api-key'
+  | 'anthropic-api-key'
+  | 'codex-subscription'
+  | 'claude-subscription'
+  | 'skip';
+
+/** Short names for `--llm-auth`; mapped to `LlmAuthKind` in `resolve-llm-auth.ts`. */
+export type LlmAuthCliChoice = 'openai' | 'anthropic' | 'codex-subscription' | 'claude-subscription' | 'skip';
+
+export type LlmAuthChoice =
+  | { kind: 'openai-api-key'; apiKey: string }
+  | { kind: 'anthropic-api-key'; apiKey: string }
+  | { kind: 'codex-subscription' }
+  | { kind: 'claude-subscription' }
+  | { kind: 'skip' };
+
+export type LlmAuthPickerOption = {
+  kind: LlmAuthKind;
+  title: string;
+  detail?: string;
+};
+
+export type GenerateSupportAgentInput = {
+  runtime: BridgeAdapterVariant;
+  agentIdentifier: string;
+  llmAuth: LlmAuthChoice;
+};

--- a/packages/novu/src/commands/connect/types.ts
+++ b/packages/novu/src/commands/connect/types.ts
@@ -1,4 +1,5 @@
 import type { CloudRegionEnum } from '../dev/enums';
+import type { LlmAuthCliChoice } from './pipeline/llm-auth/types';
 
 export type ChannelChoice = 'slack' | 'email' | 'whatsapp' | 'telegram' | 'teams' | 'skip';
 
@@ -152,6 +153,13 @@ export interface ConnectCommandOptions {
   scaffoldDir?: string;
   /** Skip scaffolding even when the target directory is empty. */
   noScaffold?: boolean;
+  /**
+   * LLM provider for ai-sdk / langchain fresh scaffolds only.
+   * openai | anthropic | codex-subscription | claude-subscription | skip
+   */
+  llmAuth?: LlmAuthCliChoice;
+  /** OpenAI API key for --llm-auth openai non-interactive scaffold runs. */
+  openaiApiKey?: string;
 }
 
 export interface AgentSummary {

--- a/packages/novu/src/commands/connect/ui/console-bridge-scaffold-prompts.ts
+++ b/packages/novu/src/commands/connect/ui/console-bridge-scaffold-prompts.ts
@@ -1,0 +1,89 @@
+import chalk from 'chalk';
+import type { BridgeScaffoldVariant } from '../pipeline/bridge/types';
+import { type BridgeReconcileVariant, installDepsPrompt } from './bridge-reconcile-variant';
+import { waitForConsoleLine } from './wait-for-console-line';
+
+function toReconcileVariant(variant: BridgeScaffoldVariant): BridgeReconcileVariant {
+  if (variant === 'custom-code') {
+    return 'ai-sdk';
+  }
+
+  return variant;
+}
+
+function scaffoldTitle(variant: BridgeScaffoldVariant): string {
+  if (variant === 'custom-code') {
+    return 'Scaffold an agent app?';
+  }
+
+  if (variant === 'ai-sdk') {
+    return 'Scaffold an AI SDK agent app?';
+  }
+
+  if (variant === 'langchain') {
+    return 'Scaffold a LangChain agent app?';
+  }
+
+  return 'Scaffold a Chat SDK app?';
+}
+
+function scaffoldSummary(variant: BridgeScaffoldVariant): string {
+  if (variant === 'custom-code') {
+    return 'This installs @novu/framework, Next.js, and wires your Novu credentials into .env.local.';
+  }
+
+  if (variant === 'ai-sdk') {
+    return 'This installs @novu/framework, Next.js, and wires your Novu credentials into .env.local. Agent handlers use @novu/framework/ai-sdk.';
+  }
+
+  if (variant === 'langchain') {
+    return 'This installs @novu/framework, langchain, Next.js, and wires your Novu credentials into .env.local. Agent handlers use @novu/framework/langchain.';
+  }
+
+  return 'This installs chat, @novu/chat-sdk-adapter, and wires your Novu credentials into .env.local.';
+}
+
+export async function promptConfirmScaffoldInConsole(opts: {
+  projectDir: string;
+  appName: string;
+  variant: BridgeScaffoldVariant;
+}): Promise<boolean> {
+  console.log('');
+  console.log(chalk.bold(scaffoldTitle(opts.variant)));
+  console.log(chalk.dim(`No project was found here. We'll create one at:`));
+  console.log(`  ${chalk.bold(opts.projectDir)}/${chalk.cyan(opts.appName)}`);
+  console.log(chalk.dim(scaffoldSummary(opts.variant)));
+  console.log(chalk.cyan('Enter · scaffold · s · cancel'));
+
+  const answer = await waitForConsoleLine();
+  const normalized = answer.trim().toLowerCase();
+
+  if (normalized === 's' || normalized === 'n' || normalized === 'no' || normalized === 'cancel') {
+    return false;
+  }
+
+  return true;
+}
+
+export async function promptConfirmInstallBridgeDepsInConsole(opts: {
+  projectDir: string;
+  installCommand: string;
+  packages: string[];
+  variant: BridgeScaffoldVariant;
+}): Promise<boolean> {
+  console.log('');
+  console.log(chalk.bold(installDepsPrompt(toReconcileVariant(opts.variant))));
+  console.log(chalk.dim(`We'll add: ${opts.packages.join(', ')}`));
+  console.log(chalk.gray(`  Project: ${opts.projectDir}`));
+  console.log(chalk.cyan(`  ${opts.installCommand}`));
+  console.log(chalk.cyan('Enter · install · s · skip'));
+
+  const answer = await waitForConsoleLine();
+  const normalized = answer.trim().toLowerCase();
+
+  if (normalized === 's' || normalized === 'n' || normalized === 'no' || normalized === 'skip') {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/novu/src/commands/connect/ui/index.tsx
+++ b/packages/novu/src/commands/connect/ui/index.tsx
@@ -5,9 +5,14 @@ import React from 'react';
 import type { GeneratedAgentSpec } from '../api/agents';
 import { ConnectChannelBackError } from '../errors';
 import { printBridgeScaffolded } from '../pipeline/bridge/print-bridge-scaffolded';
+import type { LlmAuthKind } from '../pipeline/llm-auth/types';
 import type { AgentSummary, ConnectCommandOptions } from '../types';
 import { App } from './app';
 import { promptBridgeReconcilePlanInConsole, promptBridgeTunnelInConsole } from './console-bridge-reconcile-prompts';
+import {
+  promptConfirmInstallBridgeDepsInConsole,
+  promptConfirmScaffoldInConsole,
+} from './console-bridge-scaffold-prompts';
 import { printConnectSuccess, shouldSkipConnectSuccessSummary } from './print-connect-success';
 import { restoreStdinForConsole } from './restore-stdin-for-console';
 import { type ConnectStore, createConnectStore } from './store';
@@ -254,6 +259,10 @@ function createUiController(
       });
     },
     confirmScaffold({ projectDir, appName, variant }) {
+      if (ctx.isTerminalReleased()) {
+        return promptConfirmScaffoldInConsole({ projectDir, appName, variant });
+      }
+
       return new Promise<boolean>((resolve) => {
         store.phase.set({
           kind: 'confirm-scaffold',
@@ -264,6 +273,11 @@ function createUiController(
         });
       });
     },
+    pickLlmAuthKind({ connectMode }) {
+      return new Promise<LlmAuthKind>((resolve) => {
+        store.phase.set({ kind: 'pick-llm-auth', connectMode, resolve });
+      });
+    },
     scaffoldingBridge({ variant }) {
       store.phase.set({ kind: 'scaffolding-bridge', variant });
     },
@@ -271,6 +285,15 @@ function createUiController(
       printBridgeScaffolded(opts);
     },
     confirmInstallBridgeDeps({ projectDir, installCommand, packages, variant }) {
+      if (ctx.isTerminalReleased()) {
+        return promptConfirmInstallBridgeDepsInConsole({
+          projectDir,
+          installCommand,
+          packages,
+          variant,
+        });
+      }
+
       return new Promise<boolean>((resolve) => {
         store.phase.set({
           kind: 'bridge-install-deps-confirm',

--- a/packages/novu/src/commands/connect/ui/llm-auth-picker.tsx
+++ b/packages/novu/src/commands/connect/ui/llm-auth-picker.tsx
@@ -1,0 +1,45 @@
+import { Box, Text, useInput } from 'ink';
+// biome-ignore lint/correctness/noUnusedImports: classic-JSX linter falls back here because tsconfig.json excludes ui/.
+import React from 'react';
+import type { BridgeAdapterVariant } from '../pipeline/bridge-adapter/types';
+import { getLlmAuthPickerOptions } from '../pipeline/llm-auth/llm-auth-options';
+import type { LlmAuthKind } from '../pipeline/llm-auth/types';
+
+export function LlmAuthPicker({
+  connectMode,
+  onChange,
+}: {
+  connectMode: BridgeAdapterVariant;
+  onChange: (value: LlmAuthKind) => void;
+}): React.ReactElement {
+  const options = getLlmAuthPickerOptions(connectMode);
+  const [idx, setIdx] = React.useState(0);
+
+  useInput((_input, key) => {
+    if (key.upArrow) {
+      setIdx((current) => (current - 1 + options.length) % options.length);
+    } else if (key.downArrow) {
+      setIdx((current) => (current + 1) % options.length);
+    } else if (key.return) {
+      onChange(options[idx].kind);
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {options.map((opt, rowIndex) => {
+        const isSelected = rowIndex === idx;
+
+        return (
+          <Text key={opt.kind}>
+            <Text color={isSelected ? 'cyan' : undefined}>
+              {isSelected ? '› ' : '  '}
+              {opt.title}
+            </Text>
+            {opt.detail ? <Text dimColor>{` · ${opt.detail}`}</Text> : null}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}

--- a/packages/novu/src/commands/connect/ui/logging-ui.ts
+++ b/packages/novu/src/commands/connect/ui/logging-ui.ts
@@ -208,6 +208,12 @@ export function createLoggingUI(): ConnectUI {
     confirmEnvSecretOverwrite() {
       return Promise.resolve(false);
     },
+    pickLlmAuthKind() {
+      stop();
+      console.log(chalk.gray('Non-interactive mode: skipping LLM wiring (demo echo). Pass --llm-auth to configure.'));
+
+      return Promise.resolve('skip');
+    },
     confirmScaffold({ projectDir, appName, variant = 'chat-sdk' }) {
       console.log(chalk.cyan(`→ Scaffolding ${bridgeScaffoldLabel(variant)} "${appName}" in ${projectDir}`));
 

--- a/packages/novu/src/commands/connect/ui/phase-content.tsx
+++ b/packages/novu/src/commands/connect/ui/phase-content.tsx
@@ -8,10 +8,12 @@ import { SEND_FROM_ACCOUNT_LABEL } from '../copy/email-onboarding';
 import { channelDisplayName, isDashboardOnlyChannel } from '../dashboard-urls';
 import { resolveBridgeSetupFollowUpMessage } from '../pipeline/bridge/setup-outcome-message';
 import { validateSlackConfigTokenFormat } from '../pipeline/channels/slack-config-token';
+import { LLM_AUTH_PICKER_SUBTITLE, LLM_AUTH_PICKER_TITLE } from '../pipeline/llm-auth/llm-auth-options';
 import type { ChannelChoice } from '../types';
 import { BridgeReconcilePhaseContent, isBridgeReconcilePhase } from './bridge-reconcile-phase-content';
 import { CopyableLink } from './copyable-link';
 import { GroupedConnectModeSelect } from './grouped-connect-mode-select';
+import { LlmAuthPicker } from './llm-auth-picker';
 import { PreviewGeneratedContent } from './preview-generated-content';
 import type { ConnectStore, Phase } from './store';
 import { WelcomeContent } from './welcome-content';
@@ -60,6 +62,17 @@ export function PhaseContent({
 
     case 'loading-integrations':
       return <Text color="cyan">Looking up agent runtime integrations…</Text>;
+
+    case 'pick-llm-auth':
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Box flexDirection="column">
+            <Text bold>{LLM_AUTH_PICKER_TITLE}</Text>
+            <Text dimColor>{LLM_AUTH_PICKER_SUBTITLE}</Text>
+          </Box>
+          <LlmAuthPicker connectMode={phase.connectMode} onChange={(value) => phase.resolve(value)} />
+        </Box>
+      );
 
     case 'pick-connect-mode':
       return (

--- a/packages/novu/src/commands/connect/ui/restore-stdin-for-console.ts
+++ b/packages/novu/src/commands/connect/ui/restore-stdin-for-console.ts
@@ -11,7 +11,12 @@ export function restoreStdinForConsole(): void {
 
   process.stdin.setEncoding('utf8');
 
-  if (process.stdin.isPaused()) {
-    process.stdin.resume();
+  // Ink's stdin stream and /dev/tty reference the same terminal. Keep the
+  // Node stream paused so it cannot consume input intended for an inherited
+  // OAuth process or a fresh /dev/tty prompt.
+  if (!process.stdin.isPaused()) {
+    process.stdin.pause();
   }
+
+  process.stdin.unref();
 }

--- a/packages/novu/src/commands/connect/ui/store.ts
+++ b/packages/novu/src/commands/connect/ui/store.ts
@@ -1,6 +1,8 @@
 import { atom, type WritableAtom } from 'nanostores';
 import type { GeneratedAgentSpec } from '../api/agents';
 import type { BridgeScaffoldVariant } from '../pipeline/bridge/types';
+import type { BridgeAdapterVariant } from '../pipeline/bridge-adapter/types';
+import type { LlmAuthKind } from '../pipeline/llm-auth/types';
 import type {
   AgentConnectMode,
   AgentSummary,
@@ -74,6 +76,11 @@ export type Phase =
       existingMasked: string;
       nextMasked: string;
       resolve: (overwrite: boolean) => void;
+    }
+  | {
+      kind: 'pick-llm-auth';
+      connectMode: BridgeAdapterVariant;
+      resolve: (kind: LlmAuthKind) => void;
     }
   | {
       kind: 'confirm-scaffold';

--- a/packages/novu/src/commands/connect/ui/ui.ts
+++ b/packages/novu/src/commands/connect/ui/ui.ts
@@ -1,5 +1,7 @@
 import type { GeneratedAgentSpec } from '../api/agents';
 import type { BridgeScaffoldVariant } from '../pipeline/bridge/types';
+import type { BridgeAdapterVariant } from '../pipeline/bridge-adapter/types';
+import type { LlmAuthKind } from '../pipeline/llm-auth/types';
 import type {
   AgentConnectMode,
   AgentSummary,
@@ -85,6 +87,7 @@ export interface ConnectUI {
   // Chat SDK project wiring
   promptForAgentName(defaultName: string): Promise<string>;
   confirmEnvSecretOverwrite(opts: { envPath: string; existingMasked: string; nextMasked: string }): Promise<boolean>;
+  pickLlmAuthKind(opts: { connectMode: BridgeAdapterVariant }): Promise<LlmAuthKind>;
   confirmScaffold(opts: { projectDir: string; appName: string; variant?: BridgeScaffoldVariant }): Promise<boolean>;
   scaffoldingBridge(opts: { variant: BridgeScaffoldVariant }): void;
   bridgeScaffolded(opts: {

--- a/packages/novu/src/commands/connect/ui/wait-for-console-line.spec.ts
+++ b/packages/novu/src/commands/connect/ui/wait-for-console-line.spec.ts
@@ -1,5 +1,14 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const createInterface = vi.hoisted(() => vi.fn());
+
+vi.mock('node:readline', () => ({
+  default: {
+    createInterface,
+  },
+}));
+
 import { waitForConsoleLine } from './wait-for-console-line';
 
 function createMockStdin(): EventEmitter & {
@@ -9,6 +18,10 @@ function createMockStdin(): EventEmitter & {
   setEncoding: (encoding: BufferEncoding) => void;
   resume: () => void;
   pause: () => void;
+  ref: () => void;
+  unref: () => void;
+  destroyed: boolean;
+  readableEnded: boolean;
 } {
   const stdin = new EventEmitter() as EventEmitter & {
     isTTY: boolean;
@@ -17,6 +30,10 @@ function createMockStdin(): EventEmitter & {
     setEncoding: (encoding: BufferEncoding) => void;
     resume: () => void;
     pause: () => void;
+    ref: () => void;
+    unref: () => void;
+    destroyed: boolean;
+    readableEnded: boolean;
   };
 
   let paused = true;
@@ -31,34 +48,53 @@ function createMockStdin(): EventEmitter & {
   stdin.pause = vi.fn(() => {
     paused = true;
   });
+  stdin.ref = vi.fn();
+  stdin.unref = vi.fn();
+  stdin.destroyed = false;
+  stdin.readableEnded = false;
 
   return stdin;
 }
 
+function mockReadlineLine(line: string): void {
+  createInterface.mockImplementationOnce(() => {
+    const iface = new EventEmitter() as EventEmitter & { close: () => void };
+    iface.close = vi.fn();
+    queueMicrotask(() => iface.emit('line', line));
+
+    return iface;
+  });
+}
+
 describe('waitForConsoleLine', () => {
   afterEach(() => {
+    vi.clearAllMocks();
     vi.unstubAllGlobals();
-    vi.useRealTimers();
   });
 
-  it('resolves with trimmed line after stdin data', async () => {
-    vi.useFakeTimers();
+  it('refs stdin for one line, then pauses and unrefs it', async () => {
     const stdin = createMockStdin();
     vi.stubGlobal('process', { ...process, stdin });
+    mockReadlineLine('yes\n');
 
-    const pending = waitForConsoleLine();
-    await vi.advanceTimersByTimeAsync(75);
-    stdin.emit('data', 'yes\n');
-
-    await expect(pending).resolves.toBe('yes');
+    await expect(waitForConsoleLine()).resolves.toBe('yes');
+    expect(createInterface).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: stdin,
+        output: process.stdout,
+      })
+    );
+    expect(stdin.ref).toHaveBeenCalled();
+    expect(stdin.resume).toHaveBeenCalled();
     expect(stdin.pause).toHaveBeenCalled();
+    expect(stdin.unref).toHaveBeenCalled();
   });
 
-  it('returns empty string when stdin is not a TTY', async () => {
+  it('throws when stdin is not a TTY', async () => {
     const stdin = createMockStdin();
     stdin.isTTY = false;
     vi.stubGlobal('process', { ...process, stdin });
 
-    await expect(waitForConsoleLine()).resolves.toBe('');
+    await expect(waitForConsoleLine()).rejects.toThrow('no usable terminal is available');
   });
 });

--- a/packages/novu/src/commands/connect/ui/wait-for-console-line.ts
+++ b/packages/novu/src/commands/connect/ui/wait-for-console-line.ts
@@ -1,29 +1,57 @@
-import { once } from 'node:events';
+import readline from 'node:readline';
 import { restoreStdinForConsole } from './restore-stdin-for-console';
 
 const INK_TEARDOWN_DELAY_MS = 75;
 
-export async function waitForConsoleLine(): Promise<string> {
+function prepareConsoleInput(): NodeJS.ReadStream {
   restoreStdinForConsole();
 
-  if (!process.stdin.isTTY) {
-    return '';
+  if (!process.stdin.isTTY || process.stdin.destroyed || process.stdin.readableEnded) {
+    throw new Error(
+      'Interactive input is required, but no usable terminal is available. Run from a terminal or use --ci with explicit flags.'
+    );
   }
 
-  await new Promise<void>((resolve) => setTimeout(resolve, INK_TEARDOWN_DELAY_MS));
-
-  process.stdin.setEncoding('utf8');
+  process.stdin.ref();
   process.stdin.resume();
 
-  try {
-    const [chunk] = await once(process.stdin, 'data');
+  return process.stdin;
+}
 
-    return String(chunk).replace(/\r?\n$/, '');
-  } catch {
-    return '';
+export async function waitForConsoleLine(): Promise<string> {
+  await new Promise<void>((resolve) => setTimeout(resolve, INK_TEARDOWN_DELAY_MS));
+
+  const input = prepareConsoleInput();
+
+  const rl = readline.createInterface({
+    input,
+    output: process.stdout,
+    terminal: true,
+  });
+
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      let settled = false;
+      const onError = (error: Error) => {
+        settled = true;
+        reject(new Error(`Could not read console input: ${error.message}`));
+      };
+      const onClose = () => {
+        if (!settled) {
+          reject(new Error('Console input closed before a response was received.'));
+        }
+      };
+
+      rl.once('line', (line) => {
+        settled = true;
+        resolve(line.trim());
+      });
+      rl.once('close', onClose);
+      input.once('error', onError);
+    });
   } finally {
-    if (!process.stdin.isPaused()) {
-      process.stdin.pause();
-    }
+    rl.close();
+    input.pause();
+    input.unref();
   }
 }

--- a/packages/novu/src/commands/init/templates/agent-scaffold-deps.ts
+++ b/packages/novu/src/commands/init/templates/agent-scaffold-deps.ts
@@ -1,0 +1,9 @@
+/** Zod versions shared by ai-sdk and langchain agent scaffolds (subscription CLIs require Zod 4). */
+export const AGENT_ZOD_DEPS = {
+  zod: '^4.1.8',
+  'zod-to-json-schema': '3.25.2',
+} as const;
+
+export function resolveAgentZodDependencies(): Record<string, string> {
+  return { ...AGENT_ZOD_DEPS };
+}

--- a/packages/novu/src/commands/init/templates/app-agent-ai-sdk/ts/next.config.mjs
+++ b/packages/novu/src/commands/init/templates/app-agent-ai-sdk/ts/next.config.mjs
@@ -1,4 +1,13 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  turbopack: {
+    root: projectRoot,
+  },
+};
 
 export default nextConfig;

--- a/packages/novu/src/commands/init/templates/app-agent-langchain/ts/next.config.mjs
+++ b/packages/novu/src/commands/init/templates/app-agent-langchain/ts/next.config.mjs
@@ -1,4 +1,13 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  turbopack: {
+    root: projectRoot,
+  },
+};
 
 export default nextConfig;

--- a/packages/novu/src/commands/init/templates/app-agent/ts/next.config.mjs
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/next.config.mjs
@@ -1,4 +1,13 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  turbopack: {
+    root: projectRoot,
+  },
+};
 
 export default nextConfig;

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -5,9 +5,17 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { bold, cyan } from 'picocolors';
+import type { BridgeAdapterVariant } from '../../connect/pipeline/bridge-adapter/types';
+import { generateAgentNextConfigSource } from '../../connect/pipeline/llm-auth/codegen/generate-agent-next-config';
+import { generateSupportAgentSource } from '../../connect/pipeline/llm-auth/codegen/generate-support-agent';
+import {
+  resolveLlmAuthEnvVars,
+  resolveLlmAuthPackageDependencies,
+  shouldWireLlmAuth,
+} from '../../connect/pipeline/llm-auth/registry';
 import { copy } from '../helpers/copy';
 import { install } from '../helpers/install';
-
+import { resolveAgentZodDependencies } from './agent-scaffold-deps';
 import { GetTemplateFileArgs, InstallTemplateArgs, TemplateTypeEnum } from './types';
 
 function resolveCliPackageJson(): Record<string, any> | null {
@@ -71,6 +79,7 @@ export const installTemplate = async ({
   agentIdentifier,
   silent,
   skipInstall,
+  llmAuth,
 }: InstallTemplateArgs) => {
   if (!silent) console.log(bold(`Using ${packageManager}.`));
 
@@ -141,6 +150,28 @@ export const installTemplate = async ({
         if (after !== before) await fs.writeFile(file, after);
       })
     );
+  }
+
+  const isAiSdkTemplate = template === TemplateTypeEnum.APP_AGENT_AI_SDK;
+  const isLangChainTemplate = template === TemplateTypeEnum.APP_AGENT_LANGCHAIN;
+
+  if (renameAgent && llmAuth && shouldWireLlmAuth(llmAuth) && (isAiSdkTemplate || isLangChainTemplate)) {
+    const runtime: BridgeAdapterVariant = isAiSdkTemplate ? 'ai-sdk' : 'langchain';
+    const agentFilePath = path.join(root, 'app', 'novu', 'agents', `${agentIdentifier}.tsx`);
+    const source = generateSupportAgentSource({
+      runtime,
+      agentIdentifier: agentIdentifier!,
+      llmAuth,
+    });
+
+    await fs.writeFile(agentFilePath, source);
+  }
+
+  if (isAgentTemplate) {
+    const runtime: BridgeAdapterVariant = isAiSdkTemplate ? 'ai-sdk' : 'langchain';
+    const nextConfigSource = generateAgentNextConfigSource(runtime, llmAuth ?? { kind: 'skip' });
+
+    await fs.writeFile(path.join(root, 'next.config.mjs'), nextConfigSource);
   }
 
   const tsconfigFile = path.join(root, 'tsconfig.json');
@@ -221,10 +252,12 @@ export const installTemplate = async ({
   }
 
   /* write .env file */
+  const llmEnvVars = llmAuth ? resolveLlmAuthEnvVars(llmAuth) : {};
   const envVars = isAgentTemplate
     ? {
         NOVU_SECRET_KEY: secretKey,
         NOVU_API_URL: apiUrl ?? 'https://api.novu.co',
+        ...llmEnvVars,
       }
     : template === TemplateTypeEnum.APP_CHAT_SDK
       ? {
@@ -275,6 +308,11 @@ export const installTemplate = async ({
   if (template === TemplateTypeEnum.APP_AGENT_LANGCHAIN) {
     baseDependencies.langchain = '^1.0.0';
     baseDependencies['@langchain/core'] = '^1.0.0';
+  }
+
+  if (llmAuth && shouldWireLlmAuth(llmAuth) && (isAiSdkTemplate || isLangChainTemplate)) {
+    const runtime: BridgeAdapterVariant = isAiSdkTemplate ? 'ai-sdk' : 'langchain';
+    Object.assign(baseDependencies, resolveLlmAuthPackageDependencies(runtime, llmAuth));
   }
 
   if (isChatSdkTemplate) {
@@ -341,11 +379,18 @@ export const installTemplate = async ({
     };
   }
 
-  if (template === TemplateTypeEnum.APP_REACT_EMAIL || isAgentTemplate) {
+  if (template === TemplateTypeEnum.APP_REACT_EMAIL) {
     packageJson.dependencies = {
       ...packageJson.dependencies,
       zod: '^3.23.8',
       'zod-to-json-schema': '^3.23.1',
+    };
+  }
+
+  if (isAgentTemplate) {
+    packageJson.dependencies = {
+      ...packageJson.dependencies,
+      ...resolveAgentZodDependencies(),
     };
   }
 

--- a/packages/novu/src/commands/init/templates/types.ts
+++ b/packages/novu/src/commands/init/templates/types.ts
@@ -1,3 +1,4 @@
+import type { LlmAuthChoice } from '../../connect/pipeline/llm-auth/types';
 import { PackageManager } from '../helpers/get-pkg-manager';
 
 export enum TemplateTypeEnum {
@@ -43,4 +44,6 @@ export interface InstallTemplateArgs {
    * sibling packages would cause npm to fail.
    */
   skipInstall?: boolean;
+  /** LLM provider wiring for ai-sdk / langchain agent scaffolds. */
+  llmAuth?: LlmAuthChoice;
 }

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -8,6 +8,7 @@ import { DevCommandOptions, devCommand } from './commands';
 import { connectCommand } from './commands/connect';
 import { isDashboardOnlyChannel } from './commands/connect/dashboard-urls';
 import { CONNECT_HELP_TEXT } from './commands/connect/help-text';
+import type { LlmAuthCliChoice } from './commands/connect/pipeline/llm-auth/types';
 import type { ConnectCommandInput } from './commands/connect/resolve-options';
 import { resolveConnectCommandOptions } from './commands/connect/resolve-options';
 import {
@@ -131,10 +132,7 @@ program
   )
   .option('-t, --tunnel <url>', 'Self hosted tunnel. e.g. https://my-tunnel.ngrok.app')
   .option('-H, --headless', 'Run without opening the browser', false)
-  .option(
-    '--no-studio',
-    'Skip opening the dashboard Local environment (tunnel and agent sync still run)'
-  )
+  .option('--no-studio', 'Skip opening the dashboard Local environment (tunnel and agent sync still run)')
   .option('--run <command>', 'Spawn a local app server before opening the tunnel')
   .action(async (options: DevCommandOptions) => {
     analytics.track({
@@ -218,6 +216,11 @@ program
     'Use an existing agent-runtime integration (skips credential setup for BYOK runtimes)'
   )
   .option('--anthropic-api-key <key>', 'Anthropic API key for --runtime claude non-interactive runs')
+  .option(
+    '--llm-auth <choice>',
+    'LLM provider for ai-sdk/langchain scaffold (openai | anthropic | codex-subscription | claude-subscription | skip)'
+  )
+  .option('--openai-api-key <key>', 'OpenAI API key for --llm-auth openai non-interactive scaffold runs')
   .option('--aws-claude-api-key <key>', 'AWS Claude API key for --runtime claude-aws non-interactive runs')
   .option('--aws-claude-region <region>', 'AWS Claude commercial region for --runtime claude-aws')
   .option('--aws-claude-workspace-id <id>', 'AWS Claude workspace ID for --runtime claude-aws')
@@ -292,6 +295,17 @@ program
       console.error(
         `Invalid --runtime value: "${options.runtime}". Expected one of: ${AGENT_CONNECT_MODES.join(', ')}.`
       );
+      process.exit(1);
+    }
+    const LLM_AUTH_CHOICES: readonly LlmAuthCliChoice[] = [
+      'openai',
+      'anthropic',
+      'codex-subscription',
+      'claude-subscription',
+      'skip',
+    ];
+    if (options.llmAuth && !LLM_AUTH_CHOICES.includes(options.llmAuth as LlmAuthCliChoice)) {
+      console.error(`Invalid --llm-auth value: "${options.llmAuth}". Expected one of: ${LLM_AUTH_CHOICES.join(', ')}.`);
       process.exit(1);
     }
     let resolved: ReturnType<typeof resolveConnectCommandOptions>;

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -1,10 +1,37 @@
 # Novu Agent Onboarding — instructions for an AI agent
 
-You are an AI coding agent that helps a user create their first **Novu managed agent** and connect it to a **channel of their choice**.
+You are an AI coding agent that helps a user onboard a Novu agent and connect it to a **channel of their choice**. Two paths exist:
 
-Your job, end to end: collect a couple of inputs, infer the agent's purpose from the user's project, run **one** non-interactive CLI command, hand the user whatever they need to finish connecting the channel, then report the result.
+| Path | What it does |
+|---|---|
+| **Managed agent** | Creates a **hosted** agent (demo Claude runtime). Novu runs the intelligence — **no codebase wiring**. |
+| **Custom code bridge** | Creates a bridge agent whose handler runs **in the user's app** (AI SDK or LangChain). You wire the bridge route and handler after connect. |
 
-**Out of scope:** Do not wire Novu into the user's codebase. This flow only creates a hosted agent and connects a channel.
+Your job end to end: pick the right path, run **one** non-interactive `npx novu connect` command, hand the user whatever they need to finish connecting the channel, **wire the bridge when on the custom-code path**, then report the result.
+
+---
+
+## Step 0 — Choose path (mandatory)
+
+**Pick before anything else.** Do not assume managed when the user wants custom code.
+
+| Path | Use when |
+|---|---|
+| **Custom code bridge** | The user says **"add an agent to my app"**, **"wire"**, **"in my repo/project/codebase"**, names **AI SDK** or **LangChain**, or you are in an existing app they want replies from **their code**. |
+| **Managed agent** | The user wants a **hosted/demo/managed** agent with **no codebase changes**, is trying Novu **keyless** from scratch, or explicitly asks for a managed agent. |
+
+**Mandatory routing rules:**
+
+- **"Add an agent to my app"** (or equivalent) → **custom code bridge**. Never use the managed path.
+- **"I'm signed in to the Novu dashboard"** + app/repo signal → **custom code bridge** with **dashboard OAuth** (omit `--keyless`).
+- **Keyless** is only valid on the **managed** path. Bridge agents **always** require dashboard OAuth (omit `--keyless`) — the CLI will not scaffold a bridge in keyless mode.
+
+If genuinely unclear, call `AskQuestion` / `AskUserQuestion`:
+
+| Option id | Label |
+|---|---|
+| `bridge` | Custom code — run my agent handler in this app (AI SDK / LangChain) |
+| `managed` | Managed — hosted agent, no code changes |
 
 ---
 
@@ -21,6 +48,8 @@ Your job, end to end: collect a couple of inputs, infer the agent's purpose from
 
 **Dashboard prompt rule (mandatory):** If the user's prompt contains the sentence **"I'm signed in to the Novu dashboard"** (or otherwise states they came from the Novu dashboard), you **MUST** use dashboard OAuth — omit `--keyless`. Never pass `--keyless` in that case.
 
+**Bridge path rule (mandatory):** Custom code bridge **always** omits `--keyless` — even without an explicit dashboard sentence. Bridge scaffolding requires an authenticated Novu account.
+
 ---
 
 ## Operating principles
@@ -28,7 +57,7 @@ Your job, end to end: collect a couple of inputs, infer the agent's purpose from
 These govern every step. When in doubt, follow these over any specific instruction below.
 
 - **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5, or the Step 4 `in_chat` token fallback re-run (after killing the first Connect shell).
-- **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime, auth mode) unless the user raises it.
+- **Trust user intent; ask only when genuinely unclear.** Managed path: channel (Step M1) and purpose confirmation (Step M2) require the user. Bridge path: channel (Step B1) and runtime (Step B2) when detection is ambiguous. Default everything else unless the user raises it.
 - **Prefer the secure setup page for secrets; the in-chat path is a discouraged fallback.** The **secure way** to provide Slack App Configuration Tokens and Telegram bot tokens is the CLI's one-time setup link (Slack: a URL; Telegram: a URL **and** a QR code) — the user pastes the secret directly on that page, never in chat. Always offer this first and recommend it. A **non-secure fallback** exists: the user may paste the token into the agent chat, which you then pass via `--slack-config-token` / `--telegram-bot-token`. Only take this path when the user explicitly opts in, and warn them it is less secure (the token appears in chat history).
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
 - **One Connect shell, no log watchers.** Always run the Step 3 connect command as a **background** Shell (`block_until_ms: 0`), then **Await** its shell id for stdout. **Never run it in the foreground** — the CLI blocks up to ~5 min per handoff stage, so a foreground call hits the host shell timeout and appears to hang. Use a single Shell session only. Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path. **Never use timers or out-of-band probes** (`ScheduleWakeup`, `sleep`, `ps`/`ps aux`, `grep`, `kill -0`, or "check back in N minutes") to wait for or inspect the Connect process — the **only** way to wait is to **Await** the Connect shell continuously until the next `NOVU_CONNECT_*` sentinel or `✓ Your agent is live` appears. The only exception: `--channel skip` in keyless mode may run in the foreground.
@@ -46,7 +75,7 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 - **Cursor:** `AskQuestion` with 2–4 `options` (short `label` per option). 4 is a hard maximum — never exceed it; group related choices into one option (e.g. WhatsApp / MS Teams).
 - **Claude Code:** `AskUserQuestion` with the same shape (`label` + optional `description`).
 
-**Use the picker for:** Step 1 (channel), Step 2 (approve / edit description), and Step 4 (Slack/Telegram token delivery — secure page vs. paste in chat, presented inline only when the token is actually needed).
+**Use the picker for:** Step 0 (path when unclear), Step M1 / Step B1 (channel), Step M2 (approve / edit managed description), Step B2 (runtime when ambiguous), and Step 4 (Slack/Telegram token delivery — secure page vs. paste in chat, presented inline only when the token is actually needed).
 
 **Do not use the picker for:** free-text values (e.g. edited agent description prose) — ask in chat normally. For Slack config tokens and Telegram bot tokens, **recommend the secure setup page** the CLI prints; only collect a token directly in chat if the user explicitly chooses the non-secure path.
 
@@ -66,20 +95,37 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 | **Connect shell** | The one background Shell invocation (`block_until_ms: 0`) that runs the Step 3 connect command. You **Await** its shell id for all stdout — not log files or separate watch commands. |
 | **CLI poll** | While the Connect shell runs in the background, the CLI process blocks up to ~5 min per handoff stage (OAuth, inbound email, dashboard authorization). You monitor progress by **Await**ing `NOVU_CONNECT_*` sentinels on that shell id. Success or timeout comes from its stdout only. |
 | **Claim** | Keyless only: user signs up via the in-channel link, migrating the temporary agent into their workspace. |
+| **Bridge agent** | Custom code path: agent handler runs on the user's server; Novu forwards channel messages to a `/api/novu` bridge route. |
+| **Requirements file** | Bridge path only: CLI prints `NOVU_CONNECT_AI_SDK_REQUIREMENTS_FILE=` or `NOVU_CONNECT_LANGCHAIN_REQUIREMENTS_FILE=` with a checklist and wiring prompt. |
 
 ---
 
 ## Flow overview
 
-1. **Channel** — ask which channel. Keyless + WhatsApp / MS Teams → dashboard redirect only (Steps 2–5 skipped). Dashboard OAuth supports all channels.
+### Managed agent
+
+1. **Channel** — ask which channel. Keyless + WhatsApp / MS Teams → dashboard redirect only (Steps M2–M5 skipped). Dashboard OAuth supports all channels.
 2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user.
-3. **Run** — connect command from Step 3 (`--ci`, plus `--keyless` for the default keyless mode), streamed.
-4. **Handoff** — dashboard OAuth first when omitting `--keyless` (`NOVU_CONNECT_AUTH_URL_FILE=`), then channel-specific next steps. For Slack/Telegram, present the inline secure-page-vs-paste-in-chat token choice only when the token is actually needed. Let the CLI poll.
-5. **Report** — relay the CLI's success or error, give a 1–2 sentence recap of what onboarding set up, and point the user to the next step. Keyless: explain demo limit → claim link. Authenticated: report agent identifier + dashboard URL.
+3. **Run** — connect command from [Step M3](#step-m3--run-connect-managed) (`--ci`, plus `--keyless` for the default keyless mode), streamed.
+4. **Handoff** — [Shared channel handoffs](#shared--channel-handoffs). Let the CLI poll.
+5. **Report** — relay success, recap, next step (claim link or dashboard).
+
+### Custom code bridge (AI SDK / LangChain)
+
+1. **Channel** — same picker as managed ([Step B1](#step-b1--choose-channel-bridge)).
+2. **Runtime** — detect or ask `ai-sdk` vs `langchain` ([Step B2](#step-b2--pick-bridge-runtime)).
+3. **Run** — connect with `--runtime <ai-sdk|langchain>` ([Step B3](#step-b3--run-connect-bridge)) — **no agent description positional**.
+4. **Handoff** — [Shared channel handoffs](#shared--channel-handoffs). Also **Await** the bridge requirements file sentinel on the same shell.
+5. **Wire** — read the requirements file and finish bridge setup in the repo ([Step B5](#step-b5--wire-the-bridge)).
+6. **Report** — agent + channel live, bridge wired, run `dev:novu`.
 
 ---
 
-## Step 1 — Choose channel and collect inputs
+# Managed agent path
+
+**Out of scope on this path:** Do not wire Novu into the user's codebase.
+
+## Step M1 — Choose channel and collect inputs
 
 **Goal:** lock the channel and gather only what that channel needs.
 
@@ -110,7 +156,7 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 ---
 
-## Step 2 — Infer the agent's purpose, then confirm
+## Step M2 — Infer the agent's purpose, then confirm
 
 **Goal:** produce one agent description the user signs off on.
 
@@ -170,7 +216,7 @@ If they pick **edit**, ask for their revised text in chat (not the picker), upda
 
 ---
 
-## Step 3 — Run connect (non-interactive)
+## Step M3 — Run connect (managed, non-interactive)
 
 **Goal:** create the agent (keyless by default) and start the channel connection in one Connect shell.
 
@@ -251,7 +297,108 @@ npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
 
 ---
 
-## Step 4 — Handoffs (human-in-the-loop)
+# Custom code bridge path (AI SDK / LangChain)
+
+The bridge path creates a Novu agent record, connects a channel, reconciles (or scaffolds) the project, then **you** finish handler code in the repo.
+
+## Step B1 — Choose channel and collect inputs
+
+Same channel picker and rules as [Step M1](#step-m1--choose-channel-and-collect-inputs) — **except:**
+
+- **Never pass `--keyless`** on the bridge path.
+- **Do not** infer or confirm a managed-agent description (skip [Step M2](#step-m2--infer-the-agents-purpose-then-confirm) entirely).
+- **Runtime** is chosen in Step B2, not here.
+
+## Step B2 — Pick bridge runtime
+
+**Goal:** lock `--runtime ai-sdk` or `--runtime langchain` before running connect.
+
+Read `package.json` `dependencies` and `devDependencies`:
+
+| Signal in package.json | Runtime |
+|---|---|
+| `ai` or any `@ai-sdk/*` package | `ai-sdk` |
+| `langchain`, `@langchain/core`, or any `@langchain/*` package | `langchain` |
+| Both AI SDK and LangChain signals | Ask the user (picker below) |
+| Neither | Default to **`ai-sdk`** unless the user named LangChain |
+
+If you must ask, call `AskQuestion` / `AskUserQuestion`:
+
+| Option id | Label |
+|---|---|
+| `ai-sdk` | AI SDK — Vercel AI SDK (`ai` + `@ai-sdk/*`) |
+| `langchain` | LangChain — `langchain` + `@langchain/*` |
+
+## Step B3 — Run connect (bridge, non-interactive)
+
+**Goal:** create the bridge agent, connect the channel, and let the CLI reconcile the project.
+
+**Do not** pass a positional agent description — bridge agents get a name from the project directory in `--ci` mode.
+
+**Always omit `--keyless`.** Dashboard OAuth is required (see [Auth mode](#auth-mode--pick-one-before-step-3)).
+
+```bash
+npx novu@latest connect \
+  --ci \
+  --runtime <ai-sdk|langchain> \
+  --channel <slack|email|telegram|whatsapp|teams|skip>
+```
+
+**Canonical example (dashboard OAuth, AI SDK, slack):**
+
+```bash
+npx novu@latest connect \
+  --ci \
+  --runtime ai-sdk \
+  --channel slack
+```
+
+Run the Connect shell with the same [backgrounding rules](#step-m3--run-connect-managed) as the managed path.
+
+**After channel handoffs, keep Awaiting the same shell** until you also see:
+
+```text
+NOVU_CONNECT_AI_SDK_REQUIREMENTS_FILE=<absolute path>
+```
+
+or
+
+```text
+NOVU_CONNECT_LANGCHAIN_REQUIREMENTS_FILE=<absolute path>
+```
+
+Then **Await** `✓ Your agent is live.` or `✗` on that shell id.
+
+The CLI may auto-install packages, write `.env.local`, and add a `dev:novu` script during reconcile. Unchecked items in the requirements file still need your help.
+
+## Step B5 — Wire the bridge
+
+**Goal:** satisfy every unchecked requirement and implement the agent handler so Slack (or the chosen channel) reaches the user's code.
+
+1. **Read** the requirements file from the `NOVU_CONNECT_*_REQUIREMENTS_FILE=` line (do not paste the path to the user).
+2. Note the **agent identifier** from the connect success output: `Agent: <name> (<identifier>)`.
+3. Complete every `- [ ]` item in the file (install packages, env, dev script).
+4. For **`code-wiring`**, follow the **"## Agent prompt"** section inside that file exactly — it matches what `npx novu connect` generated for this project.
+5. Use the agent identifier from step 2 in the handler (`agent('<identifier>', …)`).
+6. **Verify:** run the project's `dev:novu` script (or the package manager equivalent) and confirm the bridge registers without errors.
+
+Match the project's existing framework (App Router vs Pages Router, `src/` layout, package manager from the lockfile).
+
+**Authoritative docs when stuck:** fetch `https://docs.novu.co/llms.txt`, then append `.md` to any doc URL. AI SDK: `/agents/custom-code-agent/frameworks/ai-sdk`. LangChain: `/agents/custom-code-agent/frameworks/langchain`.
+
+## Step B6 — Report the result (bridge)
+
+Lead with whether connect succeeded and whether the bridge is wired.
+
+**Authenticated bridge recap example:**
+
+> _"Novu created a bridge agent, connected Slack, and reconciled your project. I wired the `/api/novu` route and agent handler — run `npm run dev:novu` (or your package manager's equivalent) and message the bot in Slack to test."_
+
+Include the agent identifier and dashboard URL from the CLI output.
+
+---
+
+## Shared — Channel handoffs
 
 **Goal:** give the user each action that finishes authentication and channel connection.
 
@@ -359,7 +506,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
 ---
 
-## Step 5 — Report the result
+## Step M5 — Report the result (managed)
 
 **Goal:** relay what the CLI printed, give a short recap of what onboarding set up, and point the user at the channel and the next step (claim link for keyless, dashboard for authenticated).
 
@@ -407,13 +554,21 @@ Run `novu@latest connect --help` for the full contract. Keep help text in sync w
 
 | Flag | Purpose |
 |---|---|
-| `connect "<description>"` | Positional agent description (required in `--ci`). |
+| `connect "<description>"` | Positional agent description (**managed path only**; required in `--ci` managed runs). |
 | `--ci` | Non-interactive mode (required). |
-| `--keyless` | Temporary demo agent with no Novu account — **the default for this guided flow.** |
+| `--runtime <ai-sdk\|langchain\|custom-code\|chat-sdk\|demo\|claude\|claude-aws>` | Agent brain. **Bridge path:** pass `ai-sdk` or `langchain`. **Managed path:** omit (demo runtime). |
+| `--keyless` | Temporary demo agent — **managed path only** (default for anonymous managed runs). **Never** on bridge path. |
 | `--region <us\|eu>` | Target Novu Cloud region (default: `us`). |
 | `--channel <slack\|email\|telegram\|whatsapp\|teams\|skip>` | Channel to connect. `whatsapp`/`teams` require dashboard OAuth (omit `--keyless`). |
 | `--slack-config-token` / `--telegram-bot-token` | Non-secure CI escape hatches when user opts in. |
-| *(omit `--keyless`)* | Dashboard OAuth — the CLI's own default; use only when a dashboard signal applies. Agent created in the user's Development environment. Do not pass `--secret-key` in this guided flow. |
+| *(omit `--keyless`)* | Dashboard OAuth — required for bridge; use for managed when a dashboard signal applies. Do not pass `--secret-key` in this guided flow. |
+
+**Bridge path machine-readable stdout (in addition to channel handoffs):**
+
+```text
+NOVU_CONNECT_AI_SDK_REQUIREMENTS_FILE=<absolute path>
+NOVU_CONNECT_LANGCHAIN_REQUIREMENTS_FILE=<absolute path>
+```
 
 ---
 
@@ -422,8 +577,9 @@ Run `novu@latest connect --help` for the full contract. Keep help text in sync w
 - **One run = one new agent + one channel.** Re-running creates another agent.
 - **Channel support is uneven headlessly:** `slack` and `telegram` need two user actions after auth; `email` one; `whatsapp`/`teams` need dashboard OAuth and finish in the dashboard.
 - **Prefer secure setup pages for Slack/Telegram tokens.**
-- **Keyless data is temporary** until claimed via the in-channel sign-up link.
-- **Keyless is the default for this flow** — always pass `--keyless` unless a dashboard signal applies (then omit it for dashboard OAuth).
+- **Keyless is managed-only** — bridge agents require dashboard OAuth.
+- **Keyless managed data is temporary** until claimed via the in-channel sign-up link.
+- **Keyless is the default for managed-only flows** — pass `--keyless` unless a dashboard signal applies or the user chose the bridge path (always omit `--keyless`).
 
 ---
 
@@ -431,10 +587,22 @@ Run `novu@latest connect --help` for the full contract. Keep help text in sync w
 
 **Keyless + WhatsApp / MS Teams:** done when you've delivered the dashboard sign-in URL — no agent generated.
 
+### Managed agent
+
 You are done when:
 
 1. The user picked a channel and confirmed the agent description.
 2. Keyless bootstrap succeeded (default, with `--keyless`), or dashboard OAuth completed (when omitting `--keyless`).
 3. You delivered channel handoffs (or noted `skip` / whatsapp-teams dashboard URL).
 4. Connect shell printed `✓ Your agent is live.` (exit `0`); CLI poll validated handoffs where applicable.
-5. You reported agent identifier + next step (claim link for keyless, dashboard URL for authenticated), gave a brief recap of what onboarding set up, and explained how the user can keep going.
+5. You reported agent identifier + next step (claim link for keyless, dashboard URL for authenticated), gave a brief recap, and explained how the user can keep going.
+
+### Custom code bridge
+
+You are done when:
+
+1. The user picked a channel and you locked `ai-sdk` or `langchain`.
+2. Dashboard OAuth completed (never `--keyless`).
+3. You delivered channel handoffs and the connect shell printed the requirements file path and `✓ Your agent is live.`.
+4. Every requirement in that file is satisfied and the bridge handler is implemented.
+5. You told the user to run `dev:novu` and message the agent on the connected channel.

--- a/packages/shared/docs/agent-onboarding.md
+++ b/packages/shared/docs/agent-onboarding.md
@@ -11,27 +11,27 @@ Your job end to end: pick the right path, run **one** non-interactive `npx novu 
 
 ---
 
-## Step 0 — Choose path (mandatory)
+## Step 0 — Choose path
 
-**Pick before anything else.** Do not assume managed when the user wants custom code.
+**Default to managed.** Only use the bridge path when the user clearly wants handler code in their app.
+
+Do **not** ask Step 0 when the user only wants to connect a **channel** in the current workspace — e.g. **"Connect a Novu agent to Slack for this project"** is **managed keyless**, not bridge. Go straight to Step M1.
 
 | Path | Use when |
 |---|---|
-| **Custom code bridge** | The user says **"add an agent to my app"**, **"wire"**, **"in my repo/project/codebase"**, names **AI SDK** or **LangChain**, or you are in an existing app they want replies from **their code**. |
-| **Managed agent** | The user wants a **hosted/demo/managed** agent with **no codebase changes**, is trying Novu **keyless** from scratch, or explicitly asks for a managed agent. |
+| **Custom code bridge** | The user says **"add an agent to my app"**, **"wire"** Novu into their handler code, names **AI SDK** or **LangChain**, or wants channel replies from **their application code**. |
+| **Managed agent** | The user names a **channel only**, wants a **hosted/demo/managed** agent, is trying Novu **keyless** from scratch, says **"Connect … for this project"** without bridge signals, or explicitly asks for a managed agent. |
 
 **Mandatory routing rules:**
 
 - **"Add an agent to my app"** (or equivalent) → **custom code bridge**. Never use the managed path.
-- **"I'm signed in to the Novu dashboard"** + app/repo signal → **custom code bridge** with **dashboard OAuth** (omit `--keyless`).
+- **"Connect a Novu agent to \<channel\> for this project"** (or similar channel-only wording) → **managed**. **Never** bridge. *"For this project"* means the current workspace directory, not "wire my handler."
+- **"in my repo" / "in my codebase"** alone is **not** a bridge signal unless they also want AI SDK / LangChain / handler wiring.
+- **"I'm signed in to the Novu dashboard"** + **add-to-my-app / wire / AI SDK / LangChain** signal → **custom code bridge** with **dashboard OAuth** (omit `--keyless`).
+- **"I'm signed in to the Novu dashboard"** + channel-only connect (no bridge signals) → **managed** with **dashboard OAuth** (omit `--keyless`).
 - **Keyless** is only valid on the **managed** path. Bridge agents **always** require dashboard OAuth (omit `--keyless`) — the CLI will not scaffold a bridge in keyless mode.
 
-If genuinely unclear, call `AskQuestion` / `AskUserQuestion`:
-
-| Option id | Label |
-|---|---|
-| `bridge` | Custom code — run my agent handler in this app (AI SDK / LangChain) |
-| `managed` | Managed — hosted agent, no code changes |
+Ask Step 0 **only** when the user explicitly mixes bridge and managed signals. Otherwise pick the path from the table and continue.
 
 ---
 
@@ -60,7 +60,7 @@ These govern every step. When in doubt, follow these over any specific instructi
 - **Trust user intent; ask only when genuinely unclear.** Managed path: channel (Step M1) and purpose confirmation (Step M2) require the user. Bridge path: channel (Step B1) and runtime (Step B2) when detection is ambiguous. Default everything else unless the user raises it.
 - **Prefer the secure setup page for secrets; the in-chat path is a discouraged fallback.** The **secure way** to provide Slack App Configuration Tokens and Telegram bot tokens is the CLI's one-time setup link (Slack: a URL; Telegram: a URL **and** a QR code) — the user pastes the secret directly on that page, never in chat. Always offer this first and recommend it. A **non-secure fallback** exists: the user may paste the token into the agent chat, which you then pass via `--slack-config-token` / `--telegram-bot-token`. Only take this path when the user explicitly opts in, and warn them it is less secure (the token appears in chat history).
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
-- **One Connect shell, no log watchers.** Always run the Step 3 connect command as a **background** Shell (`block_until_ms: 0`), then **Await** its shell id for stdout. **Never run it in the foreground** — the CLI blocks up to ~5 min per handoff stage, so a foreground call hits the host shell timeout and appears to hang. Use a single Shell session only. Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path. **Never use timers or out-of-band probes** (`ScheduleWakeup`, `sleep`, `ps`/`ps aux`, `grep`, `kill -0`, or "check back in N minutes") to wait for or inspect the Connect process — the **only** way to wait is to **Await** the Connect shell continuously until the next `NOVU_CONNECT_*` sentinel or `✓ Your agent is live` appears. The only exception: `--channel skip` in keyless mode may run in the foreground.
+- **One Connect shell, no log watchers.** Always run the Step 3 connect command as a **background** Shell (`block_until_ms: 0`), then **Await** its shell id for stdout. **Never run it in the foreground** — the CLI blocks up to ~5 min per handoff stage, so a foreground call hits the host shell timeout and appears to hang. Use a single Shell session only. Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path. **Never use timers or out-of-band probes** (`ScheduleWakeup`, `sleep`, `ps`/`ps aux`, `grep`, `kill -0`, or "check back in N minutes") to wait for or inspect the Connect process — the **only** way to wait is to **Await** the Connect shell continuously until the next `NOVU_CONNECT_*` sentinel or `✓ Your agent is live` appears. The only exception: `--channel skip` in keyless mode may run in the foreground. **Never use Bash `grep`/`cat`/`awk` on any file** (including `package.json`) — use the **Read** tool and parse the content in your reasoning.
 - **The CLI validates handoffs.** For dashboard OAuth, `slack`/`email`/`telegram`, that Shell blocks and polls until the handoff completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion yourself.
 - **WhatsApp / MS Teams in keyless mode never reach the CLI.** If the user picks one and you are using **`--keyless`** (the default), do **not** run connect — redirect them to the Novu dashboard instead (Step 1). With **dashboard OAuth** (omit `--keyless`), the CLI creates the agent and hands off a dashboard URL to finish channel setup.
 - **Report conclusion-first.** Lead with the CLI's result (live / failed), then the one action the user must take. Keep it terse.
@@ -75,7 +75,7 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 - **Cursor:** `AskQuestion` with 2–4 `options` (short `label` per option). 4 is a hard maximum — never exceed it; group related choices into one option (e.g. WhatsApp / MS Teams).
 - **Claude Code:** `AskUserQuestion` with the same shape (`label` + optional `description`).
 
-**Use the picker for:** Step 0 (path when unclear), Step M1 / Step B1 (channel), Step M2 (approve / edit managed description), Step B2 (runtime when ambiguous), and Step 4 (Slack/Telegram token delivery — secure page vs. paste in chat, presented inline only when the token is actually needed).
+**Use the picker for:** Step 0 (path **only when genuinely ambiguous**), Step M1 / Step B1 (channel), Step M2 (approve / edit managed description), Step B2 (runtime when ambiguous), and Step 4 (Slack/Telegram token delivery — secure page vs. paste in chat, presented inline only when the token is actually needed).
 
 **Do not use the picker for:** free-text values (e.g. edited agent description prose) — ask in chat normally. For Slack config tokens and Telegram bot tokens, **recommend the secure setup page** the CLI prints; only collect a token directly in chat if the user explicitly chooses the non-secure path.
 
@@ -313,7 +313,7 @@ Same channel picker and rules as [Step M1](#step-m1--choose-channel-and-collect-
 
 **Goal:** lock `--runtime ai-sdk` or `--runtime langchain` before running connect.
 
-Read `package.json` `dependencies` and `devDependencies`:
+Use the **Read** tool on `package.json` and inspect `dependencies` / `devDependencies` in the file content. **Never** use Bash (`grep`, `cat`, `jq`, or shell pipelines) to read package.json.
 
 | Signal in package.json | Runtime |
 |---|---|
@@ -455,7 +455,7 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
   Paste that exact `<url>` into chat, framing it as a fallback link — e.g. "If the Slack install page didn't open automatically, use this link to approve the install (within 5 minutes)." **Await** until the CLI poll finishes. Re-run on timeout (the Slack app is reused).
 
-  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **kill the first Connect shell** (the Step 3 process still polling the secure setup page) and **re-run the Step 3 connect command once with `--slack-config-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_SLACK_SETUP_URL` handoff and goes straight to OAuth. **Await** the `NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>` line, paste that exact URL into chat as a fallback link — e.g. "If the Slack install page didn't open automatically, use this link to approve the install (within 5 minutes)."
+  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **kill the first Connect shell** (the Step 3 process still polling the secure setup page) and **re-run the Step 3 connect command once with `--slack-config-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_SLACK_SETUP_URL` handoff and goes straight to OAuth. **Await** the `NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>` line, paste that exact URL into chat as a fallback link — e.g. "If the Slack install page didn't open automatically, use this link to approve the install (within 5 minutes)." Once `✓ Your agent is live` appears on the re-run, **stop asking for the token** and deliver the conclusion-first report immediately.
 
 - **email** — watch for these machine-readable lines (plain stdout, no ANSI):
 


### PR DESCRIPTION
## Summary

- Add an LLM provider picker during fresh empty-dir `novu connect` scaffolds for `--runtime ai-sdk` and `--runtime langchain` (API keys, Codex subscription, Claude subscription on ai-sdk, or skip/demo echo).
- Run subscription OAuth via local CLI tools, release the Ink TUI for browser auth, and fall back to console prompts for scaffold confirm/install when stdin was released.
- Generate wired agent handlers, provider deps, `.env.local` keys, and `next.config.mjs` `serverExternalPackages` for subscription CLIs.

```mermaid
flowchart TD
  A[Empty dir detected] --> B[resolveLlmAuthChoice]
  B --> C{Subscription?}
  C -->|yes| D[ensureSubscriptionAuth + OAuth]
  C -->|no| E[API key or skip]
  D --> F[confirmScaffold]
  E --> F
  F --> G[installTemplate + codegen]
```

## Scope

- **In:** fresh scaffold only (`ai-sdk`, `langchain`)
- **Out:** reconciliation of existing projects, managed runtimes (`demo`, `claude`, `claude-aws`)

## Test plan

- [x] `npx vitest run src/commands/connect/pipeline/llm-auth` (18 tests)
- [ ] Interactive: `novu connect --runtime ai-sdk` → pick OpenAI key → scaffold → agent uses `gpt-4o-mini`
- [ ] Interactive: `novu connect --runtime ai-sdk --llm-auth codex-subscription` → Codex OAuth → scaffold → agent uses `gpt-5.4-mini`
- [ ] Interactive: `novu connect --runtime ai-sdk --llm-auth claude-subscription` → Claude Code OAuth → scaffold → agent uses `haiku`
- [ ] Interactive: `novu connect --runtime langchain --llm-auth codex-subscription` → langchainjs-codex-oauth → scaffold
- [ ] CI: `novu connect --runtime ai-sdk --llm-auth openai --openai-api-key "$OPENAI_API_KEY" --ci`
- [ ] Existing project reconcile path unchanged (no LLM picker)

Linear: https://linear.app/novu/issue/NV-8289

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds LLM-powered fresh scaffolds for custom-code Novu agents. The main changes are:

- Provider selection for AI SDK and LangChain bridge scaffolds.
- API-key and subscription-based LLM auth wiring.
- Generated agent handlers, dependencies, env vars, and Next config.
- Console fallback prompts after subscription auth releases the terminal.
- Updated onboarding docs and eval coverage.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the scaffold build command for the LLM scaffold and confirmed it completed with exit code 0.
- I attempted to invoke the scaffold CLI in a non-interactive environment, but progress was blocked because non-interactive mode requires --channel.
- I exercised the fallback codegen path, which produced a generated file tree and captured code snippets for the handler, environment, dependencies, and Next config.

<a href="https://app.greptile.com/trex/runs/14392708/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/bridge-adapter/engine.ts | Routes empty bridge projects through LLM auth selection before scaffold installation. |
| packages/novu/src/commands/connect/pipeline/llm-auth/resolve-llm-auth.ts | Resolves CLI and interactive LLM auth choices for API-key, subscription, and skip modes. |
| packages/novu/src/commands/connect/pipeline/llm-auth/codegen/generate-support-agent.ts | Generates provider-specific support agent source for AI SDK and LangChain scaffolds. |
| packages/novu/src/commands/init/templates/index.ts | Threads LLM auth into template files, dependencies, generated config, and environment output. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
A[Empty bridge project] --> B[Choose LLM provider]
B --> C{Provider type}
C -->|API key| D[Save key for .env.local]
C -->|Subscription| E[Run local CLI auth]
C -->|Skip| F[Use demo echo handler]
D --> G[Confirm scaffold]
E --> G
F --> G
G -->|Yes| H[Install template and generated agent]
G -->|No| I[Exit without scaffold]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
A[Empty bridge project] --> B[Choose LLM provider]
B --> C{Provider type}
C -->|API key| D[Save key for .env.local]
C -->|Subscription| E[Run local CLI auth]
C -->|Skip| F[Use demo echo handler]
D --> G[Confirm scaffold]
E --> G
F --> G
G -->|Yes| H[Install template and generated agent]
G -->|No| I[Exit without scaffold]
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix(novu): prefix digit-led agent export..."](https://github.com/novuhq/novu/commit/82542d9fae771e2ea115f88d0e0d550204c8122f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44133558)</sub>

<!-- /greptile_comment -->