### PR TITLE
docs(docs): rename Connect tab to Agent Connect fixes NV-8297

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -407,7 +407,7 @@
         ]
       },
       {
-        "tab": "Connect",
+        "tab": "Agent Connect",
         "groups": [
           {
             "group": "Getting Started",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames the Mintlify docs navigation tab from **Connect** to **Agent Connect** in `docs/docs.json`.

## Why

Aligns the docs tab label with the Novu Connect product naming used elsewhere in the documentation.

## Changes

- Updated `navigation.tabs[].tab` value from `Connect` to `Agent Connect`

## Testing

- Config-only change; no runtime behavior affected.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1784036933653359?thread_ts=1784036933.653359&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-d71a1027-d441-52e2-bb3f-d2862d259033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d71a1027-d441-52e2-bb3f-d2862d259033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the docs navigation label for Connect.

- Updates the Mintlify navigation tab from `Connect` to `Agent Connect`.
- Leaves the page paths and redirects unchanged.

<h3>Confidence Score: 4/5</h3>

The docs config change looks mergeable after syncing the remaining visible label.

The navigation label change appears display-only, and no route or redirect breakage was identified.

docs/index.mdx still shows the old `Connect` label.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Biome validation ran and reported that one file was checked with no fixes applied and exit code 0.
- Agent Connect validation ran; PARSE\_OK is true, the tab shows the Agent Connect entry, AGENT\_CONNECT\_FOUND is true, and exit code is 0.
- Mintlify CLI availability check ran but Mintlify could not be executed because the CLI was unavailable from PATH and pnpm exec.

<a href="https://app.greptile.com/trex/runs/14392432/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Renames one Mintlify navigation tab label from `Connect` to `Agent Connect`. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fdocs.json%3A410%0A**Homepage%20Label%20Stays%20Stale**%0A%0AThis%20changes%20the%20main%20docs%20navigation%20to%20%60Agent%20Connect%60%2C%20but%20the%20homepage%20still%20has%20an%20inline%20tab%20titled%20%60Connect%60%20in%20%60docs%2Findex.mdx%60.%20Readers%20can%20still%20see%20the%20old%20product%20name%20on%20the%20landing%20page%2C%20so%20the%20visible%20rename%20remains%20incomplete.%0A%0A&pr=11939&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/docs.json:410
**Homepage Label Stays Stale**

This changes the main docs navigation to `Agent Connect`, but the homepage still has an inline tab titled `Connect` in `docs/index.mdx`. Readers can still see the old product name on the landing page, so the visible rename remains incomplete.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: rename Connect tab to Agent Connec..."](https://github.com/novuhq/novu/commit/c944dfa827ce0f16cf6502543d11e9a40f4cdfe6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44142361)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->