### PR TITLE
docs(agents): put CLI first in quickstart onboarding tabs fixes NV-8299

### DIFF
--- a/docs/agents/custom-code-agent/quickstart.mdx
+++ b/docs/agents/custom-code-agent/quickstart.mdx
@@ -19,11 +19,29 @@ Pick the path that matches how you like to work. All three get you to the same o
 
 | Path | Best if you… |
 | --- | --- |
-| **Dashboard** | Want step-by-step guidance in the Novu UI |
 | **CLI** | Prefer doing everything from the terminal |
+| **Dashboard** | Want step-by-step guidance in the Novu UI |
 | **AI assistant** | Want Cursor or another AI tool to set it up in your repo |
 
 <Tabs>
+  <Tab title="CLI">
+
+Run one command and follow the prompts. The CLI signs you in, creates the agent, connects a channel, and can generate a starter project for you.
+
+```bash
+npx novu connect
+```
+
+You'll be asked to:
+
+1. Sign in to Novu (or paste your secret key).
+2. Pick a runtime — **AI SDK**, **LangChain**, **Custom code**, or a managed option like Claude.
+3. Name your agent and connect Slack (or another channel).
+4. Confirm creating a starter project, if prompted.
+
+When you're done, run `npm run dev:novu` in the project folder and message your agent on Slack.
+
+  </Tab>
   <Tab title="Dashboard">
 
 Use the Novu dashboard to create the agent and connect Slack, then run a small local app on your machine that handles replies.
@@ -128,24 +146,6 @@ Message your bot in Slack. Your handler code runs and the reply appears in the t
 </Step>
 
 </Steps>
-
-  </Tab>
-  <Tab title="CLI">
-
-Run one command and follow the prompts. The CLI signs you in, creates the agent, connects a channel, and can generate a starter project for you.
-
-```bash
-npx novu connect
-```
-
-You'll be asked to:
-
-1. Sign in to Novu (or paste your secret key).
-2. Pick a runtime — **AI SDK**, **LangChain**, **Custom code**, or a managed option like Claude.
-3. Name your agent and connect Slack (or another channel).
-4. Confirm creating a starter project, if prompted.
-
-When you're done, run `npm run dev:novu` in the project folder and message your agent on Slack.
 
   </Tab>
   <Tab title="AI assistant">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the "Choose your onboarding experience" section on the custom code agent quickstart page so **CLI** is the first path in the comparison table and the first/default tab when the page loads.

## Changes

- Updated the comparison table order: CLI → Dashboard → AI assistant
- Moved the CLI `<Tab>` before Dashboard and AI assistant in `docs/agents/custom-code-agent/quickstart.mdx`

## Why

CLI is the preferred onboarding path; making it first and the default tab reduces friction for users who want the terminal-first flow.

## Test plan

- [x] Verified tab order and table order in `quickstart.mdx`
- [ ] Confirm on deployed docs that CLI tab is selected by default on page load
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34339741-6f1c-425e-b054-85ff186d6ae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34339741-6f1c-425e-b054-85ff186d6ae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes CLI the first onboarding path in the custom code agent quickstart.

- Moves CLI to the top of the onboarding comparison table.
- Moves the CLI tab before Dashboard and AI assistant.
- Keeps the existing CLI, Dashboard, and AI assistant instructions unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed documentation, and the tab order change matches the first-tab default behavior.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- In the pre-run static proof log, the tab order is CLI, Dashboard, and AI assistant.
- The static log defines the tabs with \<Tab title="CLI"\>, \<Tab title="Dashboard"\>, and \<Tab title="AI assistant"\>.
- The after-run log shows the real preview command was executed with the working directory and the Node version (Node v24.18.0) at startup.
- Startup failed with an ERR\_MODULE\_NOT\_FOUND: Cannot find package 'openapi-types' as reported in the after-run log.

<a href="https://app.greptile.com/trex/runs/14409726/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/agents/custom-code-agent/quickstart.mdx | Reorders the onboarding table and tabs so CLI appears first by default. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): put CLI first in quickstar..."](https://github.com/novuhq/novu/commit/ccb61bd0682909d08d0ddd79c9eb306a2a2ac06f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44177500)</sub>

<!-- /greptile_comment -->