### PR TITLE
fix(novu): replace sync agent warning with workflow/agent summary fixes NV-8300

### DIFF
--- a/docs/framework/deployment/cli.mdx
+++ b/docs/framework/deployment/cli.mdx
@@ -38,7 +38,14 @@ A successful sync prints how many workflows and agents were synced from your bri
 14 Workflows and 0 Agents
 ```
 
-If your bridge exposes [Agents](/agents/get-started/what-is-aci), the agent count reflects how many were discovered. When you are only syncing workflows, `0 Agents` is expected and does not indicate an error.
+If your bridge exposes [Agents](/agents/get-started/what-is-aci), the agent count reflects how many were successfully updated. When you are only syncing workflows, `0 Agents` is expected and does not indicate an error.
+
+If agent discovery is unavailable, the summary omits the agent count and prints an informational note instead:
+
+```
+14 Workflows
+Agent discovery was unavailable.
+```
 
 ## Using vercel preview url
 

--- a/docs/framework/deployment/cli.mdx
+++ b/docs/framework/deployment/cli.mdx
@@ -32,19 +32,13 @@ npx novu@latest sync \
 
 ## Understanding sync output
 
-A successful sync prints the number of workflows and steps that were discovered from your bridge endpoint, for example:
-
-```json
-{"status":"ok","sdkVersion":"2.10.0","frameworkVersion":"2024-06-26","discovered":{"workflows":14,"steps":30}}
-```
-
-You may also see the following message printed alongside a successful sync:
+A successful sync prints how many workflows and agents were synced from your bridge endpoint, for example:
 
 ```
-Could not discover agents for bridge URL sync (bridge may not expose agents yet).
+14 Workflows and 0 Agents
 ```
 
-This is an informational notice, not an error. It only indicates that your bridge does not expose any [Agents](/agents/get-started/what-is-aci) at the sync endpoint. If you are only syncing workflows, you can safely ignore this message — your workflows and steps have still been synced.
+If your bridge exposes [Agents](/agents/get-started/what-is-aci), the agent count reflects how many were discovered. When you are only syncing workflows, `0 Agents` is expected and does not indicate an error.
 
 ## Using vercel preview url
 

--- a/packages/novu/src/commands/sync.ts
+++ b/packages/novu/src/commands/sync.ts
@@ -27,7 +27,10 @@ export async function sync(bridgeUrl: string, secretKey: string, apiUrl: string)
     process.exit(1);
   }
 
-  await syncAgentBridgeUrls(bridgeUrl, secretKey, apiUrl);
+  const workflowCount = Array.isArray(syncResult.data) ? syncResult.data.length : 0;
+  const agentCount = await syncAgentBridgeUrls(bridgeUrl, secretKey, apiUrl);
+
+  console.log(`${workflowCount} Workflows and ${agentCount} Agents`);
 
   return syncResult.data;
 }
@@ -49,14 +52,14 @@ export async function executeSync(apiUrl: string, bridgeUrl: string, secretKey: 
   );
 }
 
-async function syncAgentBridgeUrls(bridgeUrl: string, secretKey: string, apiUrl: string) {
+async function syncAgentBridgeUrls(bridgeUrl: string, secretKey: string, apiUrl: string): Promise<number> {
   try {
     const discoverUrl = `${bridgeUrl}?action=discover`;
     const discoverRes = await axios.get<DiscoverResponse>(discoverUrl, { timeout: 5000 });
     const agents = discoverRes.data?.agents ?? [];
 
     if (agents.length === 0) {
-      return;
+      return 0;
     }
 
     console.log(`Setting production bridge URL for ${agents.length} agent(s)...`);
@@ -85,8 +88,10 @@ async function syncAgentBridgeUrls(bridgeUrl: string, secretKey: string, apiUrl:
         console.warn(`  ✗ ${agentId}: ${result.reason?.message || 'unknown error'}`);
       }
     }
+
+    return agents.length;
   } catch {
-    console.warn('Could not discover agents for bridge URL sync (bridge may not expose agents yet).');
+    return 0;
   }
 }
 

--- a/packages/novu/src/commands/sync.ts
+++ b/packages/novu/src/commands/sync.ts
@@ -6,6 +6,8 @@ interface DiscoverResponse {
   agents?: Array<{ agentId: string }>;
 }
 
+type AgentSyncOutcome = { status: 'none' } | { status: 'synced'; count: number } | { status: 'unavailable' };
+
 export async function sync(bridgeUrl: string, secretKey: string, apiUrl: string) {
   if (!bridgeUrl) {
     throw new Error('A bridge URL is required for the sync command, please supply it when running the command');
@@ -28,11 +30,25 @@ export async function sync(bridgeUrl: string, secretKey: string, apiUrl: string)
   }
 
   const workflowCount = Array.isArray(syncResult.data) ? syncResult.data.length : 0;
-  const agentCount = await syncAgentBridgeUrls(bridgeUrl, secretKey, apiUrl);
+  const agentOutcome = await syncAgentBridgeUrls(bridgeUrl, secretKey, apiUrl);
 
-  console.log(`${workflowCount} Workflows and ${agentCount} Agents`);
+  console.log(formatSyncSummary(workflowCount, agentOutcome));
+
+  if (agentOutcome.status === 'unavailable') {
+    console.log('Agent discovery was unavailable.');
+  }
 
   return syncResult.data;
+}
+
+function formatSyncSummary(workflowCount: number, agentOutcome: AgentSyncOutcome): string {
+  if (agentOutcome.status === 'unavailable') {
+    return `${workflowCount} Workflows`;
+  }
+
+  const agentCount = agentOutcome.status === 'synced' ? agentOutcome.count : 0;
+
+  return `${workflowCount} Workflows and ${agentCount} Agents`;
 }
 
 export async function executeSync(apiUrl: string, bridgeUrl: string, secretKey: string) {
@@ -52,14 +68,18 @@ export async function executeSync(apiUrl: string, bridgeUrl: string, secretKey: 
   );
 }
 
-async function syncAgentBridgeUrls(bridgeUrl: string, secretKey: string, apiUrl: string): Promise<number> {
+async function syncAgentBridgeUrls(
+  bridgeUrl: string,
+  secretKey: string,
+  apiUrl: string
+): Promise<AgentSyncOutcome> {
   try {
     const discoverUrl = `${bridgeUrl}?action=discover`;
     const discoverRes = await axios.get<DiscoverResponse>(discoverUrl, { timeout: 5000 });
     const agents = discoverRes.data?.agents ?? [];
 
     if (agents.length === 0) {
-      return 0;
+      return { status: 'none' };
     }
 
     console.log(`Setting production bridge URL for ${agents.length} agent(s)...`);
@@ -79,19 +99,22 @@ async function syncAgentBridgeUrls(bridgeUrl: string, secretKey: string, apiUrl:
       )
     );
 
+    let syncedCount = 0;
+
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       const agentId = agents[i].agentId;
       if (result.status === 'fulfilled') {
+        syncedCount += 1;
         console.log(`  ✓ ${agentId}`);
       } else {
         console.warn(`  ✗ ${agentId}: ${result.reason?.message || 'unknown error'}`);
       }
     }
 
-    return agents.length;
+    return { status: 'synced', count: syncedCount };
   } catch {
-    return 0;
+    return { status: 'unavailable' };
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the confusing `Could not discover agents for bridge URL sync` warning with a clear, informative sync summary.

After a successful `novu sync`, the CLI now prints:

```
14 Workflows and 0 Agents
```

This makes it obvious that syncing workflows without agents is expected and not an error.

## Changes

- **`packages/novu/src/commands/sync.ts`**: Remove the agent discovery warning; log workflow and agent counts after sync completes. Agent count reflects successfully updated agents only. Discovery failures omit the agent count and print an informational note instead.
- **`docs/framework/deployment/cli.mdx`**: Update the "Understanding sync output" section to document the new format.

## Why

Users were interpreting the previous warning as a failure even when workflow sync succeeded. The new message reports what was synced instead of implying something went wrong.

## Review follow-up

- **Discovered agents reported as synced**: Agent count now reflects successful bridge URL updates only (not discovered-but-failed agents).
- **Discovery failure becomes empty result**: Discovery failures no longer report `0 Agents`; the summary omits the agent count and prints `Agent discovery was unavailable.` as an informational note.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1448ff0a-ee6b-4951-909c-1f984140f56f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1448ff0a-ee6b-4951-909c-1f984140f56f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `novu sync` CLI output for workflow and agent sync results. The main changes are:

- Replaces the old agent discovery warning with a workflow and agent summary.
- Counts only successfully updated agents in the sync summary.
- Omits the agent count when agent discovery is unavailable.
- Updates the CLI docs to show the new output format.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the repository targeted sync spec and confirmed it passed with exit code 0.
- I verified the focused Vitest harness produced three output-behavior results and all tests passed with exit code 0.
- I captured the generated harness source in artifacts to document the test harness structure used for this change.
- I recorded the pre-change summary line from HEAD^ to provide before/after context for the change.

<a href="https://app.greptile.com/trex/runs/14412580/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/sync.ts | Adds explicit agent sync outcomes and formats the CLI summary from workflow count plus agent discovery state. |
| docs/framework/deployment/cli.mdx | Documents the new sync output for workflows, agents, and unavailable agent discovery. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(novu): count only synced agents and ..."](https://github.com/novuhq/novu/commit/2c46a91aaeb7d54c7446339f4acb0416825decf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44179478)</sub>

<!-- /greptile_comment -->