### PR TITLE
fix(shared): restore string support for IN/NOT_IN step filters fixes NV-8304

### DIFF
--- a/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
@@ -351,7 +351,95 @@ describe('Message filter matcher', () => {
     expect(matchedMessage.passed).to.equal(true);
   });
 
-  it('should handle IN operator when payload field is not an array', async () => {
+  it('should handle IN operator when payload field is a string', async () => {
+    const matchedMessage = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('String Field', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.IN,
+            value: 'premium',
+            field: 'tags',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {
+            tags: 'premium',
+          },
+        },
+      })
+    );
+
+    expect(matchedMessage.passed).to.equal(true);
+  });
+
+  it('should handle NOT_IN operator when payload field is a string', async () => {
+    const matchedMessage = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('String Field', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.NOT_IN,
+            value: 'blocked',
+            field: 'status',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {
+            status: 'active',
+          },
+        },
+      })
+    );
+
+    expect(matchedMessage.passed).to.equal(true);
+  });
+
+  it('should handle IN operator with string substring matching for old dashboard variants', async () => {
+    const tutorNameMatch = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('Tutor Name', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.IN,
+            value: ' ',
+            field: 'classDetails.tutorName',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {
+            classDetails: {
+              tutorName: 'Jane Smith',
+            },
+          },
+        },
+      })
+    );
+
+    expect(tutorNameMatch.passed).to.equal(true);
+
+    const enrollmentStatusMatch = await conditionsFilter.filter(
+      mapConditionsFilterCommand({
+        step: makeStep('Enrollment Status', FieldLogicalOperatorEnum.AND, [
+          {
+            operator: FieldOperatorEnum.IN,
+            value: 'requested',
+            field: 'enrollmentQueriesStatus',
+            on: FilterPartTypeEnum.PAYLOAD,
+          },
+        ]),
+        variables: {
+          payload: {
+            enrollmentQueriesStatus: 'requested',
+          },
+        },
+      })
+    );
+
+    expect(enrollmentStatusMatch.passed).to.equal(true);
+  });
+
+  it('should handle IN operator when payload field is not an array or string', async () => {
     const matchedMessage = await conditionsFilter.filter(
       mapConditionsFilterCommand({
         step: makeStep('Non Array Field', FieldLogicalOperatorEnum.AND, [
@@ -364,7 +452,7 @@ describe('Message filter matcher', () => {
         ]),
         variables: {
           payload: {
-            tags: 'premium',
+            tags: 42,
           },
         },
       })

--- a/libs/application-generic/src/utils/filter.ts
+++ b/libs/application-generic/src/utils/filter.ts
@@ -39,11 +39,11 @@ export abstract class Filter {
 
         break;
       case FieldOperatorEnum.NOT_IN:
-        result = Array.isArray(actualValue) ? !actualValue.includes(filterValue) : true;
+        result = this.evaluateIncludesMembership(actualValue, filterValue, false);
 
         break;
       case FieldOperatorEnum.IN:
-        result = Array.isArray(actualValue) ? actualValue.includes(filterValue) : false;
+        result = this.evaluateIncludesMembership(actualValue, filterValue, true);
 
         break;
       case FieldOperatorEnum.IS_DEFINED:
@@ -95,6 +95,16 @@ export abstract class Filter {
     }
 
     return summary;
+  }
+
+  private evaluateIncludesMembership(actualValue: unknown, filterValue: unknown, shouldMatch: boolean): boolean {
+    if (Array.isArray(actualValue) || typeof actualValue === 'string') {
+      const includes = actualValue.includes(filterValue as never);
+
+      return shouldMatch ? includes : !includes;
+    }
+
+    return !shouldMatch;
   }
 
   private parseValue(originValue, parsingValue) {


### PR DESCRIPTION
## Summary

Restores pre-novuhq/novu#11764 behavior for `IN` and `NOT_IN` step filter operators when the payload field is a **string**, while keeping the crash protection added in novuhq/novu#11764 for missing or non-includable values.

PR novuhq/novu#11764 changed `IN`/`NOT_IN` to only evaluate when the field value is an array. That fixed crashes on missing payload fields, but broke old dashboard workflow variants that rely on string matching — for example:

## What changed

* Added `evaluateIncludesMembership()` in `libs/application-generic/src/utils/filter.ts`
* `IN` / `NOT_IN` now call `.includes()` on **arrays and strings**
* `undefined`, `null`, numbers, and other non-includable types still fail closed (`IN` → `false`, `NOT_IN` → `true`)
* Updated and expanded worker conditions-filter tests for string scenarios and old-dashboard variant cases

```mermaid
flowchart TD
  A[IN / NOT_IN filter] --> B{actualValue type?}
  B -->|array or string| C["actualValue.includes(filterValue)"]
  B -->|other / missing| D["IN: false, NOT_IN: true"]
  C --> E{operator}
  E -->|IN| F[return includes result]
  E -->|NOT_IN| G[return !includes result]
```

## Test plan

- [X] `pnpm --filter @novu/application-generic build`
- [X] `cd apps/worker && pnpm test -- --grep "Message filter matcher"` — 41 passing
- [X] New tests cover string `IN`/`NOT_IN`, old-dashboard substring cases (`tutorName`, `enrollmentQueriesStatus`), and non-string non-array fail-closed behavior

Linear Issue: [NV-8304](https://linear.app/novu/issue/NV-8304/old-dashboard-variant-regression-caused-by-in-not-in-changing-from)

[<img src="https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/451abacc-43d4-4211-8242-a4ad30025cda/e5cf08f1-138d-4468-bc64-bd0566831019?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC80NTFhYmFjYy00M2Q0LTQyMTEtODI0Mi1hNGFkMzAwMjVjZGEvZTVjZjA4ZjEtMTM4ZC00NDY4LWJjNjQtYmQwNTY2ODMxMDE5IiwiaWF0IjoxNzg0MTAxMzYwLCJleHAiOjE4MTU2NzE5MjB9.iZKxcXMOdYFwlkw3UNXFKhQOI_0mSKGkWj81ujItUiE " alt="Open in Web" width="114" data-linear-height="28" />](<https://cursor.com/agents/bc-a4587847-fced-41d9-a70d-f7dbe9fee584>) [<img src="https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/2bebd658-43d7-4d70-8d3e-3f3b7c24c1a1/86eb1aac-fbd9-4dc8-b3db-f978a1424dc5?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC8yYmViZDY1OC00M2Q3LTRkNzAtOGQzZS0zZjNiN2MyNGMxYTEvODZlYjFhYWMtZmJkOS00ZGM4LWIzZGItZjk3OGExNDI0ZGM1IiwiaWF0IjoxNzg0MTAxMzYwLCJleHAiOjE4MTU2NzE5MjB9.IdT92BqjjB4r0whqyrKDywQXziaYwLsy6pFaKp4i8_k " alt="Open in Cursor" width="131" data-linear-height="28" />](<https://cursor.com/background-agent?bcId=bc-a4587847-fced-41d9-a70d-f7dbe9fee584>)

### Greptile Summary

This PR restores string support for `IN` and `NOT_IN` step filters. The main changes are:

* Adds shared membership evaluation for arrays and strings.
* Keeps fail-closed behavior for missing, `null`, numeric, and other non-includable values.
* Expands worker tests for string matches, old-dashboard substring cases, and unsupported payload types.

### Confidence Score: 5/5

Safe to merge with minimal risk.

The change is small and localized to filter membership evaluation. New tests cover the restored string behavior and the preserved unsupported-value behavior. No blocking issues were found.

No files require special attention.

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* Inspected the message-filter-matcher worker before-run log to confirm the command, working directory, and the exit code indicating a TS2307 missing module.
* Reviewed the application-generic build after-log and noted module-resolution TS2307 failures that prevented a successful build.
* Verified that the generated filter-membership direct harness file was produced.
* Ran the filter-membership direct harness and observed a successful run with exit code 0 and passing JSON rows for the IN/NOT< />IN and fail-closed behavior.
* Cross-checked the evidence-note to confirm how artifacts map to the validation objective.

[![View all artifacts](https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/7624eca7-8219-488a-a28b-63ef91e2c8bd/841388ba-043c-4ee4-a0e9-4e86e1b60a7e?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC83NjI0ZWNhNy04MjE5LTQ4OGEtYTI4Yi02M2VmOTFlMmM4YmQvODQxMzg4YmEtMDQzYy00ZWU0LWEwZTktNGU4NmUxYjYwYTdlIiwiaWF0IjoxNzg0MTAxMzYwLCJleHAiOjE4MTU2NzE5MjB9.CnkMsDVsaNXXDJXuJDwGSH8ifVxg5s_lrkit38vNRrU)](<https://app.greptile.com/trex/runs/14510633/artifacts>)

[<img src="https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/0d8ced68-3a7a-4dd7-9c6f-8607fedfc046/19931c86-65a6-40d7-a40f-029749fd5d6f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2YxM2YxOTk2LWM5YjAtNGZlYS04ZWU3LTJjM2ZhZjZhODMyZC8wZDhjZWQ2OC0zYTdhLTRkZDctOWM2Zi04NjA3ZmVkZmMwNDYvMTk5MzFjODYtNjVhNi00MGQ3LWE0MGYtMDI5NzQ5ZmQ1ZDZmIiwiaWF0IjoxNzg0MTAxMzYwLCJleHAiOjE4MTU2NzE5MjB9.8rp_Tp_pIiN14KpDXdR085BAgkP-Fkb3lWRUjp4T5Mk " alt="T-Rex" height="14" />](<https://www.greptile.com/trex>) Ran code and verified through T-Rex

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| libs/application-generic/src/utils/filter.ts | Restores `IN` and `NOT_IN` membership evaluation for both arrays and strings while preserving fail-closed behavior for non-includable values. |
| apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts | Adds tests for string membership, old-dashboard substring variants, and non-array/non-string fail-closed behavior. |

</details>

### Sequence Diagram

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Filter as Filter.processFilterEquality
participant Helper as evaluateIncludesMembership
participant Value as actualValue

Filter->>Helper: operator IN/NOT_IN, actualValue, filterValue
Helper->>Value: check array or string type
alt array or string
    Helper->>Value: actualValue.includes(filterValue)
    Helper-->>Filter: includes for IN, !includes for NOT_IN
else missing or unsupported type
    Helper-->>Filter: false for IN, true for NOT_IN
end
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Filter as Filter.processFilterEquality
participant Helper as evaluateIncludesMembership
participant Value as actualValue

Filter->>Helper: operator IN/NOT_IN, actualValue, filterValue
Helper->>Value: check array or string type
alt array or string
    Helper->>Value: actualValue.includes(filterValue)
    Helper-->>Filter: includes for IN, !includes for NOT_IN
else missing or unsupported type
    Helper-->>Filter: false for IN, true for NOT_IN
end
```

Reviews (1): Last reviewed commit: ["fix(shared): restore string support for ..."](<https://github.com/novuhq/novu/commit/b46eccb961ddeae86248e1899c6d486fc295a197>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=44390937>)