### PR TITLE
fix(docs): update MS Teams and Slack integration examples to include subscriberId fixes DOC-418

### DIFF
--- a/docs/platform/integrations/chat/ms-teams.mdx
+++ b/docs/platform/integrations/chat/ms-teams.mdx
@@ -416,9 +416,10 @@ const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 const response = await novu.integrations.generateConnectOAuthUrl({
   integrationIdentifier: 'ms-teams-bot',
+  subscriberId: 'user-123',
   context: {
-    "tenant": "acme-corp"
-},
+    tenant: 'acme-corp',
+  },
   autoLinkUser: false,
 });
 ```
@@ -431,9 +432,10 @@ from novu_py import Novu
 with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
     response = novu.integrations.generate_connect_o_auth_url(generate_connect_oauth_url_request_dto={
         "integration_identifier": "ms-teams-bot",
+        "subscriber_id": "user-123",
         "context": {
-        "tenant": "acme-corp"
-},
+            "tenant": "acme-corp",
+        },
         "auto_link_user": False,
     })
 ```
@@ -452,6 +454,7 @@ s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
 
 res, err := s.Integrations.GenerateConnectOAuthURL(context.Background(), components.GenerateConnectOauthURLRequestDto{
     IntegrationIdentifier: "ms-teams-bot",
+    SubscriberID: novugo.String("user-123"),
     Context: map[string]components.GenerateConnectOauthURLRequestDtoContext{
         "tenant": components.CreateGenerateConnectOauthURLRequestDtoContextStr("acme-corp"),
     },
@@ -468,9 +471,10 @@ $sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
 $response = $sdk->integrations->generateConnectOAuthUrl(
     generateConnectOauthUrlRequestDto: new Components\GenerateConnectOauthUrlRequestDto(
         integrationIdentifier: 'ms-teams-bot',
-        context: {
-        "tenant": "acme-corp"
-},
+        subscriberId: 'user-123',
+        context: [
+            'tenant' => 'acme-corp',
+        ],
         autoLinkUser: false,
     ),
 );
@@ -485,9 +489,10 @@ var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 var response = await sdk.Integrations.GenerateConnectOAuthUrlAsync(
     generateConnectOauthUrlRequestDto: new GenerateConnectOauthUrlRequestDto() {
         IntegrationIdentifier = "ms-teams-bot",
-        Context = {
-    "tenant": "acme-corp"
-},
+        SubscriberId = "user-123",
+        Context = new Dictionary<string, object> {
+            { "tenant", "acme-corp" },
+        },
         AutoLinkUser = false,
     });
 ```
@@ -501,9 +506,8 @@ Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 var response = novu.integrations().generateConnectOAuthUrl()
     .body(GenerateConnectOauthUrlRequestDto.builder()
         .integrationIdentifier("ms-teams-bot")
-        .context({
-        "tenant": "acme-corp"
-})
+        .subscriberId("user-123")
+        .context(java.util.Map.of("tenant", "acme-corp"))
         .autoLinkUser(false)
         .build())
     .call();
@@ -516,6 +520,7 @@ curl -L -X POST 'https://api.novu.co/v1/integrations/channel-connections/oauth' 
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "integrationIdentifier": "ms-teams-bot",
+  "subscriberId": "user-123",
   "context": {
     "tenant": "acme-corp"
   },
@@ -529,9 +534,7 @@ Call `POST /v1/integrations/channel-connections/oauth` with the same body if you
 
 Novu returns a URL pointing to Microsoft's administrator consent endpoint (`login.microsoftonline.com/organizations/v2.0/adminconsent`). It includes your Client ID, redirect URI, and the `https://graph.microsoft.com/.default` scope.
 
-Provide either `subscriberId` or `context` to scope the channel connection in Novu. If you pass `subscriberId`, that subscriber must already exist in your Novu environment.
-
-For tenant-wide admin consent, prefer `context` and set **`autoLinkUser: false`** (or omit `autoLinkUser` — the API treats omitted as `false`). Only when `autoLinkUser` is explicitly `true` **and** `subscriberId` is set does Novu chain a second OAuth flow after admin consent to link that subscriber for DMs.
+For tenant-wide admin consent, set **`autoLinkUser: false`** (or omit `autoLinkUser` — the API treats omitted as `false`). Only when `autoLinkUser` is explicitly `true` does Novu chain a second OAuth flow after admin consent to link that subscriber for DMs.
 
 <Note>
   **`@novu/react` `MsTeamsConnectButton`** defaults `autoLinkUser` to `true` in subscriber mode. That is intended for in-app end-user connect flows. For server-side tenant admin consent (Java, REST, or `@novu/api`), pass `autoLinkUser: false` explicitly.
@@ -659,19 +662,20 @@ Content-Type: application/json
   "integrationIdentifier": "ms-teams-bot-1",
   "providerId": "msteams",
   "channel": "chat",
-
-"subscriberId": "workspace_abc",
+  "subscriberId": "user-123",
+  "context": {
+    "tenant": "acme-corp"
+  },
   "connectionIdentifier": "msteams-tenant-subscriberX",
-
-"type": "ms_teams_channel",
+  "type": "ms_teams_channel",
   "endpoint": {
     "teamId": "TEAM_ID",
     "channelId": "CHANNEL_ID"
-  },
+  }
 }
 ```
 
-Novu stores this as `ChannelEndpoint<'ms_teams_channel'>`. You can later target it from workflows via `subscriberId` + `context`.
+Novu stores this as `ChannelEndpoint<'ms_teams_channel'>`.
 
 ### Send a direct message to a user
 
@@ -696,7 +700,10 @@ const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 const response = await novu.integrations.generateLinkUserOAuthUrl({
   integrationIdentifier: 'ms-teams-bot',
-  subscriberId: 'user_123',
+  subscriberId: 'user-123',
+  context: {
+    tenant: 'acme-corp',
+  },
   connectionIdentifier: 'msteams-tenant-acme',
 });
 ```
@@ -709,7 +716,10 @@ from novu_py import Novu
 with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
     response = novu.integrations.generate_link_user_o_auth_url(generate_link_user_oauth_url_request_dto={
         "integration_identifier": "ms-teams-bot",
-        "subscriber_id": "user_123",
+        "subscriber_id": "user-123",
+        "context": {
+            "tenant": "acme-corp",
+        },
         "connection_identifier": "msteams-tenant-acme",
     })
 ```
@@ -728,7 +738,10 @@ s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
 
 res, err := s.Integrations.GenerateLinkUserOAuthURL(context.Background(), components.GenerateLinkUserOauthURLRequestDto{
     IntegrationIdentifier: "ms-teams-bot",
-    SubscriberID: "user_123",
+    SubscriberID: "user-123",
+    Context: map[string]components.GenerateLinkUserOauthURLRequestDtoContext{
+        "tenant": components.CreateGenerateLinkUserOauthURLRequestDtoContextStr("acme-corp"),
+    },
     ConnectionIdentifier: novugo.String("msteams-tenant-acme"),
 }, nil)
 ```
@@ -742,7 +755,10 @@ $sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
 $response = $sdk->integrations->generateLinkUserOAuthUrl(
     generateLinkUserOauthUrlRequestDto: new Components\GenerateLinkUserOauthUrlRequestDto(
         integrationIdentifier: 'ms-teams-bot',
-        subscriberId: 'user_123',
+        subscriberId: 'user-123',
+        context: [
+            'tenant' => 'acme-corp',
+        ],
         connectionIdentifier: 'msteams-tenant-acme',
     ),
 );
@@ -757,7 +773,10 @@ var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 var response = await sdk.Integrations.GenerateLinkUserOAuthUrlAsync(
     generateLinkUserOauthUrlRequestDto: new GenerateLinkUserOauthUrlRequestDto() {
         IntegrationIdentifier = "ms-teams-bot",
-        SubscriberId = "user_123",
+        SubscriberId = "user-123",
+        Context = new Dictionary<string, object> {
+            { "tenant", "acme-corp" },
+        },
         ConnectionIdentifier = "msteams-tenant-acme",
     });
 ```
@@ -771,7 +790,8 @@ Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 var response = novu.integrations().generateLinkUserOAuthUrl()
     .body(GenerateLinkUserOauthUrlRequestDto.builder()
         .integrationIdentifier("ms-teams-bot")
-        .subscriberId("user_123")
+        .subscriberId("user-123")
+        .context(java.util.Map.of("tenant", "acme-corp"))
         .connectionIdentifier("msteams-tenant-acme")
         .build())
     .call();
@@ -784,7 +804,10 @@ curl -L -X POST 'https://api.novu.co/v1/integrations/channel-endpoints/oauth' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "integrationIdentifier": "ms-teams-bot",
-  "subscriberId": "user_123",
+  "subscriberId": "user-123",
+  "context": {
+    "tenant": "acme-corp"
+  },
   "connectionIdentifier": "msteams-tenant-acme"
 }'
 ```
@@ -846,16 +869,15 @@ Content-Type: application/json
   "integrationIdentifier": "ms-teams-bot-1",
   "providerId": "msteams",
   "channel": "chat",
-
-"subscriberId": "user_123",
+  "subscriberId": "user-123",
+  "context": {
+    "tenant": "acme-corp"
+  },
   "connectionIdentifier": "msteams-tenant-subscriberX",
-
-"type": "ms_teams_user",
+  "type": "ms_teams_user",
   "endpoint": {
     "userId": "29:1GcS4EyB_oSI8A88XmWB..."
-  },
-
-"contextKeys": []
+  }
 }
 ```
 
@@ -953,6 +975,9 @@ res, err := s.ChannelEndpoints.Create(context.Background(), operations.CreateCha
         Identifier: novugo.String("teams-workflow-alerts"),
         IntegrationIdentifier: "ms-teams-workflow",
         SubscriberID: "customer-account-id",
+        Context: map[string]any{
+            "tenant": "acme",
+        },
         Type: components.CreateWebhookEndpointDtoTypeWebhook,
         Endpoint: components.WebhookEndpointDto{URL: "https://prod-00.westeurope.logic.azure.com:443/workflows/..."},
     },
@@ -970,6 +995,9 @@ $sdk->channelEndpoints->create(
         identifier: 'teams-workflow-alerts',
         integrationIdentifier: 'ms-teams-workflow',
         subscriberId: 'customer-account-id',
+        context: [
+            'tenant' => 'acme',
+        ],
         type: Components\CreateWebhookEndpointDtoType::Webhook,
         endpoint: new Components\WebhookEndpointDto(url: 'https://prod-00.westeurope.logic.azure.com:443/workflows/...'),
     ),
@@ -988,6 +1016,9 @@ await sdk.ChannelEndpoints.CreateAsync(
             Identifier = "teams-workflow-alerts",
             IntegrationIdentifier = "ms-teams-workflow",
             SubscriberId = "customer-account-id",
+            Context = new Dictionary<string, object> {
+                { "tenant", "acme" },
+            },
             Type = CreateWebhookEndpointDtoType.Webhook,
             Endpoint = new WebhookEndpointDto() { Url = "https://prod-00.westeurope.logic.azure.com:443/workflows/..." },
         }));
@@ -1004,6 +1035,7 @@ novu.channelEndpoints().create()
         .identifier("teams-workflow-alerts")
         .integrationIdentifier("ms-teams-workflow")
         .subscriberId("customer-account-id")
+        .context(java.util.Map.of("tenant", "acme"))
         .type(CreateWebhookEndpointDtoType.WEBHOOK)
         .endpoint(WebhookEndpointDto.builder().url("https://prod-00.westeurope.logic.azure.com:443/workflows/...").build())
         .build())

--- a/docs/platform/integrations/chat/slack.mdx
+++ b/docs/platform/integrations/chat/slack.mdx
@@ -181,8 +181,6 @@ To send messages to Slack, your users must first authorize Novu to access one of
 
 When a user clicks **Connect Slack** in your application, your backend should request a unique authorization URL from Novu.
 
-This URL is specific to the Subscriber or the Context (Tenant) it will be generated for.
-
 <Warning>
   The generated OAuth URL is valid for only <strong>5 minutes</strong>. Do not cache this URL; generate it dynamically when the user initiates the flow.
 </Warning>
@@ -196,10 +194,10 @@ const novu = new Novu({ secretKey: "<NOVU_SECRET_KEY>" });
 
 const response = await novu.integrations.generateChatOAuthUrl({
   integrationIdentifier: 'slack',
-  subscriberId: 'subscriberId',
+  subscriberId: 'user-123',
   context: {
-    "tenant": "orgId"
-},
+    tenant: 'orgId',
+  },
 });
 ```
   </Tab>
@@ -211,10 +209,10 @@ from novu_py import Novu
 with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
     response = novu.integrations.generate_chat_o_auth_url(generate_chat_oauth_url_request_dto={
         "integration_identifier": "slack",
-        "subscriber_id": "subscriberId",
-        context={
-        "tenant": "orgId"
-},
+        "subscriber_id": "user-123",
+        "context": {
+            "tenant": "orgId",
+        },
     })
 ```
   </Tab>
@@ -232,7 +230,10 @@ s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
 
 res, err := s.Integrations.GenerateChatOAuthURL(context.Background(), components.GenerateChatOauthURLRequestDto{
     IntegrationIdentifier: "slack",
-    SubscriberID: novugo.String("subscriberId"),
+    SubscriberID: novugo.String("user-123"),
+    Context: map[string]components.GenerateChatOauthURLRequestDtoContext{
+        "tenant": components.CreateGenerateChatOauthURLRequestDtoContextStr("orgId"),
+    },
 }, nil)
 ```
   </Tab>
@@ -245,7 +246,10 @@ $sdk = novu\Novu::builder()->setSecurity('<NOVU_SECRET_KEY>')->build();
 $response = $sdk->integrations->generateChatOAuthUrl(
     generateChatOauthUrlRequestDto: new Components\GenerateChatOauthUrlRequestDto(
         integrationIdentifier: 'slack',
-        subscriberId: 'subscriberId',
+        subscriberId: 'user-123',
+        context: [
+            'tenant' => 'orgId',
+        ],
     ),
 );
 ```
@@ -259,7 +263,10 @@ var sdk = new NovuSDK(secretKey: "<NOVU_SECRET_KEY>");
 var response = await sdk.Integrations.GenerateChatOAuthUrlAsync(
     generateChatOauthUrlRequestDto: new GenerateChatOauthUrlRequestDto() {
         IntegrationIdentifier = "slack",
-        SubscriberId = "subscriberId",
+        SubscriberId = "user-123",
+        Context = new Dictionary<string, object> {
+            { "tenant", "orgId" },
+        },
     });
 ```
   </Tab>
@@ -272,7 +279,8 @@ Novu novu = Novu.builder().secretKey("<NOVU_SECRET_KEY>").build();
 var response = novu.integrations().generateChatOAuthUrl()
     .body(GenerateChatOauthUrlRequestDto.builder()
         .integrationIdentifier("slack")
-        .subscriberId("subscriberId")
+        .subscriberId("user-123")
+        .context(java.util.Map.of("tenant", "orgId"))
         .build())
     .call();
 ```
@@ -284,7 +292,7 @@ curl -L -X POST 'https://api.novu.co/v1/integrations/chat/oauth' \
 -H 'Authorization: ApiKey <NOVU_SECRET_KEY>' \
 -d '{
   "integrationIdentifier": "slack",
-  "subscriberId": "subscriberId",
+  "subscriberId": "user-123",
   "context": {
     "tenant": "orgId"
   }
@@ -295,7 +303,7 @@ curl -L -X POST 'https://api.novu.co/v1/integrations/chat/oauth' \
 
 Your application can support multiple Slack workspace connections per user or per tenant by triggering separate OAuth flows.
 
-Novu allows one connection per (integration + subscriber + context). To connect multiple workspaces, provide different combinations of subscriber or context.
+Novu allows one connection per (integration + subscriber + context). To connect multiple workspaces, trigger separate OAuth flows with different combinations of those values.
 
 ### Redirect the user
 
@@ -339,8 +347,8 @@ After the user approves access, Novu handles the rest of the OAuth flow automati
 ```tsx
 await novu.channelConnections.create({
   integrationIdentifier: 'slack',
-  subscriberId: 'user-123',        // provide subscriberId, context, or both — at least one is required
-  context: { tenant: 'acme' },     // scope to a tenant (required when subscriberId is omitted)
+  subscriberId: 'user-123',
+  context: { tenant: 'acme' },
   workspace: {
     id: authData.team.id,          // Slack workspace ID from OAuth
     name: authData.team.name,
@@ -350,8 +358,6 @@ await novu.channelConnections.create({
   },
 });
 ```
-
-Provide at least one of `subscriberId` or `context` — same as the Novu-managed OAuth flow.
 </Note>
 
 ## Choose delivery destinations
@@ -425,6 +431,9 @@ res, err := s.ChannelEndpoints.Create(context.Background(), operations.CreateCha
         SubscriberID: "user-123",
         IntegrationIdentifier: "slack",
         ConnectionIdentifier: novugo.String("conn_slack_acme"),
+        Context: map[string]any{
+            "tenant": "acme",
+        },
         Type: components.CreateSlackChannelEndpointDtoTypeSlackChannel,
         Endpoint: components.SlackChannelEndpointDto{ChannelID: "C012345"},
     },
@@ -442,6 +451,9 @@ $sdk->channelEndpoints->create(
         subscriberId: 'user-123',
         integrationIdentifier: 'slack',
         connectionIdentifier: 'conn_slack_acme',
+        context: [
+            'tenant' => 'acme',
+        ],
         type: Components\CreateSlackChannelEndpointDtoType::SlackChannel,
         endpoint: new Components\SlackChannelEndpointDto(channelId: 'C012345'),
     ),
@@ -460,6 +472,9 @@ await sdk.ChannelEndpoints.CreateAsync(
             SubscriberId = "user-123",
             IntegrationIdentifier = "slack",
             ConnectionIdentifier = "conn_slack_acme",
+            Context = new Dictionary<string, object> {
+                { "tenant", "acme" },
+            },
             Type = CreateSlackChannelEndpointDtoType.SlackChannel,
             Endpoint = new SlackChannelEndpointDto() { ChannelId = "C012345" },
         }));
@@ -476,6 +491,7 @@ novu.channelEndpoints().create()
         .subscriberId("user-123")
         .integrationIdentifier("slack")
         .connectionIdentifier("conn_slack_acme")
+        .context(java.util.Map.of("tenant", "acme"))
         .type(CreateSlackChannelEndpointDtoType.SLACK_CHANNEL)
         .endpoint(SlackChannelEndpointDto.builder().channelId("C012345").build())
         .build())
@@ -574,6 +590,9 @@ res, err := s.ChannelEndpoints.Create(context.Background(), operations.CreateCha
         SubscriberID: "user-123",
         IntegrationIdentifier: "slack",
         ConnectionIdentifier: novugo.String("conn_slack_acme"),
+        Context: map[string]any{
+            "tenant": "acme",
+        },
         Type: components.CreateSlackUserEndpointDtoTypeSlackUser,
         Endpoint: components.SlackUserEndpointDto{UserID: "U01234567"},
     },
@@ -591,6 +610,9 @@ $sdk->channelEndpoints->create(
         subscriberId: 'user-123',
         integrationIdentifier: 'slack',
         connectionIdentifier: 'conn_slack_acme',
+        context: [
+            'tenant' => 'acme',
+        ],
         type: Components\CreateSlackUserEndpointDtoType::SlackUser,
         endpoint: new Components\SlackUserEndpointDto(userId: 'U01234567'),
     ),
@@ -609,6 +631,9 @@ await sdk.ChannelEndpoints.CreateAsync(
             SubscriberId = "user-123",
             IntegrationIdentifier = "slack",
             ConnectionIdentifier = "conn_slack_acme",
+            Context = new Dictionary<string, object> {
+                { "tenant", "acme" },
+            },
             Type = CreateSlackUserEndpointDtoType.SlackUser,
             Endpoint = new SlackUserEndpointDto() { UserId = "U01234567" },
         }));
@@ -625,6 +650,7 @@ novu.channelEndpoints().create()
         .subscriberId("user-123")
         .integrationIdentifier("slack")
         .connectionIdentifier("conn_slack_acme")
+        .context(java.util.Map.of("tenant", "acme"))
         .type(CreateSlackUserEndpointDtoType.SLACK_USER)
         .endpoint(SlackUserEndpointDto.builder().userId("U01234567").build())
         .build())


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Slack and Microsoft Teams chat integration docs. The main changes are:

- Adds `subscriberId` and `context` to OAuth URL examples.
- Aligns endpoint creation examples across the official server-side SDK tabs.
- Updates REST examples and surrounding text for scoped chat connections.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changes are limited to MDX examples and explanatory text. The SDK tab structure remains consistent, and no blocking issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the requested markdownlint check and captured the before-log, which includes a Node engine warning and style-lint output.
- Ran a focused validation over the changed MDX sections, which exits with code 0 and shows subscriberId=true context=true for all checked sections, with line excerpts.
- The validation evidence notes integration touchpoints by referencing MS Teams and Slack URLs and endpoints in the logs.

<a href="https://app.greptile.com/trex/runs/14511112/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/integrations/chat/ms-teams.mdx | Updates Microsoft Teams integration examples to include `subscriberId` and `context` across OAuth, endpoint, and webhook flows; no blocking issues found. |
| docs/platform/integrations/chat/slack.mdx | Updates Slack OAuth and endpoint examples to show combined `subscriberId` and `context` scoping across SDK tabs; no blocking issues found. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant App as Customer backend
participant Novu as Novu API
participant Provider as Slack / Microsoft Teams
participant Endpoint as Channel endpoint

App->>Novu: Generate OAuth URL with integrationIdentifier, subscriberId, context
Novu-->>App: Return short-lived OAuth URL
App->>Provider: Redirect subscriber/admin to authorize
Provider->>Novu: OAuth callback
Novu->>Novu: Store scoped connection by integration + subscriberId + context
App->>Novu: Create channel endpoint with subscriberId, context, connectionIdentifier
Novu->>Endpoint: Persist delivery destination
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant App as Customer backend
participant Novu as Novu API
participant Provider as Slack / Microsoft Teams
participant Endpoint as Channel endpoint

App->>Novu: Generate OAuth URL with integrationIdentifier, subscriberId, context
Novu-->>App: Return short-lived OAuth URL
App->>Provider: Redirect subscriber/admin to authorize
Provider->>Novu: OAuth callback
Novu->>Novu: Store scoped connection by integration + subscriberId + context
App->>Novu: Create channel endpoint with subscriberId, context, connectionIdentifier
Novu->>Endpoint: Persist delivery destination
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): update MS Teams and Slack int..."](https://github.com/novuhq/novu/commit/a7de69ea366b1ecfbd722dcec6a5c1044082879f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44391866)</sub>

<!-- /greptile_comment -->