### PR TITLE
ci(root): pin npm version to 11.5.2 for trusted publishing in release-packages.yml

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upgrade npm for Trusted Publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.5.2
           echo "npm version: $(npm --version) (>= 11.5.1 required for trusted publishing)"
 
       - name: Install Dependencies
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upgrade npm for Trusted Publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.5.2
           echo "npm version: $(npm --version) (>= 11.5.1 required for trusted publishing)"
 
       - name: Install Dependencies


### PR DESCRIPTION
… 

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins the npm version used by the package release workflow. The main changes are:

- Replaces `npm@latest` with `npm@11.5.2` in the manual release job.
- Applies the same pinned npm version in the stable publish job after release PR merges.
- Keeps the trusted publishing version check message unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to pinning an npm version in two CI workflow steps and does not alter release control flow, permissions, or publishing commands.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Workflow validation passed for both the workflow\_dispatch path and the stable merged-PR path, with the documented line-order checks confirming upgrade \< install \< publish in both cases.
- Local tooling smoke tests ran and passed using Nx local v21.3.11.
- Expected Node engine warnings were observed due to sandbox Node v24.18.0.

<a href="https://app.greptile.com/trex/runs/14537648/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-packages.yml | Pins the npm upgrade step in both release jobs to `npm@11.5.2` instead of installing `latest`; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(workflows): pin npm version to 11...."](https://github.com/novuhq/novu/commit/6561dabd375258479601b1770252d010731f7df4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44448701)</sub>

<!-- /greptile_comment -->