### PR TITLE
feat(api-service,docs): expose bridgeUrl on trigger for local tunnels fixes NV-8311

### DIFF
--- a/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
@@ -253,12 +253,7 @@ export class TriggerEventRequestDto {
   payload?: Record<string, unknown>;
 
   @ApiPropertyOptional({
-    description:
-      'Optional Bridge Endpoint URL used to route this trigger to a specific Bridge application. ' +
-      'Useful during local development when multiple engineers share an organization: set this to your ' +
-      'personal tunnel URL from `npx novu@latest dev` (for example via `NOVU_BRIDGE_URL`) so app-fired ' +
-      'triggers hit your machine instead of the environment\'s synced Bridge URL. Must be a publicly ' +
-      'reachable https URL — private or localhost addresses are rejected.',
+    description: `Optional Bridge Endpoint URL used to route this trigger to a specific Bridge application. Useful during local development when multiple engineers share an organization: set this to your personal tunnel URL from \`npx novu@latest dev\` (for example via NOVU_BRIDGE_URL) so app-fired triggers hit your machine instead of the environment's synced Bridge URL. Must be a publicly reachable https URL — private or localhost addresses are rejected.`,
     type: 'string',
     required: false,
     example: 'https://your-tunnel.novu.co/api/novu',

--- a/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
@@ -252,7 +252,17 @@ export class TriggerEventRequestDto {
   @IsOptional()
   payload?: Record<string, unknown>;
 
-  @ApiHideProperty()
+  @ApiPropertyOptional({
+    description:
+      'Optional Bridge Endpoint URL used to route this trigger to a specific Bridge application. ' +
+      'Useful during local development when multiple engineers share an organization: set this to your ' +
+      'personal tunnel URL from `npx novu@latest dev` (for example via `NOVU_BRIDGE_URL`) so app-fired ' +
+      'triggers hit your machine instead of the environment\'s synced Bridge URL. Must be a publicly ' +
+      'reachable https URL — private or localhost addresses are rejected.',
+    type: 'string',
+    required: false,
+    example: 'https://your-tunnel.novu.co/api/novu',
+  })
   @IsString()
   @IsOptional()
   bridgeUrl?: string;

--- a/docs/framework/studio.mdx
+++ b/docs/framework/studio.mdx
@@ -60,6 +60,65 @@ See the [Syncing guide](/framework/deployment/syncing) for the full end-to-end f
 
 By default the Novu CLI will automatically create a tunnel URL connected to your local computer. This tunnel will proxy any workflow engine requests on our cloud to your local machine.
 
+When `npx novu@latest dev` starts, it prints the full Bridge URL, for example:
+
+```bash
+🛣️  Tunnel    → https://your-tunnel.novu.co/api/novu
+```
+
+Use that value as `bridgeUrl` when triggering from your application (see below).
+
+## Trigger from your app to your local tunnel
+
+The Dashboard **Local** environment is virtual and scoped to your browser session — it only shows workflows running on the machine that started `npx novu@latest dev`. It is not a shared environment for the organization.
+
+When you trigger a workflow from your application code, Novu normally executes against the Bridge URL synced to the Development (or Production) environment. If several engineers share the same organization, each can instead route those app-fired triggers to their **own** local tunnel by passing `bridgeUrl` on the [trigger request](/api-reference/events/trigger-event):
+
+<Tabs>
+  <Tab title="Node.js">
+```ts
+import { Novu } from "@novu/api";
+
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
+
+await novu.trigger({
+  workflowId: "workflow_identifier",
+  to: { subscriberId: "subscriber-id" },
+  payload: {
+    // your payload
+  },
+  // Full tunnel URL printed by `npx novu@latest dev`
+  bridgeUrl: process.env.NOVU_BRIDGE_URL,
+});
+```
+  </Tab>
+  <Tab title="cURL">
+```bash
+curl -X POST https://api.novu.co/v1/events/trigger \
+  -H "Authorization: ApiKey $NOVU_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "workflow_identifier",
+    "to": { "subscriberId": "subscriber-id" },
+    "payload": {},
+    "bridgeUrl": "'"$NOVU_BRIDGE_URL"'"
+  }'
+```
+  </Tab>
+</Tabs>
+
+Recommended pattern for a team:
+
+1. Each engineer runs `npx novu@latest dev` and copies their tunnel Bridge URL.
+2. Each sets a local env var (for example `NOVU_BRIDGE_URL`) to that URL — including the Bridge Endpoint path, typically `/api/novu`.
+3. Application trigger code passes `bridgeUrl: process.env.NOVU_BRIDGE_URL` so triggers hit that developer's machine.
+
+If you trigger via `@novu/framework`'s `workflow.trigger()`, set `NOVU_BRIDGE_ORIGIN` to the tunnel **origin** only (without the path). The Framework SDK appends `/api/novu` and injects `bridgeUrl` automatically.
+
+<Note>
+  `bridgeUrl` must be a publicly reachable URL (the CLI tunnel qualifies). Private network and `localhost` addresses are rejected for security.
+</Note>
+
 ## Connect to your local server
 
 By default, the CLI will connect to the Novu [Bridge Endpoint](/framework/endpoint) running on your local machine at `http://localhost:4000/api/novu`. If your server is running on a different port or the workflows are served from a different endpoint path you can use the following optional parameters to connect:
@@ -113,5 +172,9 @@ npx novu@latest dev --port 3002 --dashboard-url https://eu.dashboard.novu.co
       While the preview will work, you won't be able to test your notifications by triggering them from the Local environment UI.
     </Warning>
 
+  </Accordion>
+
+  <Accordion title="How do multiple engineers each get triggers on their own machine?">
+    Local mode is per computer, not a shared org environment. Have each engineer pass their personal tunnel URL as `bridgeUrl` on app-fired triggers (for example via a `NOVU_BRIDGE_URL` env var). See [Trigger from your app to your local tunnel](#trigger-from-your-app-to-your-local-tunnel).
   </Accordion>
 </AccordionGroup>

--- a/docs/framework/studio.mdx
+++ b/docs/framework/studio.mdx
@@ -92,6 +92,112 @@ await novu.trigger({
 });
 ```
   </Tab>
+  <Tab title="Python">
+```python
+import os
+import novu_py
+from novu_py import Novu
+
+with Novu(secret_key=os.getenv("NOVU_SECRET_KEY", "")) as novu:
+    novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
+        workflow_id="workflow_identifier",
+        to={"subscriber_id": "subscriber-id"},
+        payload={},
+        # Full tunnel URL printed by `npx novu@latest dev`
+        bridge_url=os.getenv("NOVU_BRIDGE_URL"),
+    ))
+```
+  </Tab>
+  <Tab title="Go">
+```go
+import (
+    "context"
+    "os"
+
+    novugo "github.com/novuhq/novu-go"
+    "github.com/novuhq/novu-go/models/components"
+)
+
+s := novugo.New(novugo.WithSecurity(os.Getenv("NOVU_SECRET_KEY")))
+
+// Full tunnel URL printed by `npx novu@latest dev`
+bridgeURL := os.Getenv("NOVU_BRIDGE_URL")
+
+res, err := s.Trigger(context.Background(), components.TriggerEventRequestDto{
+    WorkflowID: "workflow_identifier",
+    To: components.CreateToSubscriberPayloadDto(components.SubscriberPayloadDto{
+        SubscriberID: "subscriber-id",
+    }),
+    BridgeURL: &bridgeURL,
+}, nil)
+if err != nil {
+    panic(err)
+}
+_ = res
+```
+  </Tab>
+  <Tab title="PHP">
+```php
+use novu;
+use novu\Models\Components;
+
+$sdk = novu\Novu::builder()
+    ->setSecurity(getenv('NOVU_SECRET_KEY'))
+    ->build();
+
+$sdk->trigger(
+    triggerEventRequestDto: new Components\TriggerEventRequestDto(
+        workflowId: 'workflow_identifier',
+        to: new Components\SubscriberPayloadDto(subscriberId: 'subscriber-id'),
+        payload: [],
+        // Full tunnel URL printed by `npx novu@latest dev`
+        bridgeUrl: getenv('NOVU_BRIDGE_URL'),
+    ),
+);
+```
+  </Tab>
+  <Tab title=".NET">
+```csharp
+using Novu;
+using Novu.Models.Components;
+using System.Collections.Generic;
+
+var sdk = new NovuSDK(secretKey: Environment.GetEnvironmentVariable("NOVU_SECRET_KEY"));
+
+await sdk.TriggerAsync(triggerEventRequestDto: new TriggerEventRequestDto() {
+    WorkflowId = "workflow_identifier",
+    To = To.CreateSubscriberPayloadDto(new SubscriberPayloadDto() {
+        SubscriberId = "subscriber-id",
+    }),
+    Payload = new Dictionary<string, object>() {},
+    // Full tunnel URL printed by `npx novu@latest dev`
+    BridgeUrl = Environment.GetEnvironmentVariable("NOVU_BRIDGE_URL"),
+});
+```
+  </Tab>
+  <Tab title="Java">
+```java
+import co.novu.Novu;
+import co.novu.models.components.*;
+import java.util.Map;
+
+Novu novu = Novu.builder()
+    .secretKey(System.getenv("NOVU_SECRET_KEY"))
+    .build();
+
+novu.trigger()
+    .body(TriggerEventRequestDto.builder()
+        .workflowId("workflow_identifier")
+        .to(To2.of(SubscriberPayloadDto.builder()
+            .subscriberId("subscriber-id")
+            .build()))
+        .payload(Map.of())
+        // Full tunnel URL printed by `npx novu@latest dev`
+        .bridgeUrl(System.getenv("NOVU_BRIDGE_URL"))
+        .build())
+    .call();
+```
+  </Tab>
   <Tab title="cURL">
 ```bash
 curl -X POST https://api.novu.co/v1/events/trigger \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Removed `@ApiHideProperty()` from `bridgeUrl` on `TriggerEventRequestDto` and documented it with `@ApiPropertyOptional`, so it appears in OpenAPI and Speakeasy-generated SDKs.
- Documented the per-developer local tunnel pattern on the Local development docs page: pass `bridgeUrl` (e.g. via `NOVU_BRIDGE_URL`) so each engineer’s app-fired triggers hit their own tunnel.
- Added trigger examples for all official server-side SDKs (Node.js, Python, Go, PHP, .NET, Java) plus cURL.

## Why

Teams with multiple engineers on Framework workflows need app-fired triggers to hit each developer’s personal tunnel, not a shared Development Bridge URL. Hiding `bridgeUrl` blocked that pattern in official SDKs.

## Test plan

- [ ] Confirm OpenAPI includes `bridgeUrl` on `POST /v1/events/trigger`
- [ ] Trigger with a valid public tunnel `bridgeUrl` and verify the run hits the local Bridge
- [ ] Trigger without `bridgeUrl` still uses the environment’s synced Bridge URL
- [ ] Docs section renders correctly with all SDK tabs on the Local development page

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06DDPTKNF9/p1783527653839069?thread_ts=1783527653.839069&cid=C06DDPTKNF9)

<div><a href="https://cursor.com/agents/bc-09634a7c-ff97-50ab-9836-e0f35481d299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09634a7c-ff97-50ab-9836-e0f35481d299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes per-trigger Bridge routing for local development. The main changes are:

- Adds `bridgeUrl` to the trigger request OpenAPI schema.
- Documents how developers can pass their own tunnel URL when firing triggers from application code.
- Adds SDK and cURL examples for using `NOVU_BRIDGE_URL` with local tunnels.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after the unused import is removed.

The functional change is small and the docs match the intended local tunnel flow, but the DTO keeps an unused import that can fail lint or strict TypeScript checks.

`apps/api/src/app/events/dtos/trigger-event-request.dto.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a TypeScript AST harness against apps/api/src/app/events/dtos/trigger-event-request.dto.ts to count ApiHideProperty references outside import declarations and verify whether the import is unused.
- Analyzed the OpenAPI metadata generation path using the provided logs and snippet to verify the TriggerEventRequestDto schema, confirming that bridgeUrl is optional.

<a href="https://app.greptile.com/trex/runs/14656654/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/events/dtos/trigger-event-request.dto.ts | Exposes `bridgeUrl` in the trigger request OpenAPI schema, but leaves the removed Swagger decorator imported unused. |
| docs/framework/studio.mdx | Adds local tunnel trigger guidance and server-side SDK examples for passing `bridgeUrl`. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant App as Developer app
participant API as Novu API trigger endpoint
participant Tunnel as Personal tunnel Bridge URL
participant Local as Local Bridge app

App->>API: POST /v1/events/trigger with bridgeUrl
API->>Tunnel: Route workflow engine request
Tunnel->>Local: Proxy to /api/novu on developer machine
Local-->>API: Workflow execution response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant App as Developer app
participant API as Novu API trigger endpoint
participant Tunnel as Personal tunnel Bridge URL
participant Local as Local Bridge app

App->>API: POST /v1/events/trigger with bridgeUrl
API->>Tunnel: Route workflow engine request
Tunnel->>Local: Proxy to /api/novu on developer machine
Local-->>API: Workflow execution response
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/events/dtos/trigger-event-request.dto.ts`, line 1 ([link](https://github.com/novuhq/novu/blob/e063287d146ee7c385f2c87ebfba25ef40afebba/apps/api/src/app/events/dtos/trigger-event-request.dto.ts#L1)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Remove unused import**
   `ApiHideProperty` is no longer referenced after exposing `bridgeUrl`, so this import leaves the changed file with an unused symbol. In repos that enforce unused imports during lint or TypeScript checks, this blocks the API package even though the DTO change itself is valid.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/events/dtos/trigger-event-request.dto.ts
   Line: 1

   Comment:
   **Remove unused import**
   `ApiHideProperty` is no longer referenced after exposing `bridgeUrl`, so this import leaves the changed file with an unused symbol. In repos that enforce unused imports during lint or TypeScript checks, this blocks the API package even though the DTO change itself is valid.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fevents%2Fdtos%2Ftrigger-event-request.dto.ts%0ALine%3A%201%0A%0AComment%3A%0A**Remove%20unused%20import**%0A%60ApiHideProperty%60%20is%20no%20longer%20referenced%20after%20exposing%20%60bridgeUrl%60%2C%20so%20this%20import%20leaves%20the%20changed%20file%20with%20an%20unused%20symbol.%20In%20repos%20that%20enforce%20unused%20imports%20during%20lint%20or%20TypeScript%20checks%2C%20this%20blocks%20the%20API%20package%20even%20though%20the%20DTO%20change%20itself%20is%20valid.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11961&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fevents%2Fdtos%2Ftrigger-event-request.dto.ts%3A1%0A**Remove%20unused%20import**%0A%60ApiHideProperty%60%20is%20no%20longer%20referenced%20after%20exposing%20%60bridgeUrl%60%2C%20so%20this%20import%20leaves%20the%20changed%20file%20with%20an%20unused%20symbol.%20In%20repos%20that%20enforce%20unused%20imports%20during%20lint%20or%20TypeScript%20checks%2C%20this%20blocks%20the%20API%20package%20even%20though%20the%20DTO%20change%20itself%20is%20valid.%0A%0A&pr=11961&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/events/dtos/trigger-event-request.dto.ts:1
**Remove unused import**
`ApiHideProperty` is no longer referenced after exposing `bridgeUrl`, so this import leaves the changed file with an unused symbol. In repos that enforce unused imports during lint or TypeScript checks, this blocks the API package even though the DTO change itself is valid.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(framework): add all SDK examples fo..."](https://github.com/novuhq/novu/commit/e063287d146ee7c385f2c87ebfba25ef40afebba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44711360)</sub>

<!-- /greptile_comment -->