### PR TITLE
feat(framework): keep serverless agent turns alive via waitUntil fixes NV-8313

### DIFF
--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -32,6 +32,30 @@ export interface ServeHandlerOptions {
   client?: Client;
   workflows?: Array<Workflow>;
   agents?: Array<Agent>;
+  /**
+   * Extends the lifetime of the request handler until the given promise settles.
+   *
+   * Agent events are acknowledged immediately while the turn (LLM calls, replies,
+   * tool use) continues in the background. On serverless platforms the runtime is
+   * frozen as soon as the response is sent, so the background work is silently
+   * dropped unless a platform `waitUntil` primitive is provided.
+   *
+   * The Next.js adapter (on Next.js >= 15.1) and the Hono adapter (on Cloudflare
+   * Workers) wire this automatically. Provide it explicitly for other serverless
+   * platforms, or to override the automatic detection.
+   *
+   * @example Cloudflare Workers (without Hono)
+   * ```ts
+   * export default {
+   *   async fetch(request, env, ctx) {
+   *     const handler = serve({ agents: [myAgent], waitUntil: (promise) => ctx.waitUntil(promise) });
+   *
+   *     return handler(request);
+   *   },
+   * };
+   * ```
+   */
+  waitUntil?: (promise: Promise<unknown>) => void;
 }
 
 export type INovuRequestHandlerOptions<Input extends any[] = any[], Output = any> = ServeHandlerOptions & {
@@ -70,6 +94,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
   private readonly http;
   private readonly workflows: Array<Workflow>;
   private readonly agents: Array<Agent>;
+  private readonly waitUntil?: (promise: Promise<unknown>) => void;
 
   constructor(options: INovuRequestHandlerOptions<Input, Output>) {
     this.handler = options.handler;
@@ -79,6 +104,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
     this.http = initApiClient(this.client.secretKey, this.client.apiUrl);
     this.frameworkName = options.frameworkName;
     this.hmacEnabled = this.client.strictAuthentication;
+    this.waitUntil = options.waitUntil;
     this.client.addAgents(this.agents);
   }
 
@@ -164,7 +190,8 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
         action,
         agentId,
         agentEvent,
-        actions.waitUntil
+        // An explicitly provided `waitUntil` overrides the adapter's automatic detection.
+        this.waitUntil ?? actions.waitUntil
       );
       const getActionMap = this.getGetActionMap(workflowId, stepId);
 
@@ -235,11 +262,44 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
 
         if (waitUntil) {
           waitUntil(handlerPromise);
+        } else {
+          this.warnOnUnprotectedServerlessRuntime(agentId);
         }
 
         return this.createResponse(HttpStatusEnum.OK, { status: 'ack' });
       },
     };
+  }
+
+  /**
+   * Agent events are acknowledged immediately and the turn continues in the
+   * background. On serverless platforms the runtime freezes once the response
+   * is sent, so without a `waitUntil` primitive the turn is silently dropped
+   * mid-flight. Detecting the known freeze-prone platforms lets us surface an
+   * actionable warning instead of logs that just stop with no error.
+   */
+  private warnOnUnprotectedServerlessRuntime(agentId: string): void {
+    let detectedPlatform: string | undefined;
+
+    try {
+      if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
+        detectedPlatform = 'AWS Lambda';
+      } else if (process.env.VERCEL) {
+        detectedPlatform = 'Vercel';
+      }
+    } catch {
+      // `process` is unavailable on some edge runtimes.
+    }
+
+    if (!detectedPlatform) {
+      return;
+    }
+
+    this.client.logger.warn(
+      `[agent:${agentId}] Agent event acknowledged without a \`waitUntil\` primitive while running on ${detectedPlatform}. ` +
+        `The runtime may freeze once the response is sent, silently dropping the rest of the agent turn. ` +
+        `Pass \`waitUntil\` to \`serve()\` (e.g. \`serve({ agents, waitUntil })\`) to extend the invocation lifetime.`
+    );
   }
 
   public triggerAction(triggerEvent: EventTriggerParams) {

--- a/packages/framework/src/handler.wait-until.test.ts
+++ b/packages/framework/src/handler.wait-until.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import { Client } from './client';
+import { PostActionEnum } from './constants';
+import { type IActionResponse, NovuRequestHandler } from './handler';
+import { agent } from './resources/agent/agent.resource';
+import type { AgentMessage, AgentMessageContext } from './resources/agent/agent.types';
+import { createMockBridgeRequest } from './resources/agent/bridge-request.fixture';
+import type { Logger } from './types';
+
+type OnMessageMock = Mock<(message: AgentMessage, ctx: AgentMessageContext) => Promise<void>>;
+
+describe('agent event waitUntil', () => {
+  let logger: Logger;
+  let client: Client;
+  let onMessageSpy: OnMessageMock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    client = new Client({ secretKey: 'test-secret-key', strictAuthentication: false, logger });
+    onMessageSpy = vi.fn(async () => {});
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ data: { status: 'ok' } })),
+      json: () => Promise.resolve({ data: { status: 'ok' } }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  function buildHandler({
+    optionWaitUntil,
+    adapterWaitUntil,
+  }: {
+    optionWaitUntil?: (promise: Promise<unknown>) => void;
+    adapterWaitUntil?: (promise: Promise<unknown>) => void;
+  }) {
+    const testBot = agent('test-bot', { onMessage: onMessageSpy });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      waitUntil: optionWaitUntil,
+      handler: () => {
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => createMockBridgeRequest(),
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: IActionResponse<string>) => res,
+          waitUntil: adapterWaitUntil,
+        };
+      },
+    });
+
+    return handler.createHandler();
+  }
+
+  it('passes the dispatch promise to the serve() waitUntil option and still acks immediately', async () => {
+    const waitUntil = vi.fn();
+    const handler = buildHandler({ optionWaitUntil: waitUntil });
+
+    const result = await handler();
+
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).status).toBe('ack');
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(waitUntil.mock.calls[0][0]).toBeInstanceOf(Promise);
+
+    await waitUntil.mock.calls[0][0];
+    expect(onMessageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the adapter-provided waitUntil when no option is given', async () => {
+    const adapterWaitUntil = vi.fn();
+    const handler = buildHandler({ adapterWaitUntil });
+
+    const result = await handler();
+
+    expect(result.status).toBe(200);
+    expect(adapterWaitUntil).toHaveBeenCalledTimes(1);
+
+    await adapterWaitUntil.mock.calls[0][0];
+    expect(onMessageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers the explicit serve() option over the adapter-provided waitUntil', async () => {
+    const optionWaitUntil = vi.fn();
+    const adapterWaitUntil = vi.fn();
+    const handler = buildHandler({ optionWaitUntil, adapterWaitUntil });
+
+    await handler();
+
+    expect(optionWaitUntil).toHaveBeenCalledTimes(1);
+    expect(adapterWaitUntil).not.toHaveBeenCalled();
+
+    await optionWaitUntil.mock.calls[0][0];
+  });
+
+  it('warns when acking without waitUntil on Vercel', async () => {
+    vi.stubEnv('VERCEL', '1');
+    const handler = buildHandler({});
+
+    const result = await handler();
+
+    expect(result.status).toBe(200);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain('Vercel');
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain('waitUntil');
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('warns when acking without waitUntil on AWS Lambda', async () => {
+    vi.stubEnv('AWS_LAMBDA_FUNCTION_NAME', 'my-function');
+    const handler = buildHandler({});
+
+    await handler();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain('AWS Lambda');
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not warn when a waitUntil is available, even on a serverless platform', async () => {
+    vi.stubEnv('VERCEL', '1');
+    const waitUntil = vi.fn();
+    const handler = buildHandler({ optionWaitUntil: waitUntil });
+
+    await handler();
+
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    await waitUntil.mock.calls[0][0];
+  });
+
+  it('does not warn on long-lived runtimes without waitUntil', async () => {
+    const handler = buildHandler({});
+
+    const result = await handler();
+
+    expect(result.status).toBe(200);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/framework/src/resources/agent/bridge-request.fixture.ts
+++ b/packages/framework/src/resources/agent/bridge-request.fixture.ts
@@ -1,0 +1,40 @@
+import type { AgentBridgeRequest } from './agent.types';
+
+/** Test-only fixture: a minimal, valid `AgentBridgeRequest` for an `onMessage` turn. */
+export function createMockBridgeRequest(overrides?: Partial<AgentBridgeRequest>): AgentBridgeRequest {
+  return {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    deliveryId: 'del-123',
+    event: 'onMessage',
+    agentId: 'test-bot',
+    replyUrl: 'https://api.novu.co/v1/agents/test-bot/reply',
+    conversationId: 'conv-456',
+    integrationIdentifier: 'slack-main',
+    action: null,
+    reaction: null,
+    message: {
+      text: 'Hello bot!',
+      platformMessageId: 'msg-789',
+      author: { userId: 'u1', fullName: 'Alice', userName: 'alice', isBot: false },
+      timestamp: new Date().toISOString(),
+    },
+    conversation: {
+      identifier: 'conv-456',
+      status: 'active',
+      metadata: {},
+      messageCount: 1,
+      createdAt: new Date().toISOString(),
+      lastActivityAt: new Date().toISOString(),
+    },
+    subscriber: {
+      subscriberId: 'sub-001',
+      firstName: 'Alice',
+      email: 'alice@example.com',
+    },
+    history: [],
+    platform: 'slack',
+    platformContext: { threadId: 't1', channelId: 'c1', isDM: false },
+    ...overrides,
+  };
+}

--- a/packages/framework/src/servers/hono.test.ts
+++ b/packages/framework/src/servers/hono.test.ts
@@ -6,6 +6,7 @@ import { PostActionEnum } from '../constants';
 import { agent } from '../resources/agent/agent.resource';
 import type { AgentMessage, AgentMessageContext } from '../resources/agent/agent.types';
 import { createMockBridgeRequest } from '../resources/agent/bridge-request.fixture';
+import type { Logger } from '../types';
 import { serve } from './hono';
 
 type OnMessageMock = Mock<(message: AgentMessage, ctx: AgentMessageContext) => Promise<void>>;
@@ -53,6 +54,7 @@ describe('hono serve() waitUntil wiring', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -78,6 +80,21 @@ describe('hono serve() waitUntil wiring', () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: 'ack' });
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('surfaces the freeze-prone runtime warning when there is no execution context on AWS Lambda', async () => {
+    vi.stubEnv('AWS_LAMBDA_FUNCTION_NAME', 'my-function');
+    const logger: Logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const warningClient = new Client({ secretKey: 'test-secret-key', strictAuthentication: false, logger });
+    const handler = serve({ agents: [agent('test-bot', { onMessage: onMessageSpy })], client: warningClient });
+
+    const response = await handler(createMockHonoContext({}));
+
+    expect(response.status).toBe(200);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain('AWS Lambda');
 
     await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
   });

--- a/packages/framework/src/servers/hono.test.ts
+++ b/packages/framework/src/servers/hono.test.ts
@@ -1,0 +1,103 @@
+import { type Context } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import { Client } from '../client';
+import { PostActionEnum } from '../constants';
+import { agent } from '../resources/agent/agent.resource';
+import type { AgentMessage, AgentMessageContext } from '../resources/agent/agent.types';
+import { createMockBridgeRequest } from '../resources/agent/bridge-request.fixture';
+import { serve } from './hono';
+
+type OnMessageMock = Mock<(message: AgentMessage, ctx: AgentMessageContext) => Promise<void>>;
+
+function createMockHonoContext({
+  executionCtx,
+}: {
+  executionCtx?: { waitUntil: (promise: Promise<unknown>) => void };
+}) {
+  const url = `http://localhost/api/novu?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`;
+
+  return {
+    req: {
+      json: () => Promise.resolve(createMockBridgeRequest()),
+      header: () => undefined,
+      method: 'POST',
+      query: () => undefined,
+      url,
+    },
+    get executionCtx() {
+      if (!executionCtx) {
+        // Mirrors Hono's behavior on runtimes without an execution context (e.g. Node.js).
+        throw new Error('This context has no ExecutionContext');
+      }
+
+      return executionCtx;
+    },
+  } as unknown as Context;
+}
+
+describe('hono serve() waitUntil wiring', () => {
+  let client: Client;
+  let onMessageSpy: OnMessageMock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    client = new Client({ secretKey: 'test-secret-key', strictAuthentication: false });
+    onMessageSpy = vi.fn(async () => {});
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ data: { status: 'ok' } })),
+      json: () => Promise.resolve({ data: { status: 'ok' } }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('passes the agent dispatch promise to the execution context on Cloudflare Workers', async () => {
+    const waitUntil = vi.fn();
+    const handler = serve({ agents: [agent('test-bot', { onMessage: onMessageSpy })], client });
+
+    const response = await handler(createMockHonoContext({ executionCtx: { waitUntil } }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ack' });
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(waitUntil.mock.calls[0][0]).toBeInstanceOf(Promise);
+
+    await waitUntil.mock.calls[0][0];
+    expect(onMessageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still acks when the runtime has no execution context (e.g. Node.js)', async () => {
+    const handler = serve({ agents: [agent('test-bot', { onMessage: onMessageSpy })], client });
+
+    const response = await handler(createMockHonoContext({}));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ack' });
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('prefers an explicit serve({ waitUntil }) over the execution context', async () => {
+    const executionCtxWaitUntil = vi.fn();
+    const optionWaitUntil = vi.fn();
+    const handler = serve({
+      agents: [agent('test-bot', { onMessage: onMessageSpy })],
+      client,
+      waitUntil: optionWaitUntil,
+    });
+
+    const response = await handler(createMockHonoContext({ executionCtx: { waitUntil: executionCtxWaitUntil } }));
+
+    expect(response.status).toBe(200);
+    expect(optionWaitUntil).toHaveBeenCalledTimes(1);
+    expect(executionCtxWaitUntil).not.toHaveBeenCalled();
+
+    await optionWaitUntil.mock.calls[0][0];
+    expect(onMessageSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/framework/src/servers/hono.ts
+++ b/packages/framework/src/servers/hono.ts
@@ -24,6 +24,10 @@ export const frameworkName: SupportedFrameworkName = 'hono';
  * Using Hono, serve and register any declared workflows with Novu,
  * making them available to be triggered by events.
  *
+ * On Cloudflare Workers, background agent turns are kept alive after the
+ * acknowledgement response via the execution context's `waitUntil`, so agents
+ * work without extra configuration.
+ *
  * @example
  * ```ts
  * import { Hono } from "hono";
@@ -50,6 +54,21 @@ export const serve = (options: ServeHandlerOptions): ((c: Context) => Promise<Re
     handler: (c: Context) => {
       return {
         body: () => c.req.json(),
+        waitUntil: (promise: Promise<unknown>) => {
+          try {
+            /*
+             * On Cloudflare Workers, `waitUntil` extends the invocation
+             * lifetime so background agent turns complete after the
+             * acknowledgement response is sent. Accessing `c.executionCtx`
+             * throws on runtimes without an execution context (e.g. Node.js,
+             * Bun, Deno) — those keep the process alive, so fire-and-forget
+             * is already safe there.
+             */
+            c.executionCtx.waitUntil(promise);
+          } catch {
+            // No execution context available — long-lived runtime.
+          }
+        },
         headers: (key) => c.req.header(key),
         method: () => c.req.method,
         queryString: (key) => c.req.query(key),

--- a/packages/framework/src/servers/hono.ts
+++ b/packages/framework/src/servers/hono.ts
@@ -47,6 +47,30 @@ export const frameworkName: SupportedFrameworkName = 'hono';
  *
  * @public
  */
+/**
+ * On Cloudflare Workers, the execution context's `waitUntil` extends the
+ * invocation lifetime so background agent turns complete after the
+ * acknowledgement response is sent.
+ *
+ * Accessing `c.executionCtx` throws on runtimes without an execution context
+ * (e.g. Node.js, Bun, Deno). Returning `undefined` there — instead of a no-op
+ * callback — lets the core handler surface its freeze-prone runtime warning
+ * (e.g. Hono on AWS Lambda) rather than masking the missing primitive.
+ */
+const getExecutionCtxWaitUntil = (c: Context): ((promise: Promise<unknown>) => void) | undefined => {
+  try {
+    const executionCtx = c.executionCtx;
+
+    if (typeof executionCtx.waitUntil === 'function') {
+      return (promise) => executionCtx.waitUntil(promise);
+    }
+  } catch {
+    // No execution context available.
+  }
+
+  return undefined;
+};
+
 export const serve = (options: ServeHandlerOptions): ((c: Context) => Promise<Response>) => {
   const handler = new NovuRequestHandler({
     frameworkName,
@@ -54,21 +78,7 @@ export const serve = (options: ServeHandlerOptions): ((c: Context) => Promise<Re
     handler: (c: Context) => {
       return {
         body: () => c.req.json(),
-        waitUntil: (promise: Promise<unknown>) => {
-          try {
-            /*
-             * On Cloudflare Workers, `waitUntil` extends the invocation
-             * lifetime so background agent turns complete after the
-             * acknowledgement response is sent. Accessing `c.executionCtx`
-             * throws on runtimes without an execution context (e.g. Node.js,
-             * Bun, Deno) — those keep the process alive, so fire-and-forget
-             * is already safe there.
-             */
-            c.executionCtx.waitUntil(promise);
-          } catch {
-            // No execution context available — long-lived runtime.
-          }
-        },
+        waitUntil: getExecutionCtxWaitUntil(c),
         headers: (key) => c.req.header(key),
         method: () => c.req.method,
         queryString: (key) => c.req.query(key),

--- a/packages/framework/src/servers/next.test.ts
+++ b/packages/framework/src/servers/next.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+import { Client } from '../client';
+import { PostActionEnum } from '../constants';
+import { agent } from '../resources/agent/agent.resource';
+import type { AgentMessage, AgentMessageContext } from '../resources/agent/agent.types';
+import { createMockBridgeRequest } from '../resources/agent/bridge-request.fixture';
+
+type OnMessageMock = Mock<(message: AgentMessage, ctx: AgentMessageContext) => Promise<void>>;
+
+/**
+ * The adapter feature-detects `after()` from `next/server` at module scope, so
+ * each scenario mocks `next/server` and re-imports the adapter with a fresh
+ * module registry.
+ */
+async function importServeWithNextServerMock(nextServerExports: Record<string, unknown>) {
+  vi.doMock('next/server', () => nextServerExports);
+  const { serve } = await import('./next');
+
+  return serve;
+}
+
+function createMockNextRequest() {
+  return {
+    method: 'POST',
+    url: `http://localhost/api/novu?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`,
+    headers: new Headers({ host: 'localhost' }),
+    json: () => Promise.resolve(createMockBridgeRequest()),
+  };
+}
+
+describe('next serve() waitUntil wiring', () => {
+  let client: Client;
+  let onMessageSpy: OnMessageMock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    client = new Client({ secretKey: 'test-secret-key', strictAuthentication: false });
+    onMessageSpy = vi.fn(async () => {});
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ data: { status: 'ok' } })),
+      json: () => Promise.resolve({ data: { status: 'ok' } }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.doUnmock('next/server');
+    vi.restoreAllMocks();
+  });
+
+  it('passes the agent dispatch promise to after() when available (Next.js >= 15.1)', async () => {
+    const afterMock = vi.fn();
+    const serve = await importServeWithNextServerMock({ after: afterMock });
+
+    const { POST } = serve({ agents: [agent('test-bot', { onMessage: onMessageSpy })], client });
+    const response = await POST(createMockNextRequest() as never, undefined);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ack' });
+    expect(afterMock).toHaveBeenCalledTimes(1);
+    expect(afterMock.mock.calls[0][0]).toBeInstanceOf(Promise);
+
+    await afterMock.mock.calls[0][0];
+    expect(onMessageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('acks without a waitUntil when after() is not exported (Next.js < 15.1)', async () => {
+    // `after: undefined` mimics older Next.js versions where the export does not exist.
+    const serve = await importServeWithNextServerMock({ after: undefined });
+
+    const { POST } = serve({ agents: [agent('test-bot', { onMessage: onMessageSpy })], client });
+    const response = await POST(createMockNextRequest() as never, undefined);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ack' });
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('still acks when after() throws (pages router, outside App Router request scope)', async () => {
+    const afterMock = vi.fn(() => {
+      throw new Error('`after` was called outside a request scope');
+    });
+    const serve = await importServeWithNextServerMock({ after: afterMock });
+
+    const { POST } = serve({ agents: [agent('test-bot', { onMessage: onMessageSpy })], client });
+    const response = await POST(createMockNextRequest() as never, undefined);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ack' });
+    expect(afterMock).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('prefers an explicit serve({ waitUntil }) over after()', async () => {
+    const afterMock = vi.fn();
+    const serve = await importServeWithNextServerMock({ after: afterMock });
+    const waitUntil = vi.fn();
+
+    const { POST } = serve({ agents: [agent('test-bot', { onMessage: onMessageSpy })], client, waitUntil });
+    const response = await POST(createMockNextRequest() as never, undefined);
+
+    expect(response.status).toBe(200);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(afterMock).not.toHaveBeenCalled();
+
+    await waitUntil.mock.calls[0][0];
+    expect(onMessageSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/framework/src/servers/next.ts
+++ b/packages/framework/src/servers/next.ts
@@ -1,4 +1,5 @@
 import { type NextApiRequest, type NextApiResponse } from 'next';
+import * as NextServer from 'next/server';
 import { type NextRequest } from 'next/server';
 
 import { NovuRequestHandler, type ServeHandlerOptions } from '../handler';
@@ -31,6 +32,33 @@ export const frameworkName: SupportedFrameworkName = 'next';
  */
 export type RequestHandler = (expectedReq: NextRequest, res: unknown) => Promise<Response>;
 
+/**
+ * Builds a `waitUntil` implementation backed by Next.js `after()` (stable since
+ * Next.js 15.1). `after()` extends the invocation lifetime on serverless
+ * platforms (e.g. Vercel) so background agent turns complete after the
+ * acknowledgement response is sent.
+ *
+ * Feature-detected at runtime: on older Next.js versions `after` is not
+ * exported and this returns `undefined`, preserving the previous behavior.
+ */
+const getAfterWaitUntil = (): ((promise: Promise<unknown>) => void) | undefined => {
+  if (typeof NextServer.after !== 'function') {
+    return undefined;
+  }
+
+  return (promise) => {
+    try {
+      NextServer.after(promise);
+    } catch {
+      /*
+       * `after()` requires an App Router request scope and throws in the
+       * pages router. Fall back to fire-and-forget, matching the behavior
+       * on Next.js versions without `after()`.
+       */
+    }
+  };
+};
+
 // Helper function to check if the response is a Next.js 12 API response
 const isNext12ApiResponse = (val: unknown): val is NextApiResponse => {
   return (
@@ -47,6 +75,11 @@ const isNext12ApiResponse = (val: unknown): val is NextApiResponse => {
  * them available to be triggered by events.
  *
  * Supports Next.js 12+, both serverless and edge.
+ *
+ * On Next.js >= 15.1 (App Router), background agent turns are kept alive after
+ * the acknowledgement response via `after()` from `next/server`, so agents work
+ * on serverless platforms such as Vercel without extra configuration. On older
+ * versions, pass `waitUntil` to `serve()` when deploying to serverless.
  *
  * @example Next.js <=12 or the pages router can export the handler directly
  * ```ts
@@ -89,6 +122,7 @@ export const serve = (
 
       return {
         body: () => (typeof request.json === 'function' ? request.json() : request.body),
+        waitUntil: getAfterWaitUntil(),
         headers: extractHeader,
         method: () => {
           /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed & why

A customer hit a production-only hang with `@novu/framework/next` agents on Vercel: for `action=agent-event` the framework acks immediately and continues the turn in the background via `waitUntil(promise)` — but no server adapter ever set `waitUntil` on the handler response. On serverless platforms the isolate freezes once the response is sent, so everything after the ack (LLM calls, `ctx.typing()`, MCP, `ctx.reply()`) is silently dropped, with logs stopping mid-turn and no error.

### Changes

- **`serve({ waitUntil })` public option** on `ServeHandlerOptions` — universal escape hatch for any platform; an explicit option overrides adapter auto-detection.
- **Next adapter**: auto-wires `after()` from `next/server`, feature-detected at runtime. On Next.js >= 15.1 (App Router), agents now work on Vercel with zero configuration; Next.js >= 12 support is unchanged (no min-version bump). `after()` failures in the pages router are swallowed, preserving today's fire-and-forget behavior.
- **Hono adapter**: auto-wires `executionCtx.waitUntil` for Cloudflare Workers. When the runtime has no execution context (Node/Bun/Deno, or Hono on Lambda), the adapter provides no `waitUntil` at all — long-lived runtimes keep promises alive anyway, and freeze-prone ones fall through to the core warning below.
- **Self-diagnosing warning**: when an agent event is acked with no `waitUntil` on a detected freeze-prone runtime (`AWS_LAMBDA_FUNCTION_NAME`, `VERCEL`), the client logger warns with the exact fix, instead of hanging silently.
- **Lambda intentionally unchanged**: holding the ack until the turn completes would collide with the platform's 30s bridge call timeout + retries (`bridge-executor.service.ts`) and produce duplicate turns. Lambda users get the warning plus the `waitUntil` escape hatch.

```mermaid
flowchart LR
    platform[Novu platform bridge call] -->|"POST action=agent-event"| handler[NovuRequestHandler]
    handler -->|immediate| ack["200 { status: ack }"]
    handler -->|background| dispatch[dispatchAgentEvent promise]
    dispatch --> resolve{waitUntil resolution}
    resolve -->|"serve({ waitUntil }) option"| user[User-provided primitive]
    resolve -->|Next adapter| after["next/server after()"]
    resolve -->|Hono adapter| cf[Cloudflare executionCtx.waitUntil]
    resolve -->|none + Lambda/Vercel env| warn[Actionable warning log]
```

Semver-minor for `@novu/framework` (new public option); no version bump in this PR. Follow-up: document `waitUntil` on the docs.novu.co agents deployment page.

## Testing

- ✅ 15 vitest tests: handler option precedence + warning matrix (`handler.wait-until.test.ts`), Next adapter `after` present/absent/throwing (`servers/next.test.ts`), Hono `executionCtx` present/absent + Lambda warning passthrough (`servers/hono.test.ts`)
- ✅ `pnpm vitest run --typecheck` — at exact parity with `next` base branch (same 2 pre-existing `client.test.ts` failures and 11 pre-existing source typecheck errors, unrelated to this change)
- ✅ `pnpm build` in `packages/framework` (tsup + `attw` export checks + `madge` circular-dependency check)
- ✅ Live smoke test against real Next.js 16.2.10 production server (`next build && next start`): ack returned in 29ms, real `next/server after()` accepted the dispatch promise without throwing, and the deliberately slow 3s agent turn completed in the background:

[next_smoke_test_output.log](https://cursor.com/artifacts/c/art-a47de460-f4c7-42c4-832a-3eb462ce283a)

Vercel-production behavior is verified by documented contract (`after()` delegates to the platform `waitUntil`), since deployment isn't possible from this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80458ee4-e76b-4864-ac65-f494228b216b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80458ee4-e76b-4864-ac65-f494228b216b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `waitUntil` support so background agent turns can continue after an immediate ack. The main changes are:

- New `serve({ waitUntil })` option for serverless keepalive behavior.
- Core agent-event handling now registers the dispatch promise or warns on freeze-prone runtimes.
- Next and Hono adapters now auto-wire platform keepalive primitives where available.
- New tests cover option precedence, serverless warnings, and adapter behavior.

<h3>Confidence Score: 4/5</h3>

One contained adapter issue needs to be fixed before the Next.js serverless path behaves as intended.

Core handler and Hono changes are covered, but the Next adapter calls `after()` with the wrong argument shape, so the main Vercel keepalive path can fall back to fire-and-forget behavior.

`packages/framework/src/servers/next.ts`, `packages/framework/src/servers/next.test.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the after callback contract by running a focused Vitest harness against the Next adapter POST agent-event path; the mock NextServer.after threw unless given a function, the handler returned HTTP 200, and the mock recorded that after() was called with a Promise instead of a callback.
- Validated the overall Vitest execution by running the targeted test suite for handler.wait-until and Next/Hono servers; the run reported 3 test files and 15 tests passing with exit code 0, while the outer shell wrapper showed a PIPESTATUS-related exit, which did not reflect the Vitest command outcome.

<a href="https://app.greptile.com/trex/runs/14671671/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/handler.ts | Adds `waitUntil` option plumbing and serverless warnings for agent-event acknowledgements. |
| packages/framework/src/servers/next.ts | Attempts to wire Next.js `after()` for background agent turns, but passes a `Promise` where the API expects a callback. |
| packages/framework/src/servers/hono.ts | Wires Hono Cloudflare `executionCtx.waitUntil` while preserving warnings when no execution context exists. |
| packages/framework/src/servers/next.test.ts | Covers Next adapter scenarios but mocks `after` permissively, so it misses the callback-shape contract. |
| packages/framework/src/servers/hono.test.ts | Covers Hono `waitUntil` wiring, no-context fallback, AWS warning, and explicit-option precedence. |
| packages/framework/src/handler.wait-until.test.ts | Adds handler-level coverage for option precedence and serverless warning behavior. |
| packages/framework/src/resources/agent/bridge-request.fixture.ts | Introduces a focused test fixture for agent bridge requests. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Bridge as Novu bridge
participant Handler as NovuRequestHandler
participant Adapter as Server adapter
participant WaitUntil as waitUntil/after/executionCtx
participant Agent as Agent dispatch

Bridge->>Handler: "POST action=agent-event"
Handler->>Agent: dispatchAgentEvent()
Handler->>Adapter: resolve explicit or adapter waitUntil
alt waitUntil available
    Adapter->>WaitUntil: register dispatch promise
else no waitUntil on freeze-prone runtime
    Handler->>Handler: log warning
end
Handler-->>Bridge: 200 ack
WaitUntil-->>Agent: keep background turn alive until settled
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Bridge as Novu bridge
participant Handler as NovuRequestHandler
participant Adapter as Server adapter
participant WaitUntil as waitUntil/after/executionCtx
participant Agent as Agent dispatch

Bridge->>Handler: "POST action=agent-event"
Handler->>Agent: dispatchAgentEvent()
Handler->>Adapter: resolve explicit or adapter waitUntil
alt waitUntil available
    Adapter->>WaitUntil: register dispatch promise
else no waitUntil on freeze-prone runtime
    Handler->>Handler: log warning
end
Handler-->>Bridge: 200 ack
WaitUntil-->>Agent: keep background turn alive until settled
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fframework%2Fsrc%2Fservers%2Fnext.ts%3A51%0A**Pass%20callback%20to%20after**%0A%60after%28%29%60%20is%20documented%20as%20taking%20a%20callback%20function%2C%20but%20this%20passes%20the%20dispatch%20%60Promise%60%20object%20directly.%20On%20Next.js%20versions%20that%20enforce%20the%20API%20contract%2C%20the%20adapter's%20%60try%2Fcatch%60%20swallows%20the%20resulting%20failure%2C%20so%20Vercel%20App%20Router%20requests%20still%20ack%20without%20keeping%20the%20agent%20turn%20alive.%0A%0A&pr=11963&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/framework/src/servers/next.ts:51
**Pass callback to after**
`after()` is documented as taking a callback function, but this passes the dispatch `Promise` object directly. On Next.js versions that enforce the API contract, the adapter's `try/catch` swallows the resulting failure, so Vercel App Router requests still ack without keeping the agent turn alive.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(framework): only provide hono waitUn..."](https://github.com/novuhq/novu/commit/7d511e40b256d3808ef96cf45949950f0339d922) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44739721)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->