### PR TITLE
feat(worker,shared): add subscriber preferred hours with channel overrides

### DIFF
--- a/apps/api/migrations/subscribers/add-preferred-hours/add-preferred-hours-migration.spec.ts
+++ b/apps/api/migrations/subscribers/add-preferred-hours/add-preferred-hours-migration.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+import {
+  isValidChannelOverridesShape,
+  isValidPreferredHoursShape,
+  sanitizeInvalidPreferredHours,
+  sanitizeMalformedPreferredHoursObjects,
+} from './add-preferred-hours-migration';
+
+describe('add-preferred-hours migration', () => {
+  it('clears non-object preferredHours values only', async () => {
+    const updateMany = stub().resolves({ matchedCount: 3, modifiedCount: 3 });
+
+    const result = await sanitizeInvalidPreferredHours(updateMany);
+
+    expect(result.invalidCleared).to.deep.equal({ matchedCount: 3, modifiedCount: 3 });
+    expect(updateMany.calledOnce).to.equal(true);
+    const [filter, update] = updateMany.firstCall.args;
+    expect(filter).to.deep.equal({
+      preferredHours: { $exists: true, $not: { $type: 'object' } },
+    });
+    expect(update).to.deep.equal({ $unset: { preferredHours: '' } });
+  });
+
+  it('isValidPreferredHoursShape accepts HH:mm objects and rejects legacy shapes', () => {
+    expect(isValidPreferredHoursShape({ start: '09:00', end: '18:00' })).to.equal(true);
+    expect(isValidPreferredHoursShape({ start: '9:00', end: '18:00' })).to.equal(false);
+    expect(isValidPreferredHoursShape('09:00-18:00')).to.equal(false);
+    expect(isValidPreferredHoursShape({ from: 9, to: 18 })).to.equal(false);
+    expect(isValidPreferredHoursShape(null)).to.equal(false);
+    expect(isValidPreferredHoursShape(undefined)).to.equal(false);
+  });
+
+  it('isValidPreferredHoursShape accepts channelOverrides and rejects invalid ones', () => {
+    expect(
+      isValidPreferredHoursShape({
+        start: '09:00',
+        end: '18:00',
+        channelOverrides: { sms: 'always', email: 'respect' },
+      })
+    ).to.equal(true);
+    expect(
+      isValidPreferredHoursShape({
+        start: '09:00',
+        end: '18:00',
+        channelOverrides: { fax: 'always' },
+      })
+    ).to.equal(false);
+    expect(isValidChannelOverridesShape({ sms: 'always' })).to.equal(true);
+    expect(isValidChannelOverridesShape(['sms'])).to.equal(false);
+  });
+
+  it('does not clear legacy start/end-only preferredHours when adding channelOverrides support', async () => {
+    const docs = [
+      { _id: 'legacy', _environmentId: 'env', preferredHours: { start: '09:00', end: '18:00' } },
+      {
+        _id: 'with-override',
+        _environmentId: 'env',
+        preferredHours: { start: '09:00', end: '18:00', channelOverrides: { sms: 'always' } },
+      },
+    ];
+
+    async function* cursor() {
+      for (const doc of docs) {
+        yield doc;
+      }
+    }
+
+    const updateOne = stub().resolves();
+    const result = await sanitizeMalformedPreferredHoursObjects(cursor, updateOne);
+    expect(result).to.deep.equal({ processed: 2, cleared: 0 });
+    expect(updateOne.callCount).to.equal(0);
+  });
+
+  it('clears malformed object preferredHours via cursor sanitize', async () => {
+    const docs = [
+      { _id: '1', _environmentId: 'env', preferredHours: { start: '09:00', end: '18:00' } },
+      { _id: '2', _environmentId: 'env', preferredHours: { start: '9am', end: '6pm' } },
+      { _id: '3', _environmentId: 'env', preferredHours: { from: 9, to: 18 } },
+    ];
+
+    async function* cursor() {
+      for (const doc of docs) {
+        yield doc;
+      }
+    }
+
+    const updateOne = stub().resolves();
+
+    const result = await sanitizeMalformedPreferredHoursObjects(cursor, updateOne);
+
+    expect(result).to.deep.equal({ processed: 3, cleared: 2 });
+    expect(updateOne.callCount).to.equal(2);
+    expect(updateOne.firstCall.args[0]).to.deep.equal({ _id: '2', _environmentId: 'env' });
+    expect(updateOne.firstCall.args[1]).to.deep.equal({ $unset: { preferredHours: '' } });
+  });
+});

--- a/apps/api/migrations/subscribers/add-preferred-hours/add-preferred-hours-migration.ts
+++ b/apps/api/migrations/subscribers/add-preferred-hours/add-preferred-hours-migration.ts
@@ -1,0 +1,184 @@
+import '../../../src/config';
+
+import { NestFactory } from '@nestjs/core';
+import { PinoLogger } from '@novu/application-generic';
+import { SubscriberRepository } from '@novu/dal';
+import { AppModule } from '../../../src/app.module';
+
+const HH_MM = /^([01]\d|2[0-3]):[0-5]\d$/;
+const VALID_CHANNEL_KEYS = new Set(['in_app', 'email', 'sms', 'chat', 'push']);
+const VALID_POLICIES = new Set(['respect', 'always']);
+
+type UpdateManyFn = (
+  filter: Record<string, unknown>,
+  update: Record<string, unknown>
+) => Promise<{ matchedCount: number; modifiedCount: number }>;
+
+/**
+ * Safe preferredHours migration for existing subscribers.
+ *
+ * Design notes (from local MongoDB inspection of subscriber docs):
+ * - No production top-level `preferredHours` field exists today (0 affected rows
+ *   in local novu-db at channel-overrides rollout; only start/end samples).
+ * - Older/test shapes may carry unrelated keys (`hours`, `schedule`,
+ *   `preferredContactTime`) or nest similar names under `data` — those are
+ *   NOT the schema field and must not be promoted.
+ * - Absence of `preferredHours` already means "no restriction". We intentionally
+ *   do NOT set a default window on existing rows.
+ * - Optional `channelOverrides` is additive: existing `{ start, end }` docs
+ *   remain valid (all channels default to `respect`).
+ *
+ * This migration only cleans invalid top-level `preferredHours` values so a
+ * corrupted shape cannot break the worker send path. Valid values are left alone.
+ */
+export async function sanitizeInvalidPreferredHours(updateMany: UpdateManyFn): Promise<{
+  invalidCleared: { matchedCount: number; modifiedCount: number };
+}> {
+  // Clear preferredHours when it exists but is not a { start, end } object with HH:mm strings.
+  // Mongo cannot fully express HH:mm regex + object shape in a single portable filter,
+  // so we clear clearly-invalid types and leave object shapes for the optional deep scan below.
+  const invalidCleared = await updateMany(
+    {
+      preferredHours: { $exists: true, $not: { $type: 'object' } },
+    },
+    {
+      $unset: { preferredHours: '' },
+    }
+  );
+
+  return { invalidCleared };
+}
+
+/**
+ * Cursor-based deep sanitize for object-shaped preferredHours with bad fields.
+ * Safe to re-run. Existing valid windows are preserved; missing field stays missing
+ * (no restriction).
+ */
+export async function sanitizeMalformedPreferredHoursObjects(
+  findCursor: () => AsyncIterable<{
+    _id: unknown;
+    _environmentId?: unknown;
+    preferredHours?: unknown;
+  }>,
+  updateOne: (filter: Record<string, unknown>, update: Record<string, unknown>) => Promise<void>
+): Promise<{ processed: number; cleared: number }> {
+  let processed = 0;
+  let cleared = 0;
+
+  for await (const doc of findCursor()) {
+    processed += 1;
+    if (isValidPreferredHoursShape(doc.preferredHours)) {
+      continue;
+    }
+
+    await updateOne(
+      {
+        _id: doc._id,
+        ...(doc._environmentId ? { _environmentId: doc._environmentId } : {}),
+      },
+      { $unset: { preferredHours: '' } }
+    );
+    cleared += 1;
+  }
+
+  return { processed, cleared };
+}
+
+export function isValidPreferredHoursShape(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.start !== 'string' || typeof record.end !== 'string') {
+    return false;
+  }
+
+  if (!HH_MM.test(record.start) || !HH_MM.test(record.end)) {
+    return false;
+  }
+
+  if (record.channelOverrides !== undefined && !isValidChannelOverridesShape(record.channelOverrides)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isValidChannelOverridesShape(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  for (const [key, policy] of Object.entries(value as Record<string, unknown>)) {
+    if (!VALID_CHANNEL_KEYS.has(key)) {
+      return false;
+    }
+    if (!VALID_POLICIES.has(policy as string)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export async function run() {
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+
+  const logger = await app.resolve(PinoLogger);
+  logger.setContext('AddPreferredHoursMigration');
+  const subscriberRepository = app.get(SubscriberRepository);
+
+  logger.info('start migration - sanitize preferredHours on subscribers (no default window)');
+
+  const typeResult = await sanitizeInvalidPreferredHours((filter, update) =>
+    subscriberRepository._model.collection.updateMany(filter, update).then((r) => ({
+      matchedCount: r.matchedCount,
+      modifiedCount: r.modifiedCount,
+    }))
+  );
+
+  logger.info(
+    `cleared non-object preferredHours: matched ${typeResult.invalidCleared.matchedCount}, modified ${typeResult.invalidCleared.modifiedCount}`
+  );
+
+  const cursor = subscriberRepository._model
+    .find({ preferredHours: { $exists: true, $type: 'object' } })
+    .select({ _id: 1, _environmentId: 1, preferredHours: 1 })
+    .batchSize(500)
+    .cursor();
+
+  const objectResult = await sanitizeMalformedPreferredHoursObjects(
+    () => cursor as AsyncIterable<{ _id: unknown; _environmentId?: unknown; preferredHours?: unknown }>,
+    async (filter, update) => {
+      await subscriberRepository._model.collection.updateOne(filter, update);
+    }
+  );
+
+  logger.info(
+    `deep sanitize preferredHours objects: processed ${objectResult.processed}, cleared ${objectResult.cleared}`
+  );
+  logger.info(
+    'end migration - existing subscribers without preferredHours remain unrestricted (field absent)'
+  );
+
+  await app.close();
+}
+
+if (require.main === module) {
+  run()
+    .then(() => {
+      console.log('Migration completed successfully');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Migration failed', error);
+      process.exit(1);
+    });
+}

--- a/apps/api/src/app/shared/dtos/base-subscriber-fields.dto.ts
+++ b/apps/api/src/app/shared/dtos/base-subscriber-fields.dto.ts
@@ -1,6 +1,85 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { SubscriberCustomData } from '@novu/shared';
-import { IsEmail, IsLocale, IsObject, IsOptional, IsString, IsTimeZone, ValidateIf } from 'class-validator';
+import {
+  PreferredHours,
+  PreferredHoursChannelOverrides,
+  PreferredHoursChannelPolicy,
+  SubscriberCustomData,
+} from '@novu/shared';
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsIn,
+  IsLocale,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsTimeZone,
+  Matches,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+
+const HH_MM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+const CHANNEL_POLICY_VALUES = ['respect', 'always'] as const satisfies readonly PreferredHoursChannelPolicy[];
+
+export class PreferredHoursChannelOverridesDto implements PreferredHoursChannelOverrides {
+  @ApiPropertyOptional({ enum: CHANNEL_POLICY_VALUES, description: 'In-app channel preferred-hours policy' })
+  @IsOptional()
+  @IsIn(CHANNEL_POLICY_VALUES)
+  in_app?: PreferredHoursChannelPolicy;
+
+  @ApiPropertyOptional({ enum: CHANNEL_POLICY_VALUES, description: 'Email channel preferred-hours policy' })
+  @IsOptional()
+  @IsIn(CHANNEL_POLICY_VALUES)
+  email?: PreferredHoursChannelPolicy;
+
+  @ApiPropertyOptional({ enum: CHANNEL_POLICY_VALUES, description: 'SMS channel preferred-hours policy' })
+  @IsOptional()
+  @IsIn(CHANNEL_POLICY_VALUES)
+  sms?: PreferredHoursChannelPolicy;
+
+  @ApiPropertyOptional({ enum: CHANNEL_POLICY_VALUES, description: 'Chat channel preferred-hours policy' })
+  @IsOptional()
+  @IsIn(CHANNEL_POLICY_VALUES)
+  chat?: PreferredHoursChannelPolicy;
+
+  @ApiPropertyOptional({ enum: CHANNEL_POLICY_VALUES, description: 'Push channel preferred-hours policy' })
+  @IsOptional()
+  @IsIn(CHANNEL_POLICY_VALUES)
+  push?: PreferredHoursChannelPolicy;
+}
+
+export class PreferredHoursDto implements PreferredHours {
+  @ApiPropertyOptional({
+    description: 'Start of the preferred contact window in 24-hour HH:mm format',
+    example: '09:00',
+    type: String,
+  })
+  @IsString()
+  @Matches(HH_MM_PATTERN, { message: 'preferredHours.start must be HH:mm (24-hour)' })
+  start: string;
+
+  @ApiPropertyOptional({
+    description: 'End of the preferred contact window in 24-hour HH:mm format',
+    example: '18:00',
+    type: String,
+  })
+  @IsString()
+  @Matches(HH_MM_PATTERN, { message: 'preferredHours.end must be HH:mm (24-hour)' })
+  end: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Per-channel overrides. `always` lets that channel interrupt outside the window; unset channels default to `respect`.',
+    type: PreferredHoursChannelOverridesDto,
+    example: { sms: 'always', email: 'respect' },
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PreferredHoursChannelOverridesDto)
+  channelOverrides?: PreferredHoursChannelOverridesDto;
+}
 
 export class BaseSubscriberFieldsDto {
   @ApiPropertyOptional({
@@ -79,6 +158,19 @@ export class BaseSubscriberFieldsDto {
   @ValidateIf((obj) => obj.timezone !== null)
   @IsTimeZone()
   timezone?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Daily preferred contact hours in the subscriber timezone. When null/omitted, notifications are not restricted by time of day.',
+    type: PreferredHoursDto,
+    nullable: true,
+    example: { start: '09:00', end: '18:00' },
+  })
+  @IsOptional()
+  @ValidateIf((obj) => obj.preferredHours !== null)
+  @ValidateNested()
+  @Type(() => PreferredHoursDto)
+  preferredHours?: PreferredHoursDto | null;
 
   @ApiPropertyOptional({
     type: Object,

--- a/apps/worker/src/app/workflow/usecases/run-job/preferred-hours-validator.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/preferred-hours-validator.spec.ts
@@ -1,0 +1,217 @@
+import { ChannelTypeEnum, PreferredHours, StepTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import {
+  calculateNextPreferredHoursTime,
+  getChannelPreferredHoursPolicy,
+  isPreferredHoursDeliveryAllowed,
+  isValidPreferredHours,
+  isWithinPreferredHours,
+  shouldApplyPreferredHoursGate,
+} from './preferred-hours-validator';
+
+describe('PreferredHoursValidator', () => {
+  describe('isWithinPreferredHours', () => {
+    it('should return true when preferredHours is unset (no restriction)', () => {
+      expect(isWithinPreferredHours(undefined)).to.be.true;
+      expect(isWithinPreferredHours(null)).to.be.true;
+      expect(isWithinPreferredHours({} as PreferredHours)).to.be.true;
+      expect(isWithinPreferredHours({ start: '09:00' } as PreferredHours)).to.be.true;
+      expect(isWithinPreferredHours({ start: '9am', end: '6pm' })).to.be.true;
+    });
+
+    it('should return true when current time is inside the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      const noonUtc = new Date('2024-01-01T12:00:00.000Z');
+
+      expect(isWithinPreferredHours(preferredHours, noonUtc)).to.be.true;
+    });
+
+    it('should return false when current time is before the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      const early = new Date('2024-01-01T08:00:00.000Z');
+
+      expect(isWithinPreferredHours(preferredHours, early)).to.be.false;
+    });
+
+    it('should return false when current time is after the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      const late = new Date('2024-01-01T19:00:00.000Z');
+
+      expect(isWithinPreferredHours(preferredHours, late)).to.be.false;
+    });
+
+    it('should treat boundary times as inside the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+
+      expect(isWithinPreferredHours(preferredHours, new Date('2024-01-01T09:00:00.000Z'))).to.be.true;
+      expect(isWithinPreferredHours(preferredHours, new Date('2024-01-01T18:00:00.000Z'))).to.be.true;
+    });
+
+    it('should respect subscriber timezone', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      // 14:00 UTC = 09:00 America/New_York (EST, UTC-5) in January
+      const utcAfternoon = new Date('2024-01-01T14:00:00.000Z');
+
+      expect(isWithinPreferredHours(preferredHours, utcAfternoon, 'America/New_York')).to.be.true;
+
+      // 13:00 UTC = 08:00 EST — outside
+      const utcEarlier = new Date('2024-01-01T13:00:00.000Z');
+      expect(isWithinPreferredHours(preferredHours, utcEarlier, 'America/New_York')).to.be.false;
+    });
+
+    it('should handle overnight windows', () => {
+      const preferredHours: PreferredHours = { start: '22:00', end: '06:00' };
+
+      expect(isWithinPreferredHours(preferredHours, new Date('2024-01-01T23:00:00.000Z'))).to.be.true;
+      expect(isWithinPreferredHours(preferredHours, new Date('2024-01-01T03:00:00.000Z'))).to.be.true;
+      expect(isWithinPreferredHours(preferredHours, new Date('2024-01-01T12:00:00.000Z'))).to.be.false;
+    });
+
+    it('should treat equal start and end as no restriction', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '09:00' };
+      const early = new Date('2024-01-01T03:00:00.000Z');
+
+      expect(isWithinPreferredHours(preferredHours, early)).to.be.true;
+    });
+  });
+
+  describe('calculateNextPreferredHoursTime', () => {
+    it('should return current time when preferredHours is unset', () => {
+      const now = new Date('2024-01-01T10:00:00.000Z');
+      expect(calculateNextPreferredHoursTime(undefined, now).getTime()).to.equal(now.getTime());
+      expect(calculateNextPreferredHoursTime(null, now).getTime()).to.equal(now.getTime());
+    });
+
+    it('should return current time when already inside the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      const now = new Date('2024-01-01T12:00:00.000Z');
+
+      expect(calculateNextPreferredHoursTime(preferredHours, now).getTime()).to.equal(now.getTime());
+    });
+
+    it('should return today start when before the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      const now = new Date('2024-01-01T07:30:00.000Z');
+      const expected = new Date('2024-01-01T09:00:00.000Z');
+
+      expect(calculateNextPreferredHoursTime(preferredHours, now).getTime()).to.equal(expected.getTime());
+    });
+
+    it('should return tomorrow start when after the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      const now = new Date('2024-01-01T19:00:00.000Z');
+      const expected = new Date('2024-01-02T09:00:00.000Z');
+
+      expect(calculateNextPreferredHoursTime(preferredHours, now).getTime()).to.equal(expected.getTime());
+    });
+
+    it('should calculate next open in a timezone when outside the window', () => {
+      const preferredHours: PreferredHours = { start: '09:00', end: '18:00' };
+      // 08:00 EST = 13:00 UTC
+      const now = new Date('2024-01-01T13:00:00.000Z');
+      // Next open: 09:00 EST = 14:00 UTC
+      const expected = new Date('2024-01-01T14:00:00.000Z');
+
+      expect(calculateNextPreferredHoursTime(preferredHours, now, 'America/New_York').getTime()).to.equal(
+        expected.getTime()
+      );
+    });
+
+    it('should calculate next open for overnight windows during the daytime gap', () => {
+      const preferredHours: PreferredHours = { start: '22:00', end: '06:00' };
+      const now = new Date('2024-01-01T12:00:00.000Z');
+      const expected = new Date('2024-01-01T22:00:00.000Z');
+
+      expect(calculateNextPreferredHoursTime(preferredHours, now).getTime()).to.equal(expected.getTime());
+    });
+
+    it('should return current time when inside an overnight window', () => {
+      const preferredHours: PreferredHours = { start: '22:00', end: '06:00' };
+      const now = new Date('2024-01-01T23:30:00.000Z');
+
+      expect(calculateNextPreferredHoursTime(preferredHours, now).getTime()).to.equal(now.getTime());
+    });
+  });
+
+  describe('isValidPreferredHours', () => {
+    it('should accept valid HH:mm pairs', () => {
+      expect(isValidPreferredHours({ start: '00:00', end: '23:59' })).to.be.true;
+      expect(isValidPreferredHours({ start: '09:00', end: '18:00' })).to.be.true;
+    });
+
+    it('should reject invalid shapes from older/test data', () => {
+      expect(isValidPreferredHours(undefined)).to.be.false;
+      expect(isValidPreferredHours(null)).to.be.false;
+      expect(isValidPreferredHours({ start: '9:00', end: '18:00' })).to.be.false;
+      expect(isValidPreferredHours({ start: '09:00 AM', end: '06:00 PM' })).to.be.false;
+      expect(isValidPreferredHours({ start: 9, end: 18 } as unknown as PreferredHours)).to.be.false;
+      expect(isValidPreferredHours('09:00-18:00' as unknown as PreferredHours)).to.be.false;
+    });
+  });
+});
+
+  describe('channelOverrides', () => {
+    const outsideWindow = new Date('2024-01-01T03:00:00.000Z'); // 03:00 UTC, outside 09–18
+    const preferredHours: PreferredHours = {
+      start: '09:00',
+      end: '18:00',
+      channelOverrides: {
+        sms: 'always',
+        email: 'respect',
+      },
+    };
+
+    it('should allow SMS (always) outside the window', () => {
+      expect(isPreferredHoursDeliveryAllowed(preferredHours, 'sms', outsideWindow)).to.be.true;
+      expect(shouldApplyPreferredHoursGate(preferredHours, 'sms')).to.be.false;
+    });
+
+    it('should still gate email (respect) outside the window', () => {
+      expect(isPreferredHoursDeliveryAllowed(preferredHours, 'email', outsideWindow)).to.be.false;
+      expect(shouldApplyPreferredHoursGate(preferredHours, 'email')).to.be.true;
+    });
+
+    it('should default unset channels to respect', () => {
+      expect(isPreferredHoursDeliveryAllowed(preferredHours, 'push', outsideWindow)).to.be.false;
+      expect(getChannelPreferredHoursPolicy(preferredHours, ChannelTypeEnum.PUSH)).to.equal('respect');
+    });
+
+    it('should allow gated channels inside the window', () => {
+      const noon = new Date('2024-01-01T12:00:00.000Z');
+      expect(isPreferredHoursDeliveryAllowed(preferredHours, 'email', noon)).to.be.true;
+    });
+
+    it('should allow all channels when preferredHours is unset', () => {
+      expect(isPreferredHoursDeliveryAllowed(undefined, 'email', outsideWindow)).to.be.true;
+      expect(isPreferredHoursDeliveryAllowed(null, 'sms', outsideWindow)).to.be.true;
+    });
+
+    it('should map StepTypeEnum values to channel policies', () => {
+      expect(isPreferredHoursDeliveryAllowed(preferredHours, StepTypeEnum.SMS, outsideWindow)).to.be.true;
+      expect(isPreferredHoursDeliveryAllowed(preferredHours, StepTypeEnum.EMAIL, outsideWindow)).to.be.false;
+    });
+
+    it('should reject invalid channelOverrides in isValidPreferredHours', () => {
+      expect(
+        isValidPreferredHours({
+          start: '09:00',
+          end: '18:00',
+          channelOverrides: { fax: 'always' } as never,
+        })
+      ).to.be.false;
+      expect(
+        isValidPreferredHours({
+          start: '09:00',
+          end: '18:00',
+          channelOverrides: { sms: 'sometimes' as never },
+        })
+      ).to.be.false;
+      expect(
+        isValidPreferredHours({
+          start: '09:00',
+          end: '18:00',
+          channelOverrides: { sms: 'always' },
+        })
+      ).to.be.true;
+    });
+  });

--- a/apps/worker/src/app/workflow/usecases/run-job/preferred-hours-validator.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/preferred-hours-validator.ts
@@ -1,0 +1,261 @@
+import {
+  ChannelTypeEnum,
+  PreferredHours,
+  PreferredHoursChannelPolicy,
+  STEP_TYPE_TO_CHANNEL_TYPE,
+  StepTypeEnum,
+} from '@novu/shared';
+import { addDays, isAfter, set } from 'date-fns';
+import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
+
+const HH_MM = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+const VALID_CHANNEL_KEYS = new Set<string>(Object.values(ChannelTypeEnum));
+const VALID_POLICIES = new Set<PreferredHoursChannelPolicy>(['respect', 'always']);
+
+/**
+ * Returns true when preferredHours is unset/invalid (no restriction) or when
+ * the current time falls inside the subscriber's preferred daily window.
+ * Does not consider channel overrides — use `shouldApplyPreferredHoursGate` /
+ * `isPreferredHoursDeliveryAllowed` for channel-aware decisions.
+ */
+export function isWithinPreferredHours(
+  preferredHours?: PreferredHours | null,
+  currentTime: Date = new Date(),
+  timezone?: string
+): boolean {
+  if (!isValidPreferredHours(preferredHours)) {
+    return true;
+  }
+
+  const local = timezone ? utcToZonedTime(currentTime, timezone) : currentTime;
+  const minutes = getMinutesSinceMidnight(local, !!timezone);
+  const start = parseHhMmToMinutes(preferredHours.start);
+  const end = parseHhMmToMinutes(preferredHours.end);
+
+  if (start === end) {
+    // Degenerate window (zero length) — treat as no restriction rather than blocking forever.
+    return true;
+  }
+
+  if (end < start) {
+    // Overnight: e.g. 22:00–06:00
+    return minutes >= start || minutes <= end;
+  }
+
+  return minutes >= start && minutes <= end;
+}
+
+/**
+ * Whether preferred-hours gating applies to this channel.
+ * Channels with policy `always` interrupt (bypass the window).
+ * Unset channels default to `respect`.
+ */
+export function shouldApplyPreferredHoursGate(
+  preferredHours?: PreferredHours | null,
+  channelOrStep?: ChannelTypeEnum | StepTypeEnum | string | null
+): boolean {
+  if (!isValidPreferredHours(preferredHours)) {
+    return false;
+  }
+
+  const channel = resolveChannelType(channelOrStep);
+  if (!channel) {
+    // Unknown / non-delivery step — still apply window if we got here
+    return true;
+  }
+
+  return getChannelPreferredHoursPolicy(preferredHours, channel) !== 'always';
+}
+
+/**
+ * True when delivery may proceed now for the given channel:
+ * - no preferredHours restriction, or
+ * - channel is set to always interrupt, or
+ * - current time is inside the preferred window
+ */
+export function isPreferredHoursDeliveryAllowed(
+  preferredHours?: PreferredHours | null,
+  channelOrStep?: ChannelTypeEnum | StepTypeEnum | string | null,
+  currentTime: Date = new Date(),
+  timezone?: string
+): boolean {
+  if (!shouldApplyPreferredHoursGate(preferredHours, channelOrStep)) {
+    return true;
+  }
+
+  return isWithinPreferredHours(preferredHours, currentTime, timezone);
+}
+
+export function getChannelPreferredHoursPolicy(
+  preferredHours: PreferredHours,
+  channel: ChannelTypeEnum
+): PreferredHoursChannelPolicy {
+  const override = preferredHours.channelOverrides?.[channel];
+  if (override === 'always' || override === 'respect') {
+    return override;
+  }
+
+  return 'respect';
+}
+
+export function resolveChannelType(
+  channelOrStep?: ChannelTypeEnum | StepTypeEnum | string | null
+): ChannelTypeEnum | undefined {
+  if (!channelOrStep) {
+    return undefined;
+  }
+
+  if (VALID_CHANNEL_KEYS.has(channelOrStep)) {
+    return channelOrStep as ChannelTypeEnum;
+  }
+
+  return STEP_TYPE_TO_CHANNEL_TYPE.get(channelOrStep);
+}
+
+/**
+ * Next UTC instant when the preferred window opens.
+ * Returns `nowUtc` when there is no restriction or the window is currently open.
+ */
+export function calculateNextPreferredHoursTime(
+  preferredHours?: PreferredHours | null,
+  nowUtc: Date = new Date(),
+  timezone?: string
+): Date {
+  if (!isValidPreferredHours(preferredHours)) {
+    return nowUtc;
+  }
+
+  if (isWithinPreferredHours(preferredHours, nowUtc, timezone)) {
+    return nowUtc;
+  }
+
+  const localNow = timezone ? utcToZonedTime(nowUtc, timezone) : nowUtc;
+  const startParts = parseHhMm(preferredHours.start);
+  const endParts = parseHhMm(preferredHours.end);
+  const startMinutes = startParts.hours * 60 + startParts.minutes;
+  const endMinutes = endParts.hours * 60 + endParts.minutes;
+  const nowMinutes = getMinutesSinceMidnight(localNow, !!timezone);
+
+  let candidateLocal: Date;
+
+  if (endMinutes < startMinutes) {
+    // Overnight window: outside means between end and start on the same calendar day.
+    // Next open is today's start if we're after end and before start, which is the only outside case.
+    if (nowMinutes > endMinutes && nowMinutes < startMinutes) {
+      candidateLocal = setLocalTime(localNow, startParts, !!timezone);
+    } else {
+      // Should not happen if isWithin returned false, but fall back to next day start.
+      candidateLocal = setLocalTime(addDays(localNow, 1), startParts, !!timezone);
+    }
+  } else if (nowMinutes < startMinutes) {
+    // Before today's window
+    candidateLocal = setLocalTime(localNow, startParts, !!timezone);
+  } else {
+    // After today's window — open tomorrow at start
+    candidateLocal = setLocalTime(addDays(localNow, 1), startParts, !!timezone);
+  }
+
+  // Ensure candidate is strictly in the future (guards ms/clock edge cases)
+  if (!isAfter(candidateLocal, localNow)) {
+    candidateLocal = setLocalTime(addDays(localNow, 1), startParts, !!timezone);
+  }
+
+  if (timezone) {
+    return zonedTimeToUtc(candidateLocal, timezone);
+  }
+
+  return new Date(
+    Date.UTC(
+      candidateLocal.getUTCFullYear(),
+      candidateLocal.getUTCMonth(),
+      candidateLocal.getUTCDate(),
+      candidateLocal.getUTCHours(),
+      candidateLocal.getUTCMinutes(),
+      0,
+      0
+    )
+  );
+}
+
+export function isValidPreferredHours(preferredHours?: PreferredHours | null): preferredHours is PreferredHours {
+  if (!preferredHours || typeof preferredHours !== 'object') {
+    return false;
+  }
+
+  if (typeof preferredHours.start !== 'string' || typeof preferredHours.end !== 'string') {
+    return false;
+  }
+
+  if (!HH_MM.test(preferredHours.start) || !HH_MM.test(preferredHours.end)) {
+    return false;
+  }
+
+  if (preferredHours.channelOverrides !== undefined) {
+    if (!isValidChannelOverrides(preferredHours.channelOverrides)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function isValidChannelOverrides(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  for (const [key, policy] of Object.entries(value as Record<string, unknown>)) {
+    if (!VALID_CHANNEL_KEYS.has(key)) {
+      return false;
+    }
+    if (!VALID_POLICIES.has(policy as PreferredHoursChannelPolicy)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function parseHhMm(value: string): { hours: number; minutes: number } {
+  const match = HH_MM.exec(value);
+  if (!match) {
+    return { hours: 0, minutes: 0 };
+  }
+
+  return { hours: Number(match[1]), minutes: Number(match[2]) };
+}
+
+function parseHhMmToMinutes(value: string): number {
+  const { hours, minutes } = parseHhMm(value);
+
+  return hours * 60 + minutes;
+}
+
+function getMinutesSinceMidnight(date: Date, hasTimezone: boolean): number {
+  const hours = hasTimezone ? date.getHours() : date.getUTCHours();
+  const minutes = hasTimezone ? date.getMinutes() : date.getUTCMinutes();
+
+  return hours * 60 + minutes;
+}
+
+function setLocalTime(
+  day: Date,
+  time: { hours: number; minutes: number },
+  hasTimezone: boolean
+): Date {
+  if (hasTimezone) {
+    return set(day, {
+      hours: time.hours,
+      minutes: time.minutes,
+      seconds: 0,
+      milliseconds: 0,
+    });
+  }
+
+  return new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), day.getUTCDate(), time.hours, time.minutes, 0, 0));
+}

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -31,6 +31,7 @@ import {
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
   FeatureFlagsKeysEnum,
+  PreferredHours,
   Schedule,
   StepTypeEnum,
 } from '@novu/shared';
@@ -47,6 +48,10 @@ import { SendMessageStatus } from '../send-message/send-message-type.usecase';
 import { SetJobAsFailedCommand } from '../update-job-status/set-job-as.command';
 import { SetJobAsFailed } from '../update-job-status/set-job-as-failed.usecase';
 import { RunJobCommand } from './run-job.command';
+import {
+  calculateNextPreferredHoursTime,
+  isPreferredHoursDeliveryAllowed,
+} from './preferred-hours-validator';
 import { calculateNextAvailableTime, isWithinSchedule } from './schedule-validator';
 
 const nr = require('newrelic');
@@ -129,6 +134,7 @@ export class RunJob {
 
     let shouldQueueNextJob = true;
     let isJobExtendedToSubscriberSchedule = false;
+    let isJobQueuedForPreferredHours = false;
     let error: Error | undefined;
     let notification: PartialNotificationEntity | null = null;
 
@@ -189,10 +195,11 @@ export class RunJob {
           _environmentId: job._environmentId,
           _organizationId: job._organizationId,
         },
-        'timezone',
+        'timezone preferredHours',
         { readPreference: 'secondaryPreferred' }
       );
       const timezone = subscriber?.timezone;
+      const preferredHours = subscriber?.preferredHours;
       const isOutsideSubscriberSchedule = schedule?.isEnabled
         ? !isWithinSchedule(schedule, new Date(), timezone)
         : false;
@@ -254,6 +261,32 @@ export class RunJob {
         await this.conditionallyUpdateDeliveryLifecycle(job, WorkflowRunStatusEnum.PROCESSING, workflow, notification);
 
         return;
+      }
+
+      // preferredHours: when set, never drop — always queue until the window opens.
+      // Pipeline / always-on steps (trigger, in-app, delay, digest, http, critical) skip this gate.
+      // Channels with preferredHours.channelOverrides[channel] === 'always' interrupt immediately.
+      if (
+        !this.shouldSkipScheduleCheck(job, notification.critical) &&
+        !isPreferredHoursDeliveryAllowed(preferredHours, job.type, new Date(), timezone)
+      ) {
+        this.logger.info(
+          {
+            jobId: job._id,
+            subscriberId: job.subscriberId,
+            stepType: job.type,
+            preferredHours,
+            timezone,
+          },
+          'The step was queued until the subscriber preferred hours window'
+        );
+
+        isJobQueuedForPreferredHours = await this.queueJobForPreferredHours(job, preferredHours, timezone);
+        if (isJobQueuedForPreferredHours) {
+          shouldQueueNextJob = false;
+
+          return;
+        }
       }
 
       await this.jobRepository.updateStatus(job._environmentId, job._id, JobStatusEnum.RUNNING);
@@ -403,9 +436,11 @@ export class RunJob {
       }
       throw caughtError;
     } finally {
-      if (shouldQueueNextJob && !isJobExtendedToSubscriberSchedule) {
+      const jobDeferredForLater = isJobExtendedToSubscriberSchedule || isJobQueuedForPreferredHours;
+
+      if (shouldQueueNextJob && !jobDeferredForLater) {
         await this.tryQueueNextJobs(job, notification, !!error);
-      } else if (!isJobExtendedToSubscriberSchedule && !error) {
+      } else if (!jobDeferredForLater && !error) {
         // Update workflow run status based on step runs when halting on step failure.
         // Skip when an unexpected exception was thrown — the Bull worker's setJobAsFailed
         // will handle the final status to avoid duplicate traces.
@@ -1035,6 +1070,88 @@ export class RunJob {
         maxExtensions: MAX_EXTENSIONS,
       },
       'Step was extended to the next available time in the subscriber schedule'
+    );
+
+    return true;
+  }
+
+  /**
+   * When a delivery would land outside the subscriber's preferredHours, re-queue
+   * the same job until the next window start. Never drops the notification.
+   */
+  private async queueJobForPreferredHours(
+    job: JobEntity,
+    preferredHours?: PreferredHours | null,
+    timezone?: string
+  ): Promise<boolean> {
+    const nextAvailableTime = calculateNextPreferredHoursTime(preferredHours, new Date(), timezone);
+    const delayMs = Math.max(0, differenceInMilliseconds(nextAvailableTime, new Date()));
+
+    if (delayMs === 0) {
+      return false;
+    }
+
+    await this.jobRepository.updateOne(
+      {
+        _id: job._id,
+        _environmentId: job._environmentId,
+      },
+      {
+        $set: {
+          status: JobStatusEnum.DELAYED,
+        },
+      }
+    );
+
+    const updatedJob = await this.jobRepository.findOne({
+      _id: job._id,
+      _environmentId: job._environmentId,
+    });
+
+    if (!updatedJob) {
+      throw new PlatformException(`Job with id ${job._id} not found`);
+    }
+
+    await this.stepRunRepository.create(updatedJob, {
+      status: JobStatusEnum.DELAYED,
+    });
+
+    await this.createExecutionDetails.execute(
+      CreateExecutionDetailsCommand.create({
+        ...CreateExecutionDetailsCommand.getDetailsFromJob(updatedJob),
+        detail: DetailEnum.STEP_QUEUED_FOR_PREFERRED_HOURS,
+        source: ExecutionDetailsSourceEnum.INTERNAL,
+        status: ExecutionDetailsStatusEnum.PENDING,
+        isTest: false,
+        isRetry: false,
+        raw: JSON.stringify({
+          delayMs,
+          nextAvailableTime: timezone
+            ? formatInTimeZone(nextAvailableTime, timezone, 'yyyy-MM-dd HH:mm:ss zzz')
+            : nextAvailableTime.toISOString(),
+          timezone,
+          preferredHours,
+        }),
+      })
+    );
+
+    await this.addJobUsecase.queueJob({
+      job: updatedJob,
+      delay: delayMs,
+      untilDate: nextAvailableTime,
+      timezone,
+    });
+
+    this.logger.info(
+      {
+        jobId: updatedJob._id,
+        subscriberId: updatedJob.subscriberId,
+        stepType: updatedJob.type,
+        delayMs,
+        nextAvailableTime: nextAvailableTime.toISOString(),
+        preferredHours,
+      },
+      'Step was queued until the subscriber preferred hours window'
     );
 
     return true;

--- a/libs/application-generic/src/dtos/subscribers/subscriber-response.dto.ts
+++ b/libs/application-generic/src/dtos/subscribers/subscriber-response.dto.ts
@@ -99,6 +99,28 @@ export class SubscriberResponseDtoOptional {
     nullable: true,
   })
   timezone?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Daily preferred contact hours (HH:mm) in the subscriber timezone. Null/omitted means no time-of-day restriction. channelOverrides may mark channels as always (interrupt) or respect (default).',
+    type: 'object',
+    nullable: true,
+    additionalProperties: false,
+    properties: {
+      start: { type: 'string', example: '09:00' },
+      end: { type: 'string', example: '18:00' },
+      channelOverrides: {
+        type: 'object',
+        additionalProperties: { type: 'string', enum: ['respect', 'always'] },
+        example: { sms: 'always', email: 'respect' },
+      },
+    },
+  })
+  preferredHours?: {
+    start: string;
+    end: string;
+    channelOverrides?: Partial<Record<string, 'respect' | 'always'>>;
+  } | null;
 }
 
 export class SubscriberResponseDto extends SubscriberResponseDtoOptional {

--- a/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.repository.ts
+++ b/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.repository.ts
@@ -622,6 +622,8 @@ export function mapEventTypeToTitle(eventType: EventType): string {
       return 'Step was extended to the next available time in the subscriber schedule';
     case 'step_skipped_max_extensions_reached':
       return 'Step was executed due to maximum number of subscriber schedule extensions reached';
+    case 'step_queued_for_preferred_hours':
+      return 'Step was queued until the subscriber preferred hours window';
     case 'push_invalid_token_removed':
       return 'Invalid push device token was removed from subscriber';
     case 'topic_subscription_preference_evaluation':

--- a/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.schema.ts
+++ b/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.schema.ts
@@ -208,6 +208,7 @@ export type EventType =
   | 'step_skipped_outside_of_the_schedule'
   | 'step_extended_to_schedule'
   | 'step_skipped_max_extensions_reached'
+  | 'step_queued_for_preferred_hours'
   | 'push_invalid_token_removed'
   | 'topic_subscription_preference_evaluation'
   | 'action_step_execution_failed'

--- a/libs/application-generic/src/usecases/create-execution-details/create-execution-details.usecase.ts
+++ b/libs/application-generic/src/usecases/create-execution-details/create-execution-details.usecase.ts
@@ -141,6 +141,7 @@ const mapDetailToEventType = {
   [DetailEnum.SKIPPED_STEP_OUTSIDE_OF_THE_SCHEDULE]: 'step_skipped_outside_of_the_schedule',
   [DetailEnum.STEP_EXTENDED_TO_SCHEDULE]: 'step_extended_to_schedule',
   [DetailEnum.SKIPPED_STEP_MAX_EXTENSIONS_REACHED]: 'step_skipped_max_extensions_reached',
+  [DetailEnum.STEP_QUEUED_FOR_PREFERRED_HOURS]: 'step_queued_for_preferred_hours',
   [DetailEnum.PUSH_INVALID_TOKEN_REMOVED]: 'push_invalid_token_removed',
 
   [DetailEnum.TOPIC_SUBSCRIPTION_PREFERENCE_EVALUATION]: 'topic_subscription_preference_evaluation',

--- a/libs/application-generic/src/usecases/create-execution-details/types/index.ts
+++ b/libs/application-generic/src/usecases/create-execution-details/types/index.ts
@@ -78,6 +78,7 @@ export enum DetailEnum {
   THROTTLE_WINDOW_IN_PAST = 'Throttle window date is in the past',
   STEP_EXTENDED_TO_SCHEDULE = 'Step was extended to the next available time in the subscriber schedule',
   SKIPPED_STEP_MAX_EXTENSIONS_REACHED = 'Step was executed due to maximum number of subscriber schedule extensions reached',
+  STEP_QUEUED_FOR_PREFERRED_HOURS = 'Step was queued until the subscriber preferred hours window',
   PUSH_INVALID_TOKEN_REMOVED = 'Invalid push device token was removed from subscriber',
   MSTEAMS_BOT_NOT_INSTALLED = 'MS Teams bot is not installed in the team/channel or for the user',
   MSTEAMS_CHANNEL_NOT_FOUND = 'MS Teams channel or user not found',

--- a/libs/dal/src/repositories/subscriber/subscriber.entity.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.entity.ts
@@ -1,4 +1,4 @@
-import { IChannelSettings, ISubscriber, SubscriberCustomData } from '@novu/shared';
+import { IChannelSettings, ISubscriber, PreferredHours, SubscriberCustomData } from '@novu/shared';
 import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
@@ -48,6 +48,11 @@ export class SubscriberEntity implements ISubscriber {
   data?: SubscriberCustomData;
 
   timezone?: string;
+
+  /**
+   * Daily preferred contact hours. Unset/null means no restriction.
+   */
+  preferredHours?: PreferredHours | null;
 }
 
 export type SubscriberDBModel = ChangePropsValueType<SubscriberEntity, '_environmentId' | '_organizationId'>;

--- a/libs/dal/src/repositories/subscriber/subscriber.repository.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.repository.ts
@@ -355,6 +355,7 @@ const UPDATABLE_SUBSCRIBER_FIELDS: readonly (keyof ISubscribersDefine)[] = [
   'data',
   'channels',
   'timezone',
+  'preferredHours',
 ];
 
 function pickUpdatableSubscriberFields(subscriber: ISubscribersDefine): Partial<ISubscribersDefine> {

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -31,6 +31,25 @@ const subscriberSchema = new Schema<SubscriberDBModel>(
     lastOnlineAt: Schema.Types.Date,
     data: Schema.Types.Mixed,
     timezone: Schema.Types.String,
+    /**
+     * Optional daily preferred contact window (HH:mm in the subscriber timezone).
+     * Unset/null means no time-of-day restriction — safe default for existing data.
+     * channelOverrides: Partial<Record<ChannelTypeEnum, 'respect' | 'always'>>
+     * (unset channel => respect). Existing { start, end } docs remain valid.
+     */
+    preferredHours: {
+      type: {
+        start: Schema.Types.String,
+        end: Schema.Types.String,
+        channelOverrides: {
+          type: Schema.Types.Mixed,
+          required: false,
+        },
+      },
+      required: false,
+      _id: false,
+      default: undefined,
+    },
   },
   schemaOptions
 );

--- a/packages/shared/src/dto/subscriber/subscriber.dto.ts
+++ b/packages/shared/src/dto/subscriber/subscriber.dto.ts
@@ -29,6 +29,11 @@ export class SubscriberDto {
   lastOnlineAt?: string;
   data?: Record<string, unknown> | null;
   timezone?: string;
+  preferredHours?: {
+    start: string;
+    end: string;
+    channelOverrides?: Partial<Record<string, 'respect' | 'always'>>;
+  } | null;
 }
 
 export interface ISubscriberFeedResponseDto {
@@ -59,6 +64,11 @@ export interface ISubscriberResponseDto {
   updatedAt: string;
   __v?: number;
   timezone?: string;
+  preferredHours?: {
+    start: string;
+    end: string;
+    channelOverrides?: Partial<Record<string, 'respect' | 'always'>>;
+  } | null;
 }
 
 export type SubscribersListResponseDto = {

--- a/packages/shared/src/types/subscriber.ts
+++ b/packages/shared/src/types/subscriber.ts
@@ -1,5 +1,34 @@
+import { ChannelTypeEnum } from './channel';
 import { ChatProviderIdEnum, PushProviderIdEnum } from './providers';
 import { CustomDataType } from './utils';
+
+/**
+ * Per-channel policy for preferred contact hours.
+ * - `respect` (default): channel is gated by the preferred hours window
+ * - `always`: channel may interrupt / deliver immediately outside the window
+ */
+export type PreferredHoursChannelPolicy = 'respect' | 'always';
+
+/**
+ * Optional per-channel overrides. Unset channels default to `respect`.
+ */
+export type PreferredHoursChannelOverrides = Partial<Record<ChannelTypeEnum, PreferredHoursChannelPolicy>>;
+
+/**
+ * Daily preferred contact hours for a subscriber, evaluated in their timezone.
+ * Times use 24-hour `HH:mm` (e.g. `"09:00"`, `"18:00"`).
+ * When unset/null, notifications are not restricted by time of day.
+ * Overnight windows are supported when `end` is earlier than `start`
+ * (e.g. start `"22:00"`, end `"06:00"`).
+ *
+ * `channelOverrides` lets specific channels (e.g. SMS) always deliver while
+ * quieter channels (e.g. email) continue to respect the window.
+ */
+export type PreferredHours = {
+  start: string;
+  end: string;
+  channelOverrides?: PreferredHoursChannelOverrides;
+};
 
 export interface ISubscriber {
   _id?: string;
@@ -24,6 +53,11 @@ export interface ISubscriber {
   lastOnlineAt?: string;
   data?: SubscriberCustomData;
   timezone?: string;
+  /**
+   * Optional daily window when the subscriber prefers to be contacted.
+   * Absence or null means no time-of-day restriction.
+   */
+  preferredHours?: PreferredHours | null;
   __v?: number;
 }
 
@@ -71,6 +105,7 @@ export interface ISubscriberPayload {
   avatar?: string | null;
   locale?: string | null;
   timezone?: string | null;
+  preferredHours?: PreferredHours | null;
   data?: SubscriberCustomData | null;
   /**
    * @deprecated: use channelEndpoint instead


### PR DESCRIPTION
## Summary

- Adds optional `preferredHours` on the subscriber (`start`/`end` as 24h `HH:mm`, evaluated in the subscriber `timezone`). Unset/null means no time-of-day restriction so existing subscribers keep current behavior.
- Worker send path queues channel delivery until the next open window instead of dropping when outside preferred hours (with the same pipeline skips as schedule: trigger, in-app, delay, digest, http, critical).
- Supports per-channel overrides via `preferredHours.channelOverrides` (`respect` default vs `always` interrupt), e.g. SMS critical alerts can deliver immediately while email still waits.
- Safe migration sanitizes invalid `preferredHours` shapes only; does not force a default window. Unit tests cover gating, channel overrides, and migration sanitization.

## How it works

```mermaid
flowchart TD
  A[RunJob for delivery step] --> B{shouldSkipScheduleCheck?}
  B -->|yes| Z[Send now]
  B -->|no| C{preferredHours set?}
  C -->|no| Z
  C -->|yes| D{channelOverrides channel = always?}
  D -->|yes| Z
  D -->|no / respect| E{within preferred window?}
  E -->|yes| Z
  E -->|no| F[Delay job until next window start]
  F --> G[Re-queue via AddJob]
```

### Example

```json
{
  "timezone": "America/New_York",
  "preferredHours": {
    "start": "09:00",
    "end": "18:00",
    "channelOverrides": {
      "sms": "always",
      "email": "respect"
    }
  }
}
```

## Test plan

- [x] Unit tests for preferred-hours validator (window boundaries, timezone, overnight, channel overrides) — 24 passing
- [x] Unit tests for migration sanitization (invalid shapes, legacy start/end preserved, valid overrides) — 5 passing
- [ ] Manual: create subscriber with preferredHours, trigger email outside window → job delayed
- [ ] Manual: same with `channelOverrides.sms: always` → SMS sends immediately, email delayed
- [ ] Manual: subscriber without preferredHours → unchanged delivery

## Notes

- Local Mongo inspection found no production `preferredHours` / `channelOverrides` data; additive field is backward compatible.
- Linear ticket not linked (Linear MCP unavailable in this environment). Happy to attach `NV-xxxx` if one is created.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds subscriber preferred contact hours and uses them in the worker delivery path. The main changes are:

- New `preferredHours` subscriber field with `start`, `end`, and per-channel override policies.
- API, shared DTO, DAL entity, and response type updates for the new field.
- Worker gating that delays delivery jobs until the next preferred-hours window.
- Migration cleanup for malformed existing `preferredHours` data.
- Trace log and execution detail support for preferred-hours delays.

<h3>Confidence Score: 4/5</h3>

One contained validation bug needs to be fixed before relying on channel overrides.

The worker flow and migration are covered, but malformed override keys can persist and disable preferred-hours gating for that subscriber object.

apps/api/src/app/shared/dtos/base-subscriber-fields.dto.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a focused tsx harness in apps/api that imports the actual BaseSubscriberFieldsDto and validates the provided preferredHours.channelOverrides.fax payload with transform-only class-validator options; the transformed instance retained channelOverrides.fax and validation returned zero errors, showing the unknown override key is accepted.
- Encountered a sandbox/setup blocker due to a missing @novu/testing dependency in e2e/setup.ts.
- After addressing the blocker, ran the validator tests again and they completed with 24 passing tests, including email outside-window delayed/gated behavior and sms always immediate/bypass at the validator level.

<a href="https://app.greptile.com/trex/runs/14672506/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/dtos/base-subscriber-fields.dto.ts | Adds API DTO validation for `preferredHours`, but unknown `channelOverrides` keys can still pass validation and disable worker gating. |
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Integrates preferred-hours checks into the send path and requeues delayed delivery jobs until the next allowed window. |
| apps/worker/src/app/workflow/usecases/run-job/preferred-hours-validator.ts | Implements preferred-hours validation, channel policy resolution, and next-window calculation for worker delivery gating. |
| apps/api/migrations/subscribers/add-preferred-hours/add-preferred-hours-migration.ts | Adds a safe subscriber migration that unsets invalid top-level `preferredHours` values and malformed object shapes without applying defaults. |
| libs/dal/src/repositories/subscriber/subscriber.schema.ts | Adds optional `preferredHours` storage to the subscriber Mongoose schema without a default. |
| packages/shared/src/types/subscriber.ts | Defines shared `PreferredHours` types and adds the field to subscriber interfaces. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Worker as RunJob
  participant SubRepo as SubscriberRepository
  participant Validator as PreferredHoursValidator
  participant JobRepo as JobRepository
  participant AddJob as AddJob
  participant Trace as ExecutionDetails

  Worker->>SubRepo: load timezone + preferredHours
  Worker->>Validator: isPreferredHoursDeliveryAllowed(preferredHours, stepType, now, timezone)
  alt allowed or skipped step
    Worker->>JobRepo: mark RUNNING
    Worker->>Worker: continue send path
  else outside preferred window
    Worker->>Validator: calculateNextPreferredHoursTime(...)
    Worker->>JobRepo: mark DELAYED
    Worker->>Trace: record STEP_QUEUED_FOR_PREFERRED_HOURS
    Worker->>AddJob: queueJob(delay, untilDate)
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Worker as RunJob
  participant SubRepo as SubscriberRepository
  participant Validator as PreferredHoursValidator
  participant JobRepo as JobRepository
  participant AddJob as AddJob
  participant Trace as ExecutionDetails

  Worker->>SubRepo: load timezone + preferredHours
  Worker->>Validator: isPreferredHoursDeliveryAllowed(preferredHours, stepType, now, timezone)
  alt allowed or skipped step
    Worker->>JobRepo: mark RUNNING
    Worker->>Worker: continue send path
  else outside preferred window
    Worker->>Validator: calculateNextPreferredHoursTime(...)
    Worker->>JobRepo: mark DELAYED
    Worker->>Trace: record STEP_QUEUED_FOR_PREFERRED_HOURS
    Worker->>AddJob: queueJob(delay, untilDate)
  end
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fshared%2Fdtos%2Fbase-subscriber-fields.dto.ts%3A78-81%0A**Reject%20unknown%20override%20keys**%0A%60channelOverrides%60%20does%20not%20reject%20extra%20properties%20because%20the%20global%20%60ValidationPipe%60%20only%20has%20%60transform%60%20enabled%2C%20not%20%60whitelist%60%20or%20%60forbidNonWhitelisted%60.%20A%20request%20like%20%60%7B%20preferredHours%3A%20%7B%20start%3A%20'09%3A00'%2C%20end%3A%20'18%3A00'%2C%20channelOverrides%3A%20%7B%20fax%3A%20'always'%20%7D%20%7D%20%7D%60%20is%20accepted%20and%20persisted.%20The%20worker%20then%20marks%20the%20whole%20%60preferredHours%60%20object%20invalid%20and%20sends%20outside%20the%20intended%20window.%20Add%20object-level%20key%20validation%20here.%0A%0A&pr=11965&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/shared/dtos/base-subscriber-fields.dto.ts:78-81
**Reject unknown override keys**
`channelOverrides` does not reject extra properties because the global `ValidationPipe` only has `transform` enabled, not `whitelist` or `forbidNonWhitelisted`. A request like `{ preferredHours: { start: '09:00', end: '18:00', channelOverrides: { fax: 'always' } } }` is accepted and persisted. The worker then marks the whole `preferredHours` object invalid and sends outside the intended window. Add object-level key validation here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker,shared): add subscriber pref..."](https://github.com/novuhq/novu/commit/e2549037c2493c19e6b8f539a8431a2bd6a044c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44744692)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->