### PR TITLE
feat(dashboard): add cross-channel search to Connect Provider drawer

### DIFF
--- a/apps/dashboard/src/components/integrations/components/channel-tabs.tsx
+++ b/apps/dashboard/src/components/integrations/components/channel-tabs.tsx
@@ -11,6 +11,17 @@ type ChannelTabsProps = {
 };
 
 export function ChannelTabs({ integrationsByChannel, searchQuery, onIntegrationSelect }: ChannelTabsProps) {
+  const isSearching = searchQuery.trim().length > 0;
+
+  if (isSearching) {
+    return (
+      <CrossChannelSearchResults
+        integrationsByChannel={integrationsByChannel}
+        onIntegrationSelect={onIntegrationSelect}
+      />
+    );
+  }
+
   return (
     <Tabs defaultValue={INTEGRATION_CHANNELS[0]} className="flex h-full flex-col">
       <TabsList variant="regular" className="bg-background sticky top-0 z-10 gap-6 border-t-0 px-3!">
@@ -39,6 +50,47 @@ export function ChannelTabs({ integrationsByChannel, searchQuery, onIntegrationS
         </TabsContent>
       ))}
     </Tabs>
+  );
+}
+
+function CrossChannelSearchResults({
+  integrationsByChannel,
+  onIntegrationSelect,
+}: {
+  integrationsByChannel: Record<string, IProviderConfig[]>;
+  onIntegrationSelect: (integrationId: string) => void;
+}) {
+  const channelsWithMatches = INTEGRATION_CHANNELS.filter(
+    (channel) => integrationsByChannel[channel]?.length > 0
+  );
+
+  if (channelsWithMatches.length === 0) {
+    return (
+      <div className="text-muted-foreground flex min-h-[200px] items-center justify-center text-center p-3">
+        <p>No integrations match your search</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-3">
+      {channelsWithMatches.map((channel) => (
+        <div key={channel} className="flex flex-col gap-2">
+          <h3 className="text-text-soft text-[11px] font-semibold uppercase tracking-wider">
+            {CHANNEL_TYPE_TO_STRING[channel]}
+          </h3>
+          <div className="flex flex-col gap-2">
+            {integrationsByChannel[channel].map((integration) => (
+              <IntegrationListItem
+                key={integration.id}
+                integration={integration}
+                onClick={() => onIntegrationSelect(integration.id)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/apps/dashboard/src/components/integrations/components/create-integration-sidebar.tsx
+++ b/apps/dashboard/src/components/integrations/components/create-integration-sidebar.tsx
@@ -57,8 +57,6 @@ export function CreateIntegrationSidebar({ isOpened }: CreateIntegrationSidebarP
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // Focus the provider search input whenever the drawer opens on the select
-  // step so users can start typing immediately after clicking Connect Provider.
   useEffect(() => {
     if (isOpened && step === 'select') {
       const timeoutId = setTimeout(() => {

--- a/apps/dashboard/src/components/integrations/components/create-integration-sidebar.tsx
+++ b/apps/dashboard/src/components/integrations/components/create-integration-sidebar.tsx
@@ -1,5 +1,6 @@
 import { ChatProviderIdEnum, providers as novuProviders } from '@novu/shared';
 import { useEffect, useRef, useState } from 'react';
+import { RiSearchLine } from 'react-icons/ri';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
@@ -7,6 +8,7 @@ import { showSuccessToast } from '../../../components/primitives/sonner-helpers'
 import { useSetPrimaryIntegration } from '../../../hooks/use-set-primary-integration';
 import { buildRoute, ROUTES } from '../../../utils/routes';
 import { Button } from '../../primitives/button';
+import { Input } from '../../primitives/input';
 import { UnsavedChangesAlertDialog } from '../../unsaved-changes-alert-dialog';
 import { IntegrationFormData } from '../types';
 import { ChannelTabs } from './channel-tabs';
@@ -42,15 +44,30 @@ export function CreateIntegrationSidebar({ isOpened }: CreateIntegrationSidebarP
     navigate(ROUTES.INTEGRATIONS_CONNECT, { replace: true });
   };
 
-  const { selectedIntegration, step, searchQuery, onIntegrationSelect, onBack } = useSidebarNavigationManager({
-    isOpened,
-    initialProviderId: providerId,
-    onIntegrationSelect: handleIntegrationSelect,
-    onBack: handleBack,
-  });
+  const { selectedIntegration, step, searchQuery, setSearchQuery, onIntegrationSelect, onBack } =
+    useSidebarNavigationManager({
+      isOpened,
+      initialProviderId: providerId,
+      onIntegrationSelect: handleIntegrationSelect,
+      onBack: handleBack,
+    });
 
   const { integrationsByChannel } = useIntegrationList(searchQuery);
   const provider = providers?.find((providerItem) => providerItem.id === (selectedIntegration || providerId));
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the provider search input whenever the drawer opens on the select
+  // step so users can start typing immediately after clicking Connect Provider.
+  useEffect(() => {
+    if (isOpened && step === 'select') {
+      const timeoutId = setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 50);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [isOpened, step]);
 
   // While the user is on the Telegram configure step, the sidebar shows a QR
   // mobile-setup card. If the visitor completes setup on their phone, the
@@ -187,12 +204,24 @@ export function CreateIntegrationSidebar({ isOpened }: CreateIntegrationSidebarP
         onBack={onBack}
       >
         {step === 'select' ? (
-          <div className="scrollbar-custom flex-1 overflow-y-auto">
-            <ChannelTabs
-              integrationsByChannel={integrationsByChannel}
-              searchQuery={searchQuery}
-              onIntegrationSelect={onIntegrationSelect}
-            />
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <div className="border-b p-3">
+              <Input
+                ref={searchInputRef}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search providers across channels..."
+                leadingIcon={RiSearchLine}
+                size="xs"
+              />
+            </div>
+            <div className="scrollbar-custom flex-1 overflow-y-auto">
+              <ChannelTabs
+                integrationsByChannel={integrationsByChannel}
+                searchQuery={searchQuery}
+                onIntegrationSelect={onIntegrationSelect}
+              />
+            </div>
           </div>
         ) : provider ? (
           <>

--- a/apps/dashboard/src/components/integrations/components/hooks/use-integration-list.ts
+++ b/apps/dashboard/src/components/integrations/components/hooks/use-integration-list.ts
@@ -12,12 +12,15 @@ import {
 import { useMemo } from 'react';
 
 export function useIntegrationList(searchQuery: string = '') {
+  const normalizedSearchQuery = searchQuery.trim();
+
   const filteredIntegrations = useMemo(() => {
     if (!providers) return [];
 
     const filtered = providers.filter(
       (provider: IProviderConfig) =>
-        provider.displayName.toLowerCase().includes(searchQuery.toLowerCase()) && !NOVU_PROVIDERS.includes(provider.id)
+        provider.displayName.toLowerCase().includes(normalizedSearchQuery.toLowerCase()) &&
+        !NOVU_PROVIDERS.includes(provider.id)
     );
 
     const popularityOrder: Record<ChannelTypeEnum, ProvidersIdEnum[]> = {
@@ -71,7 +74,7 @@ export function useIntegrationList(searchQuery: string = '') {
 
       return 0;
     });
-  }, [providers, searchQuery]);
+  }, [providers, normalizedSearchQuery]);
 
   const integrationsByChannel = useMemo(() => {
     return Object.values(ChannelTypeEnum).reduce(

--- a/apps/dashboard/src/components/integrations/components/integrations-list.tsx
+++ b/apps/dashboard/src/components/integrations/components/integrations-list.tsx
@@ -12,7 +12,6 @@ type IntegrationsListProps = {
   onItemClick: (item: TableIntegration) => void;
   excludeIntegrationIds?: string[];
   variant?: IntegrationsListVariant;
-  searchQuery?: string;
 };
 
 function IntegrationCardSkeleton() {
@@ -79,36 +78,19 @@ function IntegrationChannelGroupSkeleton({ variant }: { variant?: IntegrationsLi
   );
 }
 
-export function IntegrationsList({
-  onItemClick,
-  excludeIntegrationIds,
-  variant = 'default',
-  searchQuery = '',
-}: IntegrationsListProps) {
+export function IntegrationsList({ onItemClick, excludeIntegrationIds, variant = 'default' }: IntegrationsListProps) {
   const { currentEnvironment, environments } = useEnvironment();
   const { integrations, isLoading } = useFetchIntegrations();
   const availableIntegrations = novuProviders;
 
   const groupedIntegrations = useMemo(() => {
-    const normalizedQuery = searchQuery.toLowerCase().trim();
-
     return integrations
       ?.filter((i) => i.providerId !== EmailProviderIdEnum.NovuAgent)
-      .filter((integration) => {
-        if (!normalizedQuery) {
-          return true;
-        }
-
-        const provider = availableIntegrations.find((p) => p.id === integration.providerId);
-        const providerName = provider?.displayName?.toLowerCase() ?? '';
-        const integrationName = integration.name?.toLowerCase() ?? '';
-
-        return providerName.includes(normalizedQuery) || integrationName.includes(normalizedQuery);
-      })
       .reduce(
         (acc, integration) => {
           const { channel } = integration;
 
+          // Skip integrations without a channel (e.g. agent-runtime integrations).
           if (!channel) {
             return acc;
           }
@@ -123,7 +105,7 @@ export function IntegrationsList({
         },
         {} as Record<ChannelTypeEnum, typeof integrations>
       );
-  }, [integrations, searchQuery, availableIntegrations]);
+  }, [integrations]);
 
   if (isLoading || !currentEnvironment) {
     return (

--- a/apps/dashboard/src/components/integrations/components/integrations-list.tsx
+++ b/apps/dashboard/src/components/integrations/components/integrations-list.tsx
@@ -12,6 +12,7 @@ type IntegrationsListProps = {
   onItemClick: (item: TableIntegration) => void;
   excludeIntegrationIds?: string[];
   variant?: IntegrationsListVariant;
+  searchQuery?: string;
 };
 
 function IntegrationCardSkeleton() {
@@ -78,19 +79,36 @@ function IntegrationChannelGroupSkeleton({ variant }: { variant?: IntegrationsLi
   );
 }
 
-export function IntegrationsList({ onItemClick, excludeIntegrationIds, variant = 'default' }: IntegrationsListProps) {
+export function IntegrationsList({
+  onItemClick,
+  excludeIntegrationIds,
+  variant = 'default',
+  searchQuery = '',
+}: IntegrationsListProps) {
   const { currentEnvironment, environments } = useEnvironment();
   const { integrations, isLoading } = useFetchIntegrations();
   const availableIntegrations = novuProviders;
 
   const groupedIntegrations = useMemo(() => {
+    const normalizedQuery = searchQuery.toLowerCase().trim();
+
     return integrations
       ?.filter((i) => i.providerId !== EmailProviderIdEnum.NovuAgent)
+      .filter((integration) => {
+        if (!normalizedQuery) {
+          return true;
+        }
+
+        const provider = availableIntegrations.find((p) => p.id === integration.providerId);
+        const providerName = provider?.displayName?.toLowerCase() ?? '';
+        const integrationName = integration.name?.toLowerCase() ?? '';
+
+        return providerName.includes(normalizedQuery) || integrationName.includes(normalizedQuery);
+      })
       .reduce(
         (acc, integration) => {
           const { channel } = integration;
 
-          // Skip integrations without a channel (e.g. agent-runtime integrations).
           if (!channel) {
             return acc;
           }
@@ -105,7 +123,7 @@ export function IntegrationsList({ onItemClick, excludeIntegrationIds, variant =
         },
         {} as Record<ChannelTypeEnum, typeof integrations>
       );
-  }, [integrations]);
+  }, [integrations, searchQuery, availableIntegrations]);
 
   if (isLoading || !currentEnvironment) {
     return (

--- a/apps/dashboard/src/pages/integrations-list-page.tsx
+++ b/apps/dashboard/src/pages/integrations-list-page.tsx
@@ -1,8 +1,6 @@
 import { PermissionsEnum } from '@novu/shared';
-import { useCallback, useRef, useState } from 'react';
-import { RiSearchLine } from 'react-icons/ri';
+import { useCallback } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
-import { Input } from '@/components/primitives/input';
 import { PermissionButton } from '@/components/primitives/permission-button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -12,16 +10,14 @@ import { TableIntegration } from '../components/integrations/types';
 
 export function IntegrationsListPage() {
   const navigate = useNavigate();
-  const [searchQuery, setSearchQuery] = useState('');
-  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const onItemClick = (item: TableIntegration) => {
     navigate(buildRoute(ROUTES.INTEGRATIONS_UPDATE, { integrationId: item.integrationId }));
   };
 
-  const onConnectProviderClick = useCallback(() => {
-    searchInputRef.current?.focus();
-  }, []);
+  const onAddIntegrationClickCallback = useCallback(() => {
+    navigate(ROUTES.INTEGRATIONS_CONNECT);
+  }, [navigate]);
 
   return (
     <DashboardLayout
@@ -43,24 +39,14 @@ export function IntegrationsListPage() {
             size="xs"
             variant="primary"
             mode="gradient"
-            onClick={onConnectProviderClick}
+            onClick={onAddIntegrationClickCallback}
             className="mr-2.5"
           >
             Connect Provider
           </PermissionButton>
         </div>
         <TabsContent value="providers" className="mt-0! p-2.5">
-          <div className="mb-4 max-w-sm">
-            <Input
-              ref={searchInputRef}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search providers across channels..."
-              leadingIcon={RiSearchLine}
-              size="xs"
-            />
-          </div>
-          <IntegrationsList onItemClick={onItemClick} searchQuery={searchQuery} />
+          <IntegrationsList onItemClick={onItemClick} />
         </TabsContent>
       </Tabs>
       <Outlet />

--- a/apps/dashboard/src/pages/integrations-list-page.tsx
+++ b/apps/dashboard/src/pages/integrations-list-page.tsx
@@ -1,25 +1,27 @@
 import { PermissionsEnum } from '@novu/shared';
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { RiSearchLine } from 'react-icons/ri';
 import { Outlet, useNavigate } from 'react-router-dom';
+import { Input } from '@/components/primitives/input';
 import { PermissionButton } from '@/components/primitives/permission-button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { DashboardLayout } from '../components/dashboard-layout';
 import { IntegrationsList } from '../components/integrations/components/integrations-list';
 import { TableIntegration } from '../components/integrations/types';
-import { Badge } from '../components/primitives/badge';
 
 export function IntegrationsListPage() {
   const navigate = useNavigate();
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const onItemClick = (item: TableIntegration) => {
     navigate(buildRoute(ROUTES.INTEGRATIONS_UPDATE, { integrationId: item.integrationId }));
   };
 
-  const onAddIntegrationClickCallback = useCallback(() => {
-    navigate(ROUTES.INTEGRATIONS_CONNECT);
-  }, [navigate]);
+  const onConnectProviderClick = useCallback(() => {
+    searchInputRef.current?.focus();
+  }, []);
 
   return (
     <DashboardLayout
@@ -41,14 +43,24 @@ export function IntegrationsListPage() {
             size="xs"
             variant="primary"
             mode="gradient"
-            onClick={onAddIntegrationClickCallback}
+            onClick={onConnectProviderClick}
             className="mr-2.5"
           >
             Connect Provider
           </PermissionButton>
         </div>
         <TabsContent value="providers" className="mt-0! p-2.5">
-          <IntegrationsList onItemClick={onItemClick} />
+          <div className="mb-4 max-w-sm">
+            <Input
+              ref={searchInputRef}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search providers across channels..."
+              leadingIcon={RiSearchLine}
+              size="xs"
+            />
+          </div>
+          <IntegrationsList onItemClick={onItemClick} searchQuery={searchQuery} />
         </TabsContent>
       </Tabs>
       <Outlet />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added a search input at the top of the Connect Provider drawer that lets users find providers across all channel types without switching between the Email / SMS / Push / Chat tabs. The input auto-focuses when the drawer opens, so clicking "Connect Provider" lets users start typing immediately.

**Changes:**
- Added a search `Input` (with `RiSearchLine` icon) at the top of the `CreateIntegrationSidebar` drawer, wired to the existing `searchQuery` state in `useSidebarNavigationManager` (which was previously present but not wired up in the UI).
- Auto-focus the search input via a `useRef` + `useEffect` that runs when the drawer opens on the `select` step.
- Updated `ChannelTabs` so that when a search query is active it renders a **flat cross-channel results list** grouped by channel (with channel headers) instead of the tab UI — this way a single query surfaces matches from every channel at once. When the query is empty, the tabbed UI is restored.

### Screenshots

![Drawer opens with search input auto-focused](https://cursor.com/artifacts/c/art-7530cc2a-e0e3-4205-bc6b-c4487f89119c)
![Searching ](https://cursor.com/artifacts/c/art-b72d3c12-803d-419c-b0ac-d634bfa6f7c6)
![Searching ](https://cursor.com/artifacts/c/art-8753ade0-395c-433c-80a4-5978febbbe2b)

<a href="https://cursor.com/agents/bc-9358532e-bf32-59a0-9fde-56d2dd98c125/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect_provider_drawer_search_demo.mp4"><img src="https://cursor.com/artifacts/c/art-a85c3b7f-d08a-4bd7-bf5e-de7d0e8ac946" alt="connect_provider_drawer_search_demo.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

The `searchQuery` / `setSearchQuery` state in `useSidebarNavigationManager` and the filter in `useIntegrationList` already existed — this PR only adds the UI that consumes them, plus the flat cross-channel results view.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1784209874347029?thread_ts=1784209874.347029&cid=D092998U7KR)

<div><a href="https://cursor.com/agents/bc-9358532e-bf32-59a0-9fde-56d2dd98c125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9358532e-bf32-59a0-9fde-56d2dd98c125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds search to the Connect Provider drawer. The main changes are:

- Adds a focused search input at the top of the provider selection step.
- Uses the existing sidebar search state to filter providers.
- Shows grouped cross-channel search results when a query is active.
- Keeps the original channel tabs when the search query is empty.
- Normalizes whitespace in provider search queries.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are localized to provider picker UI and existing search state wiring. Empty-search behavior keeps the original channel tabs. No functional or security issues were identified in the reviewed changes.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A blocker scenario was logged to explain why Playwright could not proceed without a server URL, noting that /integrations and the Connect Provider drawer could not be opened and UI states could not be captured.

<a href="https://app.greptile.com/trex/runs/14999467/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/integrations/components/channel-tabs.tsx | Adds a grouped cross-channel results view while provider search is active. |
| apps/dashboard/src/components/integrations/components/create-integration-sidebar.tsx | Adds and auto-focuses the provider search input, wired to sidebar search state. |
| apps/dashboard/src/components/integrations/components/hooks/use-integration-list.ts | Trims search input before filtering providers and keeps channel grouping unchanged. |
| apps/dashboard/src/pages/integrations-list-page.tsx | Removes unused imports from the integrations list page. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Sidebar as CreateIntegrationSidebar
participant Nav as useSidebarNavigationManager
participant List as useIntegrationList
participant Tabs as ChannelTabs

User->>Sidebar: Open Connect Provider drawer
Sidebar->>Nav: Initialize select step and searchQuery
Sidebar->>User: Focus search input
User->>Sidebar: Type provider search
Sidebar->>Nav: setSearchQuery(value)
Sidebar->>List: useIntegrationList(searchQuery)
List-->>Sidebar: integrationsByChannel
Sidebar->>Tabs: Render with searchQuery and grouped providers
Tabs-->>User: Show cross-channel grouped results
User->>Tabs: Select provider
Tabs->>Sidebar: onIntegrationSelect(providerId)
Sidebar->>Nav: Move to configure step
Sidebar-->>User: Show provider configuration form
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Sidebar as CreateIntegrationSidebar
participant Nav as useSidebarNavigationManager
participant List as useIntegrationList
participant Tabs as ChannelTabs

User->>Sidebar: Open Connect Provider drawer
Sidebar->>Nav: Initialize select step and searchQuery
Sidebar->>User: Focus search input
User->>Sidebar: Type provider search
Sidebar->>Nav: setSearchQuery(value)
Sidebar->>List: useIntegrationList(searchQuery)
List-->>Sidebar: integrationsByChannel
Sidebar->>Tabs: Render with searchQuery and grouped providers
Tabs-->>User: Show cross-channel grouped results
User->>Tabs: Select provider
Tabs->>Sidebar: onIntegrationSelect(providerId)
Sidebar->>Nav: Move to configure step
Sidebar-->>User: Show provider configuration form
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): trim provider search que..."](https://github.com/novuhq/novu/commit/4f2559b3cbfad0be0e13e1f129570d0187afff96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44804438)</sub>

<!-- /greptile_comment -->