### PR TITLE
fix(dashboard): prioritize payload, subscriber, env in {{ autocomplete fixes NV-8317

### DIFF
--- a/apps/dashboard/src/components/maily/variables.ts
+++ b/apps/dashboard/src/components/maily/variables.ts
@@ -328,7 +328,9 @@ const getRepeatBlockEachVariables = (editor: TiptapEditor): Array<LiquidVariable
   return [{ name: iterableName }];
 };
 
-const dedupAndSortVariables = (variables: Array<Variable>, query: string): Array<Variable> => {
+type SortableVariable = Variable & { boost?: number };
+
+const dedupAndSortVariables = (variables: Array<SortableVariable>, query: string): Array<SortableVariable> => {
   const lowerQuery = query.toLowerCase();
 
   const filteredVariables = variables.filter((variable) => variable.name.toLowerCase().includes(lowerQuery));
@@ -337,8 +339,8 @@ const dedupAndSortVariables = (variables: Array<Variable>, query: string): Array
 
   // Separate digest variables that match the query
   const digestLabels = new Set(DIGEST_VARIABLES.map((v) => v.name));
-  const matchedDigestVariables: Variable[] = [];
-  const others: Variable[] = [];
+  const matchedDigestVariables: SortableVariable[] = [];
+  const others: SortableVariable[] = [];
 
   for (const variable of uniqueVariables) {
     if (digestLabels.has(variable.name)) {
@@ -348,8 +350,13 @@ const dedupAndSortVariables = (variables: Array<Variable>, query: string): Array
     }
   }
 
-  // Sort the non-digest variables
+  // Sort the non-digest variables: preferred namespaces (boost) first, then match quality, then alpha
   const sortedOthers = others.sort((a, b) => {
+    const aBoost = a.boost ?? 0;
+    const bBoost = b.boost ?? 0;
+
+    if (aBoost !== bBoost) return bBoost - aBoost;
+
     const aExact = a.name.toLowerCase() === lowerQuery;
     const bExact = b.name.toLowerCase() === lowerQuery;
     const aStarts = a.name.toLowerCase().startsWith(lowerQuery);

--- a/apps/dashboard/src/utils/liquid-autocomplete.tsx
+++ b/apps/dashboard/src/utils/liquid-autocomplete.tsx
@@ -368,7 +368,10 @@ function getMatchingVariables(
   isContextEnabled?: boolean
 ): LiquidVariable[] {
   const allVariables = [...scopedVariables, ...variables];
-  if (!searchText) return allVariables;
+  if (!searchText) {
+    // Prefer payload → subscriber → env when opening `{{` with an empty query
+    return [...allVariables].sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0) || a.name.localeCompare(b.name));
+  }
 
   const searchTextTrimmed = searchText.trim();
 

--- a/apps/dashboard/src/utils/liquid-autocomplete.tsx
+++ b/apps/dashboard/src/utils/liquid-autocomplete.tsx
@@ -369,7 +369,7 @@ function getMatchingVariables(
 ): LiquidVariable[] {
   const allVariables = [...scopedVariables, ...variables];
   if (!searchText) {
-    // Prefer payload → subscriber → env → payload.* when opening `{{` with an empty query
+    // Prefer payload.* → subscriber.* → env.* → actor.* then root namespaces / rest
     return [...allVariables].sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0) || a.name.localeCompare(b.name));
   }
 

--- a/apps/dashboard/src/utils/liquid-autocomplete.tsx
+++ b/apps/dashboard/src/utils/liquid-autocomplete.tsx
@@ -369,7 +369,7 @@ function getMatchingVariables(
 ): LiquidVariable[] {
   const allVariables = [...scopedVariables, ...variables];
   if (!searchText) {
-    // Prefer payload → subscriber → env when opening `{{` with an empty query
+    // Prefer payload → subscriber → env → payload.* when opening `{{` with an empty query
     return [...allVariables].sort((a, b) => (b.boost ?? 0) - (a.boost ?? 0) || a.name.localeCompare(b.name));
   }
 

--- a/apps/dashboard/src/utils/parseStepVariables.ts
+++ b/apps/dashboard/src/utils/parseStepVariables.ts
@@ -27,6 +27,8 @@ export interface LiquidVariable {
 /**
  * Preferred root namespace order when typing `{{` in the workflow editor.
  * Higher boost ranks higher in CodeMirror / Maily autocomplete.
+ *
+ * Order: payload → subscriber → env → payload.* properties → rest
  */
 export const ROOT_NAMESPACE_BOOST: Record<string, number> = {
   payload: 99,
@@ -34,8 +36,18 @@ export const ROOT_NAMESPACE_BOOST: Record<string, number> = {
   env: 97,
 };
 
-function getRootNamespaceBoost(name: string): number | undefined {
-  return ROOT_NAMESPACE_BOOST[name];
+const PAYLOAD_PROPERTY_BOOST = 96;
+
+export function getVariableBoost(name: string): number | undefined {
+  if (name in ROOT_NAMESPACE_BOOST) {
+    return ROOT_NAMESPACE_BOOST[name];
+  }
+
+  if (name.startsWith('payload.')) {
+    return PAYLOAD_PROPERTY_BOOST;
+  }
+
+  return undefined;
 }
 
 export type FieldDataType = 'string' | 'number' | 'boolean' | 'date' | 'datetime' | 'array' | 'object';
@@ -128,11 +140,15 @@ export function parseStepVariables(
         const fullPath = path ? `${path}.${key}` : key;
 
         if (typeof value === 'object') {
+          const boost = getVariableBoost(fullPath);
+          const boostProps = boost !== undefined ? { boost } : {};
+
           if (value.type === 'array') {
-            result.arrays.push({ name: fullPath });
+            result.arrays.push({ name: fullPath, ...boostProps });
             enhancedVariables.push({
               name: fullPath,
               dataType: 'array',
+              ...boostProps,
             });
 
             if (value.properties) {
@@ -144,13 +160,11 @@ export function parseStepVariables(
               extractProperties(items, `${fullPath}.0`);
             }
           } else if (value.type === 'object') {
-            const boost = getRootNamespaceBoost(fullPath);
-
-            result.namespaces.push({ name: fullPath, ...(boost !== undefined && { boost }) });
+            result.namespaces.push({ name: fullPath, ...boostProps });
             enhancedVariables.push({
               name: fullPath,
               dataType: 'object',
-              ...(boost !== undefined && { boost }),
+              ...boostProps,
             });
 
             extractProperties(value, fullPath);
@@ -158,12 +172,13 @@ export function parseStepVariables(
             const dataType = mapJsonSchemaTypeToFieldType(value);
             const inputType = getInputTypeFromSchema(value);
 
-            result.primitives.push({ name: fullPath });
+            result.primitives.push({ name: fullPath, ...boostProps });
             enhancedVariables.push({
               name: fullPath,
               dataType,
               inputType,
               format: value.format,
+              ...boostProps,
             });
           }
         }

--- a/apps/dashboard/src/utils/parseStepVariables.ts
+++ b/apps/dashboard/src/utils/parseStepVariables.ts
@@ -24,6 +24,20 @@ export interface LiquidVariable {
   isNewSuggestion?: boolean;
 }
 
+/**
+ * Preferred root namespace order when typing `{{` in the workflow editor.
+ * Higher boost ranks higher in CodeMirror / Maily autocomplete.
+ */
+export const ROOT_NAMESPACE_BOOST: Record<string, number> = {
+  payload: 99,
+  subscriber: 98,
+  env: 97,
+};
+
+function getRootNamespaceBoost(name: string): number | undefined {
+  return ROOT_NAMESPACE_BOOST[name];
+}
+
 export type FieldDataType = 'string' | 'number' | 'boolean' | 'date' | 'datetime' | 'array' | 'object';
 
 export interface EnhancedLiquidVariable extends LiquidVariable {
@@ -130,10 +144,13 @@ export function parseStepVariables(
               extractProperties(items, `${fullPath}.0`);
             }
           } else if (value.type === 'object') {
-            result.namespaces.push({ name: fullPath });
+            const boost = getRootNamespaceBoost(fullPath);
+
+            result.namespaces.push({ name: fullPath, ...(boost !== undefined && { boost }) });
             enhancedVariables.push({
               name: fullPath,
               dataType: 'object',
+              ...(boost !== undefined && { boost }),
             });
 
             extractProperties(value, fullPath);

--- a/apps/dashboard/src/utils/parseStepVariables.ts
+++ b/apps/dashboard/src/utils/parseStepVariables.ts
@@ -25,26 +25,23 @@ export interface LiquidVariable {
 }
 
 /**
- * Preferred root namespace order when typing `{{` in the workflow editor.
+ * Preferred nested-namespace order when typing `{{` in the workflow editor.
  * Higher boost ranks higher in CodeMirror / Maily autocomplete.
  *
- * Order: payload → subscriber → env → payload.* properties → rest
+ * Order: payload.* → subscriber.* → env.* → actor.* → root namespaces / rest
  */
-export const ROOT_NAMESPACE_BOOST: Record<string, number> = {
+export const NESTED_NAMESPACE_BOOST: Record<string, number> = {
   payload: 99,
   subscriber: 98,
   env: 97,
+  actor: 96,
 };
 
-const PAYLOAD_PROPERTY_BOOST = 96;
-
 export function getVariableBoost(name: string): number | undefined {
-  if (name in ROOT_NAMESPACE_BOOST) {
-    return ROOT_NAMESPACE_BOOST[name];
-  }
-
-  if (name.startsWith('payload.')) {
-    return PAYLOAD_PROPERTY_BOOST;
+  for (const [namespace, boost] of Object.entries(NESTED_NAMESPACE_BOOST)) {
+    if (name.startsWith(`${namespace}.`)) {
+      return boost;
+    }
   }
 
   return undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

When typing `{{` in the workflow editor, variable autocomplete now ranks as:

1. `payload.*`
2. `subscriber.*`
3. `env.*`
4. `actor.*`
5. root namespaces (`payload`, `subscriber`, `env`, …) and the rest at the end

Previously suggestions were alphabetical (`actor` first), then briefly ranked bare roots above nested fields.

## Why

Authors usually pick concrete fields (`payload.name`, `subscriber.email`) more often than bare namespaces.

## How

- Assign boost only to nested paths under preferred namespaces in `parseStepVariables`
- Sort Maily and CodeMirror empty-query suggestions by that boost

```mermaid
flowchart LR
  A["Type {{"] --> B["Nested boosts"]
  B --> C["payload.* 99"]
  B --> D["subscriber.* 98"]
  B --> E["env.* 97"]
  B --> F["actor.* 96"]
  C --> G["Autocomplete"]
  D --> G
  E --> G
  F --> G
  G --> H["payload / subscriber / env / rest"]
```

## Test plan

- [x] Type `{{` in a CodeMirror control field
- [x] Confirm nested `payload.*` appear first
- [x] Confirm `subscriber.*`, then `env.*`, then `actor.*`
- [x] Confirm bare roots (`payload`, `subscriber`, `env`, `actor`) appear at the end
- [ ] Email body / Maily variable trigger shows the same order
- [ ] Digest helpers still behave sensibly when a digest step is present

### Verification

![Nested payload.* suggestions first](https://cursor.com/artifacts/c/art-9c389f5d-49e8-47c8-b310-5ed00105c603)
![Root namespaces at the end of the list](https://cursor.com/artifacts/c/art-2240b773-65be-4b8c-a5a6-cf6e5c361b13)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf0c12f5-0519-464e-b868-e8d42bbf64d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf0c12f5-0519-464e-b868-e8d42bbf64d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates workflow variable autocomplete ordering. The main changes are:

- Adds boost metadata for preferred Liquid variable namespaces.
- Sorts Maily variable suggestions by boost before match quality and alphabetical order.
- Sorts empty CodeMirror autocomplete results by boost before name.

<h3>Confidence Score: 4/5</h3>

This PR has one contained autocomplete ordering issue.

Exact root namespace suggestions remain unboosted, so the main requested ordering can be incorrect when root namespace suggestions are present. The rest of the change is scoped to autocomplete sorting and does not affect persistence, execution, or security-sensitive paths.

apps/dashboard/src/utils/parseStepVariables.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the root-namespace unranking behavior by running a narrow Node harness over parseStepVariables.ts and liquid-autocomplete.tsx to exercise getVariableBoost and the empty-query comparator, showing getVariableBoost undefined for payload, subscriber, and env while payload.foo boosted to 99 and payload.foo ordering ahead of unboosted roots.
- Collected server/UI validation artifacts showing the dashboard server log with Vite dependency scan errors for @novu/react, the Playwright-observed blank app with 500/504 responses and codemirrorCount=0, and screenshots documenting the blocked UI state.

<a href="https://app.greptile.com/trex/runs/14727427/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/maily/variables.ts | Adds boost-aware sorting for Maily variable suggestions while preserving digest-first handling. |
| apps/dashboard/src/utils/liquid-autocomplete.tsx | Sorts empty CodeMirror autocomplete queries by boost before alphabetical order. |
| apps/dashboard/src/utils/parseStepVariables.ts | Adds variable boost metadata, but exact root namespaces are not boosted. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant Editor as Workflow editor
  participant Parser as parseStepVariables
  participant AC as Autocomplete sorter
  User->>Editor: "Type {{"
  Editor->>Parser: Build LiquidVariable suggestions
  Parser-->>Editor: Variables with optional boost
  Editor->>AC: Empty-query suggestions
  AC-->>Editor: Sort by boost, then name
  Editor-->>User: Render autocomplete list
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant Editor as Workflow editor
  participant Parser as parseStepVariables
  participant AC as Autocomplete sorter
  User->>Editor: "Type {{"
  Editor->>Parser: Build LiquidVariable suggestions
  Parser-->>Editor: Variables with optional boost
  Editor->>AC: Empty-query suggestions
  AC-->>Editor: Sort by boost, then name
  Editor-->>User: Render autocomplete list
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/utils/parseStepVariables.ts`, line 311-332 ([link](https://github.com/novuhq/novu/blob/fd57b64021b5ff5b00d31296879f763aa86ab071/apps/dashboard/src/utils/parseStepVariables.ts#L311-L332)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Add env namespace suggestion**
   `env` still never enters the autocomplete list on this path: `SYSTEM_VARIABLE_DEFINITIONS` only makes `env.name` and `env.type` valid in `isAllowedVariable`, while `variables` is built from schema primitives, arrays, and namespaces. When opening `{{`, the sorter cannot place `env` third because no `env` item exists to sort.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused parseStepVariables harness](https://app.greptile.com/trex/artifacts/d3b6aeaa-7c62-480a-832e-ae7829a89225)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: harness execution output showing missing root env suggestion](https://app.greptile.com/trex/artifacts/d50263d3-87bd-4eb7-a3cc-e5358d754b5f)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14705206/artifacts?artifact=d3b6aeaa-7c62-480a-832e-ae7829a89225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/utils/parseStepVariables.ts
   Line: 311-332

   Comment:
   **Add env namespace suggestion**
   `env` still never enters the autocomplete list on this path: `SYSTEM_VARIABLE_DEFINITIONS` only makes `env.name` and `env.type` valid in `isAllowedVariable`, while `variables` is built from schema primitives, arrays, and namespaces. When opening `{{`, the sorter cannot place `env` third because no `env` item exists to sort.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Futils%2FparseStepVariables.ts%0ALine%3A%20311-332%0A%0AComment%3A%0A**Add%20env%20namespace%20suggestion**%0A%60env%60%20still%20never%20enters%20the%20autocomplete%20list%20on%20this%20path%3A%20%60SYSTEM_VARIABLE_DEFINITIONS%60%20only%20makes%20%60env.name%60%20and%20%60env.type%60%20valid%20in%20%60isAllowedVariable%60%2C%20while%20%60variables%60%20is%20built%20from%20schema%20primitives%2C%20arrays%2C%20and%20namespaces.%20When%20opening%20%60%7B%7B%60%2C%20the%20sorter%20cannot%20place%20%60env%60%20third%20because%20no%20%60env%60%20item%20exists%20to%20sort.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11972&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Futils%2FparseStepVariables.ts%3A27-48%0A**Root%20namespaces%20unranked**%0A%60getVariableBoost%60%20only%20matches%20names%20with%20a%20trailing%20dot%2C%20so%20schema%20namespaces%20named%20exactly%20%60payload%60%2C%20%60subscriber%60%2C%20or%20%60env%60%20receive%20no%20boost.%20With%20the%20new%20empty-query%20sort%2C%20boosted%20%60payload.*%60%20fields%20are%20listed%20before%20the%20unboosted%20roots%2C%20which%20breaks%20the%20requested%20%60payload%60%2C%20%60subscriber%60%2C%20%60env%60%2C%20then%20%60payload.*%60%20order.%0A%0A%60%60%60suggestion%0A%2F**%0A%20*%20Preferred%20namespace%20order%20when%20typing%20%60%7B%7B%60%20in%20the%20workflow%20editor.%0A%20*%20Higher%20boost%20ranks%20higher%20in%20CodeMirror%20%2F%20Maily%20autocomplete.%0A%20*%0A%20*%20Order%3A%20payload%20%E2%86%92%20subscriber%20%E2%86%92%20env%20%E2%86%92%20payload.*%20%E2%86%92%20root%20namespaces%20%2F%20rest%0A%20*%2F%0Aexport%20const%20ROOT_NAMESPACE_BOOST%3A%20Record%3Cstring%2C%20number%3E%20%3D%20%7B%0A%20%20payload%3A%2099%2C%0A%20%20subscriber%3A%2098%2C%0A%20%20env%3A%2097%2C%0A%7D%3B%0A%0Aexport%20const%20NESTED_NAMESPACE_BOOST%3A%20Record%3Cstring%2C%20number%3E%20%3D%20%7B%0A%20%20payload%3A%2096%2C%0A%7D%3B%0A%0Aexport%20function%20getVariableBoost%28name%3A%20string%29%3A%20number%20%7C%20undefined%20%7B%0A%20%20const%20rootBoost%20%3D%20ROOT_NAMESPACE_BOOST%5Bname%5D%3B%0A%0A%20%20if%20%28rootBoost%20!%3D%3D%20undefined%29%20%7B%0A%20%20%20%20return%20rootBoost%3B%0A%20%20%7D%0A%0A%20%20for%20%28const%20%5Bnamespace%2C%20boost%5D%20of%20Object.entries%28NESTED_NAMESPACE_BOOST%29%29%20%7B%0A%20%20%20%20if%20%28name.startsWith%28%60%24%7Bnamespace%7D.%60%29%29%20%7B%0A%20%20%20%20%20%20return%20boost%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%0A%20%20return%20undefined%3B%0A%7D%0A%60%60%60%0A%0A&pr=11972&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/utils/parseStepVariables.ts:27-48
**Root namespaces unranked**
`getVariableBoost` only matches names with a trailing dot, so schema namespaces named exactly `payload`, `subscriber`, or `env` receive no boost. With the new empty-query sort, boosted `payload.*` fields are listed before the unboosted roots, which breaks the requested `payload`, `subscriber`, `env`, then `payload.*` order.

```suggestion
/**
 * Preferred namespace order when typing `{{` in the workflow editor.
 * Higher boost ranks higher in CodeMirror / Maily autocomplete.
 *
 * Order: payload → subscriber → env → payload.* → root namespaces / rest
 */
export const ROOT_NAMESPACE_BOOST: Record<string, number> = {
  payload: 99,
  subscriber: 98,
  env: 97,
};

export const NESTED_NAMESPACE_BOOST: Record<string, number> = {
  payload: 96,
};

export function getVariableBoost(name: string): number | undefined {
  const rootBoost = ROOT_NAMESPACE_BOOST[name];

  if (rootBoost !== undefined) {
    return rootBoost;
  }

  for (const [namespace, boost] of Object.entries(NESTED_NAMESPACE_BOOST)) {
    if (name.startsWith(`${namespace}.`)) {
      return boost;
    }
  }

  return undefined;
}
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): rank nested namespace va..."](https://github.com/novuhq/novu/commit/03e1e2a644c279669e6cdfb9affd97a00feed1a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44813814)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->