### PR TITLE
fix(docs): update context filtering explanation and examples in documentation fixes DOC-419

### DIFF
--- a/docs/platform/inbox/configuration/inbox-with-context.mdx
+++ b/docs/platform/inbox/configuration/inbox-with-context.mdx
@@ -15,22 +15,24 @@ _Contexts_ let you scope each `<Inbox />` instance to a specific environment, te
 
 ## How context works in `<Inbox/>`
 
-The [`<Inbox />`](/platform/inbox/configuration/inbox-with-context) uses exact-match context filtering to determine which notifications to display. This means the context provided to the [`<Inbox />`](/platform/inbox/configuration/inbox-with-context) must match all the key-value pairs of the context used when the workflow was triggered.
+The [`<Inbox />`](/platform/inbox/configuration/inbox-with-context) filters notifications by context **type and id**. Each entry in the context object resolves to a key like `tenant:acme`. The Inbox only shows notifications whose trigger used the same set of keys.
 
-This creates predictable isolation and ensures notifications are scoped to the context provided. If the contexts do not match exactly, the notification will not be delivered to that Inbox session. 
+Nested `data` is optional metadata for personalization. It is stored on the context entity but **does not** affect which notifications appear in the Inbox.
 
 - If workflow is triggered with a context but Inbox is initialized without a context, the notification will not be delivered to that Inbox session.
 - If workflow is triggered without a context but Inbox is initialized with a context, the notification will not be delivered to that Inbox session.
 - If workflow is triggered with a context but Inbox is initialized with a different context, the notification will not be delivered to that Inbox session.
 
-| Workflow Context                           | Inbox Context            | Displayed? |
-| ------------------------------------------ | ------------------------ | ---------- |
-| `{ "tenant": "acme" }`                     | `{ "tenant": "acme" }`   |  Yes       |
-| `{}`                                       | `{}`                     |  Yes       |
-| `{}`                                       | `{ "tenant": "acme" }`   |  No        |
-| `{ "tenant": "acme" }`                     | `{ "tenant": "globex" }` |  No        |
-| `{ "tenant": "acme" }`                     | `{}`                     |  No        |
-| `{ "tenant": "acme" }, { "app": "first" }` | `{ "tenant": "acme" }`   |  No        |
+| Workflow Context | Inbox Context | Displayed? |
+| --- | --- | --- |
+| `{ "tenant": "acme" }` | `{ "tenant": "acme" }` | Yes |
+| `{ "tenant": { "id": "acme", "data": { "name": "Acme" } } }` | `{ "tenant": { "id": "acme" } }` | Yes |
+| `{ "tenant": "acme" }` | `{ "tenant": { "id": "acme" } }` | Yes |
+| `{}` | `{}` | Yes |
+| `{}` | `{ "tenant": "acme" }` | No |
+| `{ "tenant": "acme" }` | `{ "tenant": "globex" }` | No |
+| `{ "tenant": "acme" }` | `{}` | No |
+| `{ "tenant": "acme", "app": "first" }` | `{ "tenant": "acme" }` | No |
 
 ### Creating context via `<Inbox/>`
 
@@ -69,7 +71,7 @@ import { Inbox } from '@novu/react';
 />
 ```
 
-When a workflow with these exact context is triggered, as seen below
+When a workflow is triggered with the same context type and id, as seen below
 
 ![Context in trigger](/images/inbox/context-trigger.png)
 
@@ -87,8 +89,12 @@ Because the context prop is set on the client-side, a malicious user could poten
 
 To prevent this, you must fetch the context details and contextHash from your server and pass them to the Inbox component.
 
+When HMAC is enabled on your in-app integration, `subscriberHash` is always required. `contextHash` is also required if you pass a `context` prop to `<Inbox />`. If you do not pass `context`, you only need `subscriberHash`.
+
+`contextHash` is separate from notification matching. It verifies the exact `context` object you pass to `<Inbox />`, including any `data` fields. Hash the same object you send to the component.
+
 <Note>
-  We need to use `canonicalize` here, cause context is a dynamic object. `canonicalize` is used to serialize the JSON in a way that the order of keys or whitespaces etc doesn’t matter. The library should be based on [RFC-8259](https://datatracker.ietf.org/doc/html/rfc8259).
+  Use `canonicalize` when computing `contextHash`. Context is a dynamic object, and `canonicalize` serializes JSON so key order and whitespace do not change the hash. The library should be based on [RFC-8259](https://datatracker.ietf.org/doc/html/rfc8259).
 </Note>
 
 ```ts title="utils/context-hash.ts"
@@ -145,16 +151,23 @@ const context = {
 Frequently asked questions related to context in the Inbox component.
 <AccordionGroup>
   <Accordion title="Why are in-app notifications sent successfully but not showing in the Inbox?">
-    The Inbox uses **exact-match** context filtering. The `context` prop on `<Inbox />` must match the context used when the workflow was triggered, key for key and value for value.
+    The Inbox filters by context **type and id**. The `context` prop on `<Inbox />` must include the same type/id pairs used when the workflow was triggered. Nested `data` does not need to match.
 
-    A common cause: you started passing `context` on workflow triggers but did not update `<Inbox />` to use the same context. The in-app channel job can still complete with status "Success" in the activity feed, but the notification is scoped to a different context and will not appear in an Inbox session that does not match.
+    A common cause: you started passing `context` on workflow triggers but did not update `<Inbox />` to use the same context ids. The in-app channel job can still complete with status "Success" in the activity feed, but the notification is scoped to a different context and will not appear in an Inbox session that does not match.
 
     Check that:
 
-    1. If you trigger **with** context, initialize `<Inbox />` with the **same** context.
+    1. If you trigger **with** context, initialize `<Inbox />` with the **same** context type/id pairs.
     2. If you trigger **without** context, do not pass a `context` prop to `<Inbox />`.
     3. When a user switches tenants or orgs in your app, re-render `<Inbox />` with the updated context.
 
     See the context matching table above for all combinations.
+  </Accordion>
+  <Accordion title="Does nested context data need to match between trigger and Inbox?">
+    No. Matching is on **type and id** only. For example, `{ tenant: { id: "123" } }` on the Inbox matches a trigger with `{ tenant: { id: "123", data: { name: "foo" } } }`.
+
+    `data` is optional metadata stored on the context. Use it for personalization, not for filtering.
+
+    If you use `contextHash`, hash the exact `context` object you pass to `<Inbox />`. That is separate from notification matching.
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Clarified that the `<Inbox />` filters notifications by context type and id, rather than exact matches. Updated examples to reflect the new context structure and added details about the use of `contextHash` and nested data handling.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Inbox context documentation. The main changes are:

- Clarifies that Inbox filtering uses context type/id pairs.
- Explains that nested `data` is stored metadata and does not affect notification matching.
- Updates the matching examples for object-style context values.
- Adds `contextHash` guidance for secured Inbox setup.

<h3>Confidence Score: 5/5</h3>

This docs-only PR is safe to merge.

The updated MDX page is consistent with the PR intent and does not introduce code or configuration changes.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a Mintlify CLI run for the inbox context, but a dependency/runtime failure occurred before docs validation could run.
- The earlier harness run revealed assumptions in the harness path and snippet checks, prompting a correction to the harness which was then rerun.
- The corrected harness run produced a successful narrow validation with exit code 0 and the docs.json registration aligned to the exact path tabs.\[0\].groups.\[1\].pages.\[3\].pages.\[4\], with checks for the changed context filtering language and referenced assets passing.
- An artifact status log lists the generated artifacts and confirms no tracked docs/lockfile changes were introduced by validation.

<a href="https://app.greptile.com/trex/runs/14722901/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/inbox/configuration/inbox-with-context.mdx | Updates Inbox context filtering docs to explain type/id matching, nested data behavior, and `contextHash` requirements. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Trigger as Workflow trigger
participant Novu as Novu context matching
participant Inbox as <Inbox /> session
Trigger->>Novu: Send notification with context type/id pairs
Inbox->>Novu: Initialize with context prop
Novu->>Novu: Compare same set of context keys
alt Type/id pairs match
    Novu-->>Inbox: Return scoped notifications
else Missing or different context
    Novu-->>Inbox: Exclude notification from session
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Trigger as Workflow trigger
participant Novu as Novu context matching
participant Inbox as <Inbox /> session
Trigger->>Novu: Send notification with context type/id pairs
Inbox->>Novu: Initialize with context prop
Novu->>Novu: Compare same set of context keys
alt Type/id pairs match
    Novu-->>Inbox: Return scoped notifications
else Missing or different context
    Novu-->>Inbox: Exclude notification from session
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): update context filtering expl..."](https://github.com/novuhq/novu/commit/5633a0f54ea6d23d225e1a5ea54c9105919e1097) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44848830)</sub>

<!-- /greptile_comment -->