### PR TITLE
docs(inbox): fix incorrect readAll/archiveAll calls in headless mode example

### DIFF
--- a/docs/platform/inbox/headless-mode.mdx
+++ b/docs/platform/inbox/headless-mode.mdx
@@ -110,7 +110,7 @@ function NotificationItem({ notification }: { notification: INotification }) {
 
   const markAsRead = async () => {
     try {
-      await novu.notifications.readAll({ notificationId: notification.id });
+      await novu.notifications.read({ notificationId: notification.id });
     } catch (error) {
       console.error("Failed to mark as read:", error);
     }
@@ -118,7 +118,7 @@ function NotificationItem({ notification }: { notification: INotification }) {
 
   const archive = async () => {
     try {
-      await novu.notifications.archiveAll({ notificationId: notification.id });
+      await novu.notifications.archive({ notificationId: notification.id });
     } catch (error) {
       console.error("Failed to archive:", error);
     }


### PR DESCRIPTION
## Summary

This PR fixes incorrect API usage in the Headless Inbox documentation.

The example was using:

```ts
await novu.notifications.readAll({ notificationId: notification.id });
await novu.notifications.archiveAll({ notificationId: notification.id });
```

However, `readAll()` and `archiveAll()` are bulk operations and do not accept a `notificationId` parameter.

To perform actions on a single notification, the correct methods are:

```ts
await novu.notifications.read({ notificationId: notification.id });
await novu.notifications.archive({ notificationId: notification.id });
```

## Root Cause

The documentation mixed up the single-notification and bulk-notification APIs.

- `read()` / `archive()` operate on a single notification and require `notificationId`.
- `readAll()` / `archiveAll()` operate on all (or filtered) notifications and accept optional filters such as `tags` or `data`.

Passing `notificationId` to the bulk APIs is ignored at runtime and produces a TypeScript error (`TS2353`) under strict typing.

## Changes

- Replaced `readAll()` with `read()`
- Replaced `archiveAll()` with `archive()`

## Validation

- Verified SDK typings.
- Confirmed `read()` and `archive()` accept `notificationId`.
- Confirmed `readAll()` and `archiveAll()` do not accept `notificationId`.
- Searched the repository for similar incorrect usages and found no additional occurrences.

Fixes #11964

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the headless Inbox documentation example for single-notification actions. The main changes are:

- Replaces `readAll({ notificationId })` with `read({ notificationId })`.
- Replaces `archiveAll({ notificationId })` with `archive({ notificationId })`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to two documentation example API calls and matches the single-notification behavior described in the page.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the initial type-check failure documented in proof 0, where old readAll and archiveAll calls with notificationId produced a TS2353 error.
- Confirmed the corrected type-check in proof 0, with read and archive calls typed correctly and negative bulk-call assertions satisfied.
- Verified in proof 0 that the repository search for incorrect usage completed and reported no remaining issues.
- Saved harness sources used for the typing checks, as referenced by proof 0.

<a href="https://app.greptile.com/trex/runs/14833353/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/inbox/headless-mode.mdx | Updates the headless Inbox example to call single-notification `read` and `archive` APIs with `notificationId`; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(inbox): fix incorrect readAll/archi..."](https://github.com/novuhq/novu/commit/2bd9fbd1caab1d2d6cd4a845c6c5678eed4803d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45068737)</sub>

<!-- /greptile_comment -->