### PR TITLE
fix(framework): digest filter renders "and 0 others" when maxNames covers all items

### DIFF
--- a/packages/framework/src/filters/digest.test.ts
+++ b/packages/framework/src/filters/digest.test.ts
@@ -27,4 +27,26 @@ describe('digest', () => {
   it('should use the "others" format for 4+ items', () => {
     expect(digest(['John', 'Josh', 'Sarah', 'Mike'])).toBe('John, Josh and 2 others');
   });
+
+  it('should list every name when maxNames equals the number of items', () => {
+    expect(digest(['John', 'Josh', 'Sarah', 'Mike'], 4)).toBe('John, Josh, Sarah and Mike');
+  });
+
+  it('should list every name when maxNames exceeds the number of items', () => {
+    expect(digest(['John', 'Josh', 'Sarah', 'Mike', 'Emma'], 10)).toBe('John, Josh, Sarah, Mike and Emma');
+  });
+
+  it('should never render "and 0 others" when maxNames covers all items', () => {
+    const result = digest(['John', 'Josh', 'Sarah', 'Mike'], 4);
+    expect(result).not.toContain('0 other');
+  });
+
+  it('should never render a negative others count when maxNames exceeds the items', () => {
+    const result = digest(['A', 'B', 'C', 'D', 'E'], 10);
+    expect(result).not.toContain('-');
+  });
+
+  it('should honor a custom separator when listing all items', () => {
+    expect(digest(['John', 'Josh', 'Sarah', 'Mike'], 4, undefined, ' • ')).toBe('John • Josh • Sarah and Mike');
+  });
 });

--- a/packages/framework/src/filters/digest.ts
+++ b/packages/framework/src/filters/digest.ts
@@ -36,11 +36,16 @@ export function digest(array: unknown, maxNames = 2, keyPath?: string, separator
   if (values.length === 1) return values[0];
   if (values.length === 2) return `${values[0]} and ${values[1]}`;
 
-  if (values.length === 3 && maxNames >= 3) {
-    return `${values[0]}${separator}${values[1]} and ${values[2]}`;
+  // When we're allowed to show at least as many names as we have, list them all
+  // instead of appending a redundant "and 0 others" (or a negative count).
+  if (maxNames >= values.length) {
+    const allButLast = values.slice(0, -1);
+    const last = values[values.length - 1];
+
+    return `${allButLast.join(separator)} and ${last}`;
   }
 
-  // Use "others" format for 4+ items or when maxNames is less than array length
+  // Use "others" format when maxNames is less than the array length
   const shownItems = values.slice(0, maxNames);
   const othersCount = values.length - maxNames;
 


### PR DESCRIPTION
The `digest` Liquid filter only listed all names for exactly 3 items; for 4+ items where `maxNames >= values.length` it fell through to the overflow branch and appended a redundant "and 0 others" — or a negative count when `maxNames > length`.

```
{{ actors | digest: 5 }}   // 4 actors -> "A, B, C, D and 0 others"
{{ actors | digest: 10 }}  // 5 actors -> "A, B, C, D, E and -5 others"
```

Since `maxNames` is set by the template author while the digested item count is variable at runtime, any digest that yields `<= maxNames` items (4+ total) renders broken copy to subscribers.

Generalized the "show all names" guard to `maxNames >= values.length`, mirroring the sibling `toSentence` filter which already guards `limit >= wordsLength`. This subsumes and preserves the existing 3-item behavior. Added regression tests (equal-to, exceeds, no "0 others", no negative count, custom separator). Swept the class: `digest` and `toSentence` are the only overflow-suffix filters, and `toSentence` was already correct.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `digest` filter boundary case for covered item counts. The main changes are:

- Lists every value when `maxNames` is equal to or greater than the number of values.
- Avoids rendering `0 others` or negative “others” counts.
- Adds tests for equal and greater `maxNames` values, custom separators, and overflow copy checks.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, preserves existing short-array behavior, and tests the reported boundary cases.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The repository’s digest tests were executed using Vitest against the digest.test.ts file.
- The digest test run completed with exit code 0, confirming a successful test outcome.
- The verbose per-test digest log shows that all explicit regression cases ran and passed.

<a href="https://app.greptile.com/trex/runs/14968055/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/filters/digest.ts | Generalizes the all-items branch so `digest` lists every value whenever `maxNames` covers the array. |
| packages/framework/src/filters/digest.test.ts | Adds tests for equal and excessive `maxNames`, zero or negative overflow copy, and custom separators. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Template as Liquid template
participant Digest as digest filter
participant Values as values array
Template->>Digest: "actors | digest: maxNames"
Digest->>Values: extract values/keyPath
alt "values.length <= 2"
    Digest-->>Template: return simple name(s)
else "maxNames >= values.length"
    Digest-->>Template: join all names with separator + "and"
else "maxNames < values.length"
    Digest-->>Template: join shown names + "and N others"
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Template as Liquid template
participant Digest as digest filter
participant Values as values array
Template->>Digest: "actors | digest: maxNames"
Digest->>Values: extract values/keyPath
alt "values.length <= 2"
    Digest-->>Template: return simple name(s)
else "maxNames >= values.length"
    Digest-->>Template: join all names with separator + "and"
else "maxNames < values.length"
    Digest-->>Template: join shown names + "and N others"
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(framework): digest filter renders &#39;a..."](https://github.com/novuhq/novu/commit/e450af18c247b91c960ce996fd404c5fda531383) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45356059)</sub>

<!-- /greptile_comment -->