### PR TITLE
fix(worker): persist complete throttle step result with windowStart

### DIFF
--- a/apps/api/src/app/events/e2e/throttle-events.e2e.ts
+++ b/apps/api/src/app/events/e2e/throttle-events.e2e.ts
@@ -262,6 +262,13 @@ describe('Trigger event - Throttle triggered events - /v1/events/trigger (POST) 
       expect(job.stepOutput?.threshold).to.equal(1);
     }
 
+    // The completed (non-throttled) job should also persist a throttle result so that the
+    // framework `throttle` result schema (which requires `throttled`) is satisfied on hydration.
+    const [completedThrottleJob] = completedThrottleJobs;
+    expect(completedThrottleJob.stepOutput).to.be.ok;
+    expect(completedThrottleJob.stepOutput?.throttled).to.equal(false);
+    expect(completedThrottleJob.stepOutput?.threshold).to.equal(1);
+
     // Only 1 in-app message should be created
     const messages = await messageRepository.find({
       _environmentId: session.environment._id,

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -288,7 +288,13 @@ export class AddJob {
           await this.handleThrottleSkip(
             command,
             job,
-            throttleResult as { shouldSkip: boolean; executionCount: number; threshold: number; throttledUntil: string }
+            throttleResult as {
+              shouldSkip: boolean;
+              executionCount: number;
+              threshold: number;
+              windowStart: string;
+              throttledUntil: string;
+            }
           );
 
           return {
@@ -296,6 +302,11 @@ export class AddJob {
             deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.SKIPPED,
           };
         }
+
+        // The throttle slot was granted, so the step is not throttled. Persist the throttle result
+        // so the step output stays consistent with the throttled path and satisfies the framework
+        // `throttle` result schema (which requires `throttled`) when the state is hydrated.
+        await this.handleThrottlePass(command, job, throttleResult);
       } catch (error) {
         return await this.handleStepValidationError(
           command,
@@ -816,7 +827,13 @@ export class AddJob {
     command: AddJobCommand,
     job: JobEntity,
     bridgeResponse: ExecuteOutput | null
-  ): Promise<{ shouldSkip: boolean; executionCount?: number; threshold?: number; throttledUntil?: string }> {
+  ): Promise<{
+    shouldSkip: boolean;
+    executionCount?: number;
+    threshold?: number;
+    windowStart?: string;
+    throttledUntil?: string;
+  }> {
     // Get throttle configuration from bridge response or job step
     const throttleConfig = bridgeResponse?.outputs || {};
     const { type = 'fixed', threshold = 1, throttleKey } = throttleConfig;
@@ -893,12 +910,16 @@ export class AddJob {
       'Redis throttle reservation result'
     );
 
+    const windowStart = new Date(reservationResult.windowStartMs).toISOString();
+    const throttledUntil = new Date(reservationResult.windowStartMs + windowMs).toISOString();
+
     if (!reservationResult.granted) {
       return {
         shouldSkip: true,
         executionCount: reservationResult.count,
         threshold: threshold as number,
-        throttledUntil: new Date(reservationResult.windowStartMs + windowMs).toISOString(),
+        windowStart,
+        throttledUntil,
       };
     }
 
@@ -907,7 +928,8 @@ export class AddJob {
       shouldSkip: false,
       executionCount: reservationResult.count,
       threshold: threshold as number,
-      throttledUntil: new Date(reservationResult.windowStartMs + windowMs).toISOString(),
+      windowStart,
+      throttledUntil,
     };
   }
 
@@ -1004,7 +1026,13 @@ export class AddJob {
   private async handleThrottleSkip(
     command: AddJobCommand,
     job: JobEntity,
-    throttleResult: { shouldSkip: boolean; executionCount: number; threshold: number; throttledUntil: string }
+    throttleResult: {
+      shouldSkip: boolean;
+      executionCount: number;
+      threshold: number;
+      windowStart: string;
+      throttledUntil: string;
+    }
   ) {
     this.logger.info(
       `Job ${job._id} throttled: ${throttleResult.executionCount} executions exceed threshold ${throttleResult.threshold as number}`
@@ -1019,7 +1047,7 @@ export class AddJob {
             throttled: true,
             executionCount: throttleResult.executionCount,
             threshold: throttleResult.threshold as number,
-            throttledUntil: throttleResult.throttledUntil,
+            windowStart: throttleResult.windowStart,
           },
         },
       }
@@ -1048,6 +1076,26 @@ export class AddJob {
         })
       );
     }
+  }
+
+  private async handleThrottlePass(
+    command: AddJobCommand,
+    job: JobEntity,
+    throttleResult: { executionCount?: number; threshold?: number; windowStart?: string }
+  ) {
+    await this.jobRepository.updateOne(
+      { _id: job._id, _environmentId: command.environmentId },
+      {
+        $set: {
+          stepOutput: {
+            throttled: false,
+            executionCount: throttleResult.executionCount,
+            threshold: throttleResult.threshold,
+            windowStart: throttleResult.windowStart,
+          },
+        },
+      }
+    );
   }
 
   private getExecutionDelayAmount(


### PR DESCRIPTION
### What changed? Why was the change needed?

The `throttle` step result schema (`packages/framework/src/schemas/steps/actions/throttle.schema.ts`) exposes a `windowStart` field, and `ExecuteBridgeJob.mapOutput` reads `stepOutput.windowStart` when hydrating the throttle state for the framework:

```ts
case 'throttle': {
  const stepOutput = job.stepOutput as ThrottleResult | undefined;
  if (!stepOutput) {
    return { throttled: false } satisfies ThrottleResult;
  }
  return {
    throttled: stepOutput.throttled,
    executionCount: stepOutput.executionCount,
    threshold: stepOutput.threshold,
    windowStart: stepOutput.windowStart, // <-- never written
  } satisfies ThrottleResult;
}
```

But `AddJob` stored the field as `throttledUntil` (the window **end**) and never wrote `windowStart`, so `windowStart` was **always `undefined`** in the throttle step result. `throttledUntil` was effectively dead data — it is not part of the result schema and is never mapped back out.

In addition, only the throttled (skipped) path persisted a `stepOutput`. When a throttle slot was **granted** (not throttled), the step produced no persisted result, so its hydrated result fell back to a bare `{ throttled: false }`, dropping the `executionCount` / `threshold` / `windowStart` values that had already been computed by the reservation.

**Fix**

- Compute `windowStart` from `reservationResult.windowStartMs` (the actual window start) and persist it in the throttled step output, so the documented `windowStart` result field is populated instead of always `undefined`.
- Persist a complete, schema-aligned throttle result (`throttled`, `executionCount`, `threshold`, `windowStart`) on the **granted** path as well (`handleThrottlePass`), keeping the throttled and non-throttled outcomes consistent.

`throttledUntil` is still passed through to the `THROTTLE_LIMIT_EXCEEDED` execution-detail (where "throttled until \<time\>" is a meaningful display value), it is just no longer the source for the result field.

### How was it tested?

Extended the existing throttle e2e test (`apps/api/src/app/events/e2e/throttle-events.e2e.ts`) to assert that the completed (non-throttled) throttle job now persists `stepOutput.throttled === false` with its `threshold` — this assertion fails on `next` (no `stepOutput` was written for granted jobs) and passes with this change. Existing assertions on the skipped jobs (`throttled`, `threshold`, `executionCount`) are unchanged.

Relates to the throttle result validation area reported in #9919.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related gaps in the throttle step: `windowStart` was never written to `stepOutput` (despite being part of the result schema), and granted (non-throttled) jobs produced no `stepOutput` at all, causing hydration to fall back to a bare `{ throttled: false }` with no count/threshold/windowStart.

- `handleThrottle` now computes `windowStart` from `reservationResult.windowStartMs` before branching on `granted`, so both the skip and pass paths carry the correct ISO-8601 window-start string; `throttledUntil` is still forwarded to the `THROTTLE_LIMIT_EXCEEDED` execution detail for display purposes.
- A new `handleThrottlePass` method persists a complete, schema-aligned `stepOutput` (`throttled`, `executionCount`, `threshold`, `windowStart`) for granted jobs, matching the shape already written by `handleThrottleSkip` for skipped jobs.
- The e2e test is extended to assert that the completed throttle job has a non-null `stepOutput` with `throttled === false` and the correct `threshold`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is self-contained to the throttle step path and is backward-compatible.

The core logic is correct and the new handleThrottlePass mirrors the existing handleThrottleSkip pattern, but the e2e test never asserts windowStart (the exact field being fixed), and handleThrottlePass accepts all-optional types that could silently write undefined values to the DB.

add-job.usecase.ts — verify that handleThrottlePass writing stepOutput before job completion cannot be overwritten by ExecuteBridgeJob on the throttle step path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts | Adds `windowStart` to the throttle result and introduces `handleThrottlePass` to persist a complete stepOutput for granted jobs; type signature of handleThrottlePass is overly loose. |
| apps/api/src/app/events/e2e/throttle-events.e2e.ts | Extends throttle e2e test for the completed job path but omits a windowStart assertion, the exact field this PR fixes. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fevents%2Fe2e%2Fthrottle-events.e2e.ts%3A265-270%0A**Missing%20%60windowStart%60%20assertion%20in%20the%20new%20test%20block**%0A%0AThe%20primary%20motivation%20of%20this%20PR%20is%20that%20%60windowStart%60%20was%20always%20%60undefined%60%20in%20the%20persisted%20throttle%20result.%20The%20new%20assertion%20block%20validates%20%60throttled%60%20and%20%60threshold%60%20for%20the%20completed%20job%20but%20never%20checks%20%60windowStart%60%2C%20which%20means%20a%20regression%20that%20causes%20%60windowStart%60%20to%20remain%20%60undefined%60%20would%20still%20pass%20this%20test.%20Adding%20%60expect%28completedThrottleJob.stepOutput%3F.windowStart%29.to.be.a%28'string'%29%60%20%28and%20ideally%20the%20same%20for%20at%20least%20one%20skipped%20job%29%20would%20close%20this%20gap%20and%20directly%20prove%20the%20field%20is%20now%20populated.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Fadd-job%2Fadd-job.usecase.ts%3A1081-1098%0A**%60handleThrottlePass%60%20uses%20all-optional%20parameter%20type%20despite%20values%20always%20being%20defined**%0A%0AThe%20parameter%20type%20%60%7B%20executionCount%3F%3A%20number%3B%20threshold%3F%3A%20number%3B%20windowStart%3F%3A%20string%20%7D%60%20accepts%20%60undefined%60%20for%20every%20field%2C%20but%20the%20only%20call%20site%20%28%60!throttleResult.shouldSkip%60%20branch%20after%20a%20successful%20%60handleThrottle%60%29%20always%20provides%20concrete%20values%20for%20all%20three%20fields.%20If%20any%20of%20them%20were%20accidentally%20%60undefined%60%20%28e.g.%2C%20due%20to%20a%20future%20refactor%20that%20introduces%20an%20early-return%20before%20these%20fields%20are%20set%29%2C%20they%20would%20be%20silently%20written%20as%20%60undefined%60%20into%20%60stepOutput%60%20with%20no%20type-level%20warning.%20Making%20the%20fields%20required%20here%20would%20make%20the%20contract%20explicit%20and%20catch%20misuse%20earlier.%0A%0A&pr=11986&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/events/e2e/throttle-events.e2e.ts:265-270
**Missing `windowStart` assertion in the new test block**

The primary motivation of this PR is that `windowStart` was always `undefined` in the persisted throttle result. The new assertion block validates `throttled` and `threshold` for the completed job but never checks `windowStart`, which means a regression that causes `windowStart` to remain `undefined` would still pass this test. Adding `expect(completedThrottleJob.stepOutput?.windowStart).to.be.a('string')` (and ideally the same for at least one skipped job) would close this gap and directly prove the field is now populated.

### Issue 2 of 2
apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts:1081-1098
**`handleThrottlePass` uses all-optional parameter type despite values always being defined**

The parameter type `{ executionCount?: number; threshold?: number; windowStart?: string }` accepts `undefined` for every field, but the only call site (`!throttleResult.shouldSkip` branch after a successful `handleThrottle`) always provides concrete values for all three fields. If any of them were accidentally `undefined` (e.g., due to a future refactor that introduces an early-return before these fields are set), they would be silently written as `undefined` into `stepOutput` with no type-level warning. Making the fields required here would make the contract explicit and catch misuse earlier.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): persist complete throttle s..."](https://github.com/novuhq/novu/commit/31366e2e25e1173d2aabe66ba4e284bea16aae39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45397469)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->