### PR TITLE
fix(docs): change examples to example to fix broken spec

### DIFF
--- a/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
@@ -775,7 +775,7 @@ export class AgentReplyPayloadDto {
       { type: 'string', enum: ['stop'], description: 'Clear the typing indicator.' },
       { $ref: getSchemaPath(TypingStatusDto) },
     ],
-    examples: [{ status: 'Looking up your order…' }, 'stop'],
+    example: [{ status: 'Looking up your order…' }, 'stop'],
   })
   @IsOptional()
   @Validate(IsValidTypingOp)


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the agent reply DTO documentation metadata for the `typing` field. The main change is:

- Replaces the Swagger `examples` property with `example` to produce a valid OpenAPI spec entry.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to a single Swagger DTO metadata field and does not alter runtime validation or business logic.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the biome check completed successfully with the full command, the working directory, and EXIT\_CODE: 0.
- Inspected the pre-change in-memory metadata and confirmed that examples are present, while ASSERT example present: false and ASSERT examples absent: false.
- Verified the post-change DTO shows the updated example data and that ASSERT example present: true and ASSERT examples absent: true, with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14991593/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts | Updates the Swagger metadata for the `typing` DTO field from `examples` to `example`; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): change examples to example to..."](https://github.com/novuhq/novu/commit/6db075e73dedc3c99111284352ff320a2bce42ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45406071)</sub>

<!-- /greptile_comment -->