### PR TITLE
fix(api-service): enforce read tool for managed agent skills fixes NV-8327

### DIFF
--- a/apps/api/src/app/agents/managed-runtime/managed-agent-errors.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-errors.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import {
+  buildErrorMessage,
+  extractErrorMessage,
+  isMissingReadToolForSkillsError,
+  MISSING_READ_TOOL_FOR_SKILLS_REPLY,
+} from './managed-agent-errors';
+
+describe('managed-agent-errors', () => {
+  const anthropicSkillsReadError =
+    '400 {"type":"error","error":{"type":"invalid_request_error","message":"Missing required tool: skills require the read tool to be usable (enabled and not always_deny) on the session\'s `agent_toolset`"}}';
+
+  describe('isMissingReadToolForSkillsError', () => {
+    it('matches Error instances with the Anthropic skills/read message', () => {
+      expect(isMissingReadToolForSkillsError(new Error(anthropicSkillsReadError))).to.equal(true);
+    });
+
+    it('matches JSON-serialized webhook error objects', () => {
+      expect(
+        isMissingReadToolForSkillsError({
+          name: 'ThalamusError',
+          message: 'Missing required tool: skills require the read tool to be usable',
+        })
+      ).to.equal(true);
+    });
+
+    it('returns false for unrelated errors', () => {
+      expect(isMissingReadToolForSkillsError(new Error('rate limited'))).to.equal(false);
+      expect(isMissingReadToolForSkillsError({ message: 123 })).to.equal(false);
+      expect(isMissingReadToolForSkillsError(null)).to.equal(false);
+    });
+  });
+
+  describe('extractErrorMessage', () => {
+    it('reads message from Error and plain objects', () => {
+      expect(extractErrorMessage(new Error('boom'))).to.equal('boom');
+      expect(extractErrorMessage({ message: 'plain' })).to.equal('plain');
+    });
+  });
+
+  describe('buildErrorMessage', () => {
+    it('returns actionable copy for the skills/read misconfiguration', () => {
+      expect(buildErrorMessage(new Error(anthropicSkillsReadError))).to.equal(MISSING_READ_TOOL_FOR_SKILLS_REPLY);
+    });
+  });
+});

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-errors.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-errors.ts
@@ -1,0 +1,86 @@
+import { CredentialExpiredError, McpServerError } from '@novu/thalamus';
+
+/**
+ * User-facing copy and detectors for managed-agent turn failures that must
+ * reach Slack/email/etc. instead of silently aborting the inbound turn.
+ *
+ * Errors that cross the Thalamus observer webhook boundary arrive as plain
+ * `{ message, name }` objects (JSON-serialized), so detectors must match on
+ * message text rather than `instanceof`.
+ */
+
+export const MISSING_READ_TOOL_FOR_SKILLS_REPLY =
+  'This agent has skills enabled but the **Read** tool is disabled. ' +
+  'Enable the Read tool in the agent settings, then send your message again.';
+
+/**
+ * Anthropic Managed Agents reject sessions/agents when skills are attached
+ * without a usable `read` builtin on `agent_toolset`:
+ *   "Missing required tool: skills require the read tool to be usable
+ *    (enabled and not always_deny) on the session's `agent_toolset`"
+ */
+export function isMissingReadToolForSkillsError(err: unknown): boolean {
+  const message = extractErrorMessage(err);
+
+  if (!message) {
+    return false;
+  }
+
+  return /skills require the read tool/i.test(message);
+}
+
+export function extractErrorMessage(err: unknown): string | undefined {
+  if (err instanceof Error) {
+    return err.message;
+  }
+
+  // Errors that cross the webhook boundary are JSON-serialized and arrive as
+  // plain objects, so `instanceof Error` is false — read `message` directly.
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    const message = (err as { message?: unknown }).message;
+
+    return typeof message === 'string' ? message : undefined;
+  }
+
+  return undefined;
+}
+
+export function parseMcpInitFailureServerName(err: unknown): string | undefined {
+  const message = extractErrorMessage(err);
+
+  if (!message) {
+    return undefined;
+  }
+
+  const mcpInitMatch = message.match(/MCP server ['"]([^'"]+)['"] initialize failed/i);
+
+  return mcpInitMatch?.[1];
+}
+
+export function buildMcpInitFailureMessage(serverName: string): string {
+  return (
+    `I couldn't connect to the **${serverName}** MCP server yet. ` +
+    `Use Connect to authorize ${serverName}, then send your message again.`
+  );
+}
+
+export function buildErrorMessage(err: unknown): string {
+  if (err instanceof CredentialExpiredError) {
+    return `Agent error: Credentials for "${err.serverName}" have expired. Please update them in your integration settings.`;
+  }
+  if (err instanceof McpServerError) {
+    return `Agent error: MCP server "${err.serverName}" is unavailable (${err.statusCode ?? 'unknown status'}).`;
+  }
+
+  if (isMissingReadToolForSkillsError(err)) {
+    return MISSING_READ_TOOL_FOR_SKILLS_REPLY;
+  }
+
+  const failedMcpServerName = parseMcpInitFailureServerName(err);
+
+  if (failedMcpServerName) {
+    return buildMcpInitFailureMessage(failedMcpServerName);
+  }
+
+  return 'The agent is temporarily unavailable. Please try again later.';
+}

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -3,8 +3,6 @@ import { PinoLogger } from '@novu/application-generic';
 import { ConversationRepository } from '@novu/dal';
 import { NOVU_INTERNAL_TOOLS } from '@novu/shared';
 import {
-  CredentialExpiredError,
-  McpServerError,
   type SessionEventContext,
   SessionExpiredError,
   type StreamCallbacks,
@@ -19,6 +17,7 @@ import { HandlePlanProgress } from '../conversation-runtime/reply/handle-plan-pr
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
 import { captureAgentException } from '../shared/errors/capture-agent-sentry';
 import { DemoClaudeQuotaPolicy } from './demo-claude-quota-policy.service';
+import { buildErrorMessage, parseMcpInitFailureServerName } from './managed-agent-errors';
 import { HandlePendingToolApprovalsCommand } from './tool-approval/handle-pending-tool-approvals.command';
 import { HandlePendingToolApprovals } from './tool-approval/handle-pending-tool-approvals.usecase';
 
@@ -284,56 +283,4 @@ export class ManagedAgentEventHandler {
       });
     }
   }
-}
-
-function extractErrorMessage(err: unknown): string | undefined {
-  if (err instanceof Error) {
-    return err.message;
-  }
-
-  // Errors that cross the webhook boundary are JSON-serialized and arrive as
-  // plain objects, so `instanceof Error` is false — read `message` directly.
-  if (typeof err === 'object' && err !== null && 'message' in err) {
-    const message = (err as { message?: unknown }).message;
-
-    return typeof message === 'string' ? message : undefined;
-  }
-
-  return undefined;
-}
-
-export function parseMcpInitFailureServerName(err: unknown): string | undefined {
-  const message = extractErrorMessage(err);
-
-  if (!message) {
-    return undefined;
-  }
-
-  const mcpInitMatch = message.match(/MCP server ['"]([^'"]+)['"] initialize failed/i);
-
-  return mcpInitMatch?.[1];
-}
-
-export function buildErrorMessage(err: unknown): string {
-  if (err instanceof CredentialExpiredError) {
-    return `Agent error: Credentials for "${err.serverName}" have expired. Please update them in your integration settings.`;
-  }
-  if (err instanceof McpServerError) {
-    return `Agent error: MCP server "${err.serverName}" is unavailable (${err.statusCode ?? 'unknown status'}).`;
-  }
-
-  const failedMcpServerName = parseMcpInitFailureServerName(err);
-
-  if (failedMcpServerName) {
-    return buildMcpInitFailureMessage(failedMcpServerName);
-  }
-
-  return 'The agent is temporarily unavailable. Please try again later.';
-}
-
-export function buildMcpInitFailureMessage(serverName: string): string {
-  return (
-    `I couldn't connect to the **${serverName}** MCP server yet. ` +
-    `Use Connect to authorize ${serverName}, then send your message again.`
-  );
 }

--- a/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
@@ -10,6 +10,7 @@ import { AgentEventEnum } from '../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
 import { parseToolApprovalActionId } from '../shared/tool-approval/action-id';
 import { ManagedAgentService } from './managed-agent.service';
+import { isMissingReadToolForSkillsError, MISSING_READ_TOOL_FOR_SKILLS_REPLY } from './managed-agent-errors';
 import { ConfirmToolApprovalCommand } from './tool-approval/confirm-tool-approval.command';
 import { ConfirmToolApproval } from './tool-approval/confirm-tool-approval.usecase';
 
@@ -87,7 +88,24 @@ export class ManagedRuntime implements AgentRuntime {
       }
     } catch (err) {
       if (err instanceof DemoQuotaExhaustedError) {
-        await this.replyDemoQuotaExhausted(turn);
+        await this.replyOnThread(turn, DEMO_QUOTA_EXHAUSTED_REPLY);
+
+        return;
+      }
+
+      // Sync createSession / events.send failures never reach the async
+      // session.error webhook path — without this catch the ChatInstanceRegistry
+      // logs+swallows the error and Slack gets no agent reply.
+      if (isMissingReadToolForSkillsError(err)) {
+        this.logger.warn(
+          {
+            agentId: turn.agentId,
+            conversationId: turn.conversation._id,
+            err: err instanceof Error ? err.message : err,
+          },
+          'Managed dispatch rejected: skills require the read tool'
+        );
+        await this.replyOnThread(turn, MISSING_READ_TOOL_FOR_SKILLS_REPLY);
 
         return;
       }
@@ -127,17 +145,17 @@ export class ManagedRuntime implements AgentRuntime {
     );
   }
 
-  private async replyDemoQuotaExhausted(turn: ConversationTurn): Promise<void> {
+  private async replyOnThread(turn: ConversationTurn, markdown: string): Promise<void> {
     applyPlatformThreadIdToThread(turn.thread, turn.platformThreadId);
     await this.outboundGateway.replyOnThread(
       turn.thread,
-      { markdown: DEMO_QUOTA_EXHAUSTED_REPLY },
+      { markdown },
       {
         persist: {
           conversationId: turn.conversation._id,
           channel: this.conversationService.getPrimaryChannel(turn.conversation),
           agentIdentifier: turn.config.agentIdentifier,
-          content: DEMO_QUOTA_EXHAUSTED_REPLY,
+          content: markdown,
           environmentId: turn.config.environmentId,
           organizationId: turn.config.organizationId,
         },

--- a/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
@@ -104,7 +104,8 @@ You MUST select Claude built-in tools, MCP servers, and Anthropic Skills ONLY fr
 
 ## Tool selection
 - ALWAYS include \`web_search\` and \`web_fetch\` — every Novu agent should be able to pull live context from the web. Only omit them if the user explicitly forbids web access.
-- Add \`bash\`/\`read\`/\`write\`/\`edit\`/\`glob\`/\`grep\` only when the agent must work with files (code review, data files, repo automation, etc.).
+- Add \`bash\`/\`write\`/\`edit\`/\`glob\`/\`grep\` only when the agent must work with files (code review, data files, repo automation, etc.).
+- ALWAYS include \`read\` whenever you attach ANY skill (see Skill selection). Anthropic Managed Agents load skill bundles via the read tool and reject the agent otherwise.
 
 ## MCP selection
 - Decide per domain whether the agent actually needs an MCP. Many agents are pure reasoning / writing / summarisation tasks and need NO MCP at all — return an empty array in that case.
@@ -123,6 +124,7 @@ You MUST select Claude built-in tools, MCP servers, and Anthropic Skills ONLY fr
 
 ## Skill selection
 - Anthropic skills are for file generation (pdf, xlsx, docx, pptx, …). Only attach when the agent must produce one of those file types. Otherwise return an empty array.
+- If you attach one or more skills, you MUST also include \`read\` in \`tools\`. Never return skills without \`read\`.
 
 ## System prompt
 The \`systemPrompt\` is sent verbatim to Claude. Address the agent in second person ("You are a…"), describe its role, scope, tone, and the workflow it should follow when invoked. Do not enumerate the tool/MCP/skill IDs in the systemPrompt — Anthropic wires them in automatically.
@@ -161,14 +163,21 @@ Generate the complete agent configuration JSON. Pick a clear human name, derive 
  * still ships with the baseline web tools. Without this, prompts that omit a clear "use X"
  * cue (e.g. "Build a Customer Feedback Agent That Groups Requests by Theme") would surface
  * an agent with no tools or MCPs attached, which is a poor first-run experience.
+ *
+ * Also force-enables `read` whenever skills are present — Anthropic Managed Agents require
+ * a usable read tool on the agent toolset to load skill bundles.
  */
-function ensureDefaultTools(tools: string[]): string[] {
+function ensureDefaultTools(tools: string[], skills: Array<{ skillId: string }>): string[] {
   const seen = new Set(tools);
   for (const defaultTool of CLAUDE_DEFAULT_TOOL_TYPES) {
     if (!seen.has(defaultTool)) {
       tools.push(defaultTool);
       seen.add(defaultTool);
     }
+  }
+
+  if (skills.length > 0 && !seen.has('read')) {
+    tools.push('read');
   }
 
   return tools;
@@ -256,14 +265,16 @@ export class GenerateManagedAgent {
       };
     }
 
+    const skills = generated.skills.map((skill) => ({ skillId: skill.skillId }));
+
     return {
       name: generated.name,
       identifier: generated.identifier,
       systemPrompt: generated.systemPrompt,
       description: generated.description,
-      tools: ensureDefaultTools([...generated.tools]),
+      tools: ensureDefaultTools([...generated.tools], skills),
       mcpServers: generated.mcpServers,
-      skills: generated.skills.map((skill) => ({ skillId: skill.skillId })),
+      skills,
     };
   }
 

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
@@ -542,6 +542,7 @@ describe('AnthropicAgentRuntimeProvider.updateConfig', () => {
         },
       ],
       mcp_servers: [],
+      skills: [],
     });
 
     const update = jest.fn().mockResolvedValue({
@@ -578,5 +579,76 @@ describe('AnthropicAgentRuntimeProvider.updateConfig', () => {
     );
     expect(mcpToolset?.mcp_server_name).to.equal('Slack');
     expect(mcpToolset?.default_config?.permission_policy).to.deep.equal({ type: 'always_ask' });
+  });
+
+  it('force-enables read when attaching skills without rebuilding tools from a tools patch', async () => {
+    const provider = createAnthropicProvider(AgentRuntimeProviderIdEnum.Anthropic, { apiKey: 'test-key' });
+
+    const retrieve = jest.fn().mockResolvedValue({
+      version: 1,
+      tools: [
+        {
+          type: 'agent_toolset_20260401',
+          configs: [
+            { name: 'web_search', enabled: true },
+            { name: 'read', enabled: false },
+          ],
+        },
+      ],
+      mcp_servers: [],
+      skills: [],
+    });
+
+    const update = jest.fn().mockResolvedValue({
+      model: 'claude-sonnet-4-5',
+      system: '',
+      tools: [],
+      mcp_servers: [],
+      skills: [{ type: 'anthropic', skill_id: 'pdf', version: null }],
+    });
+
+    installUpdateConfigMockClient(provider, { retrieve, update });
+
+    await provider.updateConfig('ext-agent-id', {
+      skills: [{ type: 'anthropic', skillId: 'pdf', version: null }],
+    });
+
+    const [, updatePayload] = update.mock.calls[0];
+    const toolset = getToolsetPayload(updatePayload as { tools?: AgentToolsetPayloadEntry[] });
+    const enabledNames = toolset?.configs?.filter((c) => c.enabled).map((c) => c.name) ?? [];
+
+    expect(enabledNames).to.include.members(['web_search', 'read']);
+    expect(updatePayload.skills).to.deep.equal([{ type: 'anthropic', skill_id: 'pdf' }]);
+  });
+
+  it('force-enables read when tools are patched while skills remain attached', async () => {
+    const provider = createAnthropicProvider(AgentRuntimeProviderIdEnum.Anthropic, { apiKey: 'test-key' });
+
+    const retrieve = jest.fn().mockResolvedValue({
+      version: 1,
+      tools: [],
+      mcp_servers: [],
+      skills: [{ type: 'anthropic', skill_id: 'pdf', version: null }],
+    });
+
+    const update = jest.fn().mockResolvedValue({
+      model: 'claude-sonnet-4-5',
+      system: '',
+      tools: [],
+      mcp_servers: [],
+      skills: [{ type: 'anthropic', skill_id: 'pdf', version: null }],
+    });
+
+    installUpdateConfigMockClient(provider, { retrieve, update });
+
+    await provider.updateConfig('ext-agent-id', {
+      tools: [{ externalId: 'web_search', name: 'Web Search', type: 'builtin' }],
+    });
+
+    const [, updatePayload] = update.mock.calls[0];
+    const toolset = getToolsetPayload(updatePayload as { tools?: AgentToolsetPayloadEntry[] });
+    const enabledNames = toolset?.configs?.filter((c) => c.enabled).map((c) => c.name) ?? [];
+
+    expect(enabledNames).to.include.members(['web_search', 'read']);
   });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
@@ -180,7 +180,9 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
     // Not retried: agent creation is not idempotent and a retry after a
     // dropped response would create a duplicate billable agent upstream.
     try {
-      const toolsPayload = buildToolsPayload(input.tools, input.mcpServers);
+      const skills = input.skills ?? [];
+      const hasSkills = skills.length > 0;
+      const toolsPayload = buildToolsPayload(input.tools, input.mcpServers, hasSkills);
       const agent = await (client as any).beta.agents.create({
         name: input.name,
         model: input.model ?? DEFAULT_MODEL,
@@ -189,7 +191,7 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
           ? { mcp_servers: input.mcpServers.map((s) => ({ name: s.name, type: 'url', url: s.url })) }
           : {}),
         ...(toolsPayload.length > 0 ? { tools: toolsPayload } : {}),
-        ...(input.skills && input.skills.length > 0 ? { skills: input.skills.map(toSkillParam) } : {}),
+        ...(hasSkills ? { skills: skills.map(toSkillParam) } : {}),
       });
 
       return { externalAgentId: agent.id as string };
@@ -281,7 +283,17 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
         if (patch.mcpServers !== undefined) {
           updatePayload.mcp_servers = patch.mcpServers.map((s) => ({ name: s.name, type: 'url', url: s.url }));
         }
-        if (patch.tools !== undefined || patch.mcpServers !== undefined) {
+
+        // Anthropic rejects skills without a usable `read` tool. Compute the
+        // effective skill set after this patch so we can force-enable `read`
+        // even on a skills-only update that wouldn't otherwise touch tools.
+        const currentSkills = ((currentAgent.skills as any[]) ?? []).map(mapSkill);
+        const effectiveSkills = patch.skills !== undefined ? patch.skills : currentSkills;
+        const hasSkills = effectiveSkills.length > 0;
+        const shouldRebuildTools =
+          patch.tools !== undefined || patch.mcpServers !== undefined || (patch.skills !== undefined && hasSkills);
+
+        if (shouldRebuildTools) {
           const currentTools = ((currentAgent.tools as any[]) ?? []).flatMap(mapToolset);
           const currentMcpServers = ((currentAgent.mcp_servers as any[]) ?? []).map(mapMcpServer);
           // Use externalId (the provider tool `type`, e.g. "bash"), not the display `name`
@@ -293,7 +305,7 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
             patch.mcpServers !== undefined
               ? patch.mcpServers.map((s) => ({ name: s.name, url: s.url }))
               : currentMcpServers.map((s) => ({ name: s.name, url: s.url }));
-          const toolsPayload = buildToolsPayload(toolTypes, mcpServers);
+          const toolsPayload = buildToolsPayload(toolTypes, mcpServers, hasSkills);
 
           if (toolsPayload.length > 0) updatePayload.tools = toolsPayload;
         }
@@ -328,6 +340,7 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
         const rawTools = (currentAgent.tools as any[]) ?? [];
         const currentTools = rawTools.flatMap(mapToolset);
         const currentMcpServers = ((currentAgent.mcp_servers as any[]) ?? []).map(mapMcpServer);
+        const hasSkills = ((currentAgent.skills as any[]) ?? []).length > 0;
 
         // Preserve any provider-side custom tools we don't own (e.g. on an adopted agent).
         // buildToolsPayload re-emits Novu's own novu_tools, so drop it here to avoid a duplicate.
@@ -338,7 +351,8 @@ export class AnthropicAgentRuntimeProvider extends BaseAgentRuntimeProvider {
         const toolsPayload = [
           ...buildToolsPayload(
             currentTools.map((t) => t.externalId),
-            currentMcpServers.map((s) => ({ name: s.name, url: s.url }))
+            currentMcpServers.map((s) => ({ name: s.name, url: s.url })),
+            hasSkills
           ),
           ...foreignCustomTools,
         ];

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
@@ -3,8 +3,10 @@ import { expect } from 'chai';
 import {
   buildPlatformToolsPayload,
   buildToolsPayload,
+  ensureSkillRequiredTools,
   MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
   mapToolset,
+  SKILL_REQUIRED_BUILTIN_TOOL,
 } from './anthropic-runtime.helpers';
 
 describe('mapToolset', () => {
@@ -75,5 +77,35 @@ describe('buildToolsPayload', () => {
 
   it('buildPlatformToolsPayload returns novu_tools only', () => {
     expect(buildPlatformToolsPayload()).to.deep.equal([{ type: 'custom', ...NOVU_TOOLS_SCHEMA }]);
+  });
+
+  it('force-enables read when hasSkills is true', () => {
+    const payload = buildToolsPayload(['web_search'], undefined, true);
+    const toolset = payload[0] as { configs: Array<{ name: string; enabled: boolean }> };
+    const readConfig = toolset.configs.find((c) => c.name === SKILL_REQUIRED_BUILTIN_TOOL);
+
+    expect(readConfig?.enabled).to.equal(true);
+  });
+
+  it('does not enable read when hasSkills is false', () => {
+    const payload = buildToolsPayload(['web_search'], undefined, false);
+    const toolset = payload[0] as { configs: Array<{ name: string; enabled: boolean }> };
+    const readConfig = toolset.configs.find((c) => c.name === SKILL_REQUIRED_BUILTIN_TOOL);
+
+    expect(readConfig?.enabled).to.equal(false);
+  });
+});
+
+describe('ensureSkillRequiredTools', () => {
+  it('appends read when skills are present and read is missing', () => {
+    expect(ensureSkillRequiredTools(['web_search'], true)).to.deep.equal(['web_search', 'read']);
+  });
+
+  it('is idempotent when read is already selected', () => {
+    expect(ensureSkillRequiredTools(['read', 'web_search'], true)).to.deep.equal(['read', 'web_search']);
+  });
+
+  it('returns the input unchanged when skills are absent', () => {
+    expect(ensureSkillRequiredTools(['web_search'], false)).to.deep.equal(['web_search']);
   });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
@@ -278,6 +278,29 @@ function buildUserToolsetPayload(
 }
 
 /**
+ * Anthropic Managed Agents require the `read` builtin to be enabled (and not
+ * `always_deny`) whenever skills are attached — skills are loaded by reading
+ * their bundle files. Omitting it yields a 400:
+ *   "Missing required tool: skills require the read tool…"
+ */
+export const SKILL_REQUIRED_BUILTIN_TOOL = 'read';
+
+/**
+ * Ensures `read` is present in the tool-type list when the agent has skills.
+ * Idempotent — returns `toolTypes` unchanged when skills are absent or `read`
+ * is already selected.
+ */
+export function ensureSkillRequiredTools(toolTypes: string[] | undefined, hasSkills: boolean): string[] {
+  const tools = [...(toolTypes ?? [])];
+
+  if (hasSkills && !tools.includes(SKILL_REQUIRED_BUILTIN_TOOL)) {
+    tools.push(SKILL_REQUIRED_BUILTIN_TOOL);
+  }
+
+  return tools;
+}
+
+/**
  * Build the Anthropic `tools` payload array from builtin tool type strings
  * and optional MCP server entries.
  *
@@ -288,12 +311,19 @@ function buildUserToolsetPayload(
  *
  * Platform tools (e.g. `novu_tools`) are always included, even when the user
  * has no builtin tools or MCP servers enabled.
+ *
+ * When `hasSkills` is true, `read` is force-enabled — Anthropic rejects skill
+ * attachments without a usable read tool on the agent toolset.
  */
 export function buildToolsPayload(
   toolTypes?: string[],
-  mcpServers?: Array<{ name: string; url: string }>
+  mcpServers?: Array<{ name: string; url: string }>,
+  hasSkills = false
 ): Record<string, unknown>[] {
-  return [...buildUserToolsetPayload(toolTypes, mcpServers), ...buildPlatformToolsPayload()];
+  return [
+    ...buildUserToolsetPayload(ensureSkillRequiredTools(toolTypes, hasSkills), mcpServers),
+    ...buildPlatformToolsPayload(),
+  ];
 }
 
 /**


### PR DESCRIPTION
### What changed? Why was the change needed?

Anthropic Managed Agents reject agents/sessions that have skills attached when the `read` builtin is disabled (`Missing required tool: skills require the read tool…`).

That failure often happens on sync `createSession` / `events.send`, which never reaches the async `session.error` webhook — so Slack got silence (log + Sentry only).

This PR:
1. **Prevents** the misconfiguration — force-enable `read` whenever skills are present (AI generation rules + `createAgent` / `updateConfig` / `refreshPlatformDefinition` payloads).
2. **Surfaces** the error gracefully — detect the Anthropic message and reply on the channel with actionable copy (same pattern as demo-quota exhaustion).

Linear: [NV-8327](https://linear.app/novu/issue/NV-8327/managed-agents-with-skills-fail-silently-when-read-tool-is-disabled)

```mermaid
sequenceDiagram
  participant Slack
  participant ManagedRuntime
  participant Anthropic
  participant Channel as Slack thread

  Slack->>ManagedRuntime: inbound message
  ManagedRuntime->>Anthropic: createSession / events.send
  alt skills without read (legacy / adopted agent)
    Anthropic-->>ManagedRuntime: 400 skills require the read tool
    ManagedRuntime->>Channel: actionable error reply
  else normal path
    Anthropic-->>ManagedRuntime: session active
    Note over Anthropic,Channel: async events → reply as before
  end
```

### Screenshots

N/A — backend / Slack text reply only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Existing agents stuck with skills + `read` off will get a channel reply instead of silence; updating their tools/skills (or regenerating) will auto-enable `read`.
- Unit coverage: `managed-agent-errors.spec.ts`, anthropic helper/provider specs for the `read` backfill.

</details>

## Test plan
- [ ] Generate a managed agent that includes an Anthropic skill (e.g. pdf) and confirm `read` is in the selected tools
- [ ] Create/update a managed agent with skills and verify Anthropic receives `read` enabled in `agent_toolset`
- [ ] Simulate/trigger the Anthropic skills/read 400 on Slack dispatch and confirm the thread gets the actionable error reply (not silence)
- [ ] Confirm unrelated agent turn failures still use the generic unavailable message

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents Anthropic managed-agent skill setup from failing silently. The main changes are:

- Forces the `read` builtin into generated and provider-built tool payloads when skills are attached.
- Applies the same `read` backfill during agent create, config update, and platform definition refresh flows.
- Adds managed-agent error helpers for detecting Anthropic skills/read failures.
- Replies with actionable channel copy when synchronous dispatch fails before the async error webhook can run.
- Adds tests for the new error mapping and `read` backfill behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped and covered by tests for helper behavior, provider update paths, and error mapping.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked the managed-agent Slack error harness log and confirmed it reports an ACTIONABLE\_REPLY that the Read tool is disabled and a GENERIC\_REPLY that the agent is temporarily unavailable, with exit code 0.
- Inspected the managed-agent Slack read harness after the shared build and confirmed BACKFILLED\_TOOLS includes the read tool and READ\_CONFIG shows the read tool enabled, with exit code 0.
- Cross-checked both logs to validate the contract-level expectations that the Read tool can be toggled and that the agent replies align with the enabled/disabled state asserted by the configuration.

<a href="https://app.greptile.com/trex/runs/14997448/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts | Threads effective skill state into create, update, and refresh payload construction so Anthropic receives `read` enabled when skills exist. |
| libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts | Adds a reusable helper that force-includes the `read` builtin for skill-bearing Anthropic tool payloads. |
| apps/api/src/app/agents/managed-runtime/managed.runtime.ts | Handles synchronous skills/read dispatch failures by replying on the platform thread. |
| apps/api/src/app/agents/managed-runtime/managed-agent-errors.ts | Extracts managed-agent error parsing and adds the missing-read-tool detector and reply text. |
| apps/api/src/app/agents/management/usecases/generate-managed-agent/generate-managed-agent.usecase.ts | Updates generation guidance and post-processing so generated agents with skills include the required `read` tool. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Generator as Agent generation
  participant Provider as Anthropic provider
  participant Anthropic
  participant Runtime as Managed runtime
  participant Channel as Slack/email thread

  Generator->>Provider: tools + skills
  Provider->>Provider: ensure read when skills exist
  Provider->>Anthropic: create/update/refresh agent_toolset
  Runtime->>Anthropic: createSession / events.send
  alt Anthropic rejects legacy skills without read
    Anthropic-->>Runtime: skills require read tool error
    Runtime->>Channel: actionable Read-tool reply
  else valid toolset
    Anthropic-->>Runtime: session active / events
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Generator as Agent generation
  participant Provider as Anthropic provider
  participant Anthropic
  participant Runtime as Managed runtime
  participant Channel as Slack/email thread

  Generator->>Provider: tools + skills
  Provider->>Provider: ensure read when skills exist
  Provider->>Anthropic: create/update/refresh agent_toolset
  Runtime->>Anthropic: createSession / events.send
  alt Anthropic rejects legacy skills without read
    Anthropic-->>Runtime: skills require read tool error
    Runtime->>Channel: actionable Read-tool reply
  else valid toolset
    Anthropic-->>Runtime: session active / events
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(api): enforce read tool for managed ..."](https://github.com/novuhq/novu/commit/b80d813f94bd5cbc3e692104d09deb70bdc9a85c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45417729)</sub>

<!-- /greptile_comment -->