### PR TITLE
fix(api-service): use single OpenAPI example for agent reply typing

### DIFF
--- a/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
@@ -775,7 +775,7 @@ export class AgentReplyPayloadDto {
       { type: 'string', enum: ['stop'], description: 'Clear the typing indicator.' },
       { $ref: getSchemaPath(TypingStatusDto) },
     ],
-    example: [{ status: 'Looking up your order…' }, 'stop'],
+    example: { status: 'Looking up your order…' },
   })
   @IsOptional()
   @Validate(IsValidTypingOp)


### PR DESCRIPTION
## Summary
- NestJS Swagger turns an array `@ApiPropertyOptional({ example: [...] })` into schema-level `examples` (OpenAPI 3.1) on `AgentReplyPayloadDto.typing`.
- Our Speakeasy export declares OpenAPI 3.0.0, so Mintlify fails with `must have required property '$ref'` and `mint dev` cannot start.
- Use a single object `example` instead; named request-body examples already cover the `"stop"` shape.

## Test plan
- [ ] `mint validate` / `mint dev` against a Speakeasy export regenerated after this change
- [ ] Confirm `/v1/agents/{agentId}/reply` still shows a typing example in Swagger UI

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an OpenAPI 3.0.0 compatibility issue where NestJS Swagger was converting an array-valued `example` on `AgentReplyPayloadDto.typing` into an OpenAPI 3.1-style `examples` array, causing `mint dev` to fail with a `must have required property '$ref'` error against the Speakeasy 3.0.0 export.

- Replaces `example: [{ status: 'Looking up your order…' }, 'stop']` with a single object `example: { status: 'Looking up your order…' }` on the `typing` field in `agent-reply-payload.dto.ts`.
- The `\"stop\"` shape is no longer shown inline but is retained via named request-body examples in the spec.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line targeted fix with no runtime behavior change.

The change touches only decorator metadata that controls how the OpenAPI spec is rendered; no runtime validation logic, no data model, and no API contract changes. The `typing` field still accepts `TypingStatusDto | 'stop'` exactly as before, and the inline example now shows the object form, which is valid for both NestJS Swagger and OpenAPI 3.0.0 tooling.

No files require special attention. The single changed file is well-contained decorator metadata.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts | Changes the `typing` field's `example` from an array to a single object to fix OpenAPI 3.0.0 compatibility with the Speakeasy/Mintlify toolchain. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant NestJS as NestJS Swagger
    participant Speakeasy as Speakeasy Export
    participant Mintlify as Mintlify (mint dev)

    Dev->>NestJS: "@ApiPropertyOptional({ example: { status: '...' } })"
    NestJS->>Speakeasy: Emits single schema-level example (OpenAPI 3.0.0 compatible)
    Speakeasy->>Mintlify: Exports OpenAPI 3.0.0 spec
    Mintlify-->>Dev: mint validate passes, mint dev starts

    Note over NestJS,Speakeasy: Previously: array example → NestJS emits OpenAPI 3.1-style 'examples' array → Speakeasy 3.0.0 spec missing $ref → Mintlify fails
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant NestJS as NestJS Swagger
    participant Speakeasy as Speakeasy Export
    participant Mintlify as Mintlify (mint dev)

    Dev->>NestJS: "@ApiPropertyOptional({ example: { status: '...' } })"
    NestJS->>Speakeasy: Emits single schema-level example (OpenAPI 3.0.0 compatible)
    Speakeasy->>Mintlify: Exports OpenAPI 3.0.0 spec
    Mintlify-->>Dev: mint validate passes, mint dev starts

    Note over NestJS,Speakeasy: Previously: array example → NestJS emits OpenAPI 3.1-style 'examples' array → Speakeasy 3.0.0 spec missing $ref → Mintlify fails
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): use single OpenAPI exa..."](https://github.com/novuhq/novu/commit/2caf145bae3425705ca8e349cd678c168de8f22f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45424511)</sub>

<!-- /greptile_comment -->