### PR TITLE
fix(api-service): Cap list pagination limit to prevent DoS fixes NV-8329

### DIFF
--- a/apps/api/src/app/layouts-v2/e2e/list-layouts.e2e.ts
+++ b/apps/api/src/app/layouts-v2/e2e/list-layouts.e2e.ts
@@ -1,0 +1,19 @@
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('List Layouts - /v2/layouts (GET) #novu-v2', () => {
+  let session: UserSession;
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  it('should reject limit values above 100', async () => {
+    const { body } = await session.testAgent.get('/v2/layouts').query({ limit: 101 });
+
+    expect(body.statusCode).to.equal(422);
+    expect(body.message).to.equal('Validation Error');
+    expect(body.errors.general.messages).to.include('limit must not be greater than 100');
+  });
+});

--- a/apps/api/src/app/layouts-v2/layouts.controller.ts
+++ b/apps/api/src/app/layouts-v2/layouts.controller.ts
@@ -206,8 +206,8 @@ export class LayoutsController {
   ): Promise<ListLayoutResponseDto> {
     return this.listLayoutsUseCase.execute(
       ListLayoutsCommand.create({
-        offset: Number(query.offset || '0'),
-        limit: Number(query.limit || '50'),
+        offset: query.offset ?? 0,
+        limit: query.limit ?? 50,
         orderDirection: query.orderDirection ?? DirectionEnum.DESC,
         orderBy: query.orderBy ?? 'createdAt',
         searchQuery: query.query,

--- a/apps/api/src/app/shared/dtos/limit-offset-pagination.dto.spec.ts
+++ b/apps/api/src/app/shared/dtos/limit-offset-pagination.dto.spec.ts
@@ -1,0 +1,47 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { expect } from 'chai';
+import { LimitOffsetPaginationQueryDto } from './limit-offset-pagination.dto';
+
+class SortableEntity {
+  createdAt: string;
+  name: string;
+}
+
+const PaginationDto = LimitOffsetPaginationQueryDto(SortableEntity, ['createdAt', 'name']);
+
+describe('LimitOffsetPaginationQueryDto', () => {
+  it('should accept limit within the default max of 100', async () => {
+    const dto = plainToInstance(PaginationDto, { limit: '100' });
+    const errors = await validate(dto);
+
+    expect(errors).to.have.length(0);
+    expect(dto.limit).to.equal(100);
+  });
+
+  it('should reject limit above the default max of 100', async () => {
+    const dto = plainToInstance(PaginationDto, { limit: '101' });
+    const errors = await validate(dto);
+
+    expect(errors).to.have.length(1);
+    expect(errors[0].property).to.equal('limit');
+    expect(errors[0].constraints).to.have.property('max');
+  });
+
+  it('should respect a custom maxLimit', async () => {
+    const CustomPaginationDto = LimitOffsetPaginationQueryDto(SortableEntity, ['createdAt'], 50);
+    const dto = plainToInstance(CustomPaginationDto, { limit: '51' });
+    const errors = await validate(dto);
+
+    expect(errors).to.have.length(1);
+    expect(errors[0].constraints).to.have.property('max');
+  });
+
+  it('should leave limit undefined when omitted so controllers can apply defaults', async () => {
+    const dto = plainToInstance(PaginationDto, {});
+    const errors = await validate(dto);
+
+    expect(errors).to.have.length(0);
+    expect(dto.limit).to.equal(undefined);
+  });
+});

--- a/apps/api/src/app/shared/dtos/limit-offset-pagination.dto.ts
+++ b/apps/api/src/app/shared/dtos/limit-offset-pagination.dto.ts
@@ -1,16 +1,18 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsEnum, IsInt, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { IsEnum, IsInt, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
 
-// Enum for sorting direction
 export enum DirectionEnum {
   ASC = 'ASC',
   DESC = 'DESC',
 }
 
+const DEFAULT_MAX_LIMIT = 100;
+
 export function LimitOffsetPaginationQueryDto<T, K extends keyof T>(
   BaseClass: new (...args: any[]) => T,
-  allowedFields: K[]
+  allowedFields: K[],
+  maxLimit = DEFAULT_MAX_LIMIT
 ): new () => {
   limit?: number;
   offset?: number;
@@ -23,16 +25,18 @@ export function LimitOffsetPaginationQueryDto<T, K extends keyof T>(
       type: 'number',
       required: false,
       example: 10,
+      maximum: maxLimit,
+      minimum: 1,
     })
     @Transform(({ value }) => {
-      // Convert to number, handle different input types
       const parsed = Number(value);
 
       return !Number.isNaN(parsed) ? parsed : undefined;
     })
     @IsNumber()
     @IsInt()
-    @Min(1) // Optional: ensure minimum limit
+    @Min(1)
+    @Max(maxLimit)
     @IsOptional()
     limit?: number;
 
@@ -41,16 +45,16 @@ export function LimitOffsetPaginationQueryDto<T, K extends keyof T>(
       type: 'number',
       required: false,
       example: 0,
+      minimum: 0,
     })
     @Transform(({ value }) => {
-      // Convert to number, handle different input types
       const parsed = Number(value);
 
       return !Number.isNaN(parsed) ? parsed : undefined;
     })
     @IsInt()
     @IsNumber()
-    @Min(0) // Ensure non-negative offset
+    @Min(0)
     @IsOptional()
     offset?: number;
 

--- a/apps/api/src/app/workflows-v2/e2e/list-workflows.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/list-workflows.e2e.ts
@@ -46,6 +46,14 @@ describe('List Workflows - /workflows (GET) #novu-v2', () => {
       expect(uniqueIds.size).to.equal(15);
     });
 
+    it('should reject limit values above 100', async () => {
+      const { body } = await session.testAgent.get('/v2/workflows').query({ limit: 101 });
+
+      expect(body.statusCode).to.equal(422);
+      expect(body.message).to.equal('Validation Error');
+      expect(body.errors.general.messages).to.include('limit must not be greater than 100');
+    });
+
     it('should correctly search workflows by name', async () => {
       const searchTerm = 'SEARCHABLE-WORKFLOW';
 

--- a/apps/api/src/app/workflows-v2/workflow.controller.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.ts
@@ -255,8 +255,8 @@ export class WorkflowController {
   ): Promise<ListWorkflowResponse> {
     return this.listWorkflowsUseCase.execute(
       ListWorkflowsCommand.create({
-        offset: Number(query.offset || '0'),
-        limit: Number(query.limit || '50'),
+        offset: query.offset ?? 0,
+        limit: query.limit ?? 50,
         orderDirection: query.orderDirection ?? DirectionEnum.DESC,
         orderBy: query.orderBy ?? 'createdAt',
         searchQuery: query.query,


### PR DESCRIPTION
## What changed

* Added `@Max(100)` (configurable via optional `maxLimit` arg) to `LimitOffsetPaginationQueryDto`, aligning with `PaginationRequestDto` / `CursorPaginationRequestDto`
* Workflow and layout list controllers now use already-validated `query.limit ?? 50` / `query.offset ?? 0` instead of re-coercing with `Number(...)`
* Added unit + e2e coverage that `limit > 100` is rejected with 422

## Why

`LimitOffsetPaginationQueryDto` only had `@Min(1)` and no upper bound. Authenticated clients could pass an arbitrarily large `limit` on `GET /v2/workflows` and `GET /v2/layouts`, causing expensive unbounded list queries (DoS).

## Test plan

- [X] Unit: `limit-offset-pagination.dto.spec.ts` (accept 100, reject 101, custom max, omitted default)
- [X] E2E: `list-workflows.e2e.ts` rejects `limit=101`
- [X] E2E: `list-layouts.e2e.ts` rejects `limit=101`

```mermaid
flowchart LR
  Client -->|"GET ...?limit=999999"| ValidationPipe
  ValidationPipe -->|"@Max(100) fails"| Reject422[422 Validation Error]
  ValidationPipe -->|"limit omitted or 1..100"| Controller
  Controller -->|"limit ?? 50"| UseCase
```

Linear Issue: [NV-8329](https://linear.app/novu/issue/NV-8329/unbounded-list-pagination-dos)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

### Greptile Summary

This PR caps list pagination for workflow and layout APIs. The main changes are:

* Adds a default `@Max(100)` limit to `LimitOffsetPaginationQueryDto`, with an optional custom max.
* Updates workflow and layout list controllers to use validated pagination values and default with `??`.
* Adds unit and e2e tests for rejecting `limit` values above `100`.

### Confidence Score: 5/5

Safe to merge with minimal risk.

The change is narrowly scoped to shared pagination validation and controller defaulting. The updated paths use the existing DTO transformation and validation flow. Tests cover the new max-limit behavior at both unit and endpoint levels.

No files require special attention.

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* T-Rex ran the requested verification of the contract, but the local artifact references were not uploaded.

<img src="https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667 " alt="T-Rex" height="14" /> Ran code and verified through T-Rex

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/api/src/app/shared/dtos/limit-offset-pagination.dto.ts | Adds a default configurable maximum limit to shared limit/offset pagination validation and OpenAPI metadata. |
| apps/api/src/app/shared/dtos/limit-offset-pagination.dto.spec.ts | Adds unit coverage for default and custom maximum limits plus omitted limit behavior. |
| apps/api/src/app/workflows-v2/workflow.controller.ts | Uses validated numeric pagination query values with defaults for workflow listing. |
| apps/api/src/app/layouts-v2/layouts.controller.ts | Uses validated numeric pagination query values with defaults for layout listing. |
| apps/api/src/app/workflows-v2/e2e/list-workflows.e2e.ts | Adds e2e coverage that workflow list requests with limit above 100 are rejected. |
| apps/api/src/app/layouts-v2/e2e/list-layouts.e2e.ts | Adds e2e coverage that layout list requests with limit above 100 are rejected. |

</details>

### Sequence Diagram

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Client
  participant ValidationPipe
  participant PaginationDto as LimitOffsetPaginationQueryDto
  participant Controller as Workflow/Layout Controller
  participant UseCase as List Use Case

  Client->>ValidationPipe: "GET /v2/workflows or /v2/layouts?limit=..."
  ValidationPipe->>PaginationDto: Transform and validate limit
  alt "limit > 100"
    PaginationDto-->>ValidationPipe: "@Max(100) validation error"
    ValidationPipe-->>Client: 422 Validation Error
  else limit omitted or 1..100
    PaginationDto-->>Controller: validated query values
    Controller->>UseCase: limit ?? 50, offset ?? 0
    UseCase-->>Client: paginated list response
  end
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Client
  participant ValidationPipe
  participant PaginationDto as LimitOffsetPaginationQueryDto
  participant Controller as Workflow/Layout Controller
  participant UseCase as List Use Case

  Client->>ValidationPipe: "GET /v2/workflows or /v2/layouts?limit=..."
  ValidationPipe->>PaginationDto: Transform and validate limit
  alt "limit > 100"
    PaginationDto-->>ValidationPipe: "@Max(100) validation error"
    ValidationPipe-->>Client: 422 Validation Error
  else limit omitted or 1..100
    PaginationDto-->>Controller: validated query values
    Controller->>UseCase: limit ?? 50, offset ?? 0
    UseCase-->>Client: paginated list response
  end
```

Reviews (1): Last reviewed commit: ["fix(api-service): cap list pagination li..."](<https://github.com/novuhq/novu/commit/d8d3a4a324037716dd38a6145cc6f46afebb1578>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=45574331>)