### PR TITLE
feat(dashboard): improve manual MS Teams onboarding with CLI shortcut and diagnostics

### DIFF
--- a/apps/api/src/app/integrations/usecases/msteams-health-check/msteams-health-check.usecase.spec.ts
+++ b/apps/api/src/app/integrations/usecases/msteams-health-check/msteams-health-check.usecase.spec.ts
@@ -1,0 +1,170 @@
+import { GetDecryptedIntegrations, MsTeamsTokenService, PinoLogger } from '@novu/application-generic';
+import { IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+import axios from 'axios';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { MsTeamsHealthCheckCommand } from './msteams-health-check.command';
+import { MsTeamsHealthCheck } from './msteams-health-check.usecase';
+
+const MOCK_ENVIRONMENT_ID = 'env-id-123';
+const MOCK_ORGANIZATION_ID = 'org-id-456';
+const MOCK_INTEGRATION_ID = 'integration-id-789';
+const MOCK_CLIENT_ID = 'azure-client-id';
+const MOCK_TENANT_ID = 'azure-tenant-id';
+const MOCK_SECRET_KEY = 'azure-secret';
+const MOCK_GRAPH_TOKEN = 'graph-token';
+
+const ROLE_IDS = {
+  DIRECTORY_READ_ALL: '7ab1d382-f21e-4acd-a863-ba3e13f7da61',
+  TEAM_READ_BASIC_ALL: '2280dda6-0bfd-44ee-a2f4-cb867cfc4c1e',
+  CHANNEL_READ_BASIC_ALL: '59a6b24b-4225-4393-8165-ebaec5f55d7a',
+  APP_CATALOG_READ_ALL: 'e12dae10-5a57-4817-b79d-dfbec5348930',
+  TEAMS_APP_INSTALLATION_READ_WRITE_SELF_FOR_TEAM_ALL: '9f67436c-5415-4e7f-8ac1-3014a7132630',
+  TEAMS_APP_INSTALLATION_READ_WRITE_SELF_FOR_USER_ALL: '908de74d-f8b2-4d6b-a9ed-2a17b3b78179',
+};
+
+const REQUIRED_ROLE_IDS = [
+  ROLE_IDS.DIRECTORY_READ_ALL,
+  ROLE_IDS.TEAM_READ_BASIC_ALL,
+  ROLE_IDS.CHANNEL_READ_BASIC_ALL,
+  ROLE_IDS.APP_CATALOG_READ_ALL,
+];
+
+const RECOMMENDED_ROLE_IDS = [
+  ROLE_IDS.TEAMS_APP_INSTALLATION_READ_WRITE_SELF_FOR_TEAM_ALL,
+  ROLE_IDS.TEAMS_APP_INSTALLATION_READ_WRITE_SELF_FOR_USER_ALL,
+];
+
+function buildMockIntegration(overrides: Record<string, unknown> = {}) {
+
+  return {
+    _id: MOCK_INTEGRATION_ID,
+    _environmentId: MOCK_ENVIRONMENT_ID,
+    _organizationId: MOCK_ORGANIZATION_ID,
+    identifier: 'msteams-integration',
+    providerId: ChatProviderIdEnum.MsTeams,
+    credentials: {
+      clientId: MOCK_CLIENT_ID,
+      secretKey: MOCK_SECRET_KEY,
+      tenantId: MOCK_TENANT_ID,
+    },
+    ...overrides,
+  } as any;
+}
+
+function buildCommand(checks?: string[]) {
+  const command = {
+    environmentId: MOCK_ENVIRONMENT_ID,
+    organizationId: MOCK_ORGANIZATION_ID,
+    integrationId: MOCK_INTEGRATION_ID,
+    ...(checks ? { checks } : {}),
+  };
+
+  return MsTeamsHealthCheckCommand.create(command);
+}
+
+function stubPermissionsGraphCalls(axiosGetStub: sinon.SinonStub, appRoleIds: string[]) {
+  axiosGetStub.onFirstCall().resolves({ data: { value: [{ id: 'service-principal-id' }] } });
+  axiosGetStub.onSecondCall().resolves({
+    data: {
+      value: appRoleIds.map((appRoleId) => ({ appRoleId })),
+    },
+  });
+}
+
+describe('MsTeamsHealthCheck', () => {
+  let usecase: MsTeamsHealthCheck;
+  let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
+  let msTeamsTokenService: sinon.SinonStubbedInstance<MsTeamsTokenService>;
+  let logger: sinon.SinonStubbedInstance<PinoLogger>;
+  let axiosGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    integrationRepository = sinon.createStubInstance(IntegrationRepository);
+    msTeamsTokenService = sinon.createStubInstance(MsTeamsTokenService);
+    logger = sinon.createStubInstance(PinoLogger);
+    axiosGetStub = sinon.stub(axios, 'get');
+
+    integrationRepository.findOne.resolves(buildMockIntegration());
+    msTeamsTokenService.getGraphToken.resolves(MOCK_GRAPH_TOKEN);
+    sinon.stub(GetDecryptedIntegrations, 'getDecryptedCredentials').callsFake((integration) => integration as any);
+
+    usecase = new MsTeamsHealthCheck(integrationRepository as any, msTeamsTokenService as any, logger as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('permissions', () => {
+    it('should be ready when all required roles are granted and recommended roles are missing', async () => {
+      stubPermissionsGraphCalls(axiosGetStub, REQUIRED_ROLE_IDS);
+
+      const result = await usecase.execute(buildCommand(['permissions']));
+
+      expect(result.permissions).to.equal('ready');
+      expect(result.missingRequiredPermissions).to.deep.equal([]);
+      expect(result.missingRecommendedPermissions).to.deep.equal([
+        'TeamsAppInstallation.ReadWriteSelfForTeam.All',
+        'TeamsAppInstallation.ReadWriteSelfForUser.All',
+      ]);
+    });
+
+    it('should be pending when a required role is missing and list it by name', async () => {
+      stubPermissionsGraphCalls(axiosGetStub, [
+        ROLE_IDS.DIRECTORY_READ_ALL,
+        ROLE_IDS.TEAM_READ_BASIC_ALL,
+        ROLE_IDS.APP_CATALOG_READ_ALL,
+        ...RECOMMENDED_ROLE_IDS,
+      ]);
+
+      const result = await usecase.execute(buildCommand(['permissions']));
+
+      expect(result.permissions).to.equal('pending');
+      expect(result.missingRequiredPermissions).to.deep.equal(['Channel.ReadBasic.All']);
+      expect(result.missingRecommendedPermissions).to.deep.equal([]);
+    });
+  });
+
+  describe('teamsAppCatalog', () => {
+    it('should return teamsAppCatalogId when a catalog entry is found', async () => {
+      axiosGetStub.resolves({ data: { value: [{ id: 'teams-app-catalog-id' }] } });
+
+      const result = await usecase.execute(buildCommand(['teamsAppCatalog']));
+
+      expect(result.teamsAppCatalog).to.equal('ready');
+      expect(result.teamsAppCatalogId).to.equal('teams-app-catalog-id');
+    });
+
+    it('should return null teamsAppCatalogId when the catalog entry is absent', async () => {
+      axiosGetStub.resolves({ data: { value: [] } });
+
+      const result = await usecase.execute(buildCommand(['teamsAppCatalog']));
+
+      expect(result.teamsAppCatalog).to.equal('pending');
+      expect(result.teamsAppCatalogId).to.equal(null);
+    });
+  });
+
+  describe('missing credentials', () => {
+    it('should fail requested statuses with empty missing permission arrays and null catalog id', async () => {
+      integrationRepository.findOne.resolves(buildMockIntegration({ credentials: undefined }));
+
+      const result = await usecase.execute(buildCommand());
+
+      expect(result).to.deep.equal({
+        appRegistration: 'failed',
+        azureBotCreated: 'failed',
+        teamsAppCatalog: 'failed',
+        permissions: 'failed',
+        missingRequiredPermissions: [],
+        missingRecommendedPermissions: [],
+        teamsAppCatalogId: null,
+        allReady: false,
+      });
+      expect(msTeamsTokenService.getGraphToken.called).to.equal(false);
+      expect(axiosGetStub.called).to.equal(false);
+    });
+  });
+});

--- a/apps/api/src/app/integrations/usecases/msteams-health-check/msteams-health-check.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/msteams-health-check/msteams-health-check.usecase.ts
@@ -12,8 +12,45 @@ export interface MsTeamsHealthCheckResult {
   azureBotCreated: HealthCheckStatus | null;
   teamsAppCatalog: HealthCheckStatus | null;
   permissions: HealthCheckStatus | null;
+  missingRequiredPermissions: string[];
+  missingRecommendedPermissions: string[];
+  teamsAppCatalogId: string | null;
   allReady: boolean;
 }
+
+export interface MsTeamsGraphPermission {
+  id: string;
+  name: string;
+}
+
+interface MsTeamsAppCatalogCheckResult {
+  status: HealthCheckStatus | null;
+  teamsAppCatalogId: string | null;
+}
+
+interface MsTeamsPermissionsCheckResult {
+  status: HealthCheckStatus | null;
+  missingRequiredPermissions: string[];
+  missingRecommendedPermissions: string[];
+}
+
+export const MS_TEAMS_REQUIRED_GRAPH_PERMISSIONS: MsTeamsGraphPermission[] = [
+  { id: '7ab1d382-f21e-4acd-a863-ba3e13f7da61', name: 'Directory.Read.All' },
+  { id: '2280dda6-0bfd-44ee-a2f4-cb867cfc4c1e', name: 'Team.ReadBasic.All' },
+  { id: '59a6b24b-4225-4393-8165-ebaec5f55d7a', name: 'Channel.ReadBasic.All' },
+  { id: 'e12dae10-5a57-4817-b79d-dfbec5348930', name: 'AppCatalog.Read.All' },
+];
+
+export const MS_TEAMS_RECOMMENDED_GRAPH_PERMISSIONS: MsTeamsGraphPermission[] = [
+  {
+    id: '9f67436c-5415-4e7f-8ac1-3014a7132630',
+    name: 'TeamsAppInstallation.ReadWriteSelfForTeam.All',
+  },
+  {
+    id: '908de74d-f8b2-4d6b-a9ed-2a17b3b78179',
+    name: 'TeamsAppInstallation.ReadWriteSelfForUser.All',
+  },
+];
 
 /**
  * Verifies the MS Teams integration using credentials and provisioning state stored on the integration.
@@ -33,19 +70,6 @@ export interface MsTeamsHealthCheckResult {
 @Injectable()
 export class MsTeamsHealthCheck {
   private readonly MS_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
-
-  /**
-   * The Graph app roles we expect to find granted on the bot's service principal.
-   * These match REQUIRED_GRAPH_PERMISSIONS in azure-setup-oauth-callback.usecase.ts.
-   */
-  private readonly EXPECTED_ROLE_IDS = new Set([
-    '7ab1d382-f21e-4acd-a863-ba3e13f7da61', // Directory.Read.All
-    '2280dda6-0bfd-44ee-a2f4-cb867cfc4c1e', // Team.ReadBasic.All
-    '59a6b24b-4225-4393-8165-ebaec5f55d7a', // Channel.ReadBasic.All
-    'e12dae10-5a57-4817-b79d-dfbec5348930', // AppCatalog.Read.All
-    '9f67436c-5415-4e7f-8ac1-3014a7132630', // TeamsAppInstallation.ReadWriteSelfForTeam.All
-    '908de74d-f8b2-4d6b-a9ed-2a17b3b78179', // TeamsAppInstallation.ReadWriteSelfForUser.All
-  ]);
 
   constructor(
     private integrationRepository: IntegrationRepository,
@@ -71,7 +95,7 @@ export class MsTeamsHealthCheck {
     }
 
     const decrypted = GetDecryptedIntegrations.getDecryptedCredentials(integration);
-    const credentials = decrypted.credentials as Record<string, string>;
+    const credentials = (decrypted.credentials ?? {}) as Record<string, string>;
     const clientId = credentials.clientId ?? '';
     const secretKey = credentials.secretKey ?? '';
     const tenantId = credentials.tenantId ?? '';
@@ -85,6 +109,9 @@ export class MsTeamsHealthCheck {
         azureBotCreated: failedStatus('azureBotCreated'),
         teamsAppCatalog: failedStatus('teamsAppCatalog'),
         permissions: failedStatus('permissions'),
+        missingRequiredPermissions: [],
+        missingRecommendedPermissions: [],
+        teamsAppCatalogId: null,
         allReady: false,
       };
     }
@@ -92,12 +119,24 @@ export class MsTeamsHealthCheck {
     const shouldRun = (name: string): boolean => !command.checks || command.checks.includes(name);
 
     // Run only the requested checks in parallel — skipped checks resolve to null immediately
-    const [appRegistration, azureBotCreated, teamsAppCatalog, permissions] = await Promise.all([
+    const [appRegistration, azureBotCreated, teamsAppCatalogResult, permissionsResult] = await Promise.all([
       shouldRun('appRegistration') ? this.checkAppRegistration(clientId, secretKey, tenantId) : Promise.resolve(null),
       shouldRun('azureBotCreated') ? Promise.resolve(this.checkAzureBotCreated(integration)) : Promise.resolve(null),
-      shouldRun('teamsAppCatalog') ? this.checkTeamsAppCatalog(clientId, secretKey, tenantId) : Promise.resolve(null),
-      shouldRun('permissions') ? this.checkPermissions(clientId, secretKey, tenantId) : Promise.resolve(null),
+      shouldRun('teamsAppCatalog')
+        ? this.checkTeamsAppCatalog(clientId, secretKey, tenantId)
+        : Promise.resolve({ status: null, teamsAppCatalogId: null }),
+      shouldRun('permissions')
+        ? this.checkPermissions(clientId, secretKey, tenantId)
+        : Promise.resolve({
+            status: null,
+            missingRequiredPermissions: [],
+            missingRecommendedPermissions: [],
+          }),
     ]);
+    const teamsAppCatalog = teamsAppCatalogResult.status;
+    const teamsAppCatalogId = teamsAppCatalogResult.teamsAppCatalogId;
+    const permissions = permissionsResult.status;
+    const { missingRequiredPermissions, missingRecommendedPermissions } = permissionsResult;
 
     // allReady only considers non-null (requested) fields
     const allReady = [appRegistration, azureBotCreated, teamsAppCatalog, permissions]
@@ -105,10 +144,19 @@ export class MsTeamsHealthCheck {
       .every((s) => s === 'ready');
 
     this.logger.debug(
-      `Health check result integrationId=${command.integrationId} appRegistration=${appRegistration} azureBotCreated=${azureBotCreated} teamsAppCatalog=${teamsAppCatalog} permissions=${permissions} allReady=${allReady}`
+      `Health check result integrationId=${command.integrationId} appRegistration=${appRegistration} azureBotCreated=${azureBotCreated} teamsAppCatalog=${teamsAppCatalog} teamsAppCatalogId=${teamsAppCatalogId} permissions=${permissions} allReady=${allReady}`
     );
 
-    return { appRegistration, azureBotCreated, teamsAppCatalog, permissions, allReady };
+    return {
+      appRegistration,
+      azureBotCreated,
+      teamsAppCatalog,
+      permissions,
+      missingRequiredPermissions,
+      missingRecommendedPermissions,
+      teamsAppCatalogId,
+      allReady,
+    };
   }
 
   /**
@@ -137,6 +185,7 @@ export class MsTeamsHealthCheck {
    * Missing provisioning means Quick Setup has not produced a tracked Azure Bot deployment.
    */
   private checkAzureBotCreated(integration: IntegrationEntity): HealthCheckStatus {
+
     return integration.provisioning?.status ?? 'pending';
   }
 
@@ -148,25 +197,26 @@ export class MsTeamsHealthCheck {
     clientId: string,
     secretKey: string,
     tenantId: string
-  ): Promise<HealthCheckStatus> {
+  ): Promise<MsTeamsAppCatalogCheckResult> {
     try {
       const graphToken = await this.msTeamsTokenService.getGraphToken(clientId, secretKey, tenantId);
 
       if (!graphToken) {
-        return 'pending';
+        return { status: 'pending', teamsAppCatalogId: null };
       }
 
       const filter = encodeURIComponent(`externalId eq '${clientId}' and distributionMethod eq 'organization'`);
-      const response = await axios.get<{ value: unknown[] }>(
+      const response = await axios.get<{ value: Array<{ id?: string }> }>(
         `${this.MS_GRAPH_BASE_URL}/appCatalogs/teamsApps?$filter=${filter}`,
         { headers: { Authorization: `Bearer ${graphToken}` }, timeout: 10_000 }
       );
+      const teamsApp = response.data.value[0];
 
-      return response.data.value.length > 0 ? 'ready' : 'pending';
+      return { status: teamsApp ? 'ready' : 'pending', teamsAppCatalogId: teamsApp?.id ?? null };
     } catch (error) {
       this.logger.warn(`Health check: teamsAppCatalog failed clientId=${clientId} error="${(error as Error).message}"`);
 
-      return 'pending';
+      return { status: 'pending', teamsAppCatalogId: null };
     }
   }
 
@@ -174,12 +224,20 @@ export class MsTeamsHealthCheck {
    * Check 4: Are the required Graph appRoleAssignments propagated on the service principal?
    * Looks up the SP by appId then checks its appRoleAssignments.
    */
-  private async checkPermissions(clientId: string, secretKey: string, tenantId: string): Promise<HealthCheckStatus> {
+  private async checkPermissions(
+    clientId: string,
+    secretKey: string,
+    tenantId: string
+  ): Promise<MsTeamsPermissionsCheckResult> {
     try {
       const graphToken = await this.msTeamsTokenService.getGraphToken(clientId, secretKey, tenantId);
 
       if (!graphToken) {
-        return 'pending';
+        return {
+          status: 'pending',
+          missingRequiredPermissions: MS_TEAMS_REQUIRED_GRAPH_PERMISSIONS.map((permission) => permission.name),
+          missingRecommendedPermissions: MS_TEAMS_RECOMMENDED_GRAPH_PERMISSIONS.map((permission) => permission.name),
+        };
       }
 
       // Resolve service principal for the bot's app
@@ -192,7 +250,11 @@ export class MsTeamsHealthCheck {
       const spId = spResponse.data.value[0]?.id;
 
       if (!spId) {
-        return 'pending';
+        return {
+          status: 'pending',
+          missingRequiredPermissions: MS_TEAMS_REQUIRED_GRAPH_PERMISSIONS.map((permission) => permission.name),
+          missingRecommendedPermissions: MS_TEAMS_RECOMMENDED_GRAPH_PERMISSIONS.map((permission) => permission.name),
+        };
       }
 
       // Check appRoleAssignments on the service principal
@@ -202,13 +264,26 @@ export class MsTeamsHealthCheck {
       );
 
       const grantedRoleIds = new Set(assignmentsResponse.data.value.map((a) => a.appRoleId));
-      const allGranted = [...this.EXPECTED_ROLE_IDS].every((id) => grantedRoleIds.has(id));
+      const missingRequiredPermissions = MS_TEAMS_REQUIRED_GRAPH_PERMISSIONS.filter(
+        (permission) => !grantedRoleIds.has(permission.id)
+      ).map((permission) => permission.name);
+      const missingRecommendedPermissions = MS_TEAMS_RECOMMENDED_GRAPH_PERMISSIONS.filter(
+        (permission) => !grantedRoleIds.has(permission.id)
+      ).map((permission) => permission.name);
 
-      return allGranted ? 'ready' : 'pending';
+      return {
+        status: missingRequiredPermissions.length === 0 ? 'ready' : 'pending',
+        missingRequiredPermissions,
+        missingRecommendedPermissions,
+      };
     } catch (error) {
       this.logger.warn(`Health check: permissions failed clientId=${clientId} error="${(error as Error).message}"`);
 
-      return 'pending';
+      return {
+        status: 'pending',
+        missingRequiredPermissions: MS_TEAMS_REQUIRED_GRAPH_PERMISSIONS.map((permission) => permission.name),
+        missingRecommendedPermissions: MS_TEAMS_RECOMMENDED_GRAPH_PERMISSIONS.map((permission) => permission.name),
+      };
     }
   }
 }

--- a/apps/dashboard/src/api/integrations.ts
+++ b/apps/dashboard/src/api/integrations.ts
@@ -18,6 +18,9 @@ export type MsTeamsHealthCheckResult = {
   teamsAppCatalog: HealthCheckStatus | null;
   permissions: HealthCheckStatus | null;
   allReady: boolean;
+  missingRequiredPermissions: string[];
+  missingRecommendedPermissions: string[];
+  teamsAppCatalogId: string | null;
 };
 
 export type CreateIntegrationData = {

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -64,6 +64,14 @@ function buildOAuthCallbackUrl(): string {
   return `${getAgentApiBaseUrl()}/v1/integrations/chat/oauth/callback`;
 }
 
+function buildTeamsDeepLink(catalogId: string): string {
+  return `https://teams.microsoft.com/l/app/${catalogId}`;
+}
+
+function escapeShellDoubleQuotedValue(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}
+
 // ---------------------------------------------------------------------------
 // Small presentational pieces
 // ---------------------------------------------------------------------------
@@ -241,6 +249,149 @@ function ManualBotDeployFallback({ webhookUrl }: { webhookUrl: string }) {
   );
 }
 
+function OpenInTeamsButton({ catalogId }: { catalogId: string }) {
+  return <SetupButton href={buildTeamsDeepLink(catalogId)}>Open in Teams</SetupButton>;
+}
+
+function TeamsCliShortcut({ agentName, webhookUrl }: { agentName: string; webhookUrl: string }) {
+  const [open, setOpen] = useState(false);
+  const cliCommands = `npm install -g @microsoft/teams.cli
+teams app create --name "${escapeShellDoubleQuotedValue(agentName)}" --endpoint ${webhookUrl} --azure --subscription <your-sub> --resource-group <your-rg> --env .env`;
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <button
+        type="button"
+        aria-expanded={open}
+        className="text-text-sub hover:text-text-strong flex items-center gap-1 self-start transition-colors"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <RiArrowDownSLine className={cn('size-3.5 transition-transform duration-200', open && 'rotate-180')} />
+        <span className="text-label-xs font-medium">Prefer the terminal? Use the Teams CLI</span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="min-w-0 overflow-hidden"
+          >
+            <div className="border-stroke-soft bg-bg-weak flex flex-col gap-3 rounded-lg border p-4">
+              <p className="text-text-sub text-label-xs font-medium">Teams CLI shortcut</p>
+              <ol className="text-text-sub flex flex-col gap-1.5 pl-4 text-[12px] leading-5 [list-style:decimal]">
+                <li>Run these commands locally to create the Teams app registration and Azure Bot resources.</li>
+                <li>
+                  Copy the generated <strong>CLIENT_ID</strong>, <strong>CLIENT_SECRET</strong>, and{' '}
+                  <strong>TENANT_ID</strong> into step 3.
+                </li>
+                <li>
+                  The CLI replaces the portal work for steps 1 and 4. Step 2 still requires the Azure Portal so you can
+                  add Graph permissions and grant admin consent.
+                </li>
+                <li>Still download Novu's app package in step 5 and upload it to Teams in step 6.</li>
+              </ol>
+              <CodeBlock code={cliCommands} language="shell" title="Teams CLI commands" />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function TeamsAppUploadInstructions() {
+  return (
+    <ol className="flex flex-col gap-1.5 pl-4 [list-style:decimal]">
+      <li className="text-paragraph-xs text-text-sub">
+        Click <strong>Download app package</strong> on the right to save the{' '}
+        <code className="font-code text-[11px]">.zip</code> file.
+      </li>
+      <li className="text-paragraph-xs text-text-sub">
+        Open{' '}
+        <a
+          href="https://teams.microsoft.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2"
+        >
+          Microsoft Teams
+        </a>
+        .
+      </li>
+      <li className="text-paragraph-xs text-text-sub">
+        Click <strong>Apps</strong> in the left sidebar.
+      </li>
+      <li className="text-paragraph-xs text-text-sub">
+        Click <strong>Manage your apps</strong> at the bottom of the panel.
+      </li>
+      <li className="text-paragraph-xs text-text-sub">
+        Click <strong>Upload an app</strong>, then select <strong>Upload a custom app</strong>.
+      </li>
+      <li className="text-paragraph-xs text-text-sub">
+        Choose the downloaded <code className="font-code text-[11px]">.zip</code> file, then click <strong>Add</strong>{' '}
+        in the app modal.
+      </li>
+    </ol>
+  );
+}
+
+function TeamsAppUploadFallback({
+  canDownload,
+  handleDownload,
+  manifestJson,
+}: {
+  canDownload: boolean;
+  handleDownload: () => void;
+  manifestJson: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <button
+        type="button"
+        aria-expanded={open}
+        className="text-text-sub hover:text-text-strong flex items-center gap-1 self-start transition-colors"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <RiArrowDownSLine className={cn('size-3.5 transition-transform duration-200', open && 'rotate-180')} />
+        <span className="text-label-xs font-medium">
+          {open ? 'Hide manual upload instructions' : 'Need to upload manually?'}
+        </span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="min-w-0 overflow-hidden"
+          >
+            <div className="border-stroke-soft bg-bg-weak flex flex-col gap-3 rounded-lg border p-4">
+              <TeamsAppUploadInstructions />
+              <div className="self-start">
+                <SetupButton
+                  leadingIcon={<Download className="size-3.5" />}
+                  onClick={handleDownload}
+                  disabled={!canDownload}
+                >
+                  Download app package
+                </SetupButton>
+              </div>
+              <ManifestPreview manifestJson={manifestJson} />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Setup mode toggle
 // ---------------------------------------------------------------------------
@@ -251,12 +402,67 @@ function ManualBotDeployFallback({ webhookUrl }: { webhookUrl: string }) {
 
 const HEALTH_POLL_INTERVAL_MS = 10_000;
 
-const CHECKPOINT_LABELS: Record<keyof Omit<MsTeamsHealthCheckResult, 'allReady'>, string> = {
-  appRegistration: 'App Registration',
-  azureBotCreated: 'Azure Bot Created',
-  teamsAppCatalog: 'Teams App Catalog',
-  permissions: 'Permission Propagation',
+type HealthCheckKey = 'appRegistration' | 'azureBotCreated' | 'teamsAppCatalog' | 'permissions';
+type HealthCheckRemedyMode = 'quick' | 'manual';
+
+const CHECKPOINT_KEYS: HealthCheckKey[] = ['appRegistration', 'azureBotCreated', 'teamsAppCatalog', 'permissions'];
+
+const CHECKPOINT_CONFIG: Record<HealthCheckKey, { label: string; remedy: Record<HealthCheckRemedyMode, string> }> = {
+  appRegistration: {
+    label: 'App Registration',
+    remedy: {
+      quick: 'Redo Quick Setup step 1: Set Up Azure, then wait for Novu to verify the App Registration.',
+      manual: 'Redo manual step 1: create the App Registration, then save the credentials again in step 3.',
+    },
+  },
+  azureBotCreated: {
+    label: 'Azure Bot Created',
+    remedy: {
+      quick: 'Redo Quick Setup step 1: Set Up Azure so Novu can create the Azure Bot again.',
+      manual: 'Redo manual step 4: deploy the Azure Bot and make sure the Teams channel is enabled.',
+    },
+  },
+  teamsAppCatalog: {
+    label: 'Teams App Catalog',
+    remedy: {
+      quick:
+        'Redo Quick Setup step 3: upload the Teams app package, or open the fallback instructions and upload it manually.',
+      manual: 'Redo manual step 6: upload the Teams app package and make sure it is unblocked in the Teams catalog.',
+    },
+  },
+  permissions: {
+    label: 'Permission Propagation',
+    remedy: {
+      quick: 'Redo Quick Setup step 1: Set Up Azure, then grant admin consent if your tenant asks for it.',
+      manual: 'Redo manual step 2: add the Graph permissions and grant admin consent for your organization.',
+    },
+  },
 };
+
+function normalizeHealthCheckResult(result: MsTeamsHealthCheckResult): MsTeamsHealthCheckResult {
+  return {
+    appRegistration: result.appRegistration ?? null,
+    azureBotCreated: result.azureBotCreated ?? null,
+    teamsAppCatalog: result.teamsAppCatalog ?? null,
+    permissions: result.permissions ?? null,
+    allReady: result.allReady,
+    missingRequiredPermissions: Array.isArray(result.missingRequiredPermissions)
+      ? result.missingRequiredPermissions
+      : [],
+    missingRecommendedPermissions: Array.isArray(result.missingRecommendedPermissions)
+      ? result.missingRecommendedPermissions
+      : [],
+    teamsAppCatalogId: result.teamsAppCatalogId ?? null,
+  };
+}
+
+function getCheckpointLabel(key: HealthCheckKey): string {
+  return CHECKPOINT_CONFIG[key].label;
+}
+
+function getCheckpointRemedy(key: HealthCheckKey, mode: HealthCheckRemedyMode): string {
+  return CHECKPOINT_CONFIG[key].remedy[mode];
+}
 
 function CheckpointRow({ label, status }: { label: string; status: HealthCheckStatus }) {
   return (
@@ -284,16 +490,27 @@ type HealthCheckViewProps = {
   integrationId: string;
   /** True while the Azure setup popup is still open, polling is suspended until credentials are saved */
   waitingForSetup: boolean;
-  onReady: () => void;
+  onReady: (result: MsTeamsHealthCheckResult) => void;
+  onStatusChange?: (result: MsTeamsHealthCheckResult) => void;
+  remedyMode: HealthCheckRemedyMode;
   compact?: boolean;
 };
 
-function HealthCheckView({ integrationId, waitingForSetup, onReady, compact = false }: HealthCheckViewProps) {
+function HealthCheckView({
+  integrationId,
+  waitingForSetup,
+  onReady,
+  onStatusChange,
+  remedyMode,
+  compact = false,
+}: HealthCheckViewProps) {
   const { currentEnvironment } = useEnvironment();
   const [status, setStatus] = useState<MsTeamsHealthCheckResult | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onReadyRef = useRef(onReady);
+  const onStatusChangeRef = useRef(onStatusChange);
   onReadyRef.current = onReady;
+  onStatusChangeRef.current = onStatusChange;
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -307,11 +524,13 @@ function HealthCheckView({ integrationId, waitingForSetup, onReady, compact = fa
 
     try {
       const result = await getMsTeamsHealthCheck(integrationId, currentEnvironment);
-      setStatus(result);
+      const next = normalizeHealthCheckResult(result);
+      setStatus(next);
+      onStatusChangeRef.current?.(next);
 
-      if (result.allReady) {
+      if (next.allReady) {
         stopPolling();
-        onReadyRef.current();
+        onReadyRef.current(next);
 
         return;
       }
@@ -328,13 +547,13 @@ function HealthCheckView({ integrationId, waitingForSetup, onReady, compact = fa
   }, [poll, stopPolling]);
 
   const allPending: HealthCheckStatus = 'pending';
-  const checkpoints = (Object.keys(CHECKPOINT_LABELS) as Array<keyof typeof CHECKPOINT_LABELS>).map((key) => ({
+  const checkpoints = CHECKPOINT_KEYS.map((key) => ({
     key,
-    label: CHECKPOINT_LABELS[key],
+    label: getCheckpointLabel(key),
     status: (status ? (status[key] ?? allPending) : allPending) as HealthCheckStatus,
   }));
 
-  const hasFailed = status?.appRegistration === 'failed' || status?.azureBotCreated === 'failed';
+  const failedCheckpoints = checkpoints.filter(({ status: checkpointStatus }) => checkpointStatus === 'failed');
 
   return (
     <div className={cn('flex flex-col', compact ? 'w-[260px] gap-2.5' : 'gap-4')}>
@@ -352,13 +571,15 @@ function HealthCheckView({ integrationId, waitingForSetup, onReady, compact = fa
         ))}
       </div>
 
-      {!waitingForSetup && hasFailed && (
-        <InlineToast
-          variant="error"
-          title="Setup error"
-          description="App Registration or Azure Bot could not be verified. Please retry the Azure setup step."
-        />
-      )}
+      {!waitingForSetup &&
+        failedCheckpoints.map(({ key, label }) => (
+          <InlineToast
+            key={key}
+            variant="error"
+            title={`${label} needs attention`}
+            description={getCheckpointRemedy(key, remedyMode)}
+          />
+        ))}
     </div>
   );
 }
@@ -420,7 +641,7 @@ function ConnectAndLinkSection({
 
     let cancelled = false;
 
-    (async () => {
+    void (async () => {
       try {
         const connResponse = await novu.channelConnections.get({ identifier: connectionIdentifier });
         if (cancelled || !connResponse.data) return;
@@ -543,7 +764,15 @@ function ConnectAndLinkSection({
 
 const MANUAL_HEALTH_CHECKS = ['teamsAppCatalog', 'permissions'] as const;
 
-type ManualHealthState = Pick<MsTeamsHealthCheckResult, 'azureBotCreated' | 'teamsAppCatalog' | 'permissions'>;
+type ManualHealthState = Pick<
+  MsTeamsHealthCheckResult,
+  | 'azureBotCreated'
+  | 'teamsAppCatalog'
+  | 'permissions'
+  | 'missingRequiredPermissions'
+  | 'missingRecommendedPermissions'
+  | 'teamsAppCatalogId'
+>;
 
 function useManualHealthPoll(integrationId: string, enabled: boolean): ManualHealthState | null {
   const { currentEnvironment } = useEnvironment();
@@ -562,10 +791,14 @@ function useManualHealthPoll(integrationId: string, enabled: boolean): ManualHea
 
     try {
       const result = await getMsTeamsHealthCheck(integrationId, currentEnvironment, [...MANUAL_HEALTH_CHECKS]);
+      const normalized = normalizeHealthCheckResult(result);
       const next: ManualHealthState = {
         azureBotCreated: null,
-        teamsAppCatalog: result.teamsAppCatalog,
-        permissions: result.permissions,
+        teamsAppCatalog: normalized.teamsAppCatalog,
+        permissions: normalized.permissions,
+        missingRequiredPermissions: normalized.missingRequiredPermissions,
+        missingRecommendedPermissions: normalized.missingRecommendedPermissions,
+        teamsAppCatalogId: normalized.teamsAppCatalogId,
       };
 
       setState(next);
@@ -595,6 +828,46 @@ function useManualHealthPoll(integrationId: string, enabled: boolean): ManualHea
   return state;
 }
 
+function ManualPermissionsCheckpoint({ manualHealth }: { manualHealth: ManualHealthState | null }) {
+  if (!manualHealth?.permissions) {
+    return null;
+  }
+
+  const missingRequiredPermissions = manualHealth.missingRequiredPermissions;
+  const missingRecommendedPermissions = manualHealth.missingRecommendedPermissions;
+  let label = 'Waiting for admin consent to propagate';
+
+  if (manualHealth.permissions === 'ready') {
+    label = 'Required permissions verified';
+  }
+
+  if (manualHealth.permissions === 'failed') {
+    label = 'Permission verification failed';
+  }
+
+  if (manualHealth.permissions === 'pending' && missingRequiredPermissions.length > 0) {
+    label = `Waiting for admin consent: ${missingRequiredPermissions.join(', ')}`;
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <CheckpointRow label={label} status={manualHealth.permissions} />
+      {missingRecommendedPermissions.length > 0 && (
+        <p className="text-text-soft text-label-xs">
+          Recommended permissions missing: {missingRecommendedPermissions.join(', ')}.
+        </p>
+      )}
+      {manualHealth.permissions === 'failed' && (
+        <InlineToast
+          variant="error"
+          title="Permissions need attention"
+          description={getCheckpointRemedy('permissions', 'manual')}
+        />
+      )}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -620,6 +893,7 @@ export function TeamsSetupGuide({
   const [isConnectingAzure, setIsConnectingAzure] = useState(false);
   const [setupMode, setSetupMode] = useState<SetupMode>('quick');
   const [teamsAppUploaded, setTeamsAppUploaded] = useState<boolean | null>(null);
+  const [healthCheckCatalogId, setHealthCheckCatalogId] = useState<string | null>(null);
   /**
    * Whether the health-check gate has been cleared.
    * Set to `true` once the health-check poll confirms Teams readiness.
@@ -652,8 +926,7 @@ export function TeamsSetupGuide({
     ?.provisioning;
   const credentials = selectedIntegration?.credentials as Record<string, string> | undefined;
   const appId = credentials?.clientId ?? '';
-  // teamsAppCatalogId is retained for future use (e.g. restoring an "Open in Teams" deep link once catalog propagation is confirmed)
-  const teamsAppCatalogId = provisioning?.teamsAppCatalogId ?? null;
+  const provisioningTeamsAppCatalogId = provisioning?.teamsAppCatalogId ?? null;
   const hasCredentials = Boolean(appId && credentials?.secretKey && credentials?.tenantId);
   const hasQuickSetupProvisioning = Boolean(provisioning);
   const isExistingManualSetup = hasCredentials && !hasQuickSetupProvisioning;
@@ -661,12 +934,13 @@ export function TeamsSetupGuide({
   useEffect(() => {
     setIsConnected(false);
     setHealthCheckCleared(false);
+    setHealthCheckCatalogId(null);
     // Seed from provisioning: if a catalog ID already exists, the upload previously succeeded.
-    setTeamsAppUploaded(teamsAppCatalogId !== null ? true : null);
+    setTeamsAppUploaded(provisioningTeamsAppCatalogId !== null ? true : null);
     setShowHealthCheck(false);
     hasCheckedOnMountRef.current = false;
     setHasDeployedBot(sessionStorage.getItem(`novu:bot-deployed:${integrationId}`) === 'true');
-  }, [integrationId, teamsAppCatalogId]);
+  }, [integrationId, provisioningTeamsAppCatalogId]);
 
   // On page load (or when credentials first appear), run a one-time health check.
   // If the Teams health check passes immediately we silently mark the gate cleared.
@@ -687,11 +961,13 @@ export function TeamsSetupGuide({
     hasCheckedOnMountRef.current = true;
     setInitialCheckLoading(true);
 
-    (async () => {
+    void (async () => {
       try {
         const result = await getMsTeamsHealthCheck(integrationId, currentEnvironment);
+        const normalized = normalizeHealthCheckResult(result);
+        setHealthCheckCatalogId(normalized.teamsAppCatalogId);
 
-        if (result.allReady) {
+        if (normalized.allReady) {
           setHealthCheckCleared(true);
         } else {
           setShowHealthCheck(true);
@@ -777,6 +1053,9 @@ export function TeamsSetupGuide({
 
   // Build the webhook URL used in the manual Bot deployment instructions.
   const webhookUrl = `${getAgentApiBaseUrl()}/v1/agents/${agent._id}/webhook/${integrationIdentifier}`;
+  const teamsAppCatalogId = manualHealth?.teamsAppCatalogId ?? healthCheckCatalogId ?? provisioningTeamsAppCatalogId;
+  const quickAddBotAlreadyUploaded = teamsAppUploaded === true || Boolean(teamsAppCatalogId);
+  const manualTeamsAppCatalogReady = manualHealth?.teamsAppCatalog === 'ready';
 
   // Steps: App Reg + Redirect URI (base+0), Graph perms (base+1),
   //        Credentials (base+2), Deploy to Azure (base+3), Download pkg (base+4), Upload (base+5), Connect (base+6)
@@ -784,7 +1063,7 @@ export function TeamsSetupGuide({
   // Steps 1-3 are gated by hasCredentials (saving valid credentials = steps 1-3 done).
   // Steps 4-7 advance automatically as the health-check reports resources ready.
   const firstIncomplete = useMemo(() => {
-    if (isConnected && manualHealth?.teamsAppCatalog === 'ready') {
+    if (isConnected && manualTeamsAppCatalogReady) {
       return base + 7;
     }
 
@@ -792,18 +1071,18 @@ export function TeamsSetupGuide({
       return base;
     }
 
+    if (manualTeamsAppCatalogReady) {
+      return base + 6;
+    }
+
     // Step 4 (Deploy Azure Bot) is current until the user has clicked "Deploy to Azure".
     if (!hasDeployedBot) {
       return base + 3;
     }
 
-    if (manualHealth?.teamsAppCatalog === 'ready') {
-      return base + 6;
-    }
-
     // Step 6 (upload) becomes active once bot is deployed.
     return base + 5;
-  }, [base, hasCredentials, hasDeployedBot, isConnected, manualHealth]);
+  }, [base, hasCredentials, hasDeployedBot, isConnected, manualTeamsAppCatalogReady]);
 
   // Quick Setup: step 0 = Set Up Azure, step 1 = health-check gate, step 2 = Add bot to Teams, step 3 = Connect MS Teams
   //
@@ -935,11 +1214,16 @@ export function TeamsSetupGuide({
             <HealthCheckView
               integrationId={integrationId}
               waitingForSetup={!hasCredentials || !hasQuickSetupProvisioning}
-              onReady={() => {
+              onStatusChange={(result) => {
+                setHealthCheckCatalogId(result.teamsAppCatalogId);
+              }}
+              onReady={(result) => {
+                setHealthCheckCatalogId(result.teamsAppCatalogId);
                 setHealthCheckCleared(true);
                 setShowHealthCheck(false);
                 queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchIntegrations] });
               }}
+              remedyMode="quick"
               compact
             />
           ) : undefined
@@ -953,54 +1237,42 @@ export function TeamsSetupGuide({
         dimmed={!hasCredentials}
         title="Add the bot to Microsoft Teams"
         description={
-          <ol className="flex flex-col gap-1.5 pl-4 [list-style:decimal]">
-            <li className="text-paragraph-xs text-text-sub">
-              Click <strong>Download app package</strong> on the right to save the{' '}
-              <code className="font-code text-[11px]">.zip</code> file.
-            </li>
-            <li className="text-paragraph-xs text-text-sub">
-              Open{' '}
-              <a
-                href="https://teams.microsoft.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline underline-offset-2"
-              >
-                Microsoft Teams
-              </a>
-              .
-            </li>
-            <li className="text-paragraph-xs text-text-sub">
-              Click <strong>Apps</strong> in the left sidebar.
-            </li>
-            <li className="text-paragraph-xs text-text-sub">
-              Click <strong>Manage your apps</strong> at the bottom of the panel.
-            </li>
-            <li className="text-paragraph-xs text-text-sub">
-              Click <strong>Upload an app</strong>, then select <strong>Upload a custom app</strong>.
-            </li>
-            <li className="text-paragraph-xs text-text-sub">
-              Choose the downloaded <code className="font-code text-[11px]">.zip</code> file, then click{' '}
-              <strong>Add</strong> in the app modal.
-            </li>
-          </ol>
+          quickAddBotAlreadyUploaded ? (
+            <p>Already uploaded to your org catalog. Open the app in Teams to add it for testing.</p>
+          ) : (
+            <TeamsAppUploadInstructions />
+          )
         }
         rightContent={
           <div className="flex min-w-0 flex-col gap-3 w-full">
-            <div className="self-start">
-              <SetupButton
-                leadingIcon={<Download className="size-3.5" />}
-                onClick={handleDownload}
-                disabled={!canDownload}
-              >
-                Download app package
-              </SetupButton>
-            </div>
-            <ManifestPreview manifestJson={manifestJson} />
+            {quickAddBotAlreadyUploaded ? (
+              <>
+                <CheckpointRow label="Already uploaded to your org catalog" status="ready" />
+                {teamsAppCatalogId && <OpenInTeamsButton catalogId={teamsAppCatalogId} />}
+                <TeamsAppUploadFallback
+                  canDownload={canDownload}
+                  handleDownload={handleDownload}
+                  manifestJson={manifestJson}
+                />
+              </>
+            ) : (
+              <>
+                <div className="self-start">
+                  <SetupButton
+                    leadingIcon={<Download className="size-3.5" />}
+                    onClick={handleDownload}
+                    disabled={!canDownload}
+                  >
+                    Download app package
+                  </SetupButton>
+                </div>
+                <ManifestPreview manifestJson={manifestJson} />
+              </>
+            )}
           </div>
         }
         extraContent={
-          teamsAppUploaded !== true ? (
+          quickAddBotAlreadyUploaded ? null : (
             <InlineToast
               className="mt-2 w-full"
               variant="tip"
@@ -1020,7 +1292,7 @@ export function TeamsSetupGuide({
                 </span>
               }
             />
-          ) : null
+          )
         }
       />
 
@@ -1033,7 +1305,7 @@ export function TeamsSetupGuide({
         description="Grant admin consent and verify the connection by signing in with a Microsoft account that has Teams admin permissions."
         rightContent={
           <div className="flex min-w-0 flex-col gap-3 w-full">
-            {/* teamsAppCatalogId is available here for future use (e.g. an "Open in Teams" deep link once catalog propagation is confirmed) */}
+            {teamsAppCatalogId && <OpenInTeamsButton catalogId={teamsAppCatalogId} />}
             {hasCredentials && isConnectSubscriberReady && connectionIdentifier ? (
               <ConnectAndLinkSection
                 integrationIdentifier={integrationIdentifier}
@@ -1123,6 +1395,7 @@ export function TeamsSetupGuide({
             <RedirectUriSection redirectUri={buildOAuthCallbackUrl()} />
           </div>
         }
+        extraContent={<TeamsCliShortcut agentName={agent.name} webhookUrl={webhookUrl} />}
       />
 
       {/* Step 2: Add Microsoft Graph API permissions */}
@@ -1157,6 +1430,13 @@ export function TeamsSetupGuide({
                 <li>
                   <code className="font-code text-[11px]">AppCatalog.Read.All</code>
                 </li>
+                <li>
+                  <code className="font-code text-[11px]">Directory.Read.All</code>
+                  <span className="text-text-soft">
+                    {' '}
+                    Lets Novu verify that the app registration and tenant setup are complete.
+                  </span>
+                </li>
               </ul>
             </li>
             <li>
@@ -1175,8 +1455,8 @@ export function TeamsSetupGuide({
                   <code className="font-code text-[11px]">TeamsAppInstallation.ReadWriteSelfForUser.All</code>
                   <span className="text-text-soft">
                     {' '}
-                    Lets the bot install itself for individual users automatically. Without it, users must manually
-                    install the bot before they can receive direct messages.
+                    Strongly recommended because Connect auto-installs the bot for the user. Without it, users must
+                    manually install the bot before they can receive direct messages.
                   </span>
                 </li>
               </ul>
@@ -1195,9 +1475,12 @@ export function TeamsSetupGuide({
           </ol>
         }
         rightContent={
-          <SetupButton href="https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps">
-            Open App Registrations
-          </SetupButton>
+          <div className="flex min-w-0 flex-col gap-3 w-full">
+            <SetupButton href="https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps">
+              Open App Registrations
+            </SetupButton>
+            <ManualPermissionsCheckpoint manualHealth={manualHealth} />
+          </div>
         }
       />
 
@@ -1414,14 +1697,28 @@ export function TeamsSetupGuide({
               </ol>
             </div>
             {manualHealth?.teamsAppCatalog != null && (
-              <CheckpointRow
-                label={
-                  manualHealth.teamsAppCatalog === 'ready'
-                    ? 'App found in Teams catalog'
-                    : 'Waiting for app in Teams catalog…'
-                }
-                status={manualHealth.teamsAppCatalog}
-              />
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-wrap items-center gap-3">
+                  <CheckpointRow
+                    label={
+                      manualHealth.teamsAppCatalog === 'ready'
+                        ? 'App found in Teams catalog'
+                        : 'Waiting for app in Teams catalog…'
+                    }
+                    status={manualHealth.teamsAppCatalog}
+                  />
+                  {manualHealth.teamsAppCatalog === 'ready' && teamsAppCatalogId && (
+                    <OpenInTeamsButton catalogId={teamsAppCatalogId} />
+                  )}
+                </div>
+                {manualHealth.teamsAppCatalog === 'failed' && (
+                  <InlineToast
+                    variant="error"
+                    title="Teams catalog needs attention"
+                    description={getCheckpointRemedy('teamsAppCatalog', 'manual')}
+                  />
+                )}
+              </div>
             )}
           </div>
         }
@@ -1436,7 +1733,8 @@ export function TeamsSetupGuide({
         description="Grant admin consent and verify the connection by signing in with a Microsoft account that has Teams admin permissions."
         rightContent={
           <div className="flex min-w-0 flex-col gap-3 w-full">
-            {hasCredentials && isConnectSubscriberReady && connectionIdentifier ? (
+            {teamsAppCatalogId && <OpenInTeamsButton catalogId={teamsAppCatalogId} />}
+            {hasCredentials && manualTeamsAppCatalogReady && isConnectSubscriberReady && connectionIdentifier ? (
               <ConnectAndLinkSection
                 integrationIdentifier={integrationIdentifier}
                 subscriberId={connectSubscriberId}
@@ -1448,7 +1746,7 @@ export function TeamsSetupGuide({
               <>
                 <SetupButton disabled>{`Connect ${agent.name} ↗`}</SetupButton>
                 {!hasCredentials && <p className="text-text-soft text-label-xs">Complete step {base + 2} first.</p>}
-                {manualHealth?.teamsAppCatalog !== 'ready' && (
+                {hasCredentials && !manualTeamsAppCatalogReady && (
                   <p className="text-text-soft text-label-xs">Complete step {base + 5} first.</p>
                 )}
               </>

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -69,7 +69,7 @@ function buildTeamsDeepLink(catalogId: string): string {
 }
 
 function escapeShellDoubleQuotedValue(value: string): string {
-  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/platform/integrations/chat/ms-teams.mdx
+++ b/docs/platform/integrations/chat/ms-teams.mdx
@@ -256,6 +256,56 @@ This connects your bot resource to Teams and lets your Teams app install cleanly
   </Step>
 </Steps>
 
+### Using the Teams Developer CLI
+
+<Note>
+  This section is optional. The Azure Portal steps above remain the primary path. Use the [Teams Developer CLI](https://www.npmjs.com/package/@microsoft/teams.cli) only if you prefer provisioning app registration, Azure Bot Service, and the Teams channel from the terminal.
+</Note>
+
+If you use the CLI, you can skip the portal walkthroughs from [Create the app identity (Azure AD)](#create-the-app-identity-azure-ad) through [Enable the Microsoft Teams channel](#enable-the-microsoft-teams-channel). You still need to complete [Add Novu's redirect URI](#add-novus-redirect-uri), [Add Microsoft Graph app permissions](#add-microsoft-graph-app-permissions), and the Teams app package steps below.
+
+<Steps>
+  <Step title="Install the CLI">
+    ```bash
+    npm install -g @microsoft/teams.cli
+    ```
+  </Step>
+
+  <Step title="Create the bot with Azure-managed topology">
+    Run `teams app create` with `--azure` so provisioning matches Novu's supported topology (Azure Bot Service plus the Microsoft Teams channel). The default Teams-managed bot path may not match.
+
+    Replace the placeholders with your values. Use your Novu bot messaging endpoint for `--endpoint` (for example, an agent webhook URL if you use [agents on Teams](#using-microsoft-teams-with-agents)).
+
+    ```bash
+    teams app create \
+      --name "<your-bot-name>" \
+      --endpoint <novu-webhook-url> \
+      --azure \
+      --subscription <your-sub> \
+      --resource-group <your-rg> \
+      --env .env
+    ```
+  </Step>
+
+  <Step title="Map credentials into Novu">
+    The command writes a `.env` file in your working directory. Map these values when you [configure the integration in Novu](#configure-the-teams-bot-integration-in-novu):
+
+    | `.env` variable | Novu credential field |
+    | --- | --- |
+    | `CLIENT_ID` | **Client ID** (Microsoft App ID) |
+    | `CLIENT_SECRET` | **Client Secret** |
+    | `TENANT_ID` | **App Tenant ID** (Directory (tenant) ID) |
+  </Step>
+</Steps>
+
+<Warning>
+  **CLI provisioning does not replace every manual step.**
+
+  - **Graph application permissions**: You must still add Novu's required Microsoft Graph **application** permissions and grant admin consent in the [Azure Portal](#add-microsoft-graph-app-permissions). The CLI's resource-specific consent (RSC) helpers are not a substitute.
+  - **Teams app package**: You must still [create](#create-a-teams-app), download, and upload Novu's Teams app package. The manifest must include `validDomains`, `webApplicationInfo`, and the `ChannelMessage.Read.Group` RSC permission.
+  - **Prefer `--azure`**: Use the `--azure` flag so you get Azure Bot Service with the Teams channel enabled. Teams-managed bots created without `--azure` may not match Novu's supported topology.
+</Warning>
+
 ### Create a Teams app
 
 Now you create the Teams “wrapper” around your app registration and bot.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the **manual** MS Teams agent setup path without replacing it. Quick Setup is unchanged in behavior beyond better remediation copy and an install deep link when the catalog upload already succeeded.

### Manual flow stays primary
- Portal steps 1–7 are intact.
- New **Prefer the terminal? Use the Teams CLI** block is **collapsed by default** and instructions-only (no new setup mode / state machine). Users who never expand it see the same flow as before.
- CLI maps to steps 1 + 4; Graph permissions (step 2), Novu credentials (step 3), and Novu’s app package upload (steps 5–6) remain required.

### Diagnostics & deep link
- Health check splits Graph roles into **required** vs **recommended** so manual setups can actually pass `permissions`.
- Returns `missingRequiredPermissions`, `missingRecommendedPermissions`, and `teamsAppCatalogId`.
- UI shows a permissions checkpoint with missing names and per-check remediation instead of a generic “Setup error… retry” toast.
- **Open in Teams** deep link (`https://teams.microsoft.com/l/app/<catalogId>`) when the catalog id is known; Quick Setup collapses the six-step upload list when the app is already in the org catalog.

### Docs
- Optional Teams Developer CLI section in `docs/platform/integrations/chat/ms-teams.mdx`.

```mermaid
flowchart TD
  start[Manual setup] --> step1[Step 1 App Registration]
  step1 -->|optional expand| cli[Teams CLI shortcut]
  cli --> step3[Step 3 paste credentials]
  step1 -->|portal path| step2[Step 2 Graph permissions]
  step2 --> step3
  step3 --> step4[Step 4 Deploy Azure Bot]
  step4 --> step5[Step 5 Download package]
  step5 --> step6[Step 6 Upload to catalog]
  step6 -->|catalog ready| deepLink[Open in Teams]
  step6 --> step7[Step 7 Connect]
  deepLink --> step7
```

## Test plan
- [x] `MsTeamsHealthCheck` unit specs (5) — required/recommended split, catalog id, missing credentials
- [x] All `apps/api/src/app/integrations/usecases/**/*.spec.ts` — 77 passing
- [x] `nest build` — 0 TSC issues
- [x] Dashboard biome/lint on touched files
- [ ] Manual GUI: expand CLI block, confirm portal steps unchanged; verify Open in Teams when catalog ready (API was down in agent env for live walkthrough)

## Note
Linear MCP could not be authenticated in this cloud agent environment, so there is no `NV-XXXX` ticket id in the title yet. Please link a ticket before merge if required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66ecade2-b17f-47a1-819d-6082f18e4e77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66ecade2-b17f-47a1-819d-6082f18e4e77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves MS Teams onboarding diagnostics and adds an optional CLI shortcut. The main changes are:

- Split Graph permission checks into required and recommended permissions.
- Return missing permission names and the Teams app catalog ID from the health check.
- Show clearer Dashboard remediation and `Open in Teams` links when the catalog ID is available.
- Add a collapsed Teams CLI shortcut and updated manual setup docs.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing the contained CLI command escaping issue.

The API and UI health-check changes are cohesive and covered by targeted tests, but the new CLI shortcut currently misapplies agent names containing shell expansion characters.

apps/dashboard/src/components/agents/teams-setup-guide.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a Node harness that copies the helper and Teams CLI command template from the anchored dashboard file and runs the generated command through bash with a stub teams binary.
- Observed that the generated copyable command for Sales $BOT expanded to EXPANDED\_BOT when BOT was set and to 'Sales ' when BOT was empty. The agent-name containing backticks caused command substitution and wrote the PWNED side-effect file, while the stub received 'Audit Bot'.
- Sourced and linked evidence under trex-artifacts, including start logs, Playwright execution log, harness creation notes, and the Playwright script used; no valid before/after UI screenshots were produced because the real component never rendered to the expected manual setup guide content.

<a href="https://app.greptile.com/trex/runs/15079428/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/usecases/msteams-health-check/msteams-health-check.usecase.spec.ts | Adds unit coverage for required vs recommended permission diagnostics, catalog IDs, and missing credential behavior. |
| apps/api/src/app/integrations/usecases/msteams-health-check/msteams-health-check.usecase.ts | Extends MS Teams health checks with required/recommended permission details and catalog ID reporting. |
| apps/dashboard/src/api/integrations.ts | Updates Dashboard API typing for the expanded MS Teams health-check response. |
| apps/dashboard/src/components/agents/teams-setup-guide.tsx | Adds manual-flow diagnostics, Teams CLI shortcut UI, catalog deep links, and upload fallbacks; CLI shell escaping needs tightening. |
| docs/platform/integrations/chat/ms-teams.mdx | Documents the optional Teams Developer CLI path while preserving the remaining required manual setup steps. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Dashboard
participant API as Novu API
participant Graph as Microsoft Graph
participant Teams as Microsoft Teams

User->>Dashboard: Save Teams credentials / open setup guide
Dashboard->>API: "GET /integrations/{id}/msteams-health"
API->>Graph: Acquire token and check app/catalog/permissions
Graph-->>API: Check statuses, missing permissions, catalog id
API-->>Dashboard: Health result + diagnostics
Dashboard-->>User: Show checkpoints and remediation
Dashboard-->>Teams: Open deep link when catalog id exists
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Dashboard
participant API as Novu API
participant Graph as Microsoft Graph
participant Teams as Microsoft Teams

User->>Dashboard: Save Teams credentials / open setup guide
Dashboard->>API: "GET /integrations/{id}/msteams-health"
API->>Graph: Acquire token and check app/catalog/permissions
Graph-->>API: Check statuses, missing permissions, catalog id
API-->>Dashboard: Health result + diagnostics
Dashboard-->>User: Show checkpoints and remediation
Dashboard-->>Teams: Open deep link when catalog id exists
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcomponents%2Fagents%2Fteams-setup-guide.tsx%3A71-73%0A**Escape%20shell%20expansions**%0A%60agentName%60%20is%20interpolated%20inside%20a%20double-quoted%20shell%20argument%2C%20but%20this%20only%20escapes%20%60%5C%60%20and%20%60%22%60.%20Agent%20names%20containing%20%60%24%60%2C%20backticks%2C%20or%20newlines%20are%20expanded%20or%20split%20by%20the%20user's%20shell%20when%20they%20copy%20the%20CLI%20shortcut%2C%20so%20a%20valid%20name%20like%20%60Sales%20%24BOT%60%20is%20sent%20as%20a%20different%20value%20and%20backticks%20execute%20during%20paste.%0A%0A%60%60%60suggestion%0Afunction%20escapeShellDoubleQuotedValue%28value%3A%20string%29%3A%20string%20%7B%0A%20%20return%20value%0A%20%20%20%20.replace%28%2F%5C%5C%2Fg%2C%20'%5C%5C%5C%5C'%29%0A%20%20%20%20.replace%28%2F%22%2Fg%2C%20'%5C%5C%22'%29%0A%20%20%20%20.replace%28%2F%5C%24%2Fg%2C%20'%5C%5C%24'%29%0A%20%20%20%20.replace%28%2F%60%2Fg%2C%20'%5C%5C%60'%29%0A%20%20%20%20.replace%28%2F%5Cn%2Fg%2C%20'%20'%29%3B%0A%7D%0A%60%60%60%0A%0A&pr=12008&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/components/agents/teams-setup-guide.tsx:71-73
**Escape shell expansions**
`agentName` is interpolated inside a double-quoted shell argument, but this only escapes `\` and `"`. Agent names containing `$`, backticks, or newlines are expanded or split by the user's shell when they copy the CLI shortcut, so a valid name like `Sales $BOT` is sent as a different value and backticks execute during paste.

```suggestion
function escapeShellDoubleQuotedValue(value: string): string {
  return value
    .replace(/\\/g, '\\\\')
    .replace(/"/g, '\\"')
    .replace(/\$/g, '\\$')
    .replace(/`/g, '\\`')
    .replace(/\n/g, ' ');
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): escape CLI agent name wi..."](https://github.com/novuhq/novu/commit/8362e5955e29f2453565a19d7cf04e0d0d6cb659) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45615508)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->