### PR TITLE
fix(api-service): mark MCP connections error on auth failure fixes NV-8132

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -77,7 +77,7 @@
     "@novu/providers": "workspace:*",
     "@novu/shared": "workspace:*",
     "@novu/stateless": "workspace:*",
-    "@novu/thalamus": "0.1.0-alpha.15",
+    "@novu/thalamus": "0.1.0-alpha.16",
     "@novu/testing": "workspace:*",
     "@sendgrid/mail": "^8.1.6",
     "@slack/types": "2.20.1",

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-errors.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-errors.ts
@@ -45,25 +45,6 @@ export function extractErrorMessage(err: unknown): string | undefined {
   return undefined;
 }
 
-export function parseMcpInitFailureServerName(err: unknown): string | undefined {
-  const message = extractErrorMessage(err);
-
-  if (!message) {
-    return undefined;
-  }
-
-  const mcpInitMatch = message.match(/MCP server ['"]([^'"]+)['"] initialize failed/i);
-
-  return mcpInitMatch?.[1];
-}
-
-export function buildMcpInitFailureMessage(serverName: string): string {
-  return (
-    `I couldn't connect to the **${serverName}** MCP server yet. ` +
-    `Use Connect to authorize ${serverName}, then send your message again.`
-  );
-}
-
 export function buildErrorMessage(err: unknown): string {
   if (err instanceof CredentialExpiredError) {
     return `Agent error: Credentials for "${err.serverName}" have expired. Please update them in your integration settings.`;
@@ -74,12 +55,6 @@ export function buildErrorMessage(err: unknown): string {
 
   if (isMissingReadToolForSkillsError(err)) {
     return MISSING_READ_TOOL_FOR_SKILLS_REPLY;
-  }
-
-  const failedMcpServerName = parseMcpInitFailureServerName(err);
-
-  if (failedMcpServerName) {
-    return buildMcpInitFailureMessage(failedMcpServerName);
   }
 
   return 'The agent is temporarily unavailable. Please try again later.';

--- a/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
-import { ConversationRepository } from '@novu/dal';
-import { NOVU_INTERNAL_TOOLS } from '@novu/shared';
+import {
+  AgentMcpServerRepository,
+  ConversationRepository,
+  McpConnectionRepository,
+  SubscriberRepository,
+} from '@novu/dal';
+import { McpConnectionStatusEnum, NOVU_INTERNAL_TOOLS } from '@novu/shared';
 import {
   type SessionEventContext,
   SessionExpiredError,
@@ -17,9 +22,11 @@ import { HandlePlanProgress } from '../conversation-runtime/reply/handle-plan-pr
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
 import { captureAgentException } from '../shared/errors/capture-agent-sentry';
 import { DemoClaudeQuotaPolicy } from './demo-claude-quota-policy.service';
-import { buildErrorMessage, parseMcpInitFailureServerName } from './managed-agent-errors';
+import { buildErrorMessage } from './managed-agent-errors';
 import { HandlePendingToolApprovalsCommand } from './tool-approval/handle-pending-tool-approvals.command';
 import { HandlePendingToolApprovals } from './tool-approval/handle-pending-tool-approvals.usecase';
+import { listOAuthMcps } from './tool-connect/list-oauth-mcps.helper';
+import { findOAuthMcpByServerName } from './tool-connect/oauth-mcp.types';
 
 interface BaseCommandFields {
   userId: string;
@@ -34,6 +41,9 @@ interface BaseCommandFields {
 export class ManagedAgentEventHandler {
   constructor(
     private readonly conversationRepository: ConversationRepository,
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly mcpConnectionRepository: McpConnectionRepository,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly handlePlanProgress: HandlePlanProgress,
     private readonly handlePendingToolApprovals: HandlePendingToolApprovals,
@@ -224,6 +234,23 @@ export class ManagedAgentEventHandler {
           });
         }
       },
+
+      onMcpServerFailure: async (event: {
+        reason: 'authentication' | 'connection';
+        serverName: string;
+        message: string;
+      }) => {
+        try {
+          await this.handleMcpServerFailure(metadata, sessionId, event);
+        } catch (err) {
+          this.logger.error(err, `onMcpServerFailure failed: session=${sessionId}`);
+          captureAgentException(err, {
+            component: 'managed-agent-event-handler',
+            operation: 'on-mcp-server-failure',
+            sessionId,
+          });
+        }
+      },
     };
   }
 
@@ -246,6 +273,104 @@ export class ManagedAgentEventHandler {
     };
   }
 
+  /**
+   * MCP init failed upstream (non-fatal). For authentication failures, flip the
+   * connection out of `connected` so `list_available` / `request_connect` can
+   * offer reconnect. Connection failures are logged only — credentials may still
+   * be valid.
+   */
+  private async handleMcpServerFailure(
+    metadata: Record<string, string>,
+    sessionId: string,
+    event: { reason: 'authentication' | 'connection'; serverName: string; message: string }
+  ): Promise<void> {
+    if (event.reason !== 'authentication') {
+      this.logger.warn(
+        { sessionId, serverName: event.serverName, reason: event.reason, message: event.message },
+        'MCP server failure (non-auth) — session continues without updating connection status'
+      );
+
+      return;
+    }
+
+    const { environmentId, organizationId, agentId, subscriberId } = metadata;
+
+    if (!environmentId || !organizationId || !agentId || !subscriberId) {
+      this.logger.warn(
+        { sessionId, serverName: event.serverName },
+        'mcp-server-failure missing webhook metadata — skipping connection update'
+      );
+
+      return;
+    }
+
+    const mcps = await listOAuthMcps(
+      {
+        subscriberRepository: this.subscriberRepository,
+        agentMcpServerRepository: this.agentMcpServerRepository,
+        mcpConnectionRepository: this.mcpConnectionRepository,
+      },
+      {
+        environmentId,
+        organizationId,
+        agentId,
+        subscriberId,
+      }
+    );
+
+    const mcp = findOAuthMcpByServerName(mcps, event.serverName);
+
+    if (!mcp) {
+      this.logger.warn(
+        { sessionId, serverName: event.serverName, agentId },
+        'mcp-server-failure for unknown OAuth MCP — skipping connection update'
+      );
+
+      return;
+    }
+
+    if (mcp.status !== McpConnectionStatusEnum.Connected) {
+      return;
+    }
+
+    const subscriber = await this.subscriberRepository.findBySubscriberId(environmentId, subscriberId);
+
+    if (!subscriber) {
+      return;
+    }
+
+    await this.mcpConnectionRepository.update(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        _agentMcpServerId: mcp.agentMcpServerId,
+        _subscriberId: subscriber._id,
+        status: McpConnectionStatusEnum.Connected,
+      },
+      {
+        $set: {
+          status: McpConnectionStatusEnum.Error,
+          lastError: {
+            code: 'authentication_failed',
+            message: event.message,
+            at: new Date(),
+          },
+        },
+      }
+    );
+
+    this.logger.info(
+      {
+        sessionId,
+        serverName: event.serverName,
+        mcpId: mcp.mcpId,
+        agentId,
+        subscriberId,
+      },
+      'Marked MCP connection as error after authentication failure'
+    );
+  }
+
   private async handleErrorEvent(
     metadata: Record<string, string>,
     sessionId: string,
@@ -257,10 +382,6 @@ export class ManagedAgentEventHandler {
       await this.conversationRepository.clearExternalSessionId(metadata.environmentId, metadata.conversationId);
       await this.inboundAck.onManagedTurnComplete(metadata);
 
-      return;
-    }
-
-    if (parseMcpInitFailureServerName(error)) {
       return;
     }
 

--- a/enterprise/workers/thalamus-observer/package.json
+++ b/enterprise/workers/thalamus-observer/package.json
@@ -13,7 +13,7 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "@novu/thalamus": "0.1.0-alpha.15",
+    "@novu/thalamus": "0.1.0-alpha.16",
     "agents": "^0.12.4",
     "eventsource-parser": "^3.0.8"
   },

--- a/enterprise/workers/thalamus-observer/src/session-observer.ts
+++ b/enterprise/workers/thalamus-observer/src/session-observer.ts
@@ -334,10 +334,6 @@ export class SessionObserver extends Agent<Env, State> {
       return [];
     }
 
-    if (isMcpInitFailure(parsed)) {
-      return [];
-    }
-
     const parts: StreamPart[] = [];
     try {
       for (const part of parser.mapEvent(parsed, acc)) {
@@ -594,15 +590,4 @@ export class SessionObserver extends Agent<Env, State> {
   private updateObservation(obs: (ObservationParams & { status: ObservationStatus }) | null): void {
     this.setState({ ...this.state, observation: obs });
   }
-}
-
-function isMcpInitFailure(parsed: unknown): boolean {
-  if (typeof parsed !== 'object' || parsed === null) return false;
-  const obj = parsed as { type?: string; error?: { type?: string; message?: string } };
-
-  return (
-    obj.type === 'session.error' &&
-    (obj.error?.type === 'mcp_authentication_failed_error' ||
-      /MCP server .+ initialize failed/i.test(obj.error?.message ?? ''))
-  );
 }

--- a/packages/shared/src/consts/providers/novu-internal-tools.ts
+++ b/packages/shared/src/consts/providers/novu-internal-tools.ts
@@ -1,5 +1,5 @@
 /** Increment when Novu-owned managed-agent config changes (e.g. novu_tools). Agents below this version are re-synced to the provider on the next message. */
-export const AGENT_MANAGED_DEFINITION_VERSION = 1;
+export const AGENT_MANAGED_DEFINITION_VERSION = 3;
 
 /**
  * Provider-agnostic schema for the novu_tools custom tool.

--- a/packages/shared/src/consts/providers/novu-internal-tools.ts
+++ b/packages/shared/src/consts/providers/novu-internal-tools.ts
@@ -1,5 +1,5 @@
 /** Increment when Novu-owned managed-agent config changes (e.g. novu_tools). Agents below this version are re-synced to the provider on the next message. */
-export const AGENT_MANAGED_DEFINITION_VERSION = 3;
+export const AGENT_MANAGED_DEFINITION_VERSION = 1;
 
 /**
  * Provider-agnostic schema for the novu_tools custom tool.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,20 +445,20 @@ importers:
         specifier: workspace:*
         version: link:../../libs/testing
       '@novu/thalamus':
-        specifier: 0.1.0-alpha.15
-        version: 0.1.0-alpha.15(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))
+        specifier: 0.1.0-alpha.16
+        version: 0.1.0-alpha.16(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))
       '@sendgrid/mail':
         specifier: ^8.1.6
         version: 8.1.6
       '@sentry/nestjs':
         specifier: ^10.63.0
-        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
+        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
       '@sentry/node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
       '@sentry/profiling-node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
       '@slack/types':
         specifier: 2.20.1
         version: 2.20.1
@@ -578,7 +578,7 @@ importers:
         version: 3.3.8
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1428,7 +1428,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1621,7 +1621,7 @@ importers:
         version: 11.5.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1812,7 +1812,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -9139,8 +9139,8 @@ packages:
     resolution: {integrity: sha512-5E8EKp30Ee06FQRpax204nyZOb1uv0kW72VfZXkU/4hG4CcqDsJbfrNnUjB6xIPSvIwAAlwv76MdIAsOflkLXg==}
     engines: {node: '>=18.0.0'}
 
-  '@novu/thalamus@0.1.0-alpha.15':
-    resolution: {integrity: sha512-RSKaskbTOiNnLQGmqRAsevoHDkD8j5uSitqwsEN9ysM/L6Lm/Cihmr2RK5wy2eTBPvACf86iM6EBDWysGmBD6Q==}
+  '@novu/thalamus@0.1.0-alpha.16':
+    resolution: {integrity: sha512-mVVCXE/vsFe9XSnkLGD6W8Mb784MoVibnAXYeSq7REi6/cmi5FFQG8fPPfcTyn1G0pX8EAA3WnQsnsz/RJlX1Q==}
     peerDependencies:
       '@anthropic-ai/aws-sdk': '>=0.86.0'
       '@anthropic-ai/sdk': '>=0.86.0'
@@ -31388,7 +31388,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.2(zod@4.3.5)
       jose: 6.1.3
       kysely: 0.28.17
       nanostores: 1.2.0
@@ -35118,7 +35118,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@novu/thalamus@0.1.0-alpha.15(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))':
+  '@novu/thalamus@0.1.0-alpha.16(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.21.0)(zod@3.25.20))':
     optionalDependencies:
       '@anthropic-ai/sdk': 0.95.1(zod@3.25.20)
       '@aws-crypto/sha256-js': 5.2.0
@@ -36169,6 +36169,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -36304,8 +36313,9 @@ snapshots:
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
+    optional: true
 
   '@opentelemetry/sdk-logs@0.201.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -36404,8 +36414,8 @@ snapshots:
   '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
@@ -39601,6 +39611,20 @@ snapshots:
     dependencies:
       '@sentry/core': 10.63.0
 
+  '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.27)(@nestjs/websockets@11.1.27)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.12.0
+      '@sentry/core': 10.63.0
+      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
   '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -39615,17 +39639,17 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))':
+  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       import-in-the-middle: 3.0.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
 
   '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
@@ -39649,13 +39673,13 @@ snapshots:
   '@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))
+      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       '@sentry/server-utils': 10.63.0
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
@@ -39680,7 +39704,7 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))':
+  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
@@ -39695,6 +39719,16 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
+
+  '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@sentry/core': 10.63.0
+      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+      '@sentry/node-cpu-profiler': 2.4.2
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
 
   '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -44975,7 +45009,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.2(zod@4.3.5)
       defu: 6.1.6
       jose: 6.1.3
       kysely: 0.28.17
@@ -44993,6 +45027,15 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
+
+  better-call@1.3.2(zod@4.3.5):
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:
@@ -52851,7 +52894,25 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
+  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
+    dependencies:
+      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@nestjs/graphql': 12.0.9(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@24.0.0)
+    transitivePeerDependencies:
+      - '@apollo/subgraph'
+      - '@nestjs/core'
+      - bufferutil
+      - class-transformer
+      - class-validator
+      - graphql
+      - reflect-metadata
+      - ts-morph
+      - utf-8-validate
+
+  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2):
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))


### PR DESCRIPTION
## Summary
- Bump `@novu/thalamus` to `0.1.0-alpha.16` (registry) in API and thalamus-observer; remove local link override.
- Observer no longer drops MCP init failures — thalamus emits non-fatal `mcp-server-failure`.
- On `reason: authentication`, managed agent event handler flips `mcp_connection` to `error` with `lastError.code: authentication_failed` so reconnect UX works again.
- Bump `AGENT_MANAGED_DEFINITION_VERSION` to 3 for agent re-sync after prior prompt experiment.

Related: https://github.com/novuhq/thalamus/pull/16

Note: `enterprise/workers/thalamus-observer` lives in the main novu repo (not the `.source` submodule). Validate Submodule Sync / packages-enterprise PR is N/A for this change.

## Test plan
- [ ] With revoked Stripe MCP OAuth, start an agent session — session continues (no hard abort)
- [ ] Connection status becomes `error` with authentication_failed
- [ ] `novu_tools.list_available` / `request_connect` surfaces reconnect
- [ ] Unit/typecheck for touched packages

Fixes NV-8132

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes MCP authentication failures so that a revoked OAuth token no longer hard-aborts an agent session. Instead, thalamus emits a structured `mcp-server-failure` event, the observer forwards it (removing the old silent-drop filter), and the API handler flips the `mcp_connection` record to `error` with `code: authentication_failed` so the reconnect UX can surface.

- **Observer change**: removes the `isMcpInitFailure` drop gate in `session-observer.ts` so the new structured event reaches the API webhook.
- **Event handler**: adds `onMcpServerFailure` in `ManagedAgentEventHandler` which, for `reason: authentication`, resolves the affected OAuth MCP by server name and conditionally updates its connection status to `Error` with a `lastError` payload — non-auth failures are logged only.
- **Error helpers**: removes `parseMcpInitFailureServerName` / `buildMcpInitFailureMessage` now made redundant by the structured event path, and cleans up the matching early-return in `handleErrorEvent`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is non-fatal by design; failures are caught and logged, the session continues, and the DB update is guarded against TOCTOU races by filtering on status=Connected.

The core logic is well-guarded: metadata validation, an early-return for non-auth reasons, an MCP-not-found warning, a Connected-status guard before the write, and error catching around the entire handler. The only noteworthy observation is a redundant subscriber DB fetch inside handleMcpServerFailure that could be eliminated, but it has no correctness impact.

managed-agent-event-handler.service.ts — the duplicate subscriber lookup in handleMcpServerFailure is worth cleaning up in a follow-on.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/managed-runtime/managed-agent-event-handler.service.ts | Adds onMcpServerFailure handler that flips MCP connection to error on auth failures; has a redundant subscriber DB lookup inside handleMcpServerFailure |
| apps/api/src/app/agents/managed-runtime/managed-agent-errors.ts | Removes parseMcpInitFailureServerName and buildMcpInitFailureMessage helpers now superseded by the structured onMcpServerFailure event path |
| enterprise/workers/thalamus-observer/src/session-observer.ts | Removes isMcpInitFailure drop filter so the observer now forwards MCP failure events to the API webhook instead of silently swallowing them |
| apps/api/package.json | Bumps @novu/thalamus to 0.1.0-alpha.16 which adds the mcp-server-failure event type |
| enterprise/workers/thalamus-observer/package.json | Bumps @novu/thalamus to 0.1.0-alpha.16 to match the API service version |
| pnpm-lock.yaml | Lockfile updated for thalamus bump and incidental opentelemetry/sentry peer-dep re-resolution |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Thalamus as Thalamus (MCP host)
    participant Observer as Thalamus Observer (CF Worker)
    participant API as API / ManagedAgentEventHandler
    participant DB as Database

    Thalamus->>Observer: "SSE stream event mcp-server-failure {reason, serverName, message}"
    Note over Observer: Previously dropped by isMcpInitFailure() - now passes through
    Observer->>API: Webhook: onMcpServerFailure
    API->>API: "reason !== authentication? warn + return"
    API->>DB: listOAuthMcps()
    DB-->>API: OAuthMcp[]
    API->>API: findOAuthMcpByServerName(mcps, serverName)
    API->>API: "mcp.status !== Connected? return no-op"
    API->>DB: findBySubscriberId (second fetch for _id)
    DB-->>API: subscriber
    API->>DB: "mcpConnectionRepository.update() set status=Error lastError.code=authentication_failed"
    DB-->>API: updated
    API-->>Observer: 200 OK (non-fatal, session continues)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Thalamus as Thalamus (MCP host)
    participant Observer as Thalamus Observer (CF Worker)
    participant API as API / ManagedAgentEventHandler
    participant DB as Database

    Thalamus->>Observer: "SSE stream event mcp-server-failure {reason, serverName, message}"
    Note over Observer: Previously dropped by isMcpInitFailure() - now passes through
    Observer->>API: Webhook: onMcpServerFailure
    API->>API: "reason !== authentication? warn + return"
    API->>DB: listOAuthMcps()
    DB-->>API: OAuthMcp[]
    API->>API: findOAuthMcpByServerName(mcps, serverName)
    API->>API: "mcp.status !== Connected? return no-op"
    API->>DB: findBySubscriberId (second fetch for _id)
    DB-->>API: subscriber
    API->>DB: "mcpConnectionRepository.update() set status=Error lastError.code=authentication_failed"
    DB-->>API: updated
    API-->>Observer: 200 OK (non-fatal, session continues)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(shared): keep AGENT\_MANAGED\_DEFINI..."](https://github.com/novuhq/novu/commit/f456909eea83c9dd671635864d10c47364d49d27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45633017)</sub>

<!-- /greptile_comment -->