### PR TITLE
fix(api-service): handle empty userEnvironmentId in delete environment and update integration fixes NV-8337

### DIFF
--- a/apps/api/src/app/environments-v1/environments-v1.controller.ts
+++ b/apps/api/src/app/environments-v1/environments-v1.controller.ts
@@ -295,7 +295,7 @@ export class EnvironmentsControllerV1 {
         userId: user._id,
         organizationId: user.organizationId,
         environmentId,
-        userEnvironmentId: user.environmentId,
+        userEnvironmentId: user.environmentId || undefined,
         restrictToUserEnvironment: isEnvironmentScopedAuthScheme(user.scheme),
       })
     );

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -342,7 +342,7 @@ export class IntegrationsController {
           name: body.name,
           identifier: body.identifier,
           environmentId: body._environmentId,
-          userEnvironmentId: user.environmentId,
+          userEnvironmentId: user.environmentId || undefined,
           organizationId: user.organizationId,
           integrationId,
           credentials: body.credentials,

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
@@ -28,7 +28,7 @@ export class UpdateIntegrationCommand extends OrganizationCommand {
 
   @IsOptional()
   @IsMongoId()
-  userEnvironmentId: string;
+  userEnvironmentId?: string;
 
   @IsDefined()
   @IsMongoId()

--- a/apps/api/src/app/integrations/utils/assert-integration-environment-scope.ts
+++ b/apps/api/src/app/integrations/utils/assert-integration-environment-scope.ts
@@ -4,7 +4,7 @@ type IntegrationMutationAction = 'update' | 'delete' | 'set as primary' | 'auto-
 
 export function assertIntegrationEnvironmentScope(params: {
   restrictToUserEnvironment?: boolean;
-  userEnvironmentId: string;
+  userEnvironmentId?: string;
   integrationEnvironmentId: string;
   action: IntegrationMutationAction;
 }): void {


### PR DESCRIPTION
### What changed? Why was the change needed?

**Bug:** Customers using enterprise auth (Clerk/BetterAuth) cannot delete environments from the dashboard. The error: `Validation failed for DeleteEnvironmentCommand: userEnvironmentId: userEnvironmentId must be a mongodb id`

**Root cause:** When the dashboard calls `DELETE /environments/:id`, it doesn't pass the `environment` option to the API client, so the `Novu-Environment-Id` header is not sent. Enterprise auth strategies (Clerk/BetterAuth) resolve `user.environmentId` purely from this header, falling back to `''` (empty string) when absent. The controller then passes this empty string as `userEnvironmentId` to `DeleteEnvironmentCommand`, where `@IsOptional()` does not skip validation for empty strings (only for `undefined`/`null`), causing `@IsMongoId()` to reject the value.

Note: Community auth (JWT strategy) is unaffected because it falls back to `session.environmentId` from the JWT payload.

**Fix:**

1. Convert falsy `user.environmentId` to `undefined` before passing it to the command in both `EnvironmentsControllerV1.deleteEnvironment` and `IntegrationsController.updateIntegration`. This allows `@IsOptional()` to properly skip the `@IsMongoId()` validation when the environment ID is not available from the auth header.
2. Fix the `UpdateIntegrationCommand.userEnvironmentId` type from required `string` to optional `string?` so it matches its `@IsOptional()` decorator (the required type broke the build once `undefined` was passed), and widen `assertIntegrationEnvironmentScope` to accept an optional value.

The `userEnvironmentId` field is only used for environment-scoped auth schemes (`API_KEY`/`KEYLESS`), which always provide a valid environment ID, so this change has no security impact on dashboard (Bearer) auth users.

### Screenshots

N/A - backend validation fix, no UI changes.

<details><summary>Expand for optional sections</summary>

### Special notes for your reviewer

The same pattern (`userEnvironmentId: user.environmentId`) existed in the integrations controller for `UpdateIntegrationCommand`, which has the same `@IsOptional() @IsMongoId()` decorator on `userEnvironmentId`. Fixed proactively to prevent the same issue there.

Verified with `pnpm build` (0 TSC issues) and the existing `delete-environment-api-key-scope` and `manage-api-keys` e2e suites (all passing).

</details>

[Slack Thread](<https://novu.slack.com/archives/C06GS20SPE0/p1784566697705549?thread_ts=1784566697.705549&cid=C06GS20SPE0>)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

### Greptile Summary

This PR adjusts environment-scoped validation so missing dashboard environment headers do not fail optional Mongo ID validation. The main changes are:

* Converts empty `user.environmentId` values to `undefined` when deleting environments.
* Applies the same optional handling when updating integrations.
* Makes `UpdateIntegrationCommand.userEnvironmentId` optional to match its validator.
* Allows integration environment-scope assertions to receive an optional user environment ID.

### Confidence Score: 5/5

Safe to merge based on the reviewed changes.

The changes are narrow and align the runtime values with existing optional validation behavior.

No files require special attention.

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* Ran the general-contract-validation-proof harness to compare pre-change and post-change environmentId handling in the controller.
* Verified pre-change behavior from the before-log, showing absent dashboard environmentId as an empty string and 400 errors for invalid userEnvironmentId, while valid API-key-scoped MongoIds return 200.
* Verified post-change behavior from the after-log, showing absent environmentId as undefined, both endpoint validations return 200, raw empty string cases still yield 400, and valid MongoIds still yield 200.
* Validated the executable TypeScript validation harness (Env integration scope validation harness) to ensure it uses real command classes from apps/api.

![View all artifacts](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<img src="https://camo.githubusercontent.com/223063a8acd7e71fd1deaaa741d9d06948338e590a1cc633c9305234794edec8/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f56696577416c6c4172746966616374732e7376673f763d34 " alt="T-Rex" height="14" /> Ran code and verified through T-Rex

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/api/src/app/environments-v1/environments-v1.controller.ts | Normalizes an empty session environment ID to `undefined` before creating `DeleteEnvironmentCommand`. |
| apps/api/src/app/integrations/integrations.controller.ts | Normalizes an empty session environment ID to `undefined` before creating `UpdateIntegrationCommand`. |
| apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts | Updates `userEnvironmentId` to be optional, matching the existing `@IsOptional()` validation. |
| apps/api/src/app/integrations/utils/assert-integration-environment-scope.ts | Widens `userEnvironmentId` to optional while preserving the existing forbidden check when environment scoping is enabled. |

</details>

### Sequence Diagram

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Dashboard
participant Controller
participant CommandValidator
participant Usecase

Dashboard->>Controller: DELETE /environments/:id or PUT /integrations/:id
Controller->>Controller: Read user.environmentId
Controller->>CommandValidator: "Pass userEnvironmentId || undefined"
CommandValidator->>CommandValidator: "@IsOptional skips @IsMongoId when undefined"
CommandValidator->>Usecase: Execute command
Usecase->>Usecase: Enforce environment scope when required
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Dashboard
participant Controller
participant CommandValidator
participant Usecase

Dashboard->>Controller: DELETE /environments/:id or PUT /integrations/:id
Controller->>Controller: Read user.environmentId
Controller->>CommandValidator: "Pass userEnvironmentId || undefined"
CommandValidator->>CommandValidator: "@IsOptional skips @IsMongoId when undefined"
CommandValidator->>Usecase: Execute command
Usecase->>Usecase: Enforce environment scope when required
```

Reviews (2): Last reviewed commit: ["fix(api-service): make userEnvironmentId..."](<https://github.com/novuhq/novu/commit/29554bf1afc871e71cd48d7beeda392ce45372ca>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=45688650>)