### PR TITLE
docs(docs): fix platform spelling typos on homepage fixes NV-8341

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,7 +11,7 @@ mode: "wide"
 
 <div id="home-content">
 
-Novu is open-source infrastructure for managing notifications and agent conversations across different channel and messaging platfroms, without rebuilding channel logic from scratch.
+Novu is open-source infrastructure for managing notifications and agent conversations across different channel and messaging platforms, without rebuilding channel logic from scratch.
 
 <div className="hero-cards dark:hidden">
   <Columns cols={2}>
@@ -63,7 +63,7 @@ Novu is open-source infrastructure for managing notifications and agent conversa
     Understand the infrastructure layer between messaging providers and agent intelligence.
   </Card>
   <Card title="Managed Agent" icon="sparkles" href="/agents/managed-agent/overview">
-    Connect an agent built in AI platfrom like Claude directly to your Novu agent.
+    Connect an agent built in AI platform like Claude directly to your Novu agent.
   </Card>
   <Card title="Custom Code Agent" icon="square-code" href="/agents/custom-code-agent/quickstart">
     Bring your own LLM, tools, runtime, and business logic.


### PR DESCRIPTION
## What changed
- Fixed `platfroms` → `platforms` in the docs homepage intro paragraph
- Fixed `platfrom` → `platform` in the Managed Agent card description

## Why
The docs homepage is the main entry point for new users. These spelling errors hurt first impressions and readability.

## Related
- Closes #12018
- Fixes NV-8341

## Test plan
- [x] Confirmed no remaining `platfrom` matches under `docs/`
- [ ] Verify homepage copy on docs preview after merge

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects spelling errors on the documentation homepage. The changes are:

- Correct `platfroms` to `platforms` in the introduction.
- Correct `platfrom` to `platform` in the Managed Agent card.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the before-state homepage render showing the original misspellings.
- Recorded the changes to correct the intro text to 'platforms' and update the Managed Agent card to 'platform', as implemented in the PR.
- Verified that the after-record render displayed the corrected strings with the expected app styling when Connect is selected.
- Browser assertions passed for the corrected strings after selecting Connect.

<a href="https://app.greptile.com/trex/runs/15231980/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/index.mdx | Corrects two spelling errors in homepage prose without changing MDX structure or behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docs): fix platform spelling typos ..."](https://github.com/novuhq/novu/commit/ce6423d0b7a3bc1fcaaffe7afa6f9229dedf547f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45924688)</sub>

<!-- /greptile_comment -->