### PR TITLE
fix(api-service): omit tool preference channel when IS_TOOL_CHANNEL_ENABLED is off

### DIFF
--- a/apps/api/src/app/shared/dtos/preference-channels.ts
+++ b/apps/api/src/app/shared/dtos/preference-channels.ts
@@ -49,7 +49,8 @@ export class SubscriberPreferenceChannels {
 
   @ApiPropertyOptional({
     type: Boolean,
-    description: 'Tool channel preference',
+    description:
+      'Tool channel preference. Only included in API responses when the IS_TOOL_CHANNEL_ENABLED feature flag is on.',
     example: true,
   })
   @IsBoolean()

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
@@ -1,8 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import {
-  buildSubscriberKey,
-  CachedResponse,
+  buildDefaultPreferenceChannels,
+  FeatureFlagsService,
   filteredPreference,
+  filterPreferenceChannelsByFeatureFlags,
   GetPreferences,
   Instrument,
   InstrumentUsecase,
@@ -13,7 +14,7 @@ import {
   SubscriberEntity,
   SubscriberRepository,
 } from '@novu/dal';
-import { ChannelTypeEnum, IPreferenceChannels, Schedule } from '@novu/shared';
+import { ChannelTypeEnum, FeatureFlagsKeysEnum, IPreferenceChannels, Schedule } from '@novu/shared';
 import { GetSubscriberGlobalPreferenceCommand } from './get-subscriber-global-preference.command';
 
 @Injectable()
@@ -21,7 +22,8 @@ export class GetSubscriberGlobalPreference {
   constructor(
     private subscriberRepository: SubscriberRepository,
     private getPreferences: GetPreferences,
-    private notificationTemplateRepository: NotificationTemplateRepository
+    private notificationTemplateRepository: NotificationTemplateRepository,
+    private featureFlagsService: FeatureFlagsService
   ) {}
 
   @InstrumentUsecase()
@@ -29,6 +31,12 @@ export class GetSubscriberGlobalPreference {
     command: GetSubscriberGlobalPreferenceCommand
   ): Promise<{ preference: { enabled: boolean; channels: IPreferenceChannels; schedule?: Schedule } }> {
     const subscriber = command.subscriber ?? (await this.getSubscriber(command));
+
+    const isToolChannelEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_TOOL_CHANNEL_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
 
     const activeChannels = await this.getActiveChannels(command);
 
@@ -40,7 +48,10 @@ export class GetSubscriberGlobalPreference {
       subscriberGlobalPreference: command.subscriberGlobalPreference,
     });
 
-    const channelsWithDefaults = this.buildDefaultPreferences(subscriberGlobalPreference.channels);
+    const channelsWithDefaults = this.buildDefaultPreferences(
+      subscriberGlobalPreference.channels,
+      isToolChannelEnabled
+    );
 
     let channels: IPreferenceChannels;
     if (command.includeInactiveChannels === true) {
@@ -52,7 +63,7 @@ export class GetSubscriberGlobalPreference {
     return {
       preference: {
         enabled: subscriberGlobalPreference.enabled,
-        channels,
+        channels: filterPreferenceChannelsByFeatureFlags(channels, { isToolChannelEnabled }),
         schedule: subscriberGlobalPreference.schedule,
       },
     };
@@ -120,15 +131,8 @@ export class GetSubscriberGlobalPreference {
   }
 
   // adds default state for missing channels
-  private buildDefaultPreferences(preference: IPreferenceChannels) {
-    const defaultPreference: IPreferenceChannels = {
-      email: true,
-      sms: true,
-      in_app: true,
-      chat: true,
-      push: true,
-      tool: true,
-    };
+  private buildDefaultPreferences(preference: IPreferenceChannels, isToolChannelEnabled: boolean) {
+    const defaultPreference = buildDefaultPreferenceChannels({ isToolChannelEnabled });
 
     return { ...defaultPreference, ...preference };
   }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -1,7 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import {
+  buildDefaultPreferenceChannels,
   FeatureFlagsService,
   filteredPreference,
+  filterPreferenceChannelsByFeatureFlags,
   GetPreferences,
   GetPreferencesResponseDto,
   InMemoryLRUCacheService,
@@ -115,11 +117,18 @@ export class GetSubscriberPreference {
       return acc;
     }, {});
 
+    const isToolChannelEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_TOOL_CHANNEL_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
     const workflowPreferences = this.calculateWorkflowPreferences(
       workflowList,
       workflowPreferenceSets,
       subscriberGlobalPreference,
-      command.includeInactiveChannels
+      command.includeInactiveChannels,
+      isToolChannelEnabled
     );
 
     const nonCriticalWorkflowPreferences = workflowPreferences.filter(
@@ -148,7 +157,8 @@ export class GetSubscriberPreference {
     workflowList: NotificationTemplateEntity[],
     workflowPreferenceSets: Record<string, PreferenceSet>,
     subscriberGlobalPreference: PreferencesEntity | null,
-    includeInactiveChannels: boolean
+    includeInactiveChannels: boolean,
+    isToolChannelEnabled: boolean
   ): ISubscriberPreferenceResponse[] {
     /*
      * Process all workflows synchronously. filterActive caps at 200 workflows and the
@@ -171,13 +181,7 @@ export class GetSubscriberPreference {
         const includedChannels = this.getChannels(workflow, includeInactiveChannels);
 
         const initialChannels = filteredPreference(
-          {
-            email: true,
-            sms: true,
-            in_app: true,
-            chat: true,
-            push: true,
-          },
+          buildDefaultPreferenceChannels({ isToolChannelEnabled }),
           includedChannels
         );
 
@@ -185,7 +189,7 @@ export class GetSubscriberPreference {
 
         const preference: ISubscriberPreferenceResponse = {
           preference: {
-            channels,
+            channels: filterPreferenceChannelsByFeatureFlags(channels, { isToolChannelEnabled }),
             enabled: true,
             overrides,
             ...(preferences.subscriberWorkflowPreference?.updatedAt && {

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.spec.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.spec.ts
@@ -1,5 +1,11 @@
 import { ChannelTypeEnum } from '@novu/shared';
-import { filteredPreference, overridePreferences } from './get-subscriber-template-preference.usecase';
+import { overridePreferences } from './get-subscriber-template-preference.usecase';
+import {
+  buildDefaultPreferenceChannels,
+  filteredPreference,
+  filterPreferenceChannelsByFeatureFlags,
+  filterWorkflowPreferencesByFeatureFlags,
+} from './preference-channels.utils';
 
 describe('overridePreferences', () => {
   beforeEach(() => {});
@@ -153,5 +159,102 @@ describe('filteredPreference', () => {
 
     expect(Object.keys(channelPreferences).length).toEqual(5);
     expect(channelPreferences).toEqual(expectedPreferenceResult);
+  });
+});
+
+describe('buildDefaultPreferenceChannels', () => {
+  it('includes tool when the tool channel flag is enabled', () => {
+    expect(buildDefaultPreferenceChannels({ isToolChannelEnabled: true })).toEqual({
+      email: true,
+      sms: true,
+      in_app: true,
+      chat: true,
+      push: true,
+      tool: true,
+    });
+  });
+
+  it('omits tool when the tool channel flag is disabled', () => {
+    expect(buildDefaultPreferenceChannels({ isToolChannelEnabled: false })).toEqual({
+      email: true,
+      sms: true,
+      in_app: true,
+      chat: true,
+      push: true,
+    });
+  });
+});
+
+describe('filterPreferenceChannelsByFeatureFlags', () => {
+  const channels = {
+    email: true,
+    sms: false,
+    in_app: true,
+    chat: true,
+    push: true,
+    tool: true,
+  };
+
+  it('keeps tool when the tool channel flag is enabled', () => {
+    expect(filterPreferenceChannelsByFeatureFlags(channels, { isToolChannelEnabled: true })).toEqual(channels);
+  });
+
+  it('omits tool when the tool channel flag is disabled', () => {
+    expect(filterPreferenceChannelsByFeatureFlags(channels, { isToolChannelEnabled: false })).toEqual({
+      email: true,
+      sms: false,
+      in_app: true,
+      chat: true,
+      push: true,
+    });
+  });
+
+  it('returns channels unchanged when tool is already absent and the flag is disabled', () => {
+    const withoutTool = {
+      email: true,
+      sms: true,
+      in_app: true,
+      chat: true,
+      push: true,
+    };
+
+    expect(filterPreferenceChannelsByFeatureFlags(withoutTool, { isToolChannelEnabled: false })).toEqual(withoutTool);
+  });
+});
+
+describe('filterWorkflowPreferencesByFeatureFlags', () => {
+  const workflowPreferences = {
+    all: { enabled: true, readOnly: false },
+    channels: {
+      email: { enabled: true },
+      sms: { enabled: true },
+      in_app: { enabled: true },
+      chat: { enabled: true },
+      push: { enabled: true },
+      tool: { enabled: true },
+    },
+  };
+
+  it('keeps tool when the tool channel flag is enabled', () => {
+    expect(filterWorkflowPreferencesByFeatureFlags(workflowPreferences, { isToolChannelEnabled: true })).toEqual(
+      workflowPreferences
+    );
+  });
+
+  it('omits tool from channels when the tool channel flag is disabled', () => {
+    expect(filterWorkflowPreferencesByFeatureFlags(workflowPreferences, { isToolChannelEnabled: false })).toEqual({
+      all: { enabled: true, readOnly: false },
+      channels: {
+        email: { enabled: true },
+        sms: { enabled: true },
+        in_app: { enabled: true },
+        chat: { enabled: true },
+        push: { enabled: true },
+      },
+    });
+  });
+
+  it('returns null when preferences are null', () => {
+    expect(filterWorkflowPreferencesByFeatureFlags(null, { isToolChannelEnabled: false })).toBeNull();
   });
 });

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -9,6 +9,7 @@ import {
 } from '@novu/dal';
 import {
   ChannelTypeEnum,
+  FeatureFlagsKeysEnum,
   IOverridePreferencesSources,
   IPreferenceChannels,
   IPreferenceOverride,
@@ -20,9 +21,21 @@ import {
   StepTypeEnum,
 } from '@novu/shared';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
-import { buildSubscriberKey, CachedResponse } from '../../services';
+import { buildSubscriberKey, CachedResponse, FeatureFlagsService } from '../../services';
 import { GetPreferences } from '../get-preferences';
 import { GetSubscriberTemplatePreferenceCommand } from './get-subscriber-template-preference.command';
+import {
+  buildDefaultPreferenceChannels,
+  filteredPreference,
+  filterPreferenceChannelsByFeatureFlags,
+} from './preference-channels.utils';
+
+export {
+  buildDefaultPreferenceChannels,
+  filteredPreference,
+  filterPreferenceChannelsByFeatureFlags,
+  filterWorkflowPreferencesByFeatureFlags,
+} from './preference-channels.utils';
 
 const PRIORITY_ORDER = [
   PreferenceOverrideSourceEnum.TEMPLATE,
@@ -37,14 +50,21 @@ export class GetSubscriberTemplatePreference {
     private subscriberRepository: SubscriberRepository,
     private workflowOverrideRepository: WorkflowOverrideRepository,
     private tenantRepository: TenantRepository,
-    private getPreferences: GetPreferences
+    private getPreferences: GetPreferences,
+    private featureFlagsService: FeatureFlagsService
   ) {}
 
   @InstrumentUsecase()
   async execute(command: GetSubscriberTemplatePreferenceCommand): Promise<ISubscriberPreferenceResponse> {
     const subscriber: Pick<SubscriberEntity, '_id'> | null = command.subscriber ?? (await this.getSubscriber(command));
 
-    const initialChannels = await this.getChannels(command);
+    const isToolChannelEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_TOOL_CHANNEL_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
+    const initialChannels = await this.getChannels(command, isToolChannelEnabled);
 
     const workflowOverride = await this.getWorkflowOverride(command);
 
@@ -71,7 +91,7 @@ export class GetSubscriberTemplatePreference {
       template,
       preference: {
         enabled: subscriberWorkflowPreference.enabled,
-        channels,
+        channels: filterPreferenceChannelsByFeatureFlags(channels, { isToolChannelEnabled }),
         overrides,
       },
       type: subscriberWorkflowPreference.type,
@@ -146,7 +166,10 @@ export class GetSubscriberTemplatePreference {
   }
 
   @Instrument()
-  private async getChannels(command: GetSubscriberTemplatePreferenceCommand): Promise<IPreferenceChannels> {
+  private async getChannels(
+    command: GetSubscriberTemplatePreferenceCommand,
+    isToolChannelEnabled: boolean
+  ): Promise<IPreferenceChannels> {
     let includedChannels: ChannelTypeEnum[];
     if (command.includeInactiveChannels === true) {
       includedChannels = Object.values(ChannelTypeEnum);
@@ -155,14 +178,7 @@ export class GetSubscriberTemplatePreference {
     }
 
     const initialChannels = filteredPreference(
-      {
-        email: true,
-        sms: true,
-        in_app: true,
-        chat: true,
-        push: true,
-        tool: true,
-      },
+      buildDefaultPreferenceChannels({ isToolChannelEnabled }),
       includedChannels
     );
 
@@ -309,12 +325,6 @@ export function overridePreferences(
 
   return result;
 }
-
-export const filteredPreference = (preferences: IPreferenceChannels, filterKeys: string[]): IPreferenceChannels =>
-  Object.entries(preferences).reduce(
-    (obj, [key, value]) => (filterKeys.includes(key) ? { ...obj, [key]: value } : obj),
-    {}
-  );
 
 export function mapTemplateConfiguration(template: NotificationTemplateEntity): ITemplateConfiguration {
   return {

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/index.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/index.ts
@@ -1,2 +1,3 @@
 export * from './get-subscriber-template-preference.command';
 export * from './get-subscriber-template-preference.usecase';
+export * from './preference-channels.utils';

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/preference-channels.utils.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/preference-channels.utils.ts
@@ -1,0 +1,67 @@
+import { IPreferenceChannels, WorkflowPreferences } from '@novu/shared';
+
+export const filteredPreference = (preferences: IPreferenceChannels, filterKeys: string[]): IPreferenceChannels =>
+  Object.entries(preferences).reduce(
+    (obj, [key, value]) => (filterKeys.includes(key) ? { ...obj, [key]: value } : obj),
+    {}
+  );
+
+export function buildDefaultPreferenceChannels({
+  isToolChannelEnabled,
+}: {
+  isToolChannelEnabled: boolean;
+}): IPreferenceChannels {
+  return {
+    email: true,
+    sms: true,
+    in_app: true,
+    chat: true,
+    push: true,
+    ...(isToolChannelEnabled ? { tool: true } : {}),
+  };
+}
+
+/**
+ * Omits feature-flagged preference channels from API responses when the flag is off.
+ * Currently gates `tool` behind `IS_TOOL_CHANNEL_ENABLED`.
+ */
+export function filterPreferenceChannelsByFeatureFlags(
+  channels: IPreferenceChannels,
+  { isToolChannelEnabled }: { isToolChannelEnabled: boolean }
+): IPreferenceChannels {
+  if (isToolChannelEnabled) {
+    return channels;
+  }
+
+  const { tool: _omitted, ...rest } = channels;
+
+  return rest;
+}
+
+/**
+ * Omits feature-flagged channels from nested workflow preference objects
+ * (`preferences.user` / `preferences.default`) when the flag is off.
+ */
+export function filterWorkflowPreferencesByFeatureFlags(
+  preferences: WorkflowPreferences,
+  options: { isToolChannelEnabled: boolean }
+): WorkflowPreferences;
+export function filterWorkflowPreferencesByFeatureFlags(
+  preferences: WorkflowPreferences | null,
+  options: { isToolChannelEnabled: boolean }
+): WorkflowPreferences | null;
+export function filterWorkflowPreferencesByFeatureFlags(
+  preferences: WorkflowPreferences | null,
+  { isToolChannelEnabled }: { isToolChannelEnabled: boolean }
+): WorkflowPreferences | null {
+  if (!preferences || isToolChannelEnabled) {
+    return preferences;
+  }
+
+  const { tool: _omitted, ...channels } = preferences.channels;
+
+  return {
+    ...preferences,
+    channels: channels as WorkflowPreferences['channels'],
+  };
+}

--- a/libs/application-generic/src/usecases/get-workflow-with-preferences/get-workflow-with-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-workflow-with-preferences/get-workflow-with-preferences.usecase.ts
@@ -1,9 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { NotificationTemplateEntity } from '@novu/dal';
-import { buildWorkflowPreferencesFromPreferenceChannels, DEFAULT_WORKFLOW_PREFERENCES } from '@novu/shared';
+import {
+  buildWorkflowPreferencesFromPreferenceChannels,
+  DEFAULT_WORKFLOW_PREFERENCES,
+  FeatureFlagsKeysEnum,
+} from '@novu/shared';
 import { WorkflowWithPreferencesResponseDto } from '../../dtos/get-workflow-with-preferences.dto';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
+import { FeatureFlagsService } from '../../services';
 import { GetPreferences, GetPreferencesCommand } from '../get-preferences';
+import {
+  filterPreferenceChannelsByFeatureFlags,
+  filterWorkflowPreferencesByFeatureFlags,
+} from '../get-subscriber-template-preference/preference-channels.utils';
 import { GetWorkflowByIdsUseCase } from '../workflow';
 import { GetWorkflowWithPreferencesCommand } from './get-workflow-with-preferences.command';
 
@@ -11,7 +20,8 @@ import { GetWorkflowWithPreferencesCommand } from './get-workflow-with-preferenc
 export class GetWorkflowWithPreferencesUseCase {
   constructor(
     private getWorkflowByIdsUseCase: GetWorkflowByIdsUseCase,
-    private getPreferences: GetPreferences
+    private getPreferences: GetPreferences,
+    private featureFlagsService: FeatureFlagsService
   ) {}
 
   @InstrumentUsecase()
@@ -25,20 +35,33 @@ export class GetWorkflowWithPreferencesUseCase {
       includeUpdatedBy: true,
     });
 
+    const isToolChannelEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_TOOL_CHANNEL_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
     const workflowPreferences = await this.getWorkflowPreferences(command, workflowEntity);
 
     /**
      * @deprecated - use `userPreferences` and `defaultPreferences` instead
      */
-    const preferenceSettings = workflowPreferences
-      ? GetPreferences.mapWorkflowPreferencesToChannelPreferences(workflowPreferences.preferences)
-      : workflowEntity.preferenceSettings;
-    const userPreferences = workflowPreferences
-      ? workflowPreferences.source.USER_WORKFLOW
-      : buildWorkflowPreferencesFromPreferenceChannels(workflowEntity.critical, workflowEntity.preferenceSettings);
-    const defaultPreferences = workflowPreferences
-      ? workflowPreferences.source.WORKFLOW_RESOURCE
-      : DEFAULT_WORKFLOW_PREFERENCES;
+    const preferenceSettings = filterPreferenceChannelsByFeatureFlags(
+      workflowPreferences
+        ? GetPreferences.mapWorkflowPreferencesToChannelPreferences(workflowPreferences.preferences)
+        : workflowEntity.preferenceSettings,
+      { isToolChannelEnabled }
+    );
+    const userPreferences = filterWorkflowPreferencesByFeatureFlags(
+      workflowPreferences
+        ? workflowPreferences.source.USER_WORKFLOW
+        : buildWorkflowPreferencesFromPreferenceChannels(workflowEntity.critical, workflowEntity.preferenceSettings),
+      { isToolChannelEnabled }
+    );
+    const defaultPreferences = filterWorkflowPreferencesByFeatureFlags(
+      workflowPreferences?.source.WORKFLOW_RESOURCE ?? DEFAULT_WORKFLOW_PREFERENCES,
+      { isToolChannelEnabled }
+    );
 
     return {
       ...workflowEntity,

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -140,7 +140,13 @@ export enum FeatureFlagsKeysEnum {
    * organization for the duration of the rotation, then disable.
    */
   IS_MULTIPLE_SECRET_KEYS_ALLOWED = 'IS_MULTIPLE_SECRET_KEYS_ALLOWED',
-  /** Enable the Tool channel (PagerDuty, Opsgenie, and custom webhooks). */
+  /**
+   * Enable the Tool channel (PagerDuty, Opsgenie, and custom webhooks).
+   * When off, preference API responses omit the `tool` channel property
+   * (`SubscriberPreferenceChannels.tool` / `IPreferenceChannels.tool`).
+   * Create the boolean in LaunchDarkly for cloud, or set `IS_TOOL_CHANNEL_ENABLED`
+   * / `VITE_IS_TOOL_CHANNEL_ENABLED` when self-hosted.
+   */
   IS_TOOL_CHANNEL_ENABLED = 'IS_TOOL_CHANNEL_ENABLED',
   /**
    * Enable the Tool webhook provider in the integrations catalog. Keep off until


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Omits the `tool` preference channel from API responses when `IS_TOOL_CHANNEL_ENABLED` is off (default). This prevents Retrieve Workflow / subscriber preference payloads from exposing `channels.tool` to customers who do not have the Tool channel enabled — which was breaking novu-py clients that compare preference snapshots against an enum without `tool`.

Uses the existing `IS_TOOL_CHANNEL_ENABLED` flag (already used to hide Tool UI in the dashboard) rather than introducing a second flag.

## Changes

- Add `filterPreferenceChannelsByFeatureFlags` / `filterWorkflowPreferencesByFeatureFlags` helpers
- Apply filtering in:
  - `GetSubscriberGlobalPreference`
  - `GetSubscriberPreference` (bulk workflows)
  - `GetSubscriberTemplatePreference`
  - `GetWorkflowWithPreferencesUseCase` (`preferenceSettings`, `preferences.user`, `preferences.default`)
- Document the response gating on the DTO and flag enum

```mermaid
flowchart LR
  A[Preference / Workflow GET] --> B{IS_TOOL_CHANNEL_ENABLED?}
  B -->|false| C[Omit channels.tool from response]
  B -->|true| D[Include channels.tool]
```

## Notes

- Storage / defaults still include `tool` internally; only API serialization is gated
- Self-hosted: set `IS_TOOL_CHANNEL_ENABLED=true` (API) / `VITE_IS_TOOL_CHANNEL_ENABLED=true` (dashboard) to expose Tool
- Linear MCP and LaunchDarkly MCP were unavailable (auth expired) in this agent run — please attach an NV ticket and confirm the LD flag targeting if needed

## Test plan

- [ ] With flag off: `GET /v2/workflows/:id` response `preferences.user` / `preferences.default` have no `channels.tool`
- [ ] With flag off: subscriber preference endpoints omit `channels.tool`
- [ ] With flag on: `tool` is present again in those responses
- [ ] Unit helpers in `preference-channels.utils` cover omit/keep/null cases

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7069a110-e007-4d4e-adbf-e93d0ae0cd0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7069a110-e007-4d4e-adbf-e93d0ae0cd0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hides Tool channel preferences when the organization feature flag is disabled. The main changes are:

- Adds shared helpers for building and filtering preference channels.
- Applies organization-scoped filtering to subscriber preference responses.
- Filters flat and nested workflow preference responses.
- Documents the Tool channel response gating.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. Final response filtering covers persisted values as well as generated defaults, and the filtering helpers return new objects when removing the Tool channel.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The before-serialization log was captured, showing exit code 0 and that the unfiltered serialization includes tool in both flat and nested channels.
- The after-serialization log was captured, showing exit code 0 and that the real helper source passed all flag-off, flag-on, and null assertions.
- The Jest runner log was examined to locate the focused failure, including the exact command, working directory, exit code, and a dependency mismatch stack trace.
- It was confirmed that no manifests or lockfiles were modified during this work.

<a href="https://app.greptile.com/trex/runs/15235209/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/usecases/get-subscriber-template-preference/preference-channels.utils.ts | Adds non-mutating helpers for feature-gated channel defaults and response filtering. |
| apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts | Filters the Tool channel from organization-level subscriber preference responses when disabled. |
| apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts | Applies the Tool channel flag to bulk workflow preference defaults and output. |
| libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts | Applies feature-gated defaults and output filtering to template-specific preferences. |
| libs/application-generic/src/usecases/get-workflow-with-preferences/get-workflow-with-preferences.usecase.ts | Filters the deprecated flat settings and nested user and default workflow preferences. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Retrieve preferences] --> B[Resolve organization flag]
  B --> C{Tool channel enabled?}
  C -->|Yes| D[Keep tool channel]
  C -->|No| E[Omit tool channel]
  D --> F[Return API response]
  E --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
  A[Retrieve preferences] --> B[Resolve organization flag]
  B --> C{Tool channel enabled?}
  C -->|Yes| D[Keep tool channel]
  C -->|No| E[Omit tool channel]
  D --> F[Return API response]
  E --> F
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(api-service): omit tool preference ..."](https://github.com/novuhq/novu/commit/f900e74cbc2c6836aba3f31907a56dfb23fe0dc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45935080)</sub>

<!-- /greptile_comment -->