### PR TITLE
fix(docs): correct OpenAPI auth scheme for cURL ApiKey prefix

### DIFF
--- a/apps/api/src/app/shared/framework/swagger/swagger.controller.ts
+++ b/apps/api/src/app/shared/framework/swagger/swagger.controller.ts
@@ -13,9 +13,8 @@ import {
 } from './open.api.manipulation.component';
 
 export const API_KEY_SECURITY_DEFINITIONS: SecuritySchemeObject = {
-  type: 'apiKey',
-  name: 'Authorization',
-  in: 'header',
+  type: 'http',
+  scheme: 'ApiKey',
   description: 'API key authentication. Allowed headers-- "Authorization: ApiKey <novu_secret_key>".',
   'x-speakeasy-example': 'YOUR_SECRET_KEY_HERE',
 } as unknown as SecuritySchemeObject;

--- a/apps/api/swagger-spec.json
+++ b/apps/api/swagger-spec.json
@@ -29399,9 +29399,8 @@
   "components": {
     "securitySchemes": {
       "secretKey": {
-        "type": "apiKey",
-        "name": "Authorization",
-        "in": "header",
+        "type": "http",
+        "scheme": "ApiKey",
         "description": "API key authentication. Allowed headers-- \"Authorization: ApiKey <novu_secret_key>\"."
       },
       "bearerAuth": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The API reference docs at docs.novu.co generate incorrect cURL examples that show:
```bash
--header 'Authorization: <api-key>'
```
instead of the correct:
```bash
--header 'Authorization: ApiKey <api-key>'
```

This causes the "Run It" playground to return 401 Unauthorized, because the Novu API requires the `ApiKey` prefix in the `Authorization` header.

**Root cause:** The OpenAPI security scheme was defined as `type: apiKey` with `name: Authorization`, which tells doc generators (Mintlify) to put the raw key value in the header as-is. However, the API runtime actually expects `Authorization: ApiKey <key>` — an HTTP authentication scheme with a custom scheme name.

**Fix:** Changed the security scheme from `type: apiKey` (header) to `type: http` with `scheme: ApiKey`. This correctly represents the `Authorization: ApiKey <value>` format and makes OpenAPI-compliant doc generators produce the correct cURL examples.

The existing SDK hook (`novu-custom-hook.js`) already guards against double-prefixing by checking if `ApiKey` is present before adding it, so this change is backward-compatible with the current generated SDK.

**Files changed:**
- `apps/api/src/app/shared/framework/swagger/swagger.controller.ts` — source security scheme definition
- `apps/api/swagger-spec.json` — committed OpenAPI spec snapshot

### Screenshots

Before (from user report):
The cURL example shows `--header 'Authorization: <api-key>'` without the `ApiKey` prefix, and the "Run It" playground returns 401.

After this change, doc generators will produce `--header 'Authorization: ApiKey <api-key>'`.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- The fix will take effect on docs.novu.co after the next Speakeasy run publishes the updated spec to the registry that Mintlify consumes.
- The SDK hook in `libs/internal-sdk/hooks/novu-custom-hook.js` is safe — it checks `!key.includes('ApiKey')` before prepending, so once the SDK is regenerated with the new `http` scheme, no double-prefixing will occur.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GFC06JS3/p1784641977537639?thread_ts=1784641977.537639&cid=C06GFC06JS3)

<div><a href="https://cursor.com/agents/bc-6a6ef980-a7b2-5888-88f1-8385da7d1284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a6ef980-a7b2-5888-88f1-8385da7d1284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the OpenAPI definition for API-key authentication. The main changes are:

- Models the secret key as the HTTP `ApiKey` scheme.
- Updates the committed OpenAPI snapshot to match.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The security-scheme name remains unchanged, so existing endpoint references continue to resolve.
- The source definition and committed snapshot are consistent.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general contract validation and confirmed that the after snapshot passes all four assertions while the before snapshot failed.
- Verified source consistency and security by confirming Nest emitted the source definition unchanged and retained the global secretKey requirement, with fields matching the committed snapshot.
- Performed a cleanliness check and verified there are no working-tree changes to the reviewed file or the generated dist snapshot.
- Collected the seven artifacts as evidence of the validation, linking logs and JavaScript outputs to support reviewer inspection.

<a href="https://app.greptile.com/trex/runs/15245065/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/framework/swagger/swagger.controller.ts | Changes the source security definition to represent the required `Authorization: ApiKey <key>` format. |
| apps/api/swagger-spec.json | Keeps the committed OpenAPI snapshot aligned with the source security definition. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: change OpenAPI auth scheme to http/..."](https://github.com/novuhq/novu/commit/47c39da233bcaa1bc9a6b5b6879429510963e82c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45958499)</sub>

<!-- /greptile_comment -->