### PR TITLE
fix(api-service): recompute workflow status when step issues change fixes NV-8352

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/patch-workflow/patch-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/patch-workflow/patch-workflow.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import {
   BuildStepIssuesUsecase,
+  computeWorkflowStatus,
   GetWorkflowUseCase,
   GetWorkflowWithPreferencesUseCase,
   Instrument,
@@ -13,7 +14,7 @@ import {
   WorkflowWithPreferencesResponseDto,
 } from '@novu/application-generic';
 import { LocalizationResourceEnum, NotificationTemplateEntity, NotificationTemplateRepository } from '@novu/dal';
-import { UserSessionData, WebhookEventEnum, WebhookObjectTypeEnum, WorkflowStatusEnum } from '@novu/shared';
+import { UserSessionData, WebhookEventEnum, WebhookObjectTypeEnum } from '@novu/shared';
 import { MANAGE_TRANSLATIONS } from '../../../shared/constants';
 import { PatchWorkflowCommand } from './patch-workflow.command';
 
@@ -42,6 +43,11 @@ export class PatchWorkflowUsecase {
     if (hasPayloadSchemaChanged) {
       await this.recalculateStepIssues(transientWorkflow, command.user);
     }
+
+    transientWorkflow.status = computeWorkflowStatus(
+      transientWorkflow.active ?? true,
+      transientWorkflow.steps
+    );
 
     if (command.isTranslationEnabled !== undefined) {
       await this.toggleV2TranslationsForWorkflow(persistedWorkflow.triggers[0].identifier, command);
@@ -134,10 +140,6 @@ export class PatchWorkflowUsecase {
 
     if (command.tags !== undefined && command.tags !== null) {
       transientWorkflow.tags = command.tags;
-    }
-
-    if (command.active !== undefined && command.active !== null) {
-      transientWorkflow.status = command.active ? WorkflowStatusEnum.ACTIVE : WorkflowStatusEnum.INACTIVE;
     }
 
     return transientWorkflow;

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -18,7 +18,7 @@ import {
 import { ErrorDto } from '@novu/api/models/errors';
 import { WorkflowResponseDto } from '@novu/api/src/models/components';
 import { buildSlug, JSONSchemaDto } from '@novu/application-generic';
-import { PreferencesRepository } from '@novu/dal';
+import { PreferencesRepository, NotificationTemplateRepository } from '@novu/dal';
 import {
   ApiServiceLevelEnum,
   DEFAULT_WORKFLOW_PREFERENCES,
@@ -1048,6 +1048,55 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
       updatedWorkflow = await patchWorkflow(workflowDto.id, true);
       expect(updatedWorkflow.status).to.equal(WorkflowStatusEnum.Active);
     });
+
+    it('should recompute workflow status after payload schema changes clear step issues', async () => {
+      const createWorkflowDto: CreateWorkflowDto = buildWorkflow({
+        steps: [
+          {
+            name: 'In-App Test Step',
+            type: StepTypeEnum.IN_APP,
+            controlValues: {
+              redirect: { url: 'https://example.com', target: '_blank' },
+            },
+          },
+        ],
+      });
+
+      const workflowWithIssues = await createWorkflow(apiClient, createWorkflowDto);
+      expect(workflowWithIssues.status).to.equal(WorkflowStatusEnum.Error);
+
+      const fixedWorkflow = await updateWorkflow(workflowWithIssues.id, {
+        ...mapResponseToUpdateDto(workflowWithIssues),
+        steps: [
+          {
+            id: workflowWithIssues.steps[0].id,
+            type: StepTypeEnum.IN_APP,
+            name: 'In-App Test Step',
+            controlValues: {
+              body: 'Fixed body',
+              redirect: { url: 'https://example.com', target: '_blank' },
+            },
+          },
+        ],
+      });
+      expect(fixedWorkflow.status).to.equal(WorkflowStatusEnum.Active);
+
+      const templateRepository = new NotificationTemplateRepository();
+      await templateRepository.update(
+        { _id: workflowWithIssues.id, _environmentId: session.environment._id },
+        { $set: { status: WorkflowStatusEnum.Error } }
+      );
+
+      const patchedWorkflow = await patchWorkflowWithPayloadSchema(workflowWithIssues.id, {
+        type: 'object',
+        properties: {
+          userName: { type: 'string' },
+        },
+      });
+
+      expect(patchedWorkflow.status).to.equal(WorkflowStatusEnum.Active);
+      expect(patchedWorkflow.steps[0].issues?.controls).to.not.exist;
+    });
   });
 
   describe('Delete workflow', () => {
@@ -1253,6 +1302,41 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
           expect(stepData.issues?.controls?.body?.[0]?.variableName).to.equal('{{}}');
           expect(stepData.issues?.controls?.body?.[0]?.issueType).to.equal('ILLEGAL_VARIABLE_IN_CONTROL_VALUE');
         });
+
+        it('should clear workflow ERROR status after step control issues are fixed', async () => {
+          const createWorkflowDto: CreateWorkflowDto = buildWorkflow({
+            steps: [
+              {
+                name: 'In-App Test Step',
+                type: StepTypeEnum.IN_APP,
+                controlValues: {
+                  redirect: { url: 'https://example.com', target: '_blank' },
+                },
+              },
+            ],
+          });
+
+          const workflowWithIssues = await createWorkflow(apiClient, createWorkflowDto);
+          expect(workflowWithIssues.status).to.equal(WorkflowStatusEnum.Error);
+
+          const fixedWorkflow = await updateWorkflow(workflowWithIssues.id, {
+            ...mapResponseToUpdateDto(workflowWithIssues),
+            steps: [
+              {
+                id: workflowWithIssues.steps[0].id,
+                type: StepTypeEnum.IN_APP,
+                name: 'In-App Test Step',
+                controlValues: {
+                  body: 'Fixed body',
+                  redirect: { url: 'https://example.com', target: '_blank' },
+                },
+              },
+            ],
+          });
+
+          expect(fixedWorkflow.status).to.equal(WorkflowStatusEnum.Active);
+          expect(fixedWorkflow.steps[0].issues?.controls).to.not.exist;
+        });
       });
     });
   });
@@ -1267,6 +1351,17 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
     const res = await apiClient.workflows.patch(
       {
         active,
+      },
+      workflowId
+    );
+
+    return res.result;
+  }
+
+  async function patchWorkflowWithPayloadSchema(workflowId: string, payloadSchema: object) {
+    const res = await apiClient.workflows.patch(
+      {
+        payloadSchema,
       },
       workflowId
     );

--- a/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
@@ -178,8 +178,12 @@ export class UpdateWorkflowV0 {
         updatePayload.validatePayload = command.validatePayload;
       }
 
-      if (command.active !== undefined) {
-        updatePayload.status = computeWorkflowStatus(command.active, updatePayload.steps || existingTemplate.steps);
+      if (command.steps || command.active !== undefined) {
+        const isWorkflowActive = command.active ?? existingTemplate.active ?? true;
+        updatePayload.status = computeWorkflowStatus(
+          isWorkflowActive,
+          updatePayload.steps || existingTemplate.steps
+        );
       }
 
       if (command.issues) {

--- a/libs/application-generic/src/utils/compute-workflow-status.spec.ts
+++ b/libs/application-generic/src/utils/compute-workflow-status.spec.ts
@@ -1,0 +1,41 @@
+import { ContentIssueEnum, WorkflowStatusEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { computeWorkflowStatus, hasControlIssues } from './compute-workflow-status';
+
+describe('computeWorkflowStatus', () => {
+  it('should return INACTIVE when workflow is not active', () => {
+    const status = computeWorkflowStatus(false, [{ issues: { controls: { body: [{ issueType: ContentIssueEnum.MISSING_VALUE, message: 'required' }] } } }]);
+
+    expect(status).to.equal(WorkflowStatusEnum.INACTIVE);
+  });
+
+  it('should return ACTIVE when workflow is active and steps have no control issues', () => {
+    const status = computeWorkflowStatus(true, [{ issues: {} }, { issues: undefined }]);
+
+    expect(status).to.equal(WorkflowStatusEnum.ACTIVE);
+  });
+
+  it('should return ERROR when workflow is active and a step has control issues', () => {
+    const status = computeWorkflowStatus(true, [
+      { issues: { controls: { body: [{ issueType: ContentIssueEnum.MISSING_VALUE, message: 'required' }] } } },
+    ]);
+
+    expect(status).to.equal(WorkflowStatusEnum.ERROR);
+  });
+});
+
+describe('hasControlIssues', () => {
+  it('should return false when controls are empty or missing', () => {
+    expect(hasControlIssues(undefined)).to.equal(false);
+    expect(hasControlIssues({})).to.equal(false);
+    expect(hasControlIssues({ controls: {} })).to.equal(false);
+  });
+
+  it('should return true when controls contain issues', () => {
+    expect(
+      hasControlIssues({
+        controls: { body: [{ issueType: ContentIssueEnum.MISSING_VALUE, message: 'required' }] },
+      })
+    ).to.equal(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where the workflows list showed **Action required** even after step validation issues were cleared in the editor.

The list badge uses the persisted `status` field (`ERROR`), not a live recompute from current step issues. Two save paths left that field stale:

1. **Patch workflow** (e.g. payload schema save) recalculated step `issues` but never updated `status`.
2. **Update workflow** only recomputed `status` when `active` changed, not when `steps` (and their issues) changed.

## Changes

- **`PatchWorkflowUsecase`**: After applying patches (including payload-schema-driven issue recalculation), recompute `status` via `computeWorkflowStatus` instead of only toggling ACTIVE/INACTIVE on `active` changes.
- **`UpdateWorkflowV0`**: Recompute `status` when `steps` are updated, using `command.active ?? existingTemplate.active`.
- Added unit tests for `computeWorkflowStatus` and e2e coverage for clearing ERROR status after fixes and after payload schema patches.

## Test plan

- [x] `compute-workflow-status.spec.ts` (via application-generic build)
- [x] E2E: `should clear workflow ERROR status after step control issues are fixed`
- [x] E2E: `should recompute workflow status after payload schema changes clear step issues`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1784705069181419?thread_ts=1784705069.181419&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-9db3bcd5-0784-50ac-8a08-4d4512f9c8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9db3bcd5-0784-50ac-8a08-4d4512f9c8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps persisted workflow status in sync with current step issues. The main changes are:

- Recompute status after workflow patches and payload-schema validation.
- Recompute status when workflow steps or activation state change.
- Add unit and end-to-end tests for clearing stale error states.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the workflow-status-e2e-blocker.log to understand why the preflight step blocked the PR check.
- Confirmed the log shows an exit code of 2 and points to issues like missing executables and a refused Mongo connection during focused-test discovery.
- Noted environment details in the log, including a Node version caveat (v24.18.0) and Mongo configuration hints.

<a href="https://app.greptile.com/trex/runs/15373628/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/workflows-v2/usecases/patch-workflow/patch-workflow.usecase.ts | Recomputes status after patch fields and any payload-schema-driven issue updates are applied. |
| libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts | Recomputes status from the effective activation state and updated or existing steps. |
| apps/api/src/app/workflows-v2/workflow.controller.e2e.ts | Adds coverage for clearing stale error status through update and payload-schema patch requests. |
| libs/application-generic/src/utils/compute-workflow-status.spec.ts | Covers inactive precedence, control-issue detection, and active versus error status. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): recompute workflow sta..."](https://github.com/novuhq/novu/commit/f7c27d456724be4cc3cf8b828f56d6938f70e5ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46214954)</sub>

<!-- /greptile_comment -->