### PR TITLE
fix(docs): fix accordion issue on AI SDK and LangChain quickstart oages

### DIFF
--- a/docs/agents/get-started/ai-sdk.mdx
+++ b/docs/agents/get-started/ai-sdk.mdx
@@ -153,10 +153,7 @@ Export it from `app/novu/agents/index.ts`:
 export { supportBot } from './support-bot';
 ```
 
-- Match `agent('...')` to the dashboard **Identifier**.
-- `toModelMessages(ctx.history)` already includes the current inbound message.
-- Returning `generateText(...)` delivers the reply. You do not call `ctx.reply()` on this path.
-
+Match `agent('...')` to the dashboard **Identifier**. `toModelMessages(ctx.history)` already includes the current inbound message. Returning `generateText(...)` delivers the reply — you do not call `ctx.reply()` on this path.
   </Accordion>
   <Accordion title="Add the bridge route">
 Create `app/api/novu/route.ts`:

--- a/docs/agents/get-started/langchain.mdx
+++ b/docs/agents/get-started/langchain.mdx
@@ -149,10 +149,7 @@ Export it from `app/novu/agents/index.ts`:
 export { supportBot } from './support-bot';
 ```
 
-- Match `agent('...')` to the dashboard **Identifier**.
-- Returning `{ model, system }` is a `LangChainAgentConfig`. Novu calls `createAgent().invoke()` and delivers the final text.
-- Novu maps `ctx.history` for you on this path.
-
+Match `agent('...')` to the dashboard **Identifier**. Returning `{ model, system }` is a `LangChainAgentConfig` — Novu calls `createAgent().invoke()` and delivers the final text. Novu maps `ctx.history` for you on this path.
   </Accordion>
   <Accordion title="Add a tool (optional)">
 ```typescript


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts the closing content of two quickstart accordions.

- Replaces the AI SDK instruction list with an equivalent paragraph.
- Replaces the LangChain instruction list with an equivalent paragraph.
- Preserves the original guidance in both pages.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed documentation. The new MDX structure matches existing accordion patterns. Both rewrites preserve the original instructions.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I compared the shared before/after videos to confirm the regression was present and the fix is effective.
- I inspected the AI SDK screenshot to verify the expanded handler is visible and the bridge route boundary is shown.
- I inspected the LangChain screenshot to verify the expanded handler is visible and the Add a tool (optional) boundary is shown.
- I reviewed the browser and server logs to confirm executed commands, working directories, HTTP statuses, assertions, and exit codes across the workflow.

<a href="https://app.greptile.com/trex/runs/15378333/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/agents/get-started/ai-sdk.mdx | Converts three trailing accordion instructions into one equivalent prose paragraph. |
| docs/agents/get-started/langchain.mdx | Converts the trailing instruction list into equivalent prose without changing its meaning. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): fix accordion issue on AI SDK..."](https://github.com/novuhq/novu/commit/ba918157f49f1daf8c281deeff2cb225a5c6a6ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46225432)</sub>

<!-- /greptile_comment -->