### PR TITLE
fix(api): handle localhost/127.0.0.1 CORS mismatch on BetterAuth routes

### DIFF
--- a/apps/api/src/config/cors.config.spec.ts
+++ b/apps/api/src/config/cors.config.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
+
+// Module-level ALLOWED_ORIGINS_REGEX is set at import time from FRONT_BASE_URL.
+// Cache the original value so tests that mutate the env can restore it.
+const origFrontBaseUrl = process.env.FRONT_BASE_URL;
+
 import { corsOptionsDelegate } from './cors.config';
 
 const dashboardOrigin = 'https://dashboard.novu.co';
@@ -25,6 +30,75 @@ describe('CORS Configuration', () => {
       expect(callbackSpy.calledOnce).to.be.ok;
       expect(callbackSpy.firstCall.firstArg).to.be.null;
       expect(callbackSpy.firstCall.lastArg.origin).to.equal('*');
+    });
+  });
+
+  describe('BetterAuth CORS with localhost / 127.0.0.1 mismatch', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'local';
+      process.env.FRONT_BASE_URL = 'http://127.0.0.1:4201';
+      delete require.cache[require.resolve('./cors.config')];
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = 'test';
+      process.env.FRONT_BASE_URL = origFrontBaseUrl;
+      delete require.cache[require.resolve('./cors.config')];
+    });
+
+    it('should accept localhost origin on a BetterAuth route when FRONT_BASE_URL uses 127.0.0.1', () => {
+      const { corsOptionsDelegate: delegate } = require('./cors.config');
+      const callbackSpy = spy();
+
+      // @ts-expect-error - corsOptionsDelegate is not typed correctly
+      delegate(
+        {
+          url: '/v1/better-auth/sign-in',
+          headers: { origin: 'http://localhost:4201' },
+        },
+        callbackSpy
+      );
+
+      expect(callbackSpy.calledOnce).to.be.ok;
+      expect(callbackSpy.firstCall.lastArg.origin).to.include('http://localhost:4201');
+    });
+
+    it('should accept 127.0.0.1 origin on a BetterAuth route when FRONT_BASE_URL uses localhost', () => {
+      process.env.FRONT_BASE_URL = 'http://localhost:4201';
+      delete require.cache[require.resolve('./cors.config')];
+      const { corsOptionsDelegate: delegate } = require('./cors.config');
+      const callbackSpy = spy();
+
+      // @ts-expect-error - corsOptionsDelegate is not typed correctly
+      delegate(
+        {
+          url: '/v1/better-auth/sign-in',
+          headers: { origin: 'http://127.0.0.1:4201' },
+        },
+        callbackSpy
+      );
+
+      expect(callbackSpy.calledOnce).to.be.ok;
+      expect(callbackSpy.firstCall.lastArg.origin).to.include('http://127.0.0.1:4201');
+    });
+
+    it('should reject origin with no localhost/127.0.0.1 relation', () => {
+      process.env.FRONT_BASE_URL = 'http://localhost:4201';
+      delete require.cache[require.resolve('./cors.config')];
+      const { corsOptionsDelegate: delegate } = require('./cors.config');
+      const callbackSpy = spy();
+
+      // @ts-expect-error - corsOptionsDelegate is not typed correctly
+      delegate(
+        {
+          url: '/v1/better-auth/sign-in',
+          headers: { origin: 'http://my-evil-site.com' },
+        },
+        callbackSpy
+      );
+
+      expect(callbackSpy.calledOnce).to.be.ok;
+      expect(callbackSpy.firstCall.lastArg.origin).to.eql([]);
     });
   });
 

--- a/apps/api/src/config/cors.config.ts
+++ b/apps/api/src/config/cors.config.ts
@@ -31,6 +31,20 @@ export const corsOptionsDelegate: Parameters<INestApplication['enableCors']>[0] 
 
     if (ALLOWED_ORIGINS_REGEX.test(requestOrigin)) {
       corsOptions.origin.push(requestOrigin);
+    } else if (isDevelopmentEnvironment()) {
+      // In development, the dashboard may use localhost or 127.0.0.1 interchangeably
+      // while FRONT_BASE_URL may reference the other. Try the swapped form.
+      let alternateOrigin: string;
+      if (requestOrigin.includes('localhost')) {
+        alternateOrigin = requestOrigin.replace('localhost', '127.0.0.1');
+      } else if (requestOrigin.includes('127.0.0.1')) {
+        alternateOrigin = requestOrigin.replace('127.0.0.1', 'localhost');
+      } else {
+        alternateOrigin = requestOrigin;
+      }
+      if (alternateOrigin !== requestOrigin && ALLOWED_ORIGINS_REGEX.test(alternateOrigin)) {
+        corsOptions.origin.push(requestOrigin);
+      }
     }
     if (process.env.WIDGET_BASE_URL) {
       corsOptions.origin.push(process.env.WIDGET_BASE_URL);


### PR DESCRIPTION
### What changed? Why was the change needed?

The dashboard runs at `http://localhost:4201` and makes BetterAuth API requests to `http://localhost:3000/v1/better-auth/*`. BetterAuth routes are intentionally excluded from wildcard CORS for security — they require explicit origin validation via the `ALLOWED_ORIGINS_REGEX` built from `FRONT_BASE_URL`.

The default `.env` sets `FRONT_BASE_URL=http://127.0.0.1:4201`, creating a regex that doesn't match `http://localhost:4201`. This causes BetterAuth authentication requests to fail with "Response body is not available to scripts (Reason: CORS Failed)" when the dashboard is accessed via `localhost`.

In development mode, when the request origin doesn't directly match the regex, the code now tries the swapped form (`localhost` ↔ `127.0.0.1`). This is gated behind `isDevelopmentEnvironment()` so production deployments are unaffected.

Fixes novuhq/novu#12038

### Screenshots

N/A

### Greptile Summary

This PR adds development support for mismatched loopback hostnames on BetterAuth requests. The main changes are:

* A fallback that swaps `localhost` and `127.0.0.1` before origin validation.
* Tests for both loopback swap directions.
* A test that rejects an unrelated origin.

### Confidence Score: 4/5

The BetterAuth origin fallback needs exact hostname validation before merging.

Intended loopback swaps are covered by tests. Substring replacement can turn an attacker-controlled hostname into a value accepted by an unanchored allowed-origin expression.

The issue is limited to development environments and affected loopback configurations.

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* Reproduced the non-loopback CORS behavior using the local HTTP harness against the repository's CORS delegate and observed a credentials-enabled origin with a 200 OK response and proper CORS headers.
* Validated that after the changes, origins are explicitly allowed and subsequent responses use 204 No Content with Access-Control-Allow-Credentials: true and single-origin arrays instead of wildcard origins.

![View all artifacts](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<img src="https://camo.githubusercontent.com/223063a8acd7e71fd1deaaa741d9d06948338e590a1cc633c9305234794edec8/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f56696577416c6c4172746966616374732e7376673f763d34 " alt="T-Rex" height="14" /> Ran code and verified through T-Rex

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/api/src/config/cors.config.ts | Adds the development loopback fallback, but substring replacement can broaden BetterAuth origin access for an unanchored loopback configuration. |
| apps/api/src/config/cors.config.spec.ts | Adds coverage for intended loopback substitutions and an unrelated rejected origin, but not hostnames containing a loopback name as a substring. |

</details>

![Fix All in Cursor](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/config/cors.config.ts:38-42
**Substring Swap Allows Non-Loopback Hosts**

When development uses an unanchored value such as `FRONT_BASE_URL=http://127.0.0.1`, an origin like `http://localhost.evil.example` is changed to `http://127.0.0.1.evil.example`, which matches the allowed prefix. The BetterAuth route then returns the attacker-controlled origin in its CORS allowlist even though its hostname is not loopback; parse the origin and swap only when the complete hostname equals `localhost` or `127.0.0.1`.
```

</details>

Reviews (1): Last reviewed commit: ["fix(api): handle localhost/127.0.0.1 COR..."](<https://github.com/novuhq/novu/commit/42363a23bb55509f9ef0ed4efce7062b1c68287a>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=46269850>)

> Greptile also left **1 inline comment** on this PR.