### PR TITLE
fix(api-service): mint context and subscriber hash using novu secret api key

### DIFF
--- a/apps/api/src/app/novu-context/usecases/build-novu-context/build-novu-context.usecase.ts
+++ b/apps/api/src/app/novu-context/usecases/build-novu-context/build-novu-context.usecase.ts
@@ -1,10 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  createContextHash,
-  createHash,
-  GetDecryptedSecretKey,
-  GetDecryptedSecretKeyCommand,
-} from '@novu/application-generic';
+import { createContextHash, createHash } from '@novu/application-generic';
 import type { ContextPayload } from '@novu/shared';
 import { BuildNovuContextCommand } from './build-novu-context.command';
 
@@ -19,24 +14,11 @@ export interface NovuConnectContext {
 
 /**
  * Mints the customer tenant `context` + a trusted `contextHash`, plus a `subscriberHash` for the
- * caller's own identity, all signed with the Novu-hosted app environment secret key.
- *
- * The dashboard connects to the *Novu-hosted* app (`APP_ID`), whose environment is
- * `NOVU_HOSTED_AGENT_ENVIRONMENT_ID` (the same env the copilot bridge resolves its secret from).
- * This runs in the **customer's authenticated session** and builds the tenant binding server-side
- * from that session (never from client input), but signs it with the **hosted app environment's**
- * secret key — the single trust anchor the hosting env verifies against (dogfooded Inbox HMAC and
- * the NovuCopilot Slack connect flow). Because the org/env/user are taken from the authenticated
- * session and the signature can only be produced by Novu's own backend, a browser can neither forge
- * the binding nor claim a foreign tenant.
+ * caller's own identity, all signed with the Novu secret API key.
  */
 @Injectable()
 export class BuildNovuContext {
-  constructor(private readonly getDecryptedSecretKey: GetDecryptedSecretKey) {}
-
   async execute(command: BuildNovuContextCommand): Promise<NovuConnectContext> {
-    // Only mint a subscriber HMAC for the caller's own identity — never an arbitrary one,
-    // which would let an authenticated user impersonate another subscriber of the hosted app.
     const expectedSubscriberId = command.userId;
 
     const context: ContextPayload = {
@@ -49,24 +31,13 @@ export class BuildNovuContext {
       },
     };
 
-    const hostedAgentEnvironmentId = process.env.NOVU_HOSTED_AGENT_ENVIRONMENT_ID;
-
-    if (!hostedAgentEnvironmentId?.trim()) {
-      throw new Error('NOVU_HOSTED_AGENT_ENVIRONMENT_ID must be configured to mint a Novu connect context.');
+    const novuSecretApiKey = process.env.NOVU_SECRET_API_KEY;
+    if (!novuSecretApiKey?.trim()) {
+      throw new Error('NOVU_SECRET_API_KEY must be configured to mint a Novu connect context.');
     }
 
-    // Sign with the Novu-hosted app environment's key — the connection lives under that env's
-    // integration, so its secret is the key the connect/Inbox flow verifies against. The dashboard
-    // authenticates as a subscriber of this same hosted app (APP_ID), so the subscriber HMAC is
-    // minted with the same secret.
-    const secretKey = await this.getDecryptedSecretKey.execute(
-      GetDecryptedSecretKeyCommand.create({
-        environmentId: hostedAgentEnvironmentId,
-      })
-    );
-
-    const contextHash = createContextHash(secretKey, context);
-    const subscriberHash = createHash(secretKey, expectedSubscriberId);
+    const contextHash = createContextHash(novuSecretApiKey, context);
+    const subscriberHash = createHash(novuSecretApiKey, expectedSubscriberId);
 
     if (!contextHash || !subscriberHash) {
       throw new Error('Failed to compute the Novu connect context hash.');


### PR DESCRIPTION
### What changed? Why was the change needed?

API: mint context and subscriber hash using Novu secret api key.
This endpoint is used by the Novu Inbox and Slack Novu Copilot connect buttons.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how the API signs Novu connection context. The main changes are:

- Read the signing key from `NOVU_SECRET_API_KEY`.
- Remove the hosted-environment secret lookup and injected dependency.
- Use the same configured key for context and subscriber hashes.

<h3>Confidence Score: 4/5</h3>

The signing key must remain aligned with the hosted environment key before merging.

Inbox and Slack verification use environment API keys from the database. A different `NOVU_SECRET_API_KEY` produces hashes that those flows cannot verify.

apps/api/src/app/novu-context/usecases/build-novu-context/build-novu-context.usecase.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the signing-key divergence test for BuildNovuContext and verified both hashes matched recomputation when using a disposable NOVU\_SECRET\_API\_KEY.
- Recomputed hashes using a distinct simulated hosted-environment database key and confirmed context and subscriber verification were false.
- Ran the focused Mocha reproduction and verified the concrete mismatch assertions passed with exit code 0 on Node 24.18.0, with Node 22 unavailable as reported by the repository requirements.
- Compared pre-change and post-change runtime logs for novu-connect-context to confirm the post-change hash equality and missing-key failures, with both runs exiting successfully.

<a href="https://app.greptile.com/trex/runs/15399026/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/novu-context/usecases/build-novu-context/build-novu-context.usecase.ts | Replaces the hosted environment key lookup with a process-level secret, which can produce hashes that the environment-scoped verification paths reject. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fnovu-context%2Fusecases%2Fbuild-novu-context%2Fbuild-novu-context.usecase.ts%3A34%0A**Signing%20Key%20Can%20Diverge%20From%20Verifier**%0A%0AWhen%20%60NOVU_SECRET_API_KEY%60%20differs%20from%20the%20API%20key%20stored%20for%20%60NOVU_HOSTED_AGENT_ENVIRONMENT_ID%60%2C%20this%20endpoint%20signs%20with%20one%20key%20while%20Inbox%20and%20Slack%20verification%20use%20the%20environment%20key%20from%20the%20database.%20The%20returned%20context%20and%20subscriber%20hashes%20then%20fail%20verification%2C%20breaking%20both%20connect%20flows%3B%20the%20previous%20lookup%20guaranteed%20that%20the%20signer%20used%20the%20hosted%20environment's%20current%20key.%0A%0A&pr=12041&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/novu-context/usecases/build-novu-context/build-novu-context.usecase.ts:34
**Signing Key Can Diverge From Verifier**

When `NOVU_SECRET_API_KEY` differs from the API key stored for `NOVU_HOSTED_AGENT_ENVIRONMENT_ID`, this endpoint signs with one key while Inbox and Slack verification use the environment key from the database. The returned context and subscriber hashes then fail verification, breaking both connect flows; the previous lookup guaranteed that the signer used the hosted environment's current key.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): mint context and subsc..."](https://github.com/novuhq/novu/commit/bd2a19bb84011bbce825dd0602a7dfc440b31d00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46274569)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->