### PR TITLE
fix(api-service): novu copilot bridge use novu secret api key

### DIFF
--- a/apps/api/src/app/agents/copilot-bridge/novu-copilot-bridge.client.ts
+++ b/apps/api/src/app/agents/copilot-bridge/novu-copilot-bridge.client.ts
@@ -1,12 +1,6 @@
-import { Inject, NotFoundException } from '@nestjs/common';
+import { Inject } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import {
-  GetDecryptedSecretKey,
-  GetDecryptedSecretKeyCommand,
-  InMemoryLRUCacheService,
-  InMemoryLRUCacheStore,
-  PinoLogger,
-} from '@novu/application-generic';
+import { PinoLogger } from '@novu/application-generic';
 import type { Agent } from '@novu/framework';
 import { Client, NovuHandler, NovuRequestHandler } from '@novu/framework/nest';
 import type { Request, Response } from 'express';
@@ -28,18 +22,10 @@ type EeAiCopilotModule = {
 };
 
 /**
- * Serves the Novu-hosted NovuCopilot agent over the `@novu/framework` Nest bridge, mirroring
- * {@link NovuBridgeClient} (the workflow bridge): it resolves the hosting environment's decrypted
- * secret per-request and runs the framework handler with `strictAuthentication`, so inbound turns
- * signed by `BridgeExecutorService` are HMAC-verified against the same environment key.
- *
- * The agent implementation lives in `@novu/ee-ai` (`NovuCopilotAgentFactory`); it is resolved from the
- * DI container lazily and built once, then reused. The agent is stateless (it resumes from
- * `ctx.history` and `ctx.metadata`), so a single instance safely handles every turn.
- *
- * Enabled only when `NOVU_HOSTED_AGENT_ENVIRONMENT_ID` (the Novu-prod environment that owns the
- * copilot `AgentEntity`) is configured and the EE module ships; otherwise the route responds 404 and
- * the agent stays inert.
+ * Serves the Novu-hosted Novu Copilot agent over the `@novu/framework` Nest bridge, mirroring
+ * {@link NovuBridgeClient} (the workflow bridge): it resolves the Novu Copilot bridge secret
+ * and runs the framework handler with `strictAuthentication`, so inbound turns
+ * signed by `BridgeExecutorService` are HMAC-verified against the Novu Copilot bridge secret.
  */
 export class NovuCopilotBridgeClient {
   private copilotAgent: Agent | null = null;
@@ -47,17 +33,15 @@ export class NovuCopilotBridgeClient {
   constructor(
     @Inject(NovuHandler) private novuHandler: NovuHandler,
     private moduleRef: ModuleRef,
-    private getDecryptedSecretKey: GetDecryptedSecretKey,
-    private inMemoryLRUCacheService: InMemoryLRUCacheService,
     private logger: PinoLogger
   ) {}
 
   public async handleRequest(req: Request, res: Response) {
-    const environmentId = process.env.NOVU_HOSTED_AGENT_ENVIRONMENT_ID;
-    if (!environmentId || !environmentId.trim()) {
+    const novuSecretApiKey = process.env.NOVU_SECRET_API_KEY;
+    if (!novuSecretApiKey?.trim()) {
       res.status(404).json({
-        error: 'NovuCopilot bridge is not configured',
-        details: 'Set NOVU_HOSTED_AGENT_ENVIRONMENT_ID to enable the hosted NovuCopilot agent bridge.',
+        error: 'Novu Copilot bridge is not configured',
+        details: 'NOVU_SECRET_API_KEY must be configured for the Novu Copilot bridge.',
       });
 
       return;
@@ -76,33 +60,10 @@ export class NovuCopilotBridgeClient {
       return;
     }
 
-    let secretKey: string;
-    try {
-      secretKey = await this.resolveSecretKey(environmentId);
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        this.logger.warn(`NovuCopilot bridge environment not found (environmentId=${environmentId}): ${error.message}`);
-        res.status(404).json({
-          error: 'Environment not found',
-          details: `No environment for NOVU_HOSTED_AGENT_ENVIRONMENT_ID=${environmentId}.`,
-        });
-
-        return;
-      }
-
-      this.logger.error({ err: error }, `Failed to resolve NovuCopilot bridge secret (environmentId=${environmentId})`);
-      res.status(500).json({
-        error: 'Failed to resolve environment secret key',
-        details: 'Unexpected error while loading the NovuCopilot hosting environment secret.',
-      });
-
-      return;
-    }
-
     const novuRequestHandler = new NovuRequestHandler({
       frameworkName,
       agents: [agent],
-      client: new Client({ secretKey, strictAuthentication: true, verbose: false }),
+      client: new Client({ secretKey: novuSecretApiKey, strictAuthentication: true, verbose: false }),
       handler: this.novuHandler.handler,
     });
 
@@ -129,23 +90,5 @@ export class NovuCopilotBridgeClient {
     this.copilotAgent = factory.build();
 
     return this.copilotAgent;
-  }
-
-  private async resolveSecretKey(environmentId: string): Promise<string> {
-    const cacheKey = `bridge-secret-key:${environmentId}`;
-    const storeName = InMemoryLRUCacheStore.VALIDATOR;
-
-    const resolved = await this.inMemoryLRUCacheService.get(
-      storeName,
-      cacheKey,
-      () => this.getDecryptedSecretKey.execute(GetDecryptedSecretKeyCommand.create({ environmentId })),
-      { environmentId, cacheVariant: 'bridge-secret-key' }
-    );
-
-    if (typeof resolved !== 'string' || !resolved.trim()) {
-      throw new Error(`Empty or invalid secret for NovuCopilot bridge environment ${environmentId}.`);
-    }
-
-    return resolved;
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

API: in the Novu Copilot Bridge - use Novu secret API key instead of doing db lookup.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how the Novu Copilot bridge obtains its authentication secret. The main changes are:

- Read the bridge secret from `NOVU_SECRET_API_KEY`.
- Remove the per-environment database lookup and cache.
- Simplify the bridge's missing-configuration response.

<h3>Confidence Score: 4/5</h3>

The bridge configuration and HMAC key paths need to be aligned before merging.

Existing deployments can return 404 until the new variable is configured. Requests can be signed and verified with different keys, causing valid copilot turns to fail authentication.

apps/api/src/app/agents/copilot-bridge/novu-copilot-bridge.client.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the bridge configuration gate behavior by validating that a POST to /v1/novu/bridge returns 404 when NOVU\_SECRET\_API\_KEY is absent and 200 when a non-production key is provided.
- Investigated signer and verifier key divergence and attempted to run a focused HTTP harness; the initial harness failed due to top-level await incompatibility, and execution was blocked by tool limits before completion.
- Compared baseline and after-deployment logs showing the before state returned HTTP 404 with empty delegation while the after state returned HTTP 200 with frameworkName=novu-nest, indicating the changed path now reaches the framework handler; full startup could not be attempted due to missing workspace data.

<a href="https://app.greptile.com/trex/runs/15414859/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/copilot-bridge/novu-copilot-bridge.client.ts | Replaces per-environment secret resolution with a global environment variable, changing both bridge enablement and HMAC verification. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fcopilot-bridge%2Fnovu-copilot-bridge.client.ts%3A40-41%0A**Existing%20Bridge%20Configuration%20Is%20Disabled**%0A%0AA%20deployment%20that%20sets%20%60NOVU_HOSTED_AGENT_ENVIRONMENT_ID%60%20but%20not%20the%20new%20%60NOVU_SECRET_API_KEY%60%20now%20returns%20404%20for%20every%20copilot%20request.%20This%20changes%20the%20bridge's%20required%20configuration%20without%20a%20fallback%2C%20so%20existing%20deployments%20stop%20serving%20copilot%20turns%20unless%20their%20environment%20configuration%20is%20migrated%20with%20this%20change.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fcopilot-bridge%2Fnovu-copilot-bridge.client.ts%3A66%0A**Signer%20And%20Verifier%20Keys%20Diverge**%0A%0A%60BridgeExecutorService%60%20signs%20each%20request%20with%20the%20decrypted%20key%20for%20its%20configured%20environment%2C%20but%20this%20handler%20now%20verifies%20it%20with%20the%20global%20%60NOVU_SECRET_API_KEY%60.%20When%20those%20values%20differ%2C%20%60strictAuthentication%60%20rejects%20every%20valid%20copilot%20request%20with%20a%20signature%20mismatch%2C%20leaving%20the%20agent%20unable%20to%20respond.%0A%0A&pr=12044&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/agents/copilot-bridge/novu-copilot-bridge.client.ts:40-41
**Existing Bridge Configuration Is Disabled**

A deployment that sets `NOVU_HOSTED_AGENT_ENVIRONMENT_ID` but not the new `NOVU_SECRET_API_KEY` now returns 404 for every copilot request. This changes the bridge's required configuration without a fallback, so existing deployments stop serving copilot turns unless their environment configuration is migrated with this change.

### Issue 2 of 2
apps/api/src/app/agents/copilot-bridge/novu-copilot-bridge.client.ts:66
**Signer And Verifier Keys Diverge**

`BridgeExecutorService` signs each request with the decrypted key for its configured environment, but this handler now verifies it with the global `NOVU_SECRET_API_KEY`. When those values differ, `strictAuthentication` rejects every valid copilot request with a signature mismatch, leaving the agent unable to respond.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): novu copilot bridge us..."](https://github.com/novuhq/novu/commit/ca486af38ed672f46a66cb46839b59e5074632e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46319604)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->