### PR TITLE
fix(worker): wire steps namespace into HTTP request compile context fixes NV-8364

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -10,11 +10,12 @@ import {
   HttpRequestOptions,
   InstrumentUsecase,
   KeyValuePair,
+  enhanceStepsMap,
   resolveHttpRequestBody,
   SsrfBlockedError,
   shouldIncludeBody,
 } from '@novu/application-generic';
-import { createLiquidEngine } from '@novu/framework/internal';
+import { createLiquidEngine, compileJsonControlValues, repairJsonString } from '@novu/framework/internal';
 import { isOutboundSsrfProtectionEnabled } from '@novu/shared';
 import { Liquid } from 'liquidjs';
 import { TestHttpEndpointResponseDto } from '../../dtos/test-http-endpoint.dto';
@@ -65,6 +66,8 @@ export class TestHttpEndpointUsecase {
     const method = (compiled.method as string) ?? 'GET';
     const compiledHeaders = (compiled.headers as KeyValuePair[]) ?? [];
     const compiledBody = compiled.body as string | KeyValuePair[] | undefined;
+    const resolvedBodyInput =
+      typeof compiledBody === 'string' && compiledBody.trim() ? repairJsonString(compiledBody) : compiledBody;
 
     const resolvedHeaders: Record<string, string> = Object.fromEntries(
       compiledHeaders.filter(({ key }) => key).map(({ key, value }) => [key, value])
@@ -74,7 +77,7 @@ export class TestHttpEndpointUsecase {
 
     let resolvedBody: Record<string, unknown> | unknown[] | undefined;
     try {
-      resolvedBody = resolveHttpRequestBody(compiledBody);
+      resolvedBody = resolveHttpRequestBody(resolvedBodyInput);
     } catch (parseError) {
       const errorMessage = parseError instanceof Error ? parseError.message : 'Failed to parse raw JSON body';
 
@@ -181,7 +184,7 @@ export class TestHttpEndpointUsecase {
     return {
       subscriber: previewPayload.subscriber ?? {},
       payload: previewPayload.payload ?? {},
-      steps: previewPayload.steps ?? {},
+      steps: enhanceStepsMap((previewPayload.steps ?? {}) as Record<string, Record<string, unknown>>),
       env: previewPayload.env ?? {},
       ...(previewPayload.context ? { context: previewPayload.context } : {}),
     };
@@ -191,13 +194,7 @@ export class TestHttpEndpointUsecase {
     values: Record<string, unknown>,
     context: Record<string, unknown>
   ): Promise<unknown> {
-    const compiled = await this.liquidEngine.parseAndRender(JSON.stringify(values), context);
-
-    try {
-      return JSON.parse(compiled);
-    } catch {
-      throw new Error('Rendered template output is not valid JSON');
-    }
+    return compileJsonControlValues(values, context, this.liquidEngine);
   }
 }
 

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.spec.ts
@@ -266,15 +266,38 @@ describe('ExecuteBridgeJob - redundant workflow lookup', () => {
     const stepsMap = await usecase.buildStepsMap(httpJob, 'env_1');
 
     expect(notificationPayloadService.hydrateEntitiesPayload.calledOnce).to.equal(true);
-    expect(stepsMap['digest-step']).to.deep.equal({
-      events: [
-        {
-          id: 'digest_job_1',
-          time: digestJob.createdAt,
-          payload: { foo: 'bar' },
-        },
-      ],
+    expect(stepsMap['digest-step']).to.include({
       eventCount: 1,
+      countSummary: '1 notification',
     });
+    expect(stepsMap['digest-step'].events).to.deep.equal([
+      {
+        id: 'digest_job_1',
+        time: digestJob.createdAt,
+        payload: { foo: 'bar' },
+      },
+    ]);
+    expect(stepsMap['digest-step'].sentenceSummary).to.equal('');
+  });
+
+  it('buildStepsMap keeps the nearest parent output when duplicate stepIds exist', async () => {
+    const { usecase } = buildUsecase();
+
+    sinon.stub(usecase as never, 'generateStateForJob' as never).resolves([
+      {
+        stepId: 'digest-step',
+        outputs: { events: [{ id: 'latest' }], eventCount: 1 },
+        state: { status: 'completed' },
+      },
+      {
+        stepId: 'digest-step',
+        outputs: { events: [{ id: 'stale' }], eventCount: 1 },
+        state: { status: 'completed' },
+      },
+    ] as never);
+
+    const stepsMap = await usecase.buildStepsMap({ _parentId: 'digest_job_1' } as never, 'env_1');
+
+    expect(stepsMap['digest-step'].events).to.deep.equal([{ id: 'latest' }]);
   });
 });

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.spec.ts
@@ -13,6 +13,7 @@ describe('ExecuteBridgeJob - redundant workflow lookup', () => {
     const notificationTemplateRepository = { findOne: sinon.stub().resolves(null) };
     const jobRepository = { findOne: sinon.stub().resolves(null), find: sinon.stub().resolves([]) };
     const messageRepository = { findOne: sinon.stub().resolves(null) };
+    const notificationPayloadService = { hydrateEntitiesPayload: sinon.stub().resolves(undefined) };
     const environmentRepository = {
       findOne: sinon.stub().resolves({ _id: 'env_1', apiKeys: [], echo: undefined }),
     };
@@ -38,6 +39,7 @@ describe('ExecuteBridgeJob - redundant workflow lookup', () => {
     const usecase = new ExecuteBridgeJob(
       jobRepository as never,
       notificationTemplateRepository as never,
+      notificationPayloadService as never,
       messageRepository as never,
       environmentRepository as never,
       controlValuesRepository as never,
@@ -53,6 +55,8 @@ describe('ExecuteBridgeJob - redundant workflow lookup', () => {
       executeBridgeRequest,
       environmentRepository,
       controlValuesRepository,
+      jobRepository,
+      notificationPayloadService,
     };
   }
 
@@ -223,6 +227,54 @@ describe('ExecuteBridgeJob - redundant workflow lookup', () => {
       providerOverrides: {
         [ToolProviderIdEnum.PagerDuty]: { severity: 'warning', summary: 'db down' },
       },
+    });
+  });
+
+  it('buildStepsMap maps digest parent outputs to steps.<stepId> namespace', async () => {
+    const { usecase, jobRepository, notificationPayloadService } = buildUsecase();
+
+    const digestJob = {
+      _id: 'digest_job_1',
+      _parentId: undefined,
+      _environmentId: 'env_1',
+      type: 'digest',
+      status: 'completed',
+      createdAt: new Date('2026-07-23T09:00:00.000Z'),
+      step: { stepId: 'digest-step', uuid: 'digest-step' },
+      payload: { foo: 'bar' },
+    };
+
+    jobRepository.findOne
+      .withArgs({ _id: 'digest_job_1', _environmentId: 'env_1' })
+      .resolves(digestJob);
+    jobRepository.find
+      .withArgs({
+        _mergedDigestId: 'digest_job_1',
+        type: 'digest',
+        status: 'merged',
+        _environmentId: 'env_1',
+      })
+      .resolves([]);
+
+    const httpJob = {
+      _id: 'http_job_1',
+      _parentId: 'digest_job_1',
+      _environmentId: 'env_1',
+      step: { stepId: 'http-step', uuid: 'http-step' },
+    } as never;
+
+    const stepsMap = await usecase.buildStepsMap(httpJob, 'env_1');
+
+    expect(notificationPayloadService.hydrateEntitiesPayload.calledOnce).to.equal(true);
+    expect(stepsMap['digest-step']).to.deep.equal({
+      events: [
+        {
+          id: 'digest_job_1',
+          time: digestJob.createdAt,
+          payload: { foo: 'bar' },
+        },
+      ],
+      eventCount: 1,
     });
   });
 });

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -16,6 +16,7 @@ import {
   PinoLogger,
   stitchProviderOverridesFromDocs,
   withStitchedProviderOverrides,
+  enhanceStepsMap,
 } from '@novu/application-generic';
 import {
   ControlValuesRepository,
@@ -216,11 +217,15 @@ export class ExecuteBridgeJob {
   ): Promise<Record<string, Record<string, unknown>>> {
     const state = await this.generateStateForJob(job, environmentId);
 
-    return state.reduce<Record<string, Record<string, unknown>>>((acc, stepState) => {
-      acc[stepState.stepId] = stepState.outputs;
+    const stepsMap = state.reduce<Record<string, Record<string, unknown>>>((acc, stepState) => {
+      if (!(stepState.stepId in acc)) {
+        acc[stepState.stepId] = stepState.outputs;
+      }
 
       return acc;
     }, {});
+
+    return enhanceStepsMap(stepsMap);
   }
 
   private async generateState(command: ExecuteBridgeJobCommand): Promise<State[]> {

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -210,11 +210,28 @@ export class ExecuteBridgeJob {
     return payload;
   }
 
+  public async buildStepsMap(
+    job: JobEntity,
+    environmentId: string
+  ): Promise<Record<string, Record<string, unknown>>> {
+    const state = await this.generateStateForJob(job, environmentId);
+
+    return state.reduce<Record<string, Record<string, unknown>>>((acc, stepState) => {
+      acc[stepState.stepId] = stepState.outputs;
+
+      return acc;
+    }, {});
+  }
+
   private async generateState(command: ExecuteBridgeJobCommand): Promise<State[]> {
+    return this.generateStateForJob(command.job, command.environmentId);
+  }
+
+  private async generateStateForJob(job: JobEntity, environmentId: string): Promise<State[]> {
     const previousJobs: State[] = [];
     let theJob = (await this.jobRepository.findOne({
-      _id: command.job._parentId,
-      _environmentId: command.environmentId,
+      _id: job._parentId,
+      _environmentId: environmentId,
     })) as JobEntity;
 
     if (theJob) {
@@ -225,7 +242,7 @@ export class ExecuteBridgeJob {
     while (theJob) {
       theJob = (await this.jobRepository.findOne({
         _id: theJob._parentId,
-        _environmentId: command.environmentId,
+        _environmentId: environmentId,
       })) as JobEntity;
 
       if (theJob) {

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
@@ -5,7 +5,29 @@ import { SendMessageChannelCommand } from './send-message-channel.command';
 import { SendMessageStatus } from './send-message-type.usecase';
 
 describe('ExecuteHttpRequestStep - steps namespace', () => {
-  function buildUsecase() {
+  function buildDigestStepsMap() {
+    return {
+      'digest-step': {
+        events: [
+          {
+            id: 'event_1',
+            time: '2026-07-23T09:00:00.000Z',
+            payload: { name: 'Ada', orderId: '123' },
+          },
+          {
+            id: 'event_2',
+            time: '2026-07-23T09:01:00.000Z',
+            payload: { name: 'Grace', orderId: '456' },
+          },
+        ],
+        eventCount: 2,
+        countSummary: '2 notifications',
+        sentenceSummary: 'Ada, Grace',
+      },
+    };
+  }
+
+  function buildUsecase(controls: Record<string, unknown>) {
     const createExecutionDetails = { execute: sinon.stub().resolves(undefined) };
     const jobRepository = { updateOne: sinon.stub().resolves(undefined) };
     const httpClientService = {
@@ -16,13 +38,7 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
       }),
     };
     const controlValuesRepository = {
-      findOne: sinon.stub().resolves({
-        controls: {
-          url: 'https://example.com/webhook',
-          method: 'POST',
-          body: '{"eventCount":{{steps.digest-step.eventCount}}}',
-        },
-      }),
+      findOne: sinon.stub().resolves({ controls }),
     };
     const notificationTemplateRepository = {
       findById: sinon.stub().resolves({
@@ -34,18 +50,7 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
       execute: sinon.stub().resolves('secret-key'),
     };
     const executeBridgeJob = {
-      buildStepsMap: sinon.stub().resolves({
-        'digest-step': {
-          events: [
-            {
-              id: 'event_1',
-              time: '2026-07-23T09:00:00.000Z',
-              payload: { orderId: '123' },
-            },
-          ],
-          eventCount: 1,
-        },
-      }),
+      buildStepsMap: sinon.stub().resolves(buildDigestStepsMap()),
     };
     const logger = {
       error: sinon.stub(),
@@ -128,8 +133,12 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
     sinon.restore();
   });
 
-  it('compiles steps.digest-step variables into the HTTP request body', async () => {
-    const { usecase, httpClientService, executeBridgeJob } = buildUsecase();
+  it('compiles steps.digest-step.eventCount into the HTTP request body', async () => {
+    const { usecase, httpClientService, executeBridgeJob } = buildUsecase({
+      url: 'https://example.com/webhook',
+      method: 'POST',
+      body: '{"eventCount":{{steps.digest-step.eventCount}}}',
+    });
 
     const result = await usecase.execute(buildCommand());
 
@@ -137,6 +146,41 @@ describe('ExecuteHttpRequestStep - steps namespace', () => {
     expect(result.status).to.equal(SendMessageStatus.SUCCESS);
 
     const requestArgs = httpClientService.request.firstCall.args[0];
-    expect(requestArgs.body).to.deep.equal({ eventCount: 1 });
+    expect(requestArgs.body).to.deep.equal({ eventCount: 2 });
+  });
+
+  it('compiles steps.digest-step.events into the HTTP request body', async () => {
+    const { usecase, httpClientService } = buildUsecase({
+      url: 'https://example.com/webhook',
+      method: 'POST',
+      body: '{"events":{{steps.digest-step.events}}}',
+    });
+
+    const result = await usecase.execute(buildCommand());
+
+    expect(result.status).to.equal(SendMessageStatus.SUCCESS);
+
+    const requestArgs = httpClientService.request.firstCall.args[0];
+    expect(requestArgs.body).to.deep.equal({
+      events: buildDigestStepsMap()['digest-step'].events,
+    });
+  });
+
+  it('compiles digest summary helpers into headers and URL templates', async () => {
+    const { usecase, httpClientService } = buildUsecase({
+      url: 'https://example.com/{{steps.digest-step.countSummary}}',
+      method: 'POST',
+      headers: [{ key: 'X-Digest-Summary', value: '{{steps.digest-step.sentenceSummary}}' }],
+      body: '{"summary":"{{steps.digest-step.countSummary}}"}',
+    });
+
+    const result = await usecase.execute(buildCommand());
+
+    expect(result.status).to.equal(SendMessageStatus.SUCCESS);
+
+    const requestArgs = httpClientService.request.firstCall.args[0];
+    expect(requestArgs.url).to.equal('https://example.com/2 notifications');
+    expect(requestArgs.headers['X-Digest-Summary']).to.equal('Ada, Grace');
+    expect(requestArgs.body).to.deep.equal({ summary: '2 notifications' });
   });
 });

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.spec.ts
@@ -1,0 +1,142 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ExecuteHttpRequestStep } from './execute-http-request-step.usecase';
+import { SendMessageChannelCommand } from './send-message-channel.command';
+import { SendMessageStatus } from './send-message-type.usecase';
+
+describe('ExecuteHttpRequestStep - steps namespace', () => {
+  function buildUsecase() {
+    const createExecutionDetails = { execute: sinon.stub().resolves(undefined) };
+    const jobRepository = { updateOne: sinon.stub().resolves(undefined) };
+    const httpClientService = {
+      request: sinon.stub().resolves({
+        statusCode: 200,
+        body: '{"ok":true}',
+        headers: {},
+      }),
+    };
+    const controlValuesRepository = {
+      findOne: sinon.stub().resolves({
+        controls: {
+          url: 'https://example.com/webhook',
+          method: 'POST',
+          body: '{"eventCount":{{steps.digest-step.eventCount}}}',
+        },
+      }),
+    };
+    const notificationTemplateRepository = {
+      findById: sinon.stub().resolves({
+        _id: 'tpl_1',
+        origin: 'novu-cloud',
+      }),
+    };
+    const getDecryptedSecretKey = {
+      execute: sinon.stub().resolves('secret-key'),
+    };
+    const executeBridgeJob = {
+      buildStepsMap: sinon.stub().resolves({
+        'digest-step': {
+          events: [
+            {
+              id: 'event_1',
+              time: '2026-07-23T09:00:00.000Z',
+              payload: { orderId: '123' },
+            },
+          ],
+          eventCount: 1,
+        },
+      }),
+    };
+    const logger = {
+      error: sinon.stub(),
+    };
+
+    const usecase = new ExecuteHttpRequestStep(
+      jobRepository as never,
+      httpClientService as never,
+      controlValuesRepository as never,
+      notificationTemplateRepository as never,
+      logger as never,
+      getDecryptedSecretKey as never,
+      executeBridgeJob as never,
+      {} as never,
+      createExecutionDetails as never
+    );
+
+    return {
+      usecase,
+      httpClientService,
+      executeBridgeJob,
+    };
+  }
+
+  function buildCommand() {
+    return SendMessageChannelCommand.create({
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      identifier: 'wf-identifier',
+      payload: {},
+      overrides: {},
+      step: {
+        _id: 'step_tpl_1',
+        stepId: 'http-step',
+        template: { type: 'http_request' },
+      } as never,
+      transactionId: 'tx_1',
+      notificationId: 'notification_1',
+      subscriberId: 'subscriber_1',
+      _subscriberId: 'subscriber_1',
+      jobId: 'http_job_1',
+      job: {
+        _id: 'http_job_1',
+        _parentId: 'digest_job_1',
+        _environmentId: 'env_1',
+        _organizationId: 'org_1',
+        _notificationId: 'notification_1',
+        _templateId: 'tpl_1',
+        subscriberId: 'subscriber_1',
+        _subscriberId: 'subscriber_1',
+        transactionId: 'tx_1',
+        identifier: 'wf-identifier',
+        type: 'http_request',
+        step: { stepId: 'http-step', template: { type: 'http_request' } },
+      } as never,
+      tags: [],
+      contextKeys: [],
+      _templateId: 'tpl_1',
+      workflow: {
+        _id: 'tpl_1',
+        origin: 'novu-cloud',
+      } as never,
+      compileContext: {
+        subscriber: { subscriberId: 'subscriber_1' },
+        payload: {},
+        step: {
+          digest: false,
+          events: undefined,
+          total_count: undefined,
+        },
+        env: { name: 'Development', type: 'dev' },
+      } as never,
+      bridgeData: null,
+      environment: { _id: 'env_1' } as never,
+    } as never);
+  }
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('compiles steps.digest-step variables into the HTTP request body', async () => {
+    const { usecase, httpClientService, executeBridgeJob } = buildUsecase();
+
+    const result = await usecase.execute(buildCommand());
+
+    expect(executeBridgeJob.buildStepsMap.calledOnce).to.equal(true);
+    expect(result.status).to.equal(SendMessageStatus.SUCCESS);
+
+    const requestArgs = httpClientService.request.firstCall.args[0];
+    expect(requestArgs.body).to.deep.equal({ eventCount: 1 });
+  });
+});

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -10,7 +10,6 @@ import {
   GetDecryptedSecretKey,
   GetDecryptedSecretKeyCommand,
   HttpClientService,
-  ICompileContext,
   InstrumentUsecase,
   PinoLogger,
   resolveHttpRequestBody,
@@ -33,6 +32,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { AdditionalOperation, RulesLogic } from 'json-logic-js';
 
+import { ExecuteBridgeJob } from '../execute-bridge-job';
 import { SendMessageChannelCommand } from './send-message-channel.command';
 import { SendMessageResult, SendMessageStatus, SendMessageType } from './send-message-type.usecase';
 
@@ -49,6 +49,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
     private notificationTemplateRepository: NotificationTemplateRepository,
     private logger: PinoLogger,
     private getDecryptedSecretKey: GetDecryptedSecretKey,
+    private executeBridgeJob: ExecuteBridgeJob,
     protected messageRepository: MessageRepository,
     protected createExecutionDetails: CreateExecutionDetails
   ) {
@@ -59,7 +60,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
   @InstrumentUsecase()
   public async execute(command: SendMessageChannelCommand): Promise<SendMessageResult> {
     const controlValues = await this.fetchControlValues(command);
-    const compileContext = this.buildCompileContect(command.compileContext);
+    const compileContext = await this.buildCompileContext(command);
     const shouldSkip = this.evaluateSkipCondition(controlValues, compileContext);
 
     if (shouldSkip) {
@@ -355,7 +356,10 @@ export class ExecuteHttpRequestStep extends SendMessageType {
     }
   }
 
-  private buildCompileContect(compileContext: ICompileContext): Record<string, unknown> {
+  private async buildCompileContext(command: SendMessageChannelCommand): Promise<Record<string, unknown>> {
+    const { compileContext } = command;
+    const steps = await this.executeBridgeJob.buildStepsMap(command.job, command.environmentId);
+
     return {
       subscriber: compileContext.subscriber ?? {},
       payload: compileContext.payload ?? {},
@@ -363,6 +367,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
       tenant: compileContext.tenant ?? {},
       context: compileContext.context ?? {},
       step: compileContext.step,
+      steps,
       webhook: compileContext.webhook ?? {},
       env: compileContext.env ?? {},
     };

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -18,7 +18,7 @@ import {
   toHeadersRecord,
 } from '@novu/application-generic';
 import { ControlValuesRepository, JobRepository, MessageRepository, NotificationTemplateRepository } from '@novu/dal';
-import { createLiquidEngine } from '@novu/framework/internal';
+import { compileJsonControlValues, createLiquidEngine, repairJsonString } from '@novu/framework/internal';
 import {
   ControlValuesLevelEnum,
   DeliveryLifecycleDetail,
@@ -124,7 +124,9 @@ export class ExecuteHttpRequestStep extends SendMessageType {
     const url = compiled.url as string | undefined;
     const method = (compiled.method as string) ?? 'POST';
     const rawHeaders = (compiled.headers as Array<{ key: string; value: string }> | undefined) ?? [];
-    const rawBody = compiled.body as string | Array<{ key: string; value: string }> | undefined;
+    const compiledBody = compiled.body as string | Array<{ key: string; value: string }> | undefined;
+    const rawBody =
+      typeof compiledBody === 'string' && compiledBody.trim() ? repairJsonString(compiledBody) : compiledBody;
     const timeout = (compiled.timeout as number | undefined) ?? 5000;
 
     if (!url) {
@@ -347,13 +349,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
     values: Record<string, unknown>,
     context: Record<string, unknown>
   ): Promise<unknown> {
-    const compiled = await this.liquidEngine.parseAndRender(JSON.stringify(values), context);
-
-    try {
-      return JSON.parse(compiled);
-    } catch {
-      throw new Error('Rendered template output is not valid JSON');
-    }
+    return compileJsonControlValues(values, context, this.liquidEngine);
   }
 
   private async buildCompileContext(command: SendMessageChannelCommand): Promise<Record<string, unknown>> {

--- a/libs/application-generic/src/utils/enhance-digest-step-outputs.spec.ts
+++ b/libs/application-generic/src/utils/enhance-digest-step-outputs.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { enhanceDigestStepOutputs, enhanceStepsMap } from './enhance-digest-step-outputs';
+
+describe('enhanceDigestStepOutputs', () => {
+  it('adds digest summary helpers alongside events and eventCount', () => {
+    const outputs = enhanceDigestStepOutputs({
+      events: [
+        { id: '1', time: '2026-07-23T09:00:00.000Z', payload: { name: 'Ada' } },
+        { id: '2', time: '2026-07-23T09:01:00.000Z', payload: { name: 'Grace' } },
+      ],
+      eventCount: 2,
+    });
+
+    expect(outputs.eventCount).to.equal(2);
+    expect(outputs.countSummary).to.equal('2 notifications');
+    expect(outputs.sentenceSummary).to.equal('Ada, Grace');
+  });
+
+  it('returns outputs unchanged when events are missing', () => {
+    const outputs = enhanceDigestStepOutputs({ eventCount: 0 });
+
+    expect(outputs).to.deep.equal({ eventCount: 0 });
+  });
+});
+
+describe('enhanceStepsMap', () => {
+  it('enhances every step entry that contains digest events', () => {
+    const stepsMap = enhanceStepsMap({
+      'digest-step': {
+        events: [{ id: '1', time: '2026-07-23T09:00:00.000Z', payload: { name: 'Ada' } }],
+        eventCount: 1,
+      },
+      'http-step': { statusCode: 200 },
+    });
+
+    expect(stepsMap['digest-step'].countSummary).to.equal('1 notification');
+    expect(stepsMap['http-step']).to.deep.equal({ statusCode: 200 });
+  });
+});

--- a/libs/application-generic/src/utils/enhance-digest-step-outputs.ts
+++ b/libs/application-generic/src/utils/enhance-digest-step-outputs.ts
@@ -1,0 +1,37 @@
+import { pluralize, toSentence } from '@novu/framework/internal';
+
+const DEFAULT_COUNT_SINGULAR = 'notification';
+const DEFAULT_COUNT_PLURAL = 'notifications';
+const DEFAULT_SENTENCE_KEY_PATH = 'payload.name';
+const DEFAULT_SENTENCE_LIMIT = 2;
+const DEFAULT_SENTENCE_OVERFLOW = 'other';
+
+export function enhanceDigestStepOutputs(outputs: Record<string, unknown>): Record<string, unknown> {
+  const events = outputs.events;
+
+  if (!Array.isArray(events)) {
+    return outputs;
+  }
+
+  const eventCount = typeof outputs.eventCount === 'number' ? outputs.eventCount : events.length;
+
+  return {
+    ...outputs,
+    eventCount,
+    countSummary: pluralize(eventCount, DEFAULT_COUNT_SINGULAR, DEFAULT_COUNT_PLURAL),
+    sentenceSummary: toSentence(
+      events,
+      DEFAULT_SENTENCE_KEY_PATH,
+      DEFAULT_SENTENCE_LIMIT,
+      DEFAULT_SENTENCE_OVERFLOW
+    ),
+  };
+}
+
+export function enhanceStepsMap(
+  stepsMap: Record<string, Record<string, unknown>>
+): Record<string, Record<string, unknown>> {
+  return Object.fromEntries(
+    Object.entries(stepsMap).map(([stepId, outputs]) => [stepId, enhanceDigestStepOutputs(outputs)])
+  );
+}

--- a/libs/application-generic/src/utils/index.ts
+++ b/libs/application-generic/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './compute-workflow-status';
 export * from './create-schema';
 export * from './deepmerge';
 export * from './digest';
+export * from './enhance-digest-step-outputs';
 export * from './duration-utils';
 export * from './email-normalization';
 export * from './exceptions';

--- a/packages/framework/src/internal/index.ts
+++ b/packages/framework/src/internal/index.ts
@@ -21,3 +21,4 @@ export { buildApprovalActionId, parseApprovalActionId } from '../resources/agent
 export { actionStepSchemas, channelStepSchemas } from '../schemas';
 export * from '../types';
 export { createLiquidEngine } from '../utils/liquid.utils';
+export { compileJsonControlValues, repairJsonString } from '../utils/compile-json-control-values';

--- a/packages/framework/src/utils/compile-json-control-values.ts
+++ b/packages/framework/src/utils/compile-json-control-values.ts
@@ -1,0 +1,21 @@
+import { jsonrepair } from 'jsonrepair';
+
+import { createLiquidEngine } from './liquid.utils';
+
+export function repairJsonString(value: string): string {
+  return jsonrepair(value);
+}
+
+export async function compileJsonControlValues(
+  values: Record<string, unknown>,
+  context: Record<string, unknown>,
+  liquidEngine: ReturnType<typeof createLiquidEngine> = createLiquidEngine()
+): Promise<Record<string, unknown>> {
+  const compiled = await liquidEngine.parseAndRender(JSON.stringify(values), context);
+
+  try {
+    return JSON.parse(jsonrepair(compiled)) as Record<string, unknown>;
+  } catch {
+    throw new Error('Rendered template output is not valid JSON');
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

HTTP Request steps after a Digest step now resolve `{{steps.<step-id>.*}}` variables in URL, headers, body, and skip conditions.

Previously, `ExecuteHttpRequestStep` built a Liquid compile context without the `steps` namespace. Digested events were only available on the legacy singular `step` object, so dashboard/docs variables under `steps.*` rendered as empty strings.

## Changes

- Added `ExecuteBridgeJob.buildStepsMap()` to reuse parent-job traversal and digest output mapping used by bridge execution.
- **Greptile fix:** when duplicate `stepId`s exist in the parent chain, keep the nearest (most recent) parent output instead of letting older ancestors overwrite it.
- Added digest helper outputs on the `steps` namespace: `eventCount`, `events`, `countSummary`, and `sentenceSummary` (matching dashboard defaults).
- Added `compileJsonControlValues` / `repairJsonString` (framework) so liquid-rendered raw JSON bodies with embedded arrays/objects are repaired before parsing — this makes `{{steps.digest-step.events}}` work in raw JSON bodies.
- Updated `ExecuteHttpRequestStep` and `TestHttpEndpointUsecase` to use the shared compile/repair path and enhanced steps map.

## Test plan

- [x] `pnpm test -- --grep "buildStepsMap|steps namespace"` in `apps/worker`
- [ ] Trigger → Digest → HTTP Request workflow and confirm outbound request includes digested events / summaries in body, headers, and URL templates

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8364](https://linear.app/novu/issue/NV-8364/http-request-step-ignores-stepsdigest-stepevents)

<div><a href="https://cursor.com/agents/bc-c4eacc38-b729-466c-9b2b-dedbb1711493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4eacc38-b729-466c-9b2b-dedbb1711493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds prior-step outputs to HTTP request templates. The main changes are:

- Builds a `steps` map from parent job outputs.
- Keeps the nearest output when step IDs repeat.
- Adds digest event and summary helpers.
- Shares Liquid rendering and JSON repair across worker and API paths.
- Adds tests for the steps namespace and duplicate step IDs.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The nearest parent is visited first and retained when step IDs repeat. Tests cover duplicate step IDs and digest values in HTTP request templates.

No blocking issues were found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the minimal harness worker-digest-http-direct-check.ts to exercise the digest HTTP flow.
- Inspected the before-state log to confirm the exact requested command, workspace, exit code, engine warning, and missing-module blocker.
- Inspected the after-state log to verify an exit code of 0 and the rendered/repaired request values.

<a href="https://app.greptile.com/trex/runs/15564067/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts | Builds the steps map and retains the nearest parent output for duplicate step IDs. |
| apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts | Adds prior-step outputs to the HTTP request compile context and uses shared JSON rendering. |
| apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts | Aligns HTTP endpoint previews with digest output enhancement and shared JSON repair. |
| libs/application-generic/src/utils/enhance-digest-step-outputs.ts | Adds digest count and sentence summaries to step outputs. |
| packages/framework/src/utils/compile-json-control-values.ts | Centralizes Liquid rendering and repair of rendered JSON control values. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;next&#39; into fix/http-reques..."](https://github.com/novuhq/novu/commit/e4acf6eab4fa69636eb6a260bda8e23cefde311c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46609397)</sub>

<!-- /greptile_comment -->