### PR TITLE
fix(framework): resolve next/server ESM import for Next.js fixes NV-8366

### DIFF
--- a/packages/framework/src/servers/next.test.ts
+++ b/packages/framework/src/servers/next.test.ts
@@ -9,12 +9,12 @@ import { createMockBridgeRequest } from '../resources/agent/bridge-request.fixtu
 type OnMessageMock = Mock<(message: AgentMessage, ctx: AgentMessageContext) => Promise<void>>;
 
 /**
- * The adapter feature-detects `after()` from `next/server` at module scope, so
- * each scenario mocks `next/server` and re-imports the adapter with a fresh
+ * The adapter feature-detects `after()` from `next/server.js` at module scope, so
+ * each scenario mocks `next/server.js` and re-imports the adapter with a fresh
  * module registry.
  */
 async function importServeWithNextServerMock(nextServerExports: Record<string, unknown>) {
-  vi.doMock('next/server', () => nextServerExports);
+  vi.doMock('next/server.js', () => nextServerExports);
   const { serve } = await import('./next');
 
   return serve;
@@ -47,7 +47,7 @@ describe('next serve() waitUntil wiring', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    vi.doUnmock('next/server');
+    vi.doUnmock('next/server.js');
     vi.restoreAllMocks();
   });
 

--- a/packages/framework/src/servers/next.ts
+++ b/packages/framework/src/servers/next.ts
@@ -1,5 +1,6 @@
 import { type NextApiRequest, type NextApiResponse } from 'next';
-import * as NextServer from 'next/server';
+// `.js` required: Node ESM cannot resolve bare `next/server` when this package is externalized (NV-8366).
+import * as NextServer from 'next/server.js';
 import { type NextRequest } from 'next/server';
 
 import { NovuRequestHandler, type ServeHandlerOptions } from '../handler';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed & why

`@novu/framework` 2.13 (from #11963) added a **runtime** import of `next/server` so the Next adapter can feature-detect `after()` for serverless agent `waitUntil`. Before that PR, `next/server` was only a type-only import and was erased from the published ESM — so `/api/novu` never loaded that module at runtime.

When Next.js / Turbopack **externalizes** `@novu/framework/next`, Node’s native ESM loader resolves that import and fails:

```
ERR_MODULE_NOT_FOUND: Cannot find module '.../next/server'
Did you mean to import "next/server.js"?
```

Next ships a physical `server.js` file and does not provide a package `exports` map for bare `./server`, so Node ESM requires the `.js` extension.

### Fix

- Change the runtime import to `next/server.js`
- Update vitest mocks to match

```mermaid
flowchart LR
  route["/api/novu"] --> framework["@novu/framework/next ESM"]
  framework -->|before| bare["import next/server"]
  bare --> fail["ERR_MODULE_NOT_FOUND"]
  framework -->|after| js["import next/server.js"]
  js --> ok["loads after / NextRequest"]
```

## Testing

- ✅ `pnpm vitest run src/servers/next.test.ts` (4 tests)
- ✅ `pnpm build` in `packages/framework` (attw + madge clean)
- ✅ Reproduced: bare `import('next/server')` → `ERR_MODULE_NOT_FOUND`; `import('next/server.js')` OK
- ✅ Built `dist/esm/servers/next.js` imports `next/server.js` and loads successfully under Node ESM

## Notes

- Semver patch for `@novu/framework`; publish needed for the customer workaround-free fix
- Temporary customer workaround: pin `@novu/framework@2.12.x` or add `transpilePackages: ['@novu/framework']` in `next.config`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8366](https://linear.app/novu/issue/NV-8366/novuframework-213-breaks-apinovu-on-nextjs)

<div><a href="https://cursor.com/agents/bc-65825f53-b334-459c-a0aa-4e8e6e54d27f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65825f53-b334-459c-a0aa-4e8e6e54d27f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes loading the Next.js adapter through native Node ESM. The main changes are:

- Uses `next/server.js` for the runtime Next.js server import.
- Updates the Vitest mock and cleanup specifiers to match.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Rewrote the built artifact to the old next/server specifier and reproduced ERR\_MODULE\_NOT\_FOUND.
- Restored next/server.js and loaded the same artifact with frameworkName=next and serveType=function, confirming it loaded with the expected settings.
- Inspected runtime imports and found exactly one next/server.js runtime import and no bare runtime import.
- Ran targeted tests and all tests passed, 4/4.

<a href="https://app.greptile.com/trex/runs/15552064/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/framework/src/servers/next.ts | Changes the runtime server import to the explicit `.js` subpath while retaining the erased type-only import. |
| packages/framework/src/servers/next.test.ts | Updates the module mock and cleanup to use the new runtime specifier. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(framework): resolve next/server ESM ..."](https://github.com/novuhq/novu/commit/2a27463f23ecda56e28f954f75dd6e0e774ed6d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46611994)</sub>

<!-- /greptile_comment -->