### PR TITLE
fix(docs): update logo href to point to the correct documentation URL fixes DOC-421

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -16,7 +16,7 @@
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg",
-    "href": "https://novu.co"
+    "href": "https://docs.novu.co"
   },
   "seo": {
     "indexing": "all",


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the documentation logo link.

- Points the logo to the canonical `https://docs.novu.co` homepage.
- Keeps the existing light and dark logo assets unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. The new hostname is already used as the canonical documentation domain across the repository.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Confirmed in the contract validation that the logo href in docs/docs.json now resolves to the documentation root at https://docs.novu.co, instead of the marketing site at https://novu.co.
- - Noted during the preview that the Mintlify runtime is unavailable, marking an environment limitation rather than a product bug.
- - Reviewed the uploaded artifacts (logs and a JavaScript asset) to support the validation and the environment condition.

<a href="https://app.greptile.com/trex/runs/15579647/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Updates the logo destination to the documentation homepage using a valid absolute URL. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): update logo href to point to ..."](https://github.com/novuhq/novu/commit/ad29b8bd9ea99423809888289a88cea9f16b4202) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46673831)</sub>

<!-- /greptile_comment -->