### PR TITLE
fix(dashboard): isolate Mixpanel/Segment failures from app boot fixes NV-8359

### DIFF
--- a/apps/dashboard/src/hooks/use-telemetry.ts
+++ b/apps/dashboard/src/hooks/use-telemetry.ts
@@ -17,22 +17,22 @@ export const useTelemetry = () => {
 
       const mixpanelEnabled = !!MIXPANEL_KEY;
       const onboardingSessionId = readPersistedCliOnboardingSessionId();
+      let sessionReplayProperties: Record<string, unknown> = {};
 
       if (mixpanelEnabled) {
-        // @ts-expect-error missing from types
-        const sessionReplayProperties = mixpanel.get_session_recording_properties();
-
-        data = {
-          ...(data || {}),
-          ...(onboardingSessionId ? { onboardingSessionId } : {}),
-          ...sessionReplayProperties,
-        };
-      } else if (onboardingSessionId) {
-        data = {
-          ...(data || {}),
-          onboardingSessionId,
-        };
+        try {
+          // @ts-expect-error missing from types
+          sessionReplayProperties = mixpanel.get_session_recording_properties() ?? {};
+        } catch (error) {
+          console.error(error);
+        }
       }
+
+      data = {
+        ...(data || {}),
+        ...(onboardingSessionId ? { onboardingSessionId } : {}),
+        ...sessionReplayProperties,
+      };
 
       mutate({ event: `${event} - [DASHBOARD]`, data });
     },

--- a/apps/dashboard/src/utils/segment.ts
+++ b/apps/dashboard/src/utils/segment.ts
@@ -4,6 +4,11 @@ import * as Sentry from '@sentry/react';
 import * as mixpanel from 'mixpanel-browser';
 import { MIXPANEL_KEY, SEGMENT_KEY } from '@/config';
 
+function captureAnalyticsError(error: unknown) {
+  Sentry.captureException(error);
+  console.error(error);
+}
+
 export class SegmentService {
   private _segment: AnalyticsBrowser | null = null;
 
@@ -16,24 +21,38 @@ export class SegmentService {
     this._mixpanelEnabled = !!MIXPANEL_KEY;
 
     if (this._mixpanelEnabled) {
-      mixpanel.init(MIXPANEL_KEY as string, {
-        //@ts-expect-error missing from types
-        record_sessions_percent: 100,
-      });
-
       try {
-        //@ts-expect-error missing from types
-        mixpanel.start_session_recording();
+        mixpanel.init(MIXPANEL_KEY as string, {
+          //@ts-expect-error missing from types
+          record_sessions_percent: 100,
+        });
       } catch (e) {
-        Sentry.captureException(e);
-        console.error(e);
+        this._mixpanelEnabled = false;
+        captureAnalyticsError(e);
+      }
+
+      if (this._mixpanelEnabled) {
+        try {
+          //@ts-expect-error missing from types
+          mixpanel.start_session_recording();
+        } catch (e) {
+          captureAnalyticsError(e);
+        }
       }
     }
 
     if (this._segmentEnabled) {
-      this._segment = AnalyticsBrowser.load({
-        writeKey: SEGMENT_KEY as string,
-      });
+      try {
+        this._segment = AnalyticsBrowser.load({
+          writeKey: SEGMENT_KEY as string,
+        });
+      } catch (e) {
+        this._segmentEnabled = false;
+        this._segment = null;
+        captureAnalyticsError(e);
+
+        return;
+      }
 
       if (!this._mixpanelEnabled) {
         return;
@@ -100,7 +119,11 @@ export class SegmentService {
     }
 
     if (this._mixpanelEnabled) {
-      mixpanel.alias(userId, anonymousId);
+      try {
+        mixpanel.alias(userId, anonymousId);
+      } catch (e) {
+        captureAnalyticsError(e);
+      }
     }
 
     this._segment?.alias(userId, anonymousId);
@@ -120,14 +143,18 @@ export class SegmentService {
     }
 
     if (this._mixpanelEnabled) {
-      const sessionReplayProperties =
-        //@ts-expect-error missing from types
-        mixpanel.get_session_recording_properties();
+      try {
+        const sessionReplayProperties =
+          //@ts-expect-error missing from types
+          mixpanel.get_session_recording_properties();
 
-      data = {
-        ...(data || {}),
-        ...sessionReplayProperties,
-      };
+        data = {
+          ...(data || {}),
+          ...sessionReplayProperties,
+        };
+      } catch (e) {
+        captureAnalyticsError(e);
+      }
     }
 
     this._segment?.track(event, data);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Hardens dashboard analytics so Mixpanel/Segment init and session-replay helpers cannot take down boot/render when third-party scripts fail or are blocked (e.g. Brave Shields).
- Investigated [NV-8359](https://linear.app/novu/issue/NV-8359): **blocking Mixpanel (and Segment) alone does not blank the sign-up page** on production. The blank-page root-cause claim in the report is not accurate as a Mixpanel-only failure; analytics failures are still treated as optional.

## Changes

- `SegmentService`: wrap `mixpanel.init`, session recording start, Segment load, `alias`, and `get_session_recording_properties` in try/catch; disable Mixpanel/Segment flags when init fails.
- `useTelemetry`: same isolation around Mixpanel session-replay property reads.

## Test plan

- [x] Reproduced production sign-up with DevTools blocking `cdn.mxpnl.com`, `api-js.mixpanel.com`, `cdn.segment.com`, and `api.segment.io` — UI still renders.
- [x] Biome check on changed files.
- [ ] Spot-check local dashboard sign-up/sign-in still loads.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8359](https://linear.app/novu/issue/NV-8359/bug-report-dashboard-fails-to-load-in-brave-browser-when-mixpanel)

<div><a href="https://cursor.com/agents/bc-6a864aba-f519-464d-b476-a6cbb02275b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a864aba-f519-464d-b476-a6cbb02275b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents optional analytics failures from interrupting dashboard startup and telemetry. The main changes are:

- Isolates Mixpanel initialization and session-replay failures.
- Disables provider flags after synchronous initialization failures.
- Protects Segment loading and Mixpanel alias calls.
- Sends telemetry without replay metadata when property reads fail.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Failed replay-property reads fall back to the original telemetry payload.
- Synchronous provider initialization failures are contained and update provider state.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/hooks/use-telemetry.ts | Catches session-replay property failures while preserving event data and the optional onboarding session ID. |
| apps/dashboard/src/utils/segment.ts | Isolates synchronous provider failures and disables failed initialization paths without suppressing the other provider. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): isolate Mixpanel/Segment..."](https://github.com/novuhq/novu/commit/47e38c4ca32ca40baaae299771c3096e99eccc93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46692480)</sub>

<!-- /greptile_comment -->