### PR TITLE
fix(api-service): bind Slack bot token for welcome DM openDM fixes NV-8377

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -352,6 +352,7 @@ export class AgentConversationService {
     participantId: string;
     participantType?: ConversationParticipantTypeEnum;
     title?: string;
+    workspaceId?: string;
   }): Promise<ConversationEntity | null> {
     return this.conversationRepository.findByAgentIntegrationParticipant(
       params.environmentId,
@@ -360,7 +361,8 @@ export class AgentConversationService {
       params.integrationId,
       params.participantId,
       params.participantType,
-      params.title
+      params.title,
+      params.workspaceId
     );
   }
 

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.send-direct-message.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.send-direct-message.spec.ts
@@ -7,31 +7,56 @@ describe('OutboundGateway sendDirectMessage', () => {
   const agentId = 'agent1';
   const integrationIdentifier = 'email-main';
   const recipientAddress = 'user@example.com';
-  const threadId = 'email:user@example.com:abc123';
+  const emailThreadId = 'email:user@example.com:abc123';
 
   function makeGateway(
     options: {
       platform?: AgentPlatformEnum;
-      openDM?: sinon.SinonStub;
-      adapterOpenDM?: sinon.SinonStub;
+      integrationIdentifier?: string;
+      threadId?: string;
+      adapterOpenDM?: sinon.SinonStub | null;
       chatOpenDM?: sinon.SinonStub;
+      withBotToken?: sinon.SinonStub;
+      resolveSlackBotToken?: sinon.SinonStub;
+      threadPost?: sinon.SinonStub;
     } = {}
   ) {
     const platform = options.platform ?? AgentPlatformEnum.EMAIL;
-    const threadPost = sinon.stub().resolves({ id: 'msg-1', threadId });
+    const resolvedIntegrationIdentifier = options.integrationIdentifier ?? integrationIdentifier;
+    const threadId = options.threadId ?? emailThreadId;
+    const threadPost = options.threadPost ?? sinon.stub().resolves({ id: 'msg-1', threadId });
     const thread = { post: threadPost };
-    const adapterOpenDM = options.adapterOpenDM ?? sinon.stub().resolves(threadId);
-    const chatOpenDM = options.chatOpenDM ?? sinon.stub().rejects(new Error('chat.openDM should not be called'));
-    const openDM = options.openDM ?? chatOpenDM;
+    const adapterOpenDM =
+      options.adapterOpenDM === null
+        ? undefined
+        : (options.adapterOpenDM ?? sinon.stub().resolves(threadId));
+    const chatOpenDM =
+      options.chatOpenDM ?? sinon.stub().rejects(new Error('chat.openDM should not be called'));
+    const withBotToken =
+      options.withBotToken ??
+      sinon.stub().callsFake(async (_token: string, fn: () => Promise<unknown>) => fn());
+    const resolveSlackBotToken = options.resolveSlackBotToken ?? sinon.stub().resolves('xoxb-test-token');
 
     const agentConfigResolver = {
-      resolve: sinon.stub().resolves({ platform, removeNovuBranding: true, agentIdentifier: 'my-agent' }),
+      resolve: sinon.stub().resolves({
+        platform,
+        removeNovuBranding: true,
+        agentIdentifier: 'my-agent',
+        environmentId: 'env-1',
+        organizationId: 'org-1',
+        integrationIdentifier: resolvedIntegrationIdentifier,
+        integrationId: 'integration-1',
+      }),
+      resolveSlackBotToken,
     };
     const registry = {
       getOrCreate: sinon.stub().resolves({
-        openDM,
+        openDM: chatOpenDM,
         thread: sinon.stub().returns(thread),
-        getAdapter: sinon.stub().returns({ openDM: adapterOpenDM }),
+        getAdapter: sinon.stub().returns({
+          ...(adapterOpenDM ? { openDM: adapterOpenDM } : {}),
+          withBotToken,
+        }),
       }),
     };
     const fileMaterializer = {
@@ -55,7 +80,14 @@ describe('OutboundGateway sendDirectMessage', () => {
       logger as any
     );
 
-    return { gateway, adapterOpenDM, chatOpenDM: openDM, threadPost };
+    return {
+      gateway,
+      adapterOpenDM,
+      chatOpenDM,
+      threadPost,
+      withBotToken,
+      resolveSlackBotToken,
+    };
   }
 
   it('opens email DMs via the platform adapter instead of chat.openDM', async () => {
@@ -65,60 +97,70 @@ describe('OutboundGateway sendDirectMessage', () => {
       markdown: 'Connected! Reply to this email to try it out.',
     });
 
-    expect(adapterOpenDM.calledOnceWith(recipientAddress)).to.equal(true);
+    expect(adapterOpenDM?.calledOnceWith(recipientAddress)).to.equal(true);
     expect(chatOpenDM.called).to.equal(false);
     expect(threadPost.calledOnce).to.equal(true);
-    expect(result).to.deep.equal({ messageId: 'msg-1', platformThreadId: threadId });
+    expect(result).to.deep.equal({ messageId: 'msg-1', platformThreadId: emailThreadId });
   });
 
   it('falls back to chat.openDM when the platform adapter does not implement openDM', async () => {
     const slackThread = { post: sinon.stub().resolves({ id: 'msg-2', threadId: 'slack:D123:msg-2' }) };
     const chatOpenDM = sinon.stub().resolves(slackThread);
+    const withBotToken = sinon.stub().callsFake(async (_token: string, fn: () => Promise<unknown>) => fn());
+
     const { gateway } = makeGateway({
       platform: AgentPlatformEnum.SLACK,
-      openDM: chatOpenDM,
-      adapterOpenDM: undefined as unknown as sinon.SinonStub,
+      integrationIdentifier: 'slack-main',
+      adapterOpenDM: null,
+      chatOpenDM,
+      withBotToken,
+      resolveSlackBotToken: sinon.stub().resolves('xoxb-test-token'),
     });
 
-    const registry = {
-      getOrCreate: sinon.stub().resolves({
-        openDM: chatOpenDM,
-        thread: sinon.stub(),
-        getAdapter: sinon.stub().returns({}),
-      }),
-    };
-    const agentConfigResolver = {
-      resolve: sinon.stub().resolves({
-        platform: AgentPlatformEnum.SLACK,
-        removeNovuBranding: true,
-        agentIdentifier: 'my-agent',
-      }),
-    };
-    const fileMaterializer = {
-      prepareContentForDelivery: sinon.stub().callsFake(async (content: unknown) => content),
-    };
-    const actionTokenService = {
-      applyActionTokens: sinon.stub().callsFake(async (content: unknown) => content),
-    };
-    const logger = {
-      setContext: sinon.stub(),
-      warn: sinon.stub(),
-      error: sinon.stub(),
-    };
-    const slackGateway = new OutboundGateway(
-      registry as any,
-      {} as any,
-      agentConfigResolver as any,
-      fileMaterializer as any,
-      actionTokenService as any,
-      logger as any
-    );
-
-    const result = await slackGateway.sendDirectMessage(agentId, 'slack-main', 'U123456', {
+    const result = await gateway.sendDirectMessage(agentId, 'slack-main', 'U123456', {
       markdown: 'Your Slack app is connected! Send me a message to try it out.',
     });
 
     expect(chatOpenDM.calledOnceWith('U123456')).to.equal(true);
+    expect(withBotToken.calledOnce).to.equal(true);
+    expect(withBotToken.firstCall.args[0]).to.equal('xoxb-test-token');
     expect(result).to.deep.equal({ messageId: 'msg-2', platformThreadId: 'slack:D123:msg-2' });
+  });
+
+  it('binds the Slack bot token before openDM in multi-workspace mode', async () => {
+    const callOrder: string[] = [];
+    const adapterOpenDM = sinon.stub().callsFake(async () => {
+      callOrder.push('openDM');
+
+      return 'slack:D123:';
+    });
+    const threadPost = sinon.stub().callsFake(async () => {
+      callOrder.push('post');
+
+      return { id: 'msg-3', threadId: 'slack:D123:' };
+    });
+    const withBotToken = sinon.stub().callsFake(async (_token: string, fn: () => Promise<unknown>) => {
+      callOrder.push('withBotToken');
+
+      return fn();
+    });
+
+    const { gateway } = makeGateway({
+      platform: AgentPlatformEnum.SLACK,
+      integrationIdentifier: 'slack-main',
+      threadId: 'slack:D123:',
+      adapterOpenDM,
+      threadPost,
+      withBotToken,
+      resolveSlackBotToken: sinon.stub().resolves('xoxb-workspace-token'),
+    });
+
+    const result = await gateway.sendDirectMessage(agentId, 'slack-main', 'U123456', {
+      markdown: 'Your Slack app is connected! Send me a message to try it out.',
+    });
+
+    expect(callOrder).to.deep.equal(['withBotToken', 'openDM', 'post']);
+    expect(withBotToken.firstCall.args[0]).to.equal('xoxb-workspace-token');
+    expect(result).to.deep.equal({ messageId: 'msg-3', platformThreadId: 'slack:D123:msg-3' });
   });
 });

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -260,7 +260,7 @@ export class OutboundGateway {
     workspaceId?: string
   ): Promise<void> {
     if (!status.trim()) {
-      await this.stopTypingInConversation(agentId, integrationIdentifier, platformThreadId);
+      await this.stopTypingInConversation(agentId, integrationIdentifier, platformThreadId, workspaceId);
 
       return;
     }
@@ -287,12 +287,13 @@ export class OutboundGateway {
   async stopTypingInConversation(
     agentId: string,
     integrationIdentifier: string,
-    platformThreadId: string
+    platformThreadId: string,
+    workspaceId?: string
   ): Promise<void> {
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
 
     if (config.platform === AgentPlatformEnum.SLACK) {
-      await this.clearSlackAssistantStatus(agentId, integrationIdentifier, platformThreadId);
+      await this.clearSlackAssistantStatus(agentId, integrationIdentifier, platformThreadId, workspaceId);
 
       return;
     }
@@ -303,7 +304,8 @@ export class OutboundGateway {
   private async clearSlackAssistantStatus(
     agentId: string,
     integrationIdentifier: string,
-    platformThreadId: string
+    platformThreadId: string,
+    workspaceId?: string
   ): Promise<void> {
     const { channel, threadTs } = decodeSlackPlatformThreadId(platformThreadId);
     if (!threadTs) {
@@ -321,12 +323,15 @@ export class OutboundGateway {
     const adapter = chat.getAdapter(AgentPlatformEnum.SLACK) as {
       setAssistantStatus?: (channelId: string, threadTs: string, status: string) => Promise<void>;
     };
+    const setAssistantStatus = adapter.setAssistantStatus;
 
-    if (typeof adapter.setAssistantStatus !== 'function') {
+    if (typeof setAssistantStatus !== 'function') {
       return;
     }
 
-    await adapter.setAssistantStatus(channel, threadTs, '').catch((err) => {
+    await this.runWithPlatformToken(chat, config, agentId, platformThreadId, workspaceId, () =>
+      setAssistantStatus(channel, threadTs, '')
+    ).catch((err) => {
       this.logger.warn(
         { err, platformThreadId, agentId, integrationIdentifier },
         'Failed to clear Slack assistant status'
@@ -344,7 +349,6 @@ export class OutboundGateway {
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
     const instanceKey = `${agentId}:${integrationIdentifier}`;
     const chat = await this.registry.getOrCreate(instanceKey, agentId, config.platform, config);
-    const dmThread = await this.openDirectMessageThread(chat, config.platform, platformUserId);
     const deliveryContent = await this.fileMaterializer.prepareContentForDelivery(content, config.platform, agentId);
     const tokenizedContent = await this.applyActionTokensForDelivery(
       deliveryContent,
@@ -353,9 +357,13 @@ export class OutboundGateway {
 
     const postArg = this.buildAdapterPostableMessage(tokenizedContent, config);
 
-    const sent = await this.runWithPlatformToken(chat, config, agentId, platformUserId, workspaceId, () =>
-      dmThread.post(postArg)
-    ).catch(toDeliveryError);
+    // openDM must run inside the token binding: Slack multi-workspace adapters have no default
+    // bot token, and conversations.open fails with AuthenticationError outside withBotToken().
+    const sent = await this.runWithPlatformToken(chat, config, agentId, platformUserId, workspaceId, async () => {
+      const dmThread = await this.openDirectMessageThread(chat, config.platform, platformUserId);
+
+      return dmThread.post(postArg);
+    }).catch(toDeliveryError);
 
     const platformThreadId = sent.threadId.endsWith(':') ? `${sent.threadId}${sent.id}` : sent.threadId;
 
@@ -367,7 +375,8 @@ export class OutboundGateway {
     integrationIdentifier: string,
     platformThreadId: string,
     prompts: SlackAgentSuggestedPrompt[],
-    title?: string
+    title?: string,
+    workspaceId?: string
   ): Promise<void> {
     const { channel, threadTs } = decodeSlackPlatformThreadId(platformThreadId);
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
@@ -381,8 +390,9 @@ export class OutboundGateway {
         promptTitle?: string
       ) => Promise<void>;
     };
+    const setSuggestedPrompts = adapter.setSuggestedPrompts;
 
-    if (typeof adapter.setSuggestedPrompts !== 'function') {
+    if (typeof setSuggestedPrompts !== 'function') {
       return;
     }
 
@@ -396,7 +406,9 @@ export class OutboundGateway {
       return;
     }
 
-    await adapter.setSuggestedPrompts(channel, resolvedThreadTs, prompts, title).catch((err) => {
+    await this.runWithPlatformToken(chat, config, agentId, platformThreadId, workspaceId, () =>
+      setSuggestedPrompts(channel, resolvedThreadTs, prompts, title)
+    ).catch((err) => {
       this.logger.warn(
         { err, platformThreadId, agentId, integrationIdentifier },
         'Failed to set Slack suggested prompts'

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -323,7 +323,7 @@ export class OutboundGateway {
     const adapter = chat.getAdapter(AgentPlatformEnum.SLACK) as {
       setAssistantStatus?: (channelId: string, threadTs: string, status: string) => Promise<void>;
     };
-    const setAssistantStatus = adapter.setAssistantStatus;
+    const setAssistantStatus = adapter.setAssistantStatus?.bind(adapter);
 
     if (typeof setAssistantStatus !== 'function') {
       return;
@@ -390,7 +390,7 @@ export class OutboundGateway {
         promptTitle?: string
       ) => Promise<void>;
     };
-    const setSuggestedPrompts = adapter.setSuggestedPrompts;
+    const setSuggestedPrompts = adapter.setSuggestedPrompts?.bind(adapter);
 
     if (typeof setSuggestedPrompts !== 'function') {
       return;

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.typing.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.typing.spec.ts
@@ -14,14 +14,22 @@ describe('OutboundGateway typing', () => {
     const platform = options.platform ?? AgentPlatformEnum.SLACK;
     const setAssistantStatus = options.setAssistantStatus ?? sinon.stub().resolves();
     const startTyping = options.startTyping ?? sinon.stub().resolves();
+    const withBotToken = sinon.stub().callsFake(async (_token: string, fn: () => Promise<unknown>) => fn());
 
     const agentConfigResolver = {
-      resolve: sinon.stub().resolves({ platform }),
+      resolve: sinon.stub().resolves({
+        platform,
+        environmentId: 'env-1',
+        organizationId: 'org-1',
+        integrationIdentifier,
+        integrationId: 'integration-1',
+      }),
+      resolveSlackBotToken: sinon.stub().resolves('xoxb-test-token'),
     };
     const registry = {
       getOrCreate: sinon.stub().resolves({
         thread: () => ({ startTyping }),
-        getAdapter: () => ({ setAssistantStatus }),
+        getAdapter: () => ({ setAssistantStatus, withBotToken }),
       }),
     };
     const logger = {
@@ -30,23 +38,28 @@ describe('OutboundGateway typing', () => {
       error: sinon.stub(),
     };
 
+    const conversation = {
+      findByPlatformThread: sinon.stub().resolves(null),
+    };
+
     const gateway = new OutboundGateway(
       registry as any,
-      {} as any,
+      conversation as any,
       agentConfigResolver as any,
       {} as any,
       {} as any,
       logger as any
     );
 
-    return { gateway, setAssistantStatus, startTyping, logger };
+    return { gateway, setAssistantStatus, startTyping, logger, withBotToken };
   }
 
   it('clears Slack assistant status on stop without calling startTyping', async () => {
-    const { gateway, setAssistantStatus, startTyping } = makeGateway();
+    const { gateway, setAssistantStatus, startTyping, withBotToken } = makeGateway();
 
     await gateway.stopTypingInConversation(agentId, integrationIdentifier, platformThreadId);
 
+    expect(withBotToken.calledOnce).to.equal(true);
     expect(setAssistantStatus.calledOnceWith('C123', '1783695626.846689', '')).to.equal(true);
     expect(startTyping.called).to.equal(false);
   });
@@ -75,7 +88,9 @@ describe('OutboundGateway typing', () => {
 
     await gateway.stopTypingInConversation(agentId, integrationIdentifier, platformThreadId);
 
-    expect(logger.warn.calledOnce).to.equal(true);
+    expect(
+      logger.warn.calledWithMatch(sinon.match.object, 'Failed to clear Slack assistant status')
+    ).to.equal(true);
   });
 
   it('warns and does not throw when startTyping fails', async () => {

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -492,7 +492,8 @@ export class HandleAgentReply {
         await this.outboundGateway.stopTypingInConversation(
           conversation._agentId,
           command.integrationIdentifier,
-          channel.platformThreadId
+          channel.platformThreadId,
+          channel.workspace?.id
         );
 
         return;

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.spec.ts
@@ -11,6 +11,7 @@ const ORG_ID = 'org-id';
 const USER_ID = 'user-123';
 const AGENT_ID = 'agent-mongo-id';
 const INTEGRATION_IDENTIFIER = 'novu-email-agent';
+const SLACK_WORKSPACE_ID = 'T-INTENDED';
 
 function buildCommand(overrides: Partial<SendAgentWelcomeMessageCommand> = {}) {
   return SendAgentWelcomeMessageCommand.create({
@@ -27,6 +28,7 @@ describe('SendAgentWelcomeMessage usecase', () => {
   let agentRepository: { findOne: sinon.SinonStub };
   let integrationRepository: { findOne: sinon.SinonStub };
   let channelEndpointRepository: { findOne: sinon.SinonStub };
+  let channelConnectionRepository: { findOne: sinon.SinonStub };
   let subscriberRepository: { findBySubscriberId: sinon.SinonStub };
   let conversationService: {
     createOrGetConversation: sinon.SinonStub;
@@ -47,6 +49,7 @@ describe('SendAgentWelcomeMessage usecase', () => {
       agentRepository as any,
       integrationRepository as any,
       channelEndpointRepository as any,
+      channelConnectionRepository as any,
       subscriberRepository as any,
       conversationService as any,
       analyticsService as any,
@@ -67,6 +70,9 @@ describe('SendAgentWelcomeMessage usecase', () => {
       }),
     };
     channelEndpointRepository = {
+      findOne: stub().resolves(null),
+    };
+    channelConnectionRepository = {
       findOne: stub().resolves(null),
     };
     subscriberRepository = {
@@ -115,7 +121,8 @@ describe('SendAgentWelcomeMessage usecase', () => {
         AGENT_ID,
         INTEGRATION_IDENTIFIER,
         'user@example.com',
-        sinon.match({ markdown: 'Connected! Reply to this email to try it out.' })
+        sinon.match({ markdown: 'Connected! Reply to this email to try it out.' }),
+        undefined
       )
     ).to.equal(true);
   });
@@ -142,21 +149,33 @@ describe('SendAgentWelcomeMessage usecase', () => {
     expect(outboundGateway.setSlackSuggestedPrompts.called).to.equal(false);
   });
 
-  it('sets Slack suggested prompts after sending a Slack welcome message', async () => {
+  it('binds the Slack workspace from the endpoint connection for welcome DM and prompts', async () => {
     integrationRepository.findOne.resolves({
       _id: 'integration-id',
       providerId: ChatProviderIdEnum.Slack,
     });
     channelEndpointRepository.findOne.resolves({
       endpoint: { userId: 'U123456' },
+      connectionIdentifier: 'conn-intended',
+    });
+    channelConnectionRepository.findOne.resolves({
+      identifier: 'conn-intended',
+      workspace: { id: SLACK_WORKSPACE_ID, name: 'Intended Workspace' },
     });
     conversationService.createOrGetConversation.resolves({
       _id: 'conversation-id',
-      channels: [{ platform: AgentPlatformEnum.SLACK, platformThreadId: 'slack:D123:msg-1' }],
+      channels: [
+        {
+          platform: AgentPlatformEnum.SLACK,
+          platformThreadId: 'slack:D123:msg-1',
+          workspace: { id: SLACK_WORKSPACE_ID },
+        },
+      ],
     });
     conversationService.getPrimaryChannel.returns({
       platform: AgentPlatformEnum.SLACK,
       platformThreadId: 'slack:D123:msg-1',
+      workspace: { id: SLACK_WORKSPACE_ID },
     });
     outboundGateway.sendDirectMessage.resolves({
       messageId: 'msg-1',
@@ -166,14 +185,41 @@ describe('SendAgentWelcomeMessage usecase', () => {
     const result = await buildUsecase().execute(buildCommand({ integrationIdentifier: 'slack-integration' }));
 
     expect(result).to.deep.equal({ sent: true, conversationId: 'conversation-id', claimToken: undefined });
-    expect(outboundGateway.setSlackSuggestedPrompts.calledOnce).to.equal(true);
+    expect(
+      channelConnectionRepository.findOne.calledOnceWith(
+        sinon.match({
+          _environmentId: ENV_ID,
+          _organizationId: ORG_ID,
+          identifier: 'conn-intended',
+        }),
+        'workspace'
+      )
+    ).to.equal(true);
+    expect(
+      outboundGateway.sendDirectMessage.calledOnceWith(
+        AGENT_ID,
+        'slack-integration',
+        'U123456',
+        sinon.match.object,
+        SLACK_WORKSPACE_ID
+      )
+    ).to.equal(true);
+    expect(
+      conversationService.createOrGetConversation.calledOnceWith(
+        sinon.match({
+          workspaceId: SLACK_WORKSPACE_ID,
+          platformUserId: 'U123456',
+        })
+      )
+    ).to.equal(true);
     expect(
       outboundGateway.setSlackSuggestedPrompts.calledOnceWith(
         AGENT_ID,
         'slack-integration',
         'slack:D123:msg-1',
         sinon.match.array,
-        sinon.match.string
+        sinon.match.string,
+        SLACK_WORKSPACE_ID
       )
     ).to.equal(true);
   });

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.spec.ts
@@ -196,6 +196,14 @@ describe('SendAgentWelcomeMessage usecase', () => {
       )
     ).to.equal(true);
     expect(
+      conversationService.findByAgentIntegrationParticipant.calledOnceWith(
+        sinon.match({
+          participantId: 'slack:U123456',
+          workspaceId: SLACK_WORKSPACE_ID,
+        })
+      )
+    ).to.equal(true);
+    expect(
       outboundGateway.sendDirectMessage.calledOnceWith(
         AGENT_ID,
         'slack-integration',
@@ -222,6 +230,52 @@ describe('SendAgentWelcomeMessage usecase', () => {
         SLACK_WORKSPACE_ID
       )
     ).to.equal(true);
+  });
+
+  it('still sends a Slack welcome when only another workspace has an existing welcome conversation', async () => {
+    integrationRepository.findOne.resolves({
+      _id: 'integration-id',
+      providerId: ChatProviderIdEnum.Slack,
+    });
+    channelEndpointRepository.findOne.resolves({
+      endpoint: { userId: 'U123456' },
+      connectionIdentifier: 'conn-intended',
+    });
+    channelConnectionRepository.findOne.resolves({
+      identifier: 'conn-intended',
+      workspace: { id: SLACK_WORKSPACE_ID },
+    });
+    // Dedup is workspace-scoped: a welcome in another workspace must not suppress this one.
+    conversationService.findByAgentIntegrationParticipant.resolves(null);
+    conversationService.createOrGetConversation.resolves({
+      _id: 'conversation-id',
+      channels: [
+        {
+          platform: AgentPlatformEnum.SLACK,
+          platformThreadId: 'slack:D999:msg-1',
+          workspace: { id: SLACK_WORKSPACE_ID },
+        },
+      ],
+    });
+    conversationService.getPrimaryChannel.returns({
+      platform: AgentPlatformEnum.SLACK,
+      platformThreadId: 'slack:D999:msg-1',
+      workspace: { id: SLACK_WORKSPACE_ID },
+    });
+    outboundGateway.sendDirectMessage.resolves({
+      messageId: 'msg-1',
+      platformThreadId: 'slack:D999:msg-1',
+    });
+
+    const result = await buildUsecase().execute(buildCommand({ integrationIdentifier: 'slack-integration' }));
+
+    expect(result.sent).to.equal(true);
+    expect(
+      conversationService.findByAgentIntegrationParticipant.calledOnceWith(
+        sinon.match({ workspaceId: SLACK_WORKSPACE_ID })
+      )
+    ).to.equal(true);
+    expect(outboundGateway.sendDirectMessage.calledOnce).to.equal(true);
   });
 
   it('returns sent:false when the dashboard subscriber has no email', async () => {

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AnalyticsService, InstrumentUsecase, PinoLogger } from '@novu/application-generic';
 import {
   AgentRepository,
+  ChannelConnectionRepository,
   ChannelEndpointRepository,
   ConversationParticipantTypeEnum,
   IntegrationRepository,
@@ -20,12 +21,19 @@ import { AgentConversationService, getConversationTitle } from '../../conversati
 import { OutboundGateway } from '../../egress/outbound.gateway';
 import { SendAgentWelcomeMessageCommand } from './send-agent-welcome-message.command';
 
+type WelcomeRecipient = {
+  platformUserId: string;
+  /** Slack team_id (or equivalent) when the endpoint is tied to a workspace connection. */
+  workspaceId?: string;
+};
+
 @Injectable()
 export class SendAgentWelcomeMessage {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly channelEndpointRepository: ChannelEndpointRepository,
+    private readonly channelConnectionRepository: ChannelConnectionRepository,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly conversationService: AgentConversationService,
     private readonly analyticsService: AnalyticsService,
@@ -78,11 +86,12 @@ export class SendAgentWelcomeMessage {
       return { sent: false };
     }
 
-    const platformUserId = await this.resolvePlatformUserId(command, platform, integration.identifier);
-    if (!platformUserId) {
+    const recipient = await this.resolveWelcomeRecipient(command, platform, integration.identifier);
+    if (!recipient) {
       return { sent: false };
     }
 
+    const { platformUserId, workspaceId } = recipient;
     const welcomeText = getWelcomeText(platform);
     const existingWelcomeConversation = await this.findExistingWelcomeConversation({
       environmentId: command.environmentId,
@@ -106,7 +115,8 @@ export class SendAgentWelcomeMessage {
         agent._id,
         command.integrationIdentifier,
         platformUserId,
-        welcomeContent
+        welcomeContent,
+        workspaceId
       );
 
       const { platformThreadId } = sent;
@@ -122,6 +132,7 @@ export class SendAgentWelcomeMessage {
         participantType: ConversationParticipantTypeEnum.PLATFORM_USER,
         platformUserId,
         firstMessageText: welcomeText,
+        workspaceId,
       });
 
       const channel = this.conversationService.getPrimaryChannel(conversation);
@@ -143,7 +154,8 @@ export class SendAgentWelcomeMessage {
           command.integrationIdentifier,
           platformThreadId,
           SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS,
-          SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS_TITLE
+          SLACK_AGENT_WELCOME_SUGGESTED_PROMPTS_TITLE,
+          workspaceId
         );
       }
 
@@ -163,11 +175,11 @@ export class SendAgentWelcomeMessage {
     }
   }
 
-  private async resolvePlatformUserId(
+  private async resolveWelcomeRecipient(
     command: SendAgentWelcomeMessageCommand,
     platform: AgentPlatformEnum,
     integrationIdentifier: string
-  ): Promise<string | undefined> {
+  ): Promise<WelcomeRecipient | undefined> {
     if (platform === AgentPlatformEnum.EMAIL) {
       return this.resolveEmailWelcomeRecipient(command);
     }
@@ -177,12 +189,18 @@ export class SendAgentWelcomeMessage {
       return undefined;
     }
 
-    const endpoint = await this.channelEndpointRepository.findOne({
-      _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
-      integrationIdentifier,
-      type: endpointConfig.endpointType,
-    });
+    // Prefer the most recently created endpoint so a just-completed OAuth install wins over older
+    // workspaces on the same integration (multi-workspace shared Slack app).
+    const endpoint = await this.channelEndpointRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        integrationIdentifier,
+        type: endpointConfig.endpointType,
+      },
+      undefined,
+      { query: { sort: { createdAt: -1 } } }
+    );
 
     if (!endpoint) {
       return undefined;
@@ -193,14 +211,48 @@ export class SendAgentWelcomeMessage {
       return undefined;
     }
 
-    return platformUserId;
+    const workspaceId = await this.resolveWorkspaceIdForEndpoint(
+      command.environmentId,
+      command.organizationId,
+      endpoint.connectionIdentifier
+    );
+
+    return { platformUserId, workspaceId };
+  }
+
+  /**
+   * Resolve the Slack (etc.) workspace id from the channel connection linked to the endpoint.
+   * Required so proactive welcome DMs bind the bot token for the workspace that was just connected,
+   * not the integration's first installed workspace.
+   */
+  private async resolveWorkspaceIdForEndpoint(
+    environmentId: string,
+    organizationId: string,
+    connectionIdentifier?: string
+  ): Promise<string | undefined> {
+    if (!connectionIdentifier) {
+      return undefined;
+    }
+
+    const connection = await this.channelConnectionRepository.findOne(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        identifier: connectionIdentifier,
+      },
+      'workspace'
+    );
+
+    return connection?.workspace?.id;
   }
 
   /**
    * Email welcome messages are sent to the dashboard user's subscriber
    * (the same identity used by Telegram/WhatsApp test flows and workflow testing).
    */
-  private async resolveEmailWelcomeRecipient(command: SendAgentWelcomeMessageCommand): Promise<string | undefined> {
+  private async resolveEmailWelcomeRecipient(
+    command: SendAgentWelcomeMessageCommand
+  ): Promise<WelcomeRecipient | undefined> {
     const subscriberId = command.userId;
     const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, subscriberId);
 
@@ -218,7 +270,7 @@ export class SendAgentWelcomeMessage {
       return undefined;
     }
 
-    return email;
+    return { platformUserId: email };
   }
 
   private async findExistingWelcomeConversation(params: {

--- a/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts
@@ -101,6 +101,7 @@ export class SendAgentWelcomeMessage {
       platform,
       platformUserId,
       welcomeText,
+      workspaceId,
     });
 
     if (existingWelcomeConversation) {
@@ -281,6 +282,7 @@ export class SendAgentWelcomeMessage {
     platform: AgentPlatformEnum;
     platformUserId: string;
     welcomeText: string;
+    workspaceId?: string;
   }) {
     const participantId = `${params.platform}:${params.platformUserId}`;
     const welcomeTitle = getConversationTitle(params.welcomeText);
@@ -293,6 +295,7 @@ export class SendAgentWelcomeMessage {
       participantId,
       participantType: ConversationParticipantTypeEnum.PLATFORM_USER,
       title: welcomeTitle,
+      workspaceId: params.workspaceId,
     });
   }
 

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -75,7 +75,13 @@ export class ConversationRepository extends BaseRepositoryV2<
     integrationId: string,
     participantId: string,
     participantType: ConversationParticipantTypeEnum = ConversationParticipantTypeEnum.PLATFORM_USER,
-    title?: string
+    title?: string,
+    /**
+     * When set, only match conversations whose channel belongs to this platform workspace
+     * (e.g. Slack `team_id`). Required for multi-workspace welcome dedup so a prior welcome
+     * in workspace A does not suppress a welcome in workspace B for the same participant key.
+     */
+    workspaceId?: string
   ): Promise<ConversationEntity | null> {
     return this.findOne(
       {
@@ -85,6 +91,7 @@ export class ConversationRepository extends BaseRepositoryV2<
         channels: {
           $elemMatch: {
             _integrationId: new Types.ObjectId(integrationId),
+            ...(workspaceId ? { 'workspace.id': workspaceId } : {}),
           },
         },
         participants: { $elemMatch: { id: participantId, type: participantType } },


### PR DESCRIPTION
### What changed? Why was the change needed?

Post-OAuth Slack welcome DMs started failing after the multi-workspace Slack adapter change with:

```
AuthenticationError: No bot token available. In multi-workspace mode, ensure the webhook is being processed.
```

Regular inbound replies still worked. Only the proactive welcome path failed.

**Root cause:** In multi-workspace mode the Slack adapter has no baked-in default bot token. Outbound calls must bind a token via `adapter.withBotToken()`. `OutboundGateway.sendDirectMessage` wrapped `dmThread.post()` in that binding, but called `adapter.openDM()` *before* it — and `openDM` needs the token for `conversations.open`.

**Fix:**

* Bind the workspace bot token around `openDM` + post in `sendDirectMessage`
* Same binding for `setSlackSuggestedPrompts` and Slack typing-stop (`setAssistantStatus`)
* Pass `workspaceId` through typing stop on the reply path
* Resolve welcome `workspaceId` from the endpoint's channel connection (and prefer newest endpoint) so multi-workspace installs don't bind the first workspace token
* Persist that workspace on the welcome conversation; pass it to suggested prompts
* Scope welcome dedup (`findExistingWelcomeConversation`) by `workspace.id` so a prior welcome in another workspace cannot suppress the new one
* `.bind(adapter)` extracted Slack adapter methods so `this` is preserved

Linear: [NV-8377](https://linear.app/novu/issue/NV-8377/slack-welcome-dm-fails-with-no-bot-token-in-multi-workspace-mode)

```mermaid
sequenceDiagram
  participant Welcome as SendAgentWelcomeMessage
  participant Conn as ChannelConnection
  participant GW as OutboundGateway
  participant Adapter as SlackAdapter

  Welcome->>Conn: lookup via endpoint.connectionIdentifier
  Conn-->>Welcome: workspace.id
  Welcome->>Welcome: dedup by participant + workspace
  Welcome->>GW: sendDirectMessage(userId, workspaceId)
  GW->>Adapter: withBotToken(workspaceToken)
  Adapter->>Adapter: openDM (conversations.open)
  Adapter->>Adapter: thread.post(welcome)
  Adapter-->>GW: message + thread id
```

### Special notes for your reviewer

* Welcome now binds the token for the endpoint's connected workspace rather than falling back to the first installed workspace.
* Unit coverage covers token binding order, workspace propagation, and workspace-scoped welcome dedup.

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

### Greptile Summary

This PR fixes Slack multi-workspace welcome DMs. The main changes are:

* Resolves the welcome recipient workspace from the endpoint connection.
* Binds the workspace bot token around Slack `openDM`, welcome posting, suggested prompts, and typing-stop calls.
* Persists workspace identity on welcome conversations and scopes welcome deduplication by workspace.
* Adds tests for token binding order, workspace propagation, and workspace-scoped welcome behavior.

### Confidence Score: 5/5

Safe to merge with minimal risk.

The changes are narrow and centered on Slack workspace token propagation. The prior workspace-token and adapter receiver issues are addressed. Focused tests cover the affected welcome DM, prompts, deduplication, and typing-stop paths.

No files require special attention.

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* T-Rex ran the direct Slack welcome unit tests with Mocha and recorded the command, working directory, an unsupported Node engine warning, a bootstrap stack trace, and EXIT< />CODE: 1.
* T-Rex executed a build-and-run retry for the Slack welcome tests, which surfaced a long-running @novu/application-generic build that was terminated with EXIT< />CODE: 124.

![View all artifacts](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<img src="https://camo.githubusercontent.com/223063a8acd7e71fd1deaaa741d9d06948338e590a1cc633c9305234794edec8/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f56696577416c6c4172746966616374732e7376673f763d34 " alt="T-Rex" height="14" /> Ran code and verified through T-Rex

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/api/src/app/agents/conversation-runtime/reply/send-agent-welcome-message/send-agent-welcome-message.usecase.ts | Resolves the welcome recipient workspace from the endpoint connection, scopes existing-conversation lookup by workspace, and passes `workspaceId` through send/create/prompts. |
| apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts | Moves Slack DM opening, suggested prompts, and typing-stop operations into workspace bot-token binding while preserving adapter method receivers. |
| libs/dal/src/repositories/conversation/conversation.repository.ts | Adds optional channel workspace filtering to the agent/integration/participant conversation lookup used by Slack welcome deduplication. |
| apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts | Propagates channel workspace identity into typing-stop delivery so Slack status clearing resolves the correct workspace token. |

</details>

### Sequence Diagram

```mermaid
sequenceDiagram
  participant Welcome as SendAgentWelcomeMessage
  participant Endpoint as ChannelEndpointRepository
  participant Conn as ChannelConnectionRepository
  participant Conv as AgentConversationService
  participant GW as OutboundGateway
  participant Adapter as SlackAdapter

  Welcome->>Endpoint: find newest endpoint for integration/type
  Endpoint-->>Welcome: platformUserId + connectionIdentifier
  Welcome->>Conn: find connection workspace
  Conn-->>Welcome: workspace.id
  Welcome->>Conv: find existing welcome scoped by workspaceId
  alt no existing welcome
    Welcome->>GW: sendDirectMessage(userId, workspaceId)
    GW->>Adapter: withBotToken(workspace token)
    Adapter->>Adapter: openDM + post welcome
    Adapter-->>GW: message id + thread id
    Welcome->>Conv: create conversation with workspaceId
    Welcome->>GW: setSlackSuggestedPrompts(thread, workspaceId)
    GW->>Adapter: withBotToken(workspace token)
    Adapter->>Adapter: setSuggestedPrompts
  end
```

Reviews (3): Last reviewed commit: ["fix(api-service): scope Slack welcome de..."](<https://github.com/novuhq/novu/commit/ba915b407918d264d9b6c5e30cccfa0c07e1462d>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=46728575>)