### PR TITLE
feat(application-generic, dal): enhance notification job creation with template validation and error handling fixes NV-8378

### DIFF
--- a/libs/application-generic/jest.setup.js
+++ b/libs/application-generic/jest.setup.js
@@ -6,6 +6,11 @@ jest.mock('newrelic', () => ({
       return handler();
     }
   }),
+  startSegment: jest.fn((name, record, handler) => {
+    if (typeof handler === 'function') {
+      return handler();
+    }
+  }),
   getTransaction: jest.fn(() => ({
     end: jest.fn(),
   })),

--- a/libs/application-generic/src/usecases/create-change/create-change.command.ts
+++ b/libs/application-generic/src/usecases/create-change/create-change.command.ts
@@ -1,4 +1,6 @@
+import { ClientSession } from '@novu/dal';
 import { ChangeEntityTypeEnum } from '@novu/shared';
+import { Exclude } from 'class-transformer';
 import { IsDefined, IsMongoId, IsOptional, IsString } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../commands';
 
@@ -21,4 +23,13 @@ export class CreateChangeCommand extends EnvironmentWithUserCommand {
   @IsMongoId()
   @IsOptional()
   parentChangeId?: string;
+
+  /**
+   * Exclude session from serialized output only (`toPlainOnly`). A bare
+   * `@Exclude()` would also strip it during `plainToInstance` inside
+   * `BaseCommand.create`, silently losing the transaction session.
+   */
+  @Exclude({ toPlainOnly: true })
+  @IsOptional()
+  session?: ClientSession | null;
 }

--- a/libs/application-generic/src/usecases/create-change/create-change.usecase.ts
+++ b/libs/application-generic/src/usecases/create-change/create-change.usecase.ts
@@ -20,7 +20,9 @@ export class CreateChange {
       throw new BadRequestException('Item must have an _id to create a change');
     }
 
-    const changes = await this.changeRepository.getEntityChanges(command.organizationId, command.type, itemId);
+    const changes = await this.changeRepository.getEntityChanges(command.organizationId, command.type, itemId, {
+      session: command.session,
+    });
     const aggregatedItem = changes
       .filter((change) => change.enabled)
       .reduce((prev, change) => {
@@ -32,10 +34,14 @@ export class CreateChange {
 
     const changePayload = getDiff(aggregatedItem, command.item, true);
 
-    const change = await this.changeRepository.findOne({
-      _environmentId: command.environmentId,
-      _id: command.changeId,
-    });
+    const change = await this.changeRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _id: command.changeId,
+      },
+      undefined,
+      { session: command.session }
+    );
 
     if (change) {
       change.change = changePayload;
@@ -44,23 +50,27 @@ export class CreateChange {
         { _environmentId: command.environmentId, _id: command.changeId },
         {
           $set: change,
-        }
+        },
+        { session: command.session }
       );
 
       return change;
     }
 
-    const item = await this.changeRepository.create({
-      _organizationId: command.organizationId,
-      _environmentId: command.environmentId,
-      _creatorId: command.userId,
-      change: changePayload,
-      type: command.type,
-      _entityId: itemId,
-      enabled: false,
-      _parentId: command.parentChangeId,
-      _id: command.changeId,
-    });
+    const item = await this.changeRepository.create(
+      {
+        _organizationId: command.organizationId,
+        _environmentId: command.environmentId,
+        _creatorId: command.userId,
+        change: changePayload,
+        type: command.type,
+        _entityId: itemId,
+        enabled: false,
+        _parentId: command.parentChangeId,
+        _id: command.changeId,
+      },
+      { session: command.session }
+    );
 
     return item;
   }

--- a/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.spec.ts
+++ b/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.spec.ts
@@ -1,0 +1,147 @@
+import { Logger } from '@nestjs/common';
+import { NotificationStepEntity } from '@novu/dal';
+import { DigestTypeEnum, StepTypeEnum } from '@novu/shared';
+import { DigestFilterSteps } from '../digest-filter-steps';
+import { CreateNotificationJobsCommand } from './create-notification-jobs.command';
+import { CreateNotificationJobs } from './create-notification-jobs.usecase';
+
+// ESM-only dependencies pulled in transitively (analytic-logs → p-queue, feature-flags → LaunchDarkly);
+// jest 27 cannot parse them, and the spec injects its own mocks anyway.
+jest.mock('p-queue', () => ({ __esModule: true, default: class PQueueMock {} }));
+jest.mock('@launchdarkly/node-server-sdk', () => ({ init: jest.fn() }));
+
+const ENVIRONMENT_ID = 'aaaaaaaaaaaaaaaaaaaaaaa1';
+const ORGANIZATION_ID = 'aaaaaaaaaaaaaaaaaaaaaaa2';
+const USER_ID = 'aaaaaaaaaaaaaaaaaaaaaaa3';
+const WORKFLOW_ID = 'aaaaaaaaaaaaaaaaaaaaaaa4';
+const SUBSCRIBER_ID = 'aaaaaaaaaaaaaaaaaaaaaaa5';
+const NOTIFICATION_ID = 'aaaaaaaaaaaaaaaaaaaaaaa6';
+const EMAIL_TEMPLATE_ID = 'aaaaaaaaaaaaaaaaaaaaaaa7';
+const MISSING_TEMPLATE_ID = 'aaaaaaaaaaaaaaaaaaaaaaa8';
+const DIGEST_TEMPLATE_ID = 'aaaaaaaaaaaaaaaaaaaaaaa9';
+
+describe('CreateNotificationJobs', () => {
+  beforeEach(() => {
+    jest.spyOn(Logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function buildUsecase() {
+    const notificationRepository = {
+      create: jest.fn().mockResolvedValue({
+        _id: NOTIFICATION_ID,
+        _templateId: WORKFLOW_ID,
+        _subscriberId: SUBSCRIBER_ID,
+        transactionId: 'tx_1',
+        channels: [],
+      }),
+    };
+    const workflowRunRepository = { create: jest.fn() };
+    const traceLogRepository = { createWorkflowRun: jest.fn() };
+    const featureFlagsService = { getFlag: jest.fn().mockResolvedValue(false) };
+    const digestFilterSteps = new DigestFilterSteps();
+
+    const usecase = new CreateNotificationJobs(
+      digestFilterSteps,
+      notificationRepository as never,
+      workflowRunRepository as never,
+      traceLogRepository as never,
+      featureFlagsService as never
+    );
+
+    return { usecase, notificationRepository, digestFilterSteps };
+  }
+
+  function buildEmailStep(overrides: Partial<NotificationStepEntity> = {}): NotificationStepEntity {
+    return {
+      _templateId: EMAIL_TEMPLATE_ID,
+      stepId: 'email-step',
+      active: true,
+      template: { _id: EMAIL_TEMPLATE_ID, type: StepTypeEnum.EMAIL },
+      ...overrides,
+    } as NotificationStepEntity;
+  }
+
+  function buildBrokenStep(): NotificationStepEntity {
+    return {
+      _templateId: MISSING_TEMPLATE_ID,
+      stepId: 'broken-step',
+      active: true,
+      template: null,
+    } as unknown as NotificationStepEntity;
+  }
+
+  function buildDigestStep(): NotificationStepEntity {
+    return {
+      _templateId: DIGEST_TEMPLATE_ID,
+      stepId: 'digest-step',
+      active: true,
+      template: { _id: DIGEST_TEMPLATE_ID, type: StepTypeEnum.DIGEST },
+      metadata: { type: DigestTypeEnum.REGULAR, amount: 1, unit: 'hours' },
+    } as unknown as NotificationStepEntity;
+  }
+
+  function buildCommand(steps: NotificationStepEntity[]): CreateNotificationJobsCommand {
+    return {
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+      identifier: 'test-workflow',
+      overrides: {},
+      payload: {},
+      subscriber: { _id: SUBSCRIBER_ID, subscriberId: 'external-subscriber-1' },
+      template: { _id: WORKFLOW_ID, name: 'Test workflow', steps, tags: [], triggers: [] },
+      templateProviderIds: {},
+      to: { subscriberId: 'external-subscriber-1' },
+      transactionId: 'tx_1',
+      contextKeys: [],
+    } as unknown as CreateNotificationJobsCommand;
+  }
+
+  it('should skip active steps with a missing template and build jobs for the valid ones', async () => {
+    const { usecase } = buildUsecase();
+    const command = buildCommand([buildEmailStep(), buildBrokenStep()]);
+
+    const jobs = await usecase.execute(command);
+
+    expect(jobs.map((job) => job.type)).toEqual([StepTypeEnum.TRIGGER, StepTypeEnum.EMAIL]);
+    expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(MISSING_TEMPLATE_ID), expect.anything());
+  });
+
+  it('should throw when all active steps have missing templates', async () => {
+    const { usecase, notificationRepository } = buildUsecase();
+    const command = buildCommand([buildBrokenStep()]);
+
+    await expect(usecase.execute(command)).rejects.toThrow(
+      `No active steps with templates found for workflow ${WORKFLOW_ID}`
+    );
+    expect(notificationRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('should never reintroduce steps with missing templates through the digest path', async () => {
+    const { usecase, digestFilterSteps } = buildUsecase();
+    const digestFilterStepsSpy = jest.spyOn(digestFilterSteps, 'execute');
+    const command = buildCommand([buildDigestStep(), buildBrokenStep()]);
+
+    const jobs = await usecase.execute(command);
+
+    expect(jobs.map((job) => job.type)).toEqual([StepTypeEnum.TRIGGER, StepTypeEnum.DIGEST]);
+    // The digest path receives the already-filtered steps, so the orphan never re-enters
+    const digestCommand = digestFilterStepsSpy.mock.calls[0][0];
+    expect(digestCommand.steps.map((step) => step._templateId)).toEqual([DIGEST_TEMPLATE_ID]);
+  });
+
+  it('should ignore inactive steps with missing templates', async () => {
+    const { usecase } = buildUsecase();
+    const inactiveBrokenStep = { ...buildBrokenStep(), active: false } as NotificationStepEntity;
+    const command = buildCommand([buildEmailStep(), inactiveBrokenStep]);
+
+    const jobs = await usecase.execute(command);
+
+    expect(jobs.map((job) => job.type)).toEqual([StepTypeEnum.TRIGGER, StepTypeEnum.EMAIL]);
+    expect(Logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
+++ b/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
@@ -26,13 +26,16 @@ import {
 import { LogRepository } from '../../services/analytic-logs/log.repository';
 import { FeatureFlagsService } from '../../services/feature-flags';
 import { type LeanNotificationStep, toLeanStep } from '../../services/step-template-hydration.service';
-import { getNestedValue } from '../../utils';
 import { PlatformException } from '../../utils/exceptions';
+import { getNestedValue } from '../../utils/object';
 import { DigestFilterSteps, DigestFilterStepsCommand } from '../digest-filter-steps';
 import { CreateNotificationJobsCommand } from './create-notification-jobs.command';
 
 const LOG_CONTEXT = 'CreateNotificationUseCase';
 type NotificationJob = Omit<JobEntity, '_id' | 'createdAt' | 'updatedAt'>;
+type NotificationStepWithTemplate = NotificationStepEntity & {
+  template: NonNullable<NotificationStepEntity['template']>;
+};
 
 @Injectable()
 export class CreateNotificationJobs {
@@ -46,7 +49,7 @@ export class CreateNotificationJobs {
 
   @InstrumentUsecase()
   public async execute(command: CreateNotificationJobsCommand): Promise<NotificationJob[]> {
-    const activeSteps = this.filterActiveSteps(command.template.steps);
+    const activeSteps = this.filterActiveStepsWithTemplates(command.template.steps, command.template._id);
 
     const channels = activeSteps
       .map((item) => item.template.type as StepTypeEnum)
@@ -99,10 +102,6 @@ export class CreateNotificationJobs {
     }
 
     for (const step of steps) {
-      if (!step.template) {
-        throw new PlatformException('Step template was not found');
-      }
-
       jobs.push(this.buildJobFromStep(step, command, notification, isPayloadDedupEnabled, isJobStepDedupEnabled));
     }
 
@@ -206,7 +205,7 @@ export class CreateNotificationJobs {
   }
 
   private buildJobFromStep(
-    step: NotificationStepEntity,
+    step: NotificationStepWithTemplate,
     command: CreateNotificationJobsCommand,
     notification: NotificationEntity,
     isPayloadDedupEnabled: boolean,
@@ -315,7 +314,7 @@ export class CreateNotificationJobs {
     notification: NotificationEntity,
     isPayloadDedupEnabled = false
   ): NotificationJob | undefined {
-    const triggerStepExist = steps.some((step) => step.template.type === StepTypeEnum.TRIGGER);
+    const triggerStepExist = steps.some((step) => step.template?.type === StepTypeEnum.TRIGGER);
 
     if (triggerStepExist) {
       return undefined;
@@ -358,30 +357,55 @@ export class CreateNotificationJobs {
 
   private async createSteps(
     command: CreateNotificationJobsCommand,
-    activeSteps: NotificationStepEntity[],
+    activeSteps: NotificationStepWithTemplate[],
     notification: NotificationEntity
-  ): Promise<NotificationStepEntity[]> {
+  ): Promise<NotificationStepWithTemplate[]> {
     return await this.filterDigestSteps(command, notification, activeSteps);
   }
 
-  private filterActiveSteps(steps: NotificationStepEntity[]): NotificationStepEntity[] {
-    return steps.filter((step) => step.active === true);
+  private filterActiveStepsWithTemplates(
+    steps: NotificationStepEntity[],
+    workflowId: string
+  ): NotificationStepWithTemplate[] {
+    const activeSteps = steps.filter((step) => step.active === true);
+    const stepsWithTemplates: NotificationStepWithTemplate[] = [];
+
+    for (const step of activeSteps) {
+      if (step.template) {
+        stepsWithTemplates.push(step as NotificationStepWithTemplate);
+      } else {
+        Logger.error(
+          `Skipping step with missing template for workflow ${workflowId} (stepId: ${step.stepId}, _templateId: ${step._templateId})`,
+          LOG_CONTEXT
+        );
+      }
+    }
+
+    if (activeSteps.length > 0 && stepsWithTemplates.length === 0) {
+      const message = `No active steps with templates found for workflow ${workflowId}`;
+      const error = new PlatformException(message);
+      Logger.error(error, message, LOG_CONTEXT);
+      throw error;
+    }
+
+    return stepsWithTemplates;
   }
 
   private async filterDigestSteps(
     command: CreateNotificationJobsCommand,
     notification: NotificationEntity,
-    steps: NotificationStepEntity[]
-  ): Promise<NotificationStepEntity[]> {
+    steps: NotificationStepWithTemplate[]
+  ): Promise<NotificationStepWithTemplate[]> {
     // TODO: Review this for workflows with more than one digest as this will return the first element found
-    const digestStep = steps.find((step) => step.template?.type === StepTypeEnum.DIGEST);
+    const digestStep = steps.find((step) => step.template.type === StepTypeEnum.DIGEST);
 
     if (digestStep?.metadata && 'type' in digestStep.metadata) {
-      return await this.digestFilterSteps.execute(
+      // DigestFilterSteps only prepends a trigger step (which always carries a template)
+      return (await this.digestFilterSteps.execute(
         DigestFilterStepsCommand.create({
           _subscriberId: command.subscriber._id,
           payload: command.payload,
-          steps: command.template.steps,
+          steps,
           environmentId: command.environmentId,
           organizationId: command.organizationId,
           userId: command.userId,
@@ -391,7 +415,7 @@ export class CreateNotificationJobs {
           type: digestStep.metadata.type as DigestTypeEnum, // We already checked it is a DIGEST
           backoff: 'backoff' in digestStep.metadata ? digestStep.metadata.backoff : undefined,
         })
-      );
+      )) as NotificationStepWithTemplate[];
     }
 
     return steps;

--- a/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
+++ b/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
@@ -309,12 +309,12 @@ export class CreateNotificationJobs {
   }
 
   private createATriggerJobIfMissing(
-    steps: NotificationStepEntity[],
+    steps: NotificationStepWithTemplate[],
     command: CreateNotificationJobsCommand,
     notification: NotificationEntity,
     isPayloadDedupEnabled = false
   ): NotificationJob | undefined {
-    const triggerStepExist = steps.some((step) => step.template?.type === StepTypeEnum.TRIGGER);
+    const triggerStepExist = steps.some((step) => step.template.type === StepTypeEnum.TRIGGER);
 
     if (triggerStepExist) {
       return undefined;
@@ -400,9 +400,10 @@ export class CreateNotificationJobs {
     const digestStep = steps.find((step) => step.template.type === StepTypeEnum.DIGEST);
 
     if (digestStep?.metadata && 'type' in digestStep.metadata) {
-      // DigestFilterSteps only prepends a trigger step (which always carries a template)
-      return (await this.digestFilterSteps.execute(
-        DigestFilterStepsCommand.create({
+      // `steps` is re-supplied after create() because the command class widens it
+      // to NotificationStepEntity[], which would erase the narrowed step type.
+      return await this.digestFilterSteps.execute({
+        ...DigestFilterStepsCommand.create({
           _subscriberId: command.subscriber._id,
           payload: command.payload,
           steps,
@@ -414,8 +415,9 @@ export class CreateNotificationJobs {
           transactionId: command.transactionId,
           type: digestStep.metadata.type as DigestTypeEnum, // We already checked it is a DIGEST
           backoff: 'backoff' in digestStep.metadata ? digestStep.metadata.backoff : undefined,
-        })
-      )) as NotificationStepWithTemplate[];
+        }),
+        steps,
+      });
     }
 
     return steps;

--- a/libs/application-generic/src/usecases/digest-filter-steps/digest-filter-steps.usecase.ts
+++ b/libs/application-generic/src/usecases/digest-filter-steps/digest-filter-steps.usecase.ts
@@ -1,15 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { NotificationStepEntity } from '@novu/dal';
 import { StepTypeEnum } from '@novu/shared';
 
 import { DigestFilterStepsCommand } from './digest-filter-steps.command';
 
-const LOG_CONTEXT = 'DigestFilterSteps';
+type StepWithTemplate = NotificationStepEntity & { template: NonNullable<NotificationStepEntity['template']> };
 
 // TODO; Potentially rename this use case
 @Injectable()
 export class DigestFilterSteps {
-  public async execute(command: DigestFilterStepsCommand): Promise<NotificationStepEntity[]> {
+  public async execute<TStep extends NotificationStepEntity>(
+    command: Omit<DigestFilterStepsCommand, 'steps'> & { steps: TStep[] }
+  ): Promise<(TStep | StepWithTemplate)[]> {
     const { steps } = command;
 
     const triggerStep = this.createTriggerStep(command);
@@ -17,7 +19,7 @@ export class DigestFilterSteps {
     return [triggerStep, ...steps];
   }
 
-  private createTriggerStep(command: DigestFilterStepsCommand): NotificationStepEntity {
+  private createTriggerStep(command: Omit<DigestFilterStepsCommand, 'steps'>): StepWithTemplate {
     return {
       template: {
         _environmentId: command.environmentId,

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.ts
@@ -1,4 +1,6 @@
+import { ClientSession } from '@novu/dal';
 import { ResourceTypeEnum } from '@novu/shared';
+import { Exclude } from 'class-transformer';
 import { IsDefined, IsEnum, IsMongoId, IsOptional } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../commands';
 
@@ -14,4 +16,13 @@ export class DeleteMessageTemplateCommand extends EnvironmentWithUserCommand {
   @IsEnum(ResourceTypeEnum)
   @IsDefined()
   workflowType: ResourceTypeEnum;
+
+  /**
+   * Exclude session from serialized output only (`toPlainOnly`). A bare
+   * `@Exclude()` would also strip it during `plainToInstance` inside
+   * `BaseCommand.create`, silently losing the transaction session.
+   */
+  @Exclude({ toPlainOnly: true })
+  @IsOptional()
+  session?: ClientSession | null;
 }

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
@@ -46,6 +46,7 @@ export class DeleteMessageTemplate {
             item: deletedMessageTemplate[0],
             type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
             parentChangeId: command.parentChangeId,
+            session: command.session,
           })
         );
       }

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
@@ -14,10 +14,13 @@ export class DeleteMessageTemplate {
 
   async execute(command: DeleteMessageTemplateCommand): Promise<boolean> {
     try {
-      await this.messageTemplateRepository.delete({
-        _environmentId: command.environmentId,
-        _id: command.messageTemplateId,
-      });
+      await this.messageTemplateRepository.deleteById(
+        {
+          _environmentId: command.environmentId,
+          _id: command.messageTemplateId,
+        },
+        command.session ? { session: command.session } : {}
+      );
 
       const changeId = await this.changeRepository.getChangeId(
         command.environmentId,
@@ -25,10 +28,13 @@ export class DeleteMessageTemplate {
         command.messageTemplateId
       );
 
-      const deletedMessageTemplate = await this.messageTemplateRepository.findDeleted({
-        _environmentId: command.environmentId,
-        _id: command.messageTemplateId,
-      });
+      const deletedMessageTemplate = await this.messageTemplateRepository.findDeleted(
+        {
+          _environmentId: command.environmentId,
+          _id: command.messageTemplateId,
+        },
+        command.session ? { session: command.session } : {}
+      );
 
       if (!isBridgeWorkflow(command.workflowType)) {
         await this.createChange.execute(

--- a/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
@@ -49,6 +49,12 @@ import {
 } from '../upsert-preferences';
 import { UpdateWorkflowCommandV0 } from './update-workflow.command';
 
+/** The minimal step shape needed to diff which MessageTemplates a workflow references. */
+interface StepTemplateReference {
+  _templateId?: string;
+  variants?: { _templateId?: string }[];
+}
+
 /**
  * @deprecated - use `UpsertWorkflow` instead
  */
@@ -154,8 +160,6 @@ export class UpdateWorkflowV0 {
           parentChangeId,
           allowedTemplateIds
         );
-
-        await this.deleteRemovedSteps(existingTemplate.steps, command, parentChangeId);
       }
 
       if (command.tags) {
@@ -289,6 +293,17 @@ export class UpdateWorkflowV0 {
         },
         { session }
       );
+
+      if (command.steps) {
+        // Soft-delete after workflow update so concurrent triggers never see orphaned template refs.
+        await this.deleteRemovedSteps(
+          existingTemplate.steps,
+          updatePayload.steps || [],
+          command,
+          parentChangeId,
+          session
+        );
+      }
     };
 
     if (command.session) {
@@ -646,7 +661,7 @@ export class UpdateWorkflowV0 {
     return notificationTemplate;
   }
 
-  private getRemovedSteps(existingSteps: NotificationStepEntity[], newSteps: NotificationStep[]) {
+  private getRemovedSteps(existingSteps: StepTemplateReference[], newSteps: StepTemplateReference[]): string[] {
     const existingStepsIds = (existingSteps || []).flatMap((step) => [
       step._templateId,
       ...(step.variants || []).flatMap((variant) => variant._templateId),
@@ -657,7 +672,7 @@ export class UpdateWorkflowV0 {
       ...(step.variants || []).flatMap((variant) => variant._templateId),
     ]);
 
-    return existingStepsIds.filter((id) => !newStepsIds.includes(id));
+    return existingStepsIds.filter((id): id is string => !!id && !newStepsIds.includes(id));
   }
 
   private async updateVariants(
@@ -733,12 +748,15 @@ export class UpdateWorkflowV0 {
 
   @Instrument()
   private async deleteRemovedSteps(
-    existingSteps: NotificationStepEntity[] | NotificationStepData[] | undefined,
+    existingSteps: StepTemplateReference[] | undefined,
+    newSteps: StepTemplateReference[],
     command: UpdateWorkflowCommandV0,
-    parentChangeId: string
+    parentChangeId: string,
+    session?: ClientSession | null
   ) {
-    const removedStepsIds = this.getRemovedSteps(existingSteps || [], command.steps || []);
+    const removedStepsIds = this.getRemovedSteps(existingSteps || [], newSteps);
 
+    // Sequential on purpose: parallel operations inside a transaction are undefined behaviour in Mongoose.
     for (const id of removedStepsIds) {
       await this.deleteMessageTemplate.execute(
         DeleteMessageTemplateCommand.create({
@@ -748,16 +766,20 @@ export class UpdateWorkflowV0 {
           messageTemplateId: id,
           parentChangeId,
           workflowType: command.type,
+          session,
         })
       );
 
-      await this.controlValuesRepository.delete({
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-        _workflowId: command.id,
-        _stepId: id,
-        level: ControlValuesLevelEnum.STEP_CONTROLS,
-      });
+      await this.controlValuesRepository.delete(
+        {
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+          _workflowId: command.id,
+          _stepId: id,
+          level: ControlValuesLevelEnum.STEP_CONTROLS,
+        },
+        { session }
+      );
     }
   }
 }

--- a/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
@@ -758,7 +758,7 @@ export class UpdateWorkflowV0 {
 
     // Sequential on purpose: parallel operations inside a transaction are undefined behaviour in Mongoose.
     for (const id of removedStepsIds) {
-      await this.deleteMessageTemplate.execute(
+      const deleted = await this.deleteMessageTemplate.execute(
         DeleteMessageTemplateCommand.create({
           organizationId: command.organizationId,
           environmentId: command.environmentId,
@@ -769,6 +769,12 @@ export class UpdateWorkflowV0 {
           session,
         })
       );
+
+      // Abort the transaction if the template was not deleted, so we never commit a
+      // workflow that dropped the step and its controls while leaving the template behind.
+      if (!deleted) {
+        throw new BadRequestException(`Failed to delete message template ${id} while updating the workflow`);
+      }
 
       await this.controlValuesRepository.delete(
         {

--- a/libs/dal/src/repositories/change/change.repository.ts
+++ b/libs/dal/src/repositories/change/change.repository.ts
@@ -1,4 +1,5 @@
 import { ChangeEntityTypeEnum } from '@novu/shared';
+import { ClientSession } from 'mongoose';
 
 import { EnforceEnvOrOrgIds } from '../../types/enforce';
 import { BaseRepository } from '../base-repository';
@@ -15,7 +16,8 @@ export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity
   public async getEntityChanges(
     organizationId: string,
     entityType: ChangeEntityTypeEnum,
-    entityId: string
+    entityId: string,
+    options: { session?: ClientSession | null } = {}
   ): Promise<ChangeEntity[]> {
     return await this.find(
       {
@@ -26,6 +28,7 @@ export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity
       '',
       {
         sort: { createdAt: 1 },
+        session: options.session,
       }
     );
   }

--- a/libs/dal/src/repositories/message-template/message-template.repository.ts
+++ b/libs/dal/src/repositories/message-template/message-template.repository.ts
@@ -65,8 +65,16 @@ export class MessageTemplateRepository extends BaseRepository<
     return await deleteQuery;
   }
 
-  async findDeleted(query: MessageTemplateQuery): Promise<MessageTemplateEntity> {
-    const res: MessageTemplateEntity = await this.messageTemplate.findDeleted(query);
+  async findDeleted(query: MessageTemplateQuery, options: RepositoryOptions = {}): Promise<MessageTemplateEntity> {
+    const { session } = options;
+
+    const findQuery = this.messageTemplate.findDeleted(query);
+
+    if (session) {
+      findQuery.session(session);
+    }
+
+    const res: MessageTemplateEntity = await findQuery;
 
     return this.mapEntity(res);
   }


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves notification job validation and makes removed-step cleanup transactional. The main changes are:

- Skips active workflow steps whose message templates are missing.
- Preserves validated steps through digest job creation.
- Propagates MongoDB sessions through template deletion and change creation.
- Aborts workflow updates when removed templates cannot be deleted.
- Adds focused notification-job tests and repository session support.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The template deletion, change record, workflow update, and control cleanup now share the transaction. A failed template deletion aborts the workflow update. No blocking issue tied to the previous transaction failure remains in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared pre-change and post-change test results for the notification-job, noting that before the change three active-orphan scenarios with null-template access failed, with 1 of 4 tests passing and exit code 1.
- After the change, HEAD passed all tests (4/4 tests, 1/1 suite) with exit code 0, source restoration was verified after the comparison run, and non-fatal ts-jest/TypeScript and duplicate Mongoose index warnings were observed.

<a href="https://app.greptile.com/trex/runs/15617345/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts | Moves removed-step cleanup into the workflow transaction and aborts when template deletion fails. |
| libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts | Uses the workflow transaction for template deletion, deleted-template lookup, and change creation. |
| libs/application-generic/src/usecases/create-change/create-change.usecase.ts | Propagates the transaction session through change lookup, aggregation, update, and creation. |
| libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts | Validates active steps before notification and digest job creation. |
| libs/application-generic/src/usecases/digest-filter-steps/digest-filter-steps.usecase.ts | Preserves narrowed step types while adding the digest trigger step. |
| libs/dal/src/repositories/change/change.repository.ts | Adds optional transaction-session support to entity change queries. |
| libs/dal/src/repositories/message-template/message-template.repository.ts | Makes deleted-template lookup transaction-aware. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(application-generic): add session h..."](https://github.com/novuhq/novu/commit/3e3e943727524db2dc28a9d8cd23558f88dd277f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46743220)</sub>

<!-- /greptile_comment -->