### PR TITLE
ci(root): skip E2E and Linear ticket enforcement for docs-only PRs fixes NV-8379

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -47,7 +47,9 @@ jobs:
         run: |
           # Documentation-only PRs (only touching the Mintlify docs/ site) are
           # exempt from the "fixes NV-XXX" Linear ticket requirement below.
-          files=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json files --jq '.files[].path')
+          # `--paginate` walks every page so large PRs (>100 files) aren't
+          # misclassified as docs-only.
+          files=$(gh api --paginate "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --jq '.[].path')
           echo "Changed files:"
           echo "$files"
           non_docs=$(echo "$files" | grep -v '^docs/' || true)

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -39,6 +39,25 @@ jobs:
           echo "$scopes" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
+      - name: Detect docs-only PR
+        id: detect_docs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Documentation-only PRs (only touching the Mintlify docs/ site) are
+          # exempt from the "fixes NV-XXX" Linear ticket requirement below.
+          files=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json files --jq '.files[].path')
+          echo "Changed files:"
+          echo "$files"
+          non_docs=$(echo "$files" | grep -v '^docs/' || true)
+          if [ -n "$files" ] && [ -z "$non_docs" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "docs-only PR — skipping Linear ticket enforcement."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check if PR author is team member
         id: check_team_member
         run: |
@@ -73,7 +92,7 @@ jobs:
 
       - name: Extract Linear ticket from branch and auto-fix PR title
         id: auto_fix_linear_ticket
-        if: steps.check_team_member.outputs.is_team_member == 'true'
+        if: steps.check_team_member.outputs.is_team_member == 'true' && steps.detect_docs.outputs.docs_only != 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
@@ -124,7 +143,7 @@ jobs:
 
       - name: Validate Linear ticket ID for team members (fallback)
         id: validate_linear_ticket
-        if: steps.check_team_member.outputs.is_team_member == 'true' && steps.auto_fix_linear_ticket.outputs.linear_ticket_valid != 'true'
+        if: steps.check_team_member.outputs.is_team_member == 'true' && steps.detect_docs.outputs.docs_only != 'true' && steps.auto_fix_linear_ticket.outputs.linear_ticket_valid != 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -164,7 +183,7 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         # Show error if either conventional commit validation fails OR Linear ticket validation fails (for team members)
-        if: always() && (steps.lint_pr_title.outputs.error_message != null || (steps.check_team_member.outputs.is_team_member == 'true' && steps.auto_fix_linear_ticket.outputs.linear_ticket_valid != 'true' && steps.validate_linear_ticket.outputs.linear_ticket_valid != 'true'))
+        if: always() && (steps.lint_pr_title.outputs.error_message != null || (steps.detect_docs.outputs.docs_only != 'true' && steps.check_team_member.outputs.is_team_member == 'true' && steps.auto_fix_linear_ticket.outputs.linear_ticket_valid != 'true' && steps.validate_linear_ticket.outputs.linear_ticket_valid != 'true'))
         with:
           header: pr-title-lint-error
           message: |
@@ -185,7 +204,7 @@ jobs:
             ${{ steps.validate_linear_ticket.outputs.linear_error_message != null && steps.validate_linear_ticket.outputs.linear_error_message || '' }}
 
       # Delete previous comments when all issues have been resolved
-      - if: ${{ steps.lint_pr_title.outputs.error_message == null && (steps.check_team_member.outputs.is_team_member != 'true' || steps.auto_fix_linear_ticket.outputs.linear_ticket_valid == 'true' || steps.validate_linear_ticket.outputs.linear_ticket_valid == 'true') }}
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null && (steps.detect_docs.outputs.docs_only == 'true' || steps.check_team_member.outputs.is_team_member != 'true' || steps.auto_fix_linear_ticket.outputs.linear_ticket_valid == 'true' || steps.validate_linear_ticket.outputs.linear_ticket_valid == 'true') }}
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-title-lint-error

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -195,9 +195,9 @@ jobs:
 
             **Requirements:**
             1. Follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
-            2. ${{ steps.check_team_member.outputs.is_team_member == 'true' && 'As a team member, include Linear ticket ID at the end: `fixes TICKET-ID` or include it in your branch name' || '' }}
+            2. ${{ steps.check_team_member.outputs.is_team_member == 'true' && steps.detect_docs.outputs.docs_only != 'true' && 'As a team member, include Linear ticket ID at the end: `fixes TICKET-ID` or include it in your branch name' || '' }}
 
-            **Expected format:** `feat(scope): Add fancy new feature${{ steps.check_team_member.outputs.is_team_member == 'true' && ' fixes NOV-123' || '' }}`
+            **Expected format:** `feat(scope): Add fancy new feature${{ steps.check_team_member.outputs.is_team_member == 'true' && steps.detect_docs.outputs.docs_only != 'true' && ' fixes NOV-123' || '' }}`
 
             **Details:**
             ${{ steps.lint_pr_title.outputs.error_message != null && steps.lint_pr_title.outputs.error_message || '' }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -101,13 +101,15 @@ jobs:
         run: |
           # Use the GitHub API for the PR file list so detection doesn't depend
           # on the shallow local merge base (the depth-50 fetches above may not
-          # reach it, which would make a local `git diff` fail). Non-PR runs
-          # (e.g. workflow_dispatch) have no PR number, so run the full suite.
+          # reach it, which would make a local `git diff` fail). `--paginate`
+          # walks every page so large PRs (>100 files) aren't misclassified as
+          # docs-only. Non-PR runs (e.g. workflow_dispatch) have no PR number, so
+          # run the full suite.
           if [[ -z "$PR_NUMBER" ]]; then
             echo "docs-only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          changed=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json files --jq '.files[].path')
+          changed=$(gh api --paginate "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --jq '.[].path')
           echo "Changed files:"
           echo "$changed"
           non_docs=$(echo "$changed" | grep -v '^docs/' || true)

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -46,6 +46,7 @@ jobs:
     name: Get Affected Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
+      docs-only: ${{ steps.detect-docs.outputs.docs-only }}
       test-unit: ${{ steps.get-projects-arrays.outputs.test-unit }}
       test-e2e: ${{ steps.get-projects-arrays.outputs.test-e2e }}
       test-e2e-ee: ${{ steps.get-projects-arrays.outputs.test-e2e-ee }}
@@ -85,6 +86,30 @@ jobs:
         if: github.event.pull_request.base.ref != ''
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=50
+
+      # Detect PRs that only touch the Mintlify docs site (docs/). Such PRs are
+      # documentation-only and don't need the E2E / code test suites to run.
+      # `docs/` is not a pnpm workspace package, so `nx affected` already skips
+      # the unit/lib/package/openapi jobs for it; this output additionally gates
+      # the E2E suite, which otherwise always runs.
+      - name: Detect docs-only changes
+        id: detect-docs
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == "" ]]; then
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "origin/${{ github.event.pull_request.base.ref }}...HEAD")
+          echo "Changed files vs origin/${{ github.event.pull_request.base.ref }}:"
+          echo "$changed"
+          non_docs=$(echo "$changed" | grep -v '^docs/' || true)
+          if [ -n "$changed" ] && [ -z "$non_docs" ]; then
+            echo "docs-only=true" >> "$GITHUB_OUTPUT"
+            echo "Only docs/ changed — E2E and code tests will be skipped."
+          else
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: ./.github/actions/setup-project-minimal
       # Configure Nx to be able to detect changes between branches when we are in a PR
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
@@ -267,6 +292,8 @@ jobs:
   test_e2e_api:
     name: E2E test API
     needs: [get-affected]
+    # Skip the E2E suite for documentation-only PRs (docs/ changes only).
+    if: ${{ needs.get-affected.outputs.docs-only != 'true' }}
     uses: ./.github/workflows/reusable-api-e2e.yml
     with:
       # PRs opened from forks (community contributions) do not receive repo

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -94,13 +94,20 @@ jobs:
       # the E2E suite, which otherwise always runs.
       - name: Detect docs-only changes
         id: detect-docs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "" ]]; then
+          # Use the GitHub API for the PR file list so detection doesn't depend
+          # on the shallow local merge base (the depth-50 fetches above may not
+          # reach it, which would make a local `git diff` fail). Non-PR runs
+          # (e.g. workflow_dispatch) have no PR number, so run the full suite.
+          if [[ -z "$PR_NUMBER" ]]; then
             echo "docs-only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          changed=$(git diff --name-only "origin/${{ github.event.pull_request.base.ref }}...HEAD")
-          echo "Changed files vs origin/${{ github.event.pull_request.base.ref }}:"
+          changed=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json files --jq '.files[].path')
+          echo "Changed files:"
           echo "$changed"
           non_docs=$(echo "$changed" | grep -v '^docs/' || true)
           if [ -n "$changed" ] && [ -z "$non_docs" ]; then

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -1,6 +1,6 @@
 name: Check pull request
 concurrency:
-  group: '${{ github.workflow }}-${{ github.ref }}'
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 env:
@@ -16,9 +16,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: Linting
     steps:
-      - name: 'Checkout Repository'
+      - name: "Checkout Repository"
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - name: 'Dependency Review'
+      - name: "Dependency Review"
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
 
   find-flags:
@@ -56,6 +56,7 @@ jobs:
       test-libs: ${{ steps.get-projects-arrays.outputs.test-libs }}
     permissions:
       contents: read
+      pull-requests: read
       packages: write
       deployments: write
       id-token: write
@@ -159,7 +160,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-project
         with:
-          slim: 'true'
+          slim: "true"
       - uses: mansagroup/nrwl-nx-action@a531870269e0c1eeb7af6247c4a206c31cae82cc # v3
         env:
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
@@ -187,21 +188,21 @@ jobs:
 
       - uses: ./.github/actions/setup-project
         with:
-          slim: 'true'
+          slim: "true"
 
       - name: Build
         uses: mansagroup/nrwl-nx-action@a531870269e0c1eeb7af6247c4a206c31cae82cc # v3
         env:
-          LOG_LEVEL: 'info'
+          LOG_LEVEL: "info"
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: build
-          projects: '@novu/api'
+          projects: "@novu/api"
 
       - name: Run Lint, Build, Test
         uses: mansagroup/nrwl-nx-action@a531870269e0c1eeb7af6247c4a206c31cae82cc # v3
         env:
-          LOG_LEVEL: 'info'
+          LOG_LEVEL: "info"
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: lint,build,test
@@ -263,8 +264,8 @@ jobs:
           NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: build
-          projects: '@novu/api'
-          args: ''
+          projects: "@novu/api"
+          args: ""
 
       - uses: mansagroup/nrwl-nx-action@a531870269e0c1eeb7af6247c4a206c31cae82cc # v3
         name: Lint and build and test
@@ -273,7 +274,7 @@ jobs:
         with:
           targets: lint,build,test
           projects: ${{matrix.projectName}}
-          args: ''
+          args: ""
 
   validate_openapi:
     name: Validate OpenAPI


### PR DESCRIPTION
## What & why

Documentation-only PRs (only touching the Mintlify `docs/` site) were still running the full **E2E API test suite** and going through the **`fixes NV-XXX` Linear ticket** logic. Neither is meaningful for pure docs changes and the E2E suite wastes CI minutes.

This PR skips both for docs-only PRs.

> Unit/lib/package/OpenAPI jobs already skip for docs-only PRs — `docs/` isn't a pnpm workspace package, so it's invisible to `nx affected`. The only always-on code test was `test_e2e_api`.

## Changes

**`.github/workflows/on-pr.yml`**
- New `docs-only` output on the `get-affected` job, computed by a `Detect docs-only changes` step (diffs PR head vs base; `true` only when every changed file is under `docs/`). Reuses the existing checkout + base fetch — no new job, so the `pr-checks-passed` aggregator `needs` guard stays valid.
- `test_e2e_api` gated with `if: needs.get-affected.outputs.docs-only != 'true'`. A skipped job counts as success for the aggregator gate, so required checks / auto-merge stay green.

**`.github/workflows/conventional-commit.yml`**
- New `Detect docs-only PR` step (`gh pr view --json files`) setting `docs_only`.
- Linear-ticket auto-fix, fallback validation, and error sticky-comment are skipped for docs-only PRs; any stale error comment is cleaned up.
- Conventional-commit **title format** is still enforced (only the ticket requirement is dropped).

## Flow

```mermaid
flowchart TD
    A[PR opened / updated] --> B{Only docs/ changed?}
    B -- yes --> C[Skip E2E test_e2e_api]
    B -- yes --> D[Skip fixes NV-XXX enforcement]
    B -- no --> E[Run E2E + Linear ticket checks as before]
```

## Test plan

- YAML validated locally (both workflows parse).
- On this PR (not docs-only) the E2E suite runs normally, exercising the gated path.
- A follow-up docs-only PR should show `test_e2e_api` skipped and no Linear-ticket comment.

## Scope

CI-config only; no application code touched. No enterprise submodule changes.

fixes NV-8379

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates CI behavior for documentation-only pull requests. The main changes are:

- Detects PRs where every changed file is under `docs/`.
- Skips the API E2E workflow for docs-only changes.
- Skips Linear ticket auto-fix and validation for docs-only changes.
- Keeps conventional commit title validation enabled.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are limited to CI workflow gating and use the paginated GitHub PR files API, which addresses the earlier file-list and shallow-diff concerns.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the docs-only validation harness to validate the updated workflows.
- The docs-only validation log shows the commands run, the working directory, YAML parsing status for both changed workflows, all fixture tests passed, and exit code 0.
- The per-fixture results CSV records each fixture's file list, the computed docs\_only result, the expected result, the computed E2E gate behavior, the expected gate behavior, and a PASS status.
- The harness script used for execution is included as an artifact to enable reproducible validation runs.

<a href="https://app.greptile.com/trex/runs/15621139/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/conventional-commit.yml | Adds paginated PR file detection to exempt docs-only PRs from Linear ticket enforcement while keeping conventional title linting active. |
| .github/workflows/on-pr.yml | Adds paginated GitHub API based docs-only detection and gates the E2E API reusable workflow on it. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant PR as Pull Request
participant OnPR as on-pr.yml / get-affected
participant CC as conventional-commit.yml
participant GH as GitHub PR Files API
participant E2E as test_e2e_api
participant Linear as Linear ticket checks

PR->>OnPR: pull_request event
OnPR->>GH: list changed files with pagination
GH-->>OnPR: file paths
alt every path starts with docs/
    OnPR-->>E2E: skip API E2E job
else code or config changed
    OnPR-->>E2E: run API E2E job
end

PR->>CC: title lint workflow
CC->>GH: list changed files with pagination
GH-->>CC: file paths
alt every path starts with docs/
    CC-->>Linear: skip ticket auto-fix/validation
else code or config changed
    CC-->>Linear: enforce fixes NV-XXX flow
end
```

<sub>Reviews (5): Last reviewed commit: ["ci(root): paginate PR files API so large..."](https://github.com/novuhq/novu/commit/6075c5dc50e4dccb905c87aa668490963b5294da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46746660)</sub>

<!-- /greptile_comment -->