### PR TITLE
fix: sort mutations, code snippet escaping, JWT crash, and focus trap guard

### DIFF
--- a/apps/dashboard/src/utils/arrays.ts
+++ b/apps/dashboard/src/utils/arrays.ts
@@ -1,7 +1,5 @@
 export const sort = (array: number[]) => {
-  array.sort((a, b) => a - b);
-
-  return array;
+  return [...array].sort((a, b) => a - b);
 };
 
 export const range = (start: number, end: number) => {

--- a/apps/dashboard/src/utils/code-snippets.ts
+++ b/apps/dashboard/src/utils/code-snippets.ts
@@ -54,7 +54,7 @@ novu.trigger(${JSON.stringify(
     2
   )
     .replace(/"([^"]+)":/g, '$1:')
-    .replace(/"/g, "'")});
+    .replace(/\\"/g, '___ESCQ___').replace(/"/g, "'").replace(/___ESCQ___/g, '\\"')});
 `;
 };
 
@@ -188,7 +188,7 @@ novu.trigger(${JSON.stringify(
     2
   )
     .replace(/"([^"]+)":/g, '$1:')
-    .replace(/"/g, "'")});
+    .replace(/\\"/g, '___ESCQ___').replace(/"/g, "'").replace(/___ESCQ___/g, '\\"')});
 `;
 };
 
@@ -205,7 +205,7 @@ const transformJsonToPhpArray = (data: Record<string, unknown>, indentLevel = 4)
 
   const items = entries
     .map(([key, value]) => {
-      const formattedValue = JSON.stringify(value).replace(/"/g, "'");
+      const formattedValue = JSON.stringify(value).replace(/\\"/g, '___ESCQ___').replace(/"/g, "'").replace(/___ESCQ___/g, '\\"');
       return `${indent}'${key}' => ${formattedValue}`;
     })
     .join(',\n');

--- a/apps/dashboard/src/utils/self-hosted/user.resource.tsx
+++ b/apps/dashboard/src/utils/self-hosted/user.resource.tsx
@@ -13,7 +13,7 @@ export const UserContext = React.createContext<{
 
 export function UserContextProvider({ children }: any) {
   const jwt = localStorage.getItem('self-hosted-jwt');
-  const decodedJwt: DecodedJwt | null = jwt ? JSON.parse(atob(jwt.split('.')[1])) : null;
+  const decodedJwt: DecodedJwt | null = jwt && isJwtValid(jwt) ? JSON.parse(atob(jwt.split('.')[1])) : null;
   const value = {
     user: createUserFromJwt(decodedJwt),
     isLoaded: true,

--- a/libs/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/libs/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -104,9 +104,9 @@ function createHandlebarsInstance(i18next: any) {
 
   handlebars.registerHelper(HandlebarHelpersEnum.SORT_BY, (array, property) => {
     if (!Array.isArray(array)) return '';
-    if (!property) return array.sort();
+    if (!property) return [...array].sort();
 
-    return array.sort((a, b) => {
+    return [...array].sort((a, b) => {
       const _x = a[property];
       const _y = b[property];
 

--- a/packages/js/src/ui/helpers/useFocusTrap.ts
+++ b/packages/js/src/ui/helpers/useFocusTrap.ts
@@ -27,6 +27,7 @@ function createFocusTrap({ element, enabled }: FocusTrapOptions) {
       if (event.key !== 'Tab') return;
 
       const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) return;
       const firstFocusableElement = focusableElements[0];
       const lastFocusableElement = focusableElements[focusableElements.length - 1];
 


### PR DESCRIPTION
## Summary

Five bug fixes across Novu packages.

| # | File | Bug |
|---|---|---|
| 1 | `compile-template.usecase.ts` | `sort_by` Handlebars helper mutated caller's array in-place |
| 2 | `arrays.ts` | `sort()` utility mutated input array, time bomb for React state |
| 3 | `code-snippets.ts` | Regex replaced escaped double quotes in payload values |
| 4 | `user.resource.tsx` | Corrupted JWT in localStorage caused white-screen crash |
| 5 | `useFocusTrap.ts` | Empty focusableElements caused `undefined.focus()` TypeError |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds several defensive fixes across dashboard utilities, template rendering, and the JavaScript UI package. The main changes are:

- Sort helpers now return sorted copies instead of mutating caller-owned arrays.
- Code snippets preserve escaped double quotes while converting generated examples to single-quote style.
- Self-hosted JWT decoding now checks token validity before parsing localStorage data.
- The focus trap now no-ops when no focusable elements are available.

<h3>Confidence Score: 4/5</h3>

Safe to merge after the self-hosted dashboard compile error is fixed.

Most changes are small defensive fixes, but `user.resource.tsx` adds an unresolved `isJwtValid` reference on the changed path.

apps/dashboard/src/utils/self-hosted/user.resource.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused TypeScript compile harness including apps/dashboard/src/utils/self-hosted/user.resource.tsx reproduced a TypeScript error: TS2304 cannot find name 'isJwtValid' at line 16.
- The dashboard utility validation harness and its execution log were saved for review, including a module-resolution workaround that uses minimal ESM stubs for certain paths.

<a href="https://app.greptile.com/trex/runs/15641615/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/arrays.ts | Updated numeric sort helper to return a sorted copy instead of mutating the caller's array. |
| apps/dashboard/src/utils/code-snippets.ts | Adjusted generated JavaScript/Framework/PHP snippets to preserve escaped double quotes while converting JSON quotes to single quotes. |
| apps/dashboard/src/utils/self-hosted/user.resource.tsx | Added JWT validity gating before decoding localStorage JWT, but the new `isJwtValid` reference is missing its import and breaks compilation. |
| libs/application-generic/src/usecases/compile-template/compile-template.usecase.ts | Changed the Handlebars `sort_by` helper to sort a shallow copy rather than mutating template data arrays. |
| packages/js/src/ui/helpers/useFocusTrap.ts | Added an empty-list guard before focus trap Tab handling to avoid focusing undefined elements. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Dashboard as Dashboard / SDK UI
participant Helper as Changed utility/helper
participant Input as Caller-owned data or DOM/JWT input

Dashboard->>Helper: Invoke sort/snippet/JWT/focus/template helper
Helper->>Input: Read input without mutating or crashing on invalid state
alt Valid input
    Helper-->>Dashboard: Return sorted copy, snippet, decoded user, or trapped focus
else Invalid or empty input
    Helper-->>Dashboard: Return safe fallback / no-op
end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/utils/self-hosted/user.resource.tsx`, line 1-4 ([link](https://github.com/novuhq/novu/blob/1d765669a547b23d063b62a79aa2f4b2996b740c/apps/dashboard/src/utils/self-hosted/user.resource.tsx#L1-L4)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Import JWT validator**
   `isJwtValid` is now called on line 16 but this file does not import it, unlike `auth.resource.tsx`. This leaves the self-hosted user context with an unresolved identifier and breaks TypeScript compilation for the changed path.

   

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused TypeScript config that includes the self-hosted user resource](https://app.greptile.com/trex/artifacts/ebd79937-0d57-4035-8f76-357f8d555b88)**

   - Evidence file captured while the check ran.

   **[Repro: TypeScript compiler output showing unresolved isJwtValid in user.resource.tsx](https://app.greptile.com/trex/artifacts/3e449028-1bfb-4362-91b7-9d8d66c095e1)**

   - The full command output behind this check.

   <a href="https://app.greptile.com/trex/runs/15641615/artifacts?artifact=ebd79937-0d57-4035-8f76-357f8d555b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/utils/self-hosted/user.resource.tsx
   Line: 1-4

   Comment:
   **Import JWT validator**
   `isJwtValid` is now called on line 16 but this file does not import it, unlike `auth.resource.tsx`. This leaves the self-hosted user context with an unresolved identifier and breaks TypeScript compilation for the changed path.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Futils%2Fself-hosted%2Fuser.resource.tsx%0ALine%3A%201-4%0A%0AComment%3A%0A**Import%20JWT%20validator**%0A%60isJwtValid%60%20is%20now%20called%20on%20line%2016%20but%20this%20file%20does%20not%20import%20it%2C%20unlike%20%60auth.resource.tsx%60.%20This%20leaves%20the%20self-hosted%20user%20context%20with%20an%20unresolved%20identifier%20and%20breaks%20TypeScript%20compilation%20for%20the%20changed%20path.%0A%0A%60%60%60suggestion%0Aimport%20React%20from%20'react'%3B%0Aimport%20%7B%20createContextHook%20%7D%20from%20'..%2Fcontext'%3B%0Aimport%20%7B%20DecodedJwt%20%7D%20from%20'.'%3B%0Aimport%20%7B%20isJwtValid%20%7D%20from%20'.%2Fjwt-manager'%3B%0Aimport%20%7B%20createUserFromJwt%2C%20SelfHostedUser%20%7D%20from%20'.%2Fuser.types'%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=12073&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Futils%2Fself-hosted%2Fuser.resource.tsx%3A1-4%0A**Import%20JWT%20validator**%0A%60isJwtValid%60%20is%20now%20called%20on%20line%2016%20but%20this%20file%20does%20not%20import%20it%2C%20unlike%20%60auth.resource.tsx%60.%20This%20leaves%20the%20self-hosted%20user%20context%20with%20an%20unresolved%20identifier%20and%20breaks%20TypeScript%20compilation%20for%20the%20changed%20path.%0A%0A%60%60%60suggestion%0Aimport%20React%20from%20'react'%3B%0Aimport%20%7B%20createContextHook%20%7D%20from%20'..%2Fcontext'%3B%0Aimport%20%7B%20DecodedJwt%20%7D%20from%20'.'%3B%0Aimport%20%7B%20isJwtValid%20%7D%20from%20'.%2Fjwt-manager'%3B%0Aimport%20%7B%20createUserFromJwt%2C%20SelfHostedUser%20%7D%20from%20'.%2Fuser.types'%3B%0A%60%60%60%0A%0A&pr=12073&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/utils/self-hosted/user.resource.tsx:1-4
**Import JWT validator**
`isJwtValid` is now called on line 16 but this file does not import it, unlike `auth.resource.tsx`. This leaves the self-hosted user context with an unresolved identifier and breaks TypeScript compilation for the changed path.

```suggestion
import React from 'react';
import { createContextHook } from '../context';
import { DecodedJwt } from '.';
import { isJwtValid } from './jwt-manager';
import { createUserFromJwt, SelfHostedUser } from './user.types';
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sort mutations in template helper a..."](https://github.com/novuhq/novu/commit/1d765669a547b23d063b62a79aa2f4b2996b740c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46795311)</sub>

<!-- /greptile_comment -->