### PR TITLE
fix(worker, application-generic): skip step hydration for bridgeUrl jobs fixes NV-8382

### DIFF
--- a/apps/api/src/app/events/e2e/bridge-trigger.e2e.ts
+++ b/apps/api/src/app/events/e2e/bridge-trigger.e2e.ts
@@ -157,6 +157,70 @@ contexts.forEach((context: Context) => {
       expect(smsMessage?.content).to.include('sms result test_name');
     });
 
+    /**
+     * Regression for NV-8382: a synced code-first workflow triggered with an
+     * override `bridgeUrl` still carries a Mongo `_templateId`, but step content
+     * comes from the bridge discover stub (`template: { type }`). Hydration must
+     * not fail those jobs as unresolved Mongo message templates.
+     */
+    it(`should trigger a synced workflow with an override bridgeUrl [${context.name}]`, async () => {
+      const workflowId = `bridge-url-override-${context.name}`;
+      const bridgeWorkflow = workflow(
+        workflowId,
+        async ({ step, payload }) => {
+          await step.inApp('send-in-app', async () => ({
+            body: `override in-app ${payload.name}`,
+          }));
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', default: 'default_name' },
+            },
+            required: [],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      await bridgeServer.start({ workflows: [bridgeWorkflow] });
+      await discoverAndSyncBridge(session, workflowsRepository, workflowId, bridgeServer);
+
+      const foundWorkflow = await workflowsRepository.findByTriggerIdentifier(session.environment._id, workflowId);
+      expect(foundWorkflow?._id).to.be.ok;
+
+      await triggerEvent(session, workflowId, subscriber.subscriberId, { name: 'tunnel_user' }, {
+        url: `${bridgeServer.serverPath}/novu`,
+      });
+      await session.waitForJobCompletion();
+
+      const failedHydrationDetails = await executionDetailsRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+        detail: DetailEnum.MESSAGE_CONTENT_NOT_GENERATED,
+        status: ExecutionDetailsStatusEnum.FAILED,
+      });
+      expect(failedHydrationDetails, 'bridgeUrl jobs must not fail step-template hydration').to.have.length(0);
+
+      const inAppJobs = await jobRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+        type: StepTypeEnum.IN_APP,
+      });
+      expect(inAppJobs.length).to.equal(1);
+      expect(inAppJobs[0].status).to.equal(JobStatusEnum.COMPLETED);
+      expect(inAppJobs[0].step?.bridgeUrl).to.equal(`${bridgeServer.serverPath}/novu`);
+
+      const messages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+        channel: StepTypeEnum.IN_APP,
+      });
+      expect(messages.length).to.be.eq(1);
+      expect(messages[0].content).to.include('override in-app tunnel_user');
+    });
+
     it(`should update message template type when replacing a step with the same stepId after re-sync [${context.name}]`, async () => {
       const workflowId = `step-type-replace-${context.name}`;
       const middleStepId = 'shared-middle-step';

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -174,9 +174,10 @@ export class RunJob {
         notification
       );
 
-      // Stateless (bridge-URL) jobs carry no persisted workflow — the bridge
-      // is the source of truth (`job.step.bridgeUrl`). Every downstream
-      // consumer accepts an undefined workflow and falls back accordingly.
+      // Purely stateless jobs have no persisted workflow id. Synced workflows
+      // triggered with an override `bridgeUrl` still have `_templateId`, but
+      // step content comes from the bridge (`job.step.bridgeUrl`) — hydration
+      // skips those stubs; every downstream consumer tolerates either shape.
       const workflow = job._templateId
         ? await this.getWorkflow(job._templateId, job._environmentId, job._organizationId, job.payload?.__source)
         : undefined;

--- a/libs/application-generic/src/services/step-template-hydration.service.spec.ts
+++ b/libs/application-generic/src/services/step-template-hydration.service.spec.ts
@@ -18,6 +18,7 @@ type TestJob = {
     uuid?: string;
     stepId?: string;
     _templateId?: string;
+    bridgeUrl?: string;
     template: TestTemplate;
   };
 };
@@ -83,6 +84,25 @@ describe('StepTemplateHydrationService', () => {
   it('skips stateless jobs (no _templateId)', async () => {
     const { service, messageTemplateRepository } = buildService();
     const job = buildLeanJob({ _templateId: undefined });
+
+    const status = await hydrate(service, job);
+
+    expect(status).toBe(StepTemplateHydrationStatus.SKIPPED);
+    expect(messageTemplateRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('skips bridgeUrl jobs even when a synced _templateId is present', async () => {
+    const { service, messageTemplateRepository } = buildService();
+    const job = buildLeanJob({
+      step: {
+        _id: 'step_1',
+        uuid: 'uuid_1',
+        stepId: 'email-step',
+        _templateId: 'mt_1',
+        bridgeUrl: 'https://tunnel.example.com/api/novu',
+        template: { _id: 'mt_1', type: StepTypeEnum.EMAIL },
+      },
+    });
 
     const status = await hydrate(service, job);
 

--- a/libs/application-generic/src/services/step-template-hydration.service.ts
+++ b/libs/application-generic/src/services/step-template-hydration.service.ts
@@ -34,7 +34,7 @@ export type LeanNotificationStep = Pick<
 export enum StepTemplateHydrationStatus {
   /** Template was resolved and attached to the job step in place. */
   HYDRATED = 'hydrated',
-  /** Nothing to do: full snapshot, stateless job, or non-rendering lean step. */
+  /** Nothing to do: full snapshot, bridgeUrl/stateless job, or non-rendering lean step. */
   SKIPPED = 'skipped',
   /** Lean channel step whose template could not be resolved anywhere. */
   UNRESOLVED = 'unresolved',
@@ -98,18 +98,21 @@ export class StepTemplateHydrationService {
   /**
    * Restores `job.step.template` in place (never written back to Mongo) so
    * downstream rendering behaves identically to a full snapshot. No-op for full
-   * snapshots (old / flag-off jobs) and stateless bridge jobs. Returns
-   * {@link StepTemplateHydrationStatus.UNRESOLVED} for a lean channel step whose
-   * template is gone everywhere, leaving failure handling to the caller.
+   * snapshots (old / flag-off jobs) and bridgeUrl jobs (discover stub + optional
+   * synced `_templateId`). Returns {@link StepTemplateHydrationStatus.UNRESOLVED}
+   * for a lean channel step whose template is gone everywhere, leaving failure
+   * handling to the caller.
    */
   async hydrateJobStep(job: JobEntity, workflow?: NotificationTemplateEntity): Promise<StepTemplateHydrationStatus> {
     const { step } = job;
     if (!isLeanStepTemplate(step)) {
       return StepTemplateHydrationStatus.SKIPPED;
     }
-    // Stateless bridge-URL jobs have no persisted workflow/template; the bridge
-    // is the source of truth and carries its own controls.
-    if (!job._templateId) {
+    // Bridge-URL jobs (stateless discover, or a synced workflow triggered with an
+    // override bridgeUrl) use the bridge as the source of truth for step content.
+    // Their step.template is only a `{ type }` stub from discover — never hydrate
+    // from Mongo, even when a synced `_templateId` is present on the job.
+    if (!job._templateId || step.bridgeUrl) {
       return StepTemplateHydrationStatus.SKIPPED;
     }
 


### PR DESCRIPTION
## What changed

Synced code-first workflows triggered with an override `bridgeUrl` were failing with:

> Message template for the step could not be resolved for rendering

`StepTemplateHydrationService` (from [NV-8324](https://linear.app/novu/issue/NV-8324/slim-jobs-collection-stop-embedding-message-template-content-in)) treated lean `{ type }` discover stubs as needing a Mongo message template whenever the job had a synced `_templateId`. BridgeUrl jobs get content from the bridge, not Mongo — even when the workflow was previously synced.

### Fix

Skip step-template hydration when `job.step.bridgeUrl` is set.

```mermaid
flowchart TD
  A[Trigger with bridgeUrl] --> B[Discover workflow from bridge]
  B --> C[Job has synced _templateId + step.bridgeUrl + stub template]
  C --> D{hydrateJobStep}
  D -->|before| E[Try Mongo resolve → UNRESOLVED → fail]
  D -->|after| F[SKIPPED]
  F --> G[Bridge EXECUTE renders content]
```

## Test plan

- [X] Unit: `skips bridgeUrl jobs even when a synced _templateId is present`
- [X] E2E: `should trigger a synced workflow with an override bridgeUrl` in `bridge-trigger.e2e.ts`
  * Syncs a code-first workflow, triggers with override `bridgeUrl`, asserts no `MESSAGE_CONTENT_NOT_GENERATED` and in-app message is delivered

## Related

* Linear: [NV-8382](https://linear.app/novu/issue/NV-8382)
* Regression from: [NV-8324](https://linear.app/novu/issue/NV-8324/slim-jobs-collection-stop-embedding-message-template-content-in) / novuhq/novu#11982

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

---

![View with \[code\]smith](https://camo.githubusercontent.com/6e22944985996f6a1201f1d35788e9dc855f2e6b7b781e7ed1c22d7fb14217e8/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f766965772d776974682d636f6465736d6974682d6461726b2d76322e737667) ![Autofix with \[code\]smith](https://camo.githubusercontent.com/8e7d836069a9e09b18eb0f68d9afc9beb6c2b13211745830b36a5d88a500d653/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f6175746f6669782d776974682d636f6465736d6974682d6461726b2e737667) Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.

### Greptile Summary

This PR fixes bridge URL jobs so they skip Mongo step-template hydration. The main changes are:

* Skips `StepTemplateHydrationService` for lean jobs with `step.bridgeUrl`.
* Covers synced code-first workflows triggered with an override bridge URL.
* Adds unit and E2E tests for the bridge-sourced rendering path.
* Clarifies worker comments for synced override `bridgeUrl` jobs.

### Confidence Score: 5/5

Safe to merge with minimal risk.

The code change is narrow and matches the existing bridge execution contract where `step.bridgeUrl` makes the bridge the source of truth. Focused unit and E2E tests cover the fixed path. No correctness or security issues were identified.

No files require special attention.

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* T-Rex attempted to run the Jest tests for src/services/step-template-hydration.service.spec.ts via pnpm with a filter for the hydration service, but the run failed before tests started with TypeError: Cannot read properties of undefined (reading 'testEnvironmentOptions').
* A harness file named bridgeurl-hydration-harness.cjs was generated; it imports the step-template-hydration service, stubs external modules, and enforces repository methods to throw if called.
* The harness was executed and completed with exit code 0, reporting status: skipped, findOneCalls: 0, findDeletedCalls: 0, and templateIdentityPreserved: true.
* Artifacts associated with this proof include the failing Jest log, the harness source, and the harness run log, which help inspect the pre-test failure and harness behavior.

![View all artifacts](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<img src="https://camo.githubusercontent.com/223063a8acd7e71fd1deaaa741d9d06948338e590a1cc633c9305234794edec8/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f56696577416c6c4172746966616374732e7376673f763d34 " alt="T-Rex" height="14" /> Ran code and verified through T-Rex

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| libs/application-generic/src/services/step-template-hydration.service.ts | Updates step-template hydration to skip lean bridge URL jobs, including synced workflows with persisted workflow ids. |
| libs/application-generic/src/services/step-template-hydration.service.spec.ts | Adds unit coverage confirming bridge URL jobs with synced `_templateId` skip hydration and avoid repository lookups. |
| apps/api/src/app/events/e2e/bridge-trigger.e2e.ts | Adds E2E coverage for synced code-first workflows triggered with override bridge URL. |
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Clarifies run-job comments around synced override `bridgeUrl` jobs while leaving execution flow unchanged. |

</details>

### Sequence Diagram

```mermaid
sequenceDiagram
  participant Trigger as Trigger API
  participant Jobs as CreateNotificationJobs
  participant Worker as RunJob
  participant Hydration as StepTemplateHydrationService
  participant Bridge as Bridge EXECUTE
  participant Messages as Message Repository

  Trigger->>Jobs: Trigger synced workflow with override bridgeUrl
  Jobs->>Jobs: Persist lean step stub + job.step.bridgeUrl
  Jobs->>Worker: Queue channel job with _templateId
  Worker->>Hydration: hydrateJobStep(job, workflow)
  Hydration-->>Worker: SKIPPED because step.bridgeUrl is set
  Worker->>Bridge: Execute step rendering from bridge
  Bridge-->>Worker: Rendered in-app content
  Worker->>Messages: Store delivered message
```

Reviews (1): Last reviewed commit: ["fix(worker, application-generic): skip s..."](<https://github.com/novuhq/novu/commit/60c68768134d1702ebf0e9413bcd647c8d2a523a>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=46925680>)