### PR TITLE
fix: disable connector dropdown during AI agent generation

### DIFF
--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -743,6 +743,7 @@ export function CreateAgentDialog({
                 integrations={integrations}
                 status={dropdownStatus}
                 showStatusBadge={showSavedBadge}
+                disabled={isSubmitBusy}
                 onSelectConnector={handleSelectConnector}
                 onSelectIntegration={handleSelectIntegration}
                 onRequestSetupCredentials={handleRequestSetupCredentials}


### PR DESCRIPTION
## Description

Fixes novuhq/novu#12078

The connector dropdown (ConnectorIntegrationDropdown) was not disabled while AI generation was in-flight. This allowed users to switch connectors mid-generation, causing a state mismatch where the LLM was called with the original connector's runtime but the generated result (tools, MCPs, skills) was applied against the newly selected connector's runtime.

## Changes

* Pass `disabled={isSubmitBusy}` to `ConnectorIntegrationDropdown` in create-agent-dialog.tsx
* The dropdown is now disabled during AI generation or submission (when `isSubmitBusy` is true)
* Prevents connector switches that cause runtime/overrides mismatches

## Testing

Manual testing:

1. Open the "Add agent" dialog
2. Select "Claude Managed Agent" as the connector
3. Type a prompt and click "Setup agent"
4. Verify the connector dropdown is disabled while generation is running
5. Verify the dropdown re-enables after generation completes or fails

### Greptile Summary

This PR fixes a race condition in the "Add agent" dialog where users could switch connectors while AI generation was in-flight, causing a state mismatch between the LLM call's runtime context and the generated output's target runtime. The fix passes `disabled={isSubmitBusy}` to `ConnectorIntegrationDropdown`, consistent with how every other interactive control in the same dialog is already guarded.

* The `disabled` prop was already defined in `ConnectorIntegrationDropdownProps` and fully implemented in the component (trigger button, popover open handler, and visual opacity), so no changes to the dropdown component were needed.
* `isSubmitBusy` (`isSubmitting || isGenerating || isSubmitInFlight`) is the correct gate — it matches the same flag used by the prompt input, mode tabs, and submit button in the same form.

### Confidence Score: 5/5

Safe to merge — the one-line addition uses the correct existing flag and a prop already wired end-to-end in the dropdown component.

The change is a single property addition that mirrors the pattern already applied to every other interactive control in the dialog. The disabled prop was already defined in the component's type interface and fully implemented (trigger button, popover open handler, visual feedback), so there are no missing pieces or unintended side effects.

No files require special attention.

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/dashboard/src/components/agents/create-agent-dialog.tsx | Adds disabled={isSubmitBusy} to ConnectorIntegrationDropdown, aligning it with every other interactive control in the dialog that was already gated on this flag. One-line, low-risk fix. |

</details>

### Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant ConnectorDropdown
    participant Dialog as CreateAgentDialog
    participant LLM as AI Generation

    User->>ConnectorDropdown: Select connector (e.g. Claude Managed)
    User->>Dialog: Click "Setup agent"
    Dialog->>Dialog: "isSubmitBusy = true"
    Dialog->>ConnectorDropdown: "disabled={true}"
    Note over ConnectorDropdown: Trigger button disabled<br/>Popover onOpenChange = undefined<br/>opacity-60 applied
    Dialog->>LLM: Generate with connector runtime
    LLM-->>Dialog: Return tools/MCPs/skills
    Dialog->>Dialog: "isSubmitBusy = false"
    Dialog->>ConnectorDropdown: "disabled={false}"
    Note over ConnectorDropdown: Dropdown re-enabled
```

Reviews (1): Last reviewed commit: ["fix: disable connector dropdown during A..."](<https://github.com/novuhq/novu/commit/1b77b14ca1f2c03b17aa8bb640146bc1bf63946e>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=46939321>)