### PR TITLE
fix: inbox badge sync

### DIFF
--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -46,6 +46,7 @@ describe('NotificationsCache', () => {
           severity: SeverityLevelEnum.NONE,
         },
         severity: SeverityLevelEnum.NONE,
+        tags: ['tag1'],
       },
       mockEmitter,
       mockInboxService
@@ -71,6 +72,7 @@ describe('NotificationsCache', () => {
           severity: SeverityLevelEnum.NONE,
         },
         severity: SeverityLevelEnum.NONE,
+        tags: ['tag1'],
       },
       mockEmitter,
       mockInboxService
@@ -121,8 +123,7 @@ describe('NotificationsCache', () => {
     const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
     const plainNotification = {
       ...notification1,
-      isRead: true,
-      readAt: new Date().toISOString(),
+      body: 'Updated Notification',
     };
     const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
 
@@ -133,11 +134,12 @@ describe('NotificationsCache', () => {
 
     expect(result?.notifications[0]).toBeInstanceOf(Notification);
     expect(typeof result?.notifications[0].read).toBe('function');
-    expect(result?.notifications[0].isRead).toBe(true);
+    expect(result?.notifications[0].body).toBe('Updated Notification');
   });
 
   it('should set and get notifications from the cache', () => {
     const args = { tags: ['tag1'], limit: 10, offset: 0 };
+    const filter = { tags: ['tag1'] };
     const data = {
       hasMore: false,
       filter: {},
@@ -147,7 +149,11 @@ describe('NotificationsCache', () => {
     notificationsCache.set(args, data);
     const result = notificationsCache.getAll(args);
 
-    expect(result).toEqual(data);
+    expect(result).toEqual({
+      hasMore: false,
+      filter,
+      notifications: [notification1],
+    });
   });
 
   it('should clear specific filter from the cache', () => {
@@ -183,7 +189,11 @@ describe('NotificationsCache', () => {
     const result1 = notificationsCache.getAll(args1);
     expect(result1).toBeUndefined();
     const result2 = notificationsCache.getAll(args2);
-    expect(result2).toEqual(data);
+    expect(result2).toEqual({
+      hasMore: false,
+      filter: { tags: ['newsletter'] },
+      notifications: [notification1],
+    });
   });
 
   it('should clear all caches', () => {
@@ -272,14 +282,88 @@ describe('NotificationsCache', () => {
     expect(result).toEqual([notification2]);
   });
 
+  it('should remove notification from read:false bucket when marked as read', () => {
+    const filter = { tags: ['tag1'], read: false, archived: false };
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, ...filter };
+    const readNotification = new Notification(
+      { ...notification1, isRead: true, readAt: new Date().toISOString() },
+      mockEmitter,
+      mockInboxService
+    );
+    const data: ListNotificationsResponse = {
+      hasMore: false,
+      filter,
+      notifications: [notification1, notification2],
+    };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent()({ data: readNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter,
+        notifications: [notification2],
+      },
+    });
+  });
+
+  it('should deduplicate notifications across cache keys with the same filter and different limits', () => {
+    const filter = { tags: ['tag1'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter };
+    const args2: ListNotificationsArgs = { limit: 20, offset: 0, ...filter };
+
+    notificationsCache.set(args1, {
+      hasMore: false,
+      filter,
+      notifications: [notification1, notification2],
+    });
+    notificationsCache.set(args2, {
+      hasMore: false,
+      filter,
+      notifications: [notification1, notification2],
+    });
+
+    const result = notificationsCache.getAll(args1);
+
+    expect(result?.notifications).toEqual([notification1, notification2]);
+  });
+
+  it('should remove notification from seen:false bucket when marked as seen', () => {
+    const filter = { tags: ['tag1'], seen: false, archived: false };
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, ...filter };
+    const seenNotification = new Notification(
+      { ...notification1, isSeen: true, firstSeenAt: new Date().toISOString() },
+      mockEmitter,
+      mockInboxService
+    );
+    const data: ListNotificationsResponse = {
+      hasMore: false,
+      filter,
+      notifications: [notification1, notification2],
+    };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent()({ data: seenNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter,
+        notifications: [notification2],
+      },
+    });
+  });
+
   it('should update notification and emit single event', () => {
-    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const filter = { tags: ['tag1'], read: false, archived: false };
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, ...filter };
     const updatedNotification = new Notification(
       { ...notification1, body: 'Updated Notification' },
       mockEmitter,
       mockInboxService
     );
-    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+    const data: ListNotificationsResponse = { hasMore: false, filter, notifications: [notification1] };
 
     notificationsCache.set(args, data);
     (notificationsCache as any).handleNotificationEvent()({ data: updatedNotification });
@@ -287,20 +371,21 @@ describe('NotificationsCache', () => {
     expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
       data: {
         hasMore: false,
-        filter: {},
+        filter,
         notifications: [updatedNotification],
       },
     });
   });
 
   it('should remove notification and emit single event', () => {
-    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const filter = { tags: ['tag1'], read: false, archived: false };
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, ...filter };
     const updatedNotification = new Notification(
       { ...notification1, body: 'Updated Notification' },
       mockEmitter,
       mockInboxService
     );
-    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+    const data: ListNotificationsResponse = { hasMore: false, filter, notifications: [notification1] };
 
     notificationsCache.set(args, data);
     (notificationsCache as any).handleNotificationEvent({ remove: true })({ data: updatedNotification });
@@ -308,7 +393,7 @@ describe('NotificationsCache', () => {
     expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
       data: {
         hasMore: false,
-        filter: {},
+        filter,
         notifications: [],
       },
     });
@@ -341,7 +426,7 @@ describe('NotificationsCache', () => {
       data: {
         hasMore: false,
         filter: filter2,
-        notifications: [updatedNotification, notification2],
+        notifications: [notification2],
       },
     });
   });
@@ -379,7 +464,8 @@ describe('NotificationsCache', () => {
   });
 
   it('should update multiple notifications and emit single event', () => {
-    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const filter = { tags: ['tag1'], read: false, archived: false };
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, ...filter };
     const updatedNotification1 = new Notification(
       { ...notification1, body: 'Updated Notification' },
       mockEmitter,
@@ -392,7 +478,7 @@ describe('NotificationsCache', () => {
     );
     const data: ListNotificationsResponse = {
       hasMore: false,
-      filter: {},
+      filter,
       notifications: [notification1, notification2],
     };
 
@@ -404,14 +490,15 @@ describe('NotificationsCache', () => {
     expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
       data: {
         hasMore: false,
-        filter: {},
+        filter,
         notifications: [updatedNotification1, updatedNotification2],
       },
     });
   });
 
   it('should remove multiple notifications and emit single event', () => {
-    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const filter = { tags: ['tag1'], read: false, archived: false };
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, ...filter };
     const updatedNotification1 = new Notification(
       { ...notification1, body: 'Updated Notification' },
       mockEmitter,
@@ -425,7 +512,7 @@ describe('NotificationsCache', () => {
     const notification3 = new Notification({ ...notification1, id: '3' }, mockEmitter, mockInboxService);
     const data: ListNotificationsResponse = {
       hasMore: false,
-      filter: {},
+      filter,
       notifications: [notification1, notification2, notification3],
     };
 
@@ -437,7 +524,7 @@ describe('NotificationsCache', () => {
     expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
       data: {
         hasMore: false,
-        filter: {},
+        filter,
         notifications: [notification3],
       },
     });
@@ -453,8 +540,13 @@ describe('NotificationsCache', () => {
       mockEmitter,
       mockInboxService
     );
+    const notification2Tag2 = new Notification(
+      { ...notification2, tags: ['tag2'], workflow: { ...notification2.workflow!, tags: ['tag2'] } },
+      mockEmitter,
+      mockInboxService
+    );
     const updatedNotification2 = new Notification(
-      { ...notification2, body: 'Updated Notification' },
+      { ...notification2Tag2, body: 'Updated Notification' },
       mockEmitter,
       mockInboxService
     );
@@ -467,7 +559,7 @@ describe('NotificationsCache', () => {
     notificationsCache.set(args2, {
       hasMore: false,
       filter: filter2,
-      notifications: [notification2],
+      notifications: [notification2Tag2],
     });
     (notificationsCache as any).handleNotificationEvent()({
       data: [updatedNotification1, updatedNotification2],

--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -15,9 +15,14 @@ import type {
   UnreadArgs,
   UnsnoozeArgs,
 } from '../notifications';
-import type { InboxNotification, NotificationFilter, TagsFilter } from '../types';
 import { ensureNotificationInstance } from '../notifications/helpers';
-import { areDataEqual, areTagsEqual, isSameFilter } from '../utils/notification-utils';
+import type { InboxNotification, NotificationFilter, TagsFilter } from '../types';
+import {
+  areDataEqual,
+  areTagsEqual,
+  isSameFilter,
+  notificationMatchesCacheBucket,
+} from '../utils/notification-utils';
 import { InMemoryCache } from './in-memory-cache';
 import type { Cache } from './types';
 
@@ -90,12 +95,16 @@ const updateEvents: NotificationEvents[] = [
   'notification.read.resolved',
   'notification.unread.pending',
   'notification.unread.resolved',
+  'notification.seen.pending',
+  'notification.seen.resolved',
   'notification.complete_action.pending',
   'notification.complete_action.resolved',
   'notification.revert_action.pending',
   'notification.revert_action.resolved',
   'notifications.read_all.pending',
   'notifications.read_all.resolved',
+  'notifications.seen_all.pending',
+  'notifications.seen_all.resolved',
 ];
 
 // these events should remove the notification from the cache
@@ -158,23 +167,32 @@ export class NotificationsCache {
     return notifications.map((notification) => this.#toNotificationInstance(notification));
   };
 
-  private updateNotification = (key: string, data: Notification | InboxNotification): boolean => {
+  private syncNotificationInBucket = (key: string, data: Notification | InboxNotification): boolean => {
+    const notification = this.#toNotificationInstance(data);
     const notificationsResponse = this.#cache.get(key);
     if (!notificationsResponse) {
       return false;
     }
 
-    const index = notificationsResponse.notifications.findIndex((el) => el.id === data.id);
-    if (index === -1) {
-      return false;
+    const bucketFilter = getFilter(key);
+    const matchesFilter = notificationMatchesCacheBucket(notification, bucketFilter);
+    const index = notificationsResponse.notifications.findIndex((el) => el.id === notification.id);
+    const existsInBucket = index !== -1;
+
+    if (matchesFilter && existsInBucket) {
+      const updatedNotifications = [...notificationsResponse.notifications];
+      updatedNotifications[index] = notification;
+
+      this.#cache.set(key, { ...notificationsResponse, notifications: updatedNotifications });
+
+      return true;
     }
 
-    const updatedNotifications = [...notificationsResponse.notifications];
-    updatedNotifications[index] = this.#toNotificationInstance(data);
+    if (!matchesFilter && existsInBucket) {
+      return this.removeNotification(key, notification);
+    }
 
-    this.#cache.set(key, { ...notificationsResponse, notifications: updatedNotifications });
-
-    return true;
+    return false;
   };
 
   private removeNotification = (key: string, data: Notification): boolean => {
@@ -209,15 +227,15 @@ export class NotificationsCache {
       if (data !== undefined && data !== null) {
         if (
           Array.isArray(data) &&
-          data.every((item): item is Notification => typeof item === 'object' && 'id' in item)
+          data.every((item): item is Notification | InboxNotification => typeof item === 'object' && 'id' in item)
         ) {
-          notifications = data;
+          notifications = this.#normalizeNotifications(data);
         } else if (typeof data === 'object' && 'id' in data) {
-          notifications = [data as Notification];
+          notifications = [this.#toNotificationInstance(data as Notification | InboxNotification)];
         }
       } else if (remove && args) {
         if ('notification' in args && args.notification) {
-          notifications = [args.notification];
+          notifications = [this.#toNotificationInstance(args.notification)];
         } else if ('notificationId' in args && args.notificationId) {
           const foundNotifications: Notification[] = [];
           this.#cache.keys().forEach((key) => {
@@ -244,7 +262,7 @@ export class NotificationsCache {
           if (remove) {
             isNotificationFound = this.removeNotification(key, notification);
           } else {
-            isNotificationFound = this.updateNotification(key, notification);
+            isNotificationFound = this.syncNotificationInBucket(key, notification);
           }
 
           if (isNotificationFound) {
@@ -269,22 +287,27 @@ export class NotificationsCache {
       return isSameFilter(parsedFilter, filter);
     });
 
-    return cacheKeys
-      .map((key) => this.#cache.get(key))
-      .reduce<ListNotificationsResponse>(
-        (acc, el) => {
-          if (!el) {
-            return acc;
-          }
+    const uniqueNotifications = new Map<string, Notification>();
+    let hasMore = false;
 
-          return {
-            hasMore: el.hasMore,
-            filter: el.filter,
-            notifications: [...acc.notifications, ...el.notifications],
-          };
-        },
-        { hasMore: false, filter: {}, notifications: [] }
-      );
+    for (const key of cacheKeys) {
+      const cachedResponse = this.#cache.get(key);
+      if (!cachedResponse) {
+        continue;
+      }
+
+      hasMore = hasMore || cachedResponse.hasMore;
+
+      for (const notification of cachedResponse.notifications) {
+        uniqueNotifications.set(notification.id, notification);
+      }
+    }
+
+    return {
+      hasMore,
+      filter,
+      notifications: Array.from(uniqueNotifications.values()),
+    };
   }
 
   get(args: ListNotificationsArgs): ListNotificationsResponse | undefined {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -74,3 +74,4 @@ export {
   isSameFilter,
   normalizeTagGroups,
 } from './utils/notification-utils';
+export { COUNT_MUTATION_RESOLVED_EVENTS } from './notifications/count-invalidation-events';

--- a/packages/js/src/notifications/count-invalidation-events.ts
+++ b/packages/js/src/notifications/count-invalidation-events.ts
@@ -1,0 +1,7 @@
+export const COUNT_MUTATION_RESOLVED_EVENTS = [
+  'notification.read.resolved',
+  'notification.unread.resolved',
+  'notification.seen.resolved',
+  'notifications.read_all.resolved',
+  'notifications.seen_all.resolved',
+] as const;

--- a/packages/js/src/notifications/helpers.ts
+++ b/packages/js/src/notifications/helpers.ts
@@ -4,6 +4,18 @@ import type { NovuEventEmitter } from '../event-emitter';
 import { Action, ActionTypeEnum, InboxNotification, NotificationFilter, Result } from '../types';
 import { NovuError } from '../utils/errors';
 import { Notification } from './notification';
+import type {
+  ArchivedArgs,
+  CompleteArgs,
+  DeletedArgs,
+  ReadArgs,
+  RevertArgs,
+  SeenArgs,
+  SnoozeArgs,
+  UnarchivedArgs,
+  UnreadArgs,
+  UnsnoozeArgs,
+} from './types';
 
 export function ensureNotificationInstance({
   notification,
@@ -24,18 +36,6 @@ export function ensureNotificationInstance({
 
   return new Notification(notification, emitter, inboxService);
 }
-import type {
-  ArchivedArgs,
-  CompleteArgs,
-  DeletedArgs,
-  ReadArgs,
-  RevertArgs,
-  SeenArgs,
-  SnoozeArgs,
-  UnarchivedArgs,
-  UnreadArgs,
-  UnsnoozeArgs,
-} from './types';
 
 export const read = async ({
   emitter,

--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -1,4 +1,5 @@
-import { Accessor, createContext, createEffect, createMemo, createSignal, ParentProps, useContext } from 'solid-js';
+import { Accessor, createContext, createEffect, createMemo, createSignal, onCleanup, ParentProps, useContext } from 'solid-js';
+import { COUNT_MUTATION_RESOLVED_EVENTS } from '../../notifications/count-invalidation-events';
 import { Notification, NotificationFilter, SeverityLevelEnum } from '../../types';
 import { checkNotificationDataFilter, checkNotificationTagFilter } from '../../utils/notification-utils';
 import { getTagsFromTab } from '../helpers';
@@ -32,50 +33,107 @@ export const CountProvider = (props: ParentProps) => {
   });
   const [unreadCounts, setUnreadCounts] = createSignal(new Map<string, number>());
   const [newNotificationCounts, setNewNotificationCounts] = createSignal(new Map<string, number>());
+  let refreshGeneration = 0;
 
-  const updateTabCounts = async () => {
-    if (tabs().length === 0) {
-      return;
-    }
-    const filters = tabs().map((tab) => ({
-      tags: getTagsFromTab(tab),
+  const emptySeverityCounts = (): Record<string, number> => ({
+    [SeverityLevelEnum.HIGH]: 0,
+    [SeverityLevelEnum.MEDIUM]: 0,
+    [SeverityLevelEnum.LOW]: 0,
+    [SeverityLevelEnum.NONE]: 0,
+  });
+
+  const refreshCounts = async () => {
+    const generation = ++refreshGeneration;
+    const novu = novuAccessor();
+    const bellFilters = [
+      SeverityLevelEnum.HIGH,
+      SeverityLevelEnum.MEDIUM,
+      SeverityLevelEnum.LOW,
+      SeverityLevelEnum.NONE,
+    ].map((severity) => ({
       read: false,
       archived: false,
       snoozed: false,
-      data: tab.filter?.data,
-      severity: tab.filter?.severity,
+      severity,
     }));
-    const { data } = await novuAccessor().notifications.count({ filters });
-    if (!data) {
+
+    const currentTabs = tabs();
+    const tabFilters =
+      currentTabs.length > 0
+        ? currentTabs.map((tab) => ({
+            tags: getTagsFromTab(tab),
+            read: false,
+            archived: false,
+            snoozed: false,
+            data: tab.filter?.data,
+            severity: tab.filter?.severity,
+          }))
+        : null;
+
+    const [bellResult, tabResult] = await Promise.all([
+      novu.notifications.count({ filters: bellFilters }),
+      tabFilters ? novu.notifications.count({ filters: tabFilters }) : Promise.resolve(null),
+    ]);
+
+    if (generation !== refreshGeneration) {
       return;
     }
 
-    const newMap = new Map();
-    const { counts } = data;
-    for (let i = 0; i < counts.length; i += 1) {
-      const tagsKey = createKey({
-        tags: counts[i].filter.tags,
-        data: counts[i].filter.data,
-        severity: counts[i].filter.severity,
-      });
-      newMap.set(tagsKey, data?.counts[i].count);
+    if (bellResult.data) {
+      const severity = emptySeverityCounts();
+      let total = 0;
+
+      for (const item of bellResult.data.counts) {
+        const filterSeverity = item.filter.severity;
+        const severityKey = Array.isArray(filterSeverity) ? filterSeverity[0] : filterSeverity;
+
+        if (severityKey && severityKey in severity) {
+          severity[severityKey] = item.count;
+          total += item.count;
+        }
+      }
+
+      setUnreadCount({ total, severity });
     }
 
-    setUnreadCounts(newMap);
+    if (tabResult?.data) {
+      const newMap = new Map<string, number>();
+
+      for (let i = 0; i < tabResult.data.counts.length; i += 1) {
+        const countItem = tabResult.data.counts[i];
+        const tagsKey = createKey({
+          tags: countItem.filter.tags,
+          data: countItem.filter.data,
+          severity: countItem.filter.severity,
+        });
+        newMap.set(tagsKey, countItem.count);
+      }
+
+      setUnreadCounts(newMap);
+    }
   };
 
   createEffect(() => {
     // read the novu instance to trigger the effect
     novuAccessor();
-    updateTabCounts();
+    refreshCounts();
   });
 
   useWebSocketEvent({
     event: 'notifications.unread_count_changed',
     eventHandler: (data) => {
       setUnreadCount(data.result);
-      updateTabCounts();
+      refreshCounts();
     },
+  });
+
+  createEffect(() => {
+    const novu = novuAccessor();
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, refreshCounts));
+
+    onCleanup(() => {
+      cleanups.forEach((cleanup) => cleanup());
+    });
   });
 
   useNovuEvent({
@@ -189,7 +247,7 @@ export const CountProvider = (props: ParentProps) => {
 
   useWebSocketEvent({
     event: 'notifications.notification_received',
-    eventHandler: updateTabCounts,
+    eventHandler: refreshCounts,
   });
 
   const resetNewNotificationCounts = (key: string) => {

--- a/packages/js/src/utils/notification-utils.test.ts
+++ b/packages/js/src/utils/notification-utils.test.ts
@@ -3,7 +3,9 @@ import {
   checkNotificationDataFilter,
   checkNotificationTagFilter,
   normalizeTagGroups,
+  notificationMatchesCacheBucket,
 } from './notification-utils';
+import { Notification } from '../notifications/notification';
 
 describe('normalizeTagGroups', () => {
   it('wraps flat tags as one OR-group', () => {
@@ -125,5 +127,30 @@ describe('areTagsEqual', () => {
         }
       )
     ).toBe(true);
+  });
+});
+
+describe('notificationMatchesCacheBucket', () => {
+  const baseNotification = {
+    isRead: false,
+    isSeen: false,
+    isArchived: false,
+    isSnoozed: false,
+    tags: ['tag1'],
+    createdAt: new Date().toISOString(),
+  } as Notification;
+
+  it('returns false when read status no longer matches the bucket filter', () => {
+    const readNotification = { ...baseNotification, isRead: true } as Notification;
+
+    expect(notificationMatchesCacheBucket(readNotification, { read: false })).toBe(false);
+  });
+
+  it('returns false when tags no longer match the bucket filter', () => {
+    expect(notificationMatchesCacheBucket(baseNotification, { tags: ['tag2'] })).toBe(false);
+  });
+
+  it('returns true when status and tags still match the bucket filter', () => {
+    expect(notificationMatchesCacheBucket(baseNotification, { read: false, tags: ['tag1'] })).toBe(true);
   });
 });

--- a/packages/js/src/utils/notification-utils.ts
+++ b/packages/js/src/utils/notification-utils.ts
@@ -494,3 +494,17 @@ export function checkNotificationMatchesFilter(notification: Notification, filte
     checkNotificationTimeframeFilter(notification.createdAt, filter.createdGte, filter.createdLte)
   );
 }
+
+/**
+ * Whether a notification still belongs in a notifications-cache bucket after a local mutation.
+ * Status fields (read/seen/archived/snoozed) and tags can change membership; data and timeframe
+ * are stable for in-flight mutations and are validated when the bucket is populated from the API.
+ */
+export function notificationMatchesCacheBucket(
+  notification: Notification,
+  filter: NotificationFilter
+): boolean {
+  return (
+    checkBasicFilters(notification, filter) && checkNotificationTagFilter(notification.tags, filter.tags)
+  );
+}

--- a/packages/react/src/hooks/useCounts.ts
+++ b/packages/react/src/hooks/useCounts.ts
@@ -1,5 +1,5 @@
-import { areTagsEqual, isSameFilter, Notification, NotificationFilter, NovuError } from '@novu/js';
-import { useEffect, useState } from 'react';
+import { COUNT_MUTATION_RESOLVED_EVENTS, checkNotificationMatchesFilter, isSameFilter, Notification, NotificationFilter, NovuError } from '@novu/js';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useWebSocketEvent } from './internal/useWebsocketEvent';
 import { useNovu, useRealtime } from './NovuProvider';
@@ -64,69 +64,77 @@ export type UseCountsResult = {
 
 export const useCounts = (props: UseCountsProps): UseCountsResult => {
   const { filters, realtime: propsRealtime, onSuccess, onError } = props;
-  const { notifications } = useNovu();
+  const novu = useNovu();
+  const { notifications } = novu;
   const providerRealtime = useRealtime();
   const realtime = propsRealtime ?? providerRealtime;
   const filtersRef = useDataRef<NotificationFilter[]>(filters);
+  const onSuccessRef = useDataRef(onSuccess);
+  const onErrorRef = useDataRef(onError);
+  const syncGenerationRef = useRef(0);
   const [error, setError] = useState<NovuError>();
   const [counts, setCounts] = useState<Count[]>();
   const [isLoading, setIsLoading] = useState(true);
   const [isFetching, setIsFetching] = useState(false);
 
-  const sync = async (notification?: Notification, overrideFilters?: NotificationFilter[]) => {
-    const currentFilters = overrideFilters || filtersRef.current;
-    const existingCounts = currentFilters.map((filter) => ({ count: 0, filter }));
-    let countFiltersToFetch: NotificationFilter[] = [];
-    if (notification) {
-      for (let i = 0; i < existingCounts.length; i++) {
-        const filter = currentFilters[i];
-        const isSeverityMatches =
-          !filter.severity ||
-          (Array.isArray(filter.severity) && filter.severity.length === 0) ||
-          (Array.isArray(filter.severity) && filter.severity.includes(notification.severity)) ||
-          (!Array.isArray(filter.severity) && filter.severity === notification.severity);
+  const sync = useCallback(
+    async (notification?: Notification, overrideFilters?: NotificationFilter[]) => {
+      const currentFilters = overrideFilters || filtersRef.current;
+      const existingCounts = currentFilters.map((filter) => ({ count: 0, filter }));
+      let countFiltersToFetch: NotificationFilter[] = [];
 
-        if (areTagsEqual(filter.tags, notification.tags) && isSeverityMatches) {
-          countFiltersToFetch.push(filter);
-        }
-      }
-    } else {
-      countFiltersToFetch = currentFilters;
-    }
-
-    if (countFiltersToFetch.length === 0) {
-      return;
-    }
-
-    setIsFetching(true);
-    const countsRes = await notifications.count({ filters: countFiltersToFetch });
-    setIsFetching(false);
-    setIsLoading(false);
-    if (countsRes.error) {
-      setError(countsRes.error);
-      onError?.(countsRes.error);
-
-      return;
-    }
-    const data = countsRes.data!;
-    onSuccess?.(data.counts);
-
-    setCounts((oldCounts) => {
-      const newCounts: Count[] = [];
-      const countsReceived = data.counts;
-
-      for (let i = 0; i < existingCounts.length; i++) {
-        const existingFilter = existingCounts[i].filter;
-        const countReceived = countsReceived.find((c) => isSameFilter(c.filter, existingFilter));
-        const count = countReceived || oldCounts?.[i];
-        if (count) {
-          newCounts.push(count);
-        }
+      if (notification) {
+        countFiltersToFetch = currentFilters.filter((filter) =>
+          checkNotificationMatchesFilter(notification, filter)
+        );
+      } else {
+        countFiltersToFetch = currentFilters;
       }
 
-      return newCounts;
-    });
-  };
+      if (countFiltersToFetch.length === 0) {
+        return;
+      }
+
+      const generation = ++syncGenerationRef.current;
+      setIsFetching(true);
+
+      const countsRes = await notifications.count({ filters: countFiltersToFetch });
+
+      if (generation !== syncGenerationRef.current) {
+        return;
+      }
+
+      setIsFetching(false);
+      setIsLoading(false);
+
+      if (countsRes.error) {
+        setError(countsRes.error);
+        onErrorRef.current?.(countsRes.error);
+
+        return;
+      }
+
+      const data = countsRes.data!;
+      onSuccessRef.current?.(data.counts);
+
+      setCounts((oldCounts) => {
+        const newCounts: Count[] = [];
+        const countsReceived = data.counts;
+
+        for (let i = 0; i < existingCounts.length; i++) {
+          const existingFilter = existingCounts[i].filter;
+          const countReceived = countsReceived.find((c) => isSameFilter(c.filter, existingFilter));
+          const count = countReceived || oldCounts?.[i];
+          if (count) {
+            newCounts.push(count);
+          }
+        }
+
+        return newCounts;
+      });
+    },
+    [notifications, filtersRef, onErrorRef, onSuccessRef]
+  );
 
   useWebSocketEvent({
     event: 'notifications.notification_received',
@@ -145,15 +153,23 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
   });
 
   useEffect(() => {
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, () => sync()));
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
+  }, [novu, sync]);
+
+  useEffect(() => {
     setError(undefined);
     setIsLoading(true);
     setIsFetching(false);
     sync(undefined, filters);
-  }, [JSON.stringify(filters)]);
+  }, [JSON.stringify(filters), sync]);
 
-  const refetch = async () => {
+  const refetch = useCallback(async () => {
     await sync();
-  };
+  }, [sync]);
 
   return { counts, error, refetch, isLoading, isFetching };
 };


### PR DESCRIPTION
Test PR - closing immediately

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates notification cache and count refresh behavior. The main changes are:

- Removes notifications from cached buckets when read or seen status no longer matches the active filter.
- Deduplicates aggregated cached notification lists across matching cache keys.
- Adds shared count mutation resolved events for JS, Solid, and React count consumers.
- Refreshes count data after notification mutations and ignores stale count responses.
- Expands tests for cache filtering, bucket membership, and deduplication.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are focused on cache and count synchronization, and the key cache edge cases are covered by tests. No correctness or security issues were identified in the reviewed changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A Jest rerun for novu-js-notification-cache started at 2026-07-24T09:51:47+00:00 and finished at 2026-07-24T09:51:51+00:00, exited with code 0, and reported 2 passed test suites and 40 passed tests.

<a href="https://app.greptile.com/trex/runs/15721111/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/cache/notifications-cache.ts | Updates cache synchronization to normalize event payloads, remove notifications that no longer match a cache bucket, and aggregate deduplicated notification lists by filter. |
| packages/js/src/notifications/count-invalidation-events.ts | Defines the resolved notification mutation events that should trigger count invalidation across clients. |
| packages/js/src/ui/context/CountContext.tsx | Refactors Solid count refreshes to fetch bell and tab counts together, ignore stale responses, and refresh on mutation completion events. |
| packages/js/src/utils/notification-utils.ts | Adds a cache-bucket membership helper using status and tag filters for local notification cache synchronization. |
| packages/react/src/hooks/useCounts.ts | Refactors the React counts hook to use stable callbacks, suppress stale count responses, and refetch on shared mutation completion events. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant User as Notification mutation
participant Emitter as Novu event emitter
participant Cache as NotificationsCache
participant Counts as Count consumers
participant API as notifications.count API

User->>Emitter: read/seen mutation resolved event
Emitter->>Cache: syncNotificationInBucket(notification)
Cache->>Cache: remove/update cached bucket membership
Cache->>Emitter: notifications.list.updated
Emitter->>Counts: COUNT_MUTATION_RESOLVED_EVENTS listener
Counts->>API: "count({ filters })"
API-->>Counts: refreshed counts
```

<sub>Reviews (1): Last reviewed commit: ["fix: inbox badge sync across cache bucke..."](https://github.com/novuhq/novu/commit/719996c1959eed1b3c219ae7a3dbf675055e3640) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46952122)</sub>

<!-- /greptile_comment -->