### PR TITLE
fix(inbox): sync badge count across browser tabs

### DIFF
--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -20,9 +20,8 @@ import type { InboxNotification, NotificationFilter, TagsFilter } from '../types
 import {
   areDataEqual,
   areTagsEqual,
-  checkBasicFilters,
-  checkNotificationTagFilter,
   isSameFilter,
+  notificationMatchesCacheBucket,
 } from '../utils/notification-utils';
 import { InMemoryCache } from './in-memory-cache';
 import type { Cache } from './types';
@@ -176,8 +175,7 @@ export class NotificationsCache {
     }
 
     const bucketFilter = getFilter(key);
-    const matchesFilter =
-      checkBasicFilters(notification, bucketFilter) && checkNotificationTagFilter(notification.tags, bucketFilter.tags);
+    const matchesFilter = notificationMatchesCacheBucket(notification, bucketFilter);
     const index = notificationsResponse.notifications.findIndex((el) => el.id === notification.id);
     const existsInBucket = index !== -1;
 
@@ -298,7 +296,7 @@ export class NotificationsCache {
         continue;
       }
 
-      hasMore = cachedResponse.hasMore;
+      hasMore = hasMore || cachedResponse.hasMore;
 
       for (const notification of cachedResponse.notifications) {
         uniqueNotifications.set(notification.id, notification);
@@ -337,11 +335,9 @@ export class NotificationsCache {
 
     const notificationInstance = this.#toNotificationInstance({ ...notification });
 
-    const dedupedNotifications = cachedData.notifications.filter((n) => n.id !== notification.id);
-
     this.update(args, {
       ...cachedData,
-      notifications: [notificationInstance, ...dedupedNotifications],
+      notifications: [notificationInstance, ...cachedData.notifications],
     });
   }
 

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -84,3 +84,4 @@ export {
   isSameFilter,
   normalizeTagGroups,
 } from './utils/notification-utils';
+export { COUNT_MUTATION_RESOLVED_EVENTS } from './notifications/count-invalidation-events';

--- a/packages/js/src/notifications/count-invalidation-events.ts
+++ b/packages/js/src/notifications/count-invalidation-events.ts
@@ -1,0 +1,7 @@
+export const COUNT_MUTATION_RESOLVED_EVENTS = [
+  'notification.read.resolved',
+  'notification.unread.resolved',
+  'notification.seen.resolved',
+  'notifications.read_all.resolved',
+  'notifications.seen_all.resolved',
+] as const;

--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -1,16 +1,7 @@
-import {
-  Accessor,
-  createContext,
-  createEffect,
-  createMemo,
-  createSignal,
-  onCleanup,
-  ParentProps,
-  useContext,
-} from 'solid-js';
-import { NOTIFICATION_COUNT_SYNC_EVENTS } from '../../notifications/count-sync-events';
+import { Accessor, createContext, createEffect, createMemo, createSignal, onCleanup, ParentProps, useContext } from 'solid-js';
+import { COUNT_MUTATION_RESOLVED_EVENTS } from '../../notifications/count-invalidation-events';
 import { Notification, NotificationFilter, SeverityLevelEnum } from '../../types';
-import { checkNotificationMatchesFilter } from '../../utils/notification-utils';
+import { checkNotificationDataFilter, checkNotificationTagFilter } from '../../utils/notification-utils';
 import { getTagsFromTab } from '../helpers';
 import { useNovuEvent } from '../helpers/useNovuEvent';
 import { useWebSocketEvent } from '../helpers/useWebSocketEvent';
@@ -138,17 +129,11 @@ export const CountProvider = (props: ParentProps) => {
 
   createEffect(() => {
     const novu = novuAccessor();
-    const cleanups = NOTIFICATION_COUNT_SYNC_EVENTS.map((event) =>
-      novu.on(event, (payload) => {
-        if ('error' in payload && payload.error) {
-          return;
-        }
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, refreshCounts));
 
-        refreshCounts();
-      })
-    );
-
-    onCleanup(() => cleanups.forEach((cleanup) => cleanup()));
+    onCleanup(() => {
+      cleanups.forEach((cleanup) => cleanup());
+    });
   });
 
   useNovuEvent({
@@ -222,42 +207,47 @@ export const CountProvider = (props: ParentProps) => {
       if (currentTabs.length > 0) {
         for (const tab of currentTabs) {
           const tabTags = getTagsFromTab(tab);
-          const tabFilter: NotificationFilter = {
-            tags: tabTags,
-            read: false,
-            archived: false,
-            snoozed: false,
-            data: tab.filter?.data,
-            severity: tab.filter?.severity,
-          };
+          const tabDataFilterCriteria = tab.filter?.data;
+          const tabSeverityFilterCriteria = tab.filter?.severity;
 
-          if (!checkNotificationMatchesFilter(notification, tabFilter)) {
-            continue;
-          }
+          const matchesTagFilter = checkNotificationTagFilter(notification.tags, tabTags);
+          const matchesDataFilterCriteria = checkNotificationDataFilter(notification.data, tabDataFilterCriteria);
 
-          const filterKey = createKey({
-            tags: tabTags,
-            data: tab.filter?.data,
-            severity: tab.filter?.severity,
-          });
+          const matchesSeverityFilterCriteria =
+            !tabSeverityFilterCriteria ||
+            (Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria.length === 0) ||
+            (Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria.includes(notification.severity)) ||
+            (!Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria === notification.severity);
 
-          if (!processedFilters.has(filterKey)) {
-            processedFilters.add(filterKey);
-            updateNewNotificationCountsOrCache(
-              tab.label,
-              notification,
-              tabTags,
-              tab.filter?.data,
-              tab.filter?.severity
-            );
+          if (matchesTagFilter && matchesDataFilterCriteria && matchesSeverityFilterCriteria) {
+            const filterKey = createKey({
+              tags: tabTags,
+              data: tabDataFilterCriteria,
+              severity: tabSeverityFilterCriteria,
+            });
+
+            if (!processedFilters.has(filterKey)) {
+              processedFilters.add(filterKey);
+              updateNewNotificationCountsOrCache(
+                tab.label,
+                notification,
+                tabTags,
+                tabDataFilterCriteria,
+                tabSeverityFilterCriteria
+              );
+            }
           }
         }
       } else {
+        // No tabs are defined. Apply to default (no tags, no data) filter.
         updateNewNotificationCountsOrCache('', notification, [], undefined, undefined);
       }
-
-      await refreshCounts();
     },
+  });
+
+  useWebSocketEvent({
+    event: 'notifications.notification_received',
+    eventHandler: refreshCounts,
   });
 
   const resetNewNotificationCounts = (key: string) => {

--- a/packages/js/src/utils/notification-utils.test.ts
+++ b/packages/js/src/utils/notification-utils.test.ts
@@ -1,11 +1,11 @@
-import { Notification } from '../notifications/notification';
 import {
   areTagsEqual,
-  checkBasicFilters,
   checkNotificationDataFilter,
   checkNotificationTagFilter,
   normalizeTagGroups,
+  notificationMatchesCacheBucket,
 } from './notification-utils';
+import { Notification } from '../notifications/notification';
 
 describe('normalizeTagGroups', () => {
   it('wraps flat tags as one OR-group', () => {
@@ -130,7 +130,7 @@ describe('areTagsEqual', () => {
   });
 });
 
-describe('cache bucket membership', () => {
+describe('notificationMatchesCacheBucket', () => {
   const baseNotification = {
     isRead: false,
     isSeen: false,
@@ -140,21 +140,17 @@ describe('cache bucket membership', () => {
     createdAt: new Date().toISOString(),
   } as Notification;
 
-  function matchesCacheBucket(notification: Notification, filter: { read?: boolean; tags?: string[] }) {
-    return checkBasicFilters(notification, filter) && checkNotificationTagFilter(notification.tags, filter.tags);
-  }
-
   it('returns false when read status no longer matches the bucket filter', () => {
     const readNotification = { ...baseNotification, isRead: true } as Notification;
 
-    expect(matchesCacheBucket(readNotification, { read: false })).toBe(false);
+    expect(notificationMatchesCacheBucket(readNotification, { read: false })).toBe(false);
   });
 
   it('returns false when tags no longer match the bucket filter', () => {
-    expect(matchesCacheBucket(baseNotification, { tags: ['tag2'] })).toBe(false);
+    expect(notificationMatchesCacheBucket(baseNotification, { tags: ['tag2'] })).toBe(false);
   });
 
   it('returns true when status and tags still match the bucket filter', () => {
-    expect(matchesCacheBucket(baseNotification, { read: false, tags: ['tag1'] })).toBe(true);
+    expect(notificationMatchesCacheBucket(baseNotification, { read: false, tags: ['tag1'] })).toBe(true);
   });
 });

--- a/packages/js/src/utils/notification-utils.ts
+++ b/packages/js/src/utils/notification-utils.ts
@@ -494,3 +494,17 @@ export function checkNotificationMatchesFilter(notification: Notification, filte
     checkNotificationTimeframeFilter(notification.createdAt, filter.createdGte, filter.createdLte)
   );
 }
+
+/**
+ * Whether a notification still belongs in a notifications-cache bucket after a local mutation.
+ * Status fields (read/seen/archived/snoozed) and tags can change membership; data and timeframe
+ * are stable for in-flight mutations and are validated when the bucket is populated from the API.
+ */
+export function notificationMatchesCacheBucket(
+  notification: Notification,
+  filter: NotificationFilter
+): boolean {
+  return (
+    checkBasicFilters(notification, filter) && checkNotificationTagFilter(notification.tags, filter.tags)
+  );
+}

--- a/packages/react/src/hooks/useCounts.ts
+++ b/packages/react/src/hooks/useCounts.ts
@@ -1,11 +1,4 @@
-import {
-  checkNotificationMatchesFilter,
-  isSameFilter,
-  NOTIFICATION_COUNT_SYNC_EVENTS,
-  Notification,
-  NotificationFilter,
-  NovuError,
-} from '@novu/js';
+import { COUNT_MUTATION_RESOLVED_EVENTS, checkNotificationMatchesFilter, isSameFilter, Notification, NotificationFilter, NovuError } from '@novu/js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useWebSocketEvent } from './internal/useWebsocketEvent';
@@ -91,7 +84,9 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
       let countFiltersToFetch: NotificationFilter[] = [];
 
       if (notification) {
-        countFiltersToFetch = currentFilters.filter((filter) => checkNotificationMatchesFilter(notification, filter));
+        countFiltersToFetch = currentFilters.filter((filter) =>
+          checkNotificationMatchesFilter(notification, filter)
+        );
       } else {
         countFiltersToFetch = currentFilters;
       }
@@ -158,17 +153,11 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
   });
 
   useEffect(() => {
-    const cleanups = NOTIFICATION_COUNT_SYNC_EVENTS.map((event) =>
-      novu.on(event, (payload) => {
-        if ('error' in payload && payload.error) {
-          return;
-        }
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, () => sync()));
 
-        sync();
-      })
-    );
-
-    return () => cleanups.forEach((cleanup) => cleanup());
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
   }, [novu, sync]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes inbox badge synchronization issue where badge counts become stale across browser tabs.\n\n- Adds cache bucket synchronization for badge state\n- Updates count hooks to use shared cache\n- Deduplicates badge update logic

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates inbox badge count syncing across browser tabs. The main changes are:

- Adds a shared count mutation event list for JS and React count hooks.
- Refreshes Solid and React count state after resolved notification mutations.
- Refactors cache bucket matching into `notificationMatchesCacheBucket`.
- Updates notification cache aggregation and related utility tests.

<h3>Confidence Score: 4/5</h3>

One count invalidation bug should be fixed before merging.

Archive, snooze, and delete mutations can leave badge counts stale across tabs because their resolved events no longer trigger count refreshes. The rest of the changes are localized and mostly reuse existing cache and filter helpers.

`packages/js/src/notifications/count-invalidation-events.ts`, `packages/js/src/ui/context/CountContext.tsx`, `packages/react/src/hooks/useCounts.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified that archive mutations stop syncing by running a Node harness over COUNT\_MUTATION\_RESOLVED\_EVENTS and observing that notification.read.resolved, notification.unread.resolved, and notification.seen.resolved increment refreshCalls, while notification.archive.resolved, notification.snooze.resolved, and notification.delete.resolved do not.
- Documented pre- and post-invalidation state showing the cache and badge behavior: before, the list cache shows unread 0 while the badge count remains stale; after, the subscribed consumer sees read/unread resolved events and two invalidation calls with read-resolved badge count 0.
- Captured the full command outputs including the Jest harness run and test results, confirming the harness passed and the notification utility tests were passing.
- Created and attached artifacts that document the reproductions, including the harness artifact and the before/after logs plus related combined outputs.

<a href="https://app.greptile.com/trex/runs/15730303/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/notifications/count-invalidation-events.ts | Introduces shared count invalidation events but omits archive/snooze/delete resolved mutations that affect existing count filters. |
| packages/js/src/ui/context/CountContext.tsx | Moves count refreshes to the shared event list and splits notification-received count refresh from cache updates. |
| packages/react/src/hooks/useCounts.ts | Switches React count syncing to the shared mutation event list. |
| packages/js/src/cache/notifications-cache.ts | Refactors bucket membership checks, aggregates `hasMore` across buckets, and changes `unshift` behavior. |
| packages/js/src/utils/notification-utils.ts | Adds `notificationMatchesCacheBucket` as a narrower helper for cache bucket mutation membership. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant TabA as Browser Tab A
participant Emitter as Novu event emitter
participant Cache as Notifications cache
participant CountJS as Solid CountProvider
participant CountReact as React useCounts
participant API as notifications.count API
TabA->>Emitter: notification mutation resolved
Emitter->>Cache: update cached notification buckets
Emitter->>CountJS: COUNT_MUTATION_RESOLVED_EVENTS
Emitter->>CountReact: COUNT_MUTATION_RESOLVED_EVENTS
CountJS->>API: refreshCounts()
CountReact->>API: sync()
API-->>CountJS: updated badge counts
API-->>CountReact: updated badge counts
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fjs%2Fsrc%2Fnotifications%2Fcount-invalidation-events.ts%3A1-7%0A**Archive%20mutations%20stop%20syncing**%0A%60COUNT_MUTATION_RESOLVED_EVENTS%60%20drops%20the%20archive%2Fsnooze%2Fdelete%20resolved%20events%20that%20%60NOTIFICATION_COUNT_SYNC_EVENTS%60%20handled.%20When%20an%20unread%20notification%20is%20archived%20in%20one%20tab%2C%20the%20other%20tab%20no%20longer%20runs%20%60refreshCounts%28%29%60%20or%20%60sync%28%29%60%2C%20so%20filters%20like%20%60%7B%20read%3A%20false%2C%20archived%3A%20false%2C%20snoozed%3A%20false%20%7D%60%20keep%20showing%20a%20stale%20badge%20until%20another%20event%20or%20manual%20refetch.%0A%0A&pr=12082&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/js/src/notifications/count-invalidation-events.ts:1-7
**Archive mutations stop syncing**
`COUNT_MUTATION_RESOLVED_EVENTS` drops the archive/snooze/delete resolved events that `NOTIFICATION_COUNT_SYNC_EVENTS` handled. When an unread notification is archived in one tab, the other tab no longer runs `refreshCounts()` or `sync()`, so filters like `{ read: false, archived: false, snoozed: false }` keep showing a stale badge until another event or manual refetch.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: inbox badge sync across cache bucke..."](https://github.com/novuhq/novu/commit/d23fee7961bd4bfcc48464779d59dc1f19155bb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46952742)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->