### PR TITLE
feat(providers): support Twilio SMS data residency region selection fixes NV-8392

### DIFF
--- a/docs/platform/integrations/sms/twilio.mdx
+++ b/docs/platform/integrations/sms/twilio.mdx
@@ -58,7 +58,37 @@ For more detailed instructions, follow one of their many [Tutorials](https://www
    - `Account SID`
    - `Auth Token`
    - `Twilio Phone Number`
+   - `Data residency region` (optional) — leave as **US (default)** unless your Twilio account uses EU data residency
 3. Click on the **Save** button
+</Step>
+</Steps>
+
+## Multi-region data residency
+
+Twilio supports processing and storing SMS data in specific regions. Novu lets you choose the API region when connecting your Twilio integration.
+
+| Region | Twilio region | When to use |
+| --- | --- | --- |
+| US (default) | US1 | Existing Twilio accounts and US-based data residency |
+| EU (Ireland) | IE1 | EU data residency for SMS (phone numbers, message bodies, and related personal data processed in Ireland) |
+
+<Note>
+  EU data residency requires **IE1-specific credentials** from the Twilio Console and senders configured for the IE1 region. See Twilio's [Messaging API with Twilio Regions](https://www.twilio.com/docs/global-infrastructure/messaging-api-with-twilio-regions) guide for setup details.
+</Note>
+
+### Configure EU data residency
+
+<Steps>
+<Step title="Create IE1 API credentials">
+In the Twilio Console, create API credentials for the **IE1** region. Use those credentials in your Novu Twilio integration instead of your US credentials.
+</Step>
+
+<Step title="Configure senders for IE1">
+If you send with phone numbers, set each number's active messaging region to **IE1** in the Twilio Console under **Numbers & Senders**.
+</Step>
+
+<Step title="Select EU in Novu">
+When connecting or updating your Twilio integration in Novu, set **Data residency region** to **EU (Ireland)** and save your IE1 credentials.
 </Step>
 </Steps>
 

--- a/libs/application-generic/src/factories/sms/handlers/twilio.handler.ts
+++ b/libs/application-generic/src/factories/sms/handlers/twilio.handler.ts
@@ -11,6 +11,7 @@ export class TwilioHandler extends BaseSmsHandler {
       accountSid: credentials.accountSid,
       authToken: credentials.token,
       from: credentials.from,
+      region: credentials.region,
     });
   }
 }

--- a/packages/providers/src/lib/sms/twilio/twilio.provider.spec.ts
+++ b/packages/providers/src/lib/sms/twilio/twilio.provider.spec.ts
@@ -1,16 +1,43 @@
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const { twilioCreateMock, twilioConstructorMock } = vi.hoisted(() => {
+  const createMock = vi.fn().mockResolvedValue({
+    sid: 'SM123',
+    dateCreated: new Date(),
+  });
+
+  const constructorMock = vi.fn();
+
+  return {
+    twilioCreateMock: createMock,
+    twilioConstructorMock: constructorMock,
+  };
+});
+
+vi.mock('twilio', () => ({
+  Twilio: class {
+    messages = {
+      create: twilioCreateMock,
+    };
+
+    constructor(accountSid: string, authToken: string, regionConfig?: unknown) {
+      twilioConstructorMock(accountSid, authToken, regionConfig);
+    }
+  },
+}));
+
 import { TwilioSmsProvider } from './twilio.provider';
+
+beforeEach(() => {
+  twilioConstructorMock.mockClear();
+  twilioCreateMock.mockClear();
+});
 
 test('should trigger Twilio correctly', async () => {
   const provider = new TwilioSmsProvider({
     accountSid: 'AC<twilio-account-Sid>',
     authToken: '<twilio-auth-Token>',
     from: '+112345',
-  });
-  const spy = vi.spyOn((provider as any).twilioClient.messages, 'create').mockImplementation(async () => {
-    return {
-      dateCreated: new Date(),
-    };
   });
 
   await provider.sendMessage(
@@ -23,8 +50,8 @@ test('should trigger Twilio correctly', async () => {
     }
   );
 
-  expect(spy).toHaveBeenCalled();
-  expect(spy).toHaveBeenCalledWith({
+  expect(twilioConstructorMock).toHaveBeenCalledWith('AC<twilio-account-Sid>', '<twilio-auth-Token>', undefined);
+  expect(twilioCreateMock).toHaveBeenCalledWith({
     from: '+112345',
     body: 'SMS Content',
     to: '+176543',
@@ -37,11 +64,6 @@ test('should trigger Twilio correctly with _passthrough', async () => {
     accountSid: 'AC<twilio-account-Sid>',
     authToken: '<twilio-auth-Token>',
     from: '+112345',
-  });
-  const spy = vi.spyOn((provider as any).twilioClient.messages, 'create').mockImplementation(async () => {
-    return {
-      dateCreated: new Date(),
-    };
   });
 
   await provider.sendMessage(
@@ -59,11 +81,35 @@ test('should trigger Twilio correctly with _passthrough', async () => {
     }
   );
 
-  expect(spy).toHaveBeenCalled();
-  expect(spy).toHaveBeenCalledWith({
+  expect(twilioCreateMock).toHaveBeenCalledWith({
     from: '+112345',
     body: 'SMS Content _passthrough',
     to: '+176543',
     applicationSid: 'test',
   });
+});
+
+test('should initialize Twilio client with EU region config', () => {
+  new TwilioSmsProvider({
+    accountSid: 'AC<twilio-account-Sid>',
+    authToken: '<twilio-auth-Token>',
+    from: '+112345',
+    region: 'eu',
+  });
+
+  expect(twilioConstructorMock).toHaveBeenCalledWith('AC<twilio-account-Sid>', '<twilio-auth-Token>', {
+    edge: 'dublin',
+    region: 'ie1',
+  });
+});
+
+test('should initialize Twilio client without region config for US', () => {
+  new TwilioSmsProvider({
+    accountSid: 'AC<twilio-account-Sid>',
+    authToken: '<twilio-auth-Token>',
+    from: '+112345',
+    region: 'us',
+  });
+
+  expect(twilioConstructorMock).toHaveBeenCalledWith('AC<twilio-account-Sid>', '<twilio-auth-Token>', undefined);
 });

--- a/packages/providers/src/lib/sms/twilio/twilio.provider.ts
+++ b/packages/providers/src/lib/sms/twilio/twilio.provider.ts
@@ -1,4 +1,4 @@
-import { SmsProviderIdEnum } from '@novu/shared';
+import { getTwilioSmsClientRegionConfig, SmsProviderIdEnum } from '@novu/shared';
 import {
   ChannelTypeEnum,
   ISendMessageSuccessResponse,
@@ -24,10 +24,13 @@ export class TwilioSmsProvider extends BaseProvider implements ISmsProvider {
       accountSid?: string;
       authToken?: string;
       from?: string;
+      region?: string;
     }
   ) {
     super();
-    this.twilioClient = new Twilio(config.accountSid, config.authToken);
+    const regionConfig = getTwilioSmsClientRegionConfig(config.region);
+
+    this.twilioClient = new Twilio(config.accountSid, config.authToken, regionConfig);
   }
 
   async sendMessage(

--- a/packages/shared/src/consts/index.ts
+++ b/packages/shared/src/consts/index.ts
@@ -15,6 +15,7 @@ export * from './providers';
 export * from './rate-limiting';
 export * from './severity';
 export * from './sinch-sms-regions';
+export * from './twilio-sms-regions';
 export * from './slack-agent-manifest';
 export * from './slack-agent-oauth-scopes';
 export * from './slack-agent-welcome-suggested-prompts';

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -491,6 +491,18 @@ export const twilioConfig: IConfigCredential[] = [
     type: 'string',
     required: true,
   },
+  {
+    key: CredentialsKeyEnum.Region,
+    displayName: 'Data residency region',
+    description: 'Select EU if your Twilio account uses EU data residency (IE1). Use region-specific credentials.',
+    type: 'dropdown',
+    required: false,
+    value: 'us',
+    dropdown: [
+      { name: 'US (default)', value: 'us' },
+      { name: 'EU (Ireland)', value: 'eu' },
+    ],
+  },
   ...smsConfigBase,
 ];
 

--- a/packages/shared/src/consts/twilio-sms-regions.spec.ts
+++ b/packages/shared/src/consts/twilio-sms-regions.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { assertAllowedTwilioSmsRegion, getTwilioSmsClientRegionConfig } from '../consts/twilio-sms-regions';
+
+describe('twilio-sms-regions', () => {
+  it('should default to us when region is undefined', () => {
+    expect(assertAllowedTwilioSmsRegion(undefined)).toBe('us');
+    expect(getTwilioSmsClientRegionConfig(undefined)).toBeUndefined();
+  });
+
+  it('should normalize region casing', () => {
+    expect(assertAllowedTwilioSmsRegion('EU')).toBe('eu');
+    expect(getTwilioSmsClientRegionConfig('EU')).toEqual({
+      edge: 'dublin',
+      region: 'ie1',
+    });
+  });
+
+  it('should reject invalid regions', () => {
+    expect(() => assertAllowedTwilioSmsRegion('evil.com#@twilio.com')).toThrow(/Invalid Twilio SMS region/);
+    expect(() => assertAllowedTwilioSmsRegion('ie1')).toThrow(/Invalid Twilio SMS region/);
+  });
+});

--- a/packages/shared/src/consts/twilio-sms-regions.ts
+++ b/packages/shared/src/consts/twilio-sms-regions.ts
@@ -1,0 +1,39 @@
+export const TWILIO_SMS_REGIONS = ['us', 'eu'] as const;
+
+export type TwilioSmsRegion = (typeof TWILIO_SMS_REGIONS)[number];
+
+const TWILIO_SMS_REGION_SET = new Set<string>(TWILIO_SMS_REGIONS);
+
+export type TwilioSmsClientRegionConfig = {
+  edge: string;
+  region: string;
+};
+
+const TWILIO_SMS_CLIENT_REGION_CONFIG: Record<Exclude<TwilioSmsRegion, 'us'>, TwilioSmsClientRegionConfig> = {
+  eu: {
+    edge: 'dublin',
+    region: 'ie1',
+  },
+};
+
+export function assertAllowedTwilioSmsRegion(region: string | undefined): TwilioSmsRegion {
+  const normalized = (region ?? 'us').trim().toLowerCase();
+
+  if (!normalized || !TWILIO_SMS_REGION_SET.has(normalized)) {
+    throw new Error(`Invalid Twilio SMS region. Allowed regions: ${TWILIO_SMS_REGIONS.join(', ')}.`);
+  }
+
+  return normalized as TwilioSmsRegion;
+}
+
+export function getTwilioSmsClientRegionConfig(
+  region: string | undefined
+): TwilioSmsClientRegionConfig | undefined {
+  const normalizedRegion = assertAllowedTwilioSmsRegion(region);
+
+  if (normalizedRegion === 'us') {
+    return undefined;
+  }
+
+  return TWILIO_SMS_CLIENT_REGION_CONFIG[normalizedRegion];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds support for selecting a Twilio SMS data residency region when connecting the Twilio integration. US remains the default so existing customers are unaffected.

## Changes

- Added `twilio-sms-regions` constants with validation for `us` (default) and `eu` (IE1)
- Extended Twilio SMS credential schema with an optional **Data residency region** dropdown in the dashboard
- Updated `TwilioSmsProvider` to pass Twilio SDK `edge`/`region` options for EU (`dublin` / `ie1`)
- Updated `TwilioHandler` to forward the stored `region` credential
- Documented multi-region setup in the Twilio SMS integration guide

## Test plan

- [x] `npx vitest run src/consts/twilio-sms-regions.spec.ts` (shared)
- [x] `npx vitest run src/lib/sms/twilio/twilio.provider.spec.ts` (providers)
- [x] `pnpm --filter @novu/shared build`
- [x] `pnpm --filter @novu/providers build`

## Architecture

```mermaid
flowchart LR
  Dashboard["Dashboard credential dropdown"] --> API["Integration credentials.region"]
  API --> Handler["TwilioHandler"]
  Handler --> Provider["TwilioSmsProvider"]
  Provider --> Config["getTwilioSmsClientRegionConfig"]
  Config --> SDK["Twilio SDK (edge + region)"]
```

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8392](https://linear.app/novu/issue/NV-8392/support-selecting-twilio-sms-data-residency-region)

<div><a href="https://cursor.com/agents/bc-dd990528-0b45-4606-a608-97c44950efae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd990528-0b45-4606-a608-97c44950efae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Twilio SMS data residency selection. The main changes are:

- Stores an optional `region` credential for the Twilio SMS integration.
- Forwards the selected region through `TwilioHandler` into `TwilioSmsProvider`.
- Maps EU selection to Twilio SDK `edge` and `region` options.
- Adds shared validation helpers and tests for supported Twilio SMS regions.
- Documents IE1 setup requirements for Twilio SMS data residency.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped, preserves the existing US default, validates accepted region values, and includes targeted tests for the new Twilio SDK configuration path.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- First, validated that the Twilio SMS regions test and the Twilio provider test completed with exit code 0.
- Then, verified that the builds for the @novu/shared and @novu/providers packages completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/15736722/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/integrations/sms/twilio.mdx | Documents the optional Twilio SMS data residency dropdown and IE1 setup guidance. |
| libs/application-generic/src/factories/sms/handlers/twilio.handler.ts | Forwards the stored `region` credential into the Twilio SMS provider configuration. |
| packages/providers/src/lib/sms/twilio/twilio.provider.ts | Initializes the Twilio SDK with optional edge/region options derived from the configured data residency region. |
| packages/shared/src/consts/providers/credentials/provider-credentials.ts | Adds an optional Twilio data residency dropdown defaulting to US with EU selection available. |
| packages/shared/src/consts/twilio-sms-regions.ts | Defines allowed Twilio SMS regions and maps EU selection to Twilio SDK `dublin`/`ie1` options. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Dashboard
participant IntegrationCredentials as Integration credentials
participant TwilioHandler
participant TwilioSmsProvider
participant RegionConfig as getTwilioSmsClientRegionConfig
participant TwilioSDK as Twilio SDK

Dashboard->>IntegrationCredentials: Save optional region (us/eu)
IntegrationCredentials->>TwilioHandler: credentials.region
TwilioHandler->>TwilioSmsProvider: "new provider({ region })"
TwilioSmsProvider->>RegionConfig: resolve region config
RegionConfig-->>TwilioSmsProvider: undefined for us, dublin/ie1 for eu
TwilioSmsProvider->>TwilioSDK: new Twilio(accountSid, authToken, config)
```

<sub>Reviews (1): Last reviewed commit: ["feat(providers): support Twilio SMS data..."](https://github.com/novuhq/novu/commit/56538b21cfafef81074ee3b2421c4a0be2d7ea64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46984520)</sub>

<!-- /greptile_comment -->