### PR TITLE
fix(shared): update documentation references for email and SMS providers fixes NV-8393

### DIFF
--- a/packages/shared/src/consts/providers/channels/email.ts
+++ b/packages/shared/src/consts/providers/channels/email.ts
@@ -36,7 +36,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Novu Email',
     channel: ChannelTypeEnum.EMAIL,
     credentials: [],
-    docReference: `https://docs.novu.co/integrations/providers/default-providers${UTM_CAMPAIGN_QUERY_PARAM}#novu-email-provider`,
+    docReference: `https://docs.novu.co/platform/integrations/demo-integration${UTM_CAMPAIGN_QUERY_PARAM}#novu-email-provider`,
     logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
   {

--- a/packages/shared/src/consts/providers/channels/sms.ts
+++ b/packages/shared/src/consts/providers/channels/sms.ts
@@ -48,7 +48,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Novu SMS',
     channel: ChannelTypeEnum.SMS,
     credentials: [],
-    docReference: `https://docs.novu.co/integrations/providers/default-providers${UTM_CAMPAIGN_QUERY_PARAM}#novu-sms-provider`,
+    docReference: `https://docs.novu.co/platform/integrations/demo-integration${UTM_CAMPAIGN_QUERY_PARAM}#novu-sms-provider`,
     logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
   {
@@ -56,7 +56,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Nexmo',
     channel: ChannelTypeEnum.SMS,
     credentials: nexmoConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/nexmo${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/nexmo${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'nexmo.png', dark: 'nexmo.png' },
   },
   {
@@ -64,7 +64,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Plivo',
     channel: ChannelTypeEnum.SMS,
     credentials: plivoConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/plivo${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/plivo${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'plivo.png', dark: 'plivo.png' },
   },
 
@@ -73,7 +73,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'sms77',
     channel: ChannelTypeEnum.SMS,
     credentials: sms77Config,
-    docReference: `https://docs.novu.co/integrations/providers/sms/sms77${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/sms77${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sms77.svg', dark: 'sms77.svg' },
   },
   {
@@ -81,7 +81,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'SNS',
     channel: ChannelTypeEnum.SMS,
     credentials: snsConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/aws-sns${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/aws-sns${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sns.svg', dark: 'sns.svg' },
   },
   {
@@ -89,7 +89,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Telnyx',
     channel: ChannelTypeEnum.SMS,
     credentials: telnyxConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/telnyx${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/telnyx${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'telnyx.png', dark: 'telnyx.png' },
   },
   {
@@ -97,7 +97,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'MessageBird',
     channel: ChannelTypeEnum.SMS,
     credentials: messagebirdConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/messagebird${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/messagebird${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'messagebird.png', dark: 'messagebird.png' },
   },
   {
@@ -105,7 +105,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Twilio',
     channel: ChannelTypeEnum.SMS,
     credentials: twilioConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/twilio${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/twilio${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'twilio.png', dark: 'twilio.png' },
   },
   {
@@ -129,7 +129,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Infobip',
     channel: ChannelTypeEnum.SMS,
     credentials: infobipSMSConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/infobip${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/infobip${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'infobip.png', dark: 'infobip.png' },
   },
   {
@@ -162,7 +162,7 @@ export const smsProviders: IProviderConfig[] = [
     channel: ChannelTypeEnum.SMS,
     credentials: clickatellConfig,
     betaVersion: true,
-    docReference: `https://docs.novu.co/integrations/providers/sms/clickatell${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/clickatell${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'clickatell.png', dark: 'clickatell.png' },
   },
   {
@@ -203,7 +203,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Termii',
     channel: ChannelTypeEnum.SMS,
     credentials: termiiConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/termii${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/termii${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'termii.png', dark: 'termii.png' },
   },
   {
@@ -211,7 +211,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: `Africa's Talking`,
     channel: ChannelTypeEnum.SMS,
     credentials: africasTalkingConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/africas-talking${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/africas-talking${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'africas-talking.svg', dark: 'africas-talking.svg' },
   },
   {
@@ -219,7 +219,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: `Sendchamp`,
     channel: ChannelTypeEnum.SMS,
     credentials: sendchampConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/sendchamp${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/sendchamp${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sendchamp.svg', dark: 'sendchamp.svg' },
   },
   {
@@ -300,7 +300,7 @@ export const smsProviders: IProviderConfig[] = [
     displayName: 'Sinch',
     channel: ChannelTypeEnum.SMS,
     credentials: sinchConfig,
-    docReference: `https://docs.novu.co/integrations/providers/sms/sinch${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/platform/integrations/sms/sinch${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sinch.png', dark: 'sinch.png' },
   },
   {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates shared provider documentation links for email and SMS integrations. The main changes are:

- Moves the Novu email provider link to the current platform demo integration route.
- Moves Novu-hosted SMS provider links to current platform integration routes.
- Keeps provider metadata and credentials unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes only update static documentation URL strings in provider metadata and do not change runtime behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Biome checked the two changed provider channel files and reported 2 files checked in 6s with no fixes applied, EXIT\_CODE: 0.
- The TypeScript noEmit step for the packages/shared project completed with EXIT\_CODE: 0.
- The Shared package build finished with CJS and ESM TypeScript compilation and the circular dependency check reported no circular dependencies, EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/15736998/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/consts/providers/channels/email.ts | Updates the built-in Novu email provider documentation reference to the new platform integration path; no issues found. |
| packages/shared/src/consts/providers/channels/sms.ts | Updates Novu-hosted SMS provider documentation references to the new platform integration paths; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): update documentation refere..."](https://github.com/novuhq/novu/commit/252cc615c23add862d2ee11cb5b0ebc1028a6190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46985421)</sub>

<!-- /greptile_comment -->