### PR TITLE
fix(api-service): harden deprecated per-subscriber chat OAuth endpoints

### DIFF
--- a/apps/api/src/.example.env
+++ b/apps/api/src/.example.env
@@ -120,14 +120,6 @@ CLICK_HOUSE_USER=default
 CLICK_HOUSE_PASSWORD=
 CLICK_HOUSE_DATABASE=novu-local
 
-# Deprecated per-subscriber chat OAuth routes
-# (GET /v1/subscribers/:subscriberId/credentials/:providerId/oauth[/callback]).
-# enabled       - historical behavior, subscriber HMAC enforced only when the integration opts in
-# hmac_required - subscriber HMAC always enforced
-# disabled      - both routes reject every request
-# Use POST /v1/integrations/chat/oauth instead; it is authenticated and mints a signed state.
-NOVU_LEGACY_SUBSCRIBER_CHAT_OAUTH=enabled
-
 # Cloudflare Scheduler (for delayed job scheduling)
 SCHEDULER_URL=
 SCHEDULER_API_KEY=

--- a/apps/api/src/.example.env
+++ b/apps/api/src/.example.env
@@ -120,6 +120,14 @@ CLICK_HOUSE_USER=default
 CLICK_HOUSE_PASSWORD=
 CLICK_HOUSE_DATABASE=novu-local
 
+# Deprecated per-subscriber chat OAuth routes
+# (GET /v1/subscribers/:subscriberId/credentials/:providerId/oauth[/callback]).
+# enabled       - historical behavior, subscriber HMAC enforced only when the integration opts in
+# hmac_required - subscriber HMAC always enforced
+# disabled      - both routes reject every request
+# Use POST /v1/integrations/chat/oauth instead; it is authenticated and mints a signed state.
+NOVU_LEGACY_SUBSCRIBER_CHAT_OAUTH=enabled
+
 # Cloudflare Scheduler (for delayed job scheduling)
 SCHEDULER_URL=
 SCHEDULER_API_KEY=

--- a/apps/api/src/app/subscribers/dtos/chat-oauth-request.dto.ts
+++ b/apps/api/src/app/subscribers/dtos/chat-oauth-request.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
 
 export class ChatOauthRequestDto {
@@ -33,4 +33,12 @@ export class ChatOauthCallbackRequestDto extends ChatOauthRequestDto {
   })
   @IsString()
   code: string; // Make sure to define code as optional
+
+  @ApiPropertyOptional({
+    description: 'Signed state issued by the chat OAuth endpoint and echoed back by the provider',
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  state?: string;
 }

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -826,6 +826,7 @@ export class SubscribersV1Controller {
         hmacHash: query?.hmacHash,
         environmentId: query?.environmentId,
         integrationIdentifier: query?.integrationIdentifier,
+        state: query?.state,
         subscriberId,
         providerId,
       })

--- a/apps/api/src/app/subscribers/subscribersV1.module.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.module.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
+import { CommunityOrganizationRepository } from '@novu/dal';
 import { AuthModule } from '../auth/auth.module';
 import { ChannelEndpointsModule } from '../channel-endpoints/channel-endpoints.module';
 import { OutboundWebhooksModule } from '../outbound-webhooks/outbound-webhooks.module';
@@ -20,7 +21,7 @@ import { USE_CASES } from './usecases';
     OutboundWebhooksModule.forRoot(),
   ],
   controllers: [SubscribersV1Controller],
-  providers: [...USE_CASES],
+  providers: [...USE_CASES, CommunityOrganizationRepository],
   exports: [...USE_CASES],
 })
 export class SubscribersV1Module {}

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.command.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.command.ts
@@ -53,4 +53,9 @@ export class ChatOauthCallbackCommand extends BaseCommand {
   @IsOptional()
   @IsString()
   readonly integrationIdentifier?: string;
+
+  /** Signed state minted by {@link ChatOauth} and echoed back by the provider. */
+  @IsOptional()
+  @IsString()
+  readonly state?: string;
 }

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.spec.ts
@@ -1,12 +1,16 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
-import { CreateOrUpdateSubscriberUseCase, createHash, PinoLogger } from '@novu/application-generic';
-import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
-import { ChatProviderIdEnum } from '@novu/shared';
+import {
+  CreateOrUpdateSubscriberUseCase,
+  createHash,
+  FeatureFlagsService,
+  PinoLogger,
+} from '@novu/application-generic';
+import { CommunityOrganizationRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum, LegacySubscriberChatOauthMode } from '@novu/shared';
 import axios from 'axios';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
-import { LEGACY_CHAT_OAUTH_MODE_ENV_VAR, LegacyChatOauthMode } from '../chat-oauth/legacy-chat-oauth.config';
 import { encodeLegacyChatOauthState } from '../chat-oauth/legacy-chat-oauth-state';
 import { ChatOauthCallbackCommand } from './chat-oauth-callback.command';
 import { ChatOauthCallback } from './chat-oauth-callback.usecase';
@@ -44,9 +48,10 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
   let usecase: ChatOauthCallback;
   let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
   let environmentRepository: sinon.SinonStubbedInstance<EnvironmentRepository>;
+  let organizationRepository: sinon.SinonStubbedInstance<CommunityOrganizationRepository>;
+  let featureFlagsService: { getFlag: sinon.SinonStub };
   let createSubscriber: sinon.SinonStubbedInstance<CreateOrUpdateSubscriberUseCase>;
   let createChannelEndpoint: sinon.SinonStubbedInstance<CreateChannelEndpoint>;
-  let originalMode: string | undefined;
 
   function stubIntegration(credentials: Record<string, unknown>) {
     integrationRepository.findOne.resolves({
@@ -59,13 +64,17 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
     } as any);
   }
 
+  function stubLegacyMode(mode: LegacySubscriberChatOauthMode) {
+    featureFlagsService.getFlag.resolves(mode);
+  }
+
   beforeEach(() => {
-    originalMode = process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
-    delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
     process.env.API_ROOT_URL = 'https://api.novu.co';
 
     integrationRepository = sinon.createStubInstance(IntegrationRepository);
     environmentRepository = sinon.createStubInstance(EnvironmentRepository);
+    organizationRepository = sinon.createStubInstance(CommunityOrganizationRepository);
+    featureFlagsService = { getFlag: sinon.stub() };
     createSubscriber = sinon.createStubInstance(CreateOrUpdateSubscriberUseCase);
     createChannelEndpoint = sinon.createStubInstance(CreateChannelEndpoint);
 
@@ -75,6 +84,11 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
       apiKeys: [{ key: API_KEY }],
     } as any);
     environmentRepository.getApiKeys.resolves([{ key: API_KEY } as any]);
+    organizationRepository.findOne.resolves({
+      _id: ORGANIZATION_ID,
+      createdAt: new Date('2020-01-01'),
+    } as any);
+    stubLegacyMode(LegacySubscriberChatOauthMode.ENABLED);
 
     stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret' });
 
@@ -83,6 +97,8 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
     usecase = new ChatOauthCallback(
       integrationRepository as any,
       environmentRepository as any,
+      organizationRepository as any,
+      featureFlagsService as unknown as FeatureFlagsService,
       createSubscriber as any,
       createChannelEndpoint as any,
       sinon.createStubInstance(PinoLogger) as any
@@ -91,12 +107,14 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
 
   afterEach(() => {
     sinon.restore();
+  });
 
-    if (originalMode === undefined) {
-      delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
-    } else {
-      process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = originalMode;
-    }
+  it('rejects every request when the feature flag defaults to disabled', async () => {
+    stubLegacyMode(LegacySubscriberChatOauthMode.DISABLED);
+
+    await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
+
+    expect(createChannelEndpoint.execute.called).to.equal(false);
   });
 
   it('attaches the endpoint when the state was signed by the target environment', async () => {
@@ -160,24 +178,16 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
     expect(createChannelEndpoint.execute.called).to.equal(false);
   });
 
-  it('still accepts a stateless callback in the default mode', async () => {
+  it('still accepts a stateless callback when the flag is enabled', async () => {
     await usecase.execute(buildCommand());
 
     expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
   });
 
   it('blocks a stateless cross-tenant callback in hmac_required mode', async () => {
-    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.HMAC_REQUIRED;
+    stubLegacyMode(LegacySubscriberChatOauthMode.HMAC_REQUIRED);
 
     await expectRejection(usecase.execute(buildCommand()), BadRequestException);
-
-    expect(createChannelEndpoint.execute.called).to.equal(false);
-  });
-
-  it('rejects every request in disabled mode', async () => {
-    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.DISABLED;
-
-    await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
 
     expect(createChannelEndpoint.execute.called).to.equal(false);
   });

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.spec.ts
@@ -6,7 +6,7 @@ import {
   PinoLogger,
 } from '@novu/application-generic';
 import { CommunityOrganizationRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
-import { ChatProviderIdEnum, LegacySubscriberChatOauthMode } from '@novu/shared';
+import { ChatProviderIdEnum } from '@novu/shared';
 import axios from 'axios';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -64,8 +64,8 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
     } as any);
   }
 
-  function stubLegacyMode(mode: LegacySubscriberChatOauthMode) {
-    featureFlagsService.getFlag.resolves(mode);
+  function stubHmacRequiredEnabled(enabled: boolean) {
+    featureFlagsService.getFlag.resolves(enabled);
   }
 
   beforeEach(() => {
@@ -88,9 +88,9 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
       _id: ORGANIZATION_ID,
       createdAt: new Date('2020-01-01'),
     } as any);
-    stubLegacyMode(LegacySubscriberChatOauthMode.ENABLED);
+    stubHmacRequiredEnabled(true);
 
-    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret' });
+    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret', hmac: true });
 
     sinon.stub(axios, 'post').resolves({ data: { ok: true, incoming_webhook: { url: ATTACKER_WEBHOOK } } } as any);
 
@@ -109,16 +109,23 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
     sinon.restore();
   });
 
-  it('rejects every request when the feature flag defaults to disabled', async () => {
-    stubLegacyMode(LegacySubscriberChatOauthMode.DISABLED);
+  it('blocks new organizations when the Slack integration does not enable HMAC', async () => {
+    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret' });
 
-    await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
+    await expectRejection(usecase.execute(buildCommand({ state: buildState() })), ForbiddenException);
 
     expect(createChannelEndpoint.execute.called).to.equal(false);
   });
 
   it('attaches the endpoint when the state was signed by the target environment', async () => {
-    await usecase.execute(buildCommand({ state: buildState({ integrationIdentifier: 'victim-slack' }) }));
+    await usecase.execute(
+      buildCommand({
+        state: buildState({
+          integrationIdentifier: 'victim-slack',
+          hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string,
+        }),
+      })
+    );
 
     expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
     expect(createChannelEndpoint.execute.firstCall.args[0]).to.include({
@@ -132,7 +139,10 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
       buildCommand({
         environmentId: 'ffffffffffffffffffffffff',
         integrationIdentifier: 'attacker-supplied',
-        state: buildState({ integrationIdentifier: 'victim-slack' }),
+        state: buildState({
+          integrationIdentifier: 'victim-slack',
+          hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string,
+        }),
       })
     );
 
@@ -161,8 +171,6 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
   });
 
   it('completes an HMAC-protected flow using the hash carried in the state', async () => {
-    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret', hmac: true });
-
     await usecase.execute(
       buildCommand({ state: buildState({ hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string }) })
     );
@@ -171,22 +179,21 @@ describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
   });
 
   it('rejects an HMAC-protected flow whose state carries no hash', async () => {
-    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret', hmac: true });
-
     await expectRejection(usecase.execute(buildCommand({ state: buildState() })), BadRequestException);
 
     expect(createChannelEndpoint.execute.called).to.equal(false);
   });
 
-  it('still accepts a stateless callback when the flag is enabled', async () => {
+  it('still accepts a stateless callback for allowlisted legacy organizations', async () => {
+    stubHmacRequiredEnabled(false);
+    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret' });
+
     await usecase.execute(buildCommand());
 
     expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
   });
 
-  it('blocks a stateless cross-tenant callback in hmac_required mode', async () => {
-    stubLegacyMode(LegacySubscriberChatOauthMode.HMAC_REQUIRED);
-
+  it('blocks a stateless callback for new organizations without a valid HMAC hash', async () => {
     await expectRejection(usecase.execute(buildCommand()), BadRequestException);
 
     expect(createChannelEndpoint.execute.called).to.equal(false);

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.spec.ts
@@ -1,0 +1,196 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { CreateOrUpdateSubscriberUseCase, createHash, PinoLogger } from '@novu/application-generic';
+import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+import axios from 'axios';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
+import { LEGACY_CHAT_OAUTH_MODE_ENV_VAR, LegacyChatOauthMode } from '../chat-oauth/legacy-chat-oauth.config';
+import { encodeLegacyChatOauthState } from '../chat-oauth/legacy-chat-oauth-state';
+import { ChatOauthCallbackCommand } from './chat-oauth-callback.command';
+import { ChatOauthCallback } from './chat-oauth-callback.usecase';
+
+const ENVIRONMENT_ID = '6a6600c7762b9e152a1f6728';
+const ORGANIZATION_ID = '6a6600c715029ec38931ec00';
+const SUBSCRIBER_ID = 'victim-subscriber';
+const API_KEY = 'victim-environment-api-key';
+const ATTACKER_WEBHOOK = 'https://hooks.slack.com/services/ATTACKER/WORKSPACE/PWNED';
+
+function buildCommand(overrides: Partial<ChatOauthCallbackCommand> = {}): ChatOauthCallbackCommand {
+  return ChatOauthCallbackCommand.create({
+    environmentId: ENVIRONMENT_ID,
+    subscriberId: SUBSCRIBER_ID,
+    providerId: ChatProviderIdEnum.Slack,
+    providerCode: 'oauth-code',
+    ...overrides,
+  });
+}
+
+function buildState(overrides: Record<string, unknown> = {}, signingKey = API_KEY): string {
+  return encodeLegacyChatOauthState(
+    {
+      environmentId: ENVIRONMENT_ID,
+      subscriberId: SUBSCRIBER_ID,
+      providerId: ChatProviderIdEnum.Slack,
+      timestamp: Date.now(),
+      ...overrides,
+    },
+    signingKey
+  );
+}
+
+describe('ChatOauthCallback (deprecated per-subscriber chat OAuth)', () => {
+  let usecase: ChatOauthCallback;
+  let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
+  let environmentRepository: sinon.SinonStubbedInstance<EnvironmentRepository>;
+  let createSubscriber: sinon.SinonStubbedInstance<CreateOrUpdateSubscriberUseCase>;
+  let createChannelEndpoint: sinon.SinonStubbedInstance<CreateChannelEndpoint>;
+  let originalMode: string | undefined;
+
+  function stubIntegration(credentials: Record<string, unknown>) {
+    integrationRepository.findOne.resolves({
+      _id: 'integration-id',
+      _environmentId: ENVIRONMENT_ID,
+      _organizationId: ORGANIZATION_ID,
+      identifier: 'victim-slack',
+      providerId: ChatProviderIdEnum.Slack,
+      credentials,
+    } as any);
+  }
+
+  beforeEach(() => {
+    originalMode = process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
+    delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
+    process.env.API_ROOT_URL = 'https://api.novu.co';
+
+    integrationRepository = sinon.createStubInstance(IntegrationRepository);
+    environmentRepository = sinon.createStubInstance(EnvironmentRepository);
+    createSubscriber = sinon.createStubInstance(CreateOrUpdateSubscriberUseCase);
+    createChannelEndpoint = sinon.createStubInstance(CreateChannelEndpoint);
+
+    environmentRepository.findOne.resolves({
+      _id: ENVIRONMENT_ID,
+      _organizationId: ORGANIZATION_ID,
+      apiKeys: [{ key: API_KEY }],
+    } as any);
+    environmentRepository.getApiKeys.resolves([{ key: API_KEY } as any]);
+
+    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret' });
+
+    sinon.stub(axios, 'post').resolves({ data: { ok: true, incoming_webhook: { url: ATTACKER_WEBHOOK } } } as any);
+
+    usecase = new ChatOauthCallback(
+      integrationRepository as any,
+      environmentRepository as any,
+      createSubscriber as any,
+      createChannelEndpoint as any,
+      sinon.createStubInstance(PinoLogger) as any
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+
+    if (originalMode === undefined) {
+      delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
+    } else {
+      process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = originalMode;
+    }
+  });
+
+  it('attaches the endpoint when the state was signed by the target environment', async () => {
+    await usecase.execute(buildCommand({ state: buildState({ integrationIdentifier: 'victim-slack' }) }));
+
+    expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
+    expect(createChannelEndpoint.execute.firstCall.args[0]).to.include({
+      environmentId: ENVIRONMENT_ID,
+      subscriberId: SUBSCRIBER_ID,
+    });
+  });
+
+  it('routes on the signed state rather than the query string', async () => {
+    await usecase.execute(
+      buildCommand({
+        environmentId: 'ffffffffffffffffffffffff',
+        integrationIdentifier: 'attacker-supplied',
+        state: buildState({ integrationIdentifier: 'victim-slack' }),
+      })
+    );
+
+    expect(integrationRepository.findOne.firstCall.args[0]).to.include({
+      _environmentId: ENVIRONMENT_ID,
+      identifier: 'victim-slack',
+    });
+  });
+
+  it('rejects a state signed with another environment key', async () => {
+    await expectRejection(
+      usecase.execute(buildCommand({ state: buildState({}, 'attacker-environment-api-key') })),
+      BadRequestException
+    );
+
+    expect(createChannelEndpoint.execute.called).to.equal(false);
+  });
+
+  it('rejects a state minted for a different subscriber', async () => {
+    await expectRejection(
+      usecase.execute(buildCommand({ state: buildState({ subscriberId: 'someone-else' }) })),
+      BadRequestException
+    );
+
+    expect(createChannelEndpoint.execute.called).to.equal(false);
+  });
+
+  it('completes an HMAC-protected flow using the hash carried in the state', async () => {
+    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret', hmac: true });
+
+    await usecase.execute(
+      buildCommand({ state: buildState({ hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string }) })
+    );
+
+    expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
+  });
+
+  it('rejects an HMAC-protected flow whose state carries no hash', async () => {
+    stubIntegration({ clientId: 'victim-client-id', secretKey: 'victim-secret', hmac: true });
+
+    await expectRejection(usecase.execute(buildCommand({ state: buildState() })), BadRequestException);
+
+    expect(createChannelEndpoint.execute.called).to.equal(false);
+  });
+
+  it('still accepts a stateless callback in the default mode', async () => {
+    await usecase.execute(buildCommand());
+
+    expect(createChannelEndpoint.execute.calledOnce).to.equal(true);
+  });
+
+  it('blocks a stateless cross-tenant callback in hmac_required mode', async () => {
+    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.HMAC_REQUIRED;
+
+    await expectRejection(usecase.execute(buildCommand()), BadRequestException);
+
+    expect(createChannelEndpoint.execute.called).to.equal(false);
+  });
+
+  it('rejects every request in disabled mode', async () => {
+    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.DISABLED;
+
+    await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
+
+    expect(createChannelEndpoint.execute.called).to.equal(false);
+  });
+});
+
+async function expectRejection(promise: Promise<unknown>, errorType: unknown) {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).to.be.instanceOf(errorType as never);
+
+    return;
+  }
+
+  throw new Error('Expected the promise to reject');
+}

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -16,7 +16,7 @@ import { ChatProviderIdEnum, ENDPOINT_TYPES, ICredentialsDto } from '@novu/share
 import axios from 'axios';
 import { CreateChannelEndpointCommand } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
-import { CHAT_INTEGRATION_NOT_FOUND_MESSAGE, validateEncryption } from '../chat-oauth/chat-oauth.usecase';
+import { assertLegacyChatOauthHmac, CHAT_INTEGRATION_NOT_FOUND_MESSAGE } from '../chat-oauth/chat-oauth.usecase';
 import {
   getLegacyChatOauthMode,
   LEGACY_CHAT_OAUTH_MIGRATION_HINT,
@@ -76,10 +76,11 @@ export class ChatOauthCallback {
 
     const { _organizationId, apiKeys } = await this.getEnvironment(routing.environmentId);
 
-    this.hmacValidation({
+    assertLegacyChatOauthHmac({
       isHmacRequired: integrationCredentials.hmac === true || mode === LegacyChatOauthMode.HMAC_REQUIRED,
-      apiKey: apiKeys[0].key,
-      routing,
+      apiKeys: apiKeys.map(({ key }) => key),
+      subscriberId: routing.subscriberId,
+      externalHmacHash: routing.hmacHash,
     });
 
     const webhookUrl = await this.getWebhook(command.providerCode, routing, integrationCredentials);
@@ -257,31 +258,5 @@ export class ChatOauthCallback {
     integration.credentials = decryptCredentials(integration.credentials);
 
     return integration;
-  }
-
-  private hmacValidation({
-    isHmacRequired,
-    apiKey,
-    routing,
-  }: {
-    isHmacRequired: boolean;
-    apiKey: string;
-    routing: ResolvedCallbackRouting;
-  }) {
-    if (!isHmacRequired) {
-      return;
-    }
-
-    if (!routing.hmacHash) {
-      throw new BadRequestException(
-        'Hmac is enabled on the integration, please provide a HMAC hash on the request params'
-      );
-    }
-
-    validateEncryption({
-      apiKey,
-      subscriberId: routing.subscriberId,
-      externalHmacHash: routing.hmacHash,
-    });
   }
 }

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -3,24 +3,27 @@ import {
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
   decryptCredentials,
+  FeatureFlagsService,
   PinoLogger,
 } from '@novu/application-generic';
 import {
   ChannelTypeEnum,
+  CommunityOrganizationRepository,
   EnvironmentEntity,
   EnvironmentRepository,
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { ChatProviderIdEnum, ENDPOINT_TYPES, ICredentialsDto } from '@novu/shared';
+import { ChatProviderIdEnum, ENDPOINT_TYPES, ICredentialsDto, LegacySubscriberChatOauthMode } from '@novu/shared';
 import axios from 'axios';
 import { CreateChannelEndpointCommand } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
-import { assertLegacyChatOauthHmac, CHAT_INTEGRATION_NOT_FOUND_MESSAGE } from '../chat-oauth/chat-oauth.usecase';
+import { assertLegacyChatOauthHmac } from '../chat-oauth/chat-oauth.usecase';
 import {
+  CHAT_INTEGRATION_NOT_FOUND_MESSAGE,
   getLegacyChatOauthMode,
   LEGACY_CHAT_OAUTH_MIGRATION_HINT,
-  LegacyChatOauthMode,
+  resolveLegacyChatOauthOrganization,
 } from '../chat-oauth/legacy-chat-oauth.config';
 import {
   decodeLegacyChatOauthState,
@@ -56,6 +59,8 @@ export class ChatOauthCallback {
   constructor(
     private integrationRepository: IntegrationRepository,
     private environmentRepository: EnvironmentRepository,
+    private organizationRepository: CommunityOrganizationRepository,
+    private featureFlagsService: FeatureFlagsService,
     private createSubscriberUsecase: CreateOrUpdateSubscriberUseCase,
     private createChannelEndpoint: CreateChannelEndpoint,
     private logger: PinoLogger
@@ -64,9 +69,17 @@ export class ChatOauthCallback {
   }
 
   async execute(command: ChatOauthCallbackCommand): Promise<ChatOauthCallbackResult> {
-    const mode = getLegacyChatOauthMode();
+    const routingEnvironmentId = command.state
+      ? peekLegacyChatOauthStateEnvironmentId(command.state)
+      : command.environmentId;
+    const organization = await resolveLegacyChatOauthOrganization(
+      this.environmentRepository,
+      this.organizationRepository,
+      routingEnvironmentId
+    );
+    const mode = await getLegacyChatOauthMode(this.featureFlagsService, organization);
 
-    if (mode === LegacyChatOauthMode.DISABLED) {
+    if (mode === LegacySubscriberChatOauthMode.DISABLED) {
       throw new ForbiddenException(LEGACY_CHAT_OAUTH_MIGRATION_HINT);
     }
 
@@ -77,7 +90,7 @@ export class ChatOauthCallback {
     const { _organizationId, apiKeys } = await this.getEnvironment(routing.environmentId);
 
     assertLegacyChatOauthHmac({
-      isHmacRequired: integrationCredentials.hmac === true || mode === LegacyChatOauthMode.HMAC_REQUIRED,
+      isHmacRequired: integrationCredentials.hmac === true || mode === LegacySubscriberChatOauthMode.HMAC_REQUIRED,
       apiKeys: apiKeys.map(({ key }) => key),
       subscriberId: routing.subscriberId,
       externalHmacHash: routing.hmacHash,

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import {
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
@@ -14,15 +14,17 @@ import {
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { ChatProviderIdEnum, ENDPOINT_TYPES, ICredentialsDto, LegacySubscriberChatOauthMode } from '@novu/shared';
+import { ChatProviderIdEnum, ENDPOINT_TYPES, ICredentialsDto } from '@novu/shared';
 import axios from 'axios';
 import { CreateChannelEndpointCommand } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { assertLegacyChatOauthHmac } from '../chat-oauth/chat-oauth.usecase';
 import {
+  assertLegacyChatOauthIntegrationHmacEnabled,
   CHAT_INTEGRATION_NOT_FOUND_MESSAGE,
-  getLegacyChatOauthMode,
+  isLegacySubscriberChatOauthHmacRequired,
   LEGACY_CHAT_OAUTH_MIGRATION_HINT,
+  resolveLegacyChatOauthHmacRequired,
   resolveLegacyChatOauthOrganization,
 } from '../chat-oauth/legacy-chat-oauth.config';
 import {
@@ -77,20 +79,19 @@ export class ChatOauthCallback {
       this.organizationRepository,
       routingEnvironmentId
     );
-    const mode = await getLegacyChatOauthMode(this.featureFlagsService, organization);
-
-    if (mode === LegacySubscriberChatOauthMode.DISABLED) {
-      throw new ForbiddenException(LEGACY_CHAT_OAUTH_MIGRATION_HINT);
-    }
+    const hmacRequiredEnabled = await isLegacySubscriberChatOauthHmacRequired(this.featureFlagsService, organization);
 
     const routing = await this.resolveRouting(command);
     const integration = await this.getIntegration(routing);
     const integrationCredentials = integration.credentials;
+    const integrationHmacEnabled = integrationCredentials.hmac === true;
+
+    assertLegacyChatOauthIntegrationHmacEnabled(hmacRequiredEnabled, integrationHmacEnabled);
 
     const { _organizationId, apiKeys } = await this.getEnvironment(routing.environmentId);
 
     assertLegacyChatOauthHmac({
-      isHmacRequired: integrationCredentials.hmac === true || mode === LegacySubscriberChatOauthMode.HMAC_REQUIRED,
+      isHmacRequired: resolveLegacyChatOauthHmacRequired(hmacRequiredEnabled, integrationHmacEnabled),
       apiKeys: apiKeys.map(({ key }) => key),
       subscriberId: routing.subscriberId,
       externalHmacHash: routing.hmacHash,

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -1,8 +1,9 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import {
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
   decryptCredentials,
+  PinoLogger,
 } from '@novu/application-generic';
 import {
   ChannelTypeEnum,
@@ -11,13 +12,37 @@ import {
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { ENDPOINT_TYPES, ICredentialsDto } from '@novu/shared';
+import { ChatProviderIdEnum, ENDPOINT_TYPES, ICredentialsDto } from '@novu/shared';
 import axios from 'axios';
 import { CreateChannelEndpointCommand } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
-import { validateEncryption } from '../chat-oauth/chat-oauth.usecase';
+import { CHAT_INTEGRATION_NOT_FOUND_MESSAGE, validateEncryption } from '../chat-oauth/chat-oauth.usecase';
+import {
+  getLegacyChatOauthMode,
+  LEGACY_CHAT_OAUTH_MIGRATION_HINT,
+  LegacyChatOauthMode,
+} from '../chat-oauth/legacy-chat-oauth.config';
+import {
+  decodeLegacyChatOauthState,
+  peekLegacyChatOauthStateEnvironmentId,
+} from '../chat-oauth/legacy-chat-oauth-state';
 import { ChatOauthCallbackCommand } from './chat-oauth-callback.command';
 import { ChatOauthCallbackResult, ResponseTypeEnum } from './chat-oauth-callback.result';
+
+/**
+ * Routing fields the callback acts on. When the provider echoes back a `state`
+ * minted by `ChatOauth`, they come from that signed payload; otherwise they fall
+ * back to the query string, which is the pre-`state` behavior kept alive for
+ * authorization URLs that were built by hand rather than by our own endpoint.
+ */
+type ResolvedCallbackRouting = {
+  environmentId: string;
+  subscriberId: string;
+  providerId: ChatProviderIdEnum;
+  integrationIdentifier?: string;
+  hmacHash?: string;
+  isStateVerified: boolean;
+};
 
 /**
  * @deprecated Use the new channel management approach.
@@ -32,25 +57,34 @@ export class ChatOauthCallback {
     private integrationRepository: IntegrationRepository,
     private environmentRepository: EnvironmentRepository,
     private createSubscriberUsecase: CreateOrUpdateSubscriberUseCase,
-    private createChannelEndpoint: CreateChannelEndpoint
-  ) {}
+    private createChannelEndpoint: CreateChannelEndpoint,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(ChatOauthCallback.name);
+  }
 
   async execute(command: ChatOauthCallbackCommand): Promise<ChatOauthCallbackResult> {
-    const integration = await this.getIntegration(command);
+    const mode = getLegacyChatOauthMode();
+
+    if (mode === LegacyChatOauthMode.DISABLED) {
+      throw new ForbiddenException(LEGACY_CHAT_OAUTH_MIGRATION_HINT);
+    }
+
+    const routing = await this.resolveRouting(command);
+    const integration = await this.getIntegration(routing);
     const integrationCredentials = integration.credentials;
 
-    const { _organizationId, apiKeys } = await this.getEnvironment(command.environmentId);
+    const { _organizationId, apiKeys } = await this.getEnvironment(routing.environmentId);
 
-    await this.hmacValidation({
-      credentialHmac: integrationCredentials.hmac,
+    this.hmacValidation({
+      isHmacRequired: integrationCredentials.hmac === true || mode === LegacyChatOauthMode.HMAC_REQUIRED,
       apiKey: apiKeys[0].key,
-      subscriberId: command.subscriberId,
-      externalHmacHash: command.hmacHash,
+      routing,
     });
 
-    const webhookUrl = await this.getWebhook(command, integrationCredentials);
+    const webhookUrl = await this.getWebhook(command.providerCode, routing, integrationCredentials);
 
-    await this.createSubscriber(_organizationId, command, webhookUrl, integration);
+    await this.createSubscriber(_organizationId, routing, webhookUrl, integration);
 
     if (integrationCredentials?.redirectUrl) {
       return { typeOfResponse: ResponseTypeEnum.URL, resultString: integrationCredentials.redirectUrl };
@@ -59,26 +93,69 @@ export class ChatOauthCallback {
     return { typeOfResponse: ResponseTypeEnum.HTML, resultString: this.SCRIPT_CLOSE_TAB };
   }
 
+  /**
+   * A signed `state` is the only thing that ties this callback to an OAuth URL
+   * this API actually minted, so whatever it carries wins over the query string.
+   */
+  private async resolveRouting(command: ChatOauthCallbackCommand): Promise<ResolvedCallbackRouting> {
+    if (!command.state) {
+      this.logger.warn(
+        {
+          environmentId: command.environmentId,
+          providerId: command.providerId,
+          integrationIdentifier: command.integrationIdentifier,
+        },
+        `Legacy chat OAuth callback received without a signed state. ${LEGACY_CHAT_OAUTH_MIGRATION_HINT}`
+      );
+
+      return {
+        environmentId: command.environmentId,
+        subscriberId: command.subscriberId,
+        providerId: command.providerId,
+        integrationIdentifier: command.integrationIdentifier,
+        hmacHash: command.hmacHash,
+        isStateVerified: false,
+      };
+    }
+
+    const stateEnvironmentId = peekLegacyChatOauthStateEnvironmentId(command.state);
+    const apiKey = await this.getEnvironmentApiKey(stateEnvironmentId);
+    const state = decodeLegacyChatOauthState(command.state, apiKey);
+
+    if (state.subscriberId !== command.subscriberId || state.providerId !== command.providerId) {
+      throw new BadRequestException('OAuth state does not match the requested subscriber');
+    }
+
+    return {
+      environmentId: state.environmentId,
+      subscriberId: state.subscriberId,
+      providerId: state.providerId,
+      integrationIdentifier: state.integrationIdentifier,
+      hmacHash: state.hmacHash,
+      isStateVerified: true,
+    };
+  }
+
   private async createSubscriber(
     organizationId: string,
-    command: ChatOauthCallbackCommand,
+    routing: ResolvedCallbackRouting,
     webhookUrl: string,
     integration: IntegrationEntity
   ): Promise<void> {
     await this.createSubscriberUsecase.execute(
       CreateOrUpdateSubscriberCommand.create({
         organizationId,
-        environmentId: command.environmentId,
-        subscriberId: command?.subscriberId,
+        environmentId: routing.environmentId,
+        subscriberId: routing.subscriberId,
       })
     );
 
     await this.createChannelEndpoint.execute(
       CreateChannelEndpointCommand.create({
         organizationId: organizationId,
-        environmentId: command.environmentId,
+        environmentId: routing.environmentId,
         integrationIdentifier: integration.identifier,
-        subscriberId: command.subscriberId,
+        subscriberId: routing.subscriberId,
         type: ENDPOINT_TYPES.WEBHOOK,
         endpoint: {
           url: webhookUrl,
@@ -91,27 +168,38 @@ export class ChatOauthCallback {
     const environment = await this.environmentRepository.findOne({ _id: environmentId });
 
     if (environment == null) {
-      throw new NotFoundException(`Environment ID: ${environmentId} not found`);
+      throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
     }
 
     return environment;
   }
 
+  private async getEnvironmentApiKey(environmentId: string): Promise<string> {
+    const apiKeys = await this.environmentRepository.getApiKeys(environmentId);
+
+    if (!apiKeys.length) {
+      throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
+    }
+
+    return apiKeys[0].key;
+  }
+
   private async getWebhook(
-    command: ChatOauthCallbackCommand,
+    providerCode: string,
+    routing: ResolvedCallbackRouting,
     integrationCredentials: ICredentialsDto
   ): Promise<string> {
-    let redirectUri = `${
-      process.env.API_ROOT_URL
-    }/v1/subscribers/${command.subscriberId}/credentials/${command.providerId}/oauth/callback?environmentId=${command.environmentId}`;
+    let redirectUri = `${process.env.API_ROOT_URL}/v1/subscribers/${routing.subscriberId}/credentials/${
+      routing.providerId
+    }/oauth/callback?environmentId=${routing.environmentId}`;
 
-    if (command.integrationIdentifier) {
-      redirectUri = `${redirectUri}&integrationIdentifier=${command.integrationIdentifier}`;
+    if (routing.integrationIdentifier) {
+      redirectUri = `${redirectUri}&integrationIdentifier=${routing.integrationIdentifier}`;
     }
 
     const body = {
       redirect_uri: redirectUri,
-      code: command.providerCode,
+      code: providerCode,
       client_id: integrationCredentials.clientId,
       client_secret: integrationCredentials.secretKey,
     };
@@ -127,26 +215,26 @@ export class ChatOauthCallback {
     if (res?.data?.ok === false) {
       const metaData = res?.data?.response_metadata?.messages?.join(', ');
       throw new BadRequestException(
-        `Provider ${command.providerId} returned error ${res.data.error}${metaData ? `, metadata:${metaData}` : ''}`
+        `Provider ${routing.providerId} returned error ${res.data.error}${metaData ? `, metadata:${metaData}` : ''}`
       );
     }
 
     if (!webhook) {
-      throw new BadRequestException(`Provider ${command.providerId} did not return a webhook url`);
+      throw new BadRequestException(`Provider ${routing.providerId} did not return a webhook url`);
     }
 
     return webhook;
   }
 
-  private async getIntegration(command: ChatOauthCallbackCommand) {
+  private async getIntegration(routing: ResolvedCallbackRouting): Promise<IntegrationEntity> {
     const query: Partial<IntegrationEntity> & { _environmentId: string } = {
-      _environmentId: command.environmentId,
+      _environmentId: routing.environmentId,
       channel: ChannelTypeEnum.CHAT,
-      providerId: command.providerId,
+      providerId: routing.providerId,
     };
 
-    if (command.integrationIdentifier) {
-      query.identifier = command.integrationIdentifier;
+    if (routing.integrationIdentifier) {
+      query.identifier = routing.integrationIdentifier;
     }
 
     const integration = await this.integrationRepository.findOne(query, undefined, {
@@ -154,10 +242,16 @@ export class ChatOauthCallback {
     });
 
     if (integration == null) {
-      throw new NotFoundException(
-        `Integration in environment ${command.environmentId} was not found, channel: ${ChannelTypeEnum.CHAT}, ` +
-          `providerId: ${command.providerId}`
+      this.logger.warn(
+        {
+          environmentId: routing.environmentId,
+          providerId: routing.providerId,
+          integrationIdentifier: routing.integrationIdentifier,
+        },
+        'Legacy chat OAuth callback could not be resolved to an integration'
       );
+
+      throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
     }
 
     integration.credentials = decryptCredentials(integration.credentials);
@@ -165,29 +259,29 @@ export class ChatOauthCallback {
     return integration;
   }
 
-  private async hmacValidation({
-    credentialHmac,
+  private hmacValidation({
+    isHmacRequired,
     apiKey,
-    subscriberId,
-    externalHmacHash,
+    routing,
   }: {
-    credentialHmac: boolean | undefined;
+    isHmacRequired: boolean;
     apiKey: string;
-    subscriberId: string;
-    externalHmacHash: string | undefined;
+    routing: ResolvedCallbackRouting;
   }) {
-    if (credentialHmac) {
-      if (!externalHmacHash) {
-        throw new BadRequestException(
-          'Hmac is enabled on the integration, please provide a HMAC hash on the request params'
-        );
-      }
-
-      validateEncryption({
-        apiKey,
-        subscriberId,
-        externalHmacHash,
-      });
+    if (!isHmacRequired) {
+      return;
     }
+
+    if (!routing.hmacHash) {
+      throw new BadRequestException(
+        'Hmac is enabled on the integration, please provide a HMAC hash on the request params'
+      );
+    }
+
+    validateEncryption({
+      apiKey,
+      subscriberId: routing.subscriberId,
+      externalHmacHash: routing.hmacHash,
+    });
   }
 }

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { createHash, FeatureFlagsService, PinoLogger } from '@novu/application-generic';
 import { CommunityOrganizationRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
-import { ChatProviderIdEnum, LegacySubscriberChatOauthMode } from '@novu/shared';
+import { ChatProviderIdEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ChatOauthCommand } from './chat-oauth.command';
@@ -41,8 +41,8 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
     } as any);
   }
 
-  function stubLegacyMode(mode: LegacySubscriberChatOauthMode) {
-    featureFlagsService.getFlag.resolves(mode);
+  function stubHmacRequiredEnabled(enabled: boolean) {
+    featureFlagsService.getFlag.resolves(enabled);
   }
 
   beforeEach(() => {
@@ -62,7 +62,7 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
       _id: ORGANIZATION_ID,
       createdAt: new Date('2020-01-01'),
     } as any);
-    stubLegacyMode(LegacySubscriberChatOauthMode.ENABLED);
+    stubHmacRequiredEnabled(true);
 
     usecase = new ChatOauth(
       integrationRepository as any,
@@ -79,14 +79,25 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
     sinon.restore();
   });
 
-  it('rejects every request when the feature flag defaults to disabled', async () => {
-    stubLegacyMode(LegacySubscriberChatOauthMode.DISABLED);
-
+  it('blocks new organizations when the Slack integration does not enable HMAC', async () => {
     await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
   });
 
+  it('requires a valid HMAC hash for new organizations once HMAC is enabled on the integration', async () => {
+    stubIntegration({ clientId: CLIENT_ID, secretKey: 'victim-secret', hmac: true });
+
+    await expectRejection(usecase.execute(buildCommand()), BadRequestException);
+
+    const url = await usecase.execute(buildCommand({ hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string }));
+
+    expect(url).to.include('slack.com/oauth');
+  });
+
   it('mints an authorization URL carrying a state signed with the environment key', async () => {
-    const url = await usecase.execute(buildCommand({ integrationIdentifier: 'victim-slack' }));
+    stubIntegration({ clientId: CLIENT_ID, secretKey: 'victim-secret', hmac: true });
+    const hmacHash = createHash(API_KEY, SUBSCRIBER_ID) as string;
+
+    const url = await usecase.execute(buildCommand({ integrationIdentifier: 'victim-slack', hmacHash }));
 
     expect(url).to.include(`client_id=${CLIENT_ID}`);
 
@@ -114,18 +125,11 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
     await expectRejection(usecase.execute(buildCommand({ hmacHash: 'not-the-right-hash' })), BadRequestException);
   });
 
-  it('does not require an HMAC hash when the flag is enabled and the integration does not opt in', async () => {
+  it('does not require an HMAC hash for allowlisted legacy organizations without integration HMAC', async () => {
+    stubHmacRequiredEnabled(false);
+
     const url = await usecase.execute(buildCommand());
 
-    expect(url).to.include('slack.com/oauth');
-  });
-
-  it('requires an HMAC hash in hmac_required mode even when the integration does not opt in', async () => {
-    stubLegacyMode(LegacySubscriberChatOauthMode.HMAC_REQUIRED);
-
-    await expectRejection(usecase.execute(buildCommand()), BadRequestException);
-
-    const url = await usecase.execute(buildCommand({ hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string }));
     expect(url).to.include('slack.com/oauth');
   });
 

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.spec.ts
@@ -1,12 +1,11 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { createHash, PinoLogger } from '@novu/application-generic';
-import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
-import { ChatProviderIdEnum } from '@novu/shared';
+import { createHash, FeatureFlagsService, PinoLogger } from '@novu/application-generic';
+import { CommunityOrganizationRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum, LegacySubscriberChatOauthMode } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ChatOauthCommand } from './chat-oauth.command';
 import { ChatOauth } from './chat-oauth.usecase';
-import { LEGACY_CHAT_OAUTH_MODE_ENV_VAR, LegacyChatOauthMode } from './legacy-chat-oauth.config';
 import { decodeLegacyChatOauthState } from './legacy-chat-oauth-state';
 
 const ENVIRONMENT_ID = '6a6600c7762b9e152a1f6728';
@@ -28,7 +27,8 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
   let usecase: ChatOauth;
   let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
   let environmentRepository: sinon.SinonStubbedInstance<EnvironmentRepository>;
-  let originalMode: string | undefined;
+  let organizationRepository: sinon.SinonStubbedInstance<CommunityOrganizationRepository>;
+  let featureFlagsService: { getFlag: sinon.SinonStub };
 
   function stubIntegration(credentials: Record<string, unknown>) {
     integrationRepository.findOne.resolves({
@@ -41,18 +41,34 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
     } as any);
   }
 
+  function stubLegacyMode(mode: LegacySubscriberChatOauthMode) {
+    featureFlagsService.getFlag.resolves(mode);
+  }
+
   beforeEach(() => {
-    originalMode = process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
-    delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
     process.env.API_ROOT_URL = 'https://api.novu.co';
 
     integrationRepository = sinon.createStubInstance(IntegrationRepository);
     environmentRepository = sinon.createStubInstance(EnvironmentRepository);
+    organizationRepository = sinon.createStubInstance(CommunityOrganizationRepository);
+    featureFlagsService = { getFlag: sinon.stub() };
+
+    environmentRepository.findOne.resolves({
+      _id: ENVIRONMENT_ID,
+      _organizationId: ORGANIZATION_ID,
+    } as any);
     environmentRepository.getApiKeys.resolves([{ key: API_KEY } as any]);
+    organizationRepository.findOne.resolves({
+      _id: ORGANIZATION_ID,
+      createdAt: new Date('2020-01-01'),
+    } as any);
+    stubLegacyMode(LegacySubscriberChatOauthMode.ENABLED);
 
     usecase = new ChatOauth(
       integrationRepository as any,
       environmentRepository as any,
+      organizationRepository as any,
+      featureFlagsService as unknown as FeatureFlagsService,
       sinon.createStubInstance(PinoLogger) as any
     );
 
@@ -61,12 +77,12 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
 
   afterEach(() => {
     sinon.restore();
+  });
 
-    if (originalMode === undefined) {
-      delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
-    } else {
-      process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = originalMode;
-    }
+  it('rejects every request when the feature flag defaults to disabled', async () => {
+    stubLegacyMode(LegacySubscriberChatOauthMode.DISABLED);
+
+    await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
   });
 
   it('mints an authorization URL carrying a state signed with the environment key', async () => {
@@ -98,25 +114,19 @@ describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
     await expectRejection(usecase.execute(buildCommand({ hmacHash: 'not-the-right-hash' })), BadRequestException);
   });
 
-  it('does not require an HMAC hash by default', async () => {
+  it('does not require an HMAC hash when the flag is enabled and the integration does not opt in', async () => {
     const url = await usecase.execute(buildCommand());
 
     expect(url).to.include('slack.com/oauth');
   });
 
   it('requires an HMAC hash in hmac_required mode even when the integration does not opt in', async () => {
-    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.HMAC_REQUIRED;
+    stubLegacyMode(LegacySubscriberChatOauthMode.HMAC_REQUIRED);
 
     await expectRejection(usecase.execute(buildCommand()), BadRequestException);
 
     const url = await usecase.execute(buildCommand({ hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string }));
     expect(url).to.include('slack.com/oauth');
-  });
-
-  it('rejects every request in disabled mode', async () => {
-    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.DISABLED;
-
-    await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
   });
 
   it('reports a missing environment and a missing integration identically', async () => {

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.spec.ts
@@ -1,0 +1,143 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { createHash, PinoLogger } from '@novu/application-generic';
+import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ChatOauthCommand } from './chat-oauth.command';
+import { ChatOauth } from './chat-oauth.usecase';
+import { LEGACY_CHAT_OAUTH_MODE_ENV_VAR, LegacyChatOauthMode } from './legacy-chat-oauth.config';
+import { decodeLegacyChatOauthState } from './legacy-chat-oauth-state';
+
+const ENVIRONMENT_ID = '6a6600c7762b9e152a1f6728';
+const ORGANIZATION_ID = '6a6600c715029ec38931ec00';
+const SUBSCRIBER_ID = 'victim-subscriber';
+const API_KEY = 'victim-environment-api-key';
+const CLIENT_ID = 'victim-slack-client-id';
+
+function buildCommand(overrides: Partial<ChatOauthCommand> = {}): ChatOauthCommand {
+  return ChatOauthCommand.create({
+    environmentId: ENVIRONMENT_ID,
+    subscriberId: SUBSCRIBER_ID,
+    providerId: ChatProviderIdEnum.Slack,
+    ...overrides,
+  });
+}
+
+describe('ChatOauth (deprecated per-subscriber chat OAuth)', () => {
+  let usecase: ChatOauth;
+  let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
+  let environmentRepository: sinon.SinonStubbedInstance<EnvironmentRepository>;
+  let originalMode: string | undefined;
+
+  function stubIntegration(credentials: Record<string, unknown>) {
+    integrationRepository.findOne.resolves({
+      _id: 'integration-id',
+      _environmentId: ENVIRONMENT_ID,
+      _organizationId: ORGANIZATION_ID,
+      identifier: 'victim-slack',
+      providerId: ChatProviderIdEnum.Slack,
+      credentials,
+    } as any);
+  }
+
+  beforeEach(() => {
+    originalMode = process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
+    delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
+    process.env.API_ROOT_URL = 'https://api.novu.co';
+
+    integrationRepository = sinon.createStubInstance(IntegrationRepository);
+    environmentRepository = sinon.createStubInstance(EnvironmentRepository);
+    environmentRepository.getApiKeys.resolves([{ key: API_KEY } as any]);
+
+    usecase = new ChatOauth(
+      integrationRepository as any,
+      environmentRepository as any,
+      sinon.createStubInstance(PinoLogger) as any
+    );
+
+    stubIntegration({ clientId: CLIENT_ID, secretKey: 'victim-secret' });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+
+    if (originalMode === undefined) {
+      delete process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR];
+    } else {
+      process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = originalMode;
+    }
+  });
+
+  it('mints an authorization URL carrying a state signed with the environment key', async () => {
+    const url = await usecase.execute(buildCommand({ integrationIdentifier: 'victim-slack' }));
+
+    expect(url).to.include(`client_id=${CLIENT_ID}`);
+
+    const state = new URL(url).searchParams.get('state') as string;
+    const decoded = decodeLegacyChatOauthState(state, API_KEY);
+
+    expect(decoded.environmentId).to.equal(ENVIRONMENT_ID);
+    expect(decoded.subscriberId).to.equal(SUBSCRIBER_ID);
+    expect(decoded.integrationIdentifier).to.equal('victim-slack');
+  });
+
+  it('carries the validated HMAC hash in the state so it survives the provider round trip', async () => {
+    stubIntegration({ clientId: CLIENT_ID, hmac: true });
+    const hmacHash = createHash(API_KEY, SUBSCRIBER_ID) as string;
+
+    const url = await usecase.execute(buildCommand({ hmacHash }));
+    const state = new URL(url).searchParams.get('state') as string;
+
+    expect(decodeLegacyChatOauthState(state, API_KEY).hmacHash).to.equal(hmacHash);
+  });
+
+  it('rejects a wrong HMAC hash when the integration enables HMAC', async () => {
+    stubIntegration({ clientId: CLIENT_ID, hmac: true });
+
+    await expectRejection(usecase.execute(buildCommand({ hmacHash: 'not-the-right-hash' })), BadRequestException);
+  });
+
+  it('does not require an HMAC hash by default', async () => {
+    const url = await usecase.execute(buildCommand());
+
+    expect(url).to.include('slack.com/oauth');
+  });
+
+  it('requires an HMAC hash in hmac_required mode even when the integration does not opt in', async () => {
+    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.HMAC_REQUIRED;
+
+    await expectRejection(usecase.execute(buildCommand()), BadRequestException);
+
+    const url = await usecase.execute(buildCommand({ hmacHash: createHash(API_KEY, SUBSCRIBER_ID) as string }));
+    expect(url).to.include('slack.com/oauth');
+  });
+
+  it('rejects every request in disabled mode', async () => {
+    process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR] = LegacyChatOauthMode.DISABLED;
+
+    await expectRejection(usecase.execute(buildCommand()), ForbiddenException);
+  });
+
+  it('reports a missing environment and a missing integration identically', async () => {
+    integrationRepository.findOne.resolves(null);
+
+    await expectRejection(usecase.execute(buildCommand()), NotFoundException, 'Chat integration not found');
+  });
+});
+
+async function expectRejection(promise: Promise<unknown>, errorType: unknown, messageIncludes?: string) {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).to.be.instanceOf(errorType as never);
+
+    if (messageIncludes) {
+      expect((error as Error).message).to.include(messageIncludes);
+    }
+
+    return;
+  }
+
+  throw new Error('Expected the promise to reject');
+}

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
@@ -1,23 +1,23 @@
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
-import { EnvironmentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
+import { FeatureFlagsService, PinoLogger } from '@novu/application-generic';
+import {
+  CommunityOrganizationRepository,
+  EnvironmentRepository,
+  IntegrationEntity,
+  IntegrationRepository,
+} from '@novu/dal';
+import { LegacySubscriberChatOauthMode } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/stateless';
 
 import { isHmacValidForAnyKey } from '../../../shared/helpers/is-valid-hmac';
 import { ChatOauthCommand } from './chat-oauth.command';
 import {
+  CHAT_INTEGRATION_NOT_FOUND_MESSAGE,
   getLegacyChatOauthMode,
   LEGACY_CHAT_OAUTH_MIGRATION_HINT,
-  LegacyChatOauthMode,
+  resolveLegacyChatOauthOrganization,
 } from './legacy-chat-oauth.config';
 import { encodeLegacyChatOauthState } from './legacy-chat-oauth-state';
-
-/**
- * Both the environment and the integration are reported the same way so an
- * unauthenticated caller cannot use the error to tell an environment that has
- * no chat integration from one that does not exist at all.
- */
-export const CHAT_INTEGRATION_NOT_FOUND_MESSAGE = 'Chat integration not found';
 
 /**
  * @deprecated Use `POST /v1/integrations/chat/oauth`.
@@ -30,15 +30,22 @@ export class ChatOauth {
   constructor(
     private integrationRepository: IntegrationRepository,
     private environmentRepository: EnvironmentRepository,
+    private organizationRepository: CommunityOrganizationRepository,
+    private featureFlagsService: FeatureFlagsService,
     private logger: PinoLogger
   ) {
     this.logger.setContext(ChatOauth.name);
   }
 
   async execute(command: ChatOauthCommand): Promise<string> {
-    const mode = getLegacyChatOauthMode();
+    const organization = await resolveLegacyChatOauthOrganization(
+      this.environmentRepository,
+      this.organizationRepository,
+      command.environmentId
+    );
+    const mode = await getLegacyChatOauthMode(this.featureFlagsService, organization);
 
-    if (mode === LegacyChatOauthMode.DISABLED) {
+    if (mode === LegacySubscriberChatOauthMode.DISABLED) {
       throw new ForbiddenException(LEGACY_CHAT_OAUTH_MIGRATION_HINT);
     }
 
@@ -52,7 +59,7 @@ export class ChatOauth {
     const apiKeys = await this.getEnvironmentApiKeys(command.environmentId);
 
     assertLegacyChatOauthHmac({
-      isHmacRequired: hmac === true || mode === LegacyChatOauthMode.HMAC_REQUIRED,
+      isHmacRequired: hmac === true || mode === LegacySubscriberChatOauthMode.HMAC_REQUIRED,
       apiKeys,
       subscriberId: command.subscriberId,
       externalHmacHash: command.hmacHash,

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { FeatureFlagsService, PinoLogger } from '@novu/application-generic';
 import {
   CommunityOrganizationRepository,
@@ -6,15 +6,16 @@ import {
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { LegacySubscriberChatOauthMode } from '@novu/shared';
 import { ChannelTypeEnum } from '@novu/stateless';
 
 import { isHmacValidForAnyKey } from '../../../shared/helpers/is-valid-hmac';
 import { ChatOauthCommand } from './chat-oauth.command';
 import {
+  assertLegacyChatOauthIntegrationHmacEnabled,
   CHAT_INTEGRATION_NOT_FOUND_MESSAGE,
-  getLegacyChatOauthMode,
+  isLegacySubscriberChatOauthHmacRequired,
   LEGACY_CHAT_OAUTH_MIGRATION_HINT,
+  resolveLegacyChatOauthHmacRequired,
   resolveLegacyChatOauthOrganization,
 } from './legacy-chat-oauth.config';
 import { encodeLegacyChatOauthState } from './legacy-chat-oauth-state';
@@ -43,23 +44,22 @@ export class ChatOauth {
       this.organizationRepository,
       command.environmentId
     );
-    const mode = await getLegacyChatOauthMode(this.featureFlagsService, organization);
-
-    if (mode === LegacySubscriberChatOauthMode.DISABLED) {
-      throw new ForbiddenException(LEGACY_CHAT_OAUTH_MIGRATION_HINT);
-    }
+    const hmacRequiredEnabled = await isLegacySubscriberChatOauthHmacRequired(this.featureFlagsService, organization);
 
     const integration = await this.getIntegration(command);
     const { clientId, hmac } = integration.credentials;
+    const integrationHmacEnabled = hmac === true;
 
     if (!clientId) {
       throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
     }
 
+    assertLegacyChatOauthIntegrationHmacEnabled(hmacRequiredEnabled, integrationHmacEnabled);
+
     const apiKeys = await this.getEnvironmentApiKeys(command.environmentId);
 
     assertLegacyChatOauthHmac({
-      isHmacRequired: hmac === true || mode === LegacySubscriberChatOauthMode.HMAC_REQUIRED,
+      isHmacRequired: resolveLegacyChatOauthHmacRequired(hmacRequiredEnabled, integrationHmacEnabled),
       apiKeys,
       subscriberId: command.subscriberId,
       externalHmacHash: command.hmacHash,
@@ -71,8 +71,8 @@ export class ChatOauth {
         organizationId: integration._organizationId,
         providerId: command.providerId,
         integrationIdentifier: integration.identifier,
-        mode,
-        hmacEnabled: hmac === true,
+        hmacRequiredEnabled,
+        hmacEnabled: integrationHmacEnabled,
       },
       `Deprecated per-subscriber chat OAuth URL requested. ${LEGACY_CHAT_OAUTH_MIGRATION_HINT}`
     );

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
@@ -1,9 +1,9 @@
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { createHash, PinoLogger } from '@novu/application-generic';
+import { PinoLogger } from '@novu/application-generic';
 import { EnvironmentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import { ChannelTypeEnum } from '@novu/stateless';
 
-import { areHexDigestsEqual } from '../../../shared/helpers/timing-safe-equal';
+import { isHmacValidForAnyKey } from '../../../shared/helpers/is-valid-hmac';
 import { ChatOauthCommand } from './chat-oauth.command';
 import {
   getLegacyChatOauthMode,
@@ -49,11 +49,11 @@ export class ChatOauth {
       throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
     }
 
-    const apiKey = await this.getEnvironmentApiKey(command.environmentId);
+    const apiKeys = await this.getEnvironmentApiKeys(command.environmentId);
 
-    this.hmacValidation({
+    assertLegacyChatOauthHmac({
       isHmacRequired: hmac === true || mode === LegacyChatOauthMode.HMAC_REQUIRED,
-      apiKey,
+      apiKeys,
       subscriberId: command.subscriberId,
       externalHmacHash: command.hmacHash,
     });
@@ -79,7 +79,7 @@ export class ChatOauth {
         hmacHash: command.hmacHash,
         timestamp: Date.now(),
       },
-      apiKey
+      apiKeys[0]
     );
 
     return this.getOAuthUrl(
@@ -89,34 +89,6 @@ export class ChatOauth {
       state,
       command.integrationIdentifier
     );
-  }
-
-  private hmacValidation({
-    isHmacRequired,
-    apiKey,
-    subscriberId,
-    externalHmacHash,
-  }: {
-    isHmacRequired: boolean;
-    apiKey: string;
-    subscriberId: string;
-    externalHmacHash: string | undefined;
-  }) {
-    if (!isHmacRequired) {
-      return;
-    }
-
-    if (!externalHmacHash) {
-      throw new BadRequestException(
-        'Hmac is enabled on the integration, please provide a HMAC hash on the request params'
-      );
-    }
-
-    validateEncryption({
-      apiKey,
-      subscriberId,
-      externalHmacHash,
-    });
   }
 
   private getOAuthUrl(
@@ -174,29 +146,47 @@ export class ChatOauth {
     return integration;
   }
 
-  private async getEnvironmentApiKey(environmentId: string): Promise<string> {
+  private async getEnvironmentApiKeys(environmentId: string): Promise<string[]> {
     const apiKeys = await this.environmentRepository.getApiKeys(environmentId);
 
     if (!apiKeys.length) {
       throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
     }
 
-    return apiKeys[0].key;
+    return apiKeys.map(({ key }) => key);
   }
 }
 
-export function validateEncryption({
-  apiKey,
+/**
+ * Validates the subscriber HMAC the way every other subscriber-facing surface
+ * does: against the decrypted secret key the customer holds, and against every
+ * active key so a rolling rotation does not break in-flight authorizations.
+ * This flow used to hash the at-rest ciphertext instead, which no client could
+ * reproduce — enabling `hmac` on an integration made the flow unusable rather
+ * than protected.
+ */
+export function assertLegacyChatOauthHmac({
+  isHmacRequired,
+  apiKeys,
   subscriberId,
   externalHmacHash,
 }: {
-  apiKey: string;
+  isHmacRequired: boolean;
+  apiKeys: string[];
   subscriberId: string;
-  externalHmacHash: string;
+  externalHmacHash: string | undefined;
 }) {
-  const hmacHash = createHash(apiKey, subscriberId);
+  if (!isHmacRequired) {
+    return;
+  }
 
-  if (!areHexDigestsEqual(hmacHash, externalHmacHash)) {
+  if (!externalHmacHash) {
+    throw new BadRequestException(
+      'Hmac is enabled on the integration, please provide a HMAC hash on the request params'
+    );
+  }
+
+  if (!isHmacValidForAnyKey(apiKeys, subscriberId, externalHmacHash)) {
     throw new BadRequestException('Hmac is enabled on the integration, please provide a valid HMAC hash');
   }
 }

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts
@@ -1,65 +1,133 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { createHash } from '@novu/application-generic';
-import { EnvironmentRepository, ICredentialsEntity, IntegrationEntity, IntegrationRepository } from '@novu/dal';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { createHash, PinoLogger } from '@novu/application-generic';
+import { EnvironmentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import { ChannelTypeEnum } from '@novu/stateless';
 
+import { areHexDigestsEqual } from '../../../shared/helpers/timing-safe-equal';
 import { ChatOauthCommand } from './chat-oauth.command';
+import {
+  getLegacyChatOauthMode,
+  LEGACY_CHAT_OAUTH_MIGRATION_HINT,
+  LegacyChatOauthMode,
+} from './legacy-chat-oauth.config';
+import { encodeLegacyChatOauthState } from './legacy-chat-oauth-state';
 
+/**
+ * Both the environment and the integration are reported the same way so an
+ * unauthenticated caller cannot use the error to tell an environment that has
+ * no chat integration from one that does not exist at all.
+ */
+export const CHAT_INTEGRATION_NOT_FOUND_MESSAGE = 'Chat integration not found';
+
+/**
+ * @deprecated Use `POST /v1/integrations/chat/oauth`.
+ * @see apps/api/src/app/integrations/usecases/generate-chat-oath-url
+ */
 @Injectable()
 export class ChatOauth {
   readonly SLACK_OAUTH_URL = 'https://slack.com/oauth/v2/authorize?';
 
   constructor(
     private integrationRepository: IntegrationRepository,
-    private environmentRepository: EnvironmentRepository
-  ) {}
-  async execute(command: ChatOauthCommand): Promise<string> {
-    const { clientId, hmac } = await this.getCredentials(command);
+    private environmentRepository: EnvironmentRepository,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(ChatOauth.name);
+  }
 
-    await this.hmacValidation({
-      credentialHmac: hmac,
-      environmentId: command.environmentId,
+  async execute(command: ChatOauthCommand): Promise<string> {
+    const mode = getLegacyChatOauthMode();
+
+    if (mode === LegacyChatOauthMode.DISABLED) {
+      throw new ForbiddenException(LEGACY_CHAT_OAUTH_MIGRATION_HINT);
+    }
+
+    const integration = await this.getIntegration(command);
+    const { clientId, hmac } = integration.credentials;
+
+    if (!clientId) {
+      throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
+    }
+
+    const apiKey = await this.getEnvironmentApiKey(command.environmentId);
+
+    this.hmacValidation({
+      isHmacRequired: hmac === true || mode === LegacyChatOauthMode.HMAC_REQUIRED,
+      apiKey,
       subscriberId: command.subscriberId,
       externalHmacHash: command.hmacHash,
     });
 
-    return this.getOAuthUrl(command.subscriberId, command.environmentId, clientId!, command.integrationIdentifier);
+    this.logger.warn(
+      {
+        environmentId: command.environmentId,
+        organizationId: integration._organizationId,
+        providerId: command.providerId,
+        integrationIdentifier: integration.identifier,
+        mode,
+        hmacEnabled: hmac === true,
+      },
+      `Deprecated per-subscriber chat OAuth URL requested. ${LEGACY_CHAT_OAUTH_MIGRATION_HINT}`
+    );
+
+    const state = encodeLegacyChatOauthState(
+      {
+        environmentId: command.environmentId,
+        subscriberId: command.subscriberId,
+        providerId: command.providerId,
+        integrationIdentifier: command.integrationIdentifier,
+        hmacHash: command.hmacHash,
+        timestamp: Date.now(),
+      },
+      apiKey
+    );
+
+    return this.getOAuthUrl(
+      command.subscriberId,
+      command.environmentId,
+      clientId,
+      state,
+      command.integrationIdentifier
+    );
   }
 
-  private async hmacValidation({
-    credentialHmac,
-    environmentId,
+  private hmacValidation({
+    isHmacRequired,
+    apiKey,
     subscriberId,
     externalHmacHash,
   }: {
-    credentialHmac: boolean | undefined;
-    environmentId: string;
+    isHmacRequired: boolean;
+    apiKey: string;
     subscriberId: string;
     externalHmacHash: string | undefined;
   }) {
-    if (credentialHmac) {
-      if (!externalHmacHash) {
-        throw new BadRequestException(
-          'Hmac is enabled on the integration, please provide a HMAC hash on the request params'
-        );
-      }
-
-      const apiKey = await this.getEnvironmentApiKey(environmentId);
-
-      validateEncryption({
-        apiKey,
-        subscriberId,
-        externalHmacHash,
-      });
+    if (!isHmacRequired) {
+      return;
     }
+
+    if (!externalHmacHash) {
+      throw new BadRequestException(
+        'Hmac is enabled on the integration, please provide a HMAC hash on the request params'
+      );
+    }
+
+    validateEncryption({
+      apiKey,
+      subscriberId,
+      externalHmacHash,
+    });
   }
 
   private getOAuthUrl(
     subscriberId: string,
     environmentId: string,
     clientId: string,
+    state: string,
     integrationIdentifier?: string
   ): string {
+    // The redirect URI is registered with the provider and rebuilt verbatim by
+    // the callback for the token exchange — it must stay byte-identical.
     let redirectUri = `${
       process.env.API_ROOT_URL
     }/v1/subscribers/${subscriberId}/credentials/slack/oauth/callback?environmentId=${environmentId}`;
@@ -68,12 +136,13 @@ export class ChatOauth {
       redirectUri = `${redirectUri}&integrationIdentifier=${integrationIdentifier}`;
     }
 
-    return `${
-      this.SLACK_OAUTH_URL
-    }client_id=${clientId}&scope=incoming-webhook&user_scope=&redirect_uri=${encodeURIComponent(redirectUri)}`;
+    return (
+      `${this.SLACK_OAUTH_URL}client_id=${clientId}&scope=incoming-webhook&user_scope=` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}&state=${encodeURIComponent(state)}`
+    );
   }
 
-  private async getCredentials(command: ChatOauthCommand): Promise<ICredentialsEntity> {
+  private async getIntegration(command: ChatOauthCommand): Promise<IntegrationEntity> {
     const query: Partial<IntegrationEntity> & { _environmentId: string } = {
       _environmentId: command.environmentId,
       channel: ChannelTypeEnum.CHAT,
@@ -88,35 +157,28 @@ export class ChatOauth {
       query: { sort: { createdAt: -1 } },
     });
 
-    if (!integration) {
-      throw new NotFoundException(
-        `Integration in environment ${command.environmentId} was not found, channel: ${ChannelTypeEnum.CHAT}, ` +
-          `providerId: ${command.providerId}`
+    if (!integration?.credentials) {
+      this.logger.warn(
+        {
+          environmentId: command.environmentId,
+          providerId: command.providerId,
+          integrationIdentifier: command.integrationIdentifier,
+          reason: integration ? 'missing credentials' : 'no matching integration',
+        },
+        'Legacy chat OAuth URL request could not be resolved to an integration'
       );
+
+      throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
     }
 
-    if (!integration.credentials) {
-      throw new NotFoundException(
-        `Integration in environment ${command.environmentId} missing credentials, channel: ${ChannelTypeEnum.CHAT}, ` +
-          `providerId: ${command.providerId}`
-      );
-    }
-
-    if (!integration.credentials.clientId) {
-      throw new NotFoundException(
-        `Integration in environment ${command.environmentId} missing clientId, channel: ${ChannelTypeEnum.CHAT}, ` +
-          `providerId: ${command.providerId}`
-      );
-    }
-
-    return integration.credentials;
+    return integration;
   }
 
   private async getEnvironmentApiKey(environmentId: string): Promise<string> {
     const apiKeys = await this.environmentRepository.getApiKeys(environmentId);
 
     if (!apiKeys.length) {
-      throw new NotFoundException(`Environment ID: ${environmentId} not found`);
+      throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
     }
 
     return apiKeys[0].key;
@@ -133,7 +195,8 @@ export function validateEncryption({
   externalHmacHash: string;
 }) {
   const hmacHash = createHash(apiKey, subscriberId);
-  if (hmacHash !== externalHmacHash) {
+
+  if (!areHexDigestsEqual(hmacHash, externalHmacHash)) {
     throw new BadRequestException('Hmac is enabled on the integration, please provide a valid HMAC hash');
   }
 }

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth-state.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth-state.spec.ts
@@ -1,0 +1,81 @@
+import { BadRequestException } from '@nestjs/common';
+import { encodeOAuthState } from '@novu/application-generic';
+import { ChatProviderIdEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  decodeLegacyChatOauthState,
+  encodeLegacyChatOauthState,
+  type LegacyChatOauthStateData,
+  peekLegacyChatOauthStateEnvironmentId,
+} from './legacy-chat-oauth-state';
+
+const VICTIM_API_KEY = 'victim-environment-api-key';
+const ATTACKER_API_KEY = 'attacker-environment-api-key';
+
+function buildState(overrides: Partial<LegacyChatOauthStateData> = {}): LegacyChatOauthStateData {
+  return {
+    environmentId: '6a6600c7762b9e152a1f6728',
+    subscriberId: 'victim-subscriber',
+    providerId: ChatProviderIdEnum.Slack,
+    integrationIdentifier: 'victim-slack',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('legacy chat OAuth state', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('round-trips the signed payload', () => {
+    const data = buildState({ hmacHash: 'deadbeef' });
+
+    const decoded = decodeLegacyChatOauthState(encodeLegacyChatOauthState(data, VICTIM_API_KEY), VICTIM_API_KEY);
+
+    expect(decoded).to.deep.equal(data);
+  });
+
+  it('exposes the environment id before the signature is verified', () => {
+    const data = buildState();
+
+    expect(peekLegacyChatOauthStateEnvironmentId(encodeLegacyChatOauthState(data, VICTIM_API_KEY))).to.equal(
+      data.environmentId
+    );
+  });
+
+  it('rejects a state signed with another environment key', () => {
+    const state = encodeLegacyChatOauthState(buildState(), ATTACKER_API_KEY);
+
+    expect(() => decodeLegacyChatOauthState(state, VICTIM_API_KEY)).to.throw(BadRequestException);
+  });
+
+  it('rejects a payload edited after signing', () => {
+    const data = buildState();
+    const signed = encodeLegacyChatOauthState(data, VICTIM_API_KEY);
+    const { signature } = splitForTest(signed);
+    const tampered = encodeOAuthState(JSON.stringify({ ...data, subscriberId: 'other-subscriber' }), signature);
+
+    expect(() => decodeLegacyChatOauthState(tampered, VICTIM_API_KEY)).to.throw(BadRequestException);
+  });
+
+  it('rejects an unsigned payload', () => {
+    const unsigned = Buffer.from(JSON.stringify(buildState())).toString('base64url');
+
+    expect(() => decodeLegacyChatOauthState(unsigned, VICTIM_API_KEY)).to.throw(BadRequestException);
+  });
+
+  it('rejects a state older than the TTL', () => {
+    const state = encodeLegacyChatOauthState(buildState({ timestamp: Date.now() - 16 * 60 * 1000 }), VICTIM_API_KEY);
+
+    expect(() => decodeLegacyChatOauthState(state, VICTIM_API_KEY)).to.throw(BadRequestException, 'expired');
+  });
+});
+
+function splitForTest(state: string): { payload: string; signature: string } {
+  const decoded = Buffer.from(state, 'base64url').toString();
+  const lastDotIndex = decoded.lastIndexOf('.');
+
+  return { payload: decoded.slice(0, lastDotIndex), signature: decoded.slice(lastDotIndex + 1) };
+}

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth-state.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth-state.ts
@@ -1,0 +1,78 @@
+import { BadRequestException } from '@nestjs/common';
+import { createHash, encodeOAuthState, peekOAuthStatePayload, splitOAuthState } from '@novu/application-generic';
+import { ChatProviderIdEnum } from '@novu/shared';
+import { areHexDigestsEqual } from '../../../shared/helpers/timing-safe-equal';
+
+/**
+ * Signed `state` carried through the deprecated per-subscriber chat OAuth flow.
+ *
+ * The legacy flow derived every routing field from the callback's query string,
+ * so anyone able to reach the callback could name an arbitrary environment and
+ * subscriber. Signing the state with the environment's API key at the point the
+ * OAuth URL is minted binds the callback to that exact hand-off, and lets the
+ * subscriber HMAC hash survive the provider round trip — the redirect URI is
+ * registered with the provider and cannot carry it.
+ */
+export type LegacyChatOauthStateData = {
+  environmentId: string;
+  subscriberId: string;
+  providerId: ChatProviderIdEnum;
+  integrationIdentifier?: string;
+  hmacHash?: string;
+  timestamp: number;
+};
+
+/**
+ * Generous compared to the 5 minutes used by `POST /v1/integrations/chat/oauth`:
+ * the legacy flow routinely includes a full provider sign-in and workspace
+ * picker in the same hop, and expiring mid-install would be a regression.
+ */
+const STATE_TTL_MS = 15 * 60 * 1000;
+
+export function encodeLegacyChatOauthState(data: LegacyChatOauthStateData, environmentApiKey: string): string {
+  const payload = JSON.stringify(data);
+  const signature = createHash(environmentApiKey, payload);
+
+  if (!signature) {
+    throw new BadRequestException('Failed to create OAuth state signature');
+  }
+
+  return encodeOAuthState(payload, signature);
+}
+
+export function peekLegacyChatOauthStateEnvironmentId(state: string): string {
+  try {
+    const { environmentId } = peekOAuthStatePayload<Partial<LegacyChatOauthStateData>>(state);
+
+    if (!environmentId) {
+      throw new Error('Missing environmentId');
+    }
+
+    return environmentId;
+  } catch {
+    throw new BadRequestException('Invalid OAuth state parameter');
+  }
+}
+
+export function decodeLegacyChatOauthState(state: string, environmentApiKey: string): LegacyChatOauthStateData {
+  let data: LegacyChatOauthStateData;
+
+  try {
+    const { payload, signature } = splitOAuthState(state);
+    const expectedSignature = createHash(environmentApiKey, payload);
+
+    if (!areHexDigestsEqual(expectedSignature, signature)) {
+      throw new Error('Invalid state signature');
+    }
+
+    data = JSON.parse(payload) as LegacyChatOauthStateData;
+  } catch {
+    throw new BadRequestException('Invalid OAuth state parameter');
+  }
+
+  if (typeof data.timestamp !== 'number' || Date.now() - data.timestamp > STATE_TTL_MS) {
+    throw new BadRequestException('OAuth state expired, please restart the authorization flow');
+  }
+
+  return data;
+}

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.spec.ts
@@ -1,0 +1,30 @@
+import { ForbiddenException } from '@nestjs/common';
+import { expect } from 'chai';
+import {
+  assertLegacyChatOauthIntegrationHmacEnabled,
+  resolveLegacyChatOauthHmacRequired,
+} from './legacy-chat-oauth.config';
+
+describe('legacy-chat-oauth.config', () => {
+  describe('resolveLegacyChatOauthHmacRequired', () => {
+    it('requires HMAC for new organizations by default', () => {
+      expect(resolveLegacyChatOauthHmacRequired(true, false)).to.equal(true);
+      expect(resolveLegacyChatOauthHmacRequired(true, true)).to.equal(true);
+    });
+
+    it('mirrors the integration HMAC setting for allowlisted legacy organizations', () => {
+      expect(resolveLegacyChatOauthHmacRequired(false, false)).to.equal(false);
+      expect(resolveLegacyChatOauthHmacRequired(false, true)).to.equal(true);
+    });
+  });
+
+  describe('assertLegacyChatOauthIntegrationHmacEnabled', () => {
+    it('blocks new organizations when the integration does not enable HMAC', () => {
+      expect(() => assertLegacyChatOauthIntegrationHmacEnabled(true, false)).to.throw(ForbiddenException);
+    });
+
+    it('allows allowlisted legacy organizations without integration HMAC', () => {
+      expect(() => assertLegacyChatOauthIntegrationHmacEnabled(false, false)).to.not.throw();
+    });
+  });
+});

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.ts
@@ -1,0 +1,44 @@
+/**
+ * Operating mode for the deprecated per-subscriber chat OAuth endpoints
+ * (`GET /v1/subscribers/:subscriberId/credentials/:providerId/oauth[/callback]`).
+ *
+ * Those two routes are unauthenticated by design — they are opened in the
+ * subscriber's browser and hit again by the provider's redirect — so the only
+ * proof of authorization they can carry is the subscriber HMAC hash, which is
+ * opt-in per integration. `enabled` preserves that historical behavior;
+ * operators that have migrated to `POST /v1/integrations/chat/oauth` should
+ * move to `hmac_required` and then `disabled`.
+ */
+export enum LegacyChatOauthMode {
+  /** Historical behavior: HMAC enforced only when the integration opts in. */
+  ENABLED = 'enabled',
+  /** HMAC always enforced, regardless of the integration's `hmac` credential. */
+  HMAC_REQUIRED = 'hmac_required',
+  /** Both routes reject every request. */
+  DISABLED = 'disabled',
+}
+
+export const LEGACY_CHAT_OAUTH_MODE_ENV_VAR = 'NOVU_LEGACY_SUBSCRIBER_CHAT_OAUTH';
+
+export const LEGACY_CHAT_OAUTH_MIGRATION_HINT =
+  'The per-subscriber chat OAuth endpoints are deprecated. Use POST /v1/integrations/chat/oauth to mint an ' +
+  'authenticated OAuth URL instead.';
+
+const VALID_MODES = new Set<string>(Object.values(LegacyChatOauthMode));
+
+export function getLegacyChatOauthMode(): LegacyChatOauthMode {
+  const configured = process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR]?.trim().toLowerCase();
+
+  if (!configured) {
+    return LegacyChatOauthMode.ENABLED;
+  }
+
+  // Falling back to the permissive default keeps a typo from taking a working
+  // integration offline. Both endpoints log the resolved mode on every call, so
+  // a misconfiguration still shows up as `mode: enabled` in the request logs.
+  if (!VALID_MODES.has(configured)) {
+    return LegacyChatOauthMode.ENABLED;
+  }
+
+  return configured as LegacyChatOauthMode;
+}

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.ts
@@ -1,7 +1,7 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { FeatureFlagsService } from '@novu/application-generic';
 import { CommunityOrganizationRepository, EnvironmentRepository, OrganizationEntity } from '@novu/dal';
-import { FeatureFlagsKeysEnum, LegacySubscriberChatOauthMode } from '@novu/shared';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
 
 export const CHAT_INTEGRATION_NOT_FOUND_MESSAGE = 'Chat integration not found';
 
@@ -9,27 +9,41 @@ export const LEGACY_CHAT_OAUTH_MIGRATION_HINT =
   'The per-subscriber chat OAuth endpoints are deprecated. Use POST /v1/integrations/chat/oauth to mint an ' +
   'authenticated OAuth URL instead.';
 
-const VALID_MODES = new Set<string>(Object.values(LegacySubscriberChatOauthMode));
+export const LEGACY_CHAT_OAUTH_HMAC_REQUIRED_MESSAGE =
+  'HMAC must be enabled on the Slack integration to use the per-subscriber chat OAuth endpoints. ' +
+  LEGACY_CHAT_OAUTH_MIGRATION_HINT;
 
 type LegacyChatOauthOrganization = Pick<OrganizationEntity, '_id' | 'createdAt'>;
 
-export async function getLegacyChatOauthMode(
+export async function isLegacySubscriberChatOauthHmacRequired(
   featureFlagsService: FeatureFlagsService,
   organization: LegacyChatOauthOrganization
-): Promise<LegacySubscriberChatOauthMode> {
-  const configured = await featureFlagsService.getFlag({
-    key: FeatureFlagsKeysEnum.LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE,
-    defaultValue: LegacySubscriberChatOauthMode.DISABLED,
+): Promise<boolean> {
+  return featureFlagsService.getFlag({
+    key: FeatureFlagsKeysEnum.IS_SUBSCRIBER_CHAT_OAUTH_HMAC_REQUIRED_ENABLED,
+    defaultValue: true,
     organization,
   });
+}
 
-  const normalized = typeof configured === 'string' ? configured.trim().toLowerCase() : '';
-
-  if (!VALID_MODES.has(normalized)) {
-    return LegacySubscriberChatOauthMode.DISABLED;
+export function resolveLegacyChatOauthHmacRequired(
+  hmacRequiredEnabled: boolean,
+  integrationHmacEnabled: boolean
+): boolean {
+  if (hmacRequiredEnabled) {
+    return true;
   }
 
-  return normalized as LegacySubscriberChatOauthMode;
+  return integrationHmacEnabled;
+}
+
+export function assertLegacyChatOauthIntegrationHmacEnabled(
+  hmacRequiredEnabled: boolean,
+  integrationHmacEnabled: boolean
+): void {
+  if (hmacRequiredEnabled && !integrationHmacEnabled) {
+    throw new ForbiddenException(LEGACY_CHAT_OAUTH_HMAC_REQUIRED_MESSAGE);
+  }
 }
 
 export async function resolveLegacyChatOauthOrganization(

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.ts
@@ -1,44 +1,53 @@
-/**
- * Operating mode for the deprecated per-subscriber chat OAuth endpoints
- * (`GET /v1/subscribers/:subscriberId/credentials/:providerId/oauth[/callback]`).
- *
- * Those two routes are unauthenticated by design — they are opened in the
- * subscriber's browser and hit again by the provider's redirect — so the only
- * proof of authorization they can carry is the subscriber HMAC hash, which is
- * opt-in per integration. `enabled` preserves that historical behavior;
- * operators that have migrated to `POST /v1/integrations/chat/oauth` should
- * move to `hmac_required` and then `disabled`.
- */
-export enum LegacyChatOauthMode {
-  /** Historical behavior: HMAC enforced only when the integration opts in. */
-  ENABLED = 'enabled',
-  /** HMAC always enforced, regardless of the integration's `hmac` credential. */
-  HMAC_REQUIRED = 'hmac_required',
-  /** Both routes reject every request. */
-  DISABLED = 'disabled',
-}
+import { NotFoundException } from '@nestjs/common';
+import { FeatureFlagsService } from '@novu/application-generic';
+import { CommunityOrganizationRepository, EnvironmentRepository, OrganizationEntity } from '@novu/dal';
+import { FeatureFlagsKeysEnum, LegacySubscriberChatOauthMode } from '@novu/shared';
 
-export const LEGACY_CHAT_OAUTH_MODE_ENV_VAR = 'NOVU_LEGACY_SUBSCRIBER_CHAT_OAUTH';
+export const CHAT_INTEGRATION_NOT_FOUND_MESSAGE = 'Chat integration not found';
 
 export const LEGACY_CHAT_OAUTH_MIGRATION_HINT =
   'The per-subscriber chat OAuth endpoints are deprecated. Use POST /v1/integrations/chat/oauth to mint an ' +
   'authenticated OAuth URL instead.';
 
-const VALID_MODES = new Set<string>(Object.values(LegacyChatOauthMode));
+const VALID_MODES = new Set<string>(Object.values(LegacySubscriberChatOauthMode));
 
-export function getLegacyChatOauthMode(): LegacyChatOauthMode {
-  const configured = process.env[LEGACY_CHAT_OAUTH_MODE_ENV_VAR]?.trim().toLowerCase();
+type LegacyChatOauthOrganization = Pick<OrganizationEntity, '_id' | 'createdAt'>;
 
-  if (!configured) {
-    return LegacyChatOauthMode.ENABLED;
+export async function getLegacyChatOauthMode(
+  featureFlagsService: FeatureFlagsService,
+  organization: LegacyChatOauthOrganization
+): Promise<LegacySubscriberChatOauthMode> {
+  const configured = await featureFlagsService.getFlag({
+    key: FeatureFlagsKeysEnum.LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE,
+    defaultValue: LegacySubscriberChatOauthMode.DISABLED,
+    organization,
+  });
+
+  const normalized = typeof configured === 'string' ? configured.trim().toLowerCase() : '';
+
+  if (!VALID_MODES.has(normalized)) {
+    return LegacySubscriberChatOauthMode.DISABLED;
   }
 
-  // Falling back to the permissive default keeps a typo from taking a working
-  // integration offline. Both endpoints log the resolved mode on every call, so
-  // a misconfiguration still shows up as `mode: enabled` in the request logs.
-  if (!VALID_MODES.has(configured)) {
-    return LegacyChatOauthMode.ENABLED;
+  return normalized as LegacySubscriberChatOauthMode;
+}
+
+export async function resolveLegacyChatOauthOrganization(
+  environmentRepository: EnvironmentRepository,
+  organizationRepository: CommunityOrganizationRepository,
+  environmentId: string
+): Promise<LegacyChatOauthOrganization> {
+  const environment = await environmentRepository.findOne({ _id: environmentId }, '_organizationId');
+
+  if (!environment?._organizationId) {
+    throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
   }
 
-  return configured as LegacyChatOauthMode;
+  const organization = await organizationRepository.findOne({ _id: environment._organizationId }, '_id createdAt');
+
+  if (!organization) {
+    throw new NotFoundException(CHAT_INTEGRATION_NOT_FOUND_MESSAGE);
+  }
+
+  return organization;
 }

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -175,6 +175,14 @@ export enum FeatureFlagsKeysEnum {
   IS_TOOL_CHANNEL_ENABLED = 'IS_TOOL_CHANNEL_ENABLED',
 
   // String flags
+  /**
+   * Operating mode for the deprecated per-subscriber chat OAuth routes
+   * (`GET /v1/subscribers/:subscriberId/credentials/:providerId/oauth[/callback]`).
+   * Target in LaunchDarkly by `organization.createdAt` so pre-existing orgs can
+   * keep `enabled` while new orgs stay on the default `disabled`. Self-hosted:
+   * set `LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE` in the environment.
+   */
+  LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE = 'LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE',
   CF_SCHEDULER_MODE = 'CF_SCHEDULER_MODE', // Values: "off" | "shadow" | "live" | "complete"
   QUEUE_BACKEND_MODE = 'QUEUE_BACKEND_MODE', // Values: "bullmq" | "shadow" | "live" | "complete"
   USAGE_REPORT_TRIGGER_SECRET = 'USAGE_REPORT_TRIGGER_SECRET',
@@ -211,6 +219,19 @@ export enum QueueBackendMode {
   SHADOW = 'shadow',
   LIVE = 'live',
   COMPLETE = 'complete',
+}
+
+/**
+ * Operating mode for the deprecated per-subscriber chat OAuth endpoints.
+ * Evaluated via {@link FeatureFlagsKeysEnum.LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE}.
+ */
+export enum LegacySubscriberChatOauthMode {
+  /** Both routes reject every request. Default for new organizations. */
+  DISABLED = 'disabled',
+  /** Historical behavior: HMAC enforced only when the integration opts in. */
+  ENABLED = 'enabled',
+  /** HMAC always enforced, regardless of the integration's `hmac` credential. */
+  HMAC_REQUIRED = 'hmac_required',
 }
 
 export type FeatureFlags = {

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -174,15 +174,16 @@ export enum FeatureFlagsKeysEnum {
   /** Enable the Tool channel (PagerDuty, Opsgenie, and custom webhooks). */
   IS_TOOL_CHANNEL_ENABLED = 'IS_TOOL_CHANNEL_ENABLED',
 
-  // String flags
   /**
-   * Operating mode for the deprecated per-subscriber chat OAuth routes
-   * (`GET /v1/subscribers/:subscriberId/credentials/:providerId/oauth[/callback]`).
-   * Target in LaunchDarkly by `organization.createdAt` so pre-existing orgs can
-   * keep `enabled` while new orgs stay on the default `disabled`. Self-hosted:
-   * set `LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE` in the environment.
+   * When true (default), the deprecated per-subscriber chat OAuth routes require
+   * HMAC to be enabled on the Slack integration and a valid subscriber HMAC hash.
+   * Target legacy organizations to false in LaunchDarkly so they can keep the
+   * historical behavior during migration. Self-hosted: set
+   * `IS_SUBSCRIBER_CHAT_OAUTH_HMAC_REQUIRED_ENABLED=false` to disable enforcement.
    */
-  LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE = 'LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE',
+  IS_SUBSCRIBER_CHAT_OAUTH_HMAC_REQUIRED_ENABLED = 'IS_SUBSCRIBER_CHAT_OAUTH_HMAC_REQUIRED_ENABLED',
+
+  // String flags
   CF_SCHEDULER_MODE = 'CF_SCHEDULER_MODE', // Values: "off" | "shadow" | "live" | "complete"
   QUEUE_BACKEND_MODE = 'QUEUE_BACKEND_MODE', // Values: "bullmq" | "shadow" | "live" | "complete"
   USAGE_REPORT_TRIGGER_SECRET = 'USAGE_REPORT_TRIGGER_SECRET',
@@ -219,19 +220,6 @@ export enum QueueBackendMode {
   SHADOW = 'shadow',
   LIVE = 'live',
   COMPLETE = 'complete',
-}
-
-/**
- * Operating mode for the deprecated per-subscriber chat OAuth endpoints.
- * Evaluated via {@link FeatureFlagsKeysEnum.LEGACY_SUBSCRIBER_CHAT_OAUTH_MODE}.
- */
-export enum LegacySubscriberChatOauthMode {
-  /** Both routes reject every request. Default for new organizations. */
-  DISABLED = 'disabled',
-  /** Historical behavior: HMAC enforced only when the integration opts in. */
-  ENABLED = 'enabled',
-  /** HMAC always enforced, regardless of the integration's `hmac` credential. */
-  HMAC_REQUIRED = 'hmac_required',
 }
 
 export type FeatureFlags = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the deprecated per-subscriber Slack chat OAuth endpoints (`GET /v1/subscribers/:subscriberId/credentials/:providerId/oauth[/callback]`) without breaking existing legacy customers by default.

**Default behavior (unchanged for allowlisted legacy orgs):** legacy flow continues to work when an org is explicitly excluded from HMAC enforcement in LaunchDarkly.

**New orgs / default:** must enable HMAC on the Slack integration and provide a valid subscriber HMAC hash. Requests against integrations with `hmac: false` are rejected with `403`.

## Changes

- **Signed OAuth `state`** — binds callback routing to environment/subscriber minted at init; fixes broken HMAC validation (now uses decrypted API key)
- **Boolean flag `IS_SUBSCRIBER_CHAT_OAUTH_HMAC_REQUIRED_ENABLED`** (default `true`) — new orgs require HMAC; legacy orgs targeted to `false` in LaunchDarkly keep historical behavior
- **Removed** `disabled`-by-default string flag model

## LaunchDarkly rollout

Flag **`IS_SUBSCRIBER_CHAT_OAUTH_HMAC_REQUIRED_ENABLED`** already exists in LaunchDarkly (default `true`).

1. Ensure flag is **ON** in production with fallthrough = `true`
2. Add **individual org targets** (or a rule on `organization.createdAt`) for legacy customers like Bask Health → serve `false`
3. Migrate allowlisted orgs to `POST /v1/integrations/chat/oauth`, then remove their exemption

Self-hosted: set `IS_SUBSCRIBER_CHAT_OAUTH_HMAC_REQUIRED_ENABLED=false` to disable enforcement globally.

## Test plan

- [x] 31 unit tests passing (init, callback, state signing, config policy)
- [x] New org + integration without HMAC → `403`
- [x] New org + integration with HMAC → requires valid hash
- [x] Allowlisted legacy org + no integration HMAC → historical behavior preserved
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df232dab-acb2-4693-b196-5ff93472e212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df232dab-acb2-4693-b196-5ff93472e212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens deprecated subscriber chat OAuth routes.
- Adds signed, expiring OAuth state carrying callback routing and validated subscriber HMAC data.
- Applies organization-scoped feature-flag enforcement and rotation-aware subscriber HMAC validation.
- Adds callback routing checks, generic lookup errors, logging, dependency wiring, and unit coverage.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because rotating the first environment API key during an authorization flow still invalidates legitimately issued OAuth state.

State issuance and callback verification independently select the current first API key, so a supported key regeneration or deletion during the 15-minute flow causes signature verification to fail.

**Files Needing Attention:** apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused legacy OAuth key-rotation harness was prepared and executed to test that state is invalidated during the real ChatOauth initiation path and that an endpoint is attached without rejection.
- Harness execution was blocked by a missing application-generic workspace build artifact, causing module loading to fail before the use case could run.
- The API dependency build attempt did not finish within the available execution budget and could not complete in this pass.
- Review of legacy OAuth-focused artifacts showed an initial before-blocker log and a subsequent after-success log with a full 26/26 pass, plus the complete command history and the API build log.

<a href="https://app.greptile.com/trex/runs/15923016/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts | Adds signed-state routing and enforcement, but callback verification still rejects in-flight state when the first API key rotates. |
| apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.usecase.ts | Adds HMAC enforcement, signed-state issuance, migration logging, and generic integration errors. |
| apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth-state.ts | Introduces signed OAuth-state encoding, parsing, signature validation, and a 15-minute expiration. |
| apps/api/src/app/subscribers/usecases/chat-oauth/legacy-chat-oauth.config.ts | Centralizes organization-scoped feature-flag evaluation and legacy HMAC enforcement policy. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client
  participant Init as Legacy OAuth Init
  participant Slack
  participant Callback as Legacy OAuth Callback
  participant Env as Environment Repository
  Client->>Init: subscriber, environment, provider, HMAC
  Init->>Env: Load API keys
  Init->>Init: Validate HMAC and sign state with apiKeys[0]
  Init-->>Client: Slack authorization URL
  Client->>Slack: Authorize with signed state
  Slack->>Callback: code and signed state
  Callback->>Env: Reload API keys
  Callback->>Callback: Verify state with current apiKeys[0]
  Callback->>Slack: Exchange authorization code
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fsubscribers%2Fusecases%2Fchat-oauth-callback%2Fchat-oauth-callback.usecase.ts%3A199%0A**Key%20rotation%20still%20invalidates%20state**%0A%0AWhen%20the%20environment's%20first%20API%20key%20is%20regenerated%20or%20deleted%20during%20the%2015-minute%20authorization%20flow%2C%20the%20callback%20verifies%20the%20state%20using%20only%20the%20current%20%60apiKeys%5B0%5D%60%2C%20causing%20a%20legitimately%20issued%20state%20to%20be%20rejected%20and%20preventing%20the%20Slack%20endpoint%20from%20being%20attached.%0A%0A&pr=12102&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts:199
**Key rotation still invalidates state**

When the environment's first API key is regenerated or deleted during the 15-minute authorization flow, the callback verifies the state using only the current `apiKeys[0]`, causing a legitimately issued state to be rejected and preventing the Slack endpoint from being attached.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api): require HMAC by default for le..."](https://github.com/novuhq/novu/commit/52cb0e9f9bb04401abfafc49baf7cd85c8ea73a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47365805)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->