### PR TITLE
fix(api): safely normalize non-numeric status codes in exception filter

### DIFF
--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -28,8 +28,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const request = ctx.getRequest<RequestWithReqId>();
     const errorDto = this.buildErrorResponse(exception, request);
 
-    // TODO: In same cases the statusCode is a string. We should investigate why this is happening.
-    const statusCode = Number(errorDto.statusCode);
+    const statusCode = this.normalizeStatusCode(errorDto.statusCode);
     if (statusCode >= 500) {
       this.logError(errorDto, exception);
     }
@@ -223,6 +222,25 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const errorDto = this.buildErrorDto(request, HttpStatus.UNPROCESSABLE_ENTITY, 'Validation Error', {});
 
     return { ...errorDto, errors: { general: { messages: exception.response.message, value: 'No Value Recorded' } } };
+  }
+
+  private normalizeStatusCode(rawStatusCode: number | string): number {
+    if (typeof rawStatusCode === 'number' && Number.isFinite(rawStatusCode)) {
+      return rawStatusCode;
+    }
+
+    const parsed = Number(rawStatusCode);
+
+    if (!Number.isFinite(parsed)) {
+      this.logger.warn(
+        { rawStatusCode },
+        'Received non-numeric statusCode in error response, defaulting to 500'
+      );
+
+      return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    return parsed;
   }
 
   private handlerThrottlerException(request: RequestWithReqId) {


### PR DESCRIPTION
## Summary
Resolves an open TODO where the exception filter was silently casting `errorDto.statusCode` to a Number without safeguards, causing edge cases where it remained `NaN`.

## Changes
- Added `normalizeStatusCode` method to handle explicit type checking.
- Safely defaults to `500` (Internal Server Error) and logs a warning if a non-numeric string is passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes API exception status normalization explicit.
- Preserves finite numeric status values.
- Converts numeric strings to numbers.
- Logs and defaults non-finite conversions to HTTP 500.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking normalization gap for finite values that are not valid HTTP status codes.

Non-finite status values now safely fall back to 500, but blank strings and other finite invalid values can still reach the HTTP response adapter unchanged.

**Files Needing Attention:** apps/api/src/exception-filter.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the status normalization general contract validation to establish the before baseline, which shows response.status(NaN), no warning, normal status 400, and exit code 0.
- Observed the after state in the same validation, where response.status(500), a warning context with rawStatusCode 'not-a-status', the exact documented message, normal status 400, and exit code 0 were produced.
- Reviewed the harness and focused-spec artifacts accompanying the run to confirm test orchestration and the blocker context.

<a href="https://app.greptile.com/trex/runs/15936220/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/exception-filter.ts | Adds centralized status-code normalization, but finite malformed values such as blank-string conversions and out-of-range numbers still bypass the 500 fallback. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fapi%2Fsrc%2Fexception-filter.ts%3A229-241%0A**Finite%20invalid%20statuses%20pass%20through**%0A%0AThe%20finite-number%20check%20also%20accepts%20blank%20or%20whitespace-only%20strings%20as%20%600%60%2C%20along%20with%20negative%2C%20fractional%2C%20and%20out-of-range%20values.%20These%20values%20reach%20%60response.status%28statusCode%29%60%20instead%20of%20the%20intended%20500%20fallback%2C%20so%20the%20adapter%20can%20reject%20the%20status%20while%20handling%20the%20original%20exception%3B%20validate%20that%20the%20parsed%20value%20is%20an%20integer%20in%20the%20supported%20HTTP%20status%20range.%0A%0A&pr=12104&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/exception-filter.ts:229-241
**Finite invalid statuses pass through**

The finite-number check also accepts blank or whitespace-only strings as `0`, along with negative, fractional, and out-of-range values. These values reach `response.status(statusCode)` instead of the intended 500 fallback, so the adapter can reject the status while handling the original exception; validate that the parsed value is an integer in the supported HTTP status range.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): safely normalize non-numeric s..."](https://github.com/novuhq/novu/commit/73f7bda47b510780dc044e6e3f4e0cb4b78f2d66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47397019)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->