### PR TITLE
fix(api-service): increase execution details trace fetch limit to 200

### DIFF
--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -17,6 +17,7 @@ import { mapTraceToExecutionDetailDto, mapWorkflowRunStatusToDto } from '../../s
 import { GetWorkflowRunCommand } from './get-workflow-run.command';
 
 const TRACE_AFTER_BUFFER_DAYS = 1;
+const EXECUTION_DETAILS_TRACE_LIMIT = 200;
 
 const workflowRunSelectColumns = [
   'workflow_run_id',
@@ -295,6 +296,7 @@ export class GetWorkflowRun {
         where: traceQueryBuilder.build(),
         orderBy: 'created_at',
         orderDirection: 'ASC',
+        limit: EXECUTION_DETAILS_TRACE_LIMIT,
         select: traceSelectColumns,
       });
 

--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -29,6 +29,7 @@ import { GetActivityFeedCommand } from './get-activity-feed.command';
 import { mapFeedItemToDto } from './map-feed-item-to.dto';
 
 const TRACE_AFTER_BUFFER_DAYS = 1;
+const EXECUTION_DETAILS_TRACE_LIMIT = 200;
 const traceFindColumns = ['entity_id', 'id', 'status', 'title', 'raw_data', 'created_at'] as const;
 type TraceFindResult = Pick<Trace, (typeof traceFindColumns)[number]>;
 
@@ -357,6 +358,7 @@ export class GetActivityFeed {
       where: traceQuery,
       orderBy: 'created_at',
       orderDirection: 'ASC',
+      limit: EXECUTION_DETAILS_TRACE_LIMIT,
       select: traceFindColumns,
     });
 

--- a/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
@@ -34,6 +34,7 @@ import { mapFeedItemToDto } from '../get-activity-feed/map-feed-item-to.dto';
 import { GetActivityCommand } from './get-activity.command';
 
 const TRACE_AFTER_BUFFER_DAYS = 1;
+const EXECUTION_DETAILS_TRACE_LIMIT = 200;
 
 const workflowRunSelectColumns = [
   'workflow_run_id',
@@ -197,6 +198,7 @@ export class GetActivity {
       where: traceQueryBuilder.build(),
       orderBy: 'created_at',
       orderDirection: 'ASC',
+      limit: EXECUTION_DETAILS_TRACE_LIMIT,
       select: traceSelectColumns,
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

`getExecutionDetailsByEntityId` fetches traces via `TraceLogRepository.find()` with `orderDirection: 'ASC'` but did not pass an explicit `limit`. That inherited the `LogRepository` default of **100**, so only the oldest 100 traces across all step runs were returned — newer traces (e.g. `message_read`, delivery webhooks) were dropped.

Added `EXECUTION_DETAILS_TRACE_LIMIT = 200` and passed `limit: 200` on all three call sites:

- `get-workflow-run.usecase.ts`
- `get-activity-feed.usecase.ts`
- `get-activity.usecase.ts`

### Screenshots

N/A — backend query limit change only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43dd74d3-c229-4777-8c6a-38d75bfcd090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43dd74d3-c229-4777-8c6a-38d75bfcd090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the execution-detail trace query limit from the repository default of 100 to 200.
- Adds the explicit limit to workflow-run trace retrieval.
- Applies the same limit to activity-feed and individual-activity trace retrieval.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because execution details remain silently truncated when a query matches more than 200 traces.

The three changed queries retain only the oldest 200 matching traces across their full entity-ID sets, without pagination or per-entity retrieval, so newer events and traces for later entities can still be omitted.

**Files Needing Attention:** apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts, apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts, apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts | Adds an explicit 200-record limit, but the previously reported global oldest-first truncation remains. |
| apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts | Adds the same global 200-record limit to feed-page trace retrieval across all selected job IDs. |
| apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts | Adds the same global 200-record limit to activity trace retrieval. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into cursor/increase..."](https://github.com/novuhq/novu/commit/b660575982e195c5abfc1d5f4e71b35b0ba7a4d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47538766)</sub>

<!-- /greptile_comment -->