### PR TITLE
fix(docs): add FAQ section and clarify translation resolution timing

### DIFF
--- a/docs/platform/workflow/advanced-features/translations.mdx
+++ b/docs/platform/workflow/advanced-features/translations.mdx
@@ -278,8 +278,8 @@ Here are some frequently asked questions about translations.
 
 <AccordionGroup>
   <Accordion title="Is translation resolved when the notification is fetched, or when it is sent?">
-    Translation is resolved when the workflow step executes, using the subscriber's locale at that time. For in-app notifications, the translated content is stored with the message.
+    Translation is resolved when the channel step executes, using the subscriber's locale at that moment (not at trigger time, and not when the Inbox loads the message). For delayed or digest workflows, a locale update before the channel step runs is reflected in that notification.
 
-    Novu does not re-translate existing notifications when the Inbox loads them. If you later update the subscriber's locale, only new notifications use the updated language. Historical in-app messages keep the locale they were created with.
+    Once the step has executed, the translated in-app notification content is stored with the message. Novu does not re-translate existing in-app notifications when they are fetched. Historical messages keep the locale they were created with.
   </Accordion>
 </AccordionGroup>

--- a/docs/platform/workflow/advanced-features/translations.mdx
+++ b/docs/platform/workflow/advanced-features/translations.mdx
@@ -271,3 +271,15 @@ npx novu translations push
 - Use variables and translation keys consistently.
 - Set subscriber locale properly to deliver notifications in the correct language.
 - Ensure subscriber locales are mapped to a supported `language_REGION` format before sending them to Novu.
+
+## Frequently asked questions
+
+Here are some frequently asked questions about translations.
+
+<AccordionGroup>
+  <Accordion title="Is translation resolved when the notification is fetched, or when it is sent?">
+    Translation is resolved when the workflow step executes, using the subscriber's locale at that time. For in-app notifications, the translated content is stored with the message.
+
+    Novu does not re-translate existing notifications when the Inbox loads them. If you later update the subscriber's locale, only new notifications use the updated language. Historical in-app messages keep the locale they were created with.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a translations FAQ clarifying that locale resolution occurs when the channel step executes and that stored in-app messages are not re-translated when fetched.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/workflow/advanced-features/translations.mdx | The new FAQ directly resolves the prior ambiguity by covering delayed and digest workflows and distinguishing step execution from Inbox fetch time. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(translations): clarify translation ..."](https://github.com/novuhq/novu/commit/c6c7f215e02e2303f321a334aef01101c7a2fead) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47550438)</sub>

<!-- /greptile_comment -->