### PR TITLE
refactor(api-service, worker, dal): update job status handling for snooze and unsnooze operations to use DELAYED instead of PENDING, enhancing job recovery logic and ensuring proper handling of stranded jobs

### DIFF
--- a/apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts
+++ b/apps/api/src/app/events/e2e/utils/poll-for-job-status-change.util.ts
@@ -3,6 +3,16 @@ import { sleep } from './sleep.util';
 
 type EnforceEnvOrOrgIds = { _environmentId: string } | { _organizationId: string };
 
+/*
+ * Since the atomic child claim (claimNextChildAsQueued), deferred steps are flipped
+ * PENDING -> QUEUED the moment the parent hands them to AddJob, before AddJob decides
+ * their real outcome (DELAYED, FAILED, ...). Both are transient "not settled yet"
+ * states, so polling must skip past them or it races AddJob and observes QUEUED.
+ */
+function isSettled(job: JobEntity): boolean {
+  return job.status !== JobStatusEnum.PENDING && job.status !== JobStatusEnum.QUEUED;
+}
+
 interface IPollForJobOptions {
   jobRepository: JobRepository;
   query: Partial<JobEntity> & EnforceEnvOrOrgIds;
@@ -21,7 +31,7 @@ function areJobsReady(jobs: JobEntity[], expectedCount?: number, until?: (jobs: 
     return false;
   }
 
-  if (!jobs.every((job: JobEntity) => job.status !== JobStatusEnum.PENDING)) {
+  if (!jobs.every(isSettled)) {
     return false;
   }
 
@@ -52,6 +62,7 @@ export async function pollForJobStatusChange({
 }: IPollForJobOptions & { findMultiple?: boolean }): Promise<JobEntity | JobEntity[] | null> {
   const startTime = Date.now();
   let lastMultipleJobs: JobEntity[] = [];
+  let lastJob: JobEntity | null = null;
 
   while (true) {
     if (findMultiple) {
@@ -63,14 +74,16 @@ export async function pollForJobStatusChange({
       }
     } else {
       const job = await jobRepository.findOne(query);
+      lastJob = job ?? lastJob;
 
-      if (job && job.status !== JobStatusEnum.PENDING) {
+      if (job && isSettled(job)) {
         return job;
       }
     }
 
     if (Date.now() - startTime > timeout) {
-      return findMultiple ? lastMultipleJobs : null;
+      // Last observed state (possibly unsettled) so assertions fail with the actual status
+      return findMultiple ? lastMultipleJobs : lastJob;
     }
 
     await sleep(pollInterval);

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
@@ -12,6 +12,7 @@ import {
   JobRepository,
   MessageEntity,
   MessageRepository,
+  NotificationRepository,
   OrganizationEntity,
 } from '@novu/dal';
 import { ApiServiceLevelEnum, ChannelTypeEnum, JobStatusEnum, SeverityLevelEnum } from '@novu/shared';
@@ -44,6 +45,7 @@ describe('SnoozeNotification', () => {
   let loggerMock: sinon.SinonStubbedInstance<PinoLogger>;
   let messageRepositoryMock: sinon.SinonStubbedInstance<MessageRepository>;
   let jobRepositoryMock: sinon.SinonStubbedInstance<JobRepository>;
+  let notificationRepositoryMock: sinon.SinonStubbedInstance<NotificationRepository>;
   let standardQueueServiceMock: sinon.SinonStubbedInstance<StandardQueueService>;
   let organizationRepositoryMock: sinon.SinonStubbedInstance<CommunityOrganizationRepository>;
   let createExecutionDetailsMock: sinon.SinonStubbedInstance<CreateExecutionDetails>;
@@ -93,6 +95,7 @@ describe('SnoozeNotification', () => {
     loggerMock = sinon.createStubInstance(PinoLogger);
     messageRepositoryMock = sinon.createStubInstance(MessageRepository);
     jobRepositoryMock = sinon.createStubInstance(JobRepository);
+    notificationRepositoryMock = sinon.createStubInstance(NotificationRepository);
     standardQueueServiceMock = sinon.createStubInstance(StandardQueueService);
     organizationRepositoryMock = sinon.createStubInstance(CommunityOrganizationRepository);
     createExecutionDetailsMock = sinon.createStubInstance(CreateExecutionDetails);
@@ -119,6 +122,7 @@ describe('SnoozeNotification', () => {
       loggerMock as any,
       messageRepositoryMock as any,
       jobRepositoryMock as any,
+      notificationRepositoryMock as any,
       standardQueueServiceMock as any,
       organizationRepositoryMock as any,
       createExecutionDetailsMock as any,
@@ -209,7 +213,8 @@ describe('SnoozeNotification', () => {
     expect(result).to.deep.equal(mockNotification);
     expect(jobRepositoryMock.create.calledOnce).to.be.true;
     const createCallArg = jobRepositoryMock.create.firstCall.args[0];
-    expect(createCallArg).to.have.property('status', JobStatusEnum.PENDING);
+    // DELAYED so RunJob's atomic claim (QUEUED|DELAYED only) can claim the unsnooze delivery
+    expect(createCallArg).to.have.property('status', JobStatusEnum.DELAYED);
     expect(createCallArg).to.have.property('delay').that.is.a('number');
     expect(createCallArg.payload).to.have.property('unsnooze', true);
 

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
@@ -208,7 +208,13 @@ export class SnoozeNotification {
     const newJobData = {
       ...originalJob,
       transactionId: uuidv4(),
-      status: JobStatusEnum.PENDING,
+      /*
+       * DELAYED (not PENDING): this job is enqueued directly below with a
+       * delay, bypassing AddJob. RunJob's atomic claim only accepts
+       * QUEUED/DELAYED, so a PENDING unsnooze job would be unclaimable and
+       * the unsnooze delivery silently dropped.
+       */
+      status: JobStatusEnum.DELAYED,
       delay,
       createdAt: Date.now().toString(),
       _id: JobRepository.createObjectId(),

--- a/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
@@ -134,6 +134,9 @@ describe('UnsnoozeNotification', () => {
 
     expect(result).to.deep.equal(mockNotification);
     expect(jobRepositoryMock.findOneAndDelete.calledOnce).to.be.true;
+    // Matches DELAYED (current) and PENDING (unsnooze jobs created before the DELAYED switch)
+    const deleteQuery = jobRepositoryMock.findOneAndDelete.firstCall.args[0];
+    expect(deleteQuery.status).to.deep.equal({ $in: [JobStatusEnum.DELAYED, JobStatusEnum.PENDING] });
     expect(markNotificationAsMock.execute.calledOnce).to.be.true;
 
     // Verify that markNotificationAs was called with the correct args

--- a/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts
@@ -72,7 +72,8 @@ export class UnsnoozeNotification {
         _notificationId: notificationId,
         _environmentId: command.environmentId,
         delay: { $exists: true },
-        status: JobStatusEnum.PENDING,
+        // PENDING kept for unsnooze jobs created before the switch to DELAYED
+        status: { $in: [JobStatusEnum.DELAYED, JobStatusEnum.PENDING] },
         'payload.unsnooze': true,
       });
 

--- a/apps/worker/src/app/workflow/services/standard.worker.spec.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.spec.ts
@@ -636,6 +636,8 @@ describe('Standard Worker', () => {
       expect(winners.length).to.equal(1);
       expect(winners[0]?._id).to.equal(child._id);
       expect(winners[0]?.status).to.equal(JobStatusEnum.QUEUED);
+      // The claim opens the claim-to-enqueue crash window; AddJob closes it via markEnqueued.
+      expect(winners[0]?.awaitingEnqueue).to.equal(true);
 
       const fresh = await jobRepository.findOne({ _id: child._id, _environmentId: child._environmentId });
       expect(fresh?.status).to.equal(JobStatusEnum.QUEUED);
@@ -684,6 +686,28 @@ describe('Standard Worker', () => {
 
       const fresh = await jobRepository.findOne({ _id: child._id, _environmentId: child._environmentId });
       expect(fresh?.status).to.equal(JobStatusEnum.PENDING);
+    });
+
+    it('releaseStaleQueuedChildToPending never releases a child whose message was already enqueued', async () => {
+      const parent = await jobRepository.create(buildJob(JobStatusEnum.COMPLETED));
+      await jobRepository.create({
+        ...buildJob(JobStatusEnum.PENDING, { _notificationId: parent._notificationId }),
+        _parentId: parent._id,
+      });
+
+      const claimed = await jobRepository.claimNextChildAsQueued(parent._environmentId, parent._id);
+      if (!claimed) throw new Error('expected the child to be claimed');
+      expect(claimed.awaitingEnqueue).to.equal(true);
+
+      // AddJob confirms the queue message exists, then the message sits behind a long backlog.
+      await jobRepository.markEnqueued(claimed._environmentId, claimed._id);
+      await backdateJobClaim(claimed._id, RUNNING_CLAIM_STALE_AFTER_MS + 1_000);
+
+      const released = await jobRepository.releaseStaleQueuedChildToPending(parent._environmentId, parent._id);
+
+      expect(released).to.equal(null);
+      const fresh = await jobRepository.findOne({ _id: claimed._id, _environmentId: claimed._environmentId });
+      expect(fresh?.status).to.equal(JobStatusEnum.QUEUED);
     });
 
     it('releaseStaleQueuedChildToPending ignores children that already progressed past QUEUED', async () => {

--- a/apps/worker/src/app/workflow/services/standard.worker.spec.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.spec.ts
@@ -648,6 +648,56 @@ describe('Standard Worker', () => {
 
       expect(result).to.equal(null);
     });
+
+    it('releaseStaleQueuedChildToPending leaves a freshly claimed QUEUED child alone (AddJob still in flight)', async () => {
+      const parent = await jobRepository.create(buildJob(JobStatusEnum.COMPLETED));
+      await jobRepository.create({
+        ...buildJob(JobStatusEnum.QUEUED, { _notificationId: parent._notificationId }),
+        _parentId: parent._id,
+      });
+
+      const result = await jobRepository.releaseStaleQueuedChildToPending(parent._environmentId, parent._id);
+
+      expect(result).to.equal(null);
+    });
+
+    it('releaseStaleQueuedChildToPending releases a stale QUEUED child exactly once under concurrent redeliveries', async () => {
+      const parent = await jobRepository.create(buildJob(JobStatusEnum.COMPLETED));
+      const child = await jobRepository.create({
+        ...buildJob(JobStatusEnum.QUEUED, { _notificationId: parent._notificationId }),
+        _parentId: parent._id,
+      });
+      await backdateJobClaim(child._id, RUNNING_CLAIM_STALE_AFTER_MS + 1_000);
+
+      const concurrency = 6;
+      const results = await Promise.all(
+        Array.from({ length: concurrency }, () =>
+          jobRepository.releaseStaleQueuedChildToPending(parent._environmentId, parent._id)
+        )
+      );
+
+      // The winning release flips the child to PENDING, so the losers no longer match QUEUED.
+      const winners = results.filter((res) => res !== null);
+      expect(winners.length).to.equal(1);
+      expect(winners[0]?._id).to.equal(child._id);
+      expect(winners[0]?.status).to.equal(JobStatusEnum.PENDING);
+
+      const fresh = await jobRepository.findOne({ _id: child._id, _environmentId: child._environmentId });
+      expect(fresh?.status).to.equal(JobStatusEnum.PENDING);
+    });
+
+    it('releaseStaleQueuedChildToPending ignores children that already progressed past QUEUED', async () => {
+      const parent = await jobRepository.create(buildJob(JobStatusEnum.COMPLETED));
+      const child = await jobRepository.create({
+        ...buildJob(JobStatusEnum.RUNNING, { _notificationId: parent._notificationId }),
+        _parentId: parent._id,
+      });
+      await backdateJobClaim(child._id, RUNNING_CLAIM_STALE_AFTER_MS + 1_000);
+
+      const result = await jobRepository.releaseStaleQueuedChildToPending(parent._environmentId, parent._id);
+
+      expect(result).to.equal(null);
+    });
   });
 
   describe('redelivery recovery', () => {
@@ -701,6 +751,46 @@ describe('Standard Worker', () => {
         }),
         _parentId: parent._id,
       });
+
+      await standardQueueService.add({
+        name: parent._id,
+        data: {
+          _environmentId: parent._environmentId,
+          _id: parent._id,
+          _organizationId: parent._organizationId,
+          _userId: parent._userId,
+        },
+        groupId: '0',
+      });
+
+      await jobsService.waitForJobCompletion({
+        templateId: template._id,
+        organizationId: organization._id,
+      });
+
+      const resumedChild = await jobRepository.findOne({ _id: child._id, _environmentId: child._environmentId });
+      expect(resumedChild?.status).to.equal(JobStatusEnum.COMPLETED);
+
+      const parentAfter = await jobRepository.findOne({ _id: parent._id, _environmentId: parent._environmentId });
+      expect(parentAfter?.status).to.equal(JobStatusEnum.COMPLETED);
+    });
+
+    it('a redelivered completed job resumes a chain whose child was claimed QUEUED but never enqueued', async () => {
+      // Production scenario: worker died between claimNextChildAsQueued and
+      // AddJob's enqueue — the child sits QUEUED with no queue message.
+      const notification = await createNotification();
+      const parent = await jobRepository.create(
+        buildJob(JobStatusEnum.COMPLETED, { _notificationId: notification._id, _templateId: template._id })
+      );
+      const child = await jobRepository.create({
+        ...buildJob(JobStatusEnum.QUEUED, {
+          _notificationId: notification._id,
+          _templateId: template._id,
+          transactionId: parent.transactionId,
+        }),
+        _parentId: parent._id,
+      });
+      await backdateJobClaim(child._id, RUNNING_CLAIM_STALE_AFTER_MS + 1_000);
 
       await standardQueueService.add({
         name: parent._id,

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -425,6 +425,16 @@ export class AddJob {
 
     await this.queueJob({ job, delay: 0, untilDate: null });
 
+    /*
+     * The message now exists, so the claim-to-enqueue crash window is over: without
+     * this, a redelivered parent would treat a backlogged-but-live child as stranded
+     * and enqueue a duplicate message. Only claimed children carry the flag — chain
+     * roots enter as PENDING and skip the write.
+     */
+    if (job.awaitingEnqueue) {
+      await this.jobRepository.markEnqueued(command.environmentId, job._id);
+    }
+
     return {
       workflowStatus: null,
       deliveryLifecycleStatus: null,

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -491,8 +491,14 @@ export class RunJob {
   }
 
   /**
-   * If a completed job still has a PENDING child (crashed after COMPLETED, before
-   * enqueue), resume the chain. No-op when there is no pending child.
+   * If a completed job still has a stranded child, resume the chain. Two crash
+   * windows leave a child stranded:
+   * - PENDING child: the worker died after COMPLETED but before claiming the child.
+   * - stale QUEUED child: the worker died after claimNextChildAsQueued but before
+   *   AddJob enqueued it, so the child has no queue message. Staleness (lease TTL)
+   *   distinguishes this from a child whose AddJob is still in flight; releasing it
+   *   back to PENDING funnels both windows through the same recovery path.
+   * No-op when there is no stranded child.
    */
   @Instrument()
   private async resumeChainIfStrandedAfterCompletion(job: JobEntity): Promise<void> {
@@ -501,21 +507,22 @@ export class RunJob {
       return;
     }
 
-    const pendingChild = await this.jobRepository.findOne(
-      {
-        _environmentId: job._environmentId,
-        _parentId: job._id,
-        status: JobStatusEnum.PENDING,
-      },
-      '_id'
-    );
-    if (!pendingChild) {
+    const strandedChild =
+      (await this.jobRepository.findOne(
+        {
+          _environmentId: job._environmentId,
+          _parentId: job._id,
+          status: JobStatusEnum.PENDING,
+        },
+        '_id'
+      )) ?? (await this.jobRepository.releaseStaleQueuedChildToPending(job._environmentId, job._id));
+    if (!strandedChild) {
       return;
     }
 
     this.logger.info(
-      { nv: { jobId: job._id, pendingChildJobId: pendingChild._id } },
-      'Redelivered completed job still has a pending child: resuming the stranded workflow chain'
+      { nv: { jobId: job._id, strandedChildJobId: strandedChild._id } },
+      'Redelivered completed job still has a stranded child: resuming the workflow chain'
     );
 
     const notification = await this.findNotification(job);

--- a/libs/dal/src/repositories/job/job.entity.ts
+++ b/libs/dal/src/repositories/job/job.entity.ts
@@ -40,6 +40,12 @@ export class JobEntity {
   delay?: number;
   _parentId?: string;
   status: JobStatusEnum;
+  /**
+   * True from claimNextChildAsQueued until AddJob confirms the queue message exists.
+   * Lets stranded-chain recovery distinguish a child whose worker died before the
+   * enqueue (releasable) from one whose message is live but backlogged (leave alone).
+   */
+  awaitingEnqueue?: boolean;
   deliveryLifecycleState?: DeliveryLifecycleState;
   error?: any;
   createdAt: string;

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -89,15 +89,13 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
    * Returns null when another worker holds a live lease or the job is already terminal.
    */
   public async claimAsRunning(environmentId: string, jobId: string): Promise<JobEntity | null> {
-    const staleClaimCutoff = new Date(Date.now() - RUNNING_CLAIM_STALE_AFTER_MS);
-
     return this.findOneAndUpdate(
       {
         _environmentId: environmentId,
         _id: jobId,
         $or: [
           { status: { $in: [JobStatusEnum.QUEUED, JobStatusEnum.DELAYED] } },
-          { status: JobStatusEnum.RUNNING, updatedAt: { $lte: staleClaimCutoff } },
+          { status: JobStatusEnum.RUNNING, updatedAt: { $lte: this.staleClaimCutoff() } },
         ],
       },
       {
@@ -159,6 +157,42 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
       },
       { new: true }
     );
+  }
+
+  /**
+   * Release a child stuck in QUEUED back to PENDING because the worker died between
+   * {@link claimNextChildAsQueued} and AddJob's enqueue — the child then has no
+   * queue message and the chain is stranded until a redelivered parent re-drives it.
+   * Once PENDING again, the ordinary chain-resume path recovers it.
+   *
+   * Staleness (`updatedAt` older than {@link RUNNING_CLAIM_STALE_AFTER_MS}) separates
+   * that crash from a healthy child whose AddJob just ran: redeliveries only arrive
+   * after the BullMQ lock / SQS visibility window (~90s), so a fresh QUEUED child is
+   * still being processed by the original worker.
+   *
+   * Worst case — a non-deferred child legitimately QUEUED for over a minute behind a
+   * queue backlog — re-runs AddJob and enqueues a duplicate message, which
+   * {@link claimAsRunning} fences at execution time.
+   */
+  public async releaseStaleQueuedChildToPending(environmentId: string, parentJobId: string): Promise<JobEntity | null> {
+    return this.findOneAndUpdate(
+      {
+        _environmentId: environmentId,
+        _parentId: parentJobId,
+        status: JobStatusEnum.QUEUED,
+        updatedAt: { $lte: this.staleClaimCutoff() },
+      },
+      {
+        $set: {
+          status: JobStatusEnum.PENDING,
+        },
+      },
+      { new: true }
+    );
+  }
+
+  private staleClaimCutoff(): Date {
+    return new Date(Date.now() - RUNNING_CLAIM_STALE_AFTER_MS);
   }
 
   public async setError(organizationId: string, jobId: string, error: any): Promise<void> {

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -142,7 +142,11 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
     );
   }
 
-  /** Atomically claim the next PENDING child as QUEUED so a redelivered parent cannot re-enqueue it. */
+  /**
+   * Atomically claim the next PENDING child as QUEUED so a redelivered parent cannot re-enqueue it.
+   * `awaitingEnqueue` stays true until AddJob confirms the queue message exists (see
+   * {@link markEnqueued}), which is what makes the claim-to-enqueue crash window detectable.
+   */
   public async claimNextChildAsQueued(environmentId: string, parentJobId: string): Promise<JobEntity | null> {
     return this.findOneAndUpdate(
       {
@@ -153,9 +157,31 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
       {
         $set: {
           status: JobStatusEnum.QUEUED,
+          awaitingEnqueue: true,
         },
       },
       { new: true }
+    );
+  }
+
+  /**
+   * Record that the job's queue message was successfully enqueued, ending its
+   * claim-to-enqueue crash window. Guarded on QUEUED so a fast consumer that already
+   * moved the job to RUNNING (or beyond) is never touched — once a job leaves QUEUED
+   * the flag is irrelevant.
+   */
+  public async markEnqueued(environmentId: string, jobId: string): Promise<void> {
+    await this.updateOne(
+      {
+        _environmentId: environmentId,
+        _id: jobId,
+        status: JobStatusEnum.QUEUED,
+      },
+      {
+        $set: {
+          awaitingEnqueue: false,
+        },
+      }
     );
   }
 
@@ -165,14 +191,14 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
    * queue message and the chain is stranded until a redelivered parent re-drives it.
    * Once PENDING again, the ordinary chain-resume path recovers it.
    *
-   * Staleness (`updatedAt` older than {@link RUNNING_CLAIM_STALE_AFTER_MS}) separates
-   * that crash from a healthy child whose AddJob just ran: redeliveries only arrive
-   * after the BullMQ lock / SQS visibility window (~90s), so a fresh QUEUED child is
-   * still being processed by the original worker.
-   *
-   * Worst case — a non-deferred child legitimately QUEUED for over a minute behind a
-   * queue backlog — re-runs AddJob and enqueues a duplicate message, which
-   * {@link claimAsRunning} fences at execution time.
+   * Two conditions fence out healthy children:
+   * - `awaitingEnqueue` not false: {@link markEnqueued} clears the flag once the queue
+   *   message exists, so a live-but-backlogged child is never released and re-enqueued.
+   *   `$ne: false` (rather than `true`) keeps children claimed by pre-flag workers
+   *   recoverable.
+   * - Staleness (`updatedAt` older than {@link RUNNING_CLAIM_STALE_AFTER_MS}): redeliveries
+   *   only arrive after the BullMQ lock / SQS visibility window (~90s), so a fresh QUEUED
+   *   child is still being processed by the original worker's AddJob.
    */
   public async releaseStaleQueuedChildToPending(environmentId: string, parentJobId: string): Promise<JobEntity | null> {
     return this.findOneAndUpdate(
@@ -180,6 +206,7 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
         _environmentId: environmentId,
         _parentId: parentJobId,
         status: JobStatusEnum.QUEUED,
+        awaitingEnqueue: { $ne: false },
         updatedAt: { $lte: this.staleClaimCutoff() },
       },
       {

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -11,6 +11,9 @@ const jobSchema = new Schema<JobDBModel>(
       type: Schema.Types.String,
       default: JobStatusEnum.PENDING,
     },
+    awaitingEnqueue: {
+      type: Schema.Types.Boolean,
+    },
     deliveryLifecycleState: {
       type: {
         status: {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revises delayed-job state handling and adds explicit recovery tracking for workflow children stranded between their database claim and queue enqueue.
- Snoozed notification jobs are created as DELAYED, while manual unsnooze accepts both DELAYED and legacy PENDING jobs.
- Child claims now carry an `awaitingEnqueue` marker that AddJob clears after queue submission.
- Completed-parent redelivery can release stale, unconfirmed QUEUED children to PENDING and resume their workflow chain.
- Polling and worker tests are updated for the revised transient states and recovery behavior.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, although mixed-version workers can still generate redundant child queue deliveries until legacy unmarked jobs drain.

The new enqueue marker protects jobs produced entirely by the updated worker, but the stale-release query deliberately includes QUEUED records where the marker is absent; a live legacy child can therefore be reset to PENDING and submitted to the queue again during a rolling deployment.

**Files Needing Attention:** libs/dal/src/repositories/job/job.repository.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/dal/src/repositories/job/job.repository.ts | Adds enqueue-confirmation state and atomic stale-child release operations scoped by environment, parent, status, and timestamp. |
| apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts | Clears the enqueue-confirmation marker after a claimed child is submitted to the standard queue. |
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Extends completed-parent recovery to resume stale QUEUED children as well as PENDING children. |
| apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts | Persists directly enqueued unsnooze jobs in DELAYED state so RunJob can claim them. |
| apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts | Deletes both current DELAYED and legacy PENDING unsnooze jobs during manual unsnooze. |
| libs/dal/src/repositories/job/job.schema.ts | Adds the optional persisted enqueue-confirmation field to job documents. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Parent as RunJob (parent)
  participant DB as JobRepository
  participant AddJob
  participant Queue as Standard Queue
  Parent->>DB: claimNextChildAsQueued()
  DB-->>Parent: "QUEUED, awaitingEnqueue=true"
  Parent->>AddJob: execute(child)
  AddJob->>Queue: enqueue child
  Queue-->>AddJob: accepted
  AddJob->>DB: markEnqueued()
  DB-->>AddJob: "awaitingEnqueue=false"
  Note over Parent,DB: On completed-parent redelivery
  Parent->>DB: release stale unconfirmed QUEUED child
  DB-->>Parent: PENDING child, if eligible
  Parent->>AddJob: resume child
```

<sub>Reviews (2): Last reviewed commit: ["refactor(worker, dal): enhance job statu..."](https://github.com/novuhq/novu/commit/c532414cf856e59515a3c1886b4b5b74dc1b8a50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47574885)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->