### PR TITLE
fix(api-service): cascade tool step delete and register ToolStepUpsertDto fixes NV-8417

### DIFF
--- a/apps/api/src/app/workflows-v2/dtos/create-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/create-workflow.dto.ts
@@ -10,6 +10,7 @@ import {
   PushControlDto,
   SmsControlDto,
   ThrottleControlDto,
+  ToolControlDto,
   WorkflowCommonsFields,
 } from '@novu/application-generic';
 import {
@@ -33,6 +34,7 @@ import {
   PushStepUpsertDto,
   SmsStepUpsertDto,
   ThrottleStepUpsertDto,
+  ToolStepUpsertDto,
 } from './create-step.dto';
 import { PreferencesRequestDto } from './preferences.request.dto';
 
@@ -45,6 +47,7 @@ export type StepCreateDto =
   | DelayStepUpsertDto
   | DigestStepUpsertDto
   | ThrottleStepUpsertDto
+  | ToolStepUpsertDto
   | CustomStepUpsertDto
   | HttpRequestStepUpsertDto;
 
@@ -57,6 +60,7 @@ export type StepCreateDto =
   DelayStepUpsertDto,
   DigestStepUpsertDto,
   ThrottleStepUpsertDto,
+  ToolStepUpsertDto,
   CustomStepUpsertDto,
   HttpRequestStepUpsertDto,
   InAppControlDto,
@@ -67,6 +71,7 @@ export type StepCreateDto =
   DelayControlDto,
   DigestControlDto,
   ThrottleControlDto,
+  ToolControlDto,
   CustomControlDto,
   HttpRequestControlDto
 )
@@ -91,6 +96,7 @@ export class CreateWorkflowDto extends WorkflowCommonsFields {
         { $ref: getSchemaPath(DelayStepUpsertDto) },
         { $ref: getSchemaPath(DigestStepUpsertDto) },
         { $ref: getSchemaPath(ThrottleStepUpsertDto) },
+        { $ref: getSchemaPath(ToolStepUpsertDto) },
         { $ref: getSchemaPath(CustomStepUpsertDto) },
         { $ref: getSchemaPath(HttpRequestStepUpsertDto) },
       ],
@@ -105,6 +111,7 @@ export class CreateWorkflowDto extends WorkflowCommonsFields {
           [StepTypeEnum.DELAY]: getSchemaPath(DelayStepUpsertDto),
           [StepTypeEnum.DIGEST]: getSchemaPath(DigestStepUpsertDto),
           [StepTypeEnum.THROTTLE]: getSchemaPath(ThrottleStepUpsertDto),
+          [StepTypeEnum.TOOL]: getSchemaPath(ToolStepUpsertDto),
           [StepTypeEnum.CUSTOM]: getSchemaPath(CustomStepUpsertDto),
           [StepTypeEnum.HTTP_REQUEST]: getSchemaPath(HttpRequestStepUpsertDto),
         },
@@ -125,6 +132,7 @@ export class CreateWorkflowDto extends WorkflowCommonsFields {
         { name: StepTypeEnum.DELAY, value: DelayStepUpsertDto },
         { name: StepTypeEnum.DIGEST, value: DigestStepUpsertDto },
         { name: StepTypeEnum.THROTTLE, value: ThrottleStepUpsertDto },
+        { name: StepTypeEnum.TOOL, value: ToolStepUpsertDto },
         { name: StepTypeEnum.CUSTOM, value: CustomStepUpsertDto },
         { name: StepTypeEnum.HTTP_REQUEST, value: HttpRequestStepUpsertDto },
       ],
@@ -140,6 +148,7 @@ export class CreateWorkflowDto extends WorkflowCommonsFields {
     | DelayStepUpsertDto
     | DigestStepUpsertDto
     | ThrottleStepUpsertDto
+    | ToolStepUpsertDto
     | CustomStepUpsertDto
     | HttpRequestStepUpsertDto
   )[];

--- a/apps/api/src/app/workflows-v2/dtos/update-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/update-workflow.dto.ts
@@ -15,6 +15,7 @@ import {
   PushStepUpsertDto,
   SmsStepUpsertDto,
   ThrottleStepUpsertDto,
+  ToolStepUpsertDto,
 } from './create-step.dto';
 import { PreferencesRequestDto } from './preferences.request.dto';
 
@@ -27,6 +28,7 @@ import { PreferencesRequestDto } from './preferences.request.dto';
   DelayStepUpsertDto,
   DigestStepUpsertDto,
   ThrottleStepUpsertDto,
+  ToolStepUpsertDto,
   CustomStepUpsertDto,
   HttpRequestStepUpsertDto
 )
@@ -51,6 +53,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
         { $ref: getSchemaPath(DelayStepUpsertDto) },
         { $ref: getSchemaPath(DigestStepUpsertDto) },
         { $ref: getSchemaPath(ThrottleStepUpsertDto) },
+        { $ref: getSchemaPath(ToolStepUpsertDto) },
         { $ref: getSchemaPath(CustomStepUpsertDto) },
         { $ref: getSchemaPath(HttpRequestStepUpsertDto) },
       ],
@@ -65,6 +68,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
           [StepTypeEnum.DELAY]: getSchemaPath(DelayStepUpsertDto),
           [StepTypeEnum.DIGEST]: getSchemaPath(DigestStepUpsertDto),
           [StepTypeEnum.THROTTLE]: getSchemaPath(ThrottleStepUpsertDto),
+          [StepTypeEnum.TOOL]: getSchemaPath(ToolStepUpsertDto),
           [StepTypeEnum.CUSTOM]: getSchemaPath(CustomStepUpsertDto),
           [StepTypeEnum.HTTP_REQUEST]: getSchemaPath(HttpRequestStepUpsertDto),
         },
@@ -85,6 +89,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
         { name: StepTypeEnum.DELAY, value: DelayStepUpsertDto },
         { name: StepTypeEnum.DIGEST, value: DigestStepUpsertDto },
         { name: StepTypeEnum.THROTTLE, value: ThrottleStepUpsertDto },
+        { name: StepTypeEnum.TOOL, value: ToolStepUpsertDto },
         { name: StepTypeEnum.CUSTOM, value: CustomStepUpsertDto },
         { name: StepTypeEnum.HTTP_REQUEST, value: HttpRequestStepUpsertDto },
       ],
@@ -100,6 +105,7 @@ export class UpdateWorkflowDto extends WorkflowCommonsFields {
     | DelayStepUpsertDto
     | DigestStepUpsertDto
     | ThrottleStepUpsertDto
+    | ToolStepUpsertDto
     | CustomStepUpsertDto
     | HttpRequestStepUpsertDto
   )[];

--- a/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
@@ -11,7 +11,8 @@ import {
   WorkflowCreationSourceEnum,
   WorkflowResponseDto,
 } from '@novu/api/models/components';
-import { ContentIssueEnum, StepTypeEnum, ToolProviderIdEnum } from '@novu/shared';
+import { ControlValuesRepository } from '@novu/dal';
+import { ContentIssueEnum, ControlValuesLevelEnum, StepTypeEnum, ToolProviderIdEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { JSONSchemaDto } from '../../shared/dtos/json-schema.dto';
@@ -25,12 +26,55 @@ interface ITestStepConfig {
 describe('Upsert Workflow #novu-v2', () => {
   let session: UserSession;
   let novuClient: Novu;
+  const controlValuesRepository = new ControlValuesRepository();
 
   beforeEach(async () => {
     session = new UserSession();
     await session.initialize();
     novuClient = initNovuClassSdkInternalAuth(session);
   });
+
+  async function createToolWorkflow(options: {
+    name: string;
+    workflowId: string;
+    includeEmail?: boolean;
+  }): Promise<WorkflowResponseDto> {
+    const steps: Array<Record<string, unknown>> = [
+      {
+        name: 'Tool Step',
+        type: StepTypeEnum.TOOL,
+        controlValues: {
+          body: 'default alert',
+        },
+        providerOverrides: {
+          [ToolProviderIdEnum.PagerDuty]: { severity: 'info' },
+        },
+      },
+    ];
+
+    if (options.includeEmail) {
+      steps.push({
+        name: 'Email Step',
+        type: StepTypeEnum.EMAIL,
+        controlValues: {
+          subject: 'hello',
+          body: 'world',
+        },
+      });
+    }
+
+    const createResponse = await session.testAgent.post('/v2/workflows').send({
+      __source: WorkflowCreationSourceEnum.Editor,
+      name: options.name,
+      workflowId: options.workflowId,
+      active: true,
+      steps,
+    });
+
+    expect(createResponse.status).to.equal(201);
+
+    return createResponse.body.data;
+  }
 
   describe('POST /v2/workflows/:workflowId', () => {
     it('should throw error when workflowId is not a valid slug', async () => {
@@ -215,6 +259,120 @@ describe('Upsert Workflow #novu-v2', () => {
 
       expect(updateResponse.status).to.equal(200);
       expect(updateResponse.body.data.steps[0].providerOverrides).to.not.exist;
+    });
+
+    it('should delete a tool step from the workflow', async () => {
+      const workflow = await createToolWorkflow({
+        name: 'Tool Step Delete Workflow',
+        workflowId: `tool-step-delete-${randomUUID()}`,
+        includeEmail: true,
+      });
+      expect(workflow.steps).to.have.length(2);
+
+      const emailStep = workflow.steps.find((s) => s.type === StepTypeEnum.EMAIL);
+      expect(emailStep).to.exist;
+
+      const updateResponse = await session.testAgent.put(`/v2/workflows/${workflow._id}`).send({
+        ...workflow,
+        steps: [
+          {
+            _id: emailStep!._id,
+            stepId: emailStep!.stepId,
+            name: emailStep!.name,
+            type: emailStep!.type,
+            controlValues: emailStep!.controls.values,
+          },
+        ],
+      });
+
+      expect(updateResponse.status).to.equal(200);
+      expect(updateResponse.body.data.steps).to.have.length(1);
+      expect(updateResponse.body.data.steps[0].type).to.equal(StepTypeEnum.EMAIL);
+      expect(updateResponse.body.data.steps[0].controls.values.subject).to.equal('hello');
+      expect(updateResponse.body.data.steps[0].controls.values.body).to.equal('world');
+    });
+
+    it('should delete a tool step when it is the only step', async () => {
+      const workflow = await createToolWorkflow({
+        name: 'Solo Tool Step Delete Workflow',
+        workflowId: `solo-tool-step-delete-${randomUUID()}`,
+      });
+      const toolStep = workflow.steps[0];
+      expect(toolStep).to.exist;
+
+      const overrideDocsBefore = await controlValuesRepository.find({
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        _workflowId: workflow._id,
+        _stepId: toolStep._id,
+        level: ControlValuesLevelEnum.STEP_PROVIDER_CONTROLS,
+      });
+      expect(overrideDocsBefore.length).to.be.greaterThan(0);
+
+      const updateResponse = await session.testAgent.put(`/v2/workflows/${workflow._id}`).send({
+        ...workflow,
+        steps: [],
+      });
+
+      expect(updateResponse.status).to.equal(200);
+      expect(updateResponse.body.data.steps).to.have.length(0);
+
+      const overrideDocsAfter = await controlValuesRepository.find({
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        _workflowId: workflow._id,
+        _stepId: toolStep._id,
+        level: ControlValuesLevelEnum.STEP_PROVIDER_CONTROLS,
+      });
+      expect(overrideDocsAfter).to.have.length(0);
+    });
+
+    it('should keep provider overrides when omitted from the remaining tool step', async () => {
+      const workflow = await createToolWorkflow({
+        name: 'Keep Tool Step Workflow',
+        workflowId: `keep-tool-step-${randomUUID()}`,
+        includeEmail: true,
+      });
+      const toolStep = workflow.steps.find((s) => s.type === StepTypeEnum.TOOL);
+      expect(toolStep).to.exist;
+
+      // Dashboard delete omits providerOverrides on remaining steps (leave unchanged).
+      const updateResponse = await session.testAgent.put(`/v2/workflows/${workflow._id}`).send({
+        ...workflow,
+        steps: [
+          {
+            _id: toolStep!._id,
+            stepId: toolStep!.stepId,
+            name: toolStep!.name,
+            type: toolStep!.type,
+            controlValues: toolStep!.controls.values,
+          },
+        ],
+      });
+
+      expect(updateResponse.status).to.equal(200);
+      expect(updateResponse.body.data.steps).to.have.length(1);
+      expect(updateResponse.body.data.steps[0].type).to.equal(StepTypeEnum.TOOL);
+      expect(updateResponse.body.data.steps[0].providerOverrides?.[ToolProviderIdEnum.PagerDuty]).to.deep.equal({
+        severity: 'info',
+      });
+    });
+
+    it('should round-trip a tool step on PUT', async () => {
+      const workflow = await createToolWorkflow({
+        name: 'Round Trip Tool Workflow',
+        workflowId: `round-trip-tool-${randomUUID()}`,
+      });
+
+      const updateResponse = await session.testAgent.put(`/v2/workflows/${workflow._id}`).send({
+        ...workflow,
+      });
+
+      expect(updateResponse.status).to.equal(200);
+      expect(updateResponse.body.data.steps[0].type).to.equal(StepTypeEnum.TOOL);
+      expect(updateResponse.body.data.steps[0].providerOverrides?.[ToolProviderIdEnum.PagerDuty]).to.deep.equal({
+        severity: 'info',
+      });
     });
   });
 

--- a/apps/dashboard/src/components/workflow-editor/step-utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/step-utils.ts
@@ -148,6 +148,16 @@ function splitProviderOverridesFromControlValues(controlValues: Record<string, u
   };
 }
 
+function toStepUpsertShape(step: StepResponseDto): StepUpdateDto {
+  // Never coerce missing providerOverrides to null — omit means leave unchanged on the server.
+  const { providerOverrides: _existingProviderOverrides, ...stepWithoutProviderOverrides } = step;
+
+  return {
+    ...stepWithoutProviderOverrides,
+    controlValues: step.controls?.values || {},
+  };
+}
+
 export const updateStepInWorkflow = (
   workflow: WorkflowResponseDto,
   stepId: string,
@@ -156,8 +166,7 @@ export const updateStepInWorkflow = (
   return {
     ...workflow,
     steps: workflow.steps.map((step) => {
-      // Never coerce missing providerOverrides to null — omit means leave unchanged on the server.
-      const { providerOverrides: _existingProviderOverrides, ...stepWithoutProviderOverrides } = step;
+      const stepWithoutProviderOverrides = toStepUpsertShape(step);
 
       if (step.stepId === stepId) {
         const existingControlValues = step.controls?.values || {};
@@ -190,11 +199,18 @@ export const updateStepInWorkflow = (
         };
       }
 
-      return {
-        ...stepWithoutProviderOverrides,
-        controlValues: step.controls?.values || {},
-      };
+      return stepWithoutProviderOverrides;
     }),
+  };
+};
+
+export const removeStepFromWorkflow = (
+  workflow: WorkflowResponseDto,
+  shouldKeep: (step: StepResponseDto) => boolean
+): UpdateWorkflowDto => {
+  return {
+    ...workflow,
+    steps: workflow.steps.filter(shouldKeep).map(toStepUpsertShape),
   };
 };
 

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -30,7 +30,12 @@ import { SidebarContent, SidebarFooter, SidebarHeader } from '@/components/side-
 import TruncatedText from '@/components/truncated-text';
 import { UpgradeCTATooltip } from '@/components/upgrade-cta-tooltip';
 import { stepSchema } from '@/components/workflow-editor/schema';
-import { flattenIssues, getFirstErrorMessage, updateStepInWorkflow } from '@/components/workflow-editor/step-utils';
+import {
+  flattenIssues,
+  getFirstErrorMessage,
+  removeStepFromWorkflow,
+  updateStepInWorkflow,
+} from '@/components/workflow-editor/step-utils';
 import { ConfigureChatStepPreview } from '@/components/workflow-editor/steps/chat/configure-chat-step-preview';
 import {
   ConfigureStepTemplateIssueCta,
@@ -180,10 +185,7 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
 
   const onDeleteStep = () => {
     update(
-      {
-        ...workflow,
-        steps: workflow.steps.filter((s) => s._id !== step._id),
-      },
+      removeStepFromWorkflow(workflow, (s) => s._id !== step._id),
       {
         onSuccess: () => {
           navigate(buildRoute(editWorkflowRoute, { environmentSlug: environment.slug!, workflowSlug: workflow.slug }));

--- a/apps/dashboard/src/components/workflow-editor/use-canvas-nodes-edges.ts
+++ b/apps/dashboard/src/components/workflow-editor/use-canvas-nodes-edges.ts
@@ -24,7 +24,7 @@ import {
   recalculatePositionAndIndex,
 } from './node-utils';
 import { NodeData } from './nodes';
-import { createStep } from './step-utils';
+import { createStep, removeStepFromWorkflow } from './step-utils';
 import { showErrorToast } from './toasts';
 import { useAnimatedNodes } from './use-animated-nodes';
 import { useWorkflowEditorRoutes } from './use-workflow-editor-routes';
@@ -283,10 +283,7 @@ export const useCanvasNodesEdges = ({
       const nodeToRemove = nodes[removeIndex];
 
       update(
-        {
-          ...workflow,
-          steps: workflow.steps.filter((s) => s.slug !== nodeToRemove.data.stepSlug),
-        },
+        removeStepFromWorkflow(workflow, (s) => s.slug !== nodeToRemove.data.stepSlug),
         {
           onSuccess: () => {
             const newNodes = [...dataRef.current.nodes].filter((node) => node.id !== nodeToRemove.id);

--- a/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
@@ -776,13 +776,15 @@ export class UpdateWorkflowV0 {
         throw new BadRequestException(`Failed to delete message template ${id} while updating the workflow`);
       }
 
-      await this.controlValuesRepository.delete(
+      await this.controlValuesRepository.deleteMany(
         {
           _environmentId: command.environmentId,
           _organizationId: command.organizationId,
           _workflowId: command.id,
           _stepId: id,
-          level: ControlValuesLevelEnum.STEP_CONTROLS,
+          level: {
+            $in: [ControlValuesLevelEnum.STEP_CONTROLS, ControlValuesLevelEnum.STEP_PROVIDER_CONTROLS],
+          },
         },
         { session }
       );

--- a/libs/application-generic/src/utils/map-step-type-to-result.mapper.ts
+++ b/libs/application-generic/src/utils/map-step-type-to-result.mapper.ts
@@ -18,6 +18,7 @@ export function computeResultSchema({
     [ChannelStepEnum.PUSH]: channelStepSchemas[ChannelStepEnum.PUSH].result,
     [ChannelStepEnum.CHAT]: channelStepSchemas[ChannelStepEnum.CHAT].result,
     [ChannelStepEnum.IN_APP]: channelStepSchemas[ChannelStepEnum.IN_APP].result,
+    [ChannelStepEnum.TOOL]: channelStepSchemas[ChannelStepEnum.TOOL].result,
     [ActionStepEnum.DELAY]: actionStepSchemas[ActionStepEnum.DELAY].result,
     [ActionStepEnum.DIGEST]: buildDigestResult({ payloadSchema }),
     [ActionStepEnum.HTTP_REQUEST]: responseBodySchema ?? {


### PR DESCRIPTION
## Summary

- Register `ToolStepUpsertDto` on create/update workflow discriminators (same gap class as NV-7995 for throttle).
- Cascade-delete both `STEP_CONTROLS` and `STEP_PROVIDER_CONTROLS` when a step is removed from a workflow.
- Map dashboard step delete through a shared upsert-shape helper so remaining steps omit `providerOverrides` instead of coercing them to `null`.
- Add `ChannelStepEnum.TOOL` to `computeResultSchema`.

Fixes [NV-8417](https://linear.app/novu/issue/NV-8417/workflow-editor-deleting-a-tool-step-returns-500)

```mermaid
sequenceDiagram
  participant UI as Dashboard
  participant API as PUT /v2/workflows/:id
  participant UW as UpdateWorkflowV0
  participant CV as ControlValuesRepository

  UI->>API: steps without deleted tool (upsert shape)
  API->>UW: deleteRemovedSteps
  UW->>CV: deleteMany STEP_CONTROLS + STEP_PROVIDER_CONTROLS
  UW-->>API: workflow updated
  API-->>UI: 200 WorkflowResponseDto
```

## Test plan

- [x] API e2e: delete tool step leaving email — remaining content preserved
- [x] API e2e: delete solo tool step — `STEP_PROVIDER_CONTROLS` docs cleaned up
- [x] API e2e: omit `providerOverrides` on remaining tool step — overrides survive
- [x] API e2e: round-trip full tool `StepResponseDto` on PUT
- [ ] Manual: workflow editor — add tool step with PagerDuty override, delete step, confirm no 500 and step gone

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes tool-step workflow updates by registering the tool DTO discriminator, preserving omitted provider overrides during dashboard deletions, cascading deletion across both step-control levels, and exposing the tool result schema.
- Registers `ToolStepUpsertDto` in create and update workflow DTO unions, Swagger models, and class-transformer discriminators.
- Maps retained dashboard steps into the workflow upsert shape when deleting a step.
- Deletes both `STEP_CONTROLS` and `STEP_PROVIDER_CONTROLS` records for removed steps.
- Adds the tool channel result schema to `computeResultSchema`.
- Adds end-to-end coverage for deleting and round-tripping tool steps and preserving provider overrides.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the tool-step DTO, dashboard mapping, control cleanup, and result-schema changes aligned with their existing contracts.

The changed deletion query uses supported repository operators and matching step identifiers, the dashboard mapping preserves omitted provider overrides while supplying the expected control-value shape, and the tool discriminator and result schema reference existing compatible definitions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/workflows-v2/dtos/create-workflow.dto.ts | Registers tool steps consistently across the create DTO type union, Swagger schema, and runtime discriminator. |
| apps/api/src/app/workflows-v2/dtos/update-workflow.dto.ts | Registers tool steps consistently across update-workflow validation and transformation metadata. |
| apps/dashboard/src/components/workflow-editor/step-utils.ts | Centralizes response-to-upsert mapping and deliberately omits provider overrides so retained override documents remain unchanged. |
| apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx | Uses the shared upsert-shape helper for deletion from the step configuration panel. |
| apps/dashboard/src/components/workflow-editor/use-canvas-nodes-edges.ts | Uses the same shared mapping when deleting a workflow node from the canvas. |
| libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts | Cascades removed-step cleanup across the two step-scoped control-value levels using the repository’s supported transactional bulk-delete query. |
| libs/application-generic/src/utils/map-step-type-to-result.mapper.ts | Adds the existing framework tool result schema to previous-step result-schema computation. |
| apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts | Covers tool-step deletion, provider-control cleanup, omitted override preservation, and full response round-tripping. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as Dashboard
  participant API as Workflow API
  participant Update as UpdateWorkflowV0
  participant DB as ControlValuesRepository
  UI->>UI: Map retained steps to upsert shape
  UI->>API: PUT workflow without removed step
  API->>Update: Update workflow
  Update->>DB: Delete STEP_CONTROLS and STEP_PROVIDER_CONTROLS
  DB-->>Update: Cleanup complete
  Update-->>API: Updated workflow
  API-->>UI: Workflow response
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): cascade tool step dele..."](https://github.com/novuhq/novu/commit/ee3b6f1e42502e883739d272669ea27c1f5b7dad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47583230)</sub>

<!-- /greptile_comment -->