### PR TITLE
fix(worker): skip BullMQ retries for webhook filter SSRF errors fixes NV-8419

### DIFF
--- a/apps/worker/src/app/shared/utils/constants.ts
+++ b/apps/worker/src/app/shared/utils/constants.ts
@@ -1,2 +1,1 @@
-export const EXCEPTION_MESSAGE_ON_WEBHOOK_FILTER = 'Exception while performing webhook request.';
 export const TRANSLATIONS_SERVICE = 'TRANSLATIONS_SERVICE';

--- a/apps/worker/src/app/workflow/services/standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.ts
@@ -11,12 +11,12 @@ import {
   StandardWorkerService,
   Store,
   storage,
+  UnrecoverableError,
   WorkerOptions,
   WorkflowInMemoryProviderService,
 } from '@novu/application-generic';
 import { CommunityOrganizationRepository, JobRepository } from '@novu/dal';
 import { FeatureFlagsKeysEnum, JobStatusEnum, ObservabilityBackgroundTransactionEnum } from '@novu/shared';
-import { UnrecoverableError } from 'bullmq';
 import {
   HandleLastFailedJob,
   HandleLastFailedJobCommand,

--- a/apps/worker/src/app/workflow/services/standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.ts
@@ -4,6 +4,7 @@ import {
   FeatureFlagsService,
   getStandardWorkerOptions,
   IStandardDataDto,
+  isWebhookFilterSsrfBlockedError,
   Job,
   PinoLogger,
   SqsService,
@@ -15,6 +16,7 @@ import {
 } from '@novu/application-generic';
 import { CommunityOrganizationRepository, JobRepository } from '@novu/dal';
 import { FeatureFlagsKeysEnum, JobStatusEnum, ObservabilityBackgroundTransactionEnum } from '@novu/shared';
+import { UnrecoverableError } from 'bullmq';
 import {
   HandleLastFailedJob,
   HandleLastFailedJobCommand,
@@ -186,6 +188,10 @@ export class StandardWorker extends StandardWorkerService {
                     `Failed to run the job ${minimalJobData.jobId} during worker processing`,
                     LOG_CONTEXT
                   );
+
+                  if (isWebhookFilterSsrfBlockedError(error)) {
+                    return reject(new UnrecoverableError((error as Error).message));
+                  }
 
                   return reject(error);
                 })

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -12,6 +12,7 @@ import {
   InMemoryLRUCacheStore,
   Instrument,
   InstrumentUsecase,
+  isRetryableWebhookFilterError,
   NotificationPayloadService,
   PinoLogger,
   StepRunRepository,
@@ -42,7 +43,7 @@ import {
 import { setUser } from '@sentry/node';
 import { differenceInMilliseconds } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
-import { EXCEPTION_MESSAGE_ON_WEBHOOK_FILTER, PlatformException, shouldHaltOnStepFailure } from '../../../shared/utils';
+import { PlatformException, shouldHaltOnStepFailure } from '../../../shared/utils';
 import { AddJob } from '../add-job';
 import { PartialNotificationEntity } from '../add-job/add-job.command';
 import { ExecuteBridgeJob, ExecuteBridgeJobCommand } from '../execute-bridge-job';
@@ -859,7 +860,7 @@ export class RunJob {
   }
 
   public shouldBackoff(error: Error): boolean {
-    return error?.message?.includes(EXCEPTION_MESSAGE_ON_WEBHOOK_FILTER);
+    return isRetryableWebhookFilterError(error);
   }
 
   /**

--- a/libs/application-generic/src/services/bull-mq/bull-mq.service.ts
+++ b/libs/application-generic/src/services/bull-mq/bull-mq.service.ts
@@ -13,6 +13,7 @@ import {
   ConnectionOptions as RedisConnectionOptions,
   Worker,
   WorkerOptions,
+  UnrecoverableError,
 } from 'bullmq';
 
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
@@ -37,6 +38,7 @@ export {
   Worker,
   WorkerOptions,
   BulkJobOptions,
+  UnrecoverableError,
 };
 
 export class BullMqService {

--- a/libs/application-generic/src/services/index.ts
+++ b/libs/application-generic/src/services/index.ts
@@ -12,6 +12,7 @@ export {
   QueueOptions,
   Worker,
   WorkerOptions,
+  UnrecoverableError,
 } from './bull-mq';
 export * from './cache';
 export * from './calculate-delay';

--- a/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -30,11 +30,16 @@ import { buildSubscriberKey, CachedResponse, safeOutboundJsonRequest } from '../
 import {
   assertSafeOutboundUrl,
   createHash,
+  createWebhookFilterError,
   Filter,
   FilterProcessingDetails,
   IFilterVariables,
   PlatformException,
+  shouldPropagateWebhookFilterFailure,
   SsrfBlockedError,
+  WEBHOOK_FILTER_ERROR_CODE,
+  WEBHOOK_FILTER_REQUEST_FAILED_DATA,
+  WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
 } from '../../utils';
 import { CompileTemplate } from '../compile-template';
 import { CreateExecutionDetails, CreateExecutionDetailsCommand, DetailEnum } from '../create-execution-details';
@@ -258,7 +263,11 @@ export class ConditionsFilter extends Filter {
       assertSafeOutboundUrl(child.webhookUrl);
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
-        throw new Error(JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' }));
+        throw createWebhookFilterError({
+          code: WEBHOOK_FILTER_ERROR_CODE.SSRF_BLOCKED,
+          message: err.message,
+          data: WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
+        });
       }
       throw err;
     }
@@ -280,10 +289,18 @@ export class ConditionsFilter extends Filter {
       return response.body;
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
-        throw new Error(JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' }));
+        throw createWebhookFilterError({
+          code: WEBHOOK_FILTER_ERROR_CODE.SSRF_BLOCKED,
+          message: err.message,
+          data: WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
+        });
       }
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(JSON.stringify({ message, data: 'Exception while performing webhook request.' }));
+      throw createWebhookFilterError({
+        code: WEBHOOK_FILTER_ERROR_CODE.REQUEST_FAILED,
+        message,
+        data: WEBHOOK_FILTER_REQUEST_FAILED_DATA,
+      });
     }
   }
 
@@ -376,7 +393,7 @@ export class ConditionsFilter extends Filter {
 
       return passed;
     } catch (error) {
-      if (this.isRetryableWebhookFilterError(error)) {
+      if (shouldPropagateWebhookFilterFailure(error)) {
         throw error;
       }
 
@@ -384,15 +401,6 @@ export class ConditionsFilter extends Filter {
 
       return false;
     }
-  }
-
-  private isRetryableWebhookFilterError(error: unknown): boolean {
-    const message = error instanceof Error ? error.message : String(error);
-
-    return (
-      message.includes('Exception while performing webhook request.') ||
-      message.includes('Webhook URL blocked by SSRF protection.')
-    );
   }
 
   private async recordFilterEvaluationError(

--- a/libs/application-generic/src/utils/index.ts
+++ b/libs/application-generic/src/utils/index.ts
@@ -47,3 +47,4 @@ export * from './subscription';
 export * from './template-parser';
 export * from './timestamp-hex';
 export * from './variants';
+export * from './webhook-filter-errors';

--- a/libs/application-generic/src/utils/webhook-filter-errors.spec.ts
+++ b/libs/application-generic/src/utils/webhook-filter-errors.spec.ts
@@ -1,0 +1,66 @@
+import {
+  createWebhookFilterError,
+  isRetryableWebhookFilterError,
+  isWebhookFilterSsrfBlockedError,
+  parseWebhookFilterError,
+  shouldPropagateWebhookFilterFailure,
+  WEBHOOK_FILTER_ERROR_CODE,
+  WEBHOOK_FILTER_REQUEST_FAILED_DATA,
+  WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
+} from './webhook-filter-errors';
+
+describe('webhook-filter-errors', () => {
+  it('detects structured SSRF blocked errors', () => {
+    const error = createWebhookFilterError({
+      code: WEBHOOK_FILTER_ERROR_CODE.SSRF_BLOCKED,
+      message: 'Requests to "127.0.0.1" are not allowed.',
+      data: WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
+    });
+
+    expect(parseWebhookFilterError(error)).toEqual({
+      code: WEBHOOK_FILTER_ERROR_CODE.SSRF_BLOCKED,
+      message: 'Requests to "127.0.0.1" are not allowed.',
+      data: WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
+    });
+    expect(isWebhookFilterSsrfBlockedError(error)).toBe(true);
+    expect(isRetryableWebhookFilterError(error)).toBe(false);
+    expect(shouldPropagateWebhookFilterFailure(error)).toBe(true);
+  });
+
+  it('detects structured transient webhook request failures', () => {
+    const error = createWebhookFilterError({
+      code: WEBHOOK_FILTER_ERROR_CODE.REQUEST_FAILED,
+      message: 'timeout',
+      data: WEBHOOK_FILTER_REQUEST_FAILED_DATA,
+    });
+
+    expect(isRetryableWebhookFilterError(error)).toBe(true);
+    expect(isWebhookFilterSsrfBlockedError(error)).toBe(false);
+    expect(shouldPropagateWebhookFilterFailure(error)).toBe(true);
+  });
+
+  it('supports legacy substring-encoded webhook filter errors', () => {
+    const ssrfError = new Error(
+      JSON.stringify({
+        message: 'Requests to "127.0.0.1" are not allowed.',
+        data: WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
+      })
+    );
+    const transientError = new Error(
+      JSON.stringify({
+        message: 'timeout',
+        data: WEBHOOK_FILTER_REQUEST_FAILED_DATA,
+      })
+    );
+
+    expect(isWebhookFilterSsrfBlockedError(ssrfError)).toBe(true);
+    expect(isRetryableWebhookFilterError(transientError)).toBe(true);
+  });
+
+  it('returns null for unrelated errors', () => {
+    const error = new Error('Notification with id abc not found');
+
+    expect(parseWebhookFilterError(error)).toBeNull();
+    expect(shouldPropagateWebhookFilterFailure(error)).toBe(false);
+  });
+});

--- a/libs/application-generic/src/utils/webhook-filter-errors.ts
+++ b/libs/application-generic/src/utils/webhook-filter-errors.ts
@@ -1,0 +1,66 @@
+export const WEBHOOK_FILTER_ERROR_CODE = {
+  SSRF_BLOCKED: 'WEBHOOK_FILTER_SSRF_BLOCKED',
+  REQUEST_FAILED: 'WEBHOOK_FILTER_REQUEST_FAILED',
+} as const;
+
+export const WEBHOOK_FILTER_SSRF_BLOCKED_DATA = 'Webhook URL blocked by SSRF protection.';
+export const WEBHOOK_FILTER_REQUEST_FAILED_DATA = 'Exception while performing webhook request.';
+
+export type WebhookFilterErrorPayload = {
+  code: (typeof WEBHOOK_FILTER_ERROR_CODE)[keyof typeof WEBHOOK_FILTER_ERROR_CODE];
+  message: string;
+  data: string;
+};
+
+export function createWebhookFilterError(payload: WebhookFilterErrorPayload): Error {
+  return new Error(JSON.stringify(payload));
+}
+
+export function parseWebhookFilterError(error: unknown): WebhookFilterErrorPayload | null {
+  const message = error instanceof Error ? error.message : String(error);
+
+  try {
+    const parsed = JSON.parse(message) as Partial<WebhookFilterErrorPayload>;
+
+    if (
+      parsed &&
+      typeof parsed.code === 'string' &&
+      typeof parsed.message === 'string' &&
+      typeof parsed.data === 'string'
+    ) {
+      return parsed as WebhookFilterErrorPayload;
+    }
+  } catch {
+    // Fall through to legacy substring matching below.
+  }
+
+  if (message.includes(WEBHOOK_FILTER_REQUEST_FAILED_DATA)) {
+    return {
+      code: WEBHOOK_FILTER_ERROR_CODE.REQUEST_FAILED,
+      message,
+      data: WEBHOOK_FILTER_REQUEST_FAILED_DATA,
+    };
+  }
+
+  if (message.includes(WEBHOOK_FILTER_SSRF_BLOCKED_DATA)) {
+    return {
+      code: WEBHOOK_FILTER_ERROR_CODE.SSRF_BLOCKED,
+      message,
+      data: WEBHOOK_FILTER_SSRF_BLOCKED_DATA,
+    };
+  }
+
+  return null;
+}
+
+export function isWebhookFilterSsrfBlockedError(error: unknown): boolean {
+  return parseWebhookFilterError(error)?.code === WEBHOOK_FILTER_ERROR_CODE.SSRF_BLOCKED;
+}
+
+export function isRetryableWebhookFilterError(error: unknown): boolean {
+  return parseWebhookFilterError(error)?.code === WEBHOOK_FILTER_ERROR_CODE.REQUEST_FAILED;
+}
+
+export function shouldPropagateWebhookFilterFailure(error: unknown): boolean {
+  return parseWebhookFilterError(error) !== null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Webhook filter steps are enqueued with BullMQ retry options for transient request failures. SSRF-blocked URLs were inheriting that same retry budget even though they are permanent failures: the job was marked failed on the first attempt, but BullMQ still scheduled two more attempts that could not claim the job and produced misleading `WEBHOOK_FILTER_FAILED_RETRY` execution details.

This change introduces structured webhook filter error codes and treats SSRF blocks as unrecoverable at the worker level.

- Added `webhook-filter-errors` helpers in `application-generic` with explicit codes for SSRF vs transient request failures
- Updated `conditions-filter` to emit structured errors and to propagate both failure classes without substring heuristics
- Updated `RunJob.shouldBackoff()` to use the shared retryability helper
- Updated `StandardWorker` to throw `UnrecoverableError` for SSRF webhook filter failures so BullMQ does not schedule follow-up attempts

Transient webhook request failures keep the existing backoff/retry behavior.

Linear: https://linear.app/novu/issue/NV-8419/do-not-auto-retry-webhook-filter-jobs-on-ssrf-blocked-errors

```mermaid
flowchart TD
  A[Webhook filter step fails] --> B{Error code}
  B -->|REQUEST_FAILED| C[shouldBackoff = true]
  B -->|SSRF_BLOCKED| D[shouldBackoff = false]
  C --> E[releaseRunningClaim + BullMQ retry]
  D --> F[mark job failed + UnrecoverableError]
  F --> G[No BullMQ retry attempts]
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b211d8e3-a2a7-4746-80fa-e9c715ee6bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b211d8e3-a2a7-4746-80fa-e9c715ee6bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces structured webhook-filter errors and prevents BullMQ retries for SSRF-blocked requests while retaining retries for transient request failures.
- Adds shared creation, parsing, and classification helpers for webhook-filter errors.
- Propagates structured SSRF and transient request failures from condition evaluation.
- Converts SSRF failures into BullMQ `UnrecoverableError` instances in the standard worker.
- Replaces message-substring backoff detection with structured retryability checks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/utils/webhook-filter-errors.ts | Adds centralized structured and legacy-compatible webhook-filter error classification. |
| libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts | Emits and propagates structured SSRF and transient webhook request failures. |
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Uses the shared classifier so only transient webhook request failures trigger backoff. |
| apps/worker/src/app/workflow/services/standard.worker.ts | Converts SSRF webhook-filter failures to BullMQ unrecoverable failures while preserving normal failure handling. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Webhook filter evaluation] --> B{Failure classification}
  B -->|REQUEST_FAILED| C[Propagate structured error]
  C --> D[Release running claim]
  D --> E[BullMQ retry with backoff]
  B -->|SSRF_BLOCKED| F[Propagate structured error]
  F --> G[Wrap in UnrecoverableError]
  G --> H[Mark job failed without BullMQ retry]
```

<sub>Reviews (2): Last reviewed commit: ["fix(worker): import UnrecoverableError f..."](https://github.com/novuhq/novu/commit/b90a1a0fa7d0deb479fd78c29b64d5cfa7cec9b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47593493)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->