### PR TITLE
chore(root): add developer-local agent config pointer to AGENTS.md fixes NV-8420

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ Run `pnpm build` after changes to `packages/` or `enterprise/`. Direct changes t
 - If doing a monorepo wide refactor, you can touch the read only, but only when necessary.
 
 
+## Developer-local agent config
+
+If a **`.agents-local/`** directory exists in your working copy, read **`.agents-local/README.md`** first for personal, git-ignored agent configuration, skills and rules. Absence of the directory is normal.
+
 ## Novu Distribution
 Novu is distributed in 3 modes, Community Edition, Enterprise Cloud Edition, and On-Prem Enterprise Edition.
 


### PR DESCRIPTION
## What

Adds a small, generic convention to the shared `AGENTS.md`:

> If a `.agents-local/` directory exists in your working copy, read `.agents-local/README.md` first for personal, git-ignored agent configuration, skills and rules. Absence of the directory is normal.

## Why

Different agent harnesses load different instruction files (Cursor loads its own rules, Claude loads `CLAUDE.md`, others may load only `AGENTS.md`, etc.). `AGENTS.md` is the common denominator that virtually every harness reads, so it's the reliable place to put a pointer.

This one generic pointer lets each developer keep their own **git-ignored** agent setup (issue-tracker mapping, personal skills/rules) under `.agents-local/` and have it discovered regardless of harness — without committing anyone's personal tooling to the shared repo.

The pointer is intentionally **generic**: it names no specific skill kit, and does nothing when the directory is absent (the default for everyone).

## Scope

- Single file, docs-only: `AGENTS.md` (+4 lines).
- No code, build, or runtime impact. Community/Enterprise distributions unaffected.

Closes NV-8420