### PR TITLE
fix(worker): prevent job orphaning during queue scheduling

### DIFF
--- a/apps/worker/src/app/workflow/services/index.ts
+++ b/apps/worker/src/app/workflow/services/index.ts
@@ -1,4 +1,5 @@
 export * from './active-jobs-metric.service';
+export * from './job-reconciliation.service';
 export * from './standard.worker';
 export * from './subscriber-process.worker';
 export * from './workflow.worker';

--- a/apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts
+++ b/apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts
@@ -1,0 +1,225 @@
+import { PinoLogger, StandardQueueService } from '@novu/application-generic';
+import { JobRepository, JobStatusEnum } from '@novu/dal';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { JobReconciliationService } from './job-reconciliation.service';
+
+describe('JobReconciliationService', () => {
+  let service: JobReconciliationService;
+  let jobRepository: sinon.SinonStubbedInstance<JobRepository>;
+  let standardQueueService: sinon.SinonStubbedInstance<StandardQueueService>;
+  let logger: PinoLogger;
+
+  const mockLogger = {
+    setContext: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as PinoLogger;
+
+  beforeEach(() => {
+    jobRepository = sinon.createStubInstance(JobRepository);
+    standardQueueService = sinon.createStubInstance(StandardQueueService);
+    logger = mockLogger;
+
+    service = new JobReconciliationService(
+      jobRepository as unknown as JobRepository,
+      standardQueueService as unknown as StandardQueueService,
+      logger
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('reconcileOnStartup', () => {
+    it('should query for DELAYED jobs with scheduleExtensionsCount > 0 and stale updatedAt', async () => {
+      jobRepository.find.resolves([]);
+
+      await service.reconcileOnStartup();
+
+      const findCall = jobRepository.find.getCall(0);
+      expect(findCall).to.not.be.undefined;
+      expect(findCall.args[0].status).to.equal(JobStatusEnum.DELAYED);
+      expect(findCall.args[0].scheduleExtensionsCount).to.deep.equal({ $gt: 0 });
+      expect(findCall.args[0].updatedAt).to.have.property('$lt');
+      expect(findCall.args[1]).to.equal('_id _environmentId _organizationId _userId');
+    });
+
+    it('should not call add when no stuck jobs exist', async () => {
+      jobRepository.find.resolves([]);
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should atomically claim and re-enqueue a stuck job', async () => {
+      const jobId = 'job-1';
+      const envId = 'env-1';
+      const orgId = 'org-1';
+      const userId = 'user-1';
+
+      const stuckJob = {
+        _id: jobId,
+        _environmentId: envId,
+        _organizationId: orgId,
+        _userId: userId,
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(Date.now() - 60_000),
+      };
+
+      jobRepository.find.resolves([stuckJob]);
+      jobRepository.findOneAndUpdate.resolves({ ...stuckJob, status: JobStatusEnum.QUEUED });
+      standardQueueService.add.resolves();
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledWith(
+        jobRepository.findOneAndUpdate,
+        {
+          _id: jobId,
+          _environmentId: envId,
+          status: JobStatusEnum.DELAYED,
+        },
+        { $set: { status: JobStatusEnum.QUEUED } },
+        { new: true }
+      );
+
+      sinon.assert.calledWith(standardQueueService.add, {
+        name: jobId,
+        data: {
+          _environmentId: envId,
+          _id: jobId,
+          _organizationId: orgId,
+          _userId: userId,
+        },
+        groupId: orgId,
+        options: { delay: 0 },
+      });
+    });
+
+    it('should skip a job when another worker already claimed it (findOneAndUpdate returns null)', async () => {
+      const stuckJob = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(Date.now() - 60_000),
+      };
+
+      jobRepository.find.resolves([stuckJob]);
+      jobRepository.findOneAndUpdate.resolves(null);
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledOnce(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should recover multiple stuck jobs and skip those already claimed by other workers', async () => {
+      const baseTime = Date.now() - 120_000;
+
+      const job1 = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(baseTime),
+      };
+      const job2 = {
+        _id: 'job-2',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-2',
+        scheduleExtensionsCount: 2,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(baseTime),
+      };
+
+      jobRepository.find.resolves([job1, job2]);
+      // job1 gets claimed by this worker, job2 was already claimed
+      jobRepository.findOneAndUpdate
+        .withArgs(
+          { _id: 'job-1', _environmentId: 'env-1', status: JobStatusEnum.DELAYED },
+          { $set: { status: JobStatusEnum.QUEUED } },
+          { new: true }
+        )
+        .resolves({ ...job1, status: JobStatusEnum.QUEUED });
+      jobRepository.findOneAndUpdate
+        .withArgs(
+          { _id: 'job-2', _environmentId: 'env-1', status: JobStatusEnum.DELAYED },
+          { $set: { status: JobStatusEnum.QUEUED } },
+          { new: true }
+        )
+        .resolves(null);
+
+      standardQueueService.add.resolves();
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledTwice(jobRepository.findOneAndUpdate);
+      sinon.assert.calledOnce(standardQueueService.add);
+      sinon.assert.calledWith(
+        standardQueueService.add,
+        sinon.match({ name: 'job-1' })
+      );
+    });
+
+    it('should handle queue insertion failure gracefully without crashing', async () => {
+      const stuckJob = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(Date.now() - 60_000),
+      };
+
+      jobRepository.find.resolves([stuckJob]);
+      jobRepository.findOneAndUpdate.resolves({ ...stuckJob, status: JobStatusEnum.QUEUED });
+      standardQueueService.add.rejects(new Error('Queue unavailable'));
+
+      // Should not throw
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledOnce(jobRepository.findOneAndUpdate);
+      sinon.assert.calledOnce(standardQueueService.add);
+    });
+
+    it('should skip jobs that were recently updated (within the backoff window)', async () => {
+      const recentJob = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(), // very recent
+      };
+
+      jobRepository.find.resolves([]); // filtered by the MongoDB query
+      await service.reconcileOnStartup();
+
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should handle database errors gracefully', async () => {
+      jobRepository.find.rejects(new Error('MongoDB connection error'));
+
+      // Should not throw
+      await service.reconcileOnStartup();
+
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/services/job-reconciliation.service.ts
+++ b/apps/worker/src/app/workflow/services/job-reconciliation.service.ts
@@ -1,0 +1,89 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { PinoLogger, StandardQueueService } from '@novu/application-generic';
+import { JobRepository, JobStatusEnum } from '@novu/dal';
+
+const LOG_CONTEXT = 'JobReconciliationService';
+
+@Injectable()
+export class JobReconciliationService {
+  private readonly RECONCILIATION_BACKOFF_MS = 10_000;
+  private readonly MAX_RECONCILE_PER_RUN = 100;
+
+  constructor(
+    private jobRepository: JobRepository,
+    @Inject(forwardRef(() => StandardQueueService))
+    private standardQueueService: StandardQueueService,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(LOG_CONTEXT);
+  }
+
+  async reconcileOnStartup(): Promise<void> {
+    this.logger.warn('Starting startup job reconciliation for stuck DELAYED jobs');
+
+    try {
+      const delayCutoff = new Date(Date.now() - this.RECONCILIATION_BACKOFF_MS);
+      const stuckJobs = await this.jobRepository.find(
+        {
+          status: JobStatusEnum.DELAYED,
+          scheduleExtensionsCount: { $gt: 0 },
+          updatedAt: { $lt: delayCutoff },
+        },
+        '_id _environmentId _organizationId _userId',
+        { limit: this.MAX_RECONCILE_PER_RUN }
+      );
+
+      if (stuckJobs.length === 0) {
+        return;
+      }
+
+      this.logger.warn({ count: stuckJobs.length }, 'Found stuck DELAYED jobs, attempting recovery');
+
+      let recovered = 0;
+      let skipped = 0;
+
+      for (const job of stuckJobs) {
+        try {
+          const claimed = await this.jobRepository.findOneAndUpdate(
+            {
+              _id: job._id,
+              _environmentId: job._environmentId,
+              status: JobStatusEnum.DELAYED,
+            },
+            { $set: { status: JobStatusEnum.QUEUED } },
+            { new: true }
+          );
+
+          if (!claimed) {
+            skipped++;
+            continue;
+          }
+
+          await this.standardQueueService.add({
+            name: job._id,
+            data: {
+              _environmentId: job._environmentId,
+              _id: job._id,
+              _organizationId: job._organizationId,
+              _userId: job._userId,
+            },
+            groupId: job._organizationId,
+            options: { delay: 0 },
+          });
+
+          recovered++;
+          this.logger.warn({ jobId: job._id }, 'Recovered stuck DELAYED job');
+        } catch (err) {
+          this.logger.error({ err, jobId: job._id }, 'Failed to recover stuck job');
+        }
+      }
+
+      this.logger.warn(
+        { recovered, skipped, total: stuckJobs.length },
+        'Job reconciliation completed'
+      );
+    } catch (err) {
+      this.logger.error({ err }, 'Job reconciliation failed');
+    }
+  }
+}

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.spec.ts
@@ -1,0 +1,185 @@
+import { Test } from '@nestjs/testing';
+import {
+  ComputeJobWaitDurationService,
+  ConditionsFilter,
+  CreateExecutionDetails,
+  NormalizeVariables,
+  PinoLogger,
+  StandardQueueService,
+  StepRunRepository,
+  TierRestrictionsValidateUsecase,
+} from '@novu/application-generic';
+import {
+  JobEntity,
+  JobRepository,
+  JobStatusEnum,
+  NotificationRepository,
+  SubscriberRepository,
+} from '@novu/dal';
+import {
+  ExecutionDetailsSourceEnum,
+  ExecutionDetailsStatusEnum,
+  StepTypeEnum,
+} from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ExecuteBridgeJob } from '../../execute-bridge-job';
+import { AddJob, BackoffStrategiesEnum } from './add-job.usecase';
+import { AddJobCommand } from './add-job.command';
+import { MergeOrCreateDigest } from './merge-or-create-digest.usecase';
+
+describe('AddJob - reverse order (queue before DB update)', () => {
+  let addJob: AddJob;
+  let jobRepository: sinon.SinonStubbedInstance<JobRepository>;
+  let standardQueueService: sinon.SinonStubbedInstance<StandardQueueService>;
+  let stepRunRepository: sinon.SinonStubbedInstance<StepRunRepository>;
+  let createExecutionDetails: sinon.SinonStubbedInstance<CreateExecutionDetails>;
+
+  const mockLogger = {
+    setContext: () => {},
+    warn: () => {},
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+    trace: () => {},
+  } as unknown as PinoLogger;
+
+  beforeEach(async () => {
+    jobRepository = sinon.createStubInstance(JobRepository);
+    standardQueueService = sinon.createStubInstance(StandardQueueService);
+    stepRunRepository = sinon.createStubInstance(StepRunRepository);
+    createExecutionDetails = {
+      execute: sinon.stub().resolves({}),
+    } as unknown as CreateExecutionDetails;
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AddJob,
+        { provide: JobRepository, useValue: jobRepository },
+        { provide: StandardQueueService, useValue: standardQueueService },
+        { provide: CreateExecutionDetails, useValue: createExecutionDetails },
+        { provide: StepRunRepository, useValue: stepRunRepository },
+        { provide: ComputeJobWaitDurationService, useValue: { calculateDelay: async () => 0 } },
+        { provide: ConditionsFilter, useValue: { filter: async () => ({ passed: true, variables: {} }) } },
+        { provide: NormalizeVariables, useValue: { execute: async () => ({}) } },
+        { provide: TierRestrictionsValidateUsecase, useValue: { execute: async () => [] } },
+        { provide: ExecuteBridgeJob, useValue: { execute: async () => null } },
+        { provide: SubscriberRepository, useValue: { findOne: async () => null } },
+        { provide: MergeOrCreateDigest, useValue: { execute: async () => null } },
+        { provide: NotificationRepository, useValue: { findOne: async () => ({ _id: 'notif-1', _environmentId: 'env-1' }) } },
+        { provide: PinoLogger, useValue: mockLogger },
+      ],
+    }).compile();
+
+    addJob = moduleRef.get(AddJob);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('execute with non-deferred job type (EMAIL)', () => {
+    const environmentId = 'env-1';
+    const organizationId = 'org-1';
+    const userId = 'user-1';
+
+    const createJob = (overrides: Partial<JobEntity> = {}): JobEntity =>
+      ({
+        _id: 'job-1',
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        _userId: userId,
+        _subscriberId: 'sub-1',
+        _templateId: 'template-1',
+        _notificationId: 'notif-1',
+        transactionId: 'tx-1',
+        type: StepTypeEnum.EMAIL,
+        status: JobStatusEnum.PENDING,
+        step: {
+          filters: [],
+          template: { type: StepTypeEnum.EMAIL },
+        },
+        payload: {},
+        overrides: {},
+        ...overrides,
+      }) as JobEntity;
+
+    it('should call queueJob BEFORE updateStatus for non-deferred jobs', async () => {
+      const job = createJob();
+
+      jobRepository.findOne.resolves(job);
+      stepRunRepository.create.resolves();
+      standardQueueService.add.resolves();
+      jobRepository.updateStatus.resolves(job);
+
+      await addJob.execute(
+        AddJobCommand.create({
+          environmentId,
+          organizationId,
+          userId,
+          jobId: job._id,
+          job,
+        })
+      );
+
+      // queueJob (standardQueueService.add) should be called BEFORE updateStatus
+      sinon.assert.callOrder(
+        standardQueueService.add,
+        jobRepository.updateStatus
+      );
+    });
+
+    it('should NOT update status if queueJob throws', async () => {
+      const job = createJob();
+
+      jobRepository.findOne.resolves(job);
+      standardQueueService.add.rejects(new Error('Queue unavailable'));
+
+      try {
+        await addJob.execute(
+          AddJobCommand.create({
+            environmentId,
+            organizationId,
+            userId,
+            jobId: job._id,
+            job,
+          })
+        );
+        expect.fail('Should have thrown');
+      } catch (err) {
+        sinon.assert.notCalled(jobRepository.updateStatus);
+      }
+    });
+
+    it('should enqueue with the correct payload for non-deferred jobs', async () => {
+      const job = createJob();
+
+      jobRepository.findOne.resolves(job);
+      stepRunRepository.create.resolves();
+      standardQueueService.add.resolves();
+      jobRepository.updateStatus.resolves(job);
+
+      await addJob.execute(
+        AddJobCommand.create({
+          environmentId,
+          organizationId,
+          userId,
+          jobId: job._id,
+          job,
+        })
+      );
+
+      sinon.assert.calledWith(standardQueueService.add, {
+        name: job._id,
+        data: {
+          _environmentId: environmentId,
+          _id: job._id,
+          _organizationId: organizationId,
+          _userId: userId,
+        },
+        groupId: organizationId,
+        options: { delay: 0 },
+      });
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -364,11 +364,16 @@ export class AddJob {
       throw new Error(`Job with id ${job._id} not found`);
     }
 
+    // 1. Queue the job FIRST. If we crash after this point the queue message
+    //    still fires and the worker reclaims the stale RUNNING claim.
+    await this.queueJob({ job, delay, untilDate: bridgeDelayAmountDate, timezone: subscriber?.timezone });
+
+    // 2. THEN update the MongoDB status atomically.
+    await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.DELAYED);
+
     await this.stepRunRepository.create(updatedJob, {
       status: JobStatusEnum.DELAYED,
     });
-
-    await this.queueJob({ job, delay, untilDate: bridgeDelayAmountDate, timezone: subscriber?.timezone });
 
     return {
       workflowStatus: null,
@@ -416,14 +421,18 @@ export class AddJob {
   private async executeNoneDeferredJob(command: AddJobCommand): Promise<AddJobResult> {
     const { job } = command;
 
-    this.logger.trace(`Updating status to queued for job ${job._id}`);
+    this.logger.trace(`Queueing job ${job._id}`);
+
+    // 1. Queue the job FIRST. If we crash after this point the queue message
+    //    still fires and the worker reclaims the stale RUNNING claim.
+    await this.queueJob({ job, delay: 0, untilDate: null });
+
+    // 2. THEN update the MongoDB status atomically.
     await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.QUEUED);
 
     await this.stepRunRepository.create(job, {
       status: JobStatusEnum.QUEUED,
     });
-
-    await this.queueJob({ job, delay: 0, untilDate: null });
 
     /*
      * The message now exists, so the claim-to-enqueue crash window is over: without
@@ -478,8 +487,6 @@ export class AddJob {
     if (delayType === DelayTypeEnum.DYNAMIC) {
       await this.validateDynamicDuration(command, job, delayAmount, StepTypeEnum.DELAY);
     }
-
-    await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.DELAYED);
 
     this.logger.debug(`Delay step Amount is: ${delayAmount}`);
 

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -1111,6 +1111,25 @@ export class RunJob {
       return false;
     }
 
+    const updatedJob = await this.jobRepository.findOne({
+      _id: job._id,
+      _environmentId: job._environmentId,
+    });
+
+    if (!updatedJob) {
+      throw new PlatformException(`Job with id ${job._id} not found`);
+    }
+
+    // 1. Queue the job FIRST. If we crash after this point the queue message
+    //    still fires and the worker reclaims the stale RUNNING claim.
+    await this.addJobUsecase.queueJob({
+      job: updatedJob,
+      delay: delayMs,
+      untilDate: nextAvailableTime,
+      timezone,
+    });
+
+    // 2. THEN update the MongoDB status atomically.
     await this.jobRepository.updateOne(
       {
         _id: job._id,
@@ -1123,15 +1142,6 @@ export class RunJob {
         },
       }
     );
-
-    const updatedJob = await this.jobRepository.findOne({
-      _id: job._id,
-      _environmentId: job._environmentId,
-    });
-
-    if (!updatedJob) {
-      throw new PlatformException(`Job with id ${job._id} not found`);
-    }
 
     await this.stepRunRepository.create(updatedJob, {
       status: JobStatusEnum.DELAYED,
@@ -1157,14 +1167,6 @@ export class RunJob {
         }),
       })
     );
-
-    // re-queue the job with the new delay
-    await this.addJobUsecase.queueJob({
-      job: updatedJob,
-      delay: delayMs,
-      untilDate: nextAvailableTime,
-      timezone,
-    });
 
     this.logger.info(
       {

--- a/apps/worker/src/app/workflow/workflow.module.ts
+++ b/apps/worker/src/app/workflow/workflow.module.ts
@@ -89,6 +89,7 @@ import { ExecuteCodeFirstCustomStep } from './usecases/send-message/execute-code
 import { ExecuteHttpRequestStep } from './usecases/send-message/execute-http-request-step.usecase';
 import { StoreSubscriberJobs } from './usecases/store-subscriber-jobs';
 import { SubscriberJobBound } from './usecases/subscriber-job-bound/subscriber-job-bound.usecase';
+import { JobReconciliationService } from './services/job-reconciliation.service';
 
 const enterpriseImports = (): Array<Type | DynamicModule | Promise<DynamicModule> | ForwardReference> => {
   const modules: Array<Type | DynamicModule | Promise<DynamicModule> | ForwardReference> = [];
@@ -229,7 +230,7 @@ const USE_CASES = [
   ResolveChannelEndpoints,
 ];
 
-const PROVIDERS: Provider[] = [RedisThrottleService, MsTeamsTokenService, RotatingConnectionTokenService];
+const PROVIDERS: Provider[] = [RedisThrottleService, MsTeamsTokenService, RotatingConnectionTokenService, JobReconciliationService];
 const activeWorkersToken: any = {
   provide: 'ACTIVE_WORKERS',
   useFactory: (...args: any[]) => {

--- a/apps/worker/src/bootstrap.ts
+++ b/apps/worker/src/bootstrap.ts
@@ -7,6 +7,7 @@ import bodyParser from 'body-parser';
 import helmet from 'helmet';
 import { ResponseInterceptor } from './app/shared/response.interceptor';
 import { prepareAppInfra, startAppInfra } from './app/workflow/services/cold-start.service';
+import { JobReconciliationService } from './app/workflow/services/job-reconciliation.service';
 import { AppModule } from './app.module';
 import { CONTEXT_PATH, validateEnv } from './config';
 
@@ -72,6 +73,18 @@ export async function bootstrap(): Promise<INestApplication> {
   } catch (e) {
     Logger.error('[@novu/worker]: Failed to start app infra', e.message, e.start);
     process.exit(1);
+  }
+
+  // Fire-and-forget: reconcile any jobs stuck in DELAYED state without queue
+  // entries. This is a startup safety net; the reverse-order fix in
+  // extendJobToNextAvailableSchedule / executeDeferredJob / executeNoneDeferredJob
+  // prevents new occurrences.
+  try {
+    app.get(JobReconciliationService).reconcileOnStartup().catch((reconcileErr) => {
+      Logger.error('[@novu/worker]: Job reconciliation error', reconcileErr);
+    });
+  } catch (e) {
+    Logger.error('[@novu/worker]: Failed to start job reconciliation', e);
   }
 
   await app.listen(process.env.PORT!);


### PR DESCRIPTION
## Bug

A worker crash (SIGKILL, OOM, pod eviction, deployment restart) between the<br>MongoDB status update and the BullMQ / SQS enqueue permanently orphans the job.<br>The job stays in `DELAYED` or `QUEUED` with no corresponding queue entry,<br>stalling the workflow forever.

### Vulnerable code paths

<!-- linear:table-colwidths:200,200,200,200 -->
| Path | File | DB Update | Queue Call |
| -- | -- | -- | -- |
| Schedule extension | `extendJobToNextAvailableSchedule()` | `$set: { status: DELAYED }` | `queueJob()` |
| Deferred (DELAY type) | `handleDelay()` → `executeDeferredJob()` | `updateStatus(DELAYED)` | `queueJob()` |
| Non-deferred | `executeNoneDeferredJob()` | `updateStatus(QUEUED)` | `queueJob()` |

## Root cause

All three paths performed the MongoDB update **before** the queue insertion.<br>If the process died after the DB write but before `queueJob()` completed, the<br>job was stranded in `DELAYED`/`QUEUED` state with no queue message ever<br>arriving to process it.

**No existing recovery mechanism covered this window:**

* No startup reconciliation for stale `DELAYED` jobs
* No periodic reconciliation / cron job
* MongoDB transactions are not used
* BullMQ `stalledInterval` only detects enqueued jobs picked up by a stalled<br>worker — not jobs that were never enqueued

## Fix (3 crash-safety layers)

### Layer 1 — Reverse order (primary)

Queue the job **first**, then update MongoDB. If the process crashes after<br>enqueue, the queue message persists; when it fires, `claimAsRunning()`<br>reclaims the stale `RUNNING` claim. If enqueue fails, the DB is untouched and<br>the job retries naturally.

**Before:**<br>updateOne({ status: DELAYED })   ← crash here → job stranded<br>queueJob()

**After:**<br>queueJob()                       ← crash here → message in queue, stale claim reclaimed<br>updateOne({ status: DELAYED })

### Layer 2 — Idempotent processing (already existed)

`claimAsRunning()` at `job.repository.ts:91` uses `findOneAndUpdate` with an<br>atomic `$or` filter, so duplicate queue messages are silently skipped.

### Layer 3 — Startup reconciliation (new)

A fire-and-forget `JobReconciliationService` scans for `status: DELAYED` jobs<br>with `scheduleExtensionsCount > 0` and stale `updatedAt` (>10s), atomically<br>claims them via `findOneAndUpdate`, and re-enqueues with `delay: 0`. Runs<br>after `startAppInfra()` in `bootstrap.ts`.

## Files changed

<!-- linear:table-colwidths:400,400 -->
| File | Change |
| -- | -- |
| `apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts` | `extendJobToNextAvailableSchedule`: `queueJob` before `updateOne` |
| `apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts` | `handleDelay`: removed `updateStatus`. `executeDeferredJob`/`executeNoneDeferredJob`: `queueJob` before `updateStatus` |
| `apps/worker/src/app/workflow/services/job-reconciliation.service.ts` | **NEW** — startup reconciliation with atomic claim + re-enqueue |
| `apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts` | **NEW** — 8 tests (crash recovery, duplicate detection, concurrent workers, queue failures) |
| `apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.spec.ts` | **NEW** — 3 tests for reverse-order behavior |
| `apps/worker/src/bootstrap.ts` | Import + fire-and-forget `reconcileOnStartup()` after workers resume |
| `apps/worker/src/app/workflow/workflow.module.ts` | Register `JobReconciliationService` |
| `apps/worker/src/app/workflow/services/index.ts` | Export `JobReconciliationService` |

## Known limitation

`markJobAsDigestMaster()` in `merge-or-create-digest.usecase.ts:164` also sets<br>`DELAYED` before `queueJob` returns (digest-only code path). Fixing it requires<br>restructuring the digest flow — deferred to a follow-up. The startup<br>reconciliation does not yet cover this path (query filters on<br>`scheduleExtensionsCount > 0`, but digest master jobs have<br>`scheduleExtensionsCount: 0`).

Tell me the path and filename you want, then switch me to implement mode and I'll write it.

### Greptile Summary

This PR attempts to make worker scheduling crash-safe.

* Reorders standard and deferred job scheduling so queue insertion occurs before MongoDB status updates.
* Adds startup reconciliation for stale schedule-extended DELAYED jobs.
* Registers the reconciliation service during worker bootstrap and adds ordering and recovery tests.

### Confidence Score: 1/5

This PR is not safe to merge because immediate messages can still be lost during the queue-before-status race, while reconciliation can execute valid delays early or permanently strand jobs during failures and batch overflow.

The queue message can become visible before the database records a claimable status, and all three previously reported reconciliation defects remain present: legitimate delays are forced to zero, enqueue failures leave jobs QUEUED without messages, and only the first 100 matching jobs are scanned.

**Files Needing Attention:** apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts, apps/worker/src/app/workflow/services/job-reconciliation.service.ts, apps/worker/src/bootstrap.ts

### Important Files Changed

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| apps/worker/src/app/workflow/services/job-reconciliation.service.ts | Adds a one-shot startup reconciler, but the previously reported early-delivery, batch-overflow, and failed-enqueue defects remain. |
| apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts | Moves queue insertion ahead of status persistence, leaving the previously reported immediate-consumption race unresolved. |
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Applies queue-first ordering to schedule extensions before persisting the DELAYED state and extension count. |
| apps/worker/src/bootstrap.ts | Starts reconciliation once after queue infrastructure initialization and does not repeat or paginate it. |
| apps/worker/src/app/workflow/workflow.module.ts | Registers and exports JobReconciliationService through the workflow module. |
| apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts | Adds reconciliation tests, including behavior that treats enqueue failure as handled without validating rollback. |
| apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.spec.ts | Verifies queue-first ordering and enqueue payloads but does not exercise concurrent message consumption. |
| apps/worker/src/app/workflow/services/index.ts | Exports the newly introduced reconciliation service. |

### Sequence Diagram

```mermaid
sequenceDiagram
  participant Producer as AddJob / RunJob
  participant Queue as Standard Queue
  participant DB as MongoDB
  participant Consumer as StandardWorker
  Producer->>Queue: Add job
  Queue-->>Consumer: Message becomes visible
  Producer->>DB: Set QUEUED or DELAYED
  Consumer->>DB: claimAsRunning()
  Note over Consumer,DB: Correctness depends on the status write<br/>winning the race with consumption
  participant Reconciler as Startup Reconciler
  Reconciler->>DB: Find stale DELAYED jobs (limit 100)
  Reconciler->>DB: Set QUEUED
  Reconciler->>Queue: Add with delay 0
```

Reviews (2): Last reviewed commit: ["Merge branch < />next< /> into fix/delayed-job..."](<https://github.com/novuhq/novu/commit/f35e65ac55d922f34f38105bbdedaa329fd1489c>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=47633273>)

**Context used:**

* Knowledge Base — [Worker App: Job Processing and Workflow Execution](<https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md>)
* Knowledge Base — [Notification Trigger Flow](<https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md>)