### PR TITLE
refactor(js): implement Web Locks for tab coordination and enhance socket connection handling fixes NV-8425

### DIFF
--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -190,10 +190,7 @@ export const CountProvider = (props: ParentProps) => {
     // 1. Cache is nearly empty
     // 2. OR inbox is closed (will be auto-loaded when opened)
     if (hasLessThenMinAmount || !isOpened()) {
-      notificationsCache.update(tabSpecificFilterForCache, {
-        ...cachedData,
-        notifications: [notification, ...cachedData.notifications],
-      });
+      notificationsCache.unshift(tabSpecificFilterForCache, notification);
 
       return;
     }

--- a/packages/js/src/ui/helpers/browser.ts
+++ b/packages/js/src/ui/helpers/browser.ts
@@ -1,5 +1,9 @@
+export function isWebLocksAvailable(): boolean {
+  return typeof navigator !== 'undefined' && 'locks' in navigator && !!navigator.locks;
+}
+
 export function requestLock(id: string, cb: (id: string) => void) {
-  if (typeof navigator === 'undefined' || !('locks' in navigator) || !navigator.locks) {
+  if (!isWebLocksAvailable()) {
     cb(id);
 
     return () => {};

--- a/packages/js/src/ui/helpers/useWebSocketEvent.ts
+++ b/packages/js/src/ui/helpers/useWebSocketEvent.ts
@@ -1,7 +1,7 @@
 import { createEffect, onCleanup } from 'solid-js';
 import type { EventHandler, Events, SocketEventNames } from '../../event-emitter';
 import { useNovu } from '../context';
-import { requestLock } from './browser';
+import { isWebLocksAvailable, requestLock } from './browser';
 
 export const useWebSocketEvent = <E extends SocketEventNames>({
   event: webSocketEvent,
@@ -14,6 +14,24 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
 
   createEffect(() => {
     const currentNovu = novuAccessor();
+
+    // Web Locks are only available in secure contexts. `http://localhost` is
+    // treated as secure, but `http://my-app.test` is not — so the lock +
+    // BroadcastChannel coordination below is skipped there.
+    //
+    // Without locks, every subscriber must listen via `novu.on` directly and
+    // must NOT fan out through BroadcastChannel: each tab already has its own
+    // socket, and BC would double-deliver the same event across tabs.
+    if (!isWebLocksAvailable()) {
+      const cleanup = currentNovu.on(webSocketEvent, onMessage);
+
+      onCleanup(() => {
+        cleanup();
+      });
+
+      return;
+    }
+
     const channelName = `nv_ws_connection:a=${currentNovu.applicationIdentifier}:s=${currentNovu.subscriberId}:c=${currentNovu.contextKey}:e=${webSocketEvent}`;
 
     const tabsChannel = new BroadcastChannel(channelName);
@@ -23,14 +41,14 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
 
     tabsChannel.addEventListener('message', listener);
 
-    const updateReadCount: EventHandler<Events[E]> = (data) => {
+    const broadcastAndHandle: EventHandler<Events[E]> = (data) => {
       onMessage(data);
       tabsChannel.postMessage(data);
     };
 
     let cleanup: (() => void) | undefined;
     const resolveLock = requestLock(channelName, () => {
-      cleanup = currentNovu.on(webSocketEvent, updateReadCount);
+      cleanup = currentNovu.on(webSocketEvent, broadcastAndHandle);
     });
 
     onCleanup(() => {

--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -23,6 +23,7 @@ import {
 import { NovuError } from '../utils/errors';
 import { sanitizeInAppRedirect } from '../utils/in-app-redirect-url';
 import type { BaseSocketInterface } from './base-socket';
+import { runSingleFlight } from './run-single-flight';
 
 export const PRODUCTION_SOCKET_URL = 'wss://socket.novu.co';
 
@@ -117,6 +118,7 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
   #token: string;
   #emitter: NovuEventEmitter;
   #partySocket: WebSocket | undefined;
+  #connectFlight: { current?: Promise<void> } = {};
   #socketUrl: string;
   #socketOptions?: Record<string, unknown>;
   #hibernationHeartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
@@ -237,6 +239,14 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
   }
 
   async #initializeSocket(): Promise<void> {
+    if (this.#partySocket) {
+      return;
+    }
+
+    await runSingleFlight(this.#connectFlight, () => this.#openSocket());
+  }
+
+  async #openSocket(): Promise<void> {
     if (this.#partySocket) {
       return;
     }

--- a/packages/js/src/ws/run-single-flight.test.ts
+++ b/packages/js/src/ws/run-single-flight.test.ts
@@ -1,0 +1,51 @@
+import { runSingleFlight } from './run-single-flight';
+
+describe('runSingleFlight', () => {
+  test('shares one in-flight task across concurrent callers', async () => {
+    const state: { current?: Promise<void> } = {};
+    let runs = 0;
+
+    const task = async () => {
+      runs += 1;
+      await Promise.resolve();
+    };
+
+    await Promise.all([runSingleFlight(state, task), runSingleFlight(state, task), runSingleFlight(state, task)]);
+
+    expect(runs).toBe(1);
+    expect(state.current).toBeUndefined();
+  });
+
+  test('allows a new run after the previous in-flight task settles', async () => {
+    const state: { current?: Promise<void> } = {};
+    let runs = 0;
+
+    const run = () =>
+      runSingleFlight(state, async () => {
+        runs += 1;
+      });
+
+    await run();
+    await run();
+
+    expect(runs).toBe(2);
+  });
+
+  test('clears in-flight state when the task rejects so callers can retry', async () => {
+    const state: { current?: Promise<void> } = {};
+    let shouldFail = true;
+
+    const run = () =>
+      runSingleFlight(state, async () => {
+        if (shouldFail) {
+          throw new Error('boom');
+        }
+      });
+
+    await expect(run()).rejects.toThrow('boom');
+    expect(state.current).toBeUndefined();
+
+    shouldFail = false;
+    await expect(run()).resolves.toBeUndefined();
+  });
+});

--- a/packages/js/src/ws/run-single-flight.ts
+++ b/packages/js/src/ws/run-single-flight.ts
@@ -1,0 +1,21 @@
+type SingleFlightState = {
+  current?: Promise<void>;
+};
+
+/**
+ * Ensures concurrent callers share a single in-flight async task.
+ * Cleared only by that task's own `.finally`, so waiters cannot wipe a
+ * newer attempt started after the first completed.
+ */
+export async function runSingleFlight(state: SingleFlightState, task: () => Promise<void>): Promise<void> {
+  if (!state.current) {
+    const inFlight = task().finally(() => {
+      if (state.current === inFlight) {
+        state.current = undefined;
+      }
+    });
+    state.current = inFlight;
+  }
+
+  await state.current;
+}

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -22,6 +22,7 @@ import {
 import { NovuError } from '../utils/errors';
 import { sanitizeInAppRedirect } from '../utils/in-app-redirect-url';
 import type { BaseSocketInterface } from './base-socket';
+import { runSingleFlight } from './run-single-flight';
 
 const PRODUCTION_SOCKET_URL = 'https://ws.novu.co';
 const NOTIFICATION_RECEIVED: NotificationReceivedEvent = 'notifications.notification_received';
@@ -112,6 +113,7 @@ export class Socket extends BaseModule implements BaseSocketInterface {
   #token: string;
   #emitter: NovuEventEmitter;
   #socketIo: SocketIO | undefined;
+  #connectFlight: { current?: Promise<void> } = {};
   #socketUrl: string;
   #socketOptions?: Record<string, unknown>;
 
@@ -158,6 +160,14 @@ export class Socket extends BaseModule implements BaseSocketInterface {
   };
 
   async #initializeSocket(): Promise<void> {
+    if (this.#socketIo) {
+      return;
+    }
+
+    await runSingleFlight(this.#connectFlight, () => this.#openSocket());
+  }
+
+  async #openSocket(): Promise<void> {
     if (this.#socketIo) {
       return;
     }

--- a/packages/react/src/hooks/internal/useWebsocketEvent.ts
+++ b/packages/react/src/hooks/internal/useWebsocketEvent.ts
@@ -1,6 +1,6 @@
 import { EventHandler, Events, SocketEventNames } from '@novu/js';
 import { useEffect } from 'react';
-import { requestLock } from '../../utils/requestLock';
+import { isWebLocksAvailable, requestLock } from '../../utils/requestLock';
 import { useNovu } from '../NovuProvider';
 import { useBrowserTabsChannel } from './useBrowserTabsChannel';
 
@@ -15,14 +15,19 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
 }) => {
   const novu = useNovu();
   const channelName = `nv_ws_connection:a=${novu.applicationIdentifier}:s=${novu.subscriberId}:c=${novu.contextKey}:e=${webSocketEvent}`;
+  const useTabCoordination = isWebLocksAvailable();
 
+  // BroadcastChannel is only safe when Web Locks coordinate a single socket
+  // subscriber across tabs. On non-secure HTTP origins (e.g. http://my-app.test)
+  // locks are unavailable, every tab has its own socket, and BC would
+  // double-deliver events.
   const { postMessage } = useBrowserTabsChannel({
     channelName,
     onMessage,
-    enabled,
+    enabled: enabled && useTabCoordination,
   });
 
-  const updateReadCount: EventHandler<Events[E]> = (data) => {
+  const broadcastAndHandle: EventHandler<Events[E]> = (data) => {
     onMessage(data);
     postMessage(data);
   };
@@ -30,9 +35,17 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
   useEffect(() => {
     if (!enabled) return;
 
-    let cleanup: () => void;
+    if (!useTabCoordination) {
+      const cleanup = novu.on(webSocketEvent, onMessage);
+
+      return () => {
+        cleanup();
+      };
+    }
+
+    let cleanup: (() => void) | undefined;
     const resolveLock = requestLock(channelName, () => {
-      cleanup = novu.on(webSocketEvent, updateReadCount);
+      cleanup = novu.on(webSocketEvent, broadcastAndHandle);
     });
 
     return () => {
@@ -42,5 +55,7 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
 
       resolveLock();
     };
+    // Intentionally match prior dep surface: re-subscribe when enabled flips.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled]);
 };

--- a/packages/react/src/utils/requestLock.ts
+++ b/packages/react/src/utils/requestLock.ts
@@ -1,7 +1,9 @@
+export function isWebLocksAvailable(): boolean {
+  return typeof navigator !== 'undefined' && 'locks' in navigator && !!navigator.locks;
+}
+
 export function requestLock(id: string, cb: (id: string) => void) {
-  // Check if the Lock API is available
-  if (!('locks' in navigator)) {
-    // If Lock API is not available, immediately invoke the callback and return a no-op function
+  if (!isWebLocksAvailable()) {
     cb(id);
 
     return () => {};


### PR DESCRIPTION
- Introduced `isWebLocksAvailable` function to check for Web Locks support.
- Updated `useWebSocketEvent` and `CountContext` to utilize Web Locks for managing socket events across tabs.
- Refactored socket connection logic in `PartySocketClient` and `Socket` classes to prevent multiple concurrent connections using `runSingleFlight`.
- Added tests for `runSingleFlight` to ensure proper handling of concurrent tasks.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors realtime coordination and socket initialization.
- Uses Web Locks availability to choose between cross-tab BroadcastChannel coordination and direct per-tab socket subscriptions.
- Deduplicates concurrent socket initialization through a shared single-flight helper.
- Uses the notification cache’s existing deduplicating `unshift` operation for realtime inserts.
- Adds unit coverage for concurrent, sequential, and rejected single-flight tasks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defects identified.

The fallback paths preserve direct realtime subscriptions when Web Locks are unavailable, coordinated paths retain local and cross-tab delivery, single-flight state is cleared safely after settlement, and cache insertion delegates to existing deduplicating behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/ui/helpers/useWebSocketEvent.ts | Adds a direct-subscription fallback when Web Locks are unavailable while retaining coordinated event fan-out on supported browsers. |
| packages/react/src/hooks/internal/useWebsocketEvent.ts | Mirrors Web Locks capability handling in the React hook and disables BroadcastChannel when coordination cannot be guaranteed. |
| packages/js/src/ws/run-single-flight.ts | Introduces a small identity-guarded single-flight primitive that shares an in-progress task and safely clears settled state. |
| packages/js/src/ws/socket.ts | Routes Socket.IO initialization through single-flight protection without changing its event handling contract. |
| packages/js/src/ws/party-socket.ts | Routes PartySocket initialization through single-flight protection while preserving heartbeat and stale-close protections. |
| packages/js/src/ui/context/CountContext.tsx | Reuses the cache’s tested unshift operation to normalize, prepend, and deduplicate incoming notifications. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Tab as Browser tab
  participant Lock as Web Locks
  participant BC as BroadcastChannel
  participant Novu as Novu client
  participant WS as Realtime socket
  alt Web Locks available
    Tab->>Lock: Request event-specific lock
    alt Lock acquired
      Tab->>Novu: Subscribe to socket event
      Novu->>WS: Connect once via single-flight
      WS-->>Novu: Realtime event
      Novu-->>Tab: Handle event locally
      Tab->>BC: Broadcast event to peer tabs
    else Peer tab
      BC-->>Tab: Receive event
    end
  else Web Locks unavailable
    Tab->>Novu: Subscribe directly
    Novu->>WS: Maintain this tab's socket
    WS-->>Tab: Handle event locally
  end
```

<sub>Reviews (1): Last reviewed commit: ["refactor(js): implement Web Locks for ta..."](https://github.com/novuhq/novu/commit/b9b9efb657d998e7098e3dd41c2a8dd1868a1a23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47808582)</sub>

**Context used:**

- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->