### PR TITLE
fix(worker): preserve job schedule on reconciliation, fix claim order, add pagination

### DIFF
--- a/apps/worker/src/app/workflow/services/index.ts
+++ b/apps/worker/src/app/workflow/services/index.ts
@@ -1,4 +1,5 @@
 export * from './active-jobs-metric.service';
+export * from './job-reconciliation.service';
 export * from './standard.worker';
 export * from './subscriber-process.worker';
 export * from './workflow.worker';

--- a/apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts
+++ b/apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts
@@ -1,5 +1,5 @@
 import { PinoLogger, StandardQueueService } from '@novu/application-generic';
-import { JobRepository, JobStatusEnum } from '@novu/dal';
+import { JobEntity, JobRepository, JobStatusEnum } from '@novu/dal';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { JobReconciliationService } from './job-reconciliation.service';
@@ -32,6 +32,19 @@ describe('JobReconciliationService', () => {
     sinon.restore();
   });
 
+  const makeStub = (overrides: Record<string, unknown> = {}) =>
+    ({
+      _id: 'job-1',
+      _environmentId: 'env-1',
+      _organizationId: 'org-1',
+      _userId: 'user-1',
+      scheduleExtensionsCount: 1,
+      status: JobStatusEnum.DELAYED,
+      updatedAt: new Date(Date.now() - 60_000),
+      nextScheduledAt: new Date(Date.now() + 30_000).toISOString(),
+      ...overrides,
+    }) as unknown as JobEntity;
+
   describe('reconcileOnStartup', () => {
     it('should query for DELAYED jobs with scheduleExtensionsCount > 0 and stale updatedAt', async () => {
       jobRepository.find.resolves([]);
@@ -40,10 +53,11 @@ describe('JobReconciliationService', () => {
 
       const findCall = jobRepository.find.getCall(0);
       expect(findCall).to.not.be.undefined;
+      expect(findCall.args[0]._organizationId).to.deep.equal({ $exists: true });
       expect(findCall.args[0].status).to.equal(JobStatusEnum.DELAYED);
       expect(findCall.args[0].scheduleExtensionsCount).to.deep.equal({ $gt: 0 });
       expect(findCall.args[0].updatedAt).to.have.property('$lt');
-      expect(findCall.args[1]).to.equal('_id _environmentId _organizationId _userId');
+      expect(findCall.args[1]).to.equal('_id _environmentId _organizationId _userId nextScheduledAt');
     });
 
     it('should not call add when no stuck jobs exist', async () => {
@@ -55,103 +69,88 @@ describe('JobReconciliationService', () => {
       sinon.assert.notCalled(standardQueueService.add);
     });
 
-    it('should atomically claim and re-enqueue a stuck job', async () => {
-      const jobId = 'job-1';
-      const envId = 'env-1';
-      const orgId = 'org-1';
-      const userId = 'user-1';
+    it('should queue before claiming (reversed order)', async () => {
+      const stub = makeStub();
 
-      const stuckJob = {
-        _id: jobId,
-        _environmentId: envId,
-        _organizationId: orgId,
-        _userId: userId,
-        scheduleExtensionsCount: 1,
-        status: JobStatusEnum.DELAYED,
-        updatedAt: new Date(Date.now() - 60_000),
-      };
-
-      jobRepository.find.resolves([stuckJob]);
-      jobRepository.findOneAndUpdate.resolves({ ...stuckJob, status: JobStatusEnum.QUEUED });
+      jobRepository.find.resolves([stub]);
+      jobRepository.findOneAndUpdate.resolves(makeStub({ status: JobStatusEnum.QUEUED }));
       standardQueueService.add.resolves();
 
       await service.reconcileOnStartup();
 
-      sinon.assert.calledWith(
-        jobRepository.findOneAndUpdate,
-        {
-          _id: jobId,
-          _environmentId: envId,
-          status: JobStatusEnum.DELAYED,
-        },
-        { $set: { status: JobStatusEnum.QUEUED } },
-        { new: true }
-      );
-
-      sinon.assert.calledWith(standardQueueService.add, {
-        name: jobId,
-        data: {
-          _environmentId: envId,
-          _id: jobId,
-          _organizationId: orgId,
-          _userId: userId,
-        },
-        groupId: orgId,
-        options: { delay: 0 },
-      });
+      sinon.assert.callOrder(standardQueueService.add, jobRepository.findOneAndUpdate);
     });
 
-    it('should skip a job when another worker already claimed it (findOneAndUpdate returns null)', async () => {
-      const stuckJob = {
-        _id: 'job-1',
-        _environmentId: 'env-1',
-        _organizationId: 'org-1',
-        _userId: 'user-1',
-        scheduleExtensionsCount: 1,
-        status: JobStatusEnum.DELAYED,
-        updatedAt: new Date(Date.now() - 60_000),
-      };
+    it('should preserve remaining delay from nextScheduledAt', async () => {
+      const futureMs = 30_000;
+      const stub = makeStub({ nextScheduledAt: new Date(Date.now() + futureMs).toISOString() });
 
-      jobRepository.find.resolves([stuckJob]);
+      jobRepository.find.resolves([stub]);
+      jobRepository.findOneAndUpdate.resolves(makeStub({ status: JobStatusEnum.QUEUED }));
+      standardQueueService.add.resolves();
+
+      await service.reconcileOnStartup();
+
+      const addCall = standardQueueService.add.getCall(0);
+      expect(addCall).to.not.be.undefined;
+      const args = addCall!.args[0] as any;
+      expect(args.options.delay).to.be.greaterThan(0);
+      expect(args.options.delay).to.be.at.most(futureMs);
+    });
+
+    it('should use delay 0 when nextScheduledAt is in the past', async () => {
+      const stub = makeStub({ nextScheduledAt: new Date(Date.now() - 10_000).toISOString() });
+
+      jobRepository.find.resolves([stub]);
+      jobRepository.findOneAndUpdate.resolves(makeStub({ status: JobStatusEnum.QUEUED }));
+      standardQueueService.add.resolves();
+
+      await service.reconcileOnStartup();
+
+      const addCall = standardQueueService.add.getCall(0);
+      expect(addCall).to.not.be.undefined;
+      expect((addCall!.args[0] as any).options.delay).to.equal(0);
+    });
+
+    it('should skip a job when another worker already claimed it', async () => {
+      const stub = makeStub();
+
+      jobRepository.find.resolves([stub]);
+      standardQueueService.add.resolves();
       jobRepository.findOneAndUpdate.resolves(null);
 
       await service.reconcileOnStartup();
 
+      sinon.assert.calledOnce(standardQueueService.add);
       sinon.assert.calledOnce(jobRepository.findOneAndUpdate);
-      sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should not attempt to claim if queue insertion fails', async () => {
+      const stub = makeStub();
+
+      jobRepository.find.resolves([stub]);
+      standardQueueService.add.rejects(new Error('Queue unavailable'));
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledOnce(standardQueueService.add);
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
     });
 
     it('should recover multiple stuck jobs and skip those already claimed by other workers', async () => {
-      const baseTime = Date.now() - 120_000;
-
-      const job1 = {
-        _id: 'job-1',
-        _environmentId: 'env-1',
-        _organizationId: 'org-1',
-        _userId: 'user-1',
-        scheduleExtensionsCount: 1,
-        status: JobStatusEnum.DELAYED,
-        updatedAt: new Date(baseTime),
-      };
-      const job2 = {
-        _id: 'job-2',
-        _environmentId: 'env-1',
-        _organizationId: 'org-1',
-        _userId: 'user-2',
-        scheduleExtensionsCount: 2,
-        status: JobStatusEnum.DELAYED,
-        updatedAt: new Date(baseTime),
-      };
+      const job1 = makeStub({ _id: 'job-1', _userId: 'user-1' });
+      const job2 = makeStub({ _id: 'job-2', _userId: 'user-2' });
 
       jobRepository.find.resolves([job1, job2]);
-      // job1 gets claimed by this worker, job2 was already claimed
+      standardQueueService.add.resolves();
+
       jobRepository.findOneAndUpdate
         .withArgs(
           { _id: 'job-1', _environmentId: 'env-1', status: JobStatusEnum.DELAYED },
           { $set: { status: JobStatusEnum.QUEUED } },
           { new: true }
         )
-        .resolves({ ...job1, status: JobStatusEnum.QUEUED });
+        .resolves(makeStub({ _id: 'job-1', status: JobStatusEnum.QUEUED }));
       jobRepository.findOneAndUpdate
         .withArgs(
           { _id: 'job-2', _environmentId: 'env-1', status: JobStatusEnum.DELAYED },
@@ -160,52 +159,26 @@ describe('JobReconciliationService', () => {
         )
         .resolves(null);
 
-      standardQueueService.add.resolves();
-
       await service.reconcileOnStartup();
 
+      sinon.assert.calledTwice(standardQueueService.add);
       sinon.assert.calledTwice(jobRepository.findOneAndUpdate);
-      sinon.assert.calledOnce(standardQueueService.add);
-      sinon.assert.calledWith(
-        standardQueueService.add,
-        sinon.match({ name: 'job-1' })
-      );
     });
 
     it('should handle queue insertion failure gracefully without crashing', async () => {
-      const stuckJob = {
-        _id: 'job-1',
-        _environmentId: 'env-1',
-        _organizationId: 'org-1',
-        _userId: 'user-1',
-        scheduleExtensionsCount: 1,
-        status: JobStatusEnum.DELAYED,
-        updatedAt: new Date(Date.now() - 60_000),
-      };
+      const stub = makeStub();
 
-      jobRepository.find.resolves([stuckJob]);
-      jobRepository.findOneAndUpdate.resolves({ ...stuckJob, status: JobStatusEnum.QUEUED });
+      jobRepository.find.resolves([stub]);
       standardQueueService.add.rejects(new Error('Queue unavailable'));
 
-      // Should not throw
       await service.reconcileOnStartup();
 
-      sinon.assert.calledOnce(jobRepository.findOneAndUpdate);
       sinon.assert.calledOnce(standardQueueService.add);
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
     });
 
     it('should skip jobs that were recently updated (within the backoff window)', async () => {
-      const recentJob = {
-        _id: 'job-1',
-        _environmentId: 'env-1',
-        _organizationId: 'org-1',
-        _userId: 'user-1',
-        scheduleExtensionsCount: 1,
-        status: JobStatusEnum.DELAYED,
-        updatedAt: new Date(), // very recent
-      };
-
-      jobRepository.find.resolves([]); // filtered by the MongoDB query
+      jobRepository.find.resolves([]);
       await service.reconcileOnStartup();
 
       sinon.assert.notCalled(jobRepository.findOneAndUpdate);
@@ -215,11 +188,33 @@ describe('JobReconciliationService', () => {
     it('should handle database errors gracefully', async () => {
       jobRepository.find.rejects(new Error('MongoDB connection error'));
 
-      // Should not throw
       await service.reconcileOnStartup();
 
       sinon.assert.notCalled(jobRepository.findOneAndUpdate);
       sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should paginate through more than MAX_RECONCILE_PER_RUN stuck jobs', async () => {
+      const makeBatch = (start: number, count: number): JobEntity[] =>
+        Array.from({ length: count }, (_, i) =>
+          makeStub({ _id: `job-${start + i}` })
+        );
+
+      jobRepository.find
+        .onFirstCall()
+        .resolves(makeBatch(0, 100))
+        .onSecondCall()
+        .resolves(makeBatch(100, 50))
+        .onThirdCall()
+        .resolves([]);
+
+      standardQueueService.add.resolves();
+      jobRepository.findOneAndUpdate.resolves(makeStub({ status: JobStatusEnum.QUEUED }));
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledThrice(jobRepository.find);
+      sinon.assert.callCount(standardQueueService.add, 150);
     });
   });
 });

--- a/apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts
+++ b/apps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts
@@ -1,0 +1,225 @@
+import { PinoLogger, StandardQueueService } from '@novu/application-generic';
+import { JobRepository, JobStatusEnum } from '@novu/dal';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { JobReconciliationService } from './job-reconciliation.service';
+
+describe('JobReconciliationService', () => {
+  let service: JobReconciliationService;
+  let jobRepository: sinon.SinonStubbedInstance<JobRepository>;
+  let standardQueueService: sinon.SinonStubbedInstance<StandardQueueService>;
+  let logger: PinoLogger;
+
+  const mockLogger = {
+    setContext: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as PinoLogger;
+
+  beforeEach(() => {
+    jobRepository = sinon.createStubInstance(JobRepository);
+    standardQueueService = sinon.createStubInstance(StandardQueueService);
+    logger = mockLogger;
+
+    service = new JobReconciliationService(
+      jobRepository as unknown as JobRepository,
+      standardQueueService as unknown as StandardQueueService,
+      logger
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('reconcileOnStartup', () => {
+    it('should query for DELAYED jobs with scheduleExtensionsCount > 0 and stale updatedAt', async () => {
+      jobRepository.find.resolves([]);
+
+      await service.reconcileOnStartup();
+
+      const findCall = jobRepository.find.getCall(0);
+      expect(findCall).to.not.be.undefined;
+      expect(findCall.args[0].status).to.equal(JobStatusEnum.DELAYED);
+      expect(findCall.args[0].scheduleExtensionsCount).to.deep.equal({ $gt: 0 });
+      expect(findCall.args[0].updatedAt).to.have.property('$lt');
+      expect(findCall.args[1]).to.equal('_id _environmentId _organizationId _userId');
+    });
+
+    it('should not call add when no stuck jobs exist', async () => {
+      jobRepository.find.resolves([]);
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should atomically claim and re-enqueue a stuck job', async () => {
+      const jobId = 'job-1';
+      const envId = 'env-1';
+      const orgId = 'org-1';
+      const userId = 'user-1';
+
+      const stuckJob = {
+        _id: jobId,
+        _environmentId: envId,
+        _organizationId: orgId,
+        _userId: userId,
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(Date.now() - 60_000),
+      };
+
+      jobRepository.find.resolves([stuckJob]);
+      jobRepository.findOneAndUpdate.resolves({ ...stuckJob, status: JobStatusEnum.QUEUED });
+      standardQueueService.add.resolves();
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledWith(
+        jobRepository.findOneAndUpdate,
+        {
+          _id: jobId,
+          _environmentId: envId,
+          status: JobStatusEnum.DELAYED,
+        },
+        { $set: { status: JobStatusEnum.QUEUED } },
+        { new: true }
+      );
+
+      sinon.assert.calledWith(standardQueueService.add, {
+        name: jobId,
+        data: {
+          _environmentId: envId,
+          _id: jobId,
+          _organizationId: orgId,
+          _userId: userId,
+        },
+        groupId: orgId,
+        options: { delay: 0 },
+      });
+    });
+
+    it('should skip a job when another worker already claimed it (findOneAndUpdate returns null)', async () => {
+      const stuckJob = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(Date.now() - 60_000),
+      };
+
+      jobRepository.find.resolves([stuckJob]);
+      jobRepository.findOneAndUpdate.resolves(null);
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledOnce(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should recover multiple stuck jobs and skip those already claimed by other workers', async () => {
+      const baseTime = Date.now() - 120_000;
+
+      const job1 = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(baseTime),
+      };
+      const job2 = {
+        _id: 'job-2',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-2',
+        scheduleExtensionsCount: 2,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(baseTime),
+      };
+
+      jobRepository.find.resolves([job1, job2]);
+      // job1 gets claimed by this worker, job2 was already claimed
+      jobRepository.findOneAndUpdate
+        .withArgs(
+          { _id: 'job-1', _environmentId: 'env-1', status: JobStatusEnum.DELAYED },
+          { $set: { status: JobStatusEnum.QUEUED } },
+          { new: true }
+        )
+        .resolves({ ...job1, status: JobStatusEnum.QUEUED });
+      jobRepository.findOneAndUpdate
+        .withArgs(
+          { _id: 'job-2', _environmentId: 'env-1', status: JobStatusEnum.DELAYED },
+          { $set: { status: JobStatusEnum.QUEUED } },
+          { new: true }
+        )
+        .resolves(null);
+
+      standardQueueService.add.resolves();
+
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledTwice(jobRepository.findOneAndUpdate);
+      sinon.assert.calledOnce(standardQueueService.add);
+      sinon.assert.calledWith(
+        standardQueueService.add,
+        sinon.match({ name: 'job-1' })
+      );
+    });
+
+    it('should handle queue insertion failure gracefully without crashing', async () => {
+      const stuckJob = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(Date.now() - 60_000),
+      };
+
+      jobRepository.find.resolves([stuckJob]);
+      jobRepository.findOneAndUpdate.resolves({ ...stuckJob, status: JobStatusEnum.QUEUED });
+      standardQueueService.add.rejects(new Error('Queue unavailable'));
+
+      // Should not throw
+      await service.reconcileOnStartup();
+
+      sinon.assert.calledOnce(jobRepository.findOneAndUpdate);
+      sinon.assert.calledOnce(standardQueueService.add);
+    });
+
+    it('should skip jobs that were recently updated (within the backoff window)', async () => {
+      const recentJob = {
+        _id: 'job-1',
+        _environmentId: 'env-1',
+        _organizationId: 'org-1',
+        _userId: 'user-1',
+        scheduleExtensionsCount: 1,
+        status: JobStatusEnum.DELAYED,
+        updatedAt: new Date(), // very recent
+      };
+
+      jobRepository.find.resolves([]); // filtered by the MongoDB query
+      await service.reconcileOnStartup();
+
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+
+    it('should handle database errors gracefully', async () => {
+      jobRepository.find.rejects(new Error('MongoDB connection error'));
+
+      // Should not throw
+      await service.reconcileOnStartup();
+
+      sinon.assert.notCalled(jobRepository.findOneAndUpdate);
+      sinon.assert.notCalled(standardQueueService.add);
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/services/job-reconciliation.service.ts
+++ b/apps/worker/src/app/workflow/services/job-reconciliation.service.ts
@@ -1,6 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { PinoLogger, StandardQueueService } from '@novu/application-generic';
-import { JobRepository, JobStatusEnum } from '@novu/dal';
+import { JobEntity, JobRepository, JobStatusEnum } from '@novu/dal';
 
 const LOG_CONTEXT = 'JobReconciliationService';
 
@@ -23,65 +23,87 @@ export class JobReconciliationService {
 
     try {
       const delayCutoff = new Date(Date.now() - this.RECONCILIATION_BACKOFF_MS);
-      const stuckJobs = await this.jobRepository.find(
-        {
+      const projection = '_id _environmentId _organizationId _userId nextScheduledAt';
+      let skip = 0;
+      let batch: JobEntity[];
+
+      do {
+        const query = {
+          _organizationId: { $exists: true },
           status: JobStatusEnum.DELAYED,
           scheduleExtensionsCount: { $gt: 0 },
           updatedAt: { $lt: delayCutoff },
-        },
-        '_id _environmentId _organizationId _userId',
-        { limit: this.MAX_RECONCILE_PER_RUN }
-      );
-
-      if (stuckJobs.length === 0) {
-        return;
-      }
-
-      this.logger.warn({ count: stuckJobs.length }, 'Found stuck DELAYED jobs, attempting recovery');
-
-      let recovered = 0;
-      let skipped = 0;
-
-      for (const job of stuckJobs) {
-        try {
-          const claimed = await this.jobRepository.findOneAndUpdate(
-            {
-              _id: job._id,
-              _environmentId: job._environmentId,
-              status: JobStatusEnum.DELAYED,
-            },
-            { $set: { status: JobStatusEnum.QUEUED } },
-            { new: true }
-          );
-
-          if (!claimed) {
-            skipped++;
-            continue;
+        } as any;
+        batch = await this.jobRepository.find(
+          query,
+          projection,
+          {
+            limit: this.MAX_RECONCILE_PER_RUN,
+            skip,
           }
+        );
 
-          await this.standardQueueService.add({
-            name: job._id,
-            data: {
-              _environmentId: job._environmentId,
-              _id: job._id,
-              _organizationId: job._organizationId,
-              _userId: job._userId,
-            },
-            groupId: job._organizationId,
-            options: { delay: 0 },
-          });
-
-          recovered++;
-          this.logger.warn({ jobId: job._id }, 'Recovered stuck DELAYED job');
-        } catch (err) {
-          this.logger.error({ err, jobId: job._id }, 'Failed to recover stuck job');
+        if (batch.length === 0) {
+          break;
         }
-      }
 
-      this.logger.warn(
-        { recovered, skipped, total: stuckJobs.length },
-        'Job reconciliation completed'
-      );
+        this.logger.warn({ count: batch.length }, 'Found stuck DELAYED jobs, attempting recovery');
+
+        let recovered = 0;
+        let skipped = 0;
+
+        for (const job of batch) {
+          const remainingDelay = job.nextScheduledAt
+            ? Math.max(0, new Date(job.nextScheduledAt).getTime() - Date.now())
+            : 0;
+
+          try {
+            // 1. Queue the job FIRST. If the queue fails the job stays DELAYED and
+            //    will be retried on the next reconciliation run.
+            await this.standardQueueService.add({
+              name: job._id,
+              data: {
+                _environmentId: job._environmentId,
+                _id: job._id,
+                _organizationId: job._organizationId,
+                _userId: job._userId,
+              },
+              groupId: job._organizationId,
+              options: { delay: remainingDelay },
+            });
+
+            // 2. THEN claim the job atomically.
+            const claimed = await this.jobRepository.findOneAndUpdate(
+              {
+                _id: job._id,
+                _environmentId: job._environmentId,
+                status: JobStatusEnum.DELAYED,
+              },
+              { $set: { status: JobStatusEnum.QUEUED } },
+              { new: true }
+            );
+
+            if (!claimed) {
+              skipped++;
+              continue;
+            }
+
+            recovered++;
+            this.logger.warn({ jobId: job._id, remainingDelay }, 'Recovered stuck DELAYED job');
+          } catch (err) {
+            this.logger.error({ err, jobId: job._id }, 'Failed to recover stuck job');
+          }
+        }
+
+        this.logger.warn(
+          { recovered, skipped, total: batch.length },
+          'Job reconciliation batch completed'
+        );
+
+        skip += batch.length;
+      } while (batch.length === this.MAX_RECONCILE_PER_RUN);
+
+      this.logger.warn('Job reconciliation finished');
     } catch (err) {
       this.logger.error({ err }, 'Job reconciliation failed');
     }

--- a/apps/worker/src/app/workflow/services/job-reconciliation.service.ts
+++ b/apps/worker/src/app/workflow/services/job-reconciliation.service.ts
@@ -1,0 +1,89 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { PinoLogger, StandardQueueService } from '@novu/application-generic';
+import { JobRepository, JobStatusEnum } from '@novu/dal';
+
+const LOG_CONTEXT = 'JobReconciliationService';
+
+@Injectable()
+export class JobReconciliationService {
+  private readonly RECONCILIATION_BACKOFF_MS = 10_000;
+  private readonly MAX_RECONCILE_PER_RUN = 100;
+
+  constructor(
+    private jobRepository: JobRepository,
+    @Inject(forwardRef(() => StandardQueueService))
+    private standardQueueService: StandardQueueService,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(LOG_CONTEXT);
+  }
+
+  async reconcileOnStartup(): Promise<void> {
+    this.logger.warn('Starting startup job reconciliation for stuck DELAYED jobs');
+
+    try {
+      const delayCutoff = new Date(Date.now() - this.RECONCILIATION_BACKOFF_MS);
+      const stuckJobs = await this.jobRepository.find(
+        {
+          status: JobStatusEnum.DELAYED,
+          scheduleExtensionsCount: { $gt: 0 },
+          updatedAt: { $lt: delayCutoff },
+        },
+        '_id _environmentId _organizationId _userId',
+        { limit: this.MAX_RECONCILE_PER_RUN }
+      );
+
+      if (stuckJobs.length === 0) {
+        return;
+      }
+
+      this.logger.warn({ count: stuckJobs.length }, 'Found stuck DELAYED jobs, attempting recovery');
+
+      let recovered = 0;
+      let skipped = 0;
+
+      for (const job of stuckJobs) {
+        try {
+          const claimed = await this.jobRepository.findOneAndUpdate(
+            {
+              _id: job._id,
+              _environmentId: job._environmentId,
+              status: JobStatusEnum.DELAYED,
+            },
+            { $set: { status: JobStatusEnum.QUEUED } },
+            { new: true }
+          );
+
+          if (!claimed) {
+            skipped++;
+            continue;
+          }
+
+          await this.standardQueueService.add({
+            name: job._id,
+            data: {
+              _environmentId: job._environmentId,
+              _id: job._id,
+              _organizationId: job._organizationId,
+              _userId: job._userId,
+            },
+            groupId: job._organizationId,
+            options: { delay: 0 },
+          });
+
+          recovered++;
+          this.logger.warn({ jobId: job._id }, 'Recovered stuck DELAYED job');
+        } catch (err) {
+          this.logger.error({ err, jobId: job._id }, 'Failed to recover stuck job');
+        }
+      }
+
+      this.logger.warn(
+        { recovered, skipped, total: stuckJobs.length },
+        'Job reconciliation completed'
+      );
+    } catch (err) {
+      this.logger.error({ err }, 'Job reconciliation failed');
+    }
+  }
+}

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.spec.ts
@@ -1,0 +1,185 @@
+import { Test } from '@nestjs/testing';
+import {
+  ComputeJobWaitDurationService,
+  ConditionsFilter,
+  CreateExecutionDetails,
+  NormalizeVariables,
+  PinoLogger,
+  StandardQueueService,
+  StepRunRepository,
+  TierRestrictionsValidateUsecase,
+} from '@novu/application-generic';
+import {
+  JobEntity,
+  JobRepository,
+  JobStatusEnum,
+  NotificationRepository,
+  SubscriberRepository,
+} from '@novu/dal';
+import {
+  ExecutionDetailsSourceEnum,
+  ExecutionDetailsStatusEnum,
+  StepTypeEnum,
+} from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ExecuteBridgeJob } from '../../execute-bridge-job';
+import { AddJob, BackoffStrategiesEnum } from './add-job.usecase';
+import { AddJobCommand } from './add-job.command';
+import { MergeOrCreateDigest } from './merge-or-create-digest.usecase';
+
+describe('AddJob - reverse order (queue before DB update)', () => {
+  let addJob: AddJob;
+  let jobRepository: sinon.SinonStubbedInstance<JobRepository>;
+  let standardQueueService: sinon.SinonStubbedInstance<StandardQueueService>;
+  let stepRunRepository: sinon.SinonStubbedInstance<StepRunRepository>;
+  let createExecutionDetails: sinon.SinonStubbedInstance<CreateExecutionDetails>;
+
+  const mockLogger = {
+    setContext: () => {},
+    warn: () => {},
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+    trace: () => {},
+  } as unknown as PinoLogger;
+
+  beforeEach(async () => {
+    jobRepository = sinon.createStubInstance(JobRepository);
+    standardQueueService = sinon.createStubInstance(StandardQueueService);
+    stepRunRepository = sinon.createStubInstance(StepRunRepository);
+    createExecutionDetails = {
+      execute: sinon.stub().resolves({}),
+    } as unknown as CreateExecutionDetails;
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AddJob,
+        { provide: JobRepository, useValue: jobRepository },
+        { provide: StandardQueueService, useValue: standardQueueService },
+        { provide: CreateExecutionDetails, useValue: createExecutionDetails },
+        { provide: StepRunRepository, useValue: stepRunRepository },
+        { provide: ComputeJobWaitDurationService, useValue: { calculateDelay: async () => 0 } },
+        { provide: ConditionsFilter, useValue: { filter: async () => ({ passed: true, variables: {} }) } },
+        { provide: NormalizeVariables, useValue: { execute: async () => ({}) } },
+        { provide: TierRestrictionsValidateUsecase, useValue: { execute: async () => [] } },
+        { provide: ExecuteBridgeJob, useValue: { execute: async () => null } },
+        { provide: SubscriberRepository, useValue: { findOne: async () => null } },
+        { provide: MergeOrCreateDigest, useValue: { execute: async () => null } },
+        { provide: NotificationRepository, useValue: { findOne: async () => ({ _id: 'notif-1', _environmentId: 'env-1' }) } },
+        { provide: PinoLogger, useValue: mockLogger },
+      ],
+    }).compile();
+
+    addJob = moduleRef.get(AddJob);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('execute with non-deferred job type (EMAIL)', () => {
+    const environmentId = 'env-1';
+    const organizationId = 'org-1';
+    const userId = 'user-1';
+
+    const createJob = (overrides: Partial<JobEntity> = {}): JobEntity =>
+      ({
+        _id: 'job-1',
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        _userId: userId,
+        _subscriberId: 'sub-1',
+        _templateId: 'template-1',
+        _notificationId: 'notif-1',
+        transactionId: 'tx-1',
+        type: StepTypeEnum.EMAIL,
+        status: JobStatusEnum.PENDING,
+        step: {
+          filters: [],
+          template: { type: StepTypeEnum.EMAIL },
+        },
+        payload: {},
+        overrides: {},
+        ...overrides,
+      }) as JobEntity;
+
+    it('should call queueJob BEFORE updateStatus for non-deferred jobs', async () => {
+      const job = createJob();
+
+      jobRepository.findOne.resolves(job);
+      stepRunRepository.create.resolves();
+      standardQueueService.add.resolves();
+      jobRepository.updateStatus.resolves(job);
+
+      await addJob.execute(
+        AddJobCommand.create({
+          environmentId,
+          organizationId,
+          userId,
+          jobId: job._id,
+          job,
+        })
+      );
+
+      // queueJob (standardQueueService.add) should be called BEFORE updateStatus
+      sinon.assert.callOrder(
+        standardQueueService.add,
+        jobRepository.updateStatus
+      );
+    });
+
+    it('should NOT update status if queueJob throws', async () => {
+      const job = createJob();
+
+      jobRepository.findOne.resolves(job);
+      standardQueueService.add.rejects(new Error('Queue unavailable'));
+
+      try {
+        await addJob.execute(
+          AddJobCommand.create({
+            environmentId,
+            organizationId,
+            userId,
+            jobId: job._id,
+            job,
+          })
+        );
+        expect.fail('Should have thrown');
+      } catch (err) {
+        sinon.assert.notCalled(jobRepository.updateStatus);
+      }
+    });
+
+    it('should enqueue with the correct payload for non-deferred jobs', async () => {
+      const job = createJob();
+
+      jobRepository.findOne.resolves(job);
+      stepRunRepository.create.resolves();
+      standardQueueService.add.resolves();
+      jobRepository.updateStatus.resolves(job);
+
+      await addJob.execute(
+        AddJobCommand.create({
+          environmentId,
+          organizationId,
+          userId,
+          jobId: job._id,
+          job,
+        })
+      );
+
+      sinon.assert.calledWith(standardQueueService.add, {
+        name: job._id,
+        data: {
+          _environmentId: environmentId,
+          _id: job._id,
+          _organizationId: organizationId,
+          _userId: userId,
+        },
+        groupId: organizationId,
+        options: { delay: 0 },
+      });
+    });
+  });
+});

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -364,11 +364,16 @@ export class AddJob {
       throw new Error(`Job with id ${job._id} not found`);
     }
 
+    // 1. Queue the job FIRST. If we crash after this point the queue message
+    //    still fires and the worker reclaims the stale RUNNING claim.
+    await this.queueJob({ job, delay, untilDate: bridgeDelayAmountDate, timezone: subscriber?.timezone });
+
+    // 2. THEN update the MongoDB status atomically.
+    await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.DELAYED);
+
     await this.stepRunRepository.create(updatedJob, {
       status: JobStatusEnum.DELAYED,
     });
-
-    await this.queueJob({ job, delay, untilDate: bridgeDelayAmountDate, timezone: subscriber?.timezone });
 
     return {
       workflowStatus: null,
@@ -416,14 +421,18 @@ export class AddJob {
   private async executeNoneDeferredJob(command: AddJobCommand): Promise<AddJobResult> {
     const { job } = command;
 
-    this.logger.trace(`Updating status to queued for job ${job._id}`);
+    this.logger.trace(`Queueing job ${job._id}`);
+
+    // 1. Queue the job FIRST. If we crash after this point the queue message
+    //    still fires and the worker reclaims the stale RUNNING claim.
+    await this.queueJob({ job, delay: 0, untilDate: null });
+
+    // 2. THEN update the MongoDB status atomically.
     await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.QUEUED);
 
     await this.stepRunRepository.create(job, {
       status: JobStatusEnum.QUEUED,
     });
-
-    await this.queueJob({ job, delay: 0, untilDate: null });
 
     /*
      * The message now exists, so the claim-to-enqueue crash window is over: without
@@ -478,8 +487,6 @@ export class AddJob {
     if (delayType === DelayTypeEnum.DYNAMIC) {
       await this.validateDynamicDuration(command, job, delayAmount, StepTypeEnum.DELAY);
     }
-
-    await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.DELAYED);
 
     this.logger.debug(`Delay step Amount is: ${delayAmount}`);
 

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -348,6 +348,7 @@ export class AddJob {
     }
 
     const delay = this.getExecutionDelayAmount(filtered, digestAmount, delayAmount);
+    const nextScheduledAt = new Date(Date.now() + delay).toISOString();
 
     const valid = await this.validateDeferDuration(delay, job, command, digestResult?.cronExpression);
 
@@ -369,7 +370,18 @@ export class AddJob {
     await this.queueJob({ job, delay, untilDate: bridgeDelayAmountDate, timezone: subscriber?.timezone });
 
     // 2. THEN update the MongoDB status atomically.
-    await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.DELAYED);
+    await this.jobRepository.updateOne(
+      {
+        _id: job._id,
+        _environmentId: job._environmentId,
+      },
+      {
+        $set: {
+          status: JobStatusEnum.DELAYED,
+          nextScheduledAt,
+        },
+      }
+    );
 
     await this.stepRunRepository.create(updatedJob, {
       status: JobStatusEnum.DELAYED,

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -1139,6 +1139,7 @@ export class RunJob {
         $set: {
           scheduleExtensionsCount: currentExtensions + 1,
           status: JobStatusEnum.DELAYED,
+          nextScheduledAt: nextAvailableTime.toISOString(),
         },
       }
     );

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -1111,6 +1111,25 @@ export class RunJob {
       return false;
     }
 
+    const updatedJob = await this.jobRepository.findOne({
+      _id: job._id,
+      _environmentId: job._environmentId,
+    });
+
+    if (!updatedJob) {
+      throw new PlatformException(`Job with id ${job._id} not found`);
+    }
+
+    // 1. Queue the job FIRST. If we crash after this point the queue message
+    //    still fires and the worker reclaims the stale RUNNING claim.
+    await this.addJobUsecase.queueJob({
+      job: updatedJob,
+      delay: delayMs,
+      untilDate: nextAvailableTime,
+      timezone,
+    });
+
+    // 2. THEN update the MongoDB status atomically.
     await this.jobRepository.updateOne(
       {
         _id: job._id,
@@ -1123,15 +1142,6 @@ export class RunJob {
         },
       }
     );
-
-    const updatedJob = await this.jobRepository.findOne({
-      _id: job._id,
-      _environmentId: job._environmentId,
-    });
-
-    if (!updatedJob) {
-      throw new PlatformException(`Job with id ${job._id} not found`);
-    }
 
     await this.stepRunRepository.create(updatedJob, {
       status: JobStatusEnum.DELAYED,
@@ -1157,14 +1167,6 @@ export class RunJob {
         }),
       })
     );
-
-    // re-queue the job with the new delay
-    await this.addJobUsecase.queueJob({
-      job: updatedJob,
-      delay: delayMs,
-      untilDate: nextAvailableTime,
-      timezone,
-    });
 
     this.logger.info(
       {

--- a/apps/worker/src/app/workflow/workflow.module.ts
+++ b/apps/worker/src/app/workflow/workflow.module.ts
@@ -89,6 +89,7 @@ import { ExecuteCodeFirstCustomStep } from './usecases/send-message/execute-code
 import { ExecuteHttpRequestStep } from './usecases/send-message/execute-http-request-step.usecase';
 import { StoreSubscriberJobs } from './usecases/store-subscriber-jobs';
 import { SubscriberJobBound } from './usecases/subscriber-job-bound/subscriber-job-bound.usecase';
+import { JobReconciliationService } from './services/job-reconciliation.service';
 
 const enterpriseImports = (): Array<Type | DynamicModule | Promise<DynamicModule> | ForwardReference> => {
   const modules: Array<Type | DynamicModule | Promise<DynamicModule> | ForwardReference> = [];
@@ -229,7 +230,7 @@ const USE_CASES = [
   ResolveChannelEndpoints,
 ];
 
-const PROVIDERS: Provider[] = [RedisThrottleService, MsTeamsTokenService, RotatingConnectionTokenService];
+const PROVIDERS: Provider[] = [RedisThrottleService, MsTeamsTokenService, RotatingConnectionTokenService, JobReconciliationService];
 const activeWorkersToken: any = {
   provide: 'ACTIVE_WORKERS',
   useFactory: (...args: any[]) => {

--- a/apps/worker/src/bootstrap.ts
+++ b/apps/worker/src/bootstrap.ts
@@ -7,6 +7,7 @@ import bodyParser from 'body-parser';
 import helmet from 'helmet';
 import { ResponseInterceptor } from './app/shared/response.interceptor';
 import { prepareAppInfra, startAppInfra } from './app/workflow/services/cold-start.service';
+import { JobReconciliationService } from './app/workflow/services/job-reconciliation.service';
 import { AppModule } from './app.module';
 import { CONTEXT_PATH, validateEnv } from './config';
 
@@ -72,6 +73,18 @@ export async function bootstrap(): Promise<INestApplication> {
   } catch (e) {
     Logger.error('[@novu/worker]: Failed to start app infra', e.message, e.start);
     process.exit(1);
+  }
+
+  // Fire-and-forget: reconcile any jobs stuck in DELAYED state without queue
+  // entries. This is a startup safety net; the reverse-order fix in
+  // extendJobToNextAvailableSchedule / executeDeferredJob / executeNoneDeferredJob
+  // prevents new occurrences.
+  try {
+    app.get(JobReconciliationService).reconcileOnStartup().catch((reconcileErr) => {
+      Logger.error('[@novu/worker]: Job reconciliation error', reconcileErr);
+    });
+  } catch (e) {
+    Logger.error('[@novu/worker]: Failed to start job reconciliation', e);
   }
 
   await app.listen(process.env.PORT!);

--- a/libs/dal/src/repositories/job/job.entity.ts
+++ b/libs/dal/src/repositories/job/job.entity.ts
@@ -64,6 +64,11 @@ export class JobEntity {
    * used to track the number of times a step has been extended to the next available time in the subscriber schedule
    */
   scheduleExtensionsCount?: number;
+  /**
+   * The next time this job is scheduled for. Set when the job enters DELAYED status.
+   * Used by job reconciliation to preserve the remaining delay on recovery.
+   */
+  nextScheduledAt?: string;
 }
 
 export type JobDBModel = ChangePropsValueType<

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -154,6 +154,9 @@ const jobSchema = new Schema<JobDBModel>(
     scheduleExtensionsCount: {
       type: Schema.Types.Number,
     },
+    nextScheduledAt: {
+      type: Schema.Types.Date,
+    },
   },
   schemaOptions
 );


### PR DESCRIPTION
## Summary
## Fixes #12119 

Fixes three P1 issues from the Greptile review of the crash-safe worker scheduling PR:

1. **Valid delays executed early** — Reconciliation no longer uses hardcoded delay: 0. A new \
extScheduledAt\ field is written when jobs enter DELAYED (both initial defer and schedule extension). Reconciliation preserves the remaining delay.

2. **Failed enqueue strands claimed jobs** — Reversed order: queue via StandardQueueService **before** atomically claiming via findOneAndUpdate. If the queue call fails, the job stays DELAYED and will be retried next reconciliation run.

3. **One-shot scan abandons overflow** — Paginated loop fetches in batches of 100 with skip, continuing until no more results.

### Files changed
- \libs/dal/src/repositories/job/job.entity.ts\ — Added \
extScheduledAt\ field
- \libs/dal/src/repositories/job/job.schema.ts\ — Added schema field
- \pps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts\ — Write \
extScheduledAt\ on initial defer
- \pps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts\ — Write \
extScheduledAt\ on schedule extension
- \pps/worker/src/app/workflow/services/job-reconciliation.service.ts\ — All three fixes
- \pps/worker/src/app/workflow/services/job-reconciliation.service.spec.ts\ — Updated tests

Closes NV-8417

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds startup recovery for delayed workflow jobs and records their intended execution time.
- Enqueues jobs before updating their persisted scheduling state to reduce claim-to-enqueue loss.
- Adds `nextScheduledAt` to the job model and uses it to preserve remaining delays.
- Registers startup reconciliation and scans eligible jobs in batches of 100.
- Adds tests for enqueue ordering, delay preservation, error handling, and pagination.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until reconciliation stops skipping delayed jobs beyond the first batch.

The reconciliation query mutates its own filtered result set while advancing an offset, so a startup with more than 100 eligible jobs leaves later jobs unrecovered.

**Files Needing Attention:** apps/worker/src/app/workflow/services/job-reconciliation.service.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/services/job-reconciliation.service.ts | Adds delayed-job recovery, but offset pagination skips eligible jobs as processed rows leave the query result. |
| apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts | Persists the next scheduled time and changes deferred and immediate scheduling to enqueue before status updates. |
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Preserves schedule-extension timing through `nextScheduledAt` and enqueues before persisting DELAYED state. |
| apps/worker/src/bootstrap.ts | Starts reconciliation asynchronously during worker bootstrap. |
| libs/dal/src/repositories/job/job.schema.ts | Adds the Date-backed `nextScheduledAt` persistence field. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Worker startup] --> B[Query up to 100 stale DELAYED jobs]
  B --> C[Enqueue each job with remaining delay]
  C --> D[Change status to QUEUED]
  D --> E[Increment skip by batch size]
  E --> F[Query shrinking DELAYED result set]
  F -->|Offset exceeds remaining rows| G[Remaining jobs are not reconciled]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fservices%2Fjob-reconciliation.service.ts%3A103%0A**Offset%20pagination%20skips%20delayed%20jobs**%0A%0AWhen%20more%20than%20100%20jobs%20match%2C%20claiming%20the%20first%20batch%20removes%20those%20jobs%20from%20the%20%60DELAYED%60%20result%20set%20before%20%60skip%60%20advances%20by%20100.%20The%20remaining%20records%20shift%20into%20the%20skipped%20range%2C%20leaving%20them%20unreconciled%20until%20another%20worker%20restart.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12125&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/worker/src/app/workflow/services/job-reconciliation.service.ts:103
**Offset pagination skips delayed jobs**

When more than 100 jobs match, claiming the first batch removes those jobs from the `DELAYED` result set before `skip` advances by 100. The remaining records shift into the skipped range, leaving them unreconciled until another worker restart.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;next&#39; into fix/delayed-job..."](https://github.com/novuhq/novu/commit/e5691ec9bfd4e3b25a3bcf695acef381d0008fd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47874315)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->