### PR TITLE
fix(dashboard): keep Agents header Inbox out of connect NovuProvider fixes NV-8432

### DIFF
--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -417,37 +417,32 @@ const router = createBrowserRouter([
                 ],
               },
               {
-                element: <ConnectSubscriberProvider />,
-                children: [
-                  {
-                    path: ROUTES.AGENTS,
-                    element: <AgentsPage />,
-                  },
-                  {
-                    path: ROUTES.AGENT_DETAILS_INTEGRATIONS_DETAIL,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
-                        <AgentDetailsPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                  {
-                    path: ROUTES.AGENT_DETAILS_TAB,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
-                        <AgentDetailsPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                  {
-                    path: ROUTES.AGENT_DETAILS,
-                    element: (
-                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
-                        <AgentDetailsPage />
-                      </ProtectedRoute>
-                    ),
-                  },
-                ],
+                path: ROUTES.AGENTS,
+                element: <AgentsPage />,
+              },
+              {
+                path: ROUTES.AGENT_DETAILS_INTEGRATIONS_DETAIL,
+                element: (
+                  <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                    <AgentDetailsPage />
+                  </ProtectedRoute>
+                ),
+              },
+              {
+                path: ROUTES.AGENT_DETAILS_TAB,
+                element: (
+                  <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                    <AgentDetailsPage />
+                  </ProtectedRoute>
+                ),
+              },
+              {
+                path: ROUTES.AGENT_DETAILS,
+                element: (
+                  <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                    <AgentDetailsPage />
+                  </ProtectedRoute>
+                ),
               },
               {
                 path: ROUTES.DOMAINS,

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -18,6 +18,7 @@ import { AgentOverviewTab } from '@/components/agents/agent-overview-tab';
 import { AgentSetupModal } from '@/components/agents/agent-setup-modal';
 import { AgentExceedsPlanBanner } from '@/components/agents/agents-plan-limit-banner';
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
+import { ConnectSubscriberProvider } from '@/components/connect/connect-subscriber-provider';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
 import { Badge } from '@/components/primitives/badge';
@@ -287,90 +288,93 @@ export function AgentDetailsPage() {
     <>
       <PageMeta title={pageTitle} />
       <DashboardLayout headerStartItems={headerStartItems}>
-        {isNotFound ? (
-          <div className="text-text-soft text-label-sm max-w-3xl px-4 py-6 md:px-6">
-            <p>This agent does not exist or was removed.</p>
-            <Link to={agentsListPath} className="text-primary-base mt-3 inline-block text-label-sm font-medium">
-              Back to agents
-            </Link>
-          </div>
-        ) : null}
+        {/* Below header: Inbox must not nest under this customer-env NovuProvider. */}
+        <ConnectSubscriberProvider>
+          {isNotFound ? (
+            <div className="text-text-soft text-label-sm max-w-3xl px-4 py-6 md:px-6">
+              <p>This agent does not exist or was removed.</p>
+              <Link to={agentsListPath} className="text-primary-base mt-3 inline-block text-label-sm font-medium">
+                Back to agents
+              </Link>
+            </div>
+          ) : null}
 
-        {error && !isNotFound ? (
-          <div className="text-error-base text-label-sm max-w-3xl px-4 py-6 md:px-6">
-            Could not load this agent. Try again later.
-          </div>
-        ) : null}
+          {error && !isNotFound ? (
+            <div className="text-error-base text-label-sm max-w-3xl px-4 py-6 md:px-6">
+              Could not load this agent. Try again later.
+            </div>
+          ) : null}
 
-        {!error && isLoading ? (
-          <>
-            <AgentDetailsHeader agent={undefined} isLoading />
-            <AgentDetailsTabsSkeleton />
-          </>
-        ) : null}
+          {!error && isLoading ? (
+            <>
+              <AgentDetailsHeader agent={undefined} isLoading />
+              <AgentDetailsTabsSkeleton />
+            </>
+          ) : null}
 
-        {!error && !isLoading && agent ? (
-          <>
-            <AgentDetailsHeader agent={agent} isLoading={false} onRequestDelete={setAgentToDelete} />
+          {!error && !isLoading && agent ? (
+            <>
+              <AgentDetailsHeader agent={agent} isLoading={false} onRequestDelete={setAgentToDelete} />
 
-            {agent.exceedsPlanLimit ? (
-              <div className="px-4 pb-2 md:px-6">
-                <AgentExceedsPlanBanner />
-              </div>
-            ) : null}
+              {agent.exceedsPlanLimit ? (
+                <div className="px-4 pb-2 md:px-6">
+                  <AgentExceedsPlanBanner />
+                </div>
+              ) : null}
 
-            <Tabs value={currentTab} onValueChange={handleTabChange} className="-mx-2 w-full">
-              <TabsList align="start" variant="regular" className="border-t-transparent px-4 py-0! md:px-6">
-                <TabsTrigger variant="regular" value="overview" size="xl">
-                  Overview
-                </TabsTrigger>
-                <TabsTrigger variant="regular" value="integrations" size="xl">
-                  Channels
-                </TabsTrigger>
-              </TabsList>
+              <Tabs value={currentTab} onValueChange={handleTabChange} className="-mx-2 w-full">
+                <TabsList align="start" variant="regular" className="border-t-transparent px-4 py-0! md:px-6">
+                  <TabsTrigger variant="regular" value="overview" size="xl">
+                    Overview
+                  </TabsTrigger>
+                  <TabsTrigger variant="regular" value="integrations" size="xl">
+                    Channels
+                  </TabsTrigger>
+                </TabsList>
 
-              <TabsContent value="overview" className="outline-none">
-                <AgentOverviewTab agent={agent} />
-              </TabsContent>
-              <TabsContent value="integrations" className="outline-none">
-                {currentTab === 'integrations' ? (
-                  <AgentIntegrationsTab agent={agent} integrationIdentifier={integrationIdentifier} />
-                ) : null}
-              </TabsContent>
-            </Tabs>
+                <TabsContent value="overview" className="outline-none">
+                  <AgentOverviewTab agent={agent} />
+                </TabsContent>
+                <TabsContent value="integrations" className="outline-none">
+                  {currentTab === 'integrations' ? (
+                    <AgentIntegrationsTab agent={agent} integrationIdentifier={integrationIdentifier} />
+                  ) : null}
+                </TabsContent>
+              </Tabs>
 
-            <DeleteAgentDialog
-              open={Boolean(agentToDelete)}
-              onOpenChange={(open) => {
-                if (!open) {
-                  setAgentToDelete(null);
-                }
-              }}
-              onConfirm={({ deleteFromProvider }) => {
-                if (agentToDelete) {
-                  deleteMutation.mutate({
-                    identifier: agentToDelete.identifier,
-                    name: agentToDelete.name,
-                    deleteFromProvider,
-                  });
-                }
-              }}
-              agentName={agentToDelete?.name ?? ''}
-              agentIdentifier={agentToDelete?.identifier ?? ''}
-              isDeleting={deleteMutation.isPending}
-              isManagedRuntime={agentToDelete?.runtime === 'managed'}
-            />
+              <DeleteAgentDialog
+                open={Boolean(agentToDelete)}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    setAgentToDelete(null);
+                  }
+                }}
+                onConfirm={({ deleteFromProvider }) => {
+                  if (agentToDelete) {
+                    deleteMutation.mutate({
+                      identifier: agentToDelete.identifier,
+                      name: agentToDelete.name,
+                      deleteFromProvider,
+                    });
+                  }
+                }}
+                agentName={agentToDelete?.name ?? ''}
+                agentIdentifier={agentToDelete?.identifier ?? ''}
+                isDeleting={deleteMutation.isPending}
+                isManagedRuntime={agentToDelete?.runtime === 'managed'}
+              />
 
-            <AgentSetupModal
-              isOpen={showSetupModal}
-              onClose={() => setSetupModalDismissed(true)}
-              onSetupClick={() => {
-                setSetupModalDismissed(true);
-                handleTabChange('integrations');
-              }}
-            />
-          </>
-        ) : null}
+              <AgentSetupModal
+                isOpen={showSetupModal}
+                onClose={() => setSetupModalDismissed(true)}
+                onSetupClick={() => {
+                  setSetupModalDismissed(true);
+                  handleTabChange('integrations');
+                }}
+              />
+            </>
+          ) : null}
+        </ConnectSubscriberProvider>
       </DashboardLayout>
     </>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Visiting the Agents page switched the header Inbox into **Development mode**. That mode should only appear on workflow editor paths.

## Root cause

Agents routes were wrapped in `ConnectSubscriberProvider`, which mounts a `NovuProvider` with the customer's `currentEnvironment.identifier`. `AgentsPage` / `AgentDetailsPage` render `DashboardLayout` (and thus `InboxButton`) inside that tree.

`<Inbox>` from `@novu/react` reuses a parent `NovuProvider` when one exists, so the header Inbox adopted the customer Development environment session instead of Novu's production `APP_ID`.

```mermaid
flowchart TD
  before["Before: ConnectSubscriberProvider wraps route"] --> layout["DashboardLayout + InboxButton"]
  layout --> reuse["Inbox reuses parent NovuProvider"]
  reuse --> bug["Development mode footer"]

  after["After: provider only wraps page content"] --> header["Header Inbox uses APP_ID"]
  after --> content["Setup guides still get customer NovuProvider"]
```

## Fix

- Remove the route-level `ConnectSubscriberProvider` wrapper from Agents routes
- Mount `ConnectSubscriberProvider` inside `AgentDetailsPage` **below** the header so channel setup guides still work
- Agents list page no longer mounts that provider (it did not need it)

## Screenshots

**Agents page — no Development mode**

![Agents inbox without Development mode](https://cursor.com/artifacts/c/art-70ab03fa-2ef7-45f8-bca3-2e497b4a227c)

**Workflows list — no Development mode**

![Workflows list inbox without Development mode](https://cursor.com/artifacts/c/art-32d748b8-c220-4434-9a6d-eb4d69c89622)

**Workflow editor — Development mode still present (expected)**

![Workflow editor inbox with Development mode](https://cursor.com/artifacts/c/art-a7e3d893-7d87-4513-8de4-0e4c1b699377)

## Test plan

- [x] Open Agents list — header Inbox does **not** show Development mode
- [x] Open Workflows list — header Inbox does **not** show Development mode
- [x] Open a workflow editor — header Inbox still shows Development mode / test styling
- [ ] Open agent details → Channels and connect Slack/WhatsApp/Teams — connect flows still work
- [ ] Onboarding agents setup page still initializes connect subscriber session

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70e98fdb-591d-4c8a-bcc3-fbc0c451353d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70e98fdb-591d-4c8a-bcc3-fbc0c451353d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the Agents header Inbox provider scope.
- Removes the route-level `ConnectSubscriberProvider` from Agents list and detail routes.
- Reintroduces the provider around agent-details content below `DashboardLayout`, preserving channel setup flows while keeping the header Inbox on its production configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the provider boundary correctly separating the header Inbox from customer-environment agent content.

DashboardLayout renders its header separately from its children, while all current connect-subscriber consumers remain under the newly scoped provider in the agent integrations content.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/main.tsx | Removes the customer-environment subscriber provider from the Agents route boundary without dropping protection from the detail routes. |
| apps/dashboard/src/pages/agent-details.tsx | Scopes the subscriber provider to detail-page content so setup guides retain context while the header Inbox remains outside it. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Layout["DashboardLayout"] --> Header["HeaderNavigation"]
  Header --> Inbox["InboxButton"]
  Inbox --> Production["Production Inbox provider"]
  Layout --> Content["Agent details content"]
  Content --> Connect["ConnectSubscriberProvider"]
  Connect --> Guides["Channel setup guides"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): keep Agents header Inbox..."](https://github.com/novuhq/novu/commit/ea74953676a9ca4785ad7f2d13123ee7902b4ede) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47901107)</sub>

**Context used:**

- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)

<!-- /greptile_comment -->