### PR TITLE
docs(docs): remove public beta label from MS Teams fixes DOC-422

### DIFF
--- a/docs/platform/integrations/chat/ms-teams.mdx
+++ b/docs/platform/integrations/chat/ms-teams.mdx
@@ -4,10 +4,6 @@ sidebarTitle: "MS Teams"
 description: "Connect Microsoft Teams to Novu to send chat notifications through workflows. Create an incoming webhook in Teams and store the URL as a Novu credential."
 ---
 
-<Note>
-  This feature is currently in public beta, please contact us at support@novu.co to enable it for your organization.
-</Note>
-
 The Novu Microsoft Teams integration enables you to send notifications to Teams channels and direct messages (DMs) across different customer workspaces using a single multi-tenant bot.
 
 You create and host a Microsoft Teams bot in your Azure environment, and your customers then approve the app (via Admin Consent) and install it in their Teams tenants.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Removed the public beta callout from the MS Teams chat integration docs page (`docs/platform/integrations/chat/ms-teams.mdx`).

## Why
MS Teams is generally available. The docs still showed a note asking users to contact support@novu.co to enable the feature for their organization.

## Notes
- Left the Slack and HTTP step public beta notes unchanged; only MS Teams was requested.
- Linear: [DOC-422](https://linear.app/novu/issue/DOC-422/remove-public-beta-label-from-ms-teams-docs)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GFC06JS3/p1785245180419159?thread_ts=1785245180.419159&cid=C06GFC06JS3)

<div><a href="https://cursor.com/agents/bc-39adb5e0-a2ff-52be-8c64-35153281ea3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39adb5e0-a2ff-52be-8c64-35153281ea3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the outdated public beta callout and support enablement instruction from the Microsoft Teams integration documentation.

<h3>Confidence Score: 5/5</h3>

This documentation-only change appears safe to merge.

The PR narrowly removes an obsolete availability notice without changing application behavior, documentation structure, or the integration instructions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/integrations/chat/ms-teams.mdx | Removes only the obsolete public beta note; the remaining Microsoft Teams setup documentation is unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove public beta label from MS T..."](https://github.com/novuhq/novu/commit/06daeb333beab89e879656d801509ddf2f8341f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47950358)</sub>

<!-- /greptile_comment -->