### PR TITLE
feat(api): include workflow description in list response

### DIFF
--- a/apps/api/src/app/workflows-v2/e2e/list-workflows.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/list-workflows.e2e.ts
@@ -114,15 +114,28 @@ describe('List Workflows - /workflows (GET) #novu-v2', () => {
       expect(returnedWorkflow.createdAt).to.be.a('string');
       expect(returnedWorkflow.updatedAt).to.be.a('string');
     });
+
+    it('should include the workflow description in the list response', async () => {
+      const workflowDescription = 'A workflow that notifies on important events';
+      await createWorkflow('Workflow With Description', workflowDescription);
+
+      // Read the raw response: the description is part of the list payload, so a
+      // client can render it without an extra per-workflow detail request.
+      const { body } = await session.testAgent.get('/v2/workflows');
+      const returnedWorkflow = body.data.workflows[0];
+
+      expect(returnedWorkflow.description).to.equal(workflowDescription);
+    });
   });
 
-  async function createWorkflow(name: string): Promise<WorkflowResponseDto> {
+  async function createWorkflow(name: string, description?: string): Promise<WorkflowResponseDto> {
     const createWorkflowDto: CreateWorkflowDto = {
       name,
       workflowId: name.toLowerCase().replace(/\s+/g, '-'),
       source: WorkflowCreationSourceEnum.Editor,
       active: true,
       steps: [],
+      ...(description ? { description } : {}),
     };
 
     const { result } = await novuClient.workflows.create(createWorkflowDto);

--- a/libs/application-generic/src/dtos/workflow/workflow-list-response.dto.ts
+++ b/libs/application-generic/src/dtos/workflow/workflow-list-response.dto.ts
@@ -12,6 +12,14 @@ export class WorkflowListResponseDto {
   name: string;
 
   @ApiProperty({
+    description: 'Description of the workflow',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({
     description: 'Tags associated with the workflow',
     type: 'array',
     items: { type: 'string' },

--- a/libs/application-generic/src/utils/notification-template-mapper.ts
+++ b/libs/application-generic/src/utils/notification-template-mapper.ts
@@ -70,6 +70,7 @@ function toMinifiedWorkflowDto(template: NotificationTemplateEntity): WorkflowLi
     workflowId: template.triggers[0].identifier,
     slug: buildSlug(workflowName, ShortIsPrefixEnum.WORKFLOW, template._id),
     name: workflowName,
+    description: template.description,
     origin: computeOrigin(template),
     tags: template.tags,
     updatedAt: template.updatedAt || '',

--- a/libs/internal-sdk/src/models/components/workflowlistresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/workflowlistresponsedto.ts
@@ -70,6 +70,10 @@ export type WorkflowListResponseDto = {
    */
   name: string;
   /**
+   * Description of the workflow
+   */
+  description?: string | undefined;
+  /**
    * Tags associated with the workflow
    */
   tags?: Array<string> | undefined;
@@ -191,6 +195,7 @@ export const WorkflowListResponseDto$inboundSchema: z.ZodType<
   unknown
 > = z.object({
   name: z.string(),
+  description: z.string().optional(),
   tags: z.array(z.string()).optional(),
   updatedAt: z.string(),
   createdAt: z.string(),

--- a/packages/shared/src/dto/workflows/workflow.dto.ts
+++ b/packages/shared/src/dto/workflows/workflow.dto.ts
@@ -33,6 +33,7 @@ export type ListWorkflowResponse = {
 export type WorkflowListResponseDto = Pick<
   WorkflowResponseDto,
   | 'name'
+  | 'description'
   | 'tags'
   | 'updatedAt'
   | 'createdAt'


### PR DESCRIPTION
### What changed? Why was the change needed?

The workflows list endpoint (`GET /v2/workflows`) returns `WorkflowListResponseDto` items that omit the workflow `description`, even though the description already exists on the entity and is returned by the full workflow response DTO (`GET /v2/workflows/:id`).

As a result, any client that renders the workflow list and wants to show each workflow's description — for example a notification-preferences settings page built on the subscriber-preferences + workflows APIs — has to make one extra detail request per workflow just to read a field the server already has. There is no bulk endpoint that exposes it (`/v1/notification-templates` excludes `novu-cloud`-origin workflows entirely).

This adds `description` to the minified list DTO and populates it in the list mapper, so it comes back in the bulk response like the other summary fields (`name`, `tags`, `origin`, …).

- `WorkflowListResponseDto`: new optional `description?: string` (`@ApiProperty({ required: false })`).
- `toMinifiedWorkflowDto`: maps `template.description` (same source the full DTO already uses).

The field is optional and additive, so it is backward compatible.

### Special notes for your reviewer

Generated OpenAPI SDK models (e.g. `libs/internal-sdk`) may need regeneration to surface the new field; I left generated artifacts untouched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds workflow descriptions to list responses.
- Maps the stored workflow description into the minified API response.
- Updates the application DTO, shared type, and internal SDK model.
- Adds end-to-end coverage for descriptions in the workflow list payload.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/dtos/workflow/workflow-list-response.dto.ts | Adds the optional description field to the API list-item contract. |
| libs/application-generic/src/utils/notification-template-mapper.ts | Maps the workflow entity description into each minified list item. |
| libs/internal-sdk/src/models/components/workflowlistresponsedto.ts | Updates the checked-in SDK type and inbound schema to accept descriptions. |
| packages/shared/src/dto/workflows/workflow.dto.ts | Adds description to the shared workflow-list item type. |
| apps/api/src/app/workflows-v2/e2e/list-workflows.e2e.ts | Verifies that the list endpoint returns a created workflow's description. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(shared): expose workflow description..."](https://github.com/novuhq/novu/commit/3018debbc59e20a4e7318c46951066c59755ed20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47994667)</sub>

<!-- /greptile_comment -->