### PR TITLE
fix(shared): point WhatsApp Business View Guide to Novu docs

### DIFF
--- a/packages/shared/src/consts/providers/channels/chat.ts
+++ b/packages/shared/src/consts/providers/channels/chat.ts
@@ -109,8 +109,7 @@ export const chatProviders: IProviderConfig[] = [
     displayName: 'WhatsApp Business',
     channel: ChannelTypeEnum.CHAT,
     credentials: whatsAppBusinessConfig,
-    docReference:
-      'https://docs.novu.co/platform/integrations/chat/whats-app#whatsapp-business-chat-integration-with-novu',
+    docReference: `https://docs.novu.co/platform/integrations/chat/whats-app${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'whatsapp-business.svg', dark: 'whatsapp-business.svg' },
   },
   {

--- a/packages/shared/src/consts/providers/channels/chat.ts
+++ b/packages/shared/src/consts/providers/channels/chat.ts
@@ -109,7 +109,8 @@ export const chatProviders: IProviderConfig[] = [
     displayName: 'WhatsApp Business',
     channel: ChannelTypeEnum.CHAT,
     credentials: whatsAppBusinessConfig,
-    docReference: 'https://developers.facebook.com/docs/whatsapp/cloud-api',
+    docReference:
+      'https://docs.novu.co/platform/integrations/chat/whats-app#whatsapp-business-chat-integration-with-novu',
     logoFileName: { light: 'whatsapp-business.svg', dark: 'whatsapp-business.svg' },
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the WhatsApp Business chat provider `docReference` so the integrations **View Guide** link points to the Novu documentation instead of the Meta Cloud API docs.

**New URL:** `https://docs.novu.co/platform/integrations/chat/whats-app${UTM_CAMPAIGN_QUERY_PARAM}`

## Changes

- `packages/shared/src/consts/providers/channels/chat.ts` — update `docReference` for `ChatProviderIdEnum.WhatsAppBusiness`

## Testing

- Built `@novu/shared` successfully after the change.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0B0ZT91G6T/p1785319156731459?thread_ts=1785319156.731459&cid=C0B0ZT91G6T)

<div><a href="https://cursor.com/agents/bc-9bb6d28e-2d58-5f16-8012-f3a1b0fabc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bb6d28e-2d58-5f16-8012-f3a1b0fabc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the WhatsApp Business provider’s View Guide destination.
- Replaces the Meta Cloud API documentation URL with the Novu WhatsApp integration guide.
- Preserves the existing UTM campaign query parameter.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/consts/providers/channels/chat.ts | Updates the WhatsApp Business provider documentation reference to the corresponding Novu guide while retaining campaign tracking. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(shared): add UTM param to WhatsApp B..."](https://github.com/novuhq/novu/commit/7963547004ec08a000e5a9e8bddf0fa0b4ad99c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48271326)</sub>

<!-- /greptile_comment -->