### PR TITLE
feat(api-service): first web-chat message and durable conversation fixes NV-8437

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -81,10 +81,12 @@ import { AgentsMcpOAuthController } from './mcp/oauth/agents-mcp-oauth.controlle
 import { McpOAuthDiscoveryService } from './mcp/oauth/mcp-oauth-discovery.service';
 import { AgentMcpDefinitionService } from './mcp/runtime/agent-mcp-definition.service';
 import { AgentMcpSessionService } from './mcp/runtime/agent-mcp-session.service';
+import { AgentConversationEnabledGuard } from './shared/agent-conversation-enabled.guard';
 import { AgentEventSink } from './shared/agent-event-sink.service';
 import { AgentRuntimeExceptionFilter } from './shared/agent-runtime-exception.filter';
 import { AgentEventsIngestController } from './shared/ingest-agent-events/agent-events-ingest.controller';
 import { McpConnectionErrorHandler } from './shared/mcp-connection-error.handler';
+import { WebChatEnabledGuard } from './shared/web-chat-enabled.guard';
 import { USE_CASES } from './usecases';
 import { WebChatController } from './web-chat/web-chat.controller';
 import { WebChatPublicationService } from './web-chat/web-chat-publication.service';
@@ -181,6 +183,8 @@ import { WebChatThreadDeliveryService } from './web-chat/web-chat-thread-deliver
     UpdateSubscriberChannel,
     AgentEntitlementsService,
     PlanLimitGateService,
+    AgentConversationEnabledGuard,
+    WebChatEnabledGuard,
   ],
   exports: [...USE_CASES, ChatInstanceRegistry, InboundDispatcher, OutboundGateway, ConfirmLinkedAuthCards],
 })

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -88,6 +88,7 @@ import { McpConnectionErrorHandler } from './shared/mcp-connection-error.handler
 import { USE_CASES } from './usecases';
 import { WebChatController } from './web-chat/web-chat.controller';
 import { WebChatPublicationService } from './web-chat/web-chat-publication.service';
+import { WebChatThreadDeliveryService } from './web-chat/web-chat-thread-delivery.service';
 
 @Module({
   imports: [
@@ -163,6 +164,7 @@ import { WebChatPublicationService } from './web-chat/web-chat-publication.servi
     NovuEmailProvisioningService,
     NovuWebChatProvisioningService,
     WebChatPublicationService,
+    WebChatThreadDeliveryService,
     McpNovuAppCredentialsService,
     DemoClaudeQuotaPolicy,
     ChatInstanceRegistry,

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -35,6 +35,7 @@ import { TelegramLinkingModule } from '../telegram-linking/telegram-linking.modu
 import { AgentConfigResolver } from './channels/agent-config-resolver.service';
 import { AgentIntegrationsController } from './channels/integrations/agent-integrations.controller';
 import { AgentsPublicController } from './channels/slack-linking/agents-public.controller';
+import { NovuWebChatProvisioningService } from './channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service';
 import { InboundAckService } from './conversation-runtime/ack/inbound-ack.service';
 import { AgentActionTokenService } from './conversation-runtime/action-token/agent-action-token.service';
 import { AgentAttachmentStorage } from './conversation-runtime/conversation/agent-attachment-storage.service';
@@ -157,6 +158,7 @@ import { USE_CASES } from './usecases';
     AgentMcpSessionService,
     NovuEmailCleanupService,
     NovuEmailProvisioningService,
+    NovuWebChatProvisioningService,
     McpNovuAppCredentialsService,
     DemoClaudeQuotaPolicy,
     ChatInstanceRegistry,

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -36,8 +36,6 @@ import { AgentConfigResolver } from './channels/agent-config-resolver.service';
 import { AgentIntegrationsController } from './channels/integrations/agent-integrations.controller';
 import { AgentsPublicController } from './channels/slack-linking/agents-public.controller';
 import { NovuWebChatProvisioningService } from './channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service';
-import { WebChatController } from './web-chat/web-chat.controller';
-import { WebChatPublicationService } from './web-chat/web-chat-publication.service';
 import { InboundAckService } from './conversation-runtime/ack/inbound-ack.service';
 import { AgentActionTokenService } from './conversation-runtime/action-token/agent-action-token.service';
 import { AgentAttachmentStorage } from './conversation-runtime/conversation/agent-attachment-storage.service';
@@ -88,6 +86,8 @@ import { AgentRuntimeExceptionFilter } from './shared/agent-runtime-exception.fi
 import { AgentEventsIngestController } from './shared/ingest-agent-events/agent-events-ingest.controller';
 import { McpConnectionErrorHandler } from './shared/mcp-connection-error.handler';
 import { USE_CASES } from './usecases';
+import { WebChatController } from './web-chat/web-chat.controller';
+import { WebChatPublicationService } from './web-chat/web-chat-publication.service';
 
 @Module({
   imports: [

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -36,6 +36,8 @@ import { AgentConfigResolver } from './channels/agent-config-resolver.service';
 import { AgentIntegrationsController } from './channels/integrations/agent-integrations.controller';
 import { AgentsPublicController } from './channels/slack-linking/agents-public.controller';
 import { NovuWebChatProvisioningService } from './channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service';
+import { WebChatController } from './web-chat/web-chat.controller';
+import { WebChatPublicationService } from './web-chat/web-chat-publication.service';
 import { InboundAckService } from './conversation-runtime/ack/inbound-ack.service';
 import { AgentActionTokenService } from './conversation-runtime/action-token/agent-action-token.service';
 import { AgentAttachmentStorage } from './conversation-runtime/conversation/agent-attachment-storage.service';
@@ -110,6 +112,7 @@ import { USE_CASES } from './usecases';
     AgentEventsIngestController,
     AgentEmailActionsController,
     AgentsMcpOAuthController,
+    WebChatController,
   ],
   providers: [
     ...USE_CASES,
@@ -159,6 +162,7 @@ import { USE_CASES } from './usecases';
     NovuEmailCleanupService,
     NovuEmailProvisioningService,
     NovuWebChatProvisioningService,
+    WebChatPublicationService,
     McpNovuAppCredentialsService,
     DemoClaudeQuotaPolicy,
     ChatInstanceRegistry,

--- a/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
@@ -30,6 +30,7 @@ import { NovuEmailProvisioningService } from '../../../email/novu-email/find-or-
 import { trackAgentIntegrationConnected } from '../../../shared/analytics/agent-analytics';
 import type { AgentIntegrationResponseDto } from '../../../shared/dtos';
 import { toAgentIntegrationResponse } from '../../../shared/mappers/agent-response.mapper';
+import { NovuWebChatProvisioningService } from '../../web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service';
 import { AddAgentIntegrationCommand } from './add-agent-integration.command';
 
 @Injectable()
@@ -41,6 +42,7 @@ export class AddAgentIntegration {
     private readonly organizationRepository: CommunityOrganizationRepository,
     private readonly environmentRepository: EnvironmentRepository,
     private readonly findOrCreateNovuEmail: NovuEmailProvisioningService,
+    private readonly findOrCreateNovuWebChat: NovuWebChatProvisioningService,
     private readonly analyticsService: AnalyticsService
   ) {}
 
@@ -87,6 +89,31 @@ export class AddAgentIntegration {
           providerId: response.integration.providerId,
           channel: response.integration.channel,
           connectionSource: 'novu_email_provisioned',
+        });
+      }
+
+      return response;
+    }
+
+    if (command.providerId === ChatProviderIdEnum.NovuWebChat) {
+      const { response, provisionedNewLink } = await this.findOrCreateNovuWebChat.execute(
+        agent._id,
+        command.environmentId,
+        command.organizationId
+      );
+
+      if (provisionedNewLink) {
+        trackAgentIntegrationConnected(this.analyticsService, {
+          userId: command.userId,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          agentId: agent._id,
+          agentIdentifier: command.agentIdentifier,
+          integrationId: response.integration._id,
+          integrationIdentifier: response.integration.identifier,
+          providerId: response.integration.providerId,
+          channel: response.integration.channel,
+          connectionSource: 'novu_web_chat_provisioned',
         });
       }
 

--- a/apps/api/src/app/agents/channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service.ts
+++ b/apps/api/src/app/agents/channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service.ts
@@ -158,15 +158,13 @@ export class NovuWebChatProvisioningService {
       throw new ConflictException('This integration is already linked to the agent.');
     }
 
-    const link = await this.agentIntegrationRepository.createOrReviveLink(
-      {
-        agentId: agent._id,
-        integrationId: integration._id,
-        environmentId,
-        organizationId,
-      },
-      { session }
-    );
+    const link = await this.agentIntegrationRepository.createOrReviveLink({
+      agentId: agent._id,
+      integrationId: integration._id,
+      environmentId,
+      organizationId,
+      session,
+    });
 
     return toAgentIntegrationResponse(link, integration, agent);
   }

--- a/apps/api/src/app/agents/channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service.ts
+++ b/apps/api/src/app/agents/channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service.ts
@@ -1,0 +1,173 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  type AgentEntity,
+  AgentIntegrationRepository,
+  AgentRepository,
+  IntegrationEntity,
+  IntegrationRepository,
+} from '@novu/dal';
+import { ChannelTypeEnum, ChatProviderIdEnum, providers, slugify } from '@novu/shared';
+import { ClientSession } from 'mongoose';
+import shortid from 'shortid';
+
+import type { AgentIntegrationResponseDto } from '../../../shared/dtos';
+import { toAgentIntegrationResponse } from '../../../shared/mappers/agent-response.mapper';
+
+export type FindOrCreateNovuWebChatResult = {
+  response: AgentIntegrationResponseDto;
+  provisionedNewLink: boolean;
+};
+
+@Injectable()
+export class NovuWebChatProvisioningService {
+  constructor(
+    private readonly integrationRepository: IntegrationRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly agentRepository: AgentRepository
+  ) {}
+
+  /**
+   * Ensure the environment has a `novu-web-chat` integration and link the agent
+   * to it. Idempotent — safe to call repeatedly for the same agent.
+   */
+  async execute(
+    agentId: string,
+    environmentId: string,
+    organizationId: string
+  ): Promise<FindOrCreateNovuWebChatResult> {
+    const agent = await this.agentRepository.findOne(
+      { _id: agentId, _environmentId: environmentId, _organizationId: organizationId },
+      ['_id', 'identifier', 'name']
+    );
+
+    if (!agent) {
+      throw new NotFoundException(`Agent "${agentId}" was not found.`);
+    }
+
+    const existing = await this.findExistingLink(agent, environmentId, organizationId);
+    if (existing) {
+      return { response: existing, provisionedNewLink: false };
+    }
+
+    return this.agentIntegrationRepository.withTransaction(async (session) => {
+      const recheck = await this.findExistingLink(agent, environmentId, organizationId);
+      if (recheck) {
+        return { response: recheck, provisionedNewLink: false };
+      }
+
+      const integration = await this.findOrCreateEnvironmentIntegration(environmentId, organizationId, session);
+      const response = await this.createLink(agent, integration, environmentId, organizationId, session);
+
+      return { response, provisionedNewLink: true };
+    });
+  }
+
+  private async findOrCreateEnvironmentIntegration(
+    environmentId: string,
+    organizationId: string,
+    session: ClientSession | null
+  ): Promise<IntegrationEntity> {
+    const existing = await this.integrationRepository.findOne(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        providerId: ChatProviderIdEnum.NovuWebChat,
+      },
+      '_id identifier name providerId channel active credentials'
+    );
+
+    if (existing) {
+      return existing;
+    }
+
+    const displayName = providers.find((p) => p.id === ChatProviderIdEnum.NovuWebChat)?.displayName ?? 'Novu Web Chat';
+    const identifier = `${slugify(displayName)}-${shortid.generate()}`;
+
+    return this.integrationRepository.create(
+      {
+        providerId: ChatProviderIdEnum.NovuWebChat,
+        channel: ChannelTypeEnum.CHAT,
+        credentials: { hmac: false },
+        configurations: {},
+        name: displayName,
+        identifier,
+        active: true,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      } as any,
+      { session }
+    );
+  }
+
+  private async findExistingLink(
+    agent: Pick<AgentEntity, '_id' | 'identifier' | 'name'>,
+    environmentId: string,
+    organizationId: string
+  ): Promise<AgentIntegrationResponseDto | null> {
+    const links = await this.agentIntegrationRepository.find(
+      { _agentId: agent._id, _environmentId: environmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    if (links.length === 0) {
+      return null;
+    }
+
+    const linkedIntegrationIds = links.map((l) => l._integrationId);
+    const webChatIntegration = await this.integrationRepository.findOne(
+      {
+        _id: { $in: linkedIntegrationIds } as unknown as string,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        providerId: ChatProviderIdEnum.NovuWebChat,
+      },
+      '_id identifier name providerId channel active credentials'
+    );
+
+    if (!webChatIntegration) {
+      return null;
+    }
+
+    const link = links.find((l) => l._integrationId === webChatIntegration._id);
+    if (!link) {
+      return null;
+    }
+
+    return toAgentIntegrationResponse(link, webChatIntegration, agent);
+  }
+
+  private async createLink(
+    agent: Pick<AgentEntity, '_id' | 'identifier' | 'name'>,
+    integration: Pick<IntegrationEntity, '_id' | 'identifier' | 'name' | 'providerId' | 'channel' | 'active'> &
+      Partial<Pick<IntegrationEntity, 'credentials'>>,
+    environmentId: string,
+    organizationId: string,
+    session: ClientSession | null
+  ): Promise<AgentIntegrationResponseDto> {
+    const existingLink = await this.agentIntegrationRepository.findOne(
+      {
+        _agentId: agent._id,
+        _integrationId: integration._id,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      ['_id']
+    );
+
+    if (existingLink) {
+      throw new ConflictException('This integration is already linked to the agent.');
+    }
+
+    const link = await this.agentIntegrationRepository.createOrReviveLink(
+      {
+        agentId: agent._id,
+        integrationId: integration._id,
+        environmentId,
+        organizationId,
+      },
+      { session }
+    );
+
+    return toAgentIntegrationResponse(link, integration, agent);
+  }
+}

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -70,6 +70,8 @@ export interface CreateOrGetConversationParams {
    * installs. Absent for single-workspace platforms.
    */
   workspaceId?: string;
+  /** Pre-minted durable identifier; for `web_chat`, equals `platformThreadId`. */
+  identifier?: string;
 }
 
 export interface PersistInboundMessageParams {
@@ -203,7 +205,7 @@ export class AgentConversationService {
     }
 
     const conversation = await this.conversationRepository.create({
-      identifier: `conv_${shortId(12)}`,
+      identifier: params.identifier ?? `conv_${shortId(12)}`,
       _agentId: params.agentId,
       participants: [
         { type: params.participantType, id: params.participantId },

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -86,6 +86,8 @@ export interface PersistInboundMessageParams {
   richContent?: Record<string, unknown>;
   hasPlatformAttachments?: boolean;
   platformMessageId?: string;
+  /** Caller-supplied activity identifier; defaults to a server-minted act_* id */
+  identifier?: string;
   environmentId: string;
   organizationId: string;
 }
@@ -276,7 +278,7 @@ export class AgentConversationService {
 
     const [activity] = await Promise.all([
       this.activityRepository.createUserActivity({
-        identifier: `act_${shortId(12)}`,
+        identifier: params.identifier ?? `act_${shortId(12)}`,
         conversationId: params.conversationId,
         platform: params.platform,
         integrationId: params.integrationId,

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
@@ -424,10 +424,7 @@ export class AgentSubscriberResolver {
     environmentId: string;
     platformUserId: string;
   }): Promise<SubscriberResolution> {
-    const subscriber = await this.subscriberRepository.findBySubscriberId(
-      params.environmentId,
-      params.platformUserId
-    );
+    const subscriber = await this.subscriberRepository.findBySubscriberId(params.environmentId, params.platformUserId);
 
     if (!subscriber) {
       this.logger.debug(`No subscriber found for web chat identity ${params.platformUserId}`);

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-subscriber-resolver.service.ts
@@ -136,6 +136,10 @@ export class AgentSubscriberResolver {
       });
     }
 
+    if (platform === AgentPlatformEnum.WEB_CHAT) {
+      return this.resolveWebChatSubscriber({ environmentId, platformUserId });
+    }
+
     const endpointConfig = PLATFORM_ENDPOINT_CONFIG[platform];
 
     if (!endpointConfig) {
@@ -414,6 +418,26 @@ export class AgentSubscriberResolver {
     );
 
     return subscriberId;
+  }
+
+  private async resolveWebChatSubscriber(params: {
+    environmentId: string;
+    platformUserId: string;
+  }): Promise<SubscriberResolution> {
+    const subscriber = await this.subscriberRepository.findBySubscriberId(
+      params.environmentId,
+      params.platformUserId
+    );
+
+    if (!subscriber) {
+      this.logger.debug(`No subscriber found for web chat identity ${params.platformUserId}`);
+
+      return { outcome: 'not_found' };
+    }
+
+    this.logger.debug(`Resolved web chat identity ${params.platformUserId} → subscriber ${subscriber.subscriberId}`);
+
+    return { outcome: 'resolved', subscriberId: subscriber.subscriberId };
   }
 
   private async resolvePhoneSubscriber(params: {

--- a/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/conversation-activation.service.ts
@@ -294,6 +294,7 @@ export class ConversationActivationService {
           ? ACTIVATION_WINDOW_MS.MONTH_30
           : ACTIVATION_WINDOW_MS.WEEK;
       case AgentPlatformEnum.EMAIL:
+      case AgentPlatformEnum.WEB_CHAT:
         return ACTIVATION_WINDOW_MS.MONTH_30;
       default:
         return this.unhandledPlatformWindow(platform);

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -28,6 +28,17 @@ import {
 
 export type { SlackNativeDelivery } from './slack-native-delivery';
 
+function isWebChatPlatform(platform: string): boolean {
+  return platform === AgentPlatformEnum.WEB_CHAT;
+}
+
+function webChatSentMessageInfo(platformThreadId: string, messageId?: string): SentMessageInfo {
+  return {
+    messageId: messageId ?? `msg_${Date.now()}`,
+    platformThreadId,
+  };
+}
+
 /** The subset of the resolved config that drives outbound watermarking. */
 type OutboundBrandingContext = Pick<ResolvedAgentConfig, 'removeNovuBranding' | 'agentIdentifier' | 'platform'>;
 
@@ -215,6 +226,10 @@ export class OutboundGateway {
     options?: OutboundDeliveryOptions,
     workspaceId?: string
   ): Promise<SentMessageInfo> {
+    if (isWebChatPlatform(platform)) {
+      return webChatSentMessageInfo(platformThreadId);
+    }
+
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
 
     if (platform === AgentPlatformEnum.SLACK && options?.slackNative) {
@@ -268,6 +283,11 @@ export class OutboundGateway {
     }
 
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
+
+    if (isWebChatPlatform(config.platform)) {
+      return;
+    }
+
     const instanceKey = `${agentId}:${integrationIdentifier}`;
     const chat = await this.registry.getOrCreate(instanceKey, agentId, config.platform, config);
     const thread = chat.thread(platformThreadId);
@@ -293,6 +313,10 @@ export class OutboundGateway {
     workspaceId?: string
   ): Promise<void> {
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
+
+    if (isWebChatPlatform(config.platform)) {
+      return;
+    }
 
     if (config.platform === AgentPlatformEnum.SLACK) {
       await this.clearSlackAssistantStatus(agentId, integrationIdentifier, platformThreadId, workspaceId);
@@ -428,6 +452,10 @@ export class OutboundGateway {
     options?: OutboundDeliveryOptions,
     workspaceId?: string
   ): Promise<SentMessageInfo> {
+    if (isWebChatPlatform(platform)) {
+      return webChatSentMessageInfo(platformThreadId, platformMessageId);
+    }
+
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
 
     if (platform === AgentPlatformEnum.SLACK && options?.slackNative) {
@@ -484,6 +512,10 @@ export class OutboundGateway {
     platformMessageId: string,
     workspaceId?: string
   ): Promise<void> {
+    if (isWebChatPlatform(platform)) {
+      return;
+    }
+
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
     const instanceKey = `${agentId}:${integrationIdentifier}`;
     const chat = await this.registry.getOrCreate(instanceKey, agentId, config.platform, config);

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
+import { PinoLogger, shortId } from '@novu/application-generic';
 import { ConversationChannel } from '@novu/dal';
 import type { SentMessageInfo } from '@novu/framework/internal';
 import type { SlackAgentSuggestedPrompt } from '@novu/shared';
@@ -10,6 +10,7 @@ import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { toDeliveryError } from '../../shared/util/delivery-error.util';
 import { esmImport } from '../../shared/util/esm-import';
 import { buildBrandedMarkdownReply, contentHasPoweredByWatermark } from '../../shared/util/novu-powered-by-watermark';
+import { isWebChatThread } from '../../web-chat/web-chat-inbound.adapter';
 import { type AgentActionTokenBinding, AgentActionTokenService } from '../action-token/agent-action-token.service';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
 import { ChatInstanceRegistry } from '../ingress/chat-instance.registry';
@@ -118,6 +119,17 @@ export class OutboundGateway {
     persist: OutboundPersistContext,
     options?: OutboundDeliveryOptions
   ): Promise<SentMessageInfo> {
+    if (isWebChatPlatform(target.platform)) {
+      const messageId = persist.activityIdentifier ?? `act_${shortId(12)}`;
+      const sent: SentMessageInfo = {
+        messageId,
+        platformThreadId: target.platformThreadId,
+      };
+      await this.persistDelivered({ ...persist, activityIdentifier: messageId }, sent, msg);
+
+      return sent;
+    }
+
     const sent = await this.postToConversation(
       target.agentId,
       target.integrationIdentifier,
@@ -201,7 +213,7 @@ export class OutboundGateway {
       throw err;
     }
 
-    if (opts?.persist) {
+    if (opts?.persist && !isWebChatThread(thread)) {
       await this.conversation.persistAgentMessage({
         conversationId: opts.persist.conversationId,
         channel: opts.persist.channel,

--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -35,7 +35,7 @@ function isWebChatPlatform(platform: string): boolean {
 
 function webChatSentMessageInfo(platformThreadId: string, messageId?: string): SentMessageInfo {
   return {
-    messageId: messageId ?? `msg_${Date.now()}`,
+    messageId: messageId ?? `act_${shortId(12)}`,
     platformThreadId,
   };
 }

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -245,6 +245,11 @@ export interface InboundReactionEvent {
   raw?: unknown;
 }
 
+export type WebChatInboundOptions = {
+  /** Pre-minted conversation identifier; `platformThreadId` for the first web-chat turn. */
+  conversationIdentifier?: string;
+};
+
 @Injectable()
 export class AgentInboundHandler implements OnModuleInit {
   constructor(
@@ -287,7 +292,8 @@ export class AgentInboundHandler implements OnModuleInit {
     config: ResolvedAgentConfig,
     thread: Thread,
     message: Message,
-    event: AgentEventEnum
+    event: AgentEventEnum,
+    options?: WebChatInboundOptions
   ): Promise<void> {
     if (await this.consumeTelegramStartLink(agentId, config, thread, message)) {
       return;
@@ -429,7 +435,8 @@ export class AgentInboundHandler implements OnModuleInit {
       subscriberId,
       platformThreadId,
       thread.isDM,
-      extractWorkspaceId(config.platform, message.raw) ?? undefined
+      extractWorkspaceId(config.platform, message.raw) ?? undefined,
+      options?.conversationIdentifier
     );
 
     if (config.isKeyless) {
@@ -610,7 +617,8 @@ export class AgentInboundHandler implements OnModuleInit {
     subscriberId: string | null,
     platformThreadId: string,
     isDirectMessage: boolean,
-    workspaceId?: string
+    workspaceId?: string,
+    conversationIdentifier?: string
   ): Promise<ConversationEntity> {
     const participantId = subscriberId ?? `${config.platform}:${message.author.userId}`;
     const participantType = subscriberId
@@ -630,6 +638,7 @@ export class AgentInboundHandler implements OnModuleInit {
       firstMessageText: resolveInboundFirstMessageText(config.platform, message),
       isDirectMessage,
       workspaceId,
+      identifier: conversationIdentifier,
     });
   }
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -702,6 +702,7 @@ export class AgentInboundHandler implements OnModuleInit {
       richContent,
       hasPlatformAttachments: Boolean(message.attachments?.length),
       platformMessageId: message.id,
+      identifier: config.platform === AgentPlatformEnum.WEB_CHAT ? message.id : undefined,
       environmentId: config.environmentId,
       organizationId: config.organizationId,
     });

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -1,0 +1,178 @@
+import { AGENT_EVENT_PROTOCOL_VERSION, type AgentEventEnvelope } from '@novu/agent-event-protocol';
+import {
+  ConversationActivitySenderTypeEnum,
+  ConversationActivityTypeEnum,
+  ConversationParticipantTypeEnum,
+} from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+import { testServer } from '@novu/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
+import {
+  activityRepository,
+  AgentTestContext,
+  conversationRepository,
+  setupAgentTestContext,
+} from './helpers/agent-test-setup';
+
+describe('Web Chat - /web-chat/conversations #novu-v2', () => {
+  let ctx: AgentTestContext;
+  let subscriberToken: string;
+
+  before(() => {
+    process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
+    process.env.IS_AGENT_EVENT_PROTOCOL_ENABLED = 'true';
+  });
+
+  after(() => {
+    delete process.env.IS_AGENT_EVENT_PROTOCOL_ENABLED;
+  });
+
+  beforeEach(async () => {
+    ctx = await setupAgentTestContext();
+
+    const bridgeExecutor = testServer.getService(BridgeExecutorService);
+    sinon.stub(bridgeExecutor, 'execute').resolves();
+
+    const inboxSession = await ctx.session.testAgent.post('/v1/inbox/session').send({
+      applicationIdentifier: ctx.session.environment.identifier,
+      subscriberId: ctx.session.subscriberId,
+    });
+    expect(inboxSession.status).to.equal(201);
+    subscriberToken = inboxSession.body.data.token;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function linkWebChat(agentIdentifier = ctx.agentIdentifier) {
+    const res = await ctx.session.testAgent.post(`/v1/agents/${agentIdentifier}/integrations`).send({
+      providerId: ChatProviderIdEnum.NovuWebChat,
+    });
+    expect(res.status).to.equal(201);
+
+    return res.body.data;
+  }
+
+  function createConversation(body: { agentId: string; text: string }, token = subscriberToken) {
+    return ctx.session.testAgent
+      .post('/v1/web-chat/conversations')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body);
+  }
+
+  function getEvents(conversationIdentifier: string, token = subscriberToken) {
+    return ctx.session.testAgent
+      .get(`/v1/web-chat/conversations/${conversationIdentifier}/events`)
+      .set('Authorization', `Bearer ${token}`);
+  }
+
+  function messageEnvelope(conversationId: string, messageId: string): AgentEventEnvelope {
+    return {
+      version: AGENT_EVENT_PROTOCOL_VERSION,
+      conversationId,
+      agentId: ctx.agentIdentifier,
+      runId: 'run-e2e',
+      turnId: 'turn-e2e',
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      event: {
+        type: 'message',
+        messageId,
+        content: { markdown: `Agent reply ${messageId}` },
+      },
+    };
+  }
+
+  it('should create a conversation on first message when agent is published to web chat', async () => {
+    await linkWebChat();
+
+    const res = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Hello from web chat',
+    });
+
+    expect(res.status).to.equal(201);
+    expect(res.body.identifier).to.match(/^conv_/);
+
+    const conversation = await conversationRepository.findOne(
+      {
+        identifier: res.body.identifier,
+        _environmentId: ctx.session.environment._id,
+      },
+      '*'
+    );
+    expect(conversation).to.exist;
+    expect(conversation!.participants.some(
+      (p) => p.type === ConversationParticipantTypeEnum.SUBSCRIBER && p.id === ctx.session.subscriberId
+    )).to.equal(true);
+
+    const activities = await activityRepository.findByConversation(
+      ctx.session.environment._id,
+      conversation!._id,
+      20
+    );
+    const subscriberMessage = activities.find(
+      (a) =>
+        a.senderType === ConversationActivitySenderTypeEnum.SUBSCRIBER &&
+        a.type === ConversationActivityTypeEnum.MESSAGE
+    );
+    expect(subscriberMessage).to.exist;
+    expect(subscriberMessage!.content).to.equal('Hello from web chat');
+  });
+
+  it('should reject unpublished agents with 400', async () => {
+    const unpublishedIdentifier = `e2e-unpublished-${Date.now()}`;
+    await ctx.session.testAgent.post('/v1/agents').send({
+      name: 'Unpublished Agent',
+      identifier: unpublishedIdentifier,
+    });
+
+    const res = await createConversation({
+      agentId: unpublishedIdentifier,
+      text: 'Should fail',
+    });
+
+    expect(res.status).to.equal(400);
+    expect(res.body.message).to.equal('This agent is not available on web chat');
+  });
+
+  it('should return durable agent message events on GET .../events', async () => {
+    await linkWebChat();
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Start thread',
+    });
+    expect(createRes.status).to.equal(201);
+
+    const conversation = await conversationRepository.findOne(
+      {
+        identifier: createRes.body.identifier,
+        _environmentId: ctx.session.environment._id,
+      },
+      '*'
+    );
+    expect(conversation).to.exist;
+
+    const messageId = `msg-e2e-${Date.now()}`;
+    const ingestRes = await ctx.session.testAgent.post('/v1/agents/events/ingest').send({
+      events: [messageEnvelope(conversation!._id, messageId)],
+    });
+    expect(ingestRes.status).to.equal(200);
+
+    const eventsRes = await getEvents(createRes.body.identifier);
+    expect(eventsRes.status).to.equal(200);
+    expect(eventsRes.body.hasMore).to.equal(false);
+    expect(eventsRes.body.events.length).to.be.greaterThan(0);
+
+    const agentMessageEvent = eventsRes.body.events.find(
+      (envelope: AgentEventEnvelope) =>
+        envelope.event.type === 'message' && envelope.event.messageId === messageId
+    );
+    expect(agentMessageEvent).to.exist;
+    expect(agentMessageEvent.event.content.markdown).to.equal(`Agent reply ${messageId}`);
+  });
+});

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -23,10 +23,12 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
   before(() => {
     process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
     process.env.IS_AGENT_EVENT_PROTOCOL_ENABLED = 'true';
+    process.env.IS_AGENT_WEB_CHAT_ENABLED = 'true';
   });
 
   after(() => {
     delete process.env.IS_AGENT_EVENT_PROTOCOL_ENABLED;
+    delete process.env.IS_AGENT_WEB_CHAT_ENABLED;
   });
 
   beforeEach(async () => {
@@ -60,9 +62,14 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     return ctx.session.testAgent.post('/v1/web-chat/conversations').set('Authorization', `Bearer ${token}`).send(body);
   }
 
-  function getEvents(conversationIdentifier: string, token = subscriberToken) {
+  function getEvents(
+    conversationIdentifier: string,
+    token = subscriberToken,
+    query: { after?: string; before?: string; afterSequence?: number; limit?: number } = {}
+  ) {
     return ctx.session.testAgent
       .get(`/v1/web-chat/conversations/${conversationIdentifier}/events`)
+      .query(query)
       .set('Authorization', `Bearer ${token}`);
   }
 
@@ -116,6 +123,9 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     );
     expect(subscriberMessage).to.exist;
     expect(subscriberMessage!.content).to.equal('Hello from web chat');
+    expect(subscriberMessage!.identifier).to.match(/^msg_/);
+    expect(conversation!.channels.some((channel) => channel.platform === 'web_chat')).to.equal(true);
+    expect(conversation!.channels[0]?.platformThreadId).to.equal(res.body.identifier);
   });
 
   it('should reject unpublished agents with 400', async () => {
@@ -132,6 +142,28 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
 
     expect(res.status).to.equal(400);
     expect(res.body.message).to.equal('This agent is not available on web chat');
+  });
+
+  it('should return 404 when IS_AGENT_WEB_CHAT_ENABLED is off', async () => {
+    const previousFlag = process.env.IS_AGENT_WEB_CHAT_ENABLED;
+    delete process.env.IS_AGENT_WEB_CHAT_ENABLED;
+
+    try {
+      await linkWebChat();
+
+      const res = await createConversation({
+        agentId: ctx.agentIdentifier,
+        text: 'Should be hidden',
+      });
+
+      expect(res.status).to.equal(404);
+    } finally {
+      if (previousFlag === undefined) {
+        delete process.env.IS_AGENT_WEB_CHAT_ENABLED;
+      } else {
+        process.env.IS_AGENT_WEB_CHAT_ENABLED = previousFlag;
+      }
+    }
   });
 
   it('should return durable agent message events on GET .../events', async () => {
@@ -161,6 +193,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     const eventsRes = await getEvents(createRes.body.identifier);
     expect(eventsRes.status).to.equal(200);
     expect(eventsRes.body.hasMore).to.equal(false);
+    expect(eventsRes.body.next).to.equal(null);
     expect(eventsRes.body.events.length).to.be.greaterThan(0);
 
     const agentMessageEvent = eventsRes.body.events.find(
@@ -168,5 +201,98 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     );
     expect(agentMessageEvent).to.exist;
     expect(agentMessageEvent.event.content.markdown).to.equal(`Agent reply ${messageId}`);
+
+    const subscriberMessageEvent = eventsRes.body.events.find(
+      (envelope: AgentEventEnvelope) =>
+        envelope.event.type === 'custom' &&
+        envelope.event.name === 'subscriber.message' &&
+        envelope.event.data.content.markdown === 'Start thread'
+    );
+    expect(subscriberMessageEvent).to.exist;
+    expect(subscriberMessageEvent.event.data.messageId).to.match(/^msg_/);
+  });
+
+  it('should paginate events with activity cursor', async () => {
+    await linkWebChat();
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Page one',
+    });
+    expect(createRes.status).to.equal(201);
+
+    const conversation = await conversationRepository.findOne(
+      {
+        identifier: createRes.body.identifier,
+        _environmentId: ctx.session.environment._id,
+      },
+      '*'
+    );
+    expect(conversation).to.exist;
+
+    await ctx.session.testAgent.post('/v1/agents/events/ingest').send({
+      events: [messageEnvelope(conversation!._id, `msg-page-${Date.now()}`)],
+    });
+
+    const firstPage = await getEvents(createRes.body.identifier, subscriberToken, { limit: 1 });
+    expect(firstPage.status).to.equal(200);
+    expect(firstPage.body.events).to.have.length(1);
+    expect(firstPage.body.hasMore).to.equal(true);
+    expect(firstPage.body.next).to.be.a('string');
+
+    const secondPage = await ctx.session.testAgent
+      .get(`/v1/web-chat/conversations/${createRes.body.identifier}/events`)
+      .query({ after: firstPage.body.next, limit: 50 })
+      .set('Authorization', `Bearer ${subscriberToken}`);
+    expect(secondPage.status).to.equal(200);
+    expect(secondPage.body.events.length).to.be.greaterThan(0);
+    expect(secondPage.body.events[0].sequence).to.be.greaterThan(firstPage.body.events[0].sequence);
+  });
+
+  it('should reject GET events for another subscriber', async () => {
+    await linkWebChat();
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Private thread',
+    });
+    expect(createRes.status).to.equal(201);
+
+    const otherSubscriberId = `other-sub-${Date.now()}`;
+    const otherSession = await ctx.session.testAgent.post('/v1/inbox/session').send({
+      applicationIdentifier: ctx.session.environment.identifier,
+      subscriberId: otherSubscriberId,
+    });
+    expect(otherSession.status).to.equal(201);
+
+    const eventsRes = await getEvents(createRes.body.identifier, otherSession.body.data.token);
+    expect(eventsRes.status).to.equal(404);
+  });
+
+  it('should reject GET events for non-web-chat conversations', async () => {
+    const slackConversation = await conversationRepository.create({
+      identifier: `conv_e2e_slack_${Date.now()}`,
+      _agentId: ctx.agentId,
+      participants: [
+        { type: ConversationParticipantTypeEnum.AGENT, id: ctx.agentId },
+        { type: ConversationParticipantTypeEnum.SUBSCRIBER, id: ctx.session.subscriberId },
+      ],
+      channels: [
+        {
+          platform: 'slack',
+          _integrationId: ctx.integrationId,
+          platformThreadId: `thread-${Date.now()}`,
+        },
+      ],
+      status: 'active',
+      title: 'Slack thread',
+      metadata: {},
+      _environmentId: ctx.session.environment._id,
+      _organizationId: ctx.session.organization._id,
+      lastActivityAt: new Date().toISOString(),
+    });
+
+    const eventsRes = await getEvents(slackConversation.identifier);
+    expect(eventsRes.status).to.equal(404);
   });
 });

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -10,8 +10,8 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
 import {
-  activityRepository,
   AgentTestContext,
+  activityRepository,
   conversationRepository,
   setupAgentTestContext,
 } from './helpers/agent-test-setup';
@@ -57,10 +57,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
   }
 
   function createConversation(body: { agentId: string; text: string }, token = subscriberToken) {
-    return ctx.session.testAgent
-      .post('/v1/web-chat/conversations')
-      .set('Authorization', `Bearer ${token}`)
-      .send(body);
+    return ctx.session.testAgent.post('/v1/web-chat/conversations').set('Authorization', `Bearer ${token}`).send(body);
   }
 
   function getEvents(conversationIdentifier: string, token = subscriberToken) {
@@ -105,15 +102,13 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       '*'
     );
     expect(conversation).to.exist;
-    expect(conversation!.participants.some(
-      (p) => p.type === ConversationParticipantTypeEnum.SUBSCRIBER && p.id === ctx.session.subscriberId
-    )).to.equal(true);
+    expect(
+      conversation!.participants.some(
+        (p) => p.type === ConversationParticipantTypeEnum.SUBSCRIBER && p.id === ctx.session.subscriberId
+      )
+    ).to.equal(true);
 
-    const activities = await activityRepository.findByConversation(
-      ctx.session.environment._id,
-      conversation!._id,
-      20
-    );
+    const activities = await activityRepository.findByConversation(ctx.session.environment._id, conversation!._id, 20);
     const subscriberMessage = activities.find(
       (a) =>
         a.senderType === ConversationActivitySenderTypeEnum.SUBSCRIBER &&
@@ -169,8 +164,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(eventsRes.body.events.length).to.be.greaterThan(0);
 
     const agentMessageEvent = eventsRes.body.events.find(
-      (envelope: AgentEventEnvelope) =>
-        envelope.event.type === 'message' && envelope.event.messageId === messageId
+      (envelope: AgentEventEnvelope) => envelope.event.type === 'message' && envelope.event.messageId === messageId
     );
     expect(agentMessageEvent).to.exist;
     expect(agentMessageEvent.event.content.markdown).to.equal(`Agent reply ${messageId}`);

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -99,11 +99,11 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     });
 
     expect(res.status).to.equal(201);
-    expect(res.body.identifier).to.match(/^conv_/);
+    expect(res.body.data.identifier).to.match(/^conv_/);
 
     const conversation = await conversationRepository.findOne(
       {
-        identifier: res.body.identifier,
+        identifier: res.body.data.identifier,
         _environmentId: ctx.session.environment._id,
       },
       '*'
@@ -125,7 +125,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(subscriberMessage!.content).to.equal('Hello from web chat');
     expect(subscriberMessage!.identifier).to.match(/^msg_/);
     expect(conversation!.channels.some((channel) => channel.platform === 'web_chat')).to.equal(true);
-    expect(conversation!.channels[0]?.platformThreadId).to.equal(res.body.identifier);
+    expect(conversation!.channels[0]?.platformThreadId).to.equal(res.body.data.identifier);
   });
 
   it('should reject unpublished agents with 400', async () => {
@@ -177,7 +177,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
 
     const conversation = await conversationRepository.findOne(
       {
-        identifier: createRes.body.identifier,
+        identifier: createRes.body.data.identifier,
         _environmentId: ctx.session.environment._id,
       },
       '*'
@@ -190,19 +190,19 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     });
     expect(ingestRes.status).to.equal(200);
 
-    const eventsRes = await getEvents(createRes.body.identifier);
+    const eventsRes = await getEvents(createRes.body.data.identifier);
     expect(eventsRes.status).to.equal(200);
-    expect(eventsRes.body.hasMore).to.equal(false);
-    expect(eventsRes.body.next).to.equal(null);
-    expect(eventsRes.body.events.length).to.be.greaterThan(0);
+    expect(eventsRes.body.data.hasMore).to.equal(false);
+    expect(eventsRes.body.data.next).to.equal(null);
+    expect(eventsRes.body.data.events.length).to.be.greaterThan(0);
 
-    const agentMessageEvent = eventsRes.body.events.find(
+    const agentMessageEvent = eventsRes.body.data.events.find(
       (envelope: AgentEventEnvelope) => envelope.event.type === 'message' && envelope.event.messageId === messageId
     );
     expect(agentMessageEvent).to.exist;
     expect(agentMessageEvent.event.content.markdown).to.equal(`Agent reply ${messageId}`);
 
-    const subscriberMessageEvent = eventsRes.body.events.find(
+    const subscriberMessageEvent = eventsRes.body.data.events.find(
       (envelope: AgentEventEnvelope) =>
         envelope.event.type === 'custom' &&
         envelope.event.name === 'subscriber.message' &&
@@ -223,7 +223,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
 
     const conversation = await conversationRepository.findOne(
       {
-        identifier: createRes.body.identifier,
+        identifier: createRes.body.data.identifier,
         _environmentId: ctx.session.environment._id,
       },
       '*'
@@ -234,19 +234,19 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       events: [messageEnvelope(conversation!._id, `msg-page-${Date.now()}`)],
     });
 
-    const firstPage = await getEvents(createRes.body.identifier, subscriberToken, { limit: 1 });
+    const firstPage = await getEvents(createRes.body.data.identifier, subscriberToken, { limit: 1 });
     expect(firstPage.status).to.equal(200);
-    expect(firstPage.body.events).to.have.length(1);
-    expect(firstPage.body.hasMore).to.equal(true);
-    expect(firstPage.body.next).to.be.a('string');
+    expect(firstPage.body.data.events).to.have.length(1);
+    expect(firstPage.body.data.hasMore).to.equal(true);
+    expect(firstPage.body.data.next).to.be.a('string');
 
     const secondPage = await ctx.session.testAgent
-      .get(`/v1/web-chat/conversations/${createRes.body.identifier}/events`)
-      .query({ after: firstPage.body.next, limit: 50 })
+      .get(`/v1/web-chat/conversations/${createRes.body.data.identifier}/events`)
+      .query({ after: firstPage.body.data.next, limit: 50 })
       .set('Authorization', `Bearer ${subscriberToken}`);
     expect(secondPage.status).to.equal(200);
-    expect(secondPage.body.events.length).to.be.greaterThan(0);
-    expect(secondPage.body.events[0].sequence).to.be.greaterThan(firstPage.body.events[0].sequence);
+    expect(secondPage.body.data.events.length).to.be.greaterThan(0);
+    expect(secondPage.body.data.events[0].sequence).to.be.greaterThan(firstPage.body.data.events[0].sequence);
   });
 
   it('should reject GET events for another subscriber', async () => {
@@ -265,7 +265,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     });
     expect(otherSession.status).to.equal(201);
 
-    const eventsRes = await getEvents(createRes.body.identifier, otherSession.body.data.token);
+    const eventsRes = await getEvents(createRes.body.data.identifier, otherSession.body.data.token);
     expect(eventsRes.status).to.equal(404);
   });
 

--- a/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
+++ b/apps/api/src/app/agents/shared/analytics/agent-analytics.ts
@@ -66,7 +66,7 @@ export function trackAgentIntegrationConnected(
     integrationIdentifier: string;
     providerId: string;
     channel?: string;
-    connectionSource: 'existing_integration' | 'novu_email_provisioned';
+    connectionSource: 'existing_integration' | 'novu_email_provisioned' | 'novu_web_chat_provisioned';
   }
 ): void {
   analytics.track(`Agent Integration Connected - ${AGENT_SEGMENT_CATEGORY}`, params.userId, {

--- a/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
@@ -5,6 +5,7 @@ export enum AgentPlatformEnum {
   EMAIL = 'email',
   TELEGRAM = 'telegram',
   SENDBLUE = 'sendblue',
+  WEB_CHAT = 'web_chat',
 }
 
 export const PLATFORMS_WITH_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
@@ -49,6 +50,7 @@ const PLATFORM_EGRESS_CAPABILITIES: Record<AgentPlatformEnum, PlatformEgressCapa
     nativeUrlButtons: false,
     interactiveButtons: false,
   },
+  [AgentPlatformEnum.WEB_CHAT]: DEFAULT_EGRESS_CAPABILITIES,
 };
 
 function resolvePlatformEgressCapabilities(platform: string): PlatformEgressCapabilities {

--- a/apps/api/src/app/agents/shared/index.ts
+++ b/apps/api/src/app/agents/shared/index.ts
@@ -1,2 +1,3 @@
 export { AgentConversationEnabledGuard } from './agent-conversation-enabled.guard';
 export { AgentRuntimeExceptionFilter } from './agent-runtime-exception.filter';
+export { WebChatEnabledGuard } from './web-chat-enabled.guard';

--- a/apps/api/src/app/agents/shared/util/provider-to-platform.ts
+++ b/apps/api/src/app/agents/shared/util/provider-to-platform.ts
@@ -8,6 +8,7 @@ const PROVIDER_TO_PLATFORM: Partial<Record<string, AgentPlatformEnum>> = {
   [EmailProviderIdEnum.NovuAgent]: AgentPlatformEnum.EMAIL,
   [ChatProviderIdEnum.Telegram]: AgentPlatformEnum.TELEGRAM,
   [ChatProviderIdEnum.Sendblue]: AgentPlatformEnum.SENDBLUE,
+  [ChatProviderIdEnum.NovuWebChat]: AgentPlatformEnum.WEB_CHAT,
 };
 
 export function resolveAgentPlatform(providerId: string): AgentPlatformEnum | null {

--- a/apps/api/src/app/agents/shared/web-chat-enabled.guard.ts
+++ b/apps/api/src/app/agents/shared/web-chat-enabled.guard.ts
@@ -1,0 +1,36 @@
+import { CanActivate, ExecutionContext, Injectable, NotFoundException } from '@nestjs/common';
+import { FeatureFlagsService } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
+
+import type { SubscriberSession } from '../../shared/framework/user.decorator';
+
+/**
+ * Gates the subscriber web-chat API (`/v1/web-chat/*`).
+ * Requires `IS_AGENT_WEB_CHAT_ENABLED` per org/env (LaunchDarkly or env var).
+ */
+@Injectable()
+export class WebChatEnabledGuard implements CanActivate {
+  constructor(private readonly featureFlagsService: FeatureFlagsService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const session: SubscriberSession | undefined = request.user;
+
+    if (!session?.organizationId || !session?.environmentId) {
+      throw new NotFoundException();
+    }
+
+    const isEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_AGENT_WEB_CHAT_ENABLED,
+      defaultValue: false,
+      organization: { _id: session.organizationId },
+      environment: { _id: session.environmentId },
+    });
+
+    if (!isEnabled) {
+      throw new NotFoundException();
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -44,6 +44,8 @@ import { GenerateMcpOAuthUrl } from '../mcp/oauth/generate-mcp-oauth-url/generat
 import { McpOAuthCallback } from '../mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase';
 import { ListAgentEmoji } from '../shared/emoji/list-agent-emoji/list-agent-emoji.usecase';
 import { IngestAgentEvents } from '../shared/ingest-agent-events/ingest-agent-events.usecase';
+import { CreateWebChatConversation } from '../web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase';
+import { ListWebChatConversationEvents } from '../web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase';
 
 export { ConsumeSlackSetupLink, GetSlackSetupLinkStatus, IssueSlackSetupLink };
 
@@ -94,4 +96,6 @@ export const USE_CASES = [
   HandleNovuTools,
   HandleNovuResolve,
   IngestAgentEvents,
+  CreateWebChatConversation,
+  ListWebChatConversationEvents,
 ];

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -98,12 +98,37 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
   }
 }
 
+function buildEnvelope(
+  activity: ConversationActivityEntity,
+  event: AgentEvent,
+  sequence: number,
+  context: { conversationId: string; agentIdentifier: string }
+): AgentEventEnvelope {
+  return {
+    version: AGENT_EVENT_PROTOCOL_VERSION,
+    conversationId: context.conversationId,
+    agentId: context.agentIdentifier,
+    runId: 'history',
+    turnId: activity.identifier,
+    sequence,
+    timestamp: activity.createdAt,
+    event,
+  };
+}
+
+export function isMappableActivity(activity: ConversationActivityEntity): boolean {
+  const event = mapActivityToEvent(activity);
+
+  return event !== null && !isDeltaEvent(event);
+}
+
 export function activityToEvents(
   activities: ConversationActivityEntity[],
-  context: { conversationId: string; agentIdentifier: string }
+  context: { conversationId: string; agentIdentifier: string },
+  sequenceOffset = 0
 ): AgentEventEnvelope[] {
   const envelopes: AgentEventEnvelope[] = [];
-  let sequence = 0;
+  let sequence = sequenceOffset;
 
   for (const activity of activities) {
     const event = mapActivityToEvent(activity);
@@ -112,17 +137,60 @@ export function activityToEvents(
     }
 
     sequence += 1;
-    envelopes.push({
-      version: AGENT_EVENT_PROTOCOL_VERSION,
-      conversationId: context.conversationId,
-      agentId: context.agentIdentifier,
-      runId: 'history',
-      turnId: activity.identifier,
-      sequence,
-      timestamp: activity.createdAt,
-      event,
-    });
+    envelopes.push(buildEnvelope(activity, event, sequence, context));
   }
 
   return envelopes;
+}
+
+export function mapActivitiesToEventPage(
+  activities: ConversationActivityEntity[],
+  context: { conversationId: string; agentIdentifier: string },
+  options: {
+    sequenceOffset?: number;
+    afterSequence?: number;
+    limit: number;
+  }
+): {
+  events: AgentEventEnvelope[];
+  lastActivityId?: string;
+  hasMoreActivities: boolean;
+  nextSequence: number;
+} {
+  const events: AgentEventEnvelope[] = [];
+  let sequence = options.sequenceOffset ?? 0;
+  let lastActivityId: string | undefined;
+
+  for (const activity of activities) {
+    const event = mapActivityToEvent(activity);
+    if (!event || isDeltaEvent(event)) {
+      continue;
+    }
+
+    sequence += 1;
+
+    if (options.afterSequence !== undefined && sequence <= options.afterSequence) {
+      lastActivityId = activity._id;
+      continue;
+    }
+
+    events.push(buildEnvelope(activity, event, sequence, context));
+    lastActivityId = activity._id;
+
+    if (events.length > options.limit) {
+      return {
+        events: events.slice(0, options.limit),
+        lastActivityId,
+        hasMoreActivities: true,
+        nextSequence: sequence,
+      };
+    }
+  }
+
+  return {
+    events,
+    lastActivityId,
+    hasMoreActivities: false,
+    nextSequence: sequence,
+  };
 }

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -1,0 +1,128 @@
+import {
+  AGENT_EVENT_PROTOCOL_VERSION,
+  type AgentEvent,
+  type AgentEventEnvelope,
+  type AgentFileRef,
+  isDeltaEvent,
+} from '@novu/agent-event-protocol';
+import {
+  ConversationActivityEntity,
+  ConversationActivitySenderTypeEnum,
+  ConversationActivityTypeEnum,
+} from '@novu/dal';
+
+function filesFromRichContent(richContent?: Record<string, unknown>) {
+  const files = richContent?.files;
+  if (!Array.isArray(files) || files.length === 0) {
+    return undefined;
+  }
+
+  return files as AgentFileRef[];
+}
+
+function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | null {
+  switch (activity.type) {
+    case ConversationActivityTypeEnum.MESSAGE:
+      if (activity.senderType === ConversationActivitySenderTypeEnum.AGENT) {
+        return {
+          type: 'message',
+          messageId: activity.identifier,
+          content: { markdown: activity.content },
+          files: filesFromRichContent(activity.richContent),
+        };
+      }
+
+      if (activity.senderType === ConversationActivitySenderTypeEnum.SUBSCRIBER) {
+        return {
+          type: 'custom',
+          name: 'subscriber.message',
+          data: {
+            messageId: activity.identifier,
+            content: { markdown: activity.content },
+          },
+        };
+      }
+
+      return null;
+
+    case ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST: {
+      const toolData = activity.toolData;
+      if (!toolData?.approvalId || !toolData.toolCallId || !toolData.toolName) {
+        return null;
+      }
+
+      return {
+        type: 'tool-approval-request',
+        approvalId: toolData.approvalId,
+        toolUseId: toolData.toolCallId,
+        toolName: toolData.toolName,
+        input: toolData.input,
+      };
+    }
+
+    case ConversationActivityTypeEnum.TOOL_APPROVAL_DECISION: {
+      const toolData = activity.toolData;
+      if (!toolData?.approvalId) {
+        return null;
+      }
+
+      return {
+        type: 'tool-approval-response',
+        approvalId: toolData.approvalId,
+        decision: toolData.approved ? 'approved' : 'denied',
+      };
+    }
+
+    case ConversationActivityTypeEnum.TOOL_RESULT: {
+      const toolData = activity.toolData;
+      if (!toolData?.toolCallId) {
+        return null;
+      }
+
+      return {
+        type: 'tool-use-result',
+        toolUseId: toolData.toolCallId,
+        content: [{ type: 'text', text: String(toolData.output ?? activity.content) }],
+      };
+    }
+
+    case ConversationActivityTypeEnum.EDIT:
+      return {
+        type: 'channel.edit',
+        messageId: activity.platformMessageId ?? activity.identifier,
+        content: { markdown: activity.content },
+      };
+
+    default:
+      return null;
+  }
+}
+
+export function activityToEvents(
+  activities: ConversationActivityEntity[],
+  context: { conversationId: string; agentIdentifier: string }
+): AgentEventEnvelope[] {
+  const envelopes: AgentEventEnvelope[] = [];
+  let sequence = 0;
+
+  for (const activity of activities) {
+    const event = mapActivityToEvent(activity);
+    if (!event || isDeltaEvent(event)) {
+      continue;
+    }
+
+    sequence += 1;
+    envelopes.push({
+      version: AGENT_EVENT_PROTOCOL_VERSION,
+      conversationId: context.conversationId,
+      agentId: context.agentIdentifier,
+      runId: 'history',
+      turnId: activity.identifier,
+      sequence,
+      timestamp: activity.createdAt,
+      event,
+    });
+  }
+
+  return envelopes;
+}

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -174,17 +174,17 @@ export function mapActivitiesToEventPage(
       continue;
     }
 
-    events.push(buildEnvelope(activity, event, sequence, context));
-    lastActivityId = activity._id;
-
-    if (events.length > options.limit) {
+    if (events.length >= options.limit) {
       return {
-        events: events.slice(0, options.limit),
+        events,
         lastActivityId,
         hasMoreActivities: true,
-        nextSequence: sequence,
+        nextSequence: sequence - 1,
       };
     }
+
+    events.push(buildEnvelope(activity, event, sequence, context));
+    lastActivityId = activity._id;
   }
 
   return {

--- a/apps/api/src/app/agents/web-chat/dtos/create-web-chat-conversation.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/create-web-chat-conversation.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateWebChatConversationRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  agentId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+}
+
+export class CreateWebChatConversationResponseDto {
+  identifier: string;
+}

--- a/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
@@ -1,6 +1,6 @@
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
-import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 
 export class ListWebChatConversationEventsQueryDto {
   @IsOptional()

--- a/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
@@ -1,8 +1,19 @@
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class ListWebChatConversationEventsQueryDto {
+  /** Cursor: activity `_id` for forward pagination. */
+  @IsOptional()
+  @IsString()
+  after?: string;
+
+  /** Cursor: activity `_id` for reverse pagination. */
+  @IsOptional()
+  @IsString()
+  before?: string;
+
+  /** Gap-fill replay cursor — events with sequence strictly greater than this value. */
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -20,4 +31,6 @@ export class ListWebChatConversationEventsQueryDto {
 export class ListWebChatConversationEventsResponseDto {
   events: AgentEventEnvelope[];
   hasMore: boolean;
+  next: string | null;
+  previous: string | null;
 }

--- a/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
@@ -1,0 +1,23 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
+
+export class ListWebChatConversationEventsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  afterSequence?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class ListWebChatConversationEventsResponseDto {
+  events: AgentEventEnvelope[];
+  hasMore: boolean;
+}

--- a/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.command.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.command.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { EnvironmentWithSubscriber } from '../../../../shared/commands/project.command';
+
+export class CreateWebChatConversationCommand extends EnvironmentWithSubscriber {
+  @IsString()
+  @IsNotEmpty()
+  agentIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+}

--- a/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts
@@ -7,6 +7,7 @@ import { AgentEventEnum } from '../../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
 import { buildWebChatMessage, buildWebChatThread } from '../../web-chat-inbound.adapter';
 import { WebChatPublicationService } from '../../web-chat-publication.service';
+import { WebChatThreadDeliveryService } from '../../web-chat-thread-delivery.service';
 import { CreateWebChatConversationCommand } from './create-web-chat-conversation.command';
 
 @Injectable()
@@ -15,7 +16,8 @@ export class CreateWebChatConversation {
     private readonly publicationService: WebChatPublicationService,
     private readonly agentConfigResolver: AgentConfigResolver,
     private readonly inboundHandler: AgentInboundHandler,
-    private readonly conversationService: AgentConversationService
+    private readonly conversationService: AgentConversationService,
+    private readonly threadDelivery: WebChatThreadDeliveryService
   ) {}
 
   async execute(command: CreateWebChatConversationCommand): Promise<{ identifier: string }> {
@@ -37,7 +39,14 @@ export class CreateWebChatConversation {
     }
 
     const conversationIdentifier = `conv_${shortId(12)}`;
-    const thread = buildWebChatThread(conversationIdentifier);
+    const deliverMessage = this.threadDelivery.createDeliverMessage({
+      agentId: published.agentId,
+      integrationId: config.integrationId,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      agentIdentifier: published.agentIdentifier,
+    });
+    const thread = buildWebChatThread(conversationIdentifier, deliverMessage);
     const message = buildWebChatMessage(command.subscriberId, text);
 
     await this.inboundHandler.handle(published.agentId, config, thread, message, AgentEventEnum.ON_MESSAGE, {

--- a/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts
@@ -5,8 +5,8 @@ import { AgentConversationService } from '../../../conversation-runtime/conversa
 import { AgentInboundHandler } from '../../../conversation-runtime/ingress/inbound-turn.handler';
 import { AgentEventEnum } from '../../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
-import { WebChatPublicationService } from '../../web-chat-publication.service';
 import { buildWebChatMessage, buildWebChatThread } from '../../web-chat-inbound.adapter';
+import { WebChatPublicationService } from '../../web-chat-publication.service';
 import { CreateWebChatConversationCommand } from './create-web-chat-conversation.command';
 
 @Injectable()

--- a/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts
@@ -1,0 +1,61 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { shortId } from '@novu/application-generic';
+import { AgentConfigResolver } from '../../../channels/agent-config-resolver.service';
+import { AgentConversationService } from '../../../conversation-runtime/conversation/agent-conversation.service';
+import { AgentInboundHandler } from '../../../conversation-runtime/ingress/inbound-turn.handler';
+import { AgentEventEnum } from '../../../shared/enums/agent-event.enum';
+import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
+import { WebChatPublicationService } from '../../web-chat-publication.service';
+import { buildWebChatMessage, buildWebChatThread } from '../../web-chat-inbound.adapter';
+import { CreateWebChatConversationCommand } from './create-web-chat-conversation.command';
+
+@Injectable()
+export class CreateWebChatConversation {
+  constructor(
+    private readonly publicationService: WebChatPublicationService,
+    private readonly agentConfigResolver: AgentConfigResolver,
+    private readonly inboundHandler: AgentInboundHandler,
+    private readonly conversationService: AgentConversationService
+  ) {}
+
+  async execute(command: CreateWebChatConversationCommand): Promise<{ identifier: string }> {
+    const text = command.text.trim();
+    if (!text) {
+      throw new BadRequestException('text is required');
+    }
+
+    const published = await this.publicationService.resolvePublishedAgent(
+      command.agentIdentifier,
+      command.environmentId,
+      command.organizationId
+    );
+
+    const config = await this.agentConfigResolver.resolve(published.agentId, published.integrationIdentifier);
+
+    if (config.platform !== AgentPlatformEnum.WEB_CHAT) {
+      throw new BadRequestException('This agent is not available on web chat');
+    }
+
+    const conversationIdentifier = `conv_${shortId(12)}`;
+    const thread = buildWebChatThread(conversationIdentifier);
+    const message = buildWebChatMessage(command.subscriberId, text);
+
+    await this.inboundHandler.handle(published.agentId, config, thread, message, AgentEventEnum.ON_MESSAGE, {
+      conversationIdentifier,
+    });
+
+    const conversation = await this.conversationService.findByPlatformThread(
+      command.environmentId,
+      command.organizationId,
+      published.agentId,
+      config.integrationId,
+      conversationIdentifier
+    );
+
+    if (!conversation) {
+      throw new BadRequestException('Failed to create web chat conversation');
+    }
+
+    return { identifier: conversation.identifier };
+  }
+}

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command.ts
@@ -1,0 +1,20 @@
+import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
+
+import { EnvironmentWithSubscriber } from '../../../../shared/commands/project.command';
+
+export class ListWebChatConversationEventsCommand extends EnvironmentWithSubscriber {
+  @IsString()
+  @IsNotEmpty()
+  conversationIdentifier: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  afterSequence = 0;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit = 50;
+}

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command.ts
@@ -7,6 +7,17 @@ export class ListWebChatConversationEventsCommand extends EnvironmentWithSubscri
   @IsNotEmpty()
   conversationIdentifier: string;
 
+  /** Cursor: activity `_id` — fetch events after this activity (forward pagination). */
+  @IsOptional()
+  @IsString()
+  after?: string;
+
+  /** Cursor: activity `_id` — fetch events before this activity (reverse pagination). */
+  @IsOptional()
+  @IsString()
+  before?: string;
+
+  /** Gap-fill replay cursor — events with sequence strictly greater than this value. */
   @IsOptional()
   @IsInt()
   @Min(0)

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
@@ -35,8 +35,7 @@ export class ListWebChatConversationEvents {
 
     const isParticipant = conversation.participants.some(
       (participant) =>
-        participant.type === ConversationParticipantTypeEnum.SUBSCRIBER &&
-        participant.id === command.subscriberId
+        participant.type === ConversationParticipantTypeEnum.SUBSCRIBER && participant.id === command.subscriberId
     );
 
     if (!isParticipant) {

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
@@ -1,0 +1,78 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
+import {
+  AgentRepository,
+  ConversationActivityRepository,
+  ConversationParticipantTypeEnum,
+  ConversationRepository,
+} from '@novu/dal';
+import { activityToEvents } from '../../activity-to-events';
+import { ListWebChatConversationEventsCommand } from './list-web-chat-conversation-events.command';
+
+@Injectable()
+export class ListWebChatConversationEvents {
+  constructor(
+    private readonly conversationRepository: ConversationRepository,
+    private readonly activityRepository: ConversationActivityRepository,
+    private readonly agentRepository: AgentRepository
+  ) {}
+
+  async execute(
+    command: ListWebChatConversationEventsCommand
+  ): Promise<{ events: AgentEventEnvelope[]; hasMore: boolean }> {
+    const conversation = await this.conversationRepository.findOne(
+      {
+        identifier: command.conversationIdentifier,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      '*'
+    );
+
+    if (!conversation) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const isParticipant = conversation.participants.some(
+      (participant) =>
+        participant.type === ConversationParticipantTypeEnum.SUBSCRIBER &&
+        participant.id === command.subscriberId
+    );
+
+    if (!isParticipant) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const agent = await this.agentRepository.findOne(
+      { _id: conversation._agentId, _environmentId: command.environmentId },
+      ['identifier']
+    );
+
+    if (!agent) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const activities = await this.activityRepository.find(
+      {
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        _conversationId: conversation._id,
+      },
+      '*',
+      { sort: { createdAt: 1 } }
+    );
+
+    const allEvents = activityToEvents(activities, {
+      conversationId: conversation._id,
+      agentIdentifier: agent.identifier,
+    });
+
+    const filtered = allEvents.filter((envelope) => envelope.sequence > command.afterSequence);
+    const page = filtered.slice(0, command.limit);
+
+    return {
+      events: page,
+      hasMore: filtered.length > command.limit,
+    };
+  }
+}

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
@@ -1,13 +1,24 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import {
   AgentRepository,
+  ConversationActivityEntity,
   ConversationActivityRepository,
   ConversationParticipantTypeEnum,
   ConversationRepository,
 } from '@novu/dal';
-import { activityToEvents } from '../../activity-to-events';
+import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
+import { isMappableActivity, mapActivitiesToEventPage } from '../../activity-to-events';
 import { ListWebChatConversationEventsCommand } from './list-web-chat-conversation-events.command';
+
+const ACTIVITY_FETCH_BATCH_SIZE = 100;
+
+type EventPageResult = {
+  events: AgentEventEnvelope[];
+  hasMore: boolean;
+  next: string | null;
+  previous: string | null;
+};
 
 @Injectable()
 export class ListWebChatConversationEvents {
@@ -17,9 +28,15 @@ export class ListWebChatConversationEvents {
     private readonly agentRepository: AgentRepository
   ) {}
 
-  async execute(
-    command: ListWebChatConversationEventsCommand
-  ): Promise<{ events: AgentEventEnvelope[]; hasMore: boolean }> {
+  async execute(command: ListWebChatConversationEventsCommand): Promise<EventPageResult> {
+    if (command.after && command.before) {
+      throw new BadRequestException('Cannot specify both "before" and "after" cursors at the same time.');
+    }
+
+    if ((command.after || command.before) && command.afterSequence > 0) {
+      throw new BadRequestException('Use either cursor pagination (after/before) or afterSequence, not both.');
+    }
+
     const conversation = await this.conversationRepository.findOne(
       {
         identifier: command.conversationIdentifier,
@@ -42,6 +59,14 @@ export class ListWebChatConversationEvents {
       throw new NotFoundException('Conversation not found');
     }
 
+    const isWebChatConversation = conversation.channels.some(
+      (channel) => channel.platform === AgentPlatformEnum.WEB_CHAT
+    );
+
+    if (!isWebChatConversation) {
+      throw new NotFoundException('Conversation not found');
+    }
+
     const agent = await this.agentRepository.findOne(
       { _id: conversation._agentId, _environmentId: command.environmentId },
       ['identifier']
@@ -51,27 +76,135 @@ export class ListWebChatConversationEvents {
       throw new NotFoundException('Conversation not found');
     }
 
-    const activities = await this.activityRepository.find(
-      {
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-        _conversationId: conversation._id,
-      },
-      '*',
-      { sort: { createdAt: 1 } }
-    );
-
-    const allEvents = activityToEvents(activities, {
+    const mapContext = {
       conversationId: conversation._id,
       agentIdentifier: agent.identifier,
-    });
-
-    const filtered = allEvents.filter((envelope) => envelope.sequence > command.afterSequence);
-    const page = filtered.slice(0, command.limit);
-
-    return {
-      events: page,
-      hasMore: filtered.length > command.limit,
     };
+
+    if (command.afterSequence > 0) {
+      return this.fetchEventPage(command, conversation._id, mapContext, {
+        afterSequence: command.afterSequence,
+        sequenceOffset: 0,
+      });
+    }
+
+    const sequenceOffset = command.after
+      ? await this.countMappableEventsUpToActivity(
+          command.environmentId,
+          command.organizationId,
+          conversation._id,
+          command.after
+        )
+      : 0;
+
+    return this.fetchEventPage(command, conversation._id, mapContext, {
+      activityCursor: command.after ?? command.before,
+      before: command.before,
+      sequenceOffset,
+    });
+  }
+
+  private async fetchEventPage(
+    command: ListWebChatConversationEventsCommand,
+    conversationId: string,
+    mapContext: { conversationId: string; agentIdentifier: string },
+    options: {
+      activityCursor?: string;
+      before?: string;
+      sequenceOffset?: number;
+      afterSequence?: number;
+    }
+  ): Promise<EventPageResult> {
+    const sortDirection = options.before ? -1 : 1;
+    let activityCursor = options.activityCursor;
+    let dbNext: string | null = null;
+    let dbPrevious: string | null = null;
+    const collected: ConversationActivityEntity[] = [];
+
+    while (true) {
+      const page = await this.activityRepository.listActivities({
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        conversationId,
+        after: options.before ? undefined : activityCursor,
+        before: options.before ? activityCursor : undefined,
+        limit: ACTIVITY_FETCH_BATCH_SIZE,
+        sortDirection,
+      });
+
+      if (page.data.length === 0) {
+        break;
+      }
+
+      collected.push(...page.data);
+      dbNext = page.next;
+      dbPrevious = page.previous;
+
+      const mapped = mapActivitiesToEventPage(collected, mapContext, {
+        sequenceOffset: options.sequenceOffset ?? 0,
+        afterSequence: options.afterSequence,
+        limit: command.limit,
+      });
+
+      if (mapped.events.length >= command.limit || mapped.hasMoreActivities || !page.next) {
+        const events = options.before ? [...mapped.events].reverse() : mapped.events;
+
+        return {
+          events,
+          hasMore: mapped.hasMoreActivities || Boolean(page.next),
+          next: options.before ? dbPrevious : mapped.hasMoreActivities ? (mapped.lastActivityId ?? dbNext) : dbNext,
+          previous: options.before
+            ? mapped.hasMoreActivities
+              ? (mapped.lastActivityId ?? dbNext)
+              : dbNext
+            : dbPrevious,
+        };
+      }
+
+      activityCursor = page.next ?? undefined;
+    }
+
+    return { events: [], hasMore: false, next: null, previous: dbPrevious };
+  }
+
+  private async countMappableEventsUpToActivity(
+    environmentId: string,
+    organizationId: string,
+    conversationId: string,
+    activityId: string
+  ): Promise<number> {
+    let offset = 0;
+    let cursor: string | undefined;
+
+    while (true) {
+      const page = await this.activityRepository.listActivities({
+        environmentId,
+        organizationId,
+        conversationId,
+        after: cursor,
+        limit: ACTIVITY_FETCH_BATCH_SIZE,
+        sortDirection: 1,
+      });
+
+      if (page.data.length === 0) {
+        return offset;
+      }
+
+      for (const activity of page.data) {
+        if (activity._id === activityId) {
+          return isMappableActivity(activity) ? offset + 1 : offset;
+        }
+
+        if (isMappableActivity(activity)) {
+          offset += 1;
+        }
+      }
+
+      if (!page.next) {
+        return offset;
+      }
+
+      cursor = page.next;
+    }
   }
 }

--- a/apps/api/src/app/agents/web-chat/web-chat-inbound.adapter.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-inbound.adapter.ts
@@ -1,6 +1,14 @@
 import { shortId } from '@novu/application-generic';
-import type { Message, Thread } from 'chat';
+import type { CardElement, Message, Thread } from 'chat';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
+
+export type WebChatDeliverMessageParams = {
+  threadId: string;
+  content: string;
+  richContent?: Record<string, unknown>;
+};
+
+export type WebChatDeliverMessage = (params: WebChatDeliverMessageParams) => Promise<{ id: string; threadId: string }>;
 
 function sentMessageStub(messageId: string, threadId: string) {
   return {
@@ -11,6 +19,33 @@ function sentMessageStub(messageId: string, threadId: string) {
     edit: async () => sentMessageStub(messageId, threadId),
     delete: async () => {},
   };
+}
+
+function parseThreadPostArg(arg: unknown): { content: string; richContent?: Record<string, unknown> } {
+  if (typeof arg === 'string') {
+    return { content: arg };
+  }
+
+  if (arg && typeof arg === 'object') {
+    const record = arg as { markdown?: string; card?: CardElement; files?: unknown[] };
+    const richContent: Record<string, unknown> = {};
+    if (record.card) {
+      richContent.card = record.card;
+    }
+    if (record.files?.length) {
+      richContent.files = record.files;
+    }
+
+    if (record.markdown) {
+      return { content: record.markdown, richContent: Object.keys(richContent).length ? richContent : undefined };
+    }
+
+    if (record.card) {
+      return { content: record.card.title ?? '[Card]', richContent };
+    }
+  }
+
+  return { content: '' };
 }
 
 export function buildWebChatMessage(subscriberId: string, text: string): Message {
@@ -30,21 +65,35 @@ export function buildWebChatMessage(subscriberId: string, text: string): Message
 }
 
 /**
- * REST → inbound-turn bridge. `thread.post()` returns durable-shaped ids; persistence
- * for gate/runtime replies is handled by `OutboundGateway.replyOnThread({ persist })`.
+ * REST → inbound-turn bridge. When `deliverMessage` is provided, `thread.post()` persists
+ * durable agent activity (gate replies). Runtime replies use OutboundGateway.deliver().
  */
-export function buildWebChatThread(conversationIdentifier: string): Thread {
+export function buildWebChatThread(conversationIdentifier: string, deliverMessage?: WebChatDeliverMessage): Thread {
+  const post = async (arg: unknown) => {
+    const { content, richContent } = parseThreadPostArg(arg);
+
+    if (deliverMessage) {
+      const delivered = await deliverMessage({
+        threadId: conversationIdentifier,
+        content,
+        richContent,
+      });
+
+      return sentMessageStub(delivered.id, delivered.threadId);
+    }
+
+    const messageId = `msg_${shortId(12)}`;
+
+    return sentMessageStub(messageId, conversationIdentifier);
+  };
+
   return {
     id: conversationIdentifier,
     channelId: conversationIdentifier,
     isDM: true,
     startTyping: async () => {},
     subscribe: async () => {},
-    post: async () => {
-      const messageId = `msg_${shortId(12)}`;
-
-      return sentMessageStub(messageId, conversationIdentifier);
-    },
+    post,
     toJSON: () => ({ id: conversationIdentifier, platform: AgentPlatformEnum.WEB_CHAT }),
     createSentMessageFromMessage: () => {
       const messageId = `msg_${shortId(12)}`;
@@ -52,4 +101,10 @@ export function buildWebChatThread(conversationIdentifier: string): Thread {
       return sentMessageStub(messageId, conversationIdentifier);
     },
   } as unknown as Thread;
+}
+
+export function isWebChatThread(thread: Thread): boolean {
+  const json = (thread as { toJSON?: () => { platform?: string } }).toJSON?.();
+
+  return json?.platform === AgentPlatformEnum.WEB_CHAT;
 }

--- a/apps/api/src/app/agents/web-chat/web-chat-inbound.adapter.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-inbound.adapter.ts
@@ -1,0 +1,55 @@
+import { shortId } from '@novu/application-generic';
+import type { Message, Thread } from 'chat';
+import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
+
+function sentMessageStub(messageId: string, threadId: string) {
+  return {
+    id: messageId,
+    threadId,
+    addReaction: async () => {},
+    removeReaction: async () => {},
+    edit: async () => sentMessageStub(messageId, threadId),
+    delete: async () => {},
+  };
+}
+
+export function buildWebChatMessage(subscriberId: string, text: string): Message {
+  const messageId = `msg_${shortId(12)}`;
+
+  return {
+    id: messageId,
+    text,
+    author: {
+      userId: subscriberId,
+      fullName: subscriberId,
+      userName: subscriberId,
+      isBot: false,
+    },
+    metadata: { dateSent: new Date() },
+  } as Message;
+}
+
+/**
+ * REST → inbound-turn bridge. `thread.post()` returns durable-shaped ids; persistence
+ * for gate/runtime replies is handled by `OutboundGateway.replyOnThread({ persist })`.
+ */
+export function buildWebChatThread(conversationIdentifier: string): Thread {
+  return {
+    id: conversationIdentifier,
+    channelId: conversationIdentifier,
+    isDM: true,
+    startTyping: async () => {},
+    subscribe: async () => {},
+    post: async () => {
+      const messageId = `msg_${shortId(12)}`;
+
+      return sentMessageStub(messageId, conversationIdentifier);
+    },
+    toJSON: () => ({ id: conversationIdentifier, platform: AgentPlatformEnum.WEB_CHAT }),
+    createSentMessageFromMessage: () => {
+      const messageId = `msg_${shortId(12)}`;
+
+      return sentMessageStub(messageId, conversationIdentifier);
+    },
+  } as unknown as Thread;
+}

--- a/apps/api/src/app/agents/web-chat/web-chat-publication.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-publication.service.ts
@@ -1,0 +1,74 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+
+const WEB_CHAT_UNAVAILABLE_MESSAGE = 'This agent is not available on web chat';
+
+export type PublishedWebChatAgent = {
+  agentId: string;
+  agentIdentifier: string;
+  integrationId: string;
+  integrationIdentifier: string;
+};
+
+@Injectable()
+export class WebChatPublicationService {
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly integrationRepository: IntegrationRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository
+  ) {}
+
+  async resolvePublishedAgent(
+    agentIdentifier: string,
+    environmentId: string,
+    organizationId: string
+  ): Promise<PublishedWebChatAgent> {
+    const agent = await this.agentRepository.findOne(
+      {
+        identifier: agentIdentifier,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      ['_id', 'identifier', 'active']
+    );
+
+    if (!agent || agent.active === false) {
+      throw new BadRequestException(WEB_CHAT_UNAVAILABLE_MESSAGE);
+    }
+
+    const integration = await this.integrationRepository.findOne(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        providerId: ChatProviderIdEnum.NovuWebChat,
+      },
+      '_id identifier'
+    );
+
+    if (!integration) {
+      throw new BadRequestException(WEB_CHAT_UNAVAILABLE_MESSAGE);
+    }
+
+    const link = await this.agentIntegrationRepository.findOne(
+      {
+        _agentId: agent._id,
+        _integrationId: integration._id,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      ['_id']
+    );
+
+    if (!link) {
+      throw new BadRequestException(WEB_CHAT_UNAVAILABLE_MESSAGE);
+    }
+
+    return {
+      agentId: agent._id,
+      agentIdentifier: agent.identifier,
+      integrationId: integration._id,
+      integrationIdentifier: integration.identifier,
+    };
+  }
+}

--- a/apps/api/src/app/agents/web-chat/web-chat-thread-delivery.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-thread-delivery.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { shortId } from '@novu/application-generic';
 import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
 import type { WebChatDeliverMessage } from './web-chat-inbound.adapter';
@@ -26,7 +26,9 @@ export class WebChatThreadDeliveryService {
       );
 
       if (!conversation) {
-        throw new NotFoundException('Web chat conversation not found');
+        // Gate/limit replies can post before openConversation creates the thread.
+        // Ephemeral ack only — durable agent messages use OutboundGateway.deliver().
+        return { id: `act_${shortId(12)}`, threadId };
       }
 
       const channel = this.conversationService.getPrimaryChannel(conversation);

--- a/apps/api/src/app/agents/web-chat/web-chat-thread-delivery.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-thread-delivery.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { shortId } from '@novu/application-generic';
 import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
 import type { WebChatDeliverMessage } from './web-chat-inbound.adapter';
@@ -26,7 +26,7 @@ export class WebChatThreadDeliveryService {
       );
 
       if (!conversation) {
-        return { id: `msg_${threadId}`, threadId };
+        throw new NotFoundException('Web chat conversation not found');
       }
 
       const channel = this.conversationService.getPrimaryChannel(conversation);

--- a/apps/api/src/app/agents/web-chat/web-chat-thread-delivery.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-thread-delivery.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { shortId } from '@novu/application-generic';
+import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
+import type { WebChatDeliverMessage } from './web-chat-inbound.adapter';
+
+export type WebChatThreadDeliveryContext = {
+  agentId: string;
+  integrationId: string;
+  environmentId: string;
+  organizationId: string;
+  agentIdentifier: string;
+};
+
+@Injectable()
+export class WebChatThreadDeliveryService {
+  constructor(private readonly conversationService: AgentConversationService) {}
+
+  createDeliverMessage(context: WebChatThreadDeliveryContext): WebChatDeliverMessage {
+    return async ({ threadId, content, richContent }) => {
+      const conversation = await this.conversationService.findByPlatformThread(
+        context.environmentId,
+        context.organizationId,
+        context.agentId,
+        context.integrationId,
+        threadId
+      );
+
+      if (!conversation) {
+        return { id: `msg_${threadId}`, threadId };
+      }
+
+      const channel = this.conversationService.getPrimaryChannel(conversation);
+      const activityId = `act_${shortId(12)}`;
+      const activity = await this.conversationService.persistAgentMessage({
+        conversationId: conversation._id,
+        channel,
+        platformThreadId: threadId,
+        platformMessageId: activityId,
+        identifier: activityId,
+        agentIdentifier: context.agentIdentifier,
+        content,
+        richContent,
+        environmentId: context.environmentId,
+        organizationId: context.organizationId,
+      });
+
+      return { id: activity.identifier, threadId: activity.platformThreadId ?? threadId };
+    };
+  }
+}

--- a/apps/api/src/app/agents/web-chat/web-chat.controller.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat.controller.ts
@@ -1,7 +1,10 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiExcludeController } from '@nestjs/swagger';
-import { SubscriberSession, type SubscriberSession as SubscriberSessionData } from '../../shared/framework/user.decorator';
+import {
+  SubscriberSession,
+  type SubscriberSession as SubscriberSessionData,
+} from '../../shared/framework/user.decorator';
 import { AgentConversationEnabledGuard } from '../shared/agent-conversation-enabled.guard';
 import {
   CreateWebChatConversationRequestDto,

--- a/apps/api/src/app/agents/web-chat/web-chat.controller.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat.controller.ts
@@ -1,0 +1,62 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { SubscriberSession, type SubscriberSession as SubscriberSessionData } from '../../shared/framework/user.decorator';
+import { AgentConversationEnabledGuard } from '../shared/agent-conversation-enabled.guard';
+import {
+  CreateWebChatConversationRequestDto,
+  CreateWebChatConversationResponseDto,
+} from './dtos/create-web-chat-conversation.dto';
+import {
+  ListWebChatConversationEventsQueryDto,
+  ListWebChatConversationEventsResponseDto,
+} from './dtos/list-web-chat-conversation-events.dto';
+import { CreateWebChatConversationCommand } from './usecases/create-web-chat-conversation/create-web-chat-conversation.command';
+import { CreateWebChatConversation } from './usecases/create-web-chat-conversation/create-web-chat-conversation.usecase';
+import { ListWebChatConversationEventsCommand } from './usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command';
+import { ListWebChatConversationEvents } from './usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase';
+
+@Controller('/web-chat')
+@ApiExcludeController()
+@UseGuards(AuthGuard('subscriberJwt'), AgentConversationEnabledGuard)
+export class WebChatController {
+  constructor(
+    private readonly createWebChatConversation: CreateWebChatConversation,
+    private readonly listWebChatConversationEvents: ListWebChatConversationEvents
+  ) {}
+
+  @Post('/conversations')
+  @HttpCode(HttpStatus.CREATED)
+  async createConversation(
+    @SubscriberSession() subscriberSession: SubscriberSessionData,
+    @Body() body: CreateWebChatConversationRequestDto
+  ): Promise<CreateWebChatConversationResponseDto> {
+    return this.createWebChatConversation.execute(
+      CreateWebChatConversationCommand.create({
+        environmentId: subscriberSession.environmentId,
+        organizationId: subscriberSession.organizationId,
+        subscriberId: subscriberSession.subscriberId,
+        agentIdentifier: body.agentId,
+        text: body.text,
+      })
+    );
+  }
+
+  @Get('/conversations/:identifier/events')
+  async listConversationEvents(
+    @SubscriberSession() subscriberSession: SubscriberSessionData,
+    @Param('identifier') identifier: string,
+    @Query() query: ListWebChatConversationEventsQueryDto
+  ): Promise<ListWebChatConversationEventsResponseDto> {
+    return this.listWebChatConversationEvents.execute(
+      ListWebChatConversationEventsCommand.create({
+        environmentId: subscriberSession.environmentId,
+        organizationId: subscriberSession.organizationId,
+        subscriberId: subscriberSession.subscriberId,
+        conversationIdentifier: identifier,
+        afterSequence: query.afterSequence ?? 0,
+        limit: query.limit ?? 50,
+      })
+    );
+  }
+}

--- a/apps/api/src/app/agents/web-chat/web-chat.controller.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat.controller.ts
@@ -6,6 +6,7 @@ import {
   type SubscriberSession as SubscriberSessionData,
 } from '../../shared/framework/user.decorator';
 import { AgentConversationEnabledGuard } from '../shared/agent-conversation-enabled.guard';
+import { WebChatEnabledGuard } from '../shared/web-chat-enabled.guard';
 import {
   CreateWebChatConversationRequestDto,
   CreateWebChatConversationResponseDto,
@@ -21,7 +22,7 @@ import { ListWebChatConversationEvents } from './usecases/list-web-chat-conversa
 
 @Controller('/web-chat')
 @ApiExcludeController()
-@UseGuards(AuthGuard('subscriberJwt'), AgentConversationEnabledGuard)
+@UseGuards(AuthGuard('subscriberJwt'), AgentConversationEnabledGuard, WebChatEnabledGuard)
 export class WebChatController {
   constructor(
     private readonly createWebChatConversation: CreateWebChatConversation,
@@ -57,6 +58,8 @@ export class WebChatController {
         organizationId: subscriberSession.organizationId,
         subscriberId: subscriberSession.subscriberId,
         conversationIdentifier: identifier,
+        after: query.after,
+        before: query.before,
         afterSequence: query.afterSequence ?? 0,
         limit: query.limit ?? 50,
       })

--- a/packages/shared/src/consts/providers/channels/chat.ts
+++ b/packages/shared/src/consts/providers/channels/chat.ts
@@ -6,6 +6,7 @@ import {
   grafanaOnCallConfig,
   lineConfig,
   msTeamsConfig,
+  novuWebChatConfig,
   rocketChatConfig,
   sendblueConfig,
   slackConfigLegacy,
@@ -144,5 +145,13 @@ export const chatProviders: IProviderConfig[] = [
     credentials: sendblueConfig,
     docReference: 'https://docs.sendblue.com',
     logoFileName: { light: 'sendblue.svg', dark: 'sendblue.svg' },
+  },
+  {
+    id: ChatProviderIdEnum.NovuWebChat,
+    displayName: 'Novu Web Chat',
+    channel: ChannelTypeEnum.CHAT,
+    credentials: novuWebChatConfig,
+    docReference: `https://docs.novu.co/platform/integrations/chat/web-chat${UTM_CAMPAIGN_QUERY_PARAM}`,
+    logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
 ];

--- a/packages/shared/src/consts/providers/conversational-providers.ts
+++ b/packages/shared/src/consts/providers/conversational-providers.ts
@@ -14,6 +14,7 @@ export const CONVERSATIONAL_PROVIDERS: ConversationalProvider[] = [
   { providerId: ChatProviderIdEnum.Sendblue, displayName: 'Sendblue' },
   { providerId: ChatProviderIdEnum.WhatsAppBusiness, displayName: 'WhatsApp Business' },
   { providerId: ChatProviderIdEnum.MsTeams, displayName: 'MS Teams' },
+  { providerId: ChatProviderIdEnum.NovuWebChat, displayName: 'Web Chat' },
   { providerId: ChatProviderIdEnum.Discord, displayName: 'Discord', comingSoon: true },
   { providerId: 'google-chat', displayName: 'Google Chat', comingSoon: true },
   { providerId: 'linear', displayName: 'Linear', comingSoon: true },

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -1044,6 +1044,9 @@ export const novuInAppConfig: IConfigCredential[] = [
   },
 ];
 
+/** Mirrors Inbox HMAC toggle — optional per-session agent authorization for web chat. */
+export const novuWebChatConfig: IConfigCredential[] = novuInAppConfig;
+
 export const sendchampConfig: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.ApiKey,

--- a/packages/shared/src/consts/providers/providers.ts
+++ b/packages/shared/src/consts/providers/providers.ts
@@ -34,6 +34,7 @@ export const NOVU_PROVIDERS: ProvidersIdEnum[] = [
   EmailProviderIdEnum.Novu,
   EmailProviderIdEnum.NovuAgent,
   ChatProviderIdEnum.Novu,
+  ChatProviderIdEnum.NovuWebChat,
   AgentRuntimeProviderIdEnum.NovuAnthropic,
 ];
 

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -102,6 +102,12 @@ export enum FeatureFlagsKeysEnum {
   IS_DEMO_MANAGED_CLAUDE_ENABLED = 'IS_DEMO_MANAGED_CLAUDE_ENABLED',
   /** Route managed-agent StreamParts through AgentEvent mapper + sink. Create boolean in LaunchDarkly for cloud, or set env for self-hosted. */
   IS_AGENT_EVENT_PROTOCOL_ENABLED = 'IS_AGENT_EVENT_PROTOCOL_ENABLED',
+  /**
+   * Enable the agent web-chat channel (subscriber `/v1/web-chat/*`, useAgentChat wayfinder).
+   * Requires conversational agents. Create the boolean in LaunchDarkly for cloud, or set
+   * `IS_AGENT_WEB_CHAT_ENABLED` when self-hosted (`VITE_IS_AGENT_WEB_CHAT_ENABLED` for dashboard).
+   */
+  IS_AGENT_WEB_CHAT_ENABLED = 'IS_AGENT_WEB_CHAT_ENABLED',
   /** Enable the "What's next" section on the agent overview. Create the boolean in LaunchDarkly for cloud, or set `VITE_IS_AGENT_WHATS_NEXT_ENABLED` when self-hosted. */
   IS_AGENT_WHATS_NEXT_ENABLED = 'IS_AGENT_WHATS_NEXT_ENABLED',
   /** Enable the MS Teams subscriber-rollout "What's next" guide (distribute the bot + connect end users) and its post-connect "Continue" CTA. When off, MS Teams shows the generic continue note and hides the rollout guide. Create the boolean in LaunchDarkly for cloud, or set `VITE_IS_AGENT_MSTEAMS_WHATS_NEXT_ENABLED` when self-hosted. */

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -158,6 +158,7 @@ export enum ChatProviderIdEnum {
   Novu = 'novu-slack',
   Telegram = 'telegram',
   Sendblue = 'sendblue',
+  NovuWebChat = 'novu-web-chat',
 }
 
 export enum PushProviderIdEnum {


### PR DESCRIPTION
## Summary

- Add `WEB_CHAT` platform, `NovuWebChat` provisioning, and subscriber REST edge (`POST/GET /v1/web-chat/conversations`) for first-message → durable conversation
- Wire inbound shim through `AgentInboundHandler`, persist-only egress skip in `OutboundGateway`, and activity → `AgentEventEnvelope` rehydration for cold history
- Gate the wayfinder behind `IS_AGENT_WEB_CHAT_ENABLED`, harden auth/identity (web-chat-only history, `msg_*` subscriber identifiers), and paginate events via DB cursors (`listActivities`) with `afterSequence` gap-fill support

## Test plan

- [ ] `pnpm nx run @novu/api-service:build`
- [ ] Run `apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts` (create, unpublished agent 400, FF off 404, GET events, cursor pagination, cross-subscriber 404, non-web-chat 404)
- [ ] Link agent to `NovuWebChat` integration and verify first message creates `conv_*` conversation + subscriber activity
- [ ] Verify agent replies persist as activities and appear on `GET .../events`
- [ ] Confirm web-chat routes return 404 when `IS_AGENT_WEB_CHAT_ENABLED` is off

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the subscriber-facing web-chat conversation flow.
- Adds NovuWebChat provider provisioning and agent integration linking.
- Routes first subscriber messages through the agent inbound runtime and persists durable conversation activity.
- Exposes authenticated creation and cursor-paginated event-history endpoints behind a feature flag.
- Rehydrates persisted activities into agent-event protocol envelopes and makes web-chat egress persist-only.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because gate-rejected first messages still return a generic creation error and concurrent provisioning can persist duplicate web-chat integrations.

Gate paths can return before conversation creation, after which the create use case unconditionally fails its lookup; separately, provisioning still uses an unprotected check-then-create sequence that permits duplicate environment integrations under concurrency.

**Files Needing Attention:** apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts; apps/api/src/app/agents/channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/web-chat/usecases/create-web-chat-conversation/create-web-chat-conversation.usecase.ts | Creates the first durable web-chat turn, but the previously reported gate-rejection response defect remains. |
| apps/api/src/app/agents/channels/web-chat/find-or-create-novu-web-chat/find-or-create-novu-web-chat.service.ts | Provisions and links NovuWebChat integrations, while the acknowledged concurrent-provisioning race remains outstanding. |
| apps/api/src/app/agents/web-chat/web-chat-thread-delivery.service.ts | Safely returns an ephemeral acknowledgment when a gate replies before the durable conversation exists. |
| apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts | Authorizes subscriber-owned web-chat histories and translates cursor-paginated activities into event envelopes. |
| apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts | Adds persist-only web-chat delivery and bypasses provider-specific typing, reaction, edit, and delete operations. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Subscriber
    participant API as WebChatController
    participant UseCase as CreateWebChatConversation
    participant Runtime as AgentInboundHandler
    participant DB as Conversation/Activity DB
    Subscriber->>API: POST /v1/web-chat/conversations
    API->>UseCase: subscriber identity, agent, text
    UseCase->>Runtime: first inbound message
    Runtime->>DB: create conversation and persist activity
    DB-->>UseCase: durable conversation
    UseCase-->>Subscriber: conversation identifier
    Subscriber->>API: GET /conversations/:id/events
    API->>DB: cursor-paginated activities
    DB-->>API: activities
    API-->>Subscriber: AgentEventEnvelope page
```

<sub>Reviews (3): Last reviewed commit: ["fix(agents): repair web-chat e2e asserti..."](https://github.com/novuhq/novu/commit/2ad76b00984f9dceef210e0a4042b15ce365fb48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48277553)</sub>

<!-- /greptile_comment -->