### PR TITLE
fix(shared): prevent duplicate workflow status traces fixes NV-8453

### DIFF
--- a/libs/application-generic/src/services/message-interaction.service.ts
+++ b/libs/application-generic/src/services/message-interaction.service.ts
@@ -122,6 +122,7 @@ export class MessageInteractionService {
         _subscriberId: trace.subscriber_id,
         deliveryLifecycleStatus,
         ...(deliveryLifecycleDetail && { deliveryLifecycleDetail }),
+        emitStatusTrace: false,
       });
     }
   }

--- a/libs/application-generic/src/services/workflow-run.service.spec.ts
+++ b/libs/application-generic/src/services/workflow-run.service.spec.ts
@@ -168,7 +168,35 @@ describe('WorkflowRunService', () => {
   });
 
   describe('updateDeliveryLifecycle', () => {
-    it('writes zero status traces when emitStatusTrace is false', async () => {
+    it('writes zero status traces when emitStatusTrace is false (legacy path)', async () => {
+      await service.updateDeliveryLifecycle({
+        workflowStatus: WorkflowRunStatusEnum.COMPLETED,
+        notificationId,
+        environmentId,
+        organizationId,
+        _subscriberId: subscriberId,
+        deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.INTERACTED,
+        notification,
+        workflow,
+        emitStatusTrace: false,
+      });
+
+      expect(notificationRepository.tryWorkflowStatusTransition).not.toHaveBeenCalled();
+      expect(statusTraceCalls()).toHaveLength(0);
+    });
+
+    it('writes zero status traces when emitStatusTrace is false (transition path)', async () => {
+      featureFlagsService.getFlag.mockImplementation(({ key }) => {
+        if (
+          key === FeatureFlagsKeysEnum.IS_WORKFLOW_RUN_TRACES_WRITE_ENABLED ||
+          key === FeatureFlagsKeysEnum.IS_DELIVERY_LIFECYCLE_TRANSITION_ENABLED
+        ) {
+          return Promise.resolve(true);
+        }
+
+        return Promise.resolve(false);
+      });
+
       await service.updateDeliveryLifecycle({
         workflowStatus: WorkflowRunStatusEnum.COMPLETED,
         notificationId,

--- a/libs/application-generic/src/services/workflow-run.service.spec.ts
+++ b/libs/application-generic/src/services/workflow-run.service.spec.ts
@@ -129,7 +129,6 @@ describe('WorkflowRunService', () => {
     it('writes zero additional status traces when tryWorkflowStatusTransition returns isUpdated false', async () => {
       notificationRepository.tryWorkflowStatusTransition.mockResolvedValue({
         isUpdated: false,
-        previousEvent: 'workflow_run_status_completed',
       });
 
       await service.createWorkflowStatusTrace(
@@ -148,7 +147,6 @@ describe('WorkflowRunService', () => {
     it('writes zero status traces for ERROR after COMPLETED was already recorded', async () => {
       notificationRepository.tryWorkflowStatusTransition.mockResolvedValue({
         isUpdated: false,
-        previousEvent: 'workflow_run_status_completed',
       });
 
       await service.createWorkflowStatusTrace(

--- a/libs/application-generic/src/services/workflow-run.service.spec.ts
+++ b/libs/application-generic/src/services/workflow-run.service.spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobRepository, MessageRepository, NotificationRepository, NotificationTemplateRepository } from '@novu/dal';
+import { DeliveryLifecycleStatusEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { PinoLogger } from '../logging';
+import { TraceLogRepository } from './analytic-logs/trace-log';
+import { WorkflowRunRepository, WorkflowRunStatusEnum } from './analytic-logs/workflow-run';
+import { FeatureFlagsService } from './feature-flags';
+import { WorkflowRunService } from './workflow-run.service';
+
+// ESM-only dependencies pulled in transitively (analytic-logs → p-queue, feature-flags → LaunchDarkly);
+// jest 27 cannot parse them, and the spec injects its own mocks anyway.
+jest.mock('p-queue', () => ({ __esModule: true, default: class PQueueMock {} }));
+jest.mock('@launchdarkly/node-server-sdk', () => ({ init: jest.fn() }));
+
+describe('WorkflowRunService', () => {
+  let service: WorkflowRunService;
+  let notificationRepository: {
+    findOne: jest.Mock;
+    tryWorkflowStatusTransition: jest.Mock;
+    tryDeliveryLifecycleTransition: jest.Mock;
+  };
+  let notificationTemplateRepository: { findOne: jest.Mock };
+  let traceLogRepository: { createWorkflowRun: jest.Mock };
+  let workflowRunRepository: { updateWorkflowRunState: jest.Mock };
+  let featureFlagsService: { getFlag: jest.Mock };
+  let logger: { setContext: jest.Mock; debug: jest.Mock; trace: jest.Mock; error: jest.Mock };
+
+  const notificationId = 'notif-1';
+  const organizationId = 'org-1';
+  const environmentId = 'env-1';
+  const subscriberId = 'sub-1';
+
+  const notification = {
+    _id: notificationId,
+    _templateId: 'template-1',
+    _organizationId: organizationId,
+    _environmentId: environmentId,
+    _subscriberId: subscriberId,
+    transactionId: 'txn-1',
+    channels: ['in_app'],
+    to: { subscriberId: 'ext-sub-1' },
+  };
+
+  const workflow = {
+    name: 'Test Workflow',
+    triggers: [{ identifier: 'test-workflow' }],
+  };
+
+  const statusTraceCalls = () =>
+    traceLogRepository.createWorkflowRun.mock.calls.filter((call) =>
+      String(call[0]?.[0]?.event_type || '').startsWith('workflow_run_status_')
+    );
+
+  beforeEach(async () => {
+    notificationRepository = {
+      findOne: jest.fn().mockResolvedValue(notification),
+      tryWorkflowStatusTransition: jest.fn().mockResolvedValue({ isUpdated: true }),
+      tryDeliveryLifecycleTransition: jest.fn().mockResolvedValue({ isUpdated: true }),
+    };
+    notificationTemplateRepository = {
+      findOne: jest.fn().mockResolvedValue(workflow),
+    };
+    traceLogRepository = {
+      createWorkflowRun: jest.fn().mockResolvedValue(undefined),
+    };
+    workflowRunRepository = {
+      updateWorkflowRunState: jest.fn().mockResolvedValue(undefined),
+    };
+    featureFlagsService = {
+      getFlag: jest.fn().mockImplementation(({ key }) => {
+        if (key === FeatureFlagsKeysEnum.IS_WORKFLOW_RUN_TRACES_WRITE_ENABLED) {
+          return Promise.resolve(true);
+        }
+
+        return Promise.resolve(false);
+      }),
+    };
+    logger = {
+      setContext: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WorkflowRunService,
+        { provide: JobRepository, useValue: { find: jest.fn().mockResolvedValue([]) } },
+        { provide: MessageRepository, useValue: { find: jest.fn().mockResolvedValue([]) } },
+        { provide: WorkflowRunRepository, useValue: workflowRunRepository },
+        { provide: NotificationRepository, useValue: notificationRepository },
+        { provide: NotificationTemplateRepository, useValue: notificationTemplateRepository },
+        { provide: TraceLogRepository, useValue: traceLogRepository },
+        { provide: FeatureFlagsService, useValue: featureFlagsService },
+        { provide: PinoLogger, useValue: logger },
+      ],
+    }).compile();
+
+    service = module.get(WorkflowRunService);
+  });
+
+  describe('createWorkflowStatusTrace', () => {
+    it('writes exactly one workflow_run_status_completed on first COMPLETED call', async () => {
+      await service.createWorkflowStatusTrace(
+        notificationId,
+        'workflow_run_status_completed',
+        { organizationId, environmentId },
+        notification,
+        workflow
+      );
+
+      expect(notificationRepository.tryWorkflowStatusTransition).toHaveBeenCalledWith(
+        notificationId,
+        organizationId,
+        environmentId,
+        'workflow_run_status_completed'
+      );
+      expect(traceLogRepository.createWorkflowRun).toHaveBeenCalledTimes(1);
+      expect(traceLogRepository.createWorkflowRun).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event_type: 'workflow_run_status_completed',
+            entity_id: notificationId,
+          }),
+        ])
+      );
+    });
+
+    it('writes zero additional status traces when tryWorkflowStatusTransition returns isUpdated false', async () => {
+      notificationRepository.tryWorkflowStatusTransition.mockResolvedValue({
+        isUpdated: false,
+        previousEvent: 'workflow_run_status_completed',
+      });
+
+      await service.createWorkflowStatusTrace(
+        notificationId,
+        'workflow_run_status_completed',
+        { organizationId, environmentId },
+        notification,
+        workflow
+      );
+
+      expect(notificationRepository.tryWorkflowStatusTransition).toHaveBeenCalledTimes(1);
+      expect(traceLogRepository.createWorkflowRun).not.toHaveBeenCalled();
+      expect(logger.trace).toHaveBeenCalled();
+    });
+
+    it('writes zero status traces for ERROR after COMPLETED was already recorded', async () => {
+      notificationRepository.tryWorkflowStatusTransition.mockResolvedValue({
+        isUpdated: false,
+        previousEvent: 'workflow_run_status_completed',
+      });
+
+      await service.createWorkflowStatusTrace(
+        notificationId,
+        'workflow_run_status_error',
+        { organizationId, environmentId },
+        notification,
+        workflow
+      );
+
+      expect(notificationRepository.tryWorkflowStatusTransition).toHaveBeenCalledWith(
+        notificationId,
+        organizationId,
+        environmentId,
+        'workflow_run_status_error'
+      );
+      expect(traceLogRepository.createWorkflowRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateDeliveryLifecycle', () => {
+    it('writes zero status traces when emitStatusTrace is false', async () => {
+      await service.updateDeliveryLifecycle({
+        workflowStatus: WorkflowRunStatusEnum.COMPLETED,
+        notificationId,
+        environmentId,
+        organizationId,
+        _subscriberId: subscriberId,
+        deliveryLifecycleStatus: DeliveryLifecycleStatusEnum.INTERACTED,
+        notification,
+        workflow,
+        emitStatusTrace: false,
+      });
+
+      expect(notificationRepository.tryWorkflowStatusTransition).not.toHaveBeenCalled();
+      expect(statusTraceCalls()).toHaveLength(0);
+    });
+  });
+});

--- a/libs/application-generic/src/services/workflow-run.service.ts
+++ b/libs/application-generic/src/services/workflow-run.service.ts
@@ -274,36 +274,15 @@ export class WorkflowRunService {
         );
       }
 
-      if (
-        emitStatusTrace &&
-        (workflowStatus === WorkflowRunStatusEnum.COMPLETED ||
-          workflowStatus === WorkflowRunStatusEnum.ERROR ||
-          workflowStatus === WorkflowRunStatusEnum.SUCCESS)
-      ) {
-        if (!notification || !workflow) {
-          const result = await this.getNotificationAndWorkflow(
-            notificationId,
-            organizationId,
-            environmentId,
-            notification,
-            workflow
-          );
-          notification = result.notification;
-          workflow = result.workflow;
-        }
-
-        const statusToEmit =
-          workflowStatus === WorkflowRunStatusEnum.COMPLETED || workflowStatus === WorkflowRunStatusEnum.SUCCESS
-            ? ('workflow_run_status_completed' as const)
-            : ('workflow_run_status_error' as const);
-        await this.createWorkflowStatusTrace(
-          notificationId,
-          statusToEmit,
-          { organizationId, environmentId },
-          notification,
-          workflow
-        );
-      }
+      await this.maybeEmitTerminalStatusTrace({
+        emitStatusTrace,
+        workflowStatus,
+        notificationId,
+        organizationId,
+        environmentId,
+        notification,
+        workflow,
+      });
     } catch (error) {
       this.logger.error(
         {
@@ -428,24 +407,15 @@ export class WorkflowRunService {
         );
       }
 
-      if (
-        emitStatusTrace &&
-        (workflowStatus === WorkflowRunStatusEnum.COMPLETED ||
-          workflowStatus === WorkflowRunStatusEnum.ERROR ||
-          workflowStatus === WorkflowRunStatusEnum.SUCCESS)
-      ) {
-        const statusToEmit =
-          workflowStatus === WorkflowRunStatusEnum.COMPLETED || workflowStatus === WorkflowRunStatusEnum.SUCCESS
-            ? ('workflow_run_status_completed' as const)
-            : ('workflow_run_status_error' as const);
-        await this.createWorkflowStatusTrace(
-          notificationId,
-          statusToEmit,
-          { organizationId, environmentId },
-          notification,
-          workflow
-        );
-      }
+      await this.maybeEmitTerminalStatusTrace({
+        emitStatusTrace,
+        workflowStatus,
+        notificationId,
+        organizationId,
+        environmentId,
+        notification,
+        workflow,
+      });
 
       this.seedDeliveryLifecycleState({
         notificationId,
@@ -579,6 +549,63 @@ export class WorkflowRunService {
     }
   }
 
+  /**
+   * Emits a terminal workflow status trace when allowed. Shared by legacy and
+   * transition delivery-lifecycle paths so the gate/status mapping stays in one place.
+   * Inbox interactions pass emitStatusTrace: false — they update delivery lifecycle
+   * only and must not claim or emit terminal status.
+   */
+  private async maybeEmitTerminalStatusTrace(params: {
+    emitStatusTrace: boolean;
+    workflowStatus: WorkflowRunStatusEnum;
+    notificationId: string;
+    organizationId: string;
+    environmentId: string;
+    notification: NotificationForTrace | null;
+    workflow: Pick<NotificationTemplateEntity, 'name' | 'triggers'> | WorkflowForTrace | null;
+  }): Promise<void> {
+    if (!params.emitStatusTrace) {
+      return;
+    }
+
+    if (
+      params.workflowStatus !== WorkflowRunStatusEnum.COMPLETED &&
+      params.workflowStatus !== WorkflowRunStatusEnum.ERROR &&
+      params.workflowStatus !== WorkflowRunStatusEnum.SUCCESS
+    ) {
+      return;
+    }
+
+    let notification = params.notification;
+    let workflow = params.workflow;
+
+    if (!notification || !workflow) {
+      const result = await this.getNotificationAndWorkflow(
+        params.notificationId,
+        params.organizationId,
+        params.environmentId,
+        notification,
+        workflow
+      );
+      notification = result.notification;
+      workflow = result.workflow;
+    }
+
+    const statusToEmit: TerminalWorkflowStatusEvent =
+      params.workflowStatus === WorkflowRunStatusEnum.COMPLETED ||
+      params.workflowStatus === WorkflowRunStatusEnum.SUCCESS
+        ? 'workflow_run_status_completed'
+        : 'workflow_run_status_error';
+
+    await this.createWorkflowStatusTrace(
+      params.notificationId,
+      statusToEmit,
+      { organizationId: params.organizationId, environmentId: params.environmentId },
+      notification,
+      workflow
+    );
+  }
+
   async createWorkflowStatusTrace(
     notificationId: string,
     status: TerminalWorkflowStatusEvent,
@@ -611,6 +638,8 @@ export class WorkflowRunService {
         return;
       }
 
+      // Claim before write: same at-most-once tradeoff as delivery-lifecycle transitions —
+      // prefer undercount over duplicate ClickHouse status counts if the write fails after claim.
       const { isUpdated } = await this.notificationRepository.tryWorkflowStatusTransition(
         notificationId,
         context.organizationId,

--- a/libs/application-generic/src/services/workflow-run.service.ts
+++ b/libs/application-generic/src/services/workflow-run.service.ts
@@ -79,6 +79,13 @@ export interface WorkflowStatusUpdateParams {
    * where no notification template exists in the database to look up.
    */
   workflow?: WorkflowForTrace | null;
+  /**
+   * When false, skip emitting terminal workflow status traces
+   * (`workflow_run_status_completed` / `workflow_run_status_error`).
+   * Defaults to true. Inbox interactions set this to false to avoid
+   * re-emitting status traces that inflate ClickHouse counts.
+   */
+  emitStatusTrace?: boolean;
 }
 
 type JobResult = Pick<JobEntity, 'type' | 'status' | 'deliveryLifecycleState' | '_id' | '_mergedDigestId'>;
@@ -175,6 +182,7 @@ export class WorkflowRunService {
     notification: passedNotification,
     currentJob,
     workflow: passedWorkflow,
+    emitStatusTrace = true,
   }: WorkflowStatusUpdateParams): Promise<void> {
     try {
       let deliveryLifecycleStatus: DeliveryLifecycleStatusEnum;
@@ -269,9 +277,10 @@ export class WorkflowRunService {
       }
 
       if (
-        workflowStatus === WorkflowRunStatusEnum.COMPLETED ||
-        workflowStatus === WorkflowRunStatusEnum.ERROR ||
-        workflowStatus === WorkflowRunStatusEnum.SUCCESS
+        emitStatusTrace &&
+        (workflowStatus === WorkflowRunStatusEnum.COMPLETED ||
+          workflowStatus === WorkflowRunStatusEnum.ERROR ||
+          workflowStatus === WorkflowRunStatusEnum.SUCCESS)
       ) {
         if (!notification || !workflow) {
           const result = await this.getNotificationAndWorkflow(
@@ -319,6 +328,7 @@ export class WorkflowRunService {
     notification: passedNotification,
     currentJob,
     workflow: passedWorkflow,
+    emitStatusTrace = true,
   }: WorkflowStatusUpdateParams): Promise<void> {
     try {
       let deliveryLifecycleStatus: DeliveryLifecycleStatusEnum;
@@ -421,9 +431,10 @@ export class WorkflowRunService {
       }
 
       if (
-        workflowStatus === WorkflowRunStatusEnum.COMPLETED ||
-        workflowStatus === WorkflowRunStatusEnum.ERROR ||
-        workflowStatus === WorkflowRunStatusEnum.SUCCESS
+        emitStatusTrace &&
+        (workflowStatus === WorkflowRunStatusEnum.COMPLETED ||
+          workflowStatus === WorkflowRunStatusEnum.ERROR ||
+          workflowStatus === WorkflowRunStatusEnum.SUCCESS)
       ) {
         const statusToEmit =
           workflowStatus === WorkflowRunStatusEnum.COMPLETED || workflowStatus === WorkflowRunStatusEnum.SUCCESS
@@ -587,6 +598,28 @@ export class WorkflowRunService {
       });
 
       if (!isTracesWriteEnabled) {
+        return;
+      }
+
+      const { isUpdated, previousEvent } = await this.notificationRepository.tryWorkflowStatusTransition(
+        notificationId,
+        context.organizationId,
+        context.environmentId,
+        status as 'workflow_run_status_completed' | 'workflow_run_status_error'
+      );
+
+      if (!isUpdated) {
+        this.logger.trace(
+          {
+            notificationId,
+            status,
+            previousEvent,
+            organizationId: context.organizationId,
+            environmentId: context.environmentId,
+          },
+          'Skipped workflow status trace - already emitted for this run'
+        );
+
         return;
       }
 

--- a/libs/application-generic/src/services/workflow-run.service.ts
+++ b/libs/application-generic/src/services/workflow-run.service.ts
@@ -8,6 +8,7 @@ import {
   NotificationRepository,
   NotificationTemplateEntity,
   NotificationTemplateRepository,
+  TerminalWorkflowStatusEvent,
 } from '@novu/dal';
 import {
   DeliveryLifecycleDetail,
@@ -18,7 +19,6 @@ import {
 } from '@novu/shared';
 import { PinoLogger } from '../logging';
 import {
-  EventType,
   TraceLogRepository,
   WorkflowRunRepository,
   WorkflowRunStatusEnum,
@@ -37,8 +37,6 @@ const DELIVERY_STATUS_TO_EVENT: Record<DeliveryLifecycleStatusEnum, DeliveryLife
   [DeliveryLifecycleStatusEnum.DELIVERED]: 'workflow_run_delivery_delivered',
   [DeliveryLifecycleStatusEnum.INTERACTED]: 'workflow_run_delivery_interacted',
 };
-
-export type WorkflowRunStatusEventType = Extract<EventType, `workflow_run_status_${string}`>;
 
 export type NotificationForTrace = {
   _id: string;
@@ -583,7 +581,7 @@ export class WorkflowRunService {
 
   async createWorkflowStatusTrace(
     notificationId: string,
-    status: WorkflowRunStatusEventType,
+    status: TerminalWorkflowStatusEvent,
     context: { organizationId: string; environmentId: string; userId?: string },
     passedNotification?: NotificationForTrace | null,
     passedWorkflow?: WorkflowForTrace | null
@@ -601,28 +599,6 @@ export class WorkflowRunService {
         return;
       }
 
-      const { isUpdated, previousEvent } = await this.notificationRepository.tryWorkflowStatusTransition(
-        notificationId,
-        context.organizationId,
-        context.environmentId,
-        status as 'workflow_run_status_completed' | 'workflow_run_status_error'
-      );
-
-      if (!isUpdated) {
-        this.logger.trace(
-          {
-            notificationId,
-            status,
-            previousEvent,
-            organizationId: context.organizationId,
-            environmentId: context.environmentId,
-          },
-          'Skipped workflow status trace - already emitted for this run'
-        );
-
-        return;
-      }
-
       const { notification, workflow } = await this.getNotificationAndWorkflow(
         notificationId,
         context.organizationId,
@@ -632,6 +608,27 @@ export class WorkflowRunService {
       );
 
       if (!notification || !workflow) {
+        return;
+      }
+
+      const { isUpdated } = await this.notificationRepository.tryWorkflowStatusTransition(
+        notificationId,
+        context.organizationId,
+        context.environmentId,
+        status
+      );
+
+      if (!isUpdated) {
+        this.logger.trace(
+          {
+            notificationId,
+            status,
+            organizationId: context.organizationId,
+            environmentId: context.environmentId,
+          },
+          'Skipped workflow status trace - already emitted for this run'
+        );
+
         return;
       }
 

--- a/libs/application-generic/src/services/workflow-run.service.ts
+++ b/libs/application-generic/src/services/workflow-run.service.ts
@@ -549,12 +549,7 @@ export class WorkflowRunService {
     }
   }
 
-  /**
-   * Emits a terminal workflow status trace when allowed. Shared by legacy and
-   * transition delivery-lifecycle paths so the gate/status mapping stays in one place.
-   * Inbox interactions pass emitStatusTrace: false — they update delivery lifecycle
-   * only and must not claim or emit terminal status.
-   */
+  /** Shared gate for legacy/transition paths; Inbox passes emitStatusTrace: false. */
   private async maybeEmitTerminalStatusTrace(params: {
     emitStatusTrace: boolean;
     workflowStatus: WorkflowRunStatusEnum;

--- a/libs/dal/src/repositories/notification/notification.entity.ts
+++ b/libs/dal/src/repositories/notification/notification.entity.ts
@@ -23,6 +23,8 @@ export type NotificationTopic = {
   preferenceEvaluation?: TopicPreferenceEvaluation;
 };
 
+export type TerminalWorkflowStatusEvent = 'workflow_run_status_completed' | 'workflow_run_status_error';
+
 export class NotificationEntity {
   _id: string;
 
@@ -60,7 +62,7 @@ export class NotificationEntity {
   critical?: boolean;
   contextKeys?: string[];
   lastEmittedDeliveryEvent?: DeliveryLifecycleEventType;
-  lastEmittedWorkflowStatusEvent?: 'workflow_run_status_completed' | 'workflow_run_status_error';
+  lastEmittedWorkflowStatusEvent?: TerminalWorkflowStatusEvent;
 }
 
 export type NotificationDBModel = ChangePropsValueType<

--- a/libs/dal/src/repositories/notification/notification.entity.ts
+++ b/libs/dal/src/repositories/notification/notification.entity.ts
@@ -60,6 +60,7 @@ export class NotificationEntity {
   critical?: boolean;
   contextKeys?: string[];
   lastEmittedDeliveryEvent?: DeliveryLifecycleEventType;
+  lastEmittedWorkflowStatusEvent?: 'workflow_run_status_completed' | 'workflow_run_status_error';
 }
 
 export type NotificationDBModel = ChangePropsValueType<

--- a/libs/dal/src/repositories/notification/notification.repository.ts
+++ b/libs/dal/src/repositories/notification/notification.repository.ts
@@ -415,4 +415,37 @@ export class NotificationRepository extends BaseRepository<
       previousEvent: result?.lastEmittedDeliveryEvent as DeliveryLifecycleEventType | undefined,
     };
   }
+
+  /**
+   * Atomically records the first terminal workflow status event for a notification.
+   * Once completed or error is set, neither is emitted again.
+   */
+  async tryWorkflowStatusTransition(
+    notificationId: string,
+    organizationId: string,
+    environmentId: string,
+    targetEvent: 'workflow_run_status_completed' | 'workflow_run_status_error'
+  ): Promise<{
+    isUpdated: boolean;
+    previousEvent?: 'workflow_run_status_completed' | 'workflow_run_status_error';
+  }> {
+    const result = await this.findOneAndUpdate(
+      {
+        _id: notificationId,
+        _organizationId: organizationId,
+        _environmentId: environmentId,
+        $or: [{ lastEmittedWorkflowStatusEvent: { $exists: false } }, { lastEmittedWorkflowStatusEvent: null }],
+      },
+      { $set: { lastEmittedWorkflowStatusEvent: targetEvent } },
+      { returnDocument: 'before' }
+    );
+
+    return {
+      isUpdated: result !== null,
+      previousEvent: result?.lastEmittedWorkflowStatusEvent as
+        | 'workflow_run_status_completed'
+        | 'workflow_run_status_error'
+        | undefined,
+    };
+  }
 }

--- a/libs/dal/src/repositories/notification/notification.repository.ts
+++ b/libs/dal/src/repositories/notification/notification.repository.ts
@@ -5,7 +5,7 @@ import { FilterQuery, QueryWithHelpers, Types } from 'mongoose';
 import type { EnforceEnvOrOrgIds } from '../../types';
 import { BaseRepository } from '../base-repository';
 import { EnvironmentId } from '../environment';
-import { NotificationDBModel, NotificationEntity } from './notification.entity';
+import { NotificationDBModel, NotificationEntity, TerminalWorkflowStatusEvent } from './notification.entity';
 import { NotificationFeedItemEntity } from './notification.feed.Item.entity';
 import { Notification } from './notification.schema';
 
@@ -424,11 +424,8 @@ export class NotificationRepository extends BaseRepository<
     notificationId: string,
     organizationId: string,
     environmentId: string,
-    targetEvent: 'workflow_run_status_completed' | 'workflow_run_status_error'
-  ): Promise<{
-    isUpdated: boolean;
-    previousEvent?: 'workflow_run_status_completed' | 'workflow_run_status_error';
-  }> {
+    targetEvent: TerminalWorkflowStatusEvent
+  ): Promise<{ isUpdated: boolean }> {
     const result = await this.findOneAndUpdate(
       {
         _id: notificationId,
@@ -442,10 +439,6 @@ export class NotificationRepository extends BaseRepository<
 
     return {
       isUpdated: result !== null,
-      previousEvent: result?.lastEmittedWorkflowStatusEvent as
-        | 'workflow_run_status_completed'
-        | 'workflow_run_status_error'
-        | undefined,
     };
   }
 }

--- a/libs/dal/src/repositories/notification/notification.schema.ts
+++ b/libs/dal/src/repositories/notification/notification.schema.ts
@@ -73,6 +73,9 @@ const notificationSchema = new Schema<NotificationDBModel>(
     lastEmittedDeliveryEvent: {
       type: Schema.Types.String,
     },
+    lastEmittedWorkflowStatusEvent: {
+      type: Schema.Types.String,
+    },
   },
   schemaOptions
 );


### PR DESCRIPTION
## Summary

- ClickHouse `workflow_run_count` was inflating `workflow_run_status_completed` because every Inbox interaction (and every worker `updateDeliveryLifecycle(COMPLETED)` call) re-emitted a terminal status trace into `traces`, which the materialized view sums.
- Add an atomic once-only guard on the notification (`lastEmittedWorkflowStatusEvent` + `tryWorkflowStatusTransition`), claim after resolve so missing entities do not burn the slot, and skip status emission from Inbox via `emitStatusTrace: false`.
- Fix forward only — historical inflated counts age out via TTL.

```mermaid
flowchart LR
  worker[Worker terminal paths] -->|COMPLETED or ERROR| maybeEmit[maybeEmitTerminalStatusTrace]
  inbox[Inbox interactions] -->|"emitStatusTrace: false"| lifecycleOnly[Delivery lifecycle only]
  maybeEmit --> claim[tryWorkflowStatusTransition]
  claim -->|first win| traces[traces + workflow_run_count]
  claim -->|already claimed| skip[Skip duplicate]
```

## What changed

- DAL: `lastEmittedWorkflowStatusEvent` on notification + `tryWorkflowStatusTransition` (org/env scoped)
- `WorkflowRunService`: shared `maybeEmitTerminalStatusTrace`; `createWorkflowStatusTrace` claims once then writes
- `MessageInteractionService`: `emitStatusTrace: false`
- Unit coverage for once-only emit and both legacy/transition opt-out paths

## Test plan

- [x] `libs/application-generic` unit: `workflow-run.service.spec.ts` (5 tests)
- [ ] Trigger a multi-step in-app workflow, then mark seen/read repeatedly — `workflow_run_count` should gain exactly one `completed` per run
- [ ] Confirm activity feed run count still matches `workflow_run_status_processing`
- [ ] Worker multi-step completion still emits a single completed status trace

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes terminal workflow-status trace emission atomic and suppresses duplicate status traces from Inbox interactions.
- Adds a tenant-scoped, first-terminal-event claim to notification persistence.
- Routes legacy and transition lifecycle paths through a shared terminal-status emission gate.
- Disables terminal-status emission for Inbox-driven lifecycle updates.
- Adds unit coverage for once-only emission and Inbox opt-out behavior.

<h3>Confidence Score: 3/5</h3>

The claim-before-write failure path must be fixed before merging because it permanently loses terminal workflow traces after a ClickHouse insert failure.

The MongoDB claim is persisted before the ClickHouse trace write, and the write error is swallowed; subsequent terminal updates observe the existing claim and cannot repair the missing analytics event.

**Files Needing Attention:** libs/application-generic/src/services/workflow-run.service.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/message-interaction.service.ts | Inbox interactions now update delivery lifecycle state without re-emitting terminal workflow-status traces. |
| libs/application-generic/src/services/workflow-run.service.ts | Adds the shared terminal trace gate, but claiming before the ClickHouse write permanently suppresses retries after an insert failure. |
| libs/application-generic/src/services/workflow-run.service.spec.ts | Adds focused tests for first-write behavior, duplicate suppression, and opt-out behavior, without covering a failed write after a successful claim. |
| libs/dal/src/repositories/notification/notification.repository.ts | Adds an organization- and environment-scoped atomic first-terminal-event transition. |
| libs/dal/src/repositories/notification/notification.entity.ts | Adds the persisted terminal workflow-status event type to the notification entity. |
| libs/dal/src/repositories/notification/notification.schema.ts | Registers the new terminal workflow-status claim field in the Mongoose schema. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Worker["Worker terminal lifecycle update"] --> Gate["Terminal status emission gate"]
  Inbox["Inbox interaction"] -->|"emitStatusTrace: false"| Lifecycle["Delivery lifecycle update only"]
  Gate --> Resolve["Resolve notification and workflow"]
  Resolve --> Claim["Atomically claim first terminal event in MongoDB"]
  Claim -->|Claimed| Trace["Write terminal trace to ClickHouse"]
  Claim -->|Already claimed| Skip["Skip duplicate trace"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Fapplication-generic%2Fsrc%2Fservices%2Fworkflow-run.service.ts%3A638-643%0A**Claim%20permanently%20drops%20failed%20writes**%0A%0AWhen%20the%20MongoDB%20claim%20succeeds%20but%20the%20subsequent%20ClickHouse%20insert%20fails%2C%20the%20error%20is%20swallowed%20while%20the%20claim%20remains%20set%2C%20causing%20every%20later%20terminal%20update%20to%20skip%20the%20trace%20and%20permanently%20undercount%20completed%20or%20errored%20workflow%20runs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12143&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/application-generic/src/services/workflow-run.service.ts:638-643
**Claim permanently drops failed writes**

When the MongoDB claim succeeds but the subsequent ClickHouse insert fails, the error is swallowed while the claim remains set, causing every later terminal update to skip the trace and permanently undercount completed or errored workflow runs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(application-generic): trim stat..."](https://github.com/novuhq/novu/commit/6cdd82545ee4a37e1dd00e2977abd11cf902eb1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48297704)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)
- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)

<!-- /greptile_comment -->