### PR TITLE
feat(api-service): list resume ACL and history pagination fixes NV-8441

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -91,6 +91,7 @@ import { USE_CASES } from './usecases';
 import { WebChatController } from './web-chat/web-chat.controller';
 import { WebChatPlatformDeliveryService } from './web-chat/web-chat-platform-delivery.service';
 import { WebChatPublicationService } from './web-chat/web-chat-publication.service';
+import { WebChatResumeAuthorizationService } from './web-chat/web-chat-resume-authorization.service';
 import { WebChatSessionVerifier } from './web-chat/web-chat-session.verifier';
 
 @Module({
@@ -168,6 +169,7 @@ import { WebChatSessionVerifier } from './web-chat/web-chat-session.verifier';
     NovuWebChatProvisioningService,
     WebChatPublicationService,
     WebChatSessionVerifier,
+    WebChatResumeAuthorizationService,
     WebChatPlatformDeliveryService,
     McpNovuAppCredentialsService,
     DemoClaudeQuotaPolicy,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -10,6 +10,7 @@ import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { esmImport } from '../../shared/util/esm-import';
 import { WebChatPlatformDeliveryService } from '../../web-chat/web-chat-platform-delivery.service';
+import { WebChatResumeAuthorizationService } from '../../web-chat/web-chat-resume-authorization.service';
 import { WebChatSessionVerifier } from '../../web-chat/web-chat-session.verifier';
 import { AgentActionTokenService } from '../action-token/agent-action-token.service';
 import type { InboundReactionEvent } from './inbound-turn.handler';
@@ -85,7 +86,8 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     private readonly agentActionTokenService: AgentActionTokenService,
     private readonly agentEmailSender: AgentEmailSender,
     private readonly webChatSessionVerifier: WebChatSessionVerifier,
-    private readonly webChatPlatformDelivery: WebChatPlatformDeliveryService
+    private readonly webChatPlatformDelivery: WebChatPlatformDeliveryService,
+    private readonly webChatResumeAuthorization: WebChatResumeAuthorizationService
   ) {
     this.logger.setContext(this.constructor.name);
     this.instances = new LRUCache<string, CachedChat>({
@@ -451,6 +453,8 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
           web_chat: createWebChatAdapter({
             userName: config.agentName,
             verifySession: (request) => this.webChatSessionVerifier.verifySession(request),
+            authorizeResume: ({ conversationId, session }) =>
+              this.webChatResumeAuthorization.canResume({ conversationId, session, agentId }),
             deliverMessage: this.webChatPlatformDelivery.createDeliverMessage(deliveryContext),
             editMessage: this.webChatPlatformDelivery.createEditMessage(deliveryContext),
             deleteMessage: this.webChatPlatformDelivery.createDeleteMessage(deliveryContext),

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -79,8 +79,21 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     return res.body.data;
   }
 
-  function createConversation(body: { agentId: string; text: string; id?: string }, token = subscriberToken) {
+  function createConversation(
+    body: { agentId: string; text: string; id?: string; conversationIdentifier?: string },
+    token = subscriberToken
+  ) {
     return ctx.session.testAgent.post('/v1/web-chat/conversations').set('Authorization', `Bearer ${token}`).send(body);
+  }
+
+  function listConversations(token = subscriberToken, query: { after?: string; before?: string; limit?: number } = {}) {
+    return ctx.session.testAgent.get('/v1/web-chat/conversations').query(query).set('Authorization', `Bearer ${token}`);
+  }
+
+  function getConversation(conversationIdentifier: string, token = subscriberToken) {
+    return ctx.session.testAgent
+      .get(`/v1/web-chat/conversations/${conversationIdentifier}`)
+      .set('Authorization', `Bearer ${token}`);
   }
 
   function getEvents(
@@ -92,6 +105,29 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       .get(`/v1/web-chat/conversations/${conversationIdentifier}/events`)
       .query(query)
       .set('Authorization', `Bearer ${token}`);
+  }
+
+  async function createOtherSubscriberToken() {
+    const otherSubscriberId = `other-sub-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const otherSession = await ctx.session.testAgent.post('/v1/inbox/session').send({
+      applicationIdentifier: ctx.session.environment.identifier,
+      subscriberId: otherSubscriberId,
+    });
+    expect(otherSession.status).to.equal(201);
+
+    return otherSession.body.data.token as string;
+  }
+
+  async function waitForConversation(identifier: string) {
+    return pollFor(() =>
+      conversationRepository.findOne(
+        {
+          identifier,
+          _environmentId: ctx.session.environment._id,
+        },
+        '*'
+      )
+    );
   }
 
   function messageEnvelope(conversationId: string, messageId: string): AgentEventEnvelope {
@@ -323,14 +359,8 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       )
     );
 
-    const otherSubscriberId = `other-sub-${Date.now()}`;
-    const otherSession = await ctx.session.testAgent.post('/v1/inbox/session').send({
-      applicationIdentifier: ctx.session.environment.identifier,
-      subscriberId: otherSubscriberId,
-    });
-    expect(otherSession.status).to.equal(201);
-
-    const eventsRes = await getEvents(createRes.body.data.identifier, otherSession.body.data.token);
+    const otherToken = await createOtherSubscriberToken();
+    const eventsRes = await getEvents(createRes.body.data.identifier, otherToken);
     expect(eventsRes.status).to.equal(404);
   });
 
@@ -359,5 +389,186 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
 
     const eventsRes = await getEvents(slackConversation.identifier);
     expect(eventsRes.status).to.equal(404);
+  });
+
+  it('should list only the subscriber web-chat conversations', async () => {
+    await linkWebChat();
+
+    const mineA = await createConversation({ agentId: ctx.agentIdentifier, text: 'Mine A' });
+    const mineB = await createConversation({ agentId: ctx.agentIdentifier, text: 'Mine B' });
+    expect(mineA.status).to.equal(201);
+    expect(mineB.status).to.equal(201);
+    await waitForConversation(mineA.body.data.identifier);
+    await waitForConversation(mineB.body.data.identifier);
+
+    const otherToken = await createOtherSubscriberToken();
+    const otherRes = await createConversation(
+      { agentId: ctx.agentIdentifier, text: 'Other subscriber thread' },
+      otherToken
+    );
+    expect(otherRes.status).to.equal(201);
+    await waitForConversation(otherRes.body.data.identifier);
+
+    await conversationRepository.create({
+      identifier: `conv_e2e_slack_list_${Date.now()}`,
+      _agentId: ctx.agentId,
+      participants: [
+        { type: ConversationParticipantTypeEnum.AGENT, id: ctx.agentId },
+        { type: ConversationParticipantTypeEnum.SUBSCRIBER, id: ctx.session.subscriberId },
+      ],
+      channels: [
+        {
+          platform: 'slack',
+          _integrationId: ctx.integrationId,
+          platformThreadId: `thread-list-${Date.now()}`,
+        },
+      ],
+      status: 'active',
+      title: 'Slack should be hidden',
+      metadata: {},
+      _environmentId: ctx.session.environment._id,
+      _organizationId: ctx.session.organization._id,
+      lastActivityAt: new Date().toISOString(),
+    });
+
+    const listRes = await listConversations();
+    expect(listRes.status).to.equal(200);
+    expect(listRes.body.data).to.be.an('array');
+
+    const identifiers = listRes.body.data.map((item: { identifier: string }) => item.identifier);
+    expect(identifiers).to.include(mineA.body.data.identifier);
+    expect(identifiers).to.include(mineB.body.data.identifier);
+    expect(identifiers).to.not.include(otherRes.body.data.identifier);
+
+    const first = listRes.body.data.find(
+      (item: { identifier: string }) => item.identifier === mineA.body.data.identifier
+    );
+    expect(first).to.include.keys('identifier', 'title', 'status', 'agentIdentifier', 'lastActivityAt', 'createdAt');
+    expect(first.agentIdentifier).to.equal(ctx.agentIdentifier);
+    expect(first).to.not.have.property('participants');
+  });
+
+  it('should return conversation metadata for participants and 404 for others', async () => {
+    await linkWebChat();
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Metadata thread',
+    });
+    expect(createRes.status).to.equal(201);
+    await waitForConversation(createRes.body.data.identifier);
+
+    const getRes = await getConversation(createRes.body.data.identifier);
+    expect(getRes.status).to.equal(200);
+    expect(getRes.body.data.identifier).to.equal(createRes.body.data.identifier);
+    expect(getRes.body.data.agentIdentifier).to.equal(ctx.agentIdentifier);
+    expect(getRes.body.data).to.include.keys('title', 'status', 'lastActivityAt', 'createdAt');
+
+    const otherToken = await createOtherSubscriberToken();
+    const denied = await getConversation(createRes.body.data.identifier, otherToken);
+    expect(denied.status).to.equal(404);
+  });
+
+  it('should resume an existing conversation when conversationIdentifier ACL passes', async () => {
+    await linkWebChat();
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Original message',
+    });
+    expect(createRes.status).to.equal(201);
+    const identifier = createRes.body.data.identifier as string;
+    const conversation = await waitForConversation(identifier);
+
+    const resumeRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Follow-up message',
+      conversationIdentifier: identifier,
+    });
+    expect(resumeRes.status).to.equal(201);
+    expect(resumeRes.body.data.identifier).to.equal(identifier);
+
+    const subscriberMessages = await pollFor(async () => {
+      const activities = await activityRepository.findByConversation(ctx.session.environment._id, conversation._id, 50);
+      const messages = activities.filter(
+        (a) =>
+          a.senderType === ConversationActivitySenderTypeEnum.SUBSCRIBER &&
+          a.type === ConversationActivityTypeEnum.MESSAGE
+      );
+
+      return messages.length >= 2 ? messages : null;
+    });
+    expect(subscriberMessages.map((a) => a.content)).to.include.members(['Original message', 'Follow-up message']);
+  });
+
+  it('should reject resume when conversationIdentifier ACL fails', async () => {
+    await linkWebChat();
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Owner only',
+    });
+    expect(createRes.status).to.equal(201);
+    await waitForConversation(createRes.body.data.identifier);
+
+    const otherToken = await createOtherSubscriberToken();
+    const denied = await createConversation(
+      {
+        agentId: ctx.agentIdentifier,
+        text: 'Should fail',
+        conversationIdentifier: createRes.body.data.identifier,
+      },
+      otherToken
+    );
+    expect(denied.status).to.equal(404);
+  });
+
+  it('should still create a new conversation when conversationIdentifier is omitted', async () => {
+    await linkWebChat();
+
+    const first = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'First thread',
+    });
+    const second = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Second thread',
+    });
+
+    expect(first.status).to.equal(201);
+    expect(second.status).to.equal(201);
+    expect(second.body.data.identifier).to.not.equal(first.body.data.identifier);
+    expect(second.body.data.identifier).to.match(/^conv_/);
+  });
+
+  it('should paginate durable history with afterSequence', async () => {
+    await linkWebChat();
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Sequence start',
+    });
+    expect(createRes.status).to.equal(201);
+
+    const conversation = await waitForConversation(createRes.body.data.identifier);
+
+    await ctx.session.testAgent.post('/v1/agents/events/ingest').send({
+      events: [messageEnvelope(conversation._id, `msg-seq-${Date.now()}`)],
+    });
+
+    const fullPage = await getEvents(createRes.body.data.identifier);
+    expect(fullPage.status).to.equal(200);
+    expect(fullPage.body.data.events.length).to.be.greaterThan(1);
+
+    const firstSequence = fullPage.body.data.events[0].sequence as number;
+    const gapFill = await getEvents(createRes.body.data.identifier, subscriberToken, {
+      afterSequence: firstSequence,
+      limit: 50,
+    });
+    expect(gapFill.status).to.equal(200);
+    expect(gapFill.body.data.events.length).to.be.greaterThan(0);
+    for (const envelope of gapFill.body.data.events) {
+      expect(envelope.sequence).to.be.greaterThan(firstSequence);
+    }
   });
 });

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -44,7 +44,9 @@ import { GenerateMcpOAuthUrl } from '../mcp/oauth/generate-mcp-oauth-url/generat
 import { McpOAuthCallback } from '../mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase';
 import { ListAgentEmoji } from '../shared/emoji/list-agent-emoji/list-agent-emoji.usecase';
 import { IngestAgentEvents } from '../shared/ingest-agent-events/ingest-agent-events.usecase';
+import { GetWebChatConversation } from '../web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.usecase';
 import { ListWebChatConversationEvents } from '../web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase';
+import { ListWebChatConversations } from '../web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase';
 
 export { ConsumeSlackSetupLink, GetSlackSetupLinkStatus, IssueSlackSetupLink };
 
@@ -95,5 +97,7 @@ export const USE_CASES = [
   HandleNovuTools,
   HandleNovuResolve,
   IngestAgentEvents,
+  GetWebChatConversation,
+  ListWebChatConversations,
   ListWebChatConversationEvents,
 ];

--- a/apps/api/src/app/agents/web-chat/dtos/web-chat-conversation.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/web-chat-conversation.dto.ts
@@ -1,0 +1,38 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class WebChatConversationMetadataDto {
+  identifier: string;
+  title: string;
+  status: string;
+  agentIdentifier: string;
+  lastActivityAt: string;
+  createdAt: string;
+}
+
+export class ListWebChatConversationsQueryDto {
+  /** Cursor: conversation `_id` for forward pagination. */
+  @IsOptional()
+  @IsString()
+  after?: string;
+
+  /** Cursor: conversation `_id` for reverse pagination. */
+  @IsOptional()
+  @IsString()
+  before?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class ListWebChatConversationsResponseDto {
+  data: WebChatConversationMetadataDto[];
+  next: string | null;
+  previous: string | null;
+  totalCount: number;
+  totalCountCapped: boolean;
+}

--- a/apps/api/src/app/agents/web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.command.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.command.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { EnvironmentWithSubscriber } from '../../../../shared/commands/project.command';
+
+export class GetWebChatConversationCommand extends EnvironmentWithSubscriber {
+  @IsString()
+  @IsNotEmpty()
+  conversationIdentifier: string;
+}

--- a/apps/api/src/app/agents/web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.usecase.ts
@@ -1,0 +1,63 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { AgentRepository, ConversationParticipantTypeEnum, ConversationRepository } from '@novu/dal';
+import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
+import type { WebChatConversationMetadataDto } from '../../dtos/web-chat-conversation.dto';
+import { GetWebChatConversationCommand } from './get-web-chat-conversation.command';
+
+@Injectable()
+export class GetWebChatConversation {
+  constructor(
+    private readonly conversationRepository: ConversationRepository,
+    private readonly agentRepository: AgentRepository
+  ) {}
+
+  async execute(command: GetWebChatConversationCommand): Promise<WebChatConversationMetadataDto> {
+    const conversation = await this.conversationRepository.findOne(
+      {
+        identifier: command.conversationIdentifier,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      '*'
+    );
+
+    if (!conversation) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const isParticipant = conversation.participants.some(
+      (participant) =>
+        participant.type === ConversationParticipantTypeEnum.SUBSCRIBER && participant.id === command.subscriberId
+    );
+
+    if (!isParticipant) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const isWebChatConversation = conversation.channels.some(
+      (channel) => channel.platform === AgentPlatformEnum.WEB_CHAT
+    );
+
+    if (!isWebChatConversation) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const agent = await this.agentRepository.findOne(
+      { _id: conversation._agentId, _environmentId: command.environmentId },
+      ['identifier']
+    );
+
+    if (!agent) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    return {
+      identifier: conversation.identifier,
+      title: conversation.title,
+      status: conversation.status,
+      agentIdentifier: agent.identifier,
+      lastActivityAt: conversation.lastActivityAt,
+      createdAt: conversation.createdAt,
+    };
+  }
+}

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.command.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.command.ts
@@ -1,0 +1,21 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+import { EnvironmentWithSubscriber } from '../../../../shared/commands/project.command';
+
+export class ListWebChatConversationsCommand extends EnvironmentWithSubscriber {
+  /** Cursor: conversation `_id` — fetch conversations after this id (forward pagination). */
+  @IsOptional()
+  @IsString()
+  after?: string;
+
+  /** Cursor: conversation `_id` — fetch conversations before this id (reverse pagination). */
+  @IsOptional()
+  @IsString()
+  before?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit = 50;
+}

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts
@@ -1,0 +1,86 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { AgentRepository, ConversationEntity, ConversationRepository } from '@novu/dal';
+import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
+import type { WebChatConversationMetadataDto } from '../../dtos/web-chat-conversation.dto';
+import { ListWebChatConversationsCommand } from './list-web-chat-conversations.command';
+
+type ListResult = {
+  data: WebChatConversationMetadataDto[];
+  next: string | null;
+  previous: string | null;
+  totalCount: number;
+  totalCountCapped: boolean;
+};
+
+@Injectable()
+export class ListWebChatConversations {
+  constructor(
+    private readonly conversationRepository: ConversationRepository,
+    private readonly agentRepository: AgentRepository
+  ) {}
+
+  async execute(command: ListWebChatConversationsCommand): Promise<ListResult> {
+    if (command.after && command.before) {
+      throw new BadRequestException('Cannot specify both "before" and "after" cursors at the same time.');
+    }
+
+    const page = await this.conversationRepository.listConversations({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: command.subscriberId,
+      provider: [AgentPlatformEnum.WEB_CHAT],
+      after: command.after,
+      before: command.before,
+      limit: command.limit,
+      sortBy: 'lastActivityAt',
+      sortDirection: -1,
+    });
+
+    const agentIdentifierById = await this.resolveAgentIdentifiers(
+      command.environmentId,
+      page.data.map((conversation) => conversation._agentId)
+    );
+
+    return {
+      data: page.data
+        .map((conversation) => this.toMetadata(conversation, agentIdentifierById.get(conversation._agentId)))
+        .filter((item): item is WebChatConversationMetadataDto => item !== null),
+      next: page.next,
+      previous: page.previous,
+      totalCount: page.totalCount,
+      totalCountCapped: page.totalCountCapped,
+    };
+  }
+
+  private async resolveAgentIdentifiers(environmentId: string, agentIds: string[]): Promise<Map<string, string>> {
+    const uniqueIds = [...new Set(agentIds.filter(Boolean))];
+    if (uniqueIds.length === 0) {
+      return new Map();
+    }
+
+    const agents = await this.agentRepository.find({ _id: { $in: uniqueIds }, _environmentId: environmentId }, [
+      '_id',
+      'identifier',
+    ]);
+
+    return new Map(agents.map((agent) => [agent._id, agent.identifier]));
+  }
+
+  private toMetadata(
+    conversation: ConversationEntity,
+    agentIdentifier: string | undefined
+  ): WebChatConversationMetadataDto | null {
+    if (!agentIdentifier) {
+      return null;
+    }
+
+    return {
+      identifier: conversation.identifier,
+      title: conversation.title,
+      status: conversation.status,
+      agentIdentifier,
+      lastActivityAt: conversation.lastActivityAt,
+      createdAt: conversation.createdAt,
+    };
+  }
+}

--- a/apps/api/src/app/agents/web-chat/web-chat-resume-authorization.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-resume-authorization.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import type { WebChatSession } from '@novu/chat-adapter-web';
+import { ConversationParticipantTypeEnum, ConversationRepository } from '@novu/dal';
+import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
+
+@Injectable()
+export class WebChatResumeAuthorizationService {
+  constructor(private readonly conversationRepository: ConversationRepository) {}
+
+  /**
+   * Participant + web_chat + agent match. Returns false for any denial (404 semantics upstream).
+   */
+  async canResume(params: { conversationId: string; session: WebChatSession; agentId: string }): Promise<boolean> {
+    const conversation = await this.conversationRepository.findOne(
+      {
+        identifier: params.conversationId,
+        _environmentId: params.session.environmentId,
+        _organizationId: params.session.organizationId,
+      },
+      '*'
+    );
+
+    if (!conversation) {
+      return false;
+    }
+
+    const isParticipant = conversation.participants.some(
+      (participant) =>
+        participant.type === ConversationParticipantTypeEnum.SUBSCRIBER &&
+        participant.id === params.session.subscriberId
+    );
+    if (!isParticipant) {
+      return false;
+    }
+
+    const isWebChatConversation = conversation.channels.some(
+      (channel) => channel.platform === AgentPlatformEnum.WEB_CHAT
+    );
+    if (!isWebChatConversation) {
+      return false;
+    }
+
+    return conversation._agentId === params.agentId;
+  }
+}

--- a/apps/api/src/app/agents/web-chat/web-chat.controller.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat.controller.ts
@@ -26,8 +26,17 @@ import {
   ListWebChatConversationEventsQueryDto,
   ListWebChatConversationEventsResponseDto,
 } from './dtos/list-web-chat-conversation-events.dto';
+import {
+  ListWebChatConversationsQueryDto,
+  ListWebChatConversationsResponseDto,
+  WebChatConversationMetadataDto,
+} from './dtos/web-chat-conversation.dto';
+import { GetWebChatConversationCommand } from './usecases/get-web-chat-conversation/get-web-chat-conversation.command';
+import { GetWebChatConversation } from './usecases/get-web-chat-conversation/get-web-chat-conversation.usecase';
 import { ListWebChatConversationEventsCommand } from './usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command';
 import { ListWebChatConversationEvents } from './usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase';
+import { ListWebChatConversationsCommand } from './usecases/list-web-chat-conversations/list-web-chat-conversations.command';
+import { ListWebChatConversations } from './usecases/list-web-chat-conversations/list-web-chat-conversations.usecase';
 import { WebChatPublicationService } from './web-chat-publication.service';
 import { WebChatSessionVerifier } from './web-chat-session.verifier';
 
@@ -39,6 +48,8 @@ export class WebChatController {
     private readonly featureFlagsService: FeatureFlagsService,
     private readonly publicationService: WebChatPublicationService,
     private readonly inboundDispatcher: InboundDispatcher,
+    private readonly listWebChatConversations: ListWebChatConversations,
+    private readonly getWebChatConversation: GetWebChatConversation,
     private readonly listWebChatConversationEvents: ListWebChatConversationEvents
   ) {}
 
@@ -46,6 +57,7 @@ export class WebChatController {
    * POST auth boundary is adapter `verifySession` (inside `handleWebhook`).
    * Session is read here only for `assertWebChatEnabled` + publication resolve
    * before `InboundDispatcher` / registry `getOrCreate`.
+   * Optional body `conversationIdentifier` / `id` resumes via adapter ACL.
    */
   @Post('/conversations')
   async createConversation(@Req() req: ExpressRequest, @Res() res: ExpressResponse): Promise<void> {
@@ -82,6 +94,40 @@ export class WebChatController {
 
       throw err;
     }
+  }
+
+  @Get('/conversations')
+  @UseGuards(AuthGuard('subscriberJwt'), WebChatEnabledGuard)
+  async listConversations(
+    @SubscriberSession() subscriberSession: SubscriberSessionData,
+    @Query() query: ListWebChatConversationsQueryDto
+  ): Promise<ListWebChatConversationsResponseDto> {
+    return this.listWebChatConversations.execute(
+      ListWebChatConversationsCommand.create({
+        environmentId: subscriberSession.environmentId,
+        organizationId: subscriberSession.organizationId,
+        subscriberId: subscriberSession.subscriberId,
+        after: query.after,
+        before: query.before,
+        limit: query.limit ?? 50,
+      })
+    );
+  }
+
+  @Get('/conversations/:identifier')
+  @UseGuards(AuthGuard('subscriberJwt'), WebChatEnabledGuard)
+  async getConversation(
+    @SubscriberSession() subscriberSession: SubscriberSessionData,
+    @Param('identifier') identifier: string
+  ): Promise<WebChatConversationMetadataDto> {
+    return this.getWebChatConversation.execute(
+      GetWebChatConversationCommand.create({
+        environmentId: subscriberSession.environmentId,
+        organizationId: subscriberSession.organizationId,
+        subscriberId: subscriberSession.subscriberId,
+        conversationIdentifier: identifier,
+      })
+    );
   }
 
   @Get('/conversations/:identifier/events')

--- a/packages/chat-adapter-web/src/adapter.spec.ts
+++ b/packages/chat-adapter-web/src/adapter.spec.ts
@@ -106,13 +106,68 @@ describe('NovuWebChatAdapterImpl', () => {
     expect(processMessage.mock.calls[0]?.[2].author.userId).toBe('sub_1');
   });
 
-  it('ignores client messageId and always mints server message id (create-only)', async () => {
+  it('ignores client messageId and always mints server message id', async () => {
     const { adapter, processMessage } = await createAdapter();
 
     await adapter.handleWebhook(jsonRequest({ agentId: 'a', text: 'retry me', messageId: 'msg_abcdefghijkl' }));
 
     expect(processMessage.mock.calls[0]?.[2].id).toMatch(/^msg_[0-9a-z]{12}$/);
     expect(processMessage.mock.calls[0]?.[2].id).not.toBe('msg_abcdefghijkl');
+  });
+
+  it('resumes with conversationIdentifier when authorizeResume allows', async () => {
+    const authorizeResume = vi.fn(async () => true);
+    const { adapter, processMessage } = await createAdapter(createConfig({ authorizeResume }));
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({
+        agentId: 'a',
+        text: 'follow up',
+        conversationIdentifier: 'conv_abcdefghijkl',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.identifier).toBe('conv_abcdefghijkl');
+    expect(authorizeResume).toHaveBeenCalledWith({
+      conversationId: 'conv_abcdefghijkl',
+      session: SESSION,
+    });
+    expect(processMessage.mock.calls[0]?.[1]).toBe('web_chat:conv_abcdefghijkl');
+  });
+
+  it('resumes with id alias when authorizeResume allows', async () => {
+    const { adapter, processMessage } = await createAdapter(createConfig({ authorizeResume: async () => true }));
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({ agentId: 'a', text: 'follow up', id: 'conv_abcdefghijkl' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.identifier).toBe('conv_abcdefghijkl');
+    expect(processMessage.mock.calls[0]?.[1]).toBe('web_chat:conv_abcdefghijkl');
+  });
+
+  it('returns 404 when authorizeResume denies resume', async () => {
+    const { adapter, processMessage } = await createAdapter(createConfig({ authorizeResume: async () => false }));
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({ agentId: 'a', text: 'nope', conversationIdentifier: 'conv_abcdefghijkl' })
+    );
+
+    expect(response.status).toBe(404);
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when resume id is present but authorizeResume is not configured', async () => {
+    const { adapter, processMessage } = await createAdapter();
+
+    const response = await adapter.handleWebhook(jsonRequest({ agentId: 'a', text: 'nope', id: 'conv_abcdefghijkl' }));
+
+    expect(response.status).toBe(404);
+    expect(processMessage).not.toHaveBeenCalled();
   });
 
   it('postMessage delegates to deliverMessage without inventing mongo semantics', async () => {

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -118,20 +118,32 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
       });
     }
 
-    if (body.id !== undefined && body.id !== null) {
-      if (typeof body.id !== 'string' || !isValidConversationId(body.id)) {
-        return new Response(JSON.stringify({ message: 'Invalid conversation id' }), {
-          status: 400,
+    const resumeId = this.resolveResumeConversationId(body);
+    if (resumeId === 'invalid') {
+      return new Response(JSON.stringify({ message: 'Invalid conversation id' }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    let conversationId: string;
+    if (resumeId) {
+      const allowed = this.config.authorizeResume
+        ? await this.config.authorizeResume({ conversationId: resumeId, session })
+        : false;
+      if (!allowed) {
+        return new Response(JSON.stringify({ message: 'Conversation not found' }), {
+          status: 404,
           headers: { 'content-type': 'application/json' },
         });
       }
-      // Create-only this ticket: validate shape, ignore for routing (NV-8441).
+      conversationId = resumeId;
+    } else {
+      conversationId = mintConversationId();
     }
 
-    // Always mint conversation + message ids. Client `messageId` idempotency is
-    // deferred until resume (NV-8441): create-only mint-before-dedupe would ack a
-    // ghost `conv_*` on retry while suppressing the turn.
-    const conversationId = mintConversationId();
+    // Always mint message ids. Client `messageId` idempotency would ack a ghost
+    // turn if checked before durable create; keep server-minted ids for now.
     const threadId = this.encodeThreadId({ conversationId });
     const raw: WebChatRawMessage = {
       id: mintMessageId(),
@@ -149,6 +161,25 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
       status: 201,
       headers: { 'content-type': 'application/json' },
     });
+  }
+
+  /** Prefer `conversationIdentifier`, fall back to `id`. */
+  private resolveResumeConversationId(body: WebChatRequestBody): string | null | 'invalid' {
+    const raw =
+      body.conversationIdentifier !== undefined && body.conversationIdentifier !== null
+        ? body.conversationIdentifier
+        : body.id !== undefined && body.id !== null
+          ? body.id
+          : null;
+
+    if (raw === null) {
+      return null;
+    }
+    if (typeof raw !== 'string' || !isValidConversationId(raw)) {
+      return 'invalid';
+    }
+
+    return raw;
   }
 
   parseMessage(raw: WebChatRawMessage): Message<WebChatRawMessage> {

--- a/packages/chat-adapter-web/src/index.ts
+++ b/packages/chat-adapter-web/src/index.ts
@@ -4,6 +4,7 @@ import type { WebChatAdapterConfig, WebChatRawMessage, WebChatThreadId } from '.
 
 export type {
   WebChatAdapterConfig,
+  WebChatAuthorizeResumeParams,
   WebChatDeleteMessageParams,
   WebChatDeliverMessageParams,
   WebChatDeliverMessageResult,

--- a/packages/chat-adapter-web/src/types.ts
+++ b/packages/chat-adapter-web/src/types.ts
@@ -27,9 +27,19 @@ export type WebChatDeleteMessageParams = {
   messageId: string;
 };
 
+export type WebChatAuthorizeResumeParams = {
+  conversationId: string;
+  session: WebChatSession;
+};
+
 export type WebChatAdapterConfig = {
   userName?: string;
   verifySession: (request: Request) => Promise<WebChatSession | null>;
+  /**
+   * When the client supplies a conversation id, Nest ACL decides whether that
+   * thread may be resumed (participant + web_chat + agent). Denied → adapter 404.
+   */
+  authorizeResume?: (params: WebChatAuthorizeResumeParams) => Promise<boolean>;
   deliverMessage: (params: WebChatDeliverMessageParams) => Promise<WebChatDeliverMessageResult>;
   editMessage: (params: WebChatEditMessageParams) => Promise<WebChatDeliverMessageResult>;
   deleteMessage: (params: WebChatDeleteMessageParams) => Promise<void>;
@@ -50,11 +60,13 @@ export type WebChatRawMessage = {
 export type WebChatRequestBody = {
   agentId?: string;
   text?: string;
-  /** Optional client conversation id — shape-validated; ignored for create-only routing. */
+  /** Resume an existing conversation (`conv_*`). Alias of `conversationIdentifier`. */
   id?: string;
+  /** Preferred resume field (NV-8441); same semantics as `id`. */
+  conversationIdentifier?: string;
   /**
    * Reserved: client idempotency key (`msg_<shortId>`).
-   * Ignored until resume (NV-8441) — create-only mint + dedupe would return a ghost `conv_*`.
+   * Still ignored — minting a server message id avoids ghost acks on retries.
    */
   messageId?: string;
 };


### PR DESCRIPTION
## Summary
- Add subscriber `GET /v1/web-chat/conversations` (participant + `web_chat` only) and `GET /v1/web-chat/conversations/:identifier` metadata with 404 ACL denials.
- Resume via `POST /v1/web-chat/conversations` with `conversationIdentifier` or `id`: adapter authorizes through Nest participant/web_chat/agent ACL; omit id still mints a new `conv_*`.
- Keep durable history `afterSequence`/`limit` pagination and extend API e2e + adapter unit coverage for list/get/resume ACL.

Stacked on #12146 (`@novu/chat-adapter-web`).

```mermaid
flowchart TD
  POST[POST /web-chat/conversations] --> ADAPT[chat-adapter-web]
  ADAPT -->|no id| MINT[mint conv_*]
  ADAPT -->|id / conversationIdentifier| ACL[authorizeResume Nest ACL]
  ACL -->|deny| R404[404]
  ACL -->|allow| RESUME[reuse conv_* thread]
  GETL[GET /conversations] --> LIST[ListWebChatConversations]
  GETO[GET /conversations/:id] --> GET[GetWebChatConversation]
  GETE[GET .../events] --> EV[ListWebChatConversationEvents]
```

## Test plan
- [ ] CI: `web-chat-conversation.e2e.ts` (list-mine, get ACL, resume pass/fail, create-without-id, afterSequence)
- [ ] CI / local: `packages/chat-adapter-web` unit tests (resume allow/deny + id alias)
- [ ] Smoke after #12146: create → list includes it → resume with `conversationIdentifier` → GET events gap-fill via `afterSequence`
- [ ] Non-participant resume/get returns 404 (no existence leak)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds subscriber-scoped web-chat conversation listing and metadata retrieval, authorizes resuming existing conversations, and expands list, ACL, resume, and history-pagination coverage.

- Adds authenticated list and metadata endpoints for web-chat conversations.
- Adds participant, platform, and agent authorization before resuming a conversation.
- Supports `conversationIdentifier` and `id` as resume identifiers while preserving new-conversation creation when omitted.
- Adds API end-to-end and adapter unit coverage for the new behavior.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because deleted-agent conversations can still produce undersized pages and pagination metadata that does not match the visible list.

The list use case computes cursors and totalCount over repository results, then removes conversations whose agent cannot be resolved without recomputing those values, leaving the previously reported pagination defect outstanding.

**Files Needing Attention:** apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts | Adds subscriber-scoped web-chat listing, but the previously reported post-pagination filtering defect remains. |
| apps/api/src/app/agents/web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.usecase.ts | Adds metadata retrieval with environment, organization, participant, and web-chat checks. |
| apps/api/src/app/agents/web-chat/web-chat-resume-authorization.service.ts | Adds participant, platform, and agent authorization for resuming existing conversations. |
| packages/chat-adapter-web/src/adapter.ts | Adds authorized resume routing through conversationIdentifier or id while continuing to mint identifiers for new conversations. |
| apps/api/src/app/agents/web-chat/web-chat.controller.ts | Exposes guarded list and metadata routes and delegates them through commands and use cases. |
| apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts | Expands coverage for listing, metadata ACLs, resume authorization, new conversation creation, and event sequence pagination. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Client[Subscriber client] -->|GET conversations| List[List use case]
  List --> Repo[(Conversation repository)]
  Repo --> Agents[Resolve agent identifiers]
  Agents --> Response[List response]
  Client -->|GET conversation identifier| Get[Get use case]
  Get --> ACL{Participant and web-chat?}
  ACL -->|No| NotFound[404]
  ACL -->|Yes| Metadata[Conversation metadata]
  Client -->|POST with resume identifier| Adapter[Web-chat adapter]
  Adapter --> ResumeACL{Resume authorization}
  ResumeACL -->|No| NotFound
  ResumeACL -->|Yes| Existing[Existing conversation thread]
  Adapter -->|No identifier| New[Mint new conversation]
```

<sub>Reviews (2): Last reviewed commit: ["feat(api-service): list, resume ACL, and..."](https://github.com/novuhq/novu/commit/fac469d947c98eeef9ad0a3f16c94fac60e091ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48356547)</sub>

**Context used:**

- Knowledge Base — [API App (apps/api)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-app.md)

<!-- /greptile_comment -->