### PR TITLE
test: ping novu

### DIFF
--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -20,9 +20,8 @@ import type { InboxNotification, NotificationFilter, TagsFilter } from '../types
 import {
   areDataEqual,
   areTagsEqual,
-  checkBasicFilters,
-  checkNotificationTagFilter,
   isSameFilter,
+  notificationMatchesCacheBucket,
 } from '../utils/notification-utils';
 import { InMemoryCache } from './in-memory-cache';
 import type { Cache } from './types';
@@ -176,8 +175,7 @@ export class NotificationsCache {
     }
 
     const bucketFilter = getFilter(key);
-    const matchesFilter =
-      checkBasicFilters(notification, bucketFilter) && checkNotificationTagFilter(notification.tags, bucketFilter.tags);
+    const matchesFilter = notificationMatchesCacheBucket(notification, bucketFilter);
     const index = notificationsResponse.notifications.findIndex((el) => el.id === notification.id);
     const existsInBucket = index !== -1;
 
@@ -298,7 +296,7 @@ export class NotificationsCache {
         continue;
       }
 
-      hasMore = cachedResponse.hasMore;
+      hasMore = hasMore || cachedResponse.hasMore;
 
       for (const notification of cachedResponse.notifications) {
         uniqueNotifications.set(notification.id, notification);
@@ -337,11 +335,9 @@ export class NotificationsCache {
 
     const notificationInstance = this.#toNotificationInstance({ ...notification });
 
-    const dedupedNotifications = cachedData.notifications.filter((n) => n.id !== notification.id);
-
     this.update(args, {
       ...cachedData,
-      notifications: [notificationInstance, ...dedupedNotifications],
+      notifications: [notificationInstance, ...cachedData.notifications],
     });
   }
 

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -84,3 +84,4 @@ export {
   isSameFilter,
   normalizeTagGroups,
 } from './utils/notification-utils';
+export { COUNT_MUTATION_RESOLVED_EVENTS } from './notifications/count-invalidation-events';

--- a/packages/js/src/notifications/count-invalidation-events.ts
+++ b/packages/js/src/notifications/count-invalidation-events.ts
@@ -1,0 +1,7 @@
+export const COUNT_MUTATION_RESOLVED_EVENTS = [
+  'notification.read.resolved',
+  'notification.unread.resolved',
+  'notification.seen.resolved',
+  'notifications.read_all.resolved',
+  'notifications.seen_all.resolved',
+] as const;

--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -1,16 +1,7 @@
-import {
-  Accessor,
-  createContext,
-  createEffect,
-  createMemo,
-  createSignal,
-  onCleanup,
-  ParentProps,
-  useContext,
-} from 'solid-js';
-import { NOTIFICATION_COUNT_SYNC_EVENTS } from '../../notifications/count-sync-events';
+import { Accessor, createContext, createEffect, createMemo, createSignal, onCleanup, ParentProps, useContext } from 'solid-js';
+import { COUNT_MUTATION_RESOLVED_EVENTS } from '../../notifications/count-invalidation-events';
 import { Notification, NotificationFilter, SeverityLevelEnum } from '../../types';
-import { checkNotificationMatchesFilter } from '../../utils/notification-utils';
+import { checkNotificationDataFilter, checkNotificationTagFilter } from '../../utils/notification-utils';
 import { getTagsFromTab } from '../helpers';
 import { useNovuEvent } from '../helpers/useNovuEvent';
 import { useWebSocketEvent } from '../helpers/useWebSocketEvent';
@@ -138,17 +129,11 @@ export const CountProvider = (props: ParentProps) => {
 
   createEffect(() => {
     const novu = novuAccessor();
-    const cleanups = NOTIFICATION_COUNT_SYNC_EVENTS.map((event) =>
-      novu.on(event, (payload) => {
-        if ('error' in payload && payload.error) {
-          return;
-        }
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, refreshCounts));
 
-        refreshCounts();
-      })
-    );
-
-    onCleanup(() => cleanups.forEach((cleanup) => cleanup()));
+    onCleanup(() => {
+      cleanups.forEach((cleanup) => cleanup());
+    });
   });
 
   useNovuEvent({
@@ -222,42 +207,47 @@ export const CountProvider = (props: ParentProps) => {
       if (currentTabs.length > 0) {
         for (const tab of currentTabs) {
           const tabTags = getTagsFromTab(tab);
-          const tabFilter: NotificationFilter = {
-            tags: tabTags,
-            read: false,
-            archived: false,
-            snoozed: false,
-            data: tab.filter?.data,
-            severity: tab.filter?.severity,
-          };
+          const tabDataFilterCriteria = tab.filter?.data;
+          const tabSeverityFilterCriteria = tab.filter?.severity;
 
-          if (!checkNotificationMatchesFilter(notification, tabFilter)) {
-            continue;
-          }
+          const matchesTagFilter = checkNotificationTagFilter(notification.tags, tabTags);
+          const matchesDataFilterCriteria = checkNotificationDataFilter(notification.data, tabDataFilterCriteria);
 
-          const filterKey = createKey({
-            tags: tabTags,
-            data: tab.filter?.data,
-            severity: tab.filter?.severity,
-          });
+          const matchesSeverityFilterCriteria =
+            !tabSeverityFilterCriteria ||
+            (Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria.length === 0) ||
+            (Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria.includes(notification.severity)) ||
+            (!Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria === notification.severity);
 
-          if (!processedFilters.has(filterKey)) {
-            processedFilters.add(filterKey);
-            updateNewNotificationCountsOrCache(
-              tab.label,
-              notification,
-              tabTags,
-              tab.filter?.data,
-              tab.filter?.severity
-            );
+          if (matchesTagFilter && matchesDataFilterCriteria && matchesSeverityFilterCriteria) {
+            const filterKey = createKey({
+              tags: tabTags,
+              data: tabDataFilterCriteria,
+              severity: tabSeverityFilterCriteria,
+            });
+
+            if (!processedFilters.has(filterKey)) {
+              processedFilters.add(filterKey);
+              updateNewNotificationCountsOrCache(
+                tab.label,
+                notification,
+                tabTags,
+                tabDataFilterCriteria,
+                tabSeverityFilterCriteria
+              );
+            }
           }
         }
       } else {
+        // No tabs are defined. Apply to default (no tags, no data) filter.
         updateNewNotificationCountsOrCache('', notification, [], undefined, undefined);
       }
-
-      await refreshCounts();
     },
+  });
+
+  useWebSocketEvent({
+    event: 'notifications.notification_received',
+    eventHandler: refreshCounts,
   });
 
   const resetNewNotificationCounts = (key: string) => {

--- a/packages/js/src/utils/notification-utils.test.ts
+++ b/packages/js/src/utils/notification-utils.test.ts
@@ -1,11 +1,11 @@
-import { Notification } from '../notifications/notification';
 import {
   areTagsEqual,
-  checkBasicFilters,
   checkNotificationDataFilter,
   checkNotificationTagFilter,
   normalizeTagGroups,
+  notificationMatchesCacheBucket,
 } from './notification-utils';
+import { Notification } from '../notifications/notification';
 
 describe('normalizeTagGroups', () => {
   it('wraps flat tags as one OR-group', () => {
@@ -130,7 +130,7 @@ describe('areTagsEqual', () => {
   });
 });
 
-describe('cache bucket membership', () => {
+describe('notificationMatchesCacheBucket', () => {
   const baseNotification = {
     isRead: false,
     isSeen: false,
@@ -140,21 +140,17 @@ describe('cache bucket membership', () => {
     createdAt: new Date().toISOString(),
   } as Notification;
 
-  function matchesCacheBucket(notification: Notification, filter: { read?: boolean; tags?: string[] }) {
-    return checkBasicFilters(notification, filter) && checkNotificationTagFilter(notification.tags, filter.tags);
-  }
-
   it('returns false when read status no longer matches the bucket filter', () => {
     const readNotification = { ...baseNotification, isRead: true } as Notification;
 
-    expect(matchesCacheBucket(readNotification, { read: false })).toBe(false);
+    expect(notificationMatchesCacheBucket(readNotification, { read: false })).toBe(false);
   });
 
   it('returns false when tags no longer match the bucket filter', () => {
-    expect(matchesCacheBucket(baseNotification, { tags: ['tag2'] })).toBe(false);
+    expect(notificationMatchesCacheBucket(baseNotification, { tags: ['tag2'] })).toBe(false);
   });
 
   it('returns true when status and tags still match the bucket filter', () => {
-    expect(matchesCacheBucket(baseNotification, { read: false, tags: ['tag1'] })).toBe(true);
+    expect(notificationMatchesCacheBucket(baseNotification, { read: false, tags: ['tag1'] })).toBe(true);
   });
 });

--- a/packages/js/src/utils/notification-utils.ts
+++ b/packages/js/src/utils/notification-utils.ts
@@ -494,3 +494,17 @@ export function checkNotificationMatchesFilter(notification: Notification, filte
     checkNotificationTimeframeFilter(notification.createdAt, filter.createdGte, filter.createdLte)
   );
 }
+
+/**
+ * Whether a notification still belongs in a notifications-cache bucket after a local mutation.
+ * Status fields (read/seen/archived/snoozed) and tags can change membership; data and timeframe
+ * are stable for in-flight mutations and are validated when the bucket is populated from the API.
+ */
+export function notificationMatchesCacheBucket(
+  notification: Notification,
+  filter: NotificationFilter
+): boolean {
+  return (
+    checkBasicFilters(notification, filter) && checkNotificationTagFilter(notification.tags, filter.tags)
+  );
+}

--- a/packages/react/src/hooks/useCounts.ts
+++ b/packages/react/src/hooks/useCounts.ts
@@ -1,11 +1,4 @@
-import {
-  checkNotificationMatchesFilter,
-  isSameFilter,
-  NOTIFICATION_COUNT_SYNC_EVENTS,
-  Notification,
-  NotificationFilter,
-  NovuError,
-} from '@novu/js';
+import { COUNT_MUTATION_RESOLVED_EVENTS, checkNotificationMatchesFilter, isSameFilter, Notification, NotificationFilter, NovuError } from '@novu/js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useWebSocketEvent } from './internal/useWebsocketEvent';
@@ -91,7 +84,9 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
       let countFiltersToFetch: NotificationFilter[] = [];
 
       if (notification) {
-        countFiltersToFetch = currentFilters.filter((filter) => checkNotificationMatchesFilter(notification, filter));
+        countFiltersToFetch = currentFilters.filter((filter) =>
+          checkNotificationMatchesFilter(notification, filter)
+        );
       } else {
         countFiltersToFetch = currentFilters;
       }
@@ -158,17 +153,11 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
   });
 
   useEffect(() => {
-    const cleanups = NOTIFICATION_COUNT_SYNC_EVENTS.map((event) =>
-      novu.on(event, (payload) => {
-        if ('error' in payload && payload.error) {
-          return;
-        }
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, () => sync()));
 
-        sync();
-      })
-    );
-
-    return () => cleanups.forEach((cleanup) => cleanup());
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
   }, [novu, sync]);
 
   useEffect(() => {


### PR DESCRIPTION
test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revises client notification cache membership and count synchronization.
- Adds a shared list of mutation events used to refresh counts in the bundled UI and React hook.
- Changes realtime count matching and refresh behavior.
- Adjusts cache aggregation, insertion, and local mutation membership handling.
- Exports the new event list and updates notification utility tests.

<h3>Confidence Score: 2/5</h3>

This PR should not merge until cache insertion preserves notification-ID uniqueness and count invalidation again covers archive, snooze, delete, and related bulk mutations.

Removing cache deduplication breaks an existing test and can leave removed notifications cached, while the reduced event list leaves displayed counts stale after several currently supported mutations; failed mutations also cause avoidable count refetches.

**Files Needing Attention:** packages/js/src/cache/notifications-cache.ts, packages/js/src/notifications/count-invalidation-events.ts, packages/js/src/ui/context/CountContext.tsx, packages/react/src/hooks/useCounts.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/cache/notifications-cache.ts | Changes bucket aggregation and insertion; removing insertion deduplication breaks an existing uniqueness invariant and test. |
| packages/js/src/notifications/count-invalidation-events.ts | Introduces a reduced invalidation list that omits several mutations affecting count-filter membership. |
| packages/js/src/ui/context/CountContext.tsx | Reworks realtime matching and count refresh subscriptions but now refreshes after failed mutations and misses omitted mutation types. |
| packages/react/src/hooks/useCounts.ts | Adopts the reduced event list and synchronizes counts for both successful and failed resolved events. |
| packages/js/src/utils/notification-utils.ts | Extracts cache-bucket membership logic without changing its underlying status and tag checks. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Mutation[Notification mutation] --> Resolved[Resolved event]
  Resolved --> EventList[COUNT_MUTATION_RESOLVED_EVENTS]
  EventList --> Solid[CountContext refreshCounts]
  EventList --> React[useCounts sync]
  Realtime[notification_received] --> Cache[NotificationsCache unshift]
  Cache --> Consumers[Inbox notification consumers]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fjs%2Fsrc%2Fcache%2Fnotifications-cache.ts%3A338%0A**Cache%20insertion%20permits%20duplicate%20IDs**%0A%0AWhen%20a%20realtime%20notification%20is%20already%20present%20from%20an%20API%20response%20or%20earlier%20event%2C%20%60unshift%60%20prepends%20another%20copy%20with%20the%20same%20ID.%20Subsequent%20archive%20or%20delete%20handling%20removes%20only%20the%20first%20match%2C%20leaving%20the%20notification%20visible%20and%20breaking%20the%20existing%20cache%20deduplication%20test.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fjs%2Fsrc%2Fnotifications%2Fcount-invalidation-events.ts%3A1-7%0A**Count%20invalidation%20omits%20state%20mutations**%0A%0AWhen%20a%20user%20archives%2C%20unarchives%2C%20snoozes%2C%20unsnoozes%2C%20or%20deletes%20notifications%2C%20neither%20count%20consumer%20receives%20the%20resolved%20event%20because%20these%20mutations%20are%20absent%20from%20this%20replacement%20list.%20Successful%20operations%20therefore%20leave%20inbox%20and%20hook%20badge%20counts%20stale%20until%20an%20unrelated%20refresh%20occurs.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fjs%2Fsrc%2Fui%2Fcontext%2FCountContext.tsx%3A132%0A**Failed%20mutations%20trigger%20count%20requests**%0A%0AResolved%20events%20are%20emitted%20for%20both%20successful%20and%20failed%20mutations%2C%20but%20this%20direct%20handler%20no%20longer%20checks%20the%20error%20payload.%20Each%20failed%20read%2C%20unread%2C%20or%20seen%20operation%20therefore%20issues%20an%20unnecessary%20count%20request%2C%20while%20the%20equivalent%20React%20handler%20can%20refetch%20every%20configured%20count%20filter.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/js/src/cache/notifications-cache.ts:338
**Cache insertion permits duplicate IDs**

When a realtime notification is already present from an API response or earlier event, `unshift` prepends another copy with the same ID. Subsequent archive or delete handling removes only the first match, leaving the notification visible and breaking the existing cache deduplication test.

### Issue 2
packages/js/src/notifications/count-invalidation-events.ts:1-7
**Count invalidation omits state mutations**

When a user archives, unarchives, snoozes, unsnoozes, or deletes notifications, neither count consumer receives the resolved event because these mutations are absent from this replacement list. Successful operations therefore leave inbox and hook badge counts stale until an unrelated refresh occurs.

### Issue 3
packages/js/src/ui/context/CountContext.tsx:132
**Failed mutations trigger count requests**

Resolved events are emitted for both successful and failed mutations, but this direct handler no longer checks the error payload. Each failed read, unread, or seen operation therefore issues an unnecessary count request, while the equivalent React handler can refetch every configured count filter.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: inbox badge sync across cache bucke..."](https://github.com/novuhq/novu/commit/d23fee7961bd4bfcc48464779d59dc1f19155bb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48598690)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->