### PR TITLE
fix(application-generic): avoid ClientSession plainToInstance crash fixes NV-8457

### DIFF
--- a/libs/application-generic/src/commands/base.command.ts
+++ b/libs/application-generic/src/commands/base.command.ts
@@ -5,7 +5,13 @@ import { ValidationError, validateSync } from 'class-validator';
 
 // biome-ignore lint/complexity/noStaticOnlyClass: Base class pattern for command validation
 export abstract class BaseCommand {
-  static create<T extends BaseCommand>(this: new (...args: unknown[]) => T, data: T): T {
+  /**
+   * @param data - Plain command fields validated via class-transformer / class-validator.
+   * @param extras - Runtime objects that must not go through `plainToInstance`
+   *   (e.g. Mongo `ClientSession`, `AbortSignal`). Assigned onto the instance after transform.
+   *   Passing them in `data` throws (e.g. `ClientSession requires a MongoClient`).
+   */
+  static create<T extends BaseCommand>(this: new (...args: unknown[]) => T, data: T, extras?: Partial<T>): T {
     // biome-ignore lint/complexity/noThisInStatic: Biome linter is configured to newer JS/TS version than the compiler
     const convertedObject = plainToInstance<T, unknown>(this, {
       ...data,
@@ -16,6 +22,10 @@ export abstract class BaseCommand {
     if (Object.keys(flattenedErrors).length > 0) {
       // biome-ignore lint/complexity/noThisInStatic: Biome linter is configured to newer JS/TS version than the compiler
       throw new CommandValidationException(this.name, flattenedErrors);
+    }
+
+    if (extras) {
+      Object.assign(convertedObject, extras);
     }
 
     return convertedObject;

--- a/libs/application-generic/src/usecases/create-change/create-change.command.ts
+++ b/libs/application-generic/src/usecases/create-change/create-change.command.ts
@@ -1,6 +1,5 @@
 import { ClientSession } from '@novu/dal';
 import { ChangeEntityTypeEnum } from '@novu/shared';
-import { Exclude } from 'class-transformer';
 import { IsDefined, IsMongoId, IsOptional, IsString } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../commands';
 
@@ -25,11 +24,10 @@ export class CreateChangeCommand extends EnvironmentWithUserCommand {
   parentChangeId?: string;
 
   /**
-   * Exclude session from serialized output only (`toPlainOnly`). A bare
-   * `@Exclude()` would also strip it during `plainToInstance` inside
-   * `BaseCommand.create`, silently losing the transaction session.
+   * Intentionally undecorated and assigned after `BaseCommand.create`.
+   * Any decorator emits `design:type = ClientSession`, and even without metadata
+   * `plainToInstance` will call `new ClientSession()` when given a session instance —
+   * which throws `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
    */
-  @Exclude({ toPlainOnly: true })
-  @IsOptional()
   session?: ClientSession | null;
 }

--- a/libs/application-generic/src/usecases/create-change/create-change.command.ts
+++ b/libs/application-generic/src/usecases/create-change/create-change.command.ts
@@ -24,10 +24,9 @@ export class CreateChangeCommand extends EnvironmentWithUserCommand {
   parentChangeId?: string;
 
   /**
-   * Intentionally undecorated and assigned after `BaseCommand.create`.
-   * Any decorator emits `design:type = ClientSession`, and even without metadata
-   * `plainToInstance` will call `new ClientSession()` when given a session instance —
-   * which throws `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
+   * Intentionally undecorated. Pass via `BaseCommand.create(data, { session })` —
+   * putting a ClientSession through `plainToInstance` calls `new ClientSession()` and
+   * throws `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
    */
   session?: ClientSession | null;
 }

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.spec.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.spec.ts
@@ -1,0 +1,62 @@
+import { ChangeEntityTypeEnum, ResourceTypeEnum } from '@novu/shared';
+import { CreateChangeCommand } from '../../create-change/create-change.command';
+import { DeleteMessageTemplateCommand } from './delete-message-template.command';
+
+/**
+ * Regression for NV-8457: passing a ClientSession-like instance through
+ * `BaseCommand.create` / `plainToInstance` calls `new ClientSession()` and throws
+ * `MongoRuntimeError: ClientSession requires a MongoClient`. Assign session after create.
+ */
+describe('Mongo ClientSession on BaseCommand.create', () => {
+  class ThrowsWithoutClient {
+    constructor(client?: unknown) {
+      if (!client) {
+        throw new Error('ClientSession requires a MongoClient');
+      }
+    }
+  }
+
+  const fakeSession = Object.assign(Object.create(ThrowsWithoutClient.prototype), {
+    id: 'fake-client-session',
+  }) as any;
+
+  it('DeleteMessageTemplateCommand.create throws if session is passed through plainToInstance', () => {
+    expect(() =>
+      DeleteMessageTemplateCommand.create({
+        organizationId: 'aaaaaaaaaaaaaaaaaaaaaaa1',
+        environmentId: 'aaaaaaaaaaaaaaaaaaaaaaa2',
+        userId: 'aaaaaaaaaaaaaaaaaaaaaaa3',
+        messageTemplateId: 'aaaaaaaaaaaaaaaaaaaaaaa4',
+        workflowType: ResourceTypeEnum.REGULAR,
+        session: fakeSession,
+      })
+    ).toThrow('ClientSession requires a MongoClient');
+  });
+
+  it('DeleteMessageTemplateCommand preserves session when assigned after create', () => {
+    const command = DeleteMessageTemplateCommand.create({
+      organizationId: 'aaaaaaaaaaaaaaaaaaaaaaa1',
+      environmentId: 'aaaaaaaaaaaaaaaaaaaaaaa2',
+      userId: 'aaaaaaaaaaaaaaaaaaaaaaa3',
+      messageTemplateId: 'aaaaaaaaaaaaaaaaaaaaaaa4',
+      workflowType: ResourceTypeEnum.REGULAR,
+    });
+    command.session = fakeSession;
+
+    expect(command.session).toBe(fakeSession);
+  });
+
+  it('CreateChangeCommand preserves session when assigned after create', () => {
+    const command = CreateChangeCommand.create({
+      organizationId: 'aaaaaaaaaaaaaaaaaaaaaaa1',
+      environmentId: 'aaaaaaaaaaaaaaaaaaaaaaa2',
+      userId: 'aaaaaaaaaaaaaaaaaaaaaaa3',
+      changeId: 'aaaaaaaaaaaaaaaaaaaaaaa4',
+      type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
+      item: { _id: 'aaaaaaaaaaaaaaaaaaaaaaa5' },
+    });
+    command.session = fakeSession;
+
+    expect(command.session).toBe(fakeSession);
+  });
+});

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.spec.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.spec.ts
@@ -5,7 +5,8 @@ import { DeleteMessageTemplateCommand } from './delete-message-template.command'
 /**
  * Regression for NV-8457: passing a ClientSession-like instance through
  * `BaseCommand.create` / `plainToInstance` calls `new ClientSession()` and throws
- * `MongoRuntimeError: ClientSession requires a MongoClient`. Assign session after create.
+ * `MongoRuntimeError: ClientSession requires a MongoClient`. Pass session as the
+ * second `extras` argument instead.
  */
 describe('Mongo ClientSession on BaseCommand.create', () => {
   class ThrowsWithoutClient {
@@ -33,29 +34,33 @@ describe('Mongo ClientSession on BaseCommand.create', () => {
     ).toThrow('ClientSession requires a MongoClient');
   });
 
-  it('DeleteMessageTemplateCommand preserves session when assigned after create', () => {
-    const command = DeleteMessageTemplateCommand.create({
-      organizationId: 'aaaaaaaaaaaaaaaaaaaaaaa1',
-      environmentId: 'aaaaaaaaaaaaaaaaaaaaaaa2',
-      userId: 'aaaaaaaaaaaaaaaaaaaaaaa3',
-      messageTemplateId: 'aaaaaaaaaaaaaaaaaaaaaaa4',
-      workflowType: ResourceTypeEnum.REGULAR,
-    });
-    command.session = fakeSession;
+  it('DeleteMessageTemplateCommand preserves session via create extras', () => {
+    const command = DeleteMessageTemplateCommand.create(
+      {
+        organizationId: 'aaaaaaaaaaaaaaaaaaaaaaa1',
+        environmentId: 'aaaaaaaaaaaaaaaaaaaaaaa2',
+        userId: 'aaaaaaaaaaaaaaaaaaaaaaa3',
+        messageTemplateId: 'aaaaaaaaaaaaaaaaaaaaaaa4',
+        workflowType: ResourceTypeEnum.REGULAR,
+      },
+      { session: fakeSession }
+    );
 
     expect(command.session).toBe(fakeSession);
   });
 
-  it('CreateChangeCommand preserves session when assigned after create', () => {
-    const command = CreateChangeCommand.create({
-      organizationId: 'aaaaaaaaaaaaaaaaaaaaaaa1',
-      environmentId: 'aaaaaaaaaaaaaaaaaaaaaaa2',
-      userId: 'aaaaaaaaaaaaaaaaaaaaaaa3',
-      changeId: 'aaaaaaaaaaaaaaaaaaaaaaa4',
-      type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
-      item: { _id: 'aaaaaaaaaaaaaaaaaaaaaaa5' },
-    });
-    command.session = fakeSession;
+  it('CreateChangeCommand preserves session via create extras', () => {
+    const command = CreateChangeCommand.create(
+      {
+        organizationId: 'aaaaaaaaaaaaaaaaaaaaaaa1',
+        environmentId: 'aaaaaaaaaaaaaaaaaaaaaaa2',
+        userId: 'aaaaaaaaaaaaaaaaaaaaaaa3',
+        changeId: 'aaaaaaaaaaaaaaaaaaaaaaa4',
+        type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
+        item: { _id: 'aaaaaaaaaaaaaaaaaaaaaaa5' },
+      },
+      { session: fakeSession }
+    );
 
     expect(command.session).toBe(fakeSession);
   });

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.ts
@@ -17,10 +17,9 @@ export class DeleteMessageTemplateCommand extends EnvironmentWithUserCommand {
   workflowType: ResourceTypeEnum;
 
   /**
-   * Intentionally undecorated and assigned after `BaseCommand.create`.
-   * Any decorator emits `design:type = ClientSession`, and even without metadata
-   * `plainToInstance` will call `new ClientSession()` when given a session instance —
-   * which throws `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
+   * Intentionally undecorated. Pass via `BaseCommand.create(data, { session })` —
+   * putting a ClientSession through `plainToInstance` calls `new ClientSession()` and
+   * throws `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
    */
   session?: ClientSession | null;
 }

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.ts
@@ -1,6 +1,5 @@
 import { ClientSession } from '@novu/dal';
 import { ResourceTypeEnum } from '@novu/shared';
-import { Exclude } from 'class-transformer';
 import { IsDefined, IsEnum, IsMongoId, IsOptional } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../commands';
 
@@ -18,11 +17,10 @@ export class DeleteMessageTemplateCommand extends EnvironmentWithUserCommand {
   workflowType: ResourceTypeEnum;
 
   /**
-   * Exclude session from serialized output only (`toPlainOnly`). A bare
-   * `@Exclude()` would also strip it during `plainToInstance` inside
-   * `BaseCommand.create`, silently losing the transaction session.
+   * Intentionally undecorated and assigned after `BaseCommand.create`.
+   * Any decorator emits `design:type = ClientSession`, and even without metadata
+   * `plainToInstance` will call `new ClientSession()` when given a session instance —
+   * which throws `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
    */
-  @Exclude({ toPlainOnly: true })
-  @IsOptional()
   session?: ClientSession | null;
 }

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
@@ -37,20 +37,20 @@ export class DeleteMessageTemplate {
       );
 
       if (!isBridgeWorkflow(command.workflowType)) {
-        const changeCommand = CreateChangeCommand.create({
-          changeId,
-          organizationId: command.organizationId,
-          environmentId: command.environmentId,
-          userId: command.userId,
-          item: deletedMessageTemplate[0],
-          type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
-          parentChangeId: command.parentChangeId,
-        });
-        // Assign after create — passing ClientSession through plainToInstance throws
-        // `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
-        changeCommand.session = command.session;
-
-        await this.createChange.execute(changeCommand);
+        await this.createChange.execute(
+          CreateChangeCommand.create(
+            {
+              changeId,
+              organizationId: command.organizationId,
+              environmentId: command.environmentId,
+              userId: command.userId,
+              item: deletedMessageTemplate[0],
+              type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
+              parentChangeId: command.parentChangeId,
+            },
+            { session: command.session }
+          )
+        );
       }
 
       return true;

--- a/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
+++ b/libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts
@@ -37,18 +37,20 @@ export class DeleteMessageTemplate {
       );
 
       if (!isBridgeWorkflow(command.workflowType)) {
-        await this.createChange.execute(
-          CreateChangeCommand.create({
-            changeId,
-            organizationId: command.organizationId,
-            environmentId: command.environmentId,
-            userId: command.userId,
-            item: deletedMessageTemplate[0],
-            type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
-            parentChangeId: command.parentChangeId,
-            session: command.session,
-          })
-        );
+        const changeCommand = CreateChangeCommand.create({
+          changeId,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          userId: command.userId,
+          item: deletedMessageTemplate[0],
+          type: ChangeEntityTypeEnum.MESSAGE_TEMPLATE,
+          parentChangeId: command.parentChangeId,
+        });
+        // Assign after create — passing ClientSession through plainToInstance throws
+        // `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
+        changeCommand.session = command.session;
+
+        await this.createChange.execute(changeCommand);
       }
 
       return true;

--- a/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
@@ -758,17 +758,19 @@ export class UpdateWorkflowV0 {
 
     // Sequential on purpose: parallel operations inside a transaction are undefined behaviour in Mongoose.
     for (const id of removedStepsIds) {
-      const deleted = await this.deleteMessageTemplate.execute(
-        DeleteMessageTemplateCommand.create({
-          organizationId: command.organizationId,
-          environmentId: command.environmentId,
-          userId: command.userId,
-          messageTemplateId: id,
-          parentChangeId,
-          workflowType: command.type,
-          session,
-        })
-      );
+      const deleteCommand = DeleteMessageTemplateCommand.create({
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        userId: command.userId,
+        messageTemplateId: id,
+        parentChangeId,
+        workflowType: command.type,
+      });
+      // Assign after create — passing ClientSession through plainToInstance throws
+      // `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
+      deleteCommand.session = session;
+
+      const deleted = await this.deleteMessageTemplate.execute(deleteCommand);
 
       // Abort the transaction if the template was not deleted, so we never commit a
       // workflow that dropped the step and its controls while leaving the template behind.

--- a/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
@@ -758,19 +758,19 @@ export class UpdateWorkflowV0 {
 
     // Sequential on purpose: parallel operations inside a transaction are undefined behaviour in Mongoose.
     for (const id of removedStepsIds) {
-      const deleteCommand = DeleteMessageTemplateCommand.create({
-        organizationId: command.organizationId,
-        environmentId: command.environmentId,
-        userId: command.userId,
-        messageTemplateId: id,
-        parentChangeId,
-        workflowType: command.type,
-      });
-      // Assign after create — passing ClientSession through plainToInstance throws
-      // `MongoRuntimeError: ClientSession requires a MongoClient` (NV-8457).
-      deleteCommand.session = session;
-
-      const deleted = await this.deleteMessageTemplate.execute(deleteCommand);
+      const deleted = await this.deleteMessageTemplate.execute(
+        DeleteMessageTemplateCommand.create(
+          {
+            organizationId: command.organizationId,
+            environmentId: command.environmentId,
+            userId: command.userId,
+            messageTemplateId: id,
+            parentChangeId,
+            workflowType: command.type,
+          },
+          { session }
+        )
+      );
 
       // Abort the transaction if the template was not deleted, so we never commit a
       // workflow that dropped the step and its controls while leaving the template behind.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PROD-US API started returning **500** on workflow update paths that delete steps (`PUT /v1/workflows/:id`, `PUT /v2/workflows/:id`) with:

```
MongoRuntimeError: ClientSession requires a MongoClient
```

### Why it happens

Introduced in #12065 (NV-8378). Workflow update threads a Mongo `ClientSession` into `DeleteMessageTemplateCommand.create(...)` / `CreateChangeCommand.create(...)`.

`BaseCommand.create` runs `plainToInstance`. class-transformer then calls `new ClientSession()` without a `MongoClient` → crash.

### Fix

- `BaseCommand.create(data, extras?)` — optional second arg for runtime objects that must not go through `plainToInstance`
- Call sites pass `{ session }` as that extras arg
- Leave `session` undecorated on the commands

```ts
DeleteMessageTemplateCommand.create(
  { organizationId, environmentId, userId, messageTemplateId, parentChangeId, workflowType },
  { session }
);
```

## Test plan

- [x] Local repro: pass-through `create({ session })` throws; `create(data, { session })` preserves identity
- [x] Unit spec documenting the hazard + extras pattern
- [ ] Confirm New Relic `ClientSession requires a MongoClient` count drops after deploy on workflow update paths

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ce4550-4f90-4e26-a856-09a839b33de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ce4550-4f90-4e26-a856-09a839b33de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents Mongo `ClientSession` objects from passing through class-transformer by:
- Extending `BaseCommand.create` with a post-transformation `extras` argument.
- Passing workflow-update transaction sessions through that argument.
- Adding regression coverage for session identity preservation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/commands/base.command.ts | Adds an optional post-validation assignment path for runtime objects that cannot safely pass through class-transformer. |
| libs/application-generic/src/usecases/create-change/create-change.command.ts | Makes the transaction session an undecorated runtime field intended for assignment through command extras. |
| libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.ts | Makes the deletion transaction session an undecorated runtime field intended for assignment through command extras. |
| libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.usecase.ts | Propagates the existing session into nested change creation without transforming the session object. |
| libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts | Passes the workflow transaction session separately when constructing deletion commands. |
| libs/application-generic/src/usecases/message-template/delete-message-template/delete-message-template.command.spec.ts | Covers the class-transformer constructor failure and verifies session identity preservation through extras. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Update as UpdateWorkflowV0
  participant Base as BaseCommand.create
  participant Delete as DeleteMessageTemplate
  participant Change as CreateChange
  participant Mongo as MongoDB transaction
  Update->>Base: "create(command data, { session })"
  Base->>Base: plainToInstance(command data)
  Base->>Base: validateSync(instance)
  Base->>Base: "Object.assign(instance, { session })"
  Base-->>Update: command retaining session identity
  Update->>Delete: execute(command)
  Delete->>Mongo: delete template with session
  Delete->>Base: "CreateChangeCommand.create(data, { session })"
  Base-->>Delete: change command retaining session
  Delete->>Change: execute(command)
  Change->>Mongo: persist change with session
```

<sub>Reviews (2): Last reviewed commit: ["fix(application-generic): pass ClientSes..."](https://github.com/novuhq/novu/commit/e0d4a5fdeb51a2fd6a67cf506cbfc336a51cb7f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48654325)</sub>

**Context used:**

- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)

<!-- /greptile_comment -->