### PR TITLE
fix(api-service): preserve enabled on workflowId preference shape fixes NV-8458

### DIFF
--- a/apps/api/src/app/inbox/inbox.topic.controller.ts
+++ b/apps/api/src/app/inbox/inbox.topic.controller.ts
@@ -17,10 +17,6 @@ import { AuthGuard } from '@nestjs/passport';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { Response } from 'express';
 import { SubscriptionDetailsResponseDto } from '../shared/dtos/subscription-details-response.dto';
-import {
-  GroupPreferenceFilterDto,
-  WorkflowPreferenceRequestDto,
-} from '../shared/dtos/subscriptions/create-subscriptions.dto';
 import { UpdateSubscriptionRequestDto } from '../shared/dtos/subscriptions/update-subscription.dto';
 import { ExcludeFromIdempotency } from '../shared/framework/exclude-from-idempotency';
 import { ApiCommonResponses } from '../shared/framework/response.decorator';
@@ -29,6 +25,7 @@ import { CreateSubscriptionsCommand, CreateSubscriptionsUsecase } from '../subsc
 import { GetSubscriptionCommand } from '../subscriptions/usecases/get-subscription/get-subscription.command';
 import { GetSubscription } from '../subscriptions/usecases/get-subscription/get-subscription.usecase';
 import { UpdateSubscriptionCommand, UpdateSubscriptionUsecase } from '../subscriptions/usecases/update-subscription';
+import { convertPreferencesToGroupFilters } from '../subscriptions/utils/subscriptions';
 import { CreateTopicSubscriptionRequestDto } from './dtos/create-topic-subscription-request.dto';
 import { ContextCompatibilityInterceptor } from './interceptors/context-compatibility.interceptor';
 import { DeleteTopicSubscriptionCommand } from './usecases/delete-subscription/delete-subscription.command';
@@ -124,7 +121,7 @@ export class InboxTopicController {
           },
         ],
         name: body.topic?.name,
-        preferences: body.preferences ? this.convertPreferencesToGroupFilters(body.preferences) : undefined,
+        preferences: body.preferences ? convertPreferencesToGroupFilters(body.preferences) : undefined,
         contextKeys: subscriberSession.contextKeys,
       })
     );
@@ -164,7 +161,7 @@ export class InboxTopicController {
         identifier,
         _subscriberId: subscriberSession._id,
         name: body.name,
-        preferences: body.preferences ? this.convertPreferencesToGroupFilters(body.preferences) : undefined,
+        preferences: body.preferences ? convertPreferencesToGroupFilters(body.preferences) : undefined,
         contextKeys: subscriberSession.contextKeys,
       })
     );
@@ -195,37 +192,5 @@ export class InboxTopicController {
         contextKeys: subscriberSession.contextKeys,
       })
     );
-  }
-
-  private convertPreferencesToGroupFilters(
-    preferences: Array<string | WorkflowPreferenceRequestDto | GroupPreferenceFilterDto>
-  ): Array<GroupPreferenceFilterDto> {
-    return preferences.map((preference) => {
-      if (typeof preference === 'string') {
-        return {
-          filter: {
-            workflowIds: [preference],
-          },
-        };
-      }
-
-      if (this.isGroupPreferenceFilter(preference)) {
-        return preference;
-      }
-
-      return {
-        filter: {
-          workflowIds: [preference.workflowId],
-        },
-        condition: preference.condition,
-        enabled: preference.enabled,
-      };
-    });
-  }
-
-  private isGroupPreferenceFilter(
-    preference: WorkflowPreferenceRequestDto | GroupPreferenceFilterDto
-  ): preference is GroupPreferenceFilterDto {
-    return 'filter' in preference;
   }
 }

--- a/apps/api/src/app/subscriptions/utils/subscriptions.spec.ts
+++ b/apps/api/src/app/subscriptions/utils/subscriptions.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { convertPreferencesToGroupFilters } from './subscriptions';
+
+describe('convertPreferencesToGroupFilters', () => {
+  it('should convert a string workflow id into a group filter', () => {
+    const result = convertPreferencesToGroupFilters(['workflow-1']);
+
+    expect(result).to.deep.equal([
+      {
+        filter: {
+          workflowIds: ['workflow-1'],
+        },
+      },
+    ]);
+  });
+
+  it('should pass through group filter preferences unchanged', () => {
+    const preference = {
+      filter: { workflowIds: ['workflow-1'] },
+      enabled: false,
+      condition: { '==': [{ var: 'status' }, 'active'] },
+    };
+
+    const result = convertPreferencesToGroupFilters([preference]);
+
+    expect(result).to.deep.equal([preference]);
+  });
+
+  it('should preserve enabled and condition when converting the workflowId shape', () => {
+    const result = convertPreferencesToGroupFilters([
+      {
+        workflowId: 'workflow-1',
+        enabled: false,
+        condition: { '==': [{ var: 'tier' }, 'premium'] },
+      },
+    ]);
+
+    expect(result).to.deep.equal([
+      {
+        filter: {
+          workflowIds: ['workflow-1'],
+        },
+        condition: { '==': [{ var: 'tier' }, 'premium'] },
+        enabled: false,
+      },
+    ]);
+  });
+});

--- a/apps/api/src/app/subscriptions/utils/subscriptions.ts
+++ b/apps/api/src/app/subscriptions/utils/subscriptions.ts
@@ -3,6 +3,10 @@ import { NotificationTemplateEntity, PreferencesEntity, TopicSubscribersEntity }
 import { SeverityLevelEnum } from '@novu/shared';
 import { RulesLogic } from 'json-logic-js';
 import { SubscriptionDetailsResponseDto } from '../../shared/dtos/subscription-details-response.dto';
+import {
+  GroupPreferenceFilterDto,
+  WorkflowPreferenceRequestDto,
+} from '../../shared/dtos/subscriptions/create-subscriptions.dto';
 import { SubscriptionPreferenceDto } from '../../shared/dtos/subscriptions/create-subscriptions-response.dto';
 
 export type SelectedWorkflowFields = Pick<
@@ -91,3 +95,39 @@ export const SELECTED_WORKFLOW_FIELDS_PROJECTION: Record<keyof SelectedWorkflowF
   data: 1,
   severity: 1,
 } as const;
+
+function isGroupPreferenceFilter(
+  preference: WorkflowPreferenceRequestDto | GroupPreferenceFilterDto
+): preference is GroupPreferenceFilterDto {
+  return 'filter' in preference;
+}
+
+/**
+ * Normalizes subscription preference request shapes (string workflow id,
+ * `{ workflowId, enabled, condition }`, or group filter) into group filters.
+ */
+export function convertPreferencesToGroupFilters(
+  preferences: Array<string | WorkflowPreferenceRequestDto | GroupPreferenceFilterDto>
+): Array<GroupPreferenceFilterDto> {
+  return preferences.map((preference) => {
+    if (typeof preference === 'string') {
+      return {
+        filter: {
+          workflowIds: [preference],
+        },
+      };
+    }
+
+    if (isGroupPreferenceFilter(preference)) {
+      return preference;
+    }
+
+    return {
+      filter: {
+        workflowIds: [preference.workflowId],
+      },
+      condition: preference.condition,
+      enabled: preference.enabled,
+    };
+  });
+}

--- a/apps/api/src/app/topics-v2/e2e/create-topic-subscriptions.e2e.ts
+++ b/apps/api/src/app/topics-v2/e2e/create-topic-subscriptions.e2e.ts
@@ -325,6 +325,39 @@ describe('Create topic subscriptions - /v2/topics/:topicKey/subscriptions (POST)
     expect(subscriptionsAfterDuplicate.length, 'expect subscriptionsAfterDuplicate.length to be 2').to.equal(2);
   });
 
+  it('should preserve enabled=false when preferences use the workflowId shape', async () => {
+    const topicKey = `topic-key-enabled-false-${Date.now()}`;
+
+    await novuClient.topics.create({
+      key: topicKey,
+      name: 'Test Topic for Enabled Flag',
+    });
+
+    const workflow = await session.createTemplate({
+      name: 'Workflow Enabled False',
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Test content',
+        },
+      ],
+    });
+
+    const response = await session.testAgent.post(`/v2/topics/${topicKey}/subscriptions`).send({
+      subscriptions: [
+        {
+          identifier: `${subscriber1.subscriberId}-disabled-pref`,
+          subscriberId: subscriber1.subscriberId,
+        },
+      ],
+      preferences: [{ workflowId: workflow._id, enabled: false }],
+    });
+
+    expect(response.status, 'Should create the subscription').to.equal(201);
+    expect(response.body.data[0].preferences, 'Should return preferences').to.exist;
+    expect(response.body.data[0].preferences[0].enabled, 'Should preserve enabled=false').to.equal(false);
+  });
+
   it('should enforce subscription limit of 10 per subscriber per topic', async () => {
     try {
       const topicKey = `topic-key-limit-${Date.now()}`;

--- a/apps/api/src/app/topics-v2/e2e/update-topic-subscription.e2e.ts
+++ b/apps/api/src/app/topics-v2/e2e/update-topic-subscription.e2e.ts
@@ -306,6 +306,34 @@ describe('Update topic subscription - /v2/topics/:topicKey/subscriptions/:identi
     expect(updateResponse.result.preferences?.length).to.be.greaterThan(0);
   });
 
+  it('should preserve enabled=false when updating preferences with the workflowId shape', async () => {
+    const topicKey = `topic-key-enabled-false-${Date.now()}`;
+
+    await novuClient.topics.create({
+      key: topicKey,
+      name: 'Test Topic',
+    });
+
+    const subscriptionResponse = await novuClient.topics.subscriptions.create(
+      {
+        subscriberIds: [subscriber1.subscriberId],
+      },
+      topicKey
+    );
+
+    const subscriptionIdentifier = subscriptionResponse.result.data[0].identifier;
+
+    const response = await session.testAgent
+      .patch(`/v2/topics/${topicKey}/subscriptions/${subscriptionIdentifier}`)
+      .send({
+        preferences: [{ workflowId: 'workflow-1', enabled: false }],
+      });
+
+    expect(response.status, 'Should update the subscription').to.equal(200);
+    expect(response.body.data.preferences, 'Should return preferences').to.exist;
+    expect(response.body.data.preferences[0].enabled, 'Should preserve enabled=false').to.equal(false);
+  });
+
   it('should update subscription name', async () => {
     const topicKey = `topic-key-name-${Date.now()}`;
 

--- a/apps/api/src/app/topics-v2/topics.controller.ts
+++ b/apps/api/src/app/topics-v2/topics.controller.ts
@@ -23,10 +23,6 @@ import { ThrottlerCategory } from '../rate-limiting/guards/throttler.decorator';
 import { DirectionEnum } from '../shared/dtos/base-responses';
 import { SubscriptionDetailsResponseDto } from '../shared/dtos/subscription-details-response.dto';
 import {
-  GroupPreferenceFilterDto,
-  WorkflowPreferenceRequestDto,
-} from '../shared/dtos/subscriptions/create-subscriptions.dto';
-import {
   CreateSubscriptionsResponseDto,
   SubscriptionResponseDto,
 } from '../shared/dtos/subscriptions/create-subscriptions-response.dto';
@@ -37,6 +33,7 @@ import { CreateSubscriptionsCommand, CreateSubscriptionsUsecase } from '../subsc
 import { GetSubscriptionCommand } from '../subscriptions/usecases/get-subscription/get-subscription.command';
 import { GetSubscription } from '../subscriptions/usecases/get-subscription/get-subscription.usecase';
 import { UpdateSubscriptionCommand, UpdateSubscriptionUsecase } from '../subscriptions/usecases/update-subscription';
+import { convertPreferencesToGroupFilters } from '../subscriptions/utils/subscriptions';
 import { CreateTopicSubscriptionsRequestDto } from './dtos/create-topic-subscriptions.dto';
 import { CreateUpdateTopicRequestDto } from './dtos/create-update-topic.dto';
 import { DeleteTopicResponseDto } from './dtos/delete-topic-response.dto';
@@ -300,7 +297,7 @@ export class TopicsController {
         topicKey,
         subscriptions: this.mapSubscriptions(body.subscriptions || body.subscriberIds || []),
         name: body.name,
-        preferences: body.preferences ? this.convertPreferencesToGroupFilters(body.preferences) : undefined,
+        preferences: body.preferences ? convertPreferencesToGroupFilters(body.preferences) : undefined,
         context: body.context,
       })
     );
@@ -442,7 +439,7 @@ export class TopicsController {
         topicKey,
         identifier,
         name: body.name,
-        preferences: body.preferences ? this.convertPreferencesToGroupFilters(body.preferences) : undefined,
+        preferences: body.preferences ? convertPreferencesToGroupFilters(body.preferences) : undefined,
       })
     );
   }
@@ -473,36 +470,5 @@ export class TopicsController {
 
       return subscription;
     });
-  }
-
-  private convertPreferencesToGroupFilters(
-    preferences: Array<string | WorkflowPreferenceRequestDto | GroupPreferenceFilterDto>
-  ): Array<GroupPreferenceFilterDto> {
-    return preferences.map((preference) => {
-      if (typeof preference === 'string') {
-        return {
-          filter: {
-            workflowIds: [preference],
-          },
-        };
-      }
-
-      if (this.isGroupPreferenceFilter(preference)) {
-        return preference;
-      }
-
-      return {
-        filter: {
-          workflowIds: [preference.workflowId],
-        },
-        condition: preference.condition,
-      };
-    });
-  }
-
-  private isGroupPreferenceFilter(
-    preference: WorkflowPreferenceRequestDto | GroupPreferenceFilterDto
-  ): preference is GroupPreferenceFilterDto {
-    return 'filter' in preference;
   }
 }


### PR DESCRIPTION
## Summary

- Topics v2 create/update dropped `enabled` when preferences used the `{ workflowId, enabled }` shape (`TopicsController.convertPreferencesToGroupFilters` never forwarded `enabled`).
- Extracted shared `convertPreferencesToGroupFilters` used by topics + inbox controllers so `enabled: false` is preserved.
- Added unit and e2e coverage for the regression.

```mermaid
flowchart LR
  A["Preference input<br/>string | workflowId shape | group filter"] --> B["convertPreferencesToGroupFilters"]
  B --> C["GroupPreferenceFilterDto<br/>filter + enabled + condition"]
  C --> D["Create/Update subscription usecase"]
```

## Test plan

- [x] Unit: `convertPreferencesToGroupFilters` preserves `enabled: false` and `condition`
- [x] E2E: create topic subscriptions with `{ workflowId, enabled: false }`
- [x] E2E: update topic subscription preferences with `{ workflowId, enabled: false }`
- [x] `pnpm --filter @novu/api-service build` (0 TSC issues)

Linear: https://linear.app/novu/issue/NV-8458/preserve-enabledfalse-when-converting-subscription-preferences-with

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes subscription preference normalization and preserves `enabled` for workflow-scoped preferences.
- Extracts `convertPreferencesToGroupFilters` into a shared subscriptions utility used by topics and inbox controllers.
- Preserves `enabled: false` and `condition` when converting the `{ workflowId, ... }` request shape.
- Adds unit and end-to-end regression coverage for create and update flows.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The shared converter retains the existing handling of strings and group filters while fixing the workflowId-shaped path to forward both `enabled` and `condition`, with focused unit and end-to-end coverage.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/subscriptions/utils/subscriptions.ts | Adds the shared normalization helper and correctly retains `enabled`, including an explicit false value. |
| apps/api/src/app/topics-v2/topics.controller.ts | Replaces duplicated controller normalization with the shared helper for topic subscription creation and updates. |
| apps/api/src/app/inbox/inbox.topic.controller.ts | Reuses the shared helper without changing the inbox controller's established normalization behavior. |
| apps/api/src/app/subscriptions/utils/subscriptions.spec.ts | Covers all supported preference shapes, including preservation of false and conditional expressions. |
| apps/api/src/app/topics-v2/e2e/create-topic-subscriptions.e2e.ts | Adds regression coverage proving create responses preserve `enabled: false`. |
| apps/api/src/app/topics-v2/e2e/update-topic-subscription.e2e.ts | Adds regression coverage proving update responses preserve `enabled: false`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Preference request] --> B{Input shape}
  B -->|String| C[Workflow ID group filter]
  B -->|workflowId object| D[Group filter with enabled and condition]
  B -->|Existing group filter| E[Pass through unchanged]
  C --> F[Create or update subscription]
  D --> F
  E --> F
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): preserve enabled on wo..."](https://github.com/novuhq/novu/commit/c9309fd03efcee056cad9f2c2655f7e42435e8ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48655858)</sub>

<!-- /greptile_comment -->