### PR TITLE
feat(api-service): persist productUseCases to Mongo alongside Clerk fixes NV-8459

### DIFF
--- a/apps/dashboard/src/api/organization.ts
+++ b/apps/dashboard/src/api/organization.ts
@@ -31,8 +31,8 @@ export async function updateOrganizationSettings({
   return patch('/organizations/settings', { environment, body: data });
 }
 
-// Writes onboarding metadata (e.g. productUseCases) onto the external (Clerk) organization.
-// Org context is resolved server-side from the session, so no environment is required.
+// Writes onboarding metadata (e.g. productUseCases) onto the external (Clerk) organization
+// and the internal Mongo organization. Org context is resolved server-side from the session.
 export async function updateExternalOrganization(data: UpdateExternalOrganizationDto): Promise<unknown> {
   return post('/clerk/organization', { body: data });
 }

--- a/apps/dashboard/src/hooks/use-update-product-use-cases.ts
+++ b/apps/dashboard/src/hooks/use-update-product-use-cases.ts
@@ -9,8 +9,8 @@ export function useUpdateProductUseCases() {
   return useMutation<unknown, Error, ProductUseCases>({
     mutationFn: async (productUseCases) => updateExternalOrganization({ productUseCases }),
     onSuccess: async () => {
-      // The org's productUseCases live in Clerk's publicMetadata, which the API just updated.
-      // Reload the Clerk resource so useAuth().currentOrganization reflects the change.
+      // The API persists productUseCases to Clerk publicMetadata (and Mongo). Reload Clerk so
+      // useAuth().currentOrganization reflects the change.
       await organization?.reload();
     },
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Onboarding usecase selection (Agents/Inbox) previously wrote `productUseCases` only to Clerk org `publicMetadata` via `POST /clerk/organization`. Backend/analytics code that reads Mongo `organization.productUseCases` never saw the pick.

This updates enterprise `UpdateExternalOrganization` so the same (merged) `productUseCases` patch is written to the Mongo organization document alongside Clerk.

Linear: https://linear.app/novu/issue/NV-8459/persist-onboarding-productusecases-to-mongo-org-alongside-clerk

```mermaid
sequenceDiagram
  participant UI as Dashboard usecase picker
  participant API as POST /clerk/organization
  participant Mongo as Mongo organizations
  participant Clerk as Clerk org publicMetadata

  UI->>API: productUseCases patch
  API->>API: merge with existing productUseCases
  API->>Mongo: update organization.productUseCases
  API->>Clerk: update publicMetadata.productUseCases
```

### Screenshots

N/A — backend persistence change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

Branch pushed; open/compare:
https://github.com/novuhq/packages-enterprise/compare/next...cursor/persist-product-usecases-mongo-53b6

(`gh pr create` for `packages-enterprise` is not permitted from this agent token — please open that PR from the compare link if it is not created automatically.)

### Special notes for your reviewer

- Partial patches (e.g. deeplink `{ agents: true }`) are merged with the existing Clerk-backed flags before writing both stores.
- Dashboard comment-only updates clarify that persistence is Clerk + Mongo.
- Validate Submodule Sync may fail until the enterprise PR is opened/merged — expected per submodule workflow.

### Test plan

1. Pick Agents (or Inbox) on `/onboarding/usecase`.
2. Confirm Clerk `publicMetadata.productUseCases` updates.
3. Confirm Mongo `organizations.productUseCases` has matching `agents` / `in_app` flags.
4. Hit agents setup via `?product_type=agents` and confirm Mongo gets `agents: true`.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1c036cf-b502-46b6-a859-6256b4ba53b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1c036cf-b502-46b6-a859-6256b4ba53b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the enterprise source revision to persist onboarding product-use-case selections in MongoDB alongside Clerk.
- Advances the `.source` enterprise submodule revision.
- Clarifies dashboard API and mutation-hook comments to describe dual persistence and Clerk resource reloading.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .source | Advances the enterprise source revision containing the server-side organization persistence change. |
| apps/dashboard/src/api/organization.ts | Updates documentation for the existing API call to state that organization metadata is persisted to Clerk and MongoDB. |
| apps/dashboard/src/hooks/use-update-product-use-cases.ts | Updates the success-handler comment to clarify that Clerk is reloaded after dual-store persistence. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as Dashboard use-case picker
  participant API as POST /clerk/organization
  participant Mongo as Mongo organization
  participant Clerk as Clerk organization
  UI->>API: productUseCases patch
  API->>Mongo: Persist merged productUseCases
  API->>Clerk: Update publicMetadata
  API-->>UI: Success
  UI->>Clerk: Reload organization resource
```

<sub>Reviews (2): Last reviewed commit: ["Update .source"](https://github.com/novuhq/novu/commit/c370ce028341d4657888d6140d816bc5cb3be96a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48677145)</sub>

<!-- /greptile_comment -->