### PR TITLE
fix(api): IdempotencyInterceptor emits Promise instead of response (mergeMap)

### DIFF
--- a/apps/api/src/app/shared/framework/idempotency.interceptor.ts
+++ b/apps/api/src/app/shared/framework/idempotency.interceptor.ts
@@ -21,7 +21,7 @@ import {
 import { ApiAuthSchemeEnum, FeatureFlagsKeysEnum, UserSessionData } from '@novu/shared';
 import { createHash } from 'crypto';
 import { Observable, of, throwError } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, mergeMap } from 'rxjs/operators';
 import { EXCLUDE_FROM_IDEMPOTENCY } from './exclude-from-idempotency';
 
 const IDEMPOTENCY_CACHE_TTL = 60 * 60 * 24; // 24h
@@ -245,7 +245,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
     const idempotencyKey = this.getIdempotencyKey(context)!;
 
     return next.handle().pipe(
-      map(async (response) => {
+      mergeMap(async (response) => {
         const httpResponse = context.switchToHttp().getResponse();
         const { statusCode } = httpResponse;
 


### PR DESCRIPTION
## What

Fix `IdempotencyInterceptor` emitting a `Promise` instead of the resolved response.

Closes #12117

## Why

`handleNewRequest()` pipes the response through an **`async` callback inside RxJS `map`**:

```ts
return next.handle().pipe(
  map(async (response) => {
    await this.setCache(...);
    return response;
  }),
  ...
);
```

`map` does **not** await Promises — it emits whatever the callback returns. Since an `async` function always returns a `Promise`, the interceptor emits `Promise<Response>` instead of `Response`. Downstream interceptors (e.g. `ResponseInterceptor`) then receive a `Promise` and can serialize it incorrectly (e.g. `{ data: {} }` / `{ data: Promise }`).

## Fix

Use `mergeMap`, which subscribes to the Promise returned by the async callback and emits its **resolved** value:

```diff
-import { catchError, map } from 'rxjs/operators';
+import { catchError, mergeMap } from 'rxjs/operators';
...
     return next.handle().pipe(
-      map(async (response) => {
+      mergeMap(async (response) => {
```

`catchError` after it is unchanged. The cache write is still awaited, and the correct response object is now emitted.

## Verification

RxJS doesn't run standalone in my environment, so I confirmed the operator semantics with a minimal faithful model of `map` vs `mergeMap`:

```
--- BEFORE (map): downstream receives ---
  isPromise: true   value: Promise { <pending> }
--- AFTER (mergeMap): downstream receives ---
  isPromise: false  value: {"message":"created","id":"wf_123"}
```

Existing idempotency coverage lives in `apps/api/src/app/shared/framework/idempotency.e2e.ts`; this change makes the cached/returned body the actual response rather than a pending Promise. I couldn't run the full API e2e locally (needs the app + datastores), so CI validates end-to-end.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes idempotent API responses by flattening the asynchronous success-cache operation before emitting the response.
- Replaces `map` with `mergeMap` in `IdempotencyInterceptor`.
- Preserves the awaited cache write, response value, headers, and existing error handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the focused operator change correcting Promise emission without altering established request behavior.

The interceptor now waits for the success cache write and emits the resolved controller response, while existing single-response handlers, headers, and error propagation retain their intended behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/framework/idempotency.interceptor.ts | Correctly resolves the asynchronous cache callback before passing successful responses to downstream interceptors; no actionable regression identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): IdempotencyInterceptor emits P..."](https://github.com/novuhq/novu/commit/e99f308d8d28926f0a12b7c686850024b29529ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48951951)</sub>

**Context used:**

- Knowledge Base — [API App (apps/api)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-app.md)

<!-- /greptile_comment -->