### PR TITLE
test

### DIFF
--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -20,9 +20,8 @@ import type { InboxNotification, NotificationFilter, TagsFilter } from '../types
 import {
   areDataEqual,
   areTagsEqual,
-  checkBasicFilters,
-  checkNotificationTagFilter,
   isSameFilter,
+  notificationMatchesCacheBucket,
 } from '../utils/notification-utils';
 import { InMemoryCache } from './in-memory-cache';
 import type { Cache } from './types';
@@ -176,8 +175,7 @@ export class NotificationsCache {
     }
 
     const bucketFilter = getFilter(key);
-    const matchesFilter =
-      checkBasicFilters(notification, bucketFilter) && checkNotificationTagFilter(notification.tags, bucketFilter.tags);
+    const matchesFilter = notificationMatchesCacheBucket(notification, bucketFilter);
     const index = notificationsResponse.notifications.findIndex((el) => el.id === notification.id);
     const existsInBucket = index !== -1;
 
@@ -298,7 +296,7 @@ export class NotificationsCache {
         continue;
       }
 
-      hasMore = cachedResponse.hasMore;
+      hasMore = hasMore || cachedResponse.hasMore;
 
       for (const notification of cachedResponse.notifications) {
         uniqueNotifications.set(notification.id, notification);
@@ -337,11 +335,9 @@ export class NotificationsCache {
 
     const notificationInstance = this.#toNotificationInstance({ ...notification });
 
-    const dedupedNotifications = cachedData.notifications.filter((n) => n.id !== notification.id);
-
     this.update(args, {
       ...cachedData,
-      notifications: [notificationInstance, ...dedupedNotifications],
+      notifications: [notificationInstance, ...cachedData.notifications],
     });
   }
 

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -84,3 +84,4 @@ export {
   isSameFilter,
   normalizeTagGroups,
 } from './utils/notification-utils';
+export { COUNT_MUTATION_RESOLVED_EVENTS } from './notifications/count-invalidation-events';

--- a/packages/js/src/notifications/count-invalidation-events.ts
+++ b/packages/js/src/notifications/count-invalidation-events.ts
@@ -1,0 +1,7 @@
+export const COUNT_MUTATION_RESOLVED_EVENTS = [
+  'notification.read.resolved',
+  'notification.unread.resolved',
+  'notification.seen.resolved',
+  'notifications.read_all.resolved',
+  'notifications.seen_all.resolved',
+] as const;

--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -1,16 +1,7 @@
-import {
-  Accessor,
-  createContext,
-  createEffect,
-  createMemo,
-  createSignal,
-  onCleanup,
-  ParentProps,
-  useContext,
-} from 'solid-js';
-import { NOTIFICATION_COUNT_SYNC_EVENTS } from '../../notifications/count-sync-events';
+import { Accessor, createContext, createEffect, createMemo, createSignal, onCleanup, ParentProps, useContext } from 'solid-js';
+import { COUNT_MUTATION_RESOLVED_EVENTS } from '../../notifications/count-invalidation-events';
 import { Notification, NotificationFilter, SeverityLevelEnum } from '../../types';
-import { checkNotificationMatchesFilter } from '../../utils/notification-utils';
+import { checkNotificationDataFilter, checkNotificationTagFilter } from '../../utils/notification-utils';
 import { getTagsFromTab } from '../helpers';
 import { useNovuEvent } from '../helpers/useNovuEvent';
 import { useWebSocketEvent } from '../helpers/useWebSocketEvent';
@@ -138,17 +129,11 @@ export const CountProvider = (props: ParentProps) => {
 
   createEffect(() => {
     const novu = novuAccessor();
-    const cleanups = NOTIFICATION_COUNT_SYNC_EVENTS.map((event) =>
-      novu.on(event, (payload) => {
-        if ('error' in payload && payload.error) {
-          return;
-        }
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, refreshCounts));
 
-        refreshCounts();
-      })
-    );
-
-    onCleanup(() => cleanups.forEach((cleanup) => cleanup()));
+    onCleanup(() => {
+      cleanups.forEach((cleanup) => cleanup());
+    });
   });
 
   useNovuEvent({
@@ -222,42 +207,47 @@ export const CountProvider = (props: ParentProps) => {
       if (currentTabs.length > 0) {
         for (const tab of currentTabs) {
           const tabTags = getTagsFromTab(tab);
-          const tabFilter: NotificationFilter = {
-            tags: tabTags,
-            read: false,
-            archived: false,
-            snoozed: false,
-            data: tab.filter?.data,
-            severity: tab.filter?.severity,
-          };
+          const tabDataFilterCriteria = tab.filter?.data;
+          const tabSeverityFilterCriteria = tab.filter?.severity;
 
-          if (!checkNotificationMatchesFilter(notification, tabFilter)) {
-            continue;
-          }
+          const matchesTagFilter = checkNotificationTagFilter(notification.tags, tabTags);
+          const matchesDataFilterCriteria = checkNotificationDataFilter(notification.data, tabDataFilterCriteria);
 
-          const filterKey = createKey({
-            tags: tabTags,
-            data: tab.filter?.data,
-            severity: tab.filter?.severity,
-          });
+          const matchesSeverityFilterCriteria =
+            !tabSeverityFilterCriteria ||
+            (Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria.length === 0) ||
+            (Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria.includes(notification.severity)) ||
+            (!Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria === notification.severity);
 
-          if (!processedFilters.has(filterKey)) {
-            processedFilters.add(filterKey);
-            updateNewNotificationCountsOrCache(
-              tab.label,
-              notification,
-              tabTags,
-              tab.filter?.data,
-              tab.filter?.severity
-            );
+          if (matchesTagFilter && matchesDataFilterCriteria && matchesSeverityFilterCriteria) {
+            const filterKey = createKey({
+              tags: tabTags,
+              data: tabDataFilterCriteria,
+              severity: tabSeverityFilterCriteria,
+            });
+
+            if (!processedFilters.has(filterKey)) {
+              processedFilters.add(filterKey);
+              updateNewNotificationCountsOrCache(
+                tab.label,
+                notification,
+                tabTags,
+                tabDataFilterCriteria,
+                tabSeverityFilterCriteria
+              );
+            }
           }
         }
       } else {
+        // No tabs are defined. Apply to default (no tags, no data) filter.
         updateNewNotificationCountsOrCache('', notification, [], undefined, undefined);
       }
-
-      await refreshCounts();
     },
+  });
+
+  useWebSocketEvent({
+    event: 'notifications.notification_received',
+    eventHandler: refreshCounts,
   });
 
   const resetNewNotificationCounts = (key: string) => {

--- a/packages/js/src/utils/notification-utils.test.ts
+++ b/packages/js/src/utils/notification-utils.test.ts
@@ -1,11 +1,11 @@
-import { Notification } from '../notifications/notification';
 import {
   areTagsEqual,
-  checkBasicFilters,
   checkNotificationDataFilter,
   checkNotificationTagFilter,
   normalizeTagGroups,
+  notificationMatchesCacheBucket,
 } from './notification-utils';
+import { Notification } from '../notifications/notification';
 
 describe('normalizeTagGroups', () => {
   it('wraps flat tags as one OR-group', () => {
@@ -130,7 +130,7 @@ describe('areTagsEqual', () => {
   });
 });
 
-describe('cache bucket membership', () => {
+describe('notificationMatchesCacheBucket', () => {
   const baseNotification = {
     isRead: false,
     isSeen: false,
@@ -140,21 +140,17 @@ describe('cache bucket membership', () => {
     createdAt: new Date().toISOString(),
   } as Notification;
 
-  function matchesCacheBucket(notification: Notification, filter: { read?: boolean; tags?: string[] }) {
-    return checkBasicFilters(notification, filter) && checkNotificationTagFilter(notification.tags, filter.tags);
-  }
-
   it('returns false when read status no longer matches the bucket filter', () => {
     const readNotification = { ...baseNotification, isRead: true } as Notification;
 
-    expect(matchesCacheBucket(readNotification, { read: false })).toBe(false);
+    expect(notificationMatchesCacheBucket(readNotification, { read: false })).toBe(false);
   });
 
   it('returns false when tags no longer match the bucket filter', () => {
-    expect(matchesCacheBucket(baseNotification, { tags: ['tag2'] })).toBe(false);
+    expect(notificationMatchesCacheBucket(baseNotification, { tags: ['tag2'] })).toBe(false);
   });
 
   it('returns true when status and tags still match the bucket filter', () => {
-    expect(matchesCacheBucket(baseNotification, { read: false, tags: ['tag1'] })).toBe(true);
+    expect(notificationMatchesCacheBucket(baseNotification, { read: false, tags: ['tag1'] })).toBe(true);
   });
 });

--- a/packages/js/src/utils/notification-utils.ts
+++ b/packages/js/src/utils/notification-utils.ts
@@ -494,3 +494,17 @@ export function checkNotificationMatchesFilter(notification: Notification, filte
     checkNotificationTimeframeFilter(notification.createdAt, filter.createdGte, filter.createdLte)
   );
 }
+
+/**
+ * Whether a notification still belongs in a notifications-cache bucket after a local mutation.
+ * Status fields (read/seen/archived/snoozed) and tags can change membership; data and timeframe
+ * are stable for in-flight mutations and are validated when the bucket is populated from the API.
+ */
+export function notificationMatchesCacheBucket(
+  notification: Notification,
+  filter: NotificationFilter
+): boolean {
+  return (
+    checkBasicFilters(notification, filter) && checkNotificationTagFilter(notification.tags, filter.tags)
+  );
+}

--- a/packages/react/src/hooks/useCounts.ts
+++ b/packages/react/src/hooks/useCounts.ts
@@ -1,11 +1,4 @@
-import {
-  checkNotificationMatchesFilter,
-  isSameFilter,
-  NOTIFICATION_COUNT_SYNC_EVENTS,
-  Notification,
-  NotificationFilter,
-  NovuError,
-} from '@novu/js';
+import { COUNT_MUTATION_RESOLVED_EVENTS, checkNotificationMatchesFilter, isSameFilter, Notification, NotificationFilter, NovuError } from '@novu/js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useWebSocketEvent } from './internal/useWebsocketEvent';
@@ -91,7 +84,9 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
       let countFiltersToFetch: NotificationFilter[] = [];
 
       if (notification) {
-        countFiltersToFetch = currentFilters.filter((filter) => checkNotificationMatchesFilter(notification, filter));
+        countFiltersToFetch = currentFilters.filter((filter) =>
+          checkNotificationMatchesFilter(notification, filter)
+        );
       } else {
         countFiltersToFetch = currentFilters;
       }
@@ -158,17 +153,11 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
   });
 
   useEffect(() => {
-    const cleanups = NOTIFICATION_COUNT_SYNC_EVENTS.map((event) =>
-      novu.on(event, (payload) => {
-        if ('error' in payload && payload.error) {
-          return;
-        }
+    const cleanups = COUNT_MUTATION_RESOLVED_EVENTS.map((event) => novu.on(event, () => sync()));
 
-        sync();
-      })
-    );
-
-    return () => cleanups.forEach((cleanup) => cleanup());
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
   }, [novu, sync]);
 
   useEffect(() => {


### PR DESCRIPTION
test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revises notification-cache membership and aggregation behavior and changes how Solid and React count hooks refresh after notification events.
- Adds and exports a shared set of count-mutation resolution events.
- Splits Solid notification-received count refresh from local tab-count updates.
- Adds a cache-bucket membership helper and associated tests.
- Changes cache aggregation to preserve `hasMore` from any contributing bucket.
- Changes cache unshift behavior to retain existing entries.

<h3>Confidence Score: 4/5</h3>

The duplicate-entry regression in the notification cache should be fixed before merging because subsequent mutations can surface stale notification state.

Cache unshift retains an existing entry with the same notification ID, while later synchronization updates only the first match and aggregation can select the remaining stale duplicate; failed count mutations also cause unnecessary count requests.

**Files Needing Attention:** packages/js/src/cache/notifications-cache.ts, packages/js/src/ui/context/CountContext.tsx, packages/react/src/hooks/useCounts.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/cache/notifications-cache.ts | Refactors bucket matching and aggregation but introduces duplicate cache entries by removing ID deduplication from unshift. |
| packages/js/src/ui/context/CountContext.tsx | Reworks mutation and websocket-driven count refreshes, but failed subscribed mutations now trigger unnecessary count requests. |
| packages/react/src/hooks/useCounts.ts | Switches count synchronization to the shared event list and refreshes counts for both successful and failed resolved mutations. |
| packages/js/src/utils/notification-utils.ts | Adds a focused helper for deciding whether a locally mutated notification remains in a cache bucket. |
| packages/js/src/notifications/count-invalidation-events.ts | Defines the shared mutation-resolution events used to invalidate notification counts. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  WS[Notification websocket event] --> Hook[Notification hooks]
  Hook --> Cache[Notifications cache]
  Cache --> Aggregate[Aggregate cached buckets]
  Aggregate --> UI[Rendered notification list]
  Hook --> Counts[Refresh filtered counts]
  Counts --> UI
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fjs%2Fsrc%2Fcache%2Fnotifications-cache.ts%3A338-341%0A**Duplicate%20cache%20entries%20retain%20stale%20state**%0A%0AWhen%20a%20websocket%20notification%20has%20an%20ID%20already%20present%20in%20this%20bucket%2C%20%60unshift%60%20retains%20both%20entries.%20A%20later%20mutation%20updates%20only%20the%20first%20match%2C%20while%20ID-keyed%20aggregation%20lets%20the%20later%20stale%20duplicate%20replace%20it%2C%20causing%20outdated%20read%2C%20seen%2C%20archived%2C%20or%20snoozed%20state%20to%20reappear%20in%20the%20rendered%20list.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20dedupedNotifications%20%3D%20cachedData.notifications.filter%28%28n%29%20%3D%3E%20n.id%20!%3D%3D%20notification.id%29%3B%0A%0A%20%20%20%20this.update%28args%2C%20%7B%0A%20%20%20%20%20%20...cachedData%2C%0A%20%20%20%20%20%20notifications%3A%20%5BnotificationInstance%2C%20...dedupedNotifications%5D%2C%0A%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Apackages%2Fjs%2Fsrc%2Fui%2Fcontext%2FCountContext.tsx%3A132%0A**Failed%20mutations%20trigger%20count%20requests**%0A%0AThe%20subscribed%20%60.resolved%60%20events%20fire%20for%20failed%20mutations%20with%20an%20error%20payload%2C%20but%20these%20handlers%20now%20refresh%20counts%20unconditionally.%20Each%20failed%20read%2C%20unread%2C%20seen%2C%20read-all%2C%20or%20seen-all%20operation%20therefore%20issues%20a%20count%20request%20even%20though%20no%20count%20changed%3B%20the%20same%20regression%20is%20present%20in%20%60packages%2Freact%2Fsrc%2Fhooks%2FuseCounts.ts%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/js/src/cache/notifications-cache.ts:338-341
**Duplicate cache entries retain stale state**

When a websocket notification has an ID already present in this bucket, `unshift` retains both entries. A later mutation updates only the first match, while ID-keyed aggregation lets the later stale duplicate replace it, causing outdated read, seen, archived, or snoozed state to reappear in the rendered list.

```suggestion
    const dedupedNotifications = cachedData.notifications.filter((n) => n.id !== notification.id);

    this.update(args, {
      ...cachedData,
      notifications: [notificationInstance, ...dedupedNotifications],
    });
```

### Issue 2
packages/js/src/ui/context/CountContext.tsx:132
**Failed mutations trigger count requests**

The subscribed `.resolved` events fire for failed mutations with an error payload, but these handlers now refresh counts unconditionally. Each failed read, unread, seen, read-all, or seen-all operation therefore issues a count request even though no count changed; the same regression is present in `packages/react/src/hooks/useCounts.ts`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: inbox badge sync across cache bucke..."](https://github.com/novuhq/novu/commit/d23fee7961bd4bfcc48464779d59dc1f19155bb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49036883)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->