### PR TITLE
fix(js,react): when web locks not available then dont broadcast messages fixes NV-8425

### DIFF
--- a/packages/js/src/ui/helpers/browser.ts
+++ b/packages/js/src/ui/helpers/browser.ts
@@ -1,5 +1,9 @@
+export function isWebLocksSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'locks' in navigator && !!navigator.locks;
+}
+
 export function requestLock(id: string, cb: (id: string) => void) {
-  if (typeof navigator === 'undefined' || !('locks' in navigator) || !navigator.locks) {
+  if (!isWebLocksSupported()) {
     cb(id);
 
     return () => {};

--- a/packages/js/src/ui/helpers/useWebSocketEvent.ts
+++ b/packages/js/src/ui/helpers/useWebSocketEvent.ts
@@ -1,7 +1,7 @@
 import { createEffect, onCleanup } from 'solid-js';
 import type { EventHandler, Events, SocketEventNames } from '../../event-emitter';
 import { useNovu } from '../context';
-import { requestLock } from './browser';
+import { isWebLocksSupported, requestLock } from './browser';
 
 export const useWebSocketEvent = <E extends SocketEventNames>({
   event: webSocketEvent,
@@ -23,9 +23,16 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
 
     tabsChannel.addEventListener('message', listener);
 
+    // When Web Locks are unavailable, requestLock runs the callback in every tab,
+    // so each tab already receives the event through its own socket. Re-broadcasting
+    // in that case would duplicate the event across tabs (count multiplied by tab
+    // count). Only the exclusive lock owner should fan out to the other tabs.
+    const shouldBroadcast = isWebLocksSupported();
     const updateReadCount: EventHandler<Events[E]> = (data) => {
       onMessage(data);
-      tabsChannel.postMessage(data);
+      if (shouldBroadcast) {
+        tabsChannel.postMessage(data);
+      }
     };
 
     let cleanup: (() => void) | undefined;

--- a/packages/react/src/hooks/internal/useWebsocketEvent.ts
+++ b/packages/react/src/hooks/internal/useWebsocketEvent.ts
@@ -1,6 +1,6 @@
 import { EventHandler, Events, SocketEventNames } from '@novu/js';
 import { useEffect } from 'react';
-import { requestLock } from '../../utils/requestLock';
+import { isWebLocksSupported, requestLock } from '../../utils/requestLock';
 import { useNovu } from '../NovuProvider';
 import { useBrowserTabsChannel } from './useBrowserTabsChannel';
 
@@ -22,9 +22,16 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
     enabled,
   });
 
+  // When Web Locks are unavailable, requestLock runs the callback in every tab,
+  // so each tab already receives the event through its own socket. Re-broadcasting
+  // in that case would duplicate the event across tabs (count multiplied by tab
+  // count). Only the exclusive lock owner should fan out to the other tabs.
+  const shouldBroadcast = isWebLocksSupported();
   const updateReadCount: EventHandler<Events[E]> = (data) => {
     onMessage(data);
-    postMessage(data);
+    if (shouldBroadcast) {
+      postMessage(data);
+    }
   };
 
   useEffect(() => {

--- a/packages/react/src/utils/requestLock.ts
+++ b/packages/react/src/utils/requestLock.ts
@@ -1,6 +1,10 @@
+export function isWebLocksSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'locks' in navigator && !!navigator.locks;
+}
+
 export function requestLock(id: string, cb: (id: string) => void) {
   // Check if the Lock API is available
-  if (!('locks' in navigator)) {
+  if (!isWebLocksSupported()) {
     // If Lock API is not available, immediately invoke the callback and return a no-op function
     cb(id);
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Inbox: when web locks api is not available then don't broadcast messages between the tabs

### Screenshots


https://github.com/user-attachments/assets/92555ef3-cd1b-43d7-9b31-1e5057e456e3


https://github.com/user-attachments/assets/9d54564e-961c-4b2e-ba5b-0fc25f15aa79

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents duplicate cross-tab inbox events when Web Locks are unavailable.
- Adds shared Web Locks capability checks to the JavaScript and React implementations.
- Suppresses BroadcastChannel forwarding in both websocket-event hooks when locking is unsupported.

<h3>Confidence Score: 4/5</h3>

The initialization-window event loss should be fixed before merging because an enabled tab can miss realtime inbox updates while its session-backed socket is still connecting.

The change removes the only active delivery path to a tab during the interval after its BroadcastChannel listener is mounted but before its own socket connection completes.

**Files Needing Attention:** packages/react/src/hooks/internal/useWebsocketEvent.ts and packages/js/src/ui/helpers/useWebSocketEvent.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/ui/helpers/browser.ts | Extracts a server-safe Web Locks capability check and reuses it in the lock fallback. |
| packages/js/src/ui/helpers/useWebSocketEvent.ts | Stops channel fan-out without Web Locks, which can drop events in tabs whose sockets are not connected yet. |
| packages/react/src/hooks/internal/useWebsocketEvent.ts | Mirrors the broadcast suppression and exposes the same initialization-window event loss. |
| packages/react/src/utils/requestLock.ts | Makes the React lock capability check safe when navigator or navigator.locks is unavailable. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant A as Tab A (connected socket)
  participant WS as Realtime service
  participant BC as BroadcastChannel
  participant B as Tab B (session initializing)
  WS->>A: Inbox event
  A->>A: Apply event locally
  Note over A,BC: Web Locks unavailable, so forwarding is suppressed
  B-->>WS: Socket connection deferred
  Note over B: Event is missed
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Freact%2Fsrc%2Fhooks%2Finternal%2FuseWebsocketEvent.ts%3A31-33%0A**Broadcast%20suppression%20drops%20initializing%20tabs**%0A%0AWhen%20Web%20Locks%20are%20unavailable%20and%20another%20tab's%20session-backed%20socket%20is%20still%20connecting%2C%20the%20connected%20tab%20suppresses%20%60postMessage%60%2C%20causing%20the%20initializing%20tab%20to%20miss%20realtime%20notification%20and%20unread-count%20updates.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/react/src/hooks/internal/useWebsocketEvent.ts:31-33
**Broadcast suppression drops initializing tabs**

When Web Locks are unavailable and another tab's session-backed socket is still connecting, the connected tab suppresses `postMessage`, causing the initializing tab to miss realtime notification and unread-count updates.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js,react): when web locks not availa..."](https://github.com/novuhq/novu/commit/0b59c6a41ea980cc9f73bca33d73b447e8f26fa4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49045369)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->