### PR TITLE
fix(shared): support long workflow identifiers in parseSlugId fixes NV-8468

### DIFF
--- a/libs/application-generic/src/pipes/parse-slug-id.pipe.spec.ts
+++ b/libs/application-generic/src/pipes/parse-slug-id.pipe.spec.ts
@@ -42,6 +42,11 @@ describe('ParseSlugIdPipe', () => {
       const identifier = 'sendgrid-prod';
       expect(pipe.transform(identifier, {} as ArgumentMetadata)).to.equal(identifier);
     });
+
+    it('should return long workflow identifiers unchanged', () => {
+      const identifier = 'dailyDigestPatient';
+      expect(pipe.transform(identifier, {} as ArgumentMetadata)).to.equal(identifier);
+    });
   });
 
   describe('Slug IDs with various prefixes', () => {

--- a/libs/application-generic/src/pipes/parse-slug-id.ts
+++ b/libs/application-generic/src/pipes/parse-slug-id.ts
@@ -1,11 +1,9 @@
 import { BaseRepository } from '@novu/dal';
-import { ShortIsPrefixEnum } from '@novu/shared';
 import { decodeBase62 } from '../utils/base62';
 
 export type InternalId = string;
 const INTERNAL_ID_LENGTH = 24;
 const ENCODED_ID_LENGTH = 16;
-const SLUG_ENCODED_SUFFIX_MARKERS = Object.values(ShortIsPrefixEnum).map((prefix) => `_${prefix}`);
 
 /**
  * Checks if the value is a short resource identifier (less than encoded ID length)
@@ -40,25 +38,19 @@ function lookoutForResourceId(value: string): string | null {
 }
 
 /**
- * Checks if the value ends with a slug-encoded internal ID suffix.
- * Examples: 'welcome-email_wf_1A2B3C4D5E6F7890', 'my-step_st_AbC1Xyz9KlmNOpQr'
+ * Slug IDs always end with `_` followed by a 16-character base62-encoded internal ID.
+ * Examples: 'welcome-email_wf_1A2B3C4D5E6F7890', 'email-template_et_1A2B3C4D5E6F7890'
  */
-function hasSlugEncodedSuffix(value: string): boolean {
-  return SLUG_ENCODED_SUFFIX_MARKERS.some((marker) => {
-    const markerIndex = value.lastIndexOf(marker);
-
-    if (markerIndex === -1) {
-      return false;
-    }
-
-    const encodedPart = value.slice(markerIndex + marker.length);
-
-    return encodedPart.length === ENCODED_ID_LENGTH;
-  });
-}
-
 function shouldAttemptSlugDecode(value: string): boolean {
-  return value.length === ENCODED_ID_LENGTH || hasSlugEncodedSuffix(value);
+  if (value.length === ENCODED_ID_LENGTH) {
+    return true;
+  }
+
+  if (value.length < ENCODED_ID_LENGTH) {
+    return false;
+  }
+
+  return value[value.length - ENCODED_ID_LENGTH - 1] === '_';
 }
 
 /**

--- a/libs/application-generic/src/pipes/parse-slug-id.ts
+++ b/libs/application-generic/src/pipes/parse-slug-id.ts
@@ -1,9 +1,11 @@
 import { BaseRepository } from '@novu/dal';
+import { ShortIsPrefixEnum } from '@novu/shared';
 import { decodeBase62 } from '../utils/base62';
 
 export type InternalId = string;
 const INTERNAL_ID_LENGTH = 24;
 const ENCODED_ID_LENGTH = 16;
+const SLUG_ENCODED_SUFFIX_MARKERS = Object.values(ShortIsPrefixEnum).map((prefix) => `_${prefix}`);
 
 /**
  * Checks if the value is a short resource identifier (less than encoded ID length)
@@ -38,6 +40,28 @@ function lookoutForResourceId(value: string): string | null {
 }
 
 /**
+ * Checks if the value ends with a slug-encoded internal ID suffix.
+ * Examples: 'welcome-email_wf_1A2B3C4D5E6F7890', 'my-step_st_AbC1Xyz9KlmNOpQr'
+ */
+function hasSlugEncodedSuffix(value: string): boolean {
+  return SLUG_ENCODED_SUFFIX_MARKERS.some((marker) => {
+    const markerIndex = value.lastIndexOf(marker);
+
+    if (markerIndex === -1) {
+      return false;
+    }
+
+    const encodedPart = value.slice(markerIndex + marker.length);
+
+    return encodedPart.length === ENCODED_ID_LENGTH;
+  });
+}
+
+function shouldAttemptSlugDecode(value: string): boolean {
+  return value.length === ENCODED_ID_LENGTH || hasSlugEncodedSuffix(value);
+}
+
+/**
  * Parses a slug ID and returns the internal resource ID
  *
  * Handles multiple input formats:
@@ -58,6 +82,10 @@ export function parseSlugId(value: string): InternalId {
   const validId = lookoutForResourceId(value);
   if (validId) {
     return validId;
+  }
+
+  if (!shouldAttemptSlugDecode(value)) {
+    return value;
   }
 
   // Try to extract and decode the base62 encoded part from the end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes translations failing for workflow identifiers with length >= 16 characters (e.g. `dailyDigestPatient`).

## Problem

`parseSlugId` treated any identifier with length >= 16 as a potential slug-encoded internal ID and attempted to base62-decode the last 16 characters. For identifiers like `dailyDigestPatient` (18 chars), this produced an incorrect MongoDB ObjectId instead of returning the original workflow identifier.

This broke translation endpoints that use `ParseSlugIdPipe` on `resourceId`, causing "View & Manage Translations" to fail for affected workflows.

## Solution

Only attempt slug decoding when the value:
- is exactly 16 characters (raw encoded ID), or
- has an underscore immediately before the final 16-character encoded suffix (all slug formats: `_wf_`, `_et_`, `_prefix_`, etc.)

Long user-defined identifiers without that slug structure (e.g. camelCase `dailyDigestPatient`) are returned unchanged.

## Test plan

- [x] Verified `parseSlugId('dailyDigestPatient')` returns `'dailyDigestPatient'`
- [x] Verified all existing slug format IDs still decode correctly (workflow, template, topic, integration, generic prefix)
- [x] All 39 `parse-slug-id` / `parse-slug-env-id` unit tests pass
- [x] Built `@novu/application-generic` successfully

Fixes NV-8468
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8468](https://linear.app/novu/issue/NV-8468/translations-fail-for-workflow-identifier-dailydigestpatient)

<div><a href="https://cursor.com/agents/bc-50e2b768-9cf5-4338-b930-4477d9ac90a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50e2b768-9cf5-4338-b930-4477d9ac90a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrows slug decoding so long workflow identifiers remain unchanged while preserving decoding for raw encoded IDs and generic slug prefixes.
- Adds a positional delimiter check before decoding the final 16-character suffix.
- Adds regression coverage for `dailyDigestPatient`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current positional delimiter check resolves the previously reported generic-prefix compatibility issue.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/pipes/parse-slug-id.ts | Adds a decoding gate that preserves all previously supported generic prefix formats and avoids decoding ordinary long identifiers. |
| libs/application-generic/src/pipes/parse-slug-id.pipe.spec.ts | Adds regression coverage confirming that a long workflow identifier is returned unchanged. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(shared): preserve generic slug prefi..."](https://github.com/novuhq/novu/commit/685f673fa2263cd56e556351fbfe30aa261cd337) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49059197)</sub>

<!-- /greptile_comment -->