### PR TITLE
feat(chat-adapter-web): demux actionId ingress via processAction fixes NV-8443

### DIFF
--- a/packages/chat-adapter-web/src/adapter.spec.ts
+++ b/packages/chat-adapter-web/src/adapter.spec.ts
@@ -40,9 +40,10 @@ function createConfig(overrides: Partial<WebChatAdapterConfig> = {}): WebChatAda
 async function createAdapter(config: WebChatAdapterConfig = createConfig()) {
   const adapter = new NovuWebChatAdapterImpl(config);
   const processMessage = vi.fn();
-  await adapter.initialize({ processMessage, getState: () => ({}) } as never);
+  const processAction = vi.fn();
+  await adapter.initialize({ processMessage, processAction, getState: () => ({}) } as never);
 
-  return { adapter, processMessage, config };
+  return { adapter, processMessage, processAction, config };
 }
 
 function jsonRequest(body: unknown, headers?: Record<string, string>): Request {
@@ -89,7 +90,26 @@ describe('NovuWebChatAdapterImpl', () => {
     const badId = await adapter.handleWebhook(jsonRequest({ agentId: 'a', text: 'hi', id: 'not-a-conv' }));
 
     expect(empty.status).toBe(400);
+    expect(await empty.json()).toEqual({ message: 'text or actionId is required' });
     expect(badId.status).toBe(400);
+  });
+
+  it('returns 400 when both text and actionId are provided', async () => {
+    const { adapter, processMessage, processAction } = await createAdapter();
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({
+        agentId: 'a',
+        text: 'hi',
+        actionId: 'tool-approval:approve:tc1',
+        sourceMessageId: 'act_card0000001',
+        conversationIdentifier: 'conv_abcdefghijkl',
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(processAction).not.toHaveBeenCalled();
   });
 
   it('dispatches processMessage then returns 201', async () => {
@@ -167,6 +187,57 @@ describe('NovuWebChatAdapterImpl', () => {
 
     expect(response.status).toBe(404);
     expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it('dispatches processAction then returns 200 for actionId ingress', async () => {
+    const authorizeResume = vi.fn(async () => true);
+    const { adapter, processMessage, processAction } = await createAdapter(createConfig({ authorizeResume }));
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({
+        agentId: 'a',
+        actionId: 'tool-approval:approve:tc1',
+        sourceMessageId: 'act_card0000001',
+        value: 'Approve once',
+        conversationIdentifier: 'conv_abcdefghijkl',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.identifier).toBe('conv_abcdefghijkl');
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(processAction).toHaveBeenCalledOnce();
+    expect(processAction.mock.calls[0]?.[0]).toMatchObject({
+      actionId: 'tool-approval:approve:tc1',
+      messageId: 'act_card0000001',
+      value: 'Approve once',
+      threadId: 'web_chat:conv_abcdefghijkl',
+      user: { userId: 'sub_1' },
+    });
+  });
+
+  it('returns 400 when actionId is missing conversationIdentifier or sourceMessageId', async () => {
+    const { adapter, processAction } = await createAdapter(createConfig({ authorizeResume: async () => true }));
+
+    const missingConv = await adapter.handleWebhook(
+      jsonRequest({
+        agentId: 'a',
+        actionId: 'tool-approval:approve:tc1',
+        sourceMessageId: 'act_card0000001',
+      })
+    );
+    const missingSource = await adapter.handleWebhook(
+      jsonRequest({
+        agentId: 'a',
+        actionId: 'tool-approval:approve:tc1',
+        conversationIdentifier: 'conv_abcdefghijkl',
+      })
+    );
+
+    expect(missingConv.status).toBe(400);
+    expect(missingSource.status).toBe(400);
+    expect(processAction).not.toHaveBeenCalled();
   });
 
   it('postMessage delegates to deliverMessage without inventing mongo semantics', async () => {

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -10,7 +10,13 @@ import type {
   ThreadInfo,
   WebhookOptions,
 } from 'chat';
-import type { WebChatAdapterConfig, WebChatRawMessage, WebChatRequestBody, WebChatThreadId } from './types.js';
+import type {
+  WebChatAdapterConfig,
+  WebChatRawMessage,
+  WebChatRequestBody,
+  WebChatSession,
+  WebChatThreadId,
+} from './types.js';
 import {
   ADAPTER_NAME,
   conversationIdFromThreadId,
@@ -31,6 +37,20 @@ class NotImplementedError extends Error {
 
 type MessageConstructor = new (data: unknown) => Message<WebChatRawMessage>;
 
+const JSON_HEADERS = { 'content-type': 'application/json' } as const;
+
+type IngressKind =
+  | { type: 'message'; text: string }
+  | { type: 'action'; actionId: string; sourceMessageId: string; value?: string };
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+/**
+ * Telegram/WhatsApp-style demux: thin `handleWebhook` → private ingress
+ * handlers that call `processMessage` / `processAction`.
+ */
 export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatRawMessage> {
   readonly name = ADAPTER_NAME;
   readonly userName: string;
@@ -86,87 +106,182 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
       throw new Error('Adapter not initialized. Call initialize() first.');
     }
 
-    let session;
+    const session = await this.verifySession(request);
+    if (session instanceof Response) {
+      return session;
+    }
+
+    const body = await this.parseRequestBody(request);
+    if (body instanceof Response) {
+      return body;
+    }
+
+    const kind = this.resolveIngressKind(body);
+    if (kind instanceof Response) {
+      return kind;
+    }
+
+    switch (kind.type) {
+      case 'message':
+        return this.handleMessageIngress(kind, session, body, options);
+      case 'action':
+        return this.handleActionIngress(kind, session, body, options);
+      default: {
+        const _exhaustive: never = kind;
+
+        return _exhaustive;
+      }
+    }
+  }
+
+  /** Auth edge — same role as Slack signature / Telegram secret token checks. */
+  private async verifySession(request: Request): Promise<WebChatSession | Response> {
     try {
-      session = await this.config.verifySession(request);
+      const session = await this.config.verifySession(request);
+      if (!session) {
+        return jsonResponse({ message: 'Unauthorized' }, 401);
+      }
+
+      return session;
     } catch (err) {
       console.error('[chat-adapter-web] verifySession threw', err);
 
-      return new Response(JSON.stringify({ message: 'Unauthorized' }), {
-        status: 401,
-        headers: { 'content-type': 'application/json' },
-      });
+      return jsonResponse({ message: 'Unauthorized' }, 401);
     }
+  }
 
-    if (!session) {
-      return new Response(JSON.stringify({ message: 'Unauthorized' }), {
-        status: 401,
-        headers: { 'content-type': 'application/json' },
-      });
-    }
-
-    let body: WebChatRequestBody;
+  private async parseRequestBody(request: Request): Promise<WebChatRequestBody | Response> {
     try {
-      body = (await request.json()) as WebChatRequestBody;
+      return (await request.json()) as WebChatRequestBody;
     } catch {
-      return new Response(JSON.stringify({ message: 'Invalid JSON body' }), {
-        status: 400,
-        headers: { 'content-type': 'application/json' },
-      });
+      return jsonResponse({ message: 'Invalid JSON body' }, 400);
     }
+  }
 
+  /** Exactly one of `text` | `actionId` (WhatsApp-style type demux). */
+  private resolveIngressKind(body: WebChatRequestBody): IngressKind | Response {
     const text = typeof body.text === 'string' ? body.text.trim() : '';
-    if (!text) {
-      return new Response(JSON.stringify({ message: 'text is required' }), {
-        status: 400,
-        headers: { 'content-type': 'application/json' },
-      });
+    const actionId = typeof body.actionId === 'string' ? body.actionId.trim() : '';
+    const hasText = text.length > 0;
+    const hasAction = actionId.length > 0;
+
+    if (hasText && hasAction) {
+      return jsonResponse({ message: 'Provide exactly one of text or actionId' }, 400);
     }
 
-    const resumeId = this.resolveResumeConversationId(body);
-    if (resumeId === 'invalid') {
-      return new Response(JSON.stringify({ message: 'Invalid conversation id' }), {
-        status: 400,
-        headers: { 'content-type': 'application/json' },
-      });
+    if (hasText) {
+      return { type: 'message', text };
     }
 
-    let conversationId: string;
-    if (resumeId) {
-      const allowed = this.config.authorizeResume
-        ? await this.config.authorizeResume({ conversationId: resumeId, session })
-        : false;
-      if (!allowed) {
-        return new Response(JSON.stringify({ message: 'Conversation not found' }), {
-          status: 404,
-          headers: { 'content-type': 'application/json' },
-        });
+    if (hasAction) {
+      const sourceMessageId = typeof body.sourceMessageId === 'string' ? body.sourceMessageId.trim() : '';
+      if (!sourceMessageId) {
+        return jsonResponse({ message: 'sourceMessageId is required with actionId' }, 400);
       }
-      conversationId = resumeId;
-    } else {
-      conversationId = mintConversationId();
+
+      const value = typeof body.value === 'string' ? body.value : undefined;
+
+      return { type: 'action', actionId, sourceMessageId, value };
+    }
+
+    return jsonResponse({ message: 'text or actionId is required' }, 400);
+  }
+
+  private async handleMessageIngress(
+    kind: Extract<IngressKind, { type: 'message' }>,
+    session: WebChatSession,
+    body: WebChatRequestBody,
+    options?: WebhookOptions
+  ): Promise<Response> {
+    const conversationId = await this.resolveConversationId(body, session, { requireExisting: false });
+    if (conversationId instanceof Response) {
+      return conversationId;
     }
 
     // Always mint message ids. Client `messageId` idempotency would ack a ghost
     // turn if checked before durable create; keep server-minted ids for now.
     const threadId = this.encodeThreadId({ conversationId });
-    const messageId = mintMessageId();
-    const raw: WebChatRawMessage = {
-      id: messageId,
-      text,
+    const message = this.parseMessage({
+      id: mintMessageId(),
+      text: kind.text,
       subscriberId: session.subscriberId,
       createdAt: new Date().toISOString(),
-    };
-    const message = this.parseMessage(raw);
+    });
 
-    this.chat.processMessage(this, threadId, message, options);
+    this.chat!.processMessage(this, threadId, message, options);
 
     // Public conversation identifier stays bare `conv_*`; chat-sdk thread ids are
     // `web_chat:conv_*` so `chat.thread()` can resolve this adapter by prefix.
-    return new Response(JSON.stringify({ data: { identifier: conversationId } }), {
-      status: 201,
-      headers: { 'content-type': 'application/json' },
-    });
+    return jsonResponse({ data: { identifier: conversationId } }, 201);
+  }
+
+  /** Button / approval click — mirrors Telegram `handleCallbackQuery`. */
+  private async handleActionIngress(
+    kind: Extract<IngressKind, { type: 'action' }>,
+    session: WebChatSession,
+    body: WebChatRequestBody,
+    options?: WebhookOptions
+  ): Promise<Response> {
+    const conversationId = await this.resolveConversationId(body, session, { requireExisting: true });
+    if (conversationId instanceof Response) {
+      return conversationId;
+    }
+
+    const threadId = this.encodeThreadId({ conversationId });
+    const user = {
+      userId: session.subscriberId,
+      userName: session.subscriberId,
+      fullName: session.subscriberId,
+      isBot: false,
+      isMe: false,
+    };
+
+    this.chat!.processAction(
+      {
+        adapter: this,
+        actionId: kind.actionId,
+        value: kind.value,
+        messageId: kind.sourceMessageId,
+        threadId,
+        user,
+        raw: body,
+      },
+      options
+    );
+
+    return jsonResponse({ data: { identifier: conversationId } }, 200);
+  }
+
+  /**
+   * Resolve / mint conversation id + resume ACL.
+   * Actions always require an existing conversation (no mint).
+   */
+  private async resolveConversationId(
+    body: WebChatRequestBody,
+    session: WebChatSession,
+    opts: { requireExisting: boolean }
+  ): Promise<string | Response> {
+    const resumeId = this.resolveResumeConversationId(body);
+    if (resumeId === 'invalid') {
+      return jsonResponse({ message: 'Invalid conversation id' }, 400);
+    }
+
+    if (!resumeId) {
+      if (opts.requireExisting) {
+        return jsonResponse({ message: 'conversationIdentifier is required with actionId' }, 400);
+      }
+
+      return mintConversationId();
+    }
+
+    const allowed = this.config.authorizeResume
+      ? await this.config.authorizeResume({ conversationId: resumeId, session })
+      : false;
+    if (!allowed) {
+      return jsonResponse({ message: 'Conversation not found' }, 404);
+    }
+
+    return resumeId;
   }
 
   /** Prefer `conversationIdentifier`, fall back to `id`. */

--- a/packages/chat-adapter-web/src/types.ts
+++ b/packages/chat-adapter-web/src/types.ts
@@ -72,7 +72,14 @@ export type WebChatRawMessage = {
 
 export type WebChatRequestBody = {
   agentId?: string;
+  /** Exactly one of `text` | `actionId` per request. */
   text?: string;
+  /** Interactive / approval button id (e.g. `tool-approval:approve:…`). XOR with `text`. */
+  actionId?: string;
+  /** Platform message id of the clicked card/button; required with `actionId`. */
+  sourceMessageId?: string;
+  /** Optional button/select value alongside `actionId`. */
+  value?: string;
   /** Resume an existing conversation (`conv_*`). Alias of `conversationIdentifier`. */
   id?: string;
   /** Preferred resume field (NV-8441); same semantics as `id`. */


### PR DESCRIPTION
## Summary
- Reshape `@novu/chat-adapter-web` `handleWebhook` into Telegram/WhatsApp-style demux: thin edge → private message/action ingress handlers.
- `POST /v1/web-chat/conversations` now accepts `{ actionId, sourceMessageId, conversationIdentifier }` (XOR with `text`) and routes via `chat.processAction` into the existing `onAction` → `handleAction` → `ON_ACTION` spine.
- Approvals and interactive buttons share one write edge; no dedicated `/approvals` or `/mcp-connect` REST. Durable approval state continues through the shared persist + `GET …/events` path.

```mermaid
flowchart TD
  A["POST /v1/web-chat/conversations"] --> B{"Exactly one of text | actionId"}
  B -->|text| C["processMessage → ON_MESSAGE"]
  B -->|actionId| D{"conversationIdentifier + sourceMessageId"}
  D -->|missing| E["4xx"]
  D -->|ok| F["processAction → onAction → ON_ACTION"]
  C --> G["201 if new conv else 200"]
  F --> H["200 { data: { identifier } }"]
```

## Test plan
- [x] Adapter unit tests: actionId → `processAction` + 200; XOR / missing fields → 400
- [ ] Manual: click approve/deny in web-chat UI → UI flips from `GET …/events` / WS (not local click)
- [ ] Manual: double-click already-resolved approval still returns 200; events remain source of truth
- Note: API e2e for action ingress deliberately skipped (parity with Slack/Teams/Telegram/WhatsApp; Sendblue has reply-based coverage only)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds interactive action ingress to the web chat adapter.
- Demultiplexes message and action request bodies with XOR validation.
- Routes actions through processAction using the existing conversation authorization path.
- Extends request types and adapter tests for action payloads and validation.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until web action identifiers are bound to the authorized conversation, source message, and subscriber.

The new endpoint accepts independently controlled conversation, message, and action identifiers, while downstream token checks do not establish that they belong together; action dispatch is also acknowledged without waiting for asynchronous completion.

**Files Needing Attention:** packages/chat-adapter-web/src/adapter.ts

<details open><summary><h3>Security Review</h3></summary>

The action ingress authorizes the named conversation but does not bind the submitted action and source-message identifiers to that conversation, card, or subscriber, allowing identifier replay or substitution. **How this was verified:** The request-controlled identifiers were traced through conversation-only authorization to action resolution that performs no thread, message, or user binding.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/chat-adapter-web/src/adapter.ts | Adds message/action demultiplexing and action dispatch, but leaves action identifiers unbound to the authorized conversation and does not await dispatch. |
| packages/chat-adapter-web/src/adapter.spec.ts | Adds useful happy-path and validation coverage, but mocks synchronous dispatch and does not cover cross-message replay or asynchronous failure. |
| packages/chat-adapter-web/src/types.ts | Extends the web request shape with action identifiers, source-message identity, and optional action values. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Adapter as Web Chat Adapter
    participant ACL as authorizeResume
    participant Chat as processAction
    participant Resolver as Action Token Resolver
    participant Handler as onAction Handler
    Client->>Adapter: actionId, sourceMessageId, conversationIdentifier
    Adapter->>ACL: authorize conversationIdentifier
    ACL-->>Adapter: allowed
    Note over Adapter: actionId/sourceMessageId are not bound to conversation
    Adapter->>Chat: processAction(actionId, sourceMessageId, threadId)
    Chat->>Resolver: resolve actionId
    Resolver-->>Chat: raw/resolved action
    Chat->>Handler: action + claimed source message/thread
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fchat-adapter-web%2Fsrc%2Fadapter.ts%3A239-249%0A**Actions%20lack%20message%20binding**%0A%0AWhen%20an%20authenticated%20subscriber%20submits%20an%20action%20or%20source-message%20identifier%20from%20another%20card%20or%20conversation%2C%20this%20ingress%20authorizes%20only%20the%20supplied%20conversation%20and%20forwards%20both%20identifiers%20without%20binding%20them%20to%20its%20message%2C%20thread%2C%20or%20subscriber%2C%20causing%20the%20action%20callback%20to%20process%20a%20replayed%20or%20substituted%20approval%20as%20legitimate.%0A%0A**How%20this%20was%20verified%3A**%20The%20request-controlled%20identifiers%20were%20traced%20through%20conversation-only%20authorization%20to%20action%20resolution%20that%20performs%20no%20thread%2C%20message%2C%20or%20user%20binding.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fchat-adapter-web%2Fsrc%2Fadapter.ts%3A239-249%0A**Action%20dispatch%20is%20not%20awaited**%0A%0A%60handleActionIngress%60%20returns%20HTTP%20200%20without%20awaiting%20or%20handling%20rejection%20from%20%60processAction%60%2C%20unlike%20the%20existing%20action-ingress%20paths%2C%20so%20asynchronous%20dispatch%20errors%20are%20detached%20from%20the%20request%20lifecycle%20and%20the%20tests%20cannot%20assert%20completion%20or%20failure%20handling.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/chat-adapter-web/src/adapter.ts:239-249
**Actions lack message binding**

When an authenticated subscriber submits an action or source-message identifier from another card or conversation, this ingress authorizes only the supplied conversation and forwards both identifiers without binding them to its message, thread, or subscriber, causing the action callback to process a replayed or substituted approval as legitimate.

**How this was verified:** The request-controlled identifiers were traced through conversation-only authorization to action resolution that performs no thread, message, or user binding.

### Issue 2
packages/chat-adapter-web/src/adapter.ts:239-249
**Action dispatch is not awaited**

`handleActionIngress` returns HTTP 200 without awaiting or handling rejection from `processAction`, unlike the existing action-ingress paths, so asynchronous dispatch errors are detached from the request lifecycle and the tests cannot assert completion or failure handling.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(chat-adapter-web): demux actionId i..."](https://github.com/novuhq/novu/commit/b6bc42949a16c9bd50058b785816e5f6ed80eec7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49090205)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->