### PR TITLE
refactor(api-service): remove dead conversation activity helpers fixes NV-8469

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -359,21 +359,6 @@ export class AgentConversationService {
     return this.activityRepository.findByPlatformMessageId(environmentId, conversationId, platformMessageId);
   }
 
-  async findActivityByIdentifier(
-    environmentId: string,
-    conversationId: string,
-    identifier: string
-  ): Promise<ConversationActivityEntity | null> {
-    return this.activityRepository.findOne(
-      {
-        _environmentId: environmentId,
-        _conversationId: conversationId,
-        identifier,
-      },
-      '*'
-    );
-  }
-
   async countAgentMessages(environmentId: string, conversationId: string): Promise<number> {
     return this.activityRepository.countAgentMessages(environmentId, conversationId);
   }

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -149,31 +149,6 @@ export function isMappableActivity(activity: ConversationActivityEntity): boolea
   return event !== null && !isDeltaEvent(event);
 }
 
-export function activityToEvents(
-  activities: ConversationActivityEntity[],
-  context: { conversationId: string; agentIdentifier: string },
-  sequenceOffset = 0
-): AgentEventEnvelope[] {
-  const envelopes: AgentEventEnvelope[] = [];
-  let computed = sequenceOffset;
-
-  for (const activity of activities) {
-    const event = mapActivityToEvent(activity);
-    if (!event || isDeltaEvent(event)) {
-      continue;
-    }
-
-    computed += 1;
-    const sequence = resolveSequence(activity, computed);
-    if (typeof activity.sequence === 'number') {
-      computed = Math.max(computed, activity.sequence);
-    }
-    envelopes.push(buildEnvelope(activity, event, sequence, context));
-  }
-
-  return envelopes;
-}
-
 export function mapActivitiesToEventPage(
   activities: ConversationActivityEntity[],
   context: { conversationId: string; agentIdentifier: string },


### PR DESCRIPTION
## Summary

Deletes two functions that have no callers anywhere in the codebase.

- `activityToEvents` in `apps/api/src/app/agents/web-chat/activity-to-events.ts` — superseded by `mapActivitiesToEventPage`, which does the same mapping with pagination.
- `findActivityByIdentifier` in `agent-conversation.service.ts` — never had a caller.

Found during the code-quality review of NV-8456 (finding F8). Split out from the adapter typing work in NV-8470 because it is unrelated and reviewable on its own.

## Notes for reviewers

Pure deletion, 40 lines, no behavior change. The helpers these two used (`buildEnvelope`, `resolveSequence`, `AgentEventEnvelope`) are still needed by `mapActivitiesToEventPage`, so nothing is left orphaned.

## Test plan

- [x] `rg` confirms no remaining references to either function in `apps/api`, including specs and e2e
- [x] `tsc --noEmit` on `apps/api` shows no new errors against the pre-existing baseline
- [x] `biome check` clean on both touched files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes two unused conversation activity helpers without changing active behavior.
- Removes the unreferenced `findActivityByIdentifier` service method.
- Removes the superseded `activityToEvents` mapping helper while retaining the paginated mapper.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both deleted helpers are internal and have no remaining callers.

Repository consumers use the retained service and paginated mapping APIs, so removing these unreferenced helpers does not break an active build or runtime path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts | Removes an unused service method with no remaining repository callers or contract dependencies. |
| apps/api/src/app/agents/web-chat/activity-to-events.ts | Removes an unused mapping export while preserving the mapper used by all current history call sites. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api-service): remove dead conve..."](https://github.com/novuhq/novu/commit/dae23f824edb4acb91d12fc6887750f12d2647f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49204058)</sub>

<!-- /greptile_comment -->