### PR TITLE
test-draft-check

### DIFF
--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.spec.ts
@@ -1,11 +1,12 @@
 import { GetNovuProviderCredentials } from '@novu/application-generic';
-import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChannelConnectionRepository, ContextRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
 import { expect } from 'chai';
 import { createHmac } from 'crypto';
 import sinon from 'sinon';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
+import { UpdateChannelConnection } from '../../../../channel-connections/usecases/update-channel-connection/update-channel-connection.usecase';
 import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { encodeOAuthState } from '../../generate-chat-oath-url/chat-oauth-state.util';
 import { SlackOauthCallbackCommand } from './slack-oauth-callback.command';
@@ -21,7 +22,9 @@ const MOCK_SUBSCRIBER_ID = 'subscriber-abc';
 const MOCK_SLACK_USER_ID = 'U012AB3CD';
 const MOCK_TEAM_ID = 'T012AB3CD';
 const MOCK_TEAM_NAME = 'My Workspace';
+const MOCK_CONNECTION_IDENTIFIER = 'connect:user-1:agent:agent-1';
 const MOCK_ACCESS_TOKEN = 'xoxb-mock-access-token';
+const MOCK_REFRESHED_ACCESS_TOKEN = 'xoxb-refreshed-access-token';
 const MOCK_API_ROOT_URL = 'https://api.novu.co';
 
 function buildMockIntegration(overrides: Record<string, unknown> = {}) {
@@ -57,47 +60,67 @@ function buildSlackAuthResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createSlackOauthCallbackHarness() {
+  const integrationRepository = sinon.createStubInstance(IntegrationRepository);
+  const environmentRepository = sinon.createStubInstance(EnvironmentRepository);
+  const channelConnectionRepository = sinon.createStubInstance(ChannelConnectionRepository);
+  const contextRepository = sinon.createStubInstance(ContextRepository);
+  const createChannelConnection = sinon.createStubInstance(CreateChannelConnection);
+  const updateChannelConnection = sinon.createStubInstance(UpdateChannelConnection);
+  const createChannelEndpoint = sinon.createStubInstance(CreateChannelEndpoint);
+  const getNovuProviderCredentials = sinon.createStubInstance(GetNovuProviderCredentials);
+
+  const usecase = new SlackOauthCallback(
+    integrationRepository as any,
+    environmentRepository as any,
+    getNovuProviderCredentials as any,
+    channelConnectionRepository as any,
+    contextRepository as any,
+    createChannelConnection as any,
+    updateChannelConnection as any,
+    createChannelEndpoint as any
+  );
+
+  return {
+    usecase,
+    integrationRepository,
+    environmentRepository,
+    channelConnectionRepository,
+    contextRepository,
+    createChannelConnection,
+    updateChannelConnection,
+    createChannelEndpoint,
+    getNovuProviderCredentials,
+  };
+}
+
 describe('SlackOauthCallback — autoLinkUser', () => {
-  let usecase: SlackOauthCallback;
-  let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
-  let environmentRepository: sinon.SinonStubbedInstance<EnvironmentRepository>;
-  let createChannelConnection: sinon.SinonStubbedInstance<CreateChannelConnection>;
-  let createChannelEndpoint: sinon.SinonStubbedInstance<CreateChannelEndpoint>;
-  let getNovuProviderCredentials: sinon.SinonStubbedInstance<GetNovuProviderCredentials>;
+  let harness: ReturnType<typeof createSlackOauthCallbackHarness>;
   let axiosPost: sinon.SinonStub;
   let originalApiRootUrl: string | undefined;
 
   beforeEach(() => {
-    integrationRepository = sinon.createStubInstance(IntegrationRepository);
-    environmentRepository = sinon.createStubInstance(EnvironmentRepository);
-    createChannelConnection = sinon.createStubInstance(CreateChannelConnection);
-    createChannelEndpoint = sinon.createStubInstance(CreateChannelEndpoint);
-    getNovuProviderCredentials = sinon.createStubInstance(GetNovuProviderCredentials);
-
-    usecase = new SlackOauthCallback(
-      integrationRepository as any,
-      environmentRepository as any,
-      getNovuProviderCredentials as any,
-      createChannelConnection as any,
-      createChannelEndpoint as any
-    );
+    harness = createSlackOauthCallbackHarness();
 
     originalApiRootUrl = process.env.API_ROOT_URL;
     process.env.API_ROOT_URL = MOCK_API_ROOT_URL;
 
-    environmentRepository.findOne.resolves({
+    harness.environmentRepository.findOne.resolves({
       _id: MOCK_ENVIRONMENT_ID,
       apiKeys: [{ key: MOCK_API_KEY }],
     } as any);
 
-    environmentRepository.getApiKeys.resolves([{ key: MOCK_API_KEY }] as any);
+    harness.environmentRepository.getApiKeys.resolves([{ key: MOCK_API_KEY }] as any);
 
-    integrationRepository.findOne.resolves(buildMockIntegration());
+    harness.integrationRepository.findOne.resolves(buildMockIntegration());
+    harness.channelConnectionRepository.findOne.resolves(null);
+    harness.channelConnectionRepository.buildContextExactMatchQuery.returns({});
+    harness.contextRepository.findOrCreateContextsFromPayload.resolves([]);
 
     axiosPost = sinon.stub(axios, 'post').resolves({ data: buildSlackAuthResponse() });
 
-    createChannelConnection.execute.resolves({ identifier: 'conn-abc' } as any);
-    createChannelEndpoint.execute.resolves({} as any);
+    harness.createChannelConnection.execute.resolves({ identifier: 'conn-abc' } as any);
+    harness.createChannelEndpoint.execute.resolves({} as any);
   });
 
   afterEach(() => {
@@ -120,12 +143,12 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.calledOnce).to.be.true;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.calledOnce).to.be.true;
 
-    const endpointArg = createChannelEndpoint.execute.firstCall.args[0];
+    const endpointArg = harness.createChannelEndpoint.execute.firstCall.args[0];
     expect(endpointArg.subscriberId).to.equal(MOCK_SUBSCRIBER_ID);
     expect(endpointArg.type).to.equal(ENDPOINT_TYPES.SLACK_USER);
     expect(endpointArg.endpoint.userId).to.equal(MOCK_SLACK_USER_ID);
@@ -150,10 +173,10 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
   });
 
   it('should create connection but skip endpoint when autoLinkUser=false even if subscriberId and authed_user.id are present', async () => {
@@ -171,10 +194,10 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
   });
 
   it('should create connection but skip endpoint when autoLinkUser is absent (raw API callers default to false)', async () => {
@@ -191,10 +214,10 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
   });
 
   it('should create connection but skip endpoint when autoLinkUser=true but subscriberId is absent', async () => {
@@ -211,9 +234,103 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
+  });
+});
+
+describe('SlackOauthCallback — reconnect token refresh', () => {
+  let harness: ReturnType<typeof createSlackOauthCallbackHarness>;
+  let originalApiRootUrl: string | undefined;
+
+  beforeEach(() => {
+    harness = createSlackOauthCallbackHarness();
+
+    originalApiRootUrl = process.env.API_ROOT_URL;
+    process.env.API_ROOT_URL = MOCK_API_ROOT_URL;
+
+    harness.environmentRepository.findOne.resolves({
+      _id: MOCK_ENVIRONMENT_ID,
+      apiKeys: [{ key: MOCK_API_KEY }],
+    } as any);
+
+    harness.integrationRepository.findOne.resolves(buildMockIntegration());
+    harness.channelConnectionRepository.buildContextExactMatchQuery.returns({});
+    harness.contextRepository.findOrCreateContextsFromPayload.resolves([]);
+
+    sinon.stub(axios, 'post').resolves({
+      data: buildSlackAuthResponse({ access_token: MOCK_REFRESHED_ACCESS_TOKEN }),
+    });
+
+    harness.updateChannelConnection.execute.resolves({
+      identifier: MOCK_CONNECTION_IDENTIFIER,
+      auth: { accessToken: MOCK_REFRESHED_ACCESS_TOKEN },
+    } as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    process.env.API_ROOT_URL = originalApiRootUrl;
+  });
+
+  it('should update the existing connection token when reconnecting with the same identifier', async () => {
+    harness.channelConnectionRepository.findOne.onFirstCall().resolves({
+      identifier: MOCK_CONNECTION_IDENTIFIER,
+    } as any);
+
+    const state = buildEncodedState({
+      environmentId: MOCK_ENVIRONMENT_ID,
+      organizationId: MOCK_ORGANIZATION_ID,
+      integrationIdentifier: MOCK_INTEGRATION_IDENTIFIER,
+      providerId: ChatProviderIdEnum.Slack,
+      identifier: MOCK_CONNECTION_IDENTIFIER,
+      subscriberId: MOCK_SUBSCRIBER_ID,
+    });
+
+    const command = SlackOauthCallbackCommand.create({
+      providerCode: 'slack-code',
+      state,
+    });
+
+    await harness.usecase.execute(command);
+
+    expect(harness.createChannelConnection.execute.called).to.be.false;
+    expect(harness.updateChannelConnection.execute.calledOnce).to.be.true;
+
+    const updateArg = harness.updateChannelConnection.execute.firstCall.args[0];
+    expect(updateArg.identifier).to.equal(MOCK_CONNECTION_IDENTIFIER);
+    expect(updateArg.auth.accessToken).to.equal(MOCK_REFRESHED_ACCESS_TOKEN);
+    expect(updateArg.workspace.id).to.equal(MOCK_TEAM_ID);
+    expect(updateArg.workspace.name).to.equal(MOCK_TEAM_NAME);
+  });
+
+  it('should update the existing connection token when reconnecting with the same integration, subscriber, and context', async () => {
+    harness.channelConnectionRepository.findOne.resolves({
+      identifier: 'existing-generated-identifier',
+    } as any);
+
+    const state = buildEncodedState({
+      environmentId: MOCK_ENVIRONMENT_ID,
+      organizationId: MOCK_ORGANIZATION_ID,
+      integrationIdentifier: MOCK_INTEGRATION_IDENTIFIER,
+      providerId: ChatProviderIdEnum.Slack,
+      subscriberId: MOCK_SUBSCRIBER_ID,
+    });
+
+    const command = SlackOauthCallbackCommand.create({
+      providerCode: 'slack-code',
+      state,
+    });
+
+    await harness.usecase.execute(command);
+
+    expect(harness.createChannelConnection.execute.called).to.be.false;
+    expect(harness.updateChannelConnection.execute.calledOnce).to.be.true;
+
+    const updateArg = harness.updateChannelConnection.execute.firstCall.args[0];
+    expect(updateArg.identifier).to.equal('existing-generated-identifier');
+    expect(updateArg.auth.accessToken).to.equal(MOCK_REFRESHED_ACCESS_TOKEN);
   });
 });

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -5,7 +5,10 @@ import {
   GetNovuProviderCredentialsCommand,
 } from '@novu/application-generic';
 import {
+  ChannelConnectionEntity,
+  ChannelConnectionRepository,
   ChannelTypeEnum,
+  ContextRepository,
   EnvironmentRepository,
   ICredentialsEntity,
   IntegrationEntity,
@@ -15,6 +18,8 @@ import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
+import { UpdateChannelConnectionCommand } from '../../../../channel-connections/usecases/update-channel-connection/update-channel-connection.command';
+import { UpdateChannelConnection } from '../../../../channel-connections/usecases/update-channel-connection/update-channel-connection.usecase';
 import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
@@ -34,7 +39,10 @@ export class SlackOauthCallback {
     private integrationRepository: IntegrationRepository,
     private environmentRepository: EnvironmentRepository,
     private getNovuProviderCredentials: GetNovuProviderCredentials,
+    private channelConnectionRepository: ChannelConnectionRepository,
+    private contextRepository: ContextRepository,
     private createChannelConnection: CreateChannelConnection,
+    private updateChannelConnection: UpdateChannelConnection,
     private createChannelEndpoint: CreateChannelEndpoint
   ) {}
 
@@ -62,25 +70,7 @@ export class SlackOauthCallback {
        */
       await this.createIncomingWebhookEndpoint(stateData, integration, authData);
     } else {
-      const isSharedMode = stateData.connectionMode === 'shared';
-      const connection = await this.createChannelConnection.execute(
-        CreateChannelConnectionCommand.create({
-          identifier: stateData.identifier,
-          organizationId: stateData.organizationId,
-          environmentId: stateData.environmentId,
-          integrationIdentifier: integration.identifier,
-          subscriberId: isSharedMode ? undefined : stateData.subscriberId,
-          context: stateData.context,
-          connectionMode: stateData.connectionMode,
-          auth: {
-            accessToken: authData.access_token,
-          },
-          workspace: {
-            id: authData.team.id,
-            name: authData.team.name,
-          },
-        })
-      );
+      const connection = await this.upsertWorkspaceConnection(stateData, integration, authData);
       if (stateData.autoLinkUser === true && stateData.subscriberId && authData.authed_user?.id) {
         await this.createChannelEndpoint.execute(
           CreateChannelEndpointCommand.create({
@@ -110,6 +100,93 @@ export class SlackOauthCallback {
         message: 'Your Slack workspace is connected and ready to use.',
       }),
     };
+  }
+
+  private async upsertWorkspaceConnection(
+    stateData: StateData,
+    integration: IntegrationEntity,
+    authData: { access_token: string; team: { id: string; name: string } }
+  ): Promise<ChannelConnectionEntity> {
+    const isSharedMode = stateData.connectionMode === 'shared';
+    const subscriberId = isSharedMode ? undefined : stateData.subscriberId;
+    const contextKeys = await this.resolveContextKeys(stateData);
+    const existingConnection = await this.findExistingConnection(
+      stateData,
+      integration,
+      subscriberId,
+      contextKeys
+    );
+    const auth = { accessToken: authData.access_token };
+    const workspace = { id: authData.team.id, name: authData.team.name };
+
+    if (existingConnection) {
+      return await this.updateChannelConnection.execute(
+        UpdateChannelConnectionCommand.create({
+          identifier: existingConnection.identifier,
+          organizationId: stateData.organizationId,
+          environmentId: stateData.environmentId,
+          auth,
+          workspace,
+        })
+      );
+    }
+
+    return await this.createChannelConnection.execute(
+      CreateChannelConnectionCommand.create({
+        identifier: stateData.identifier,
+        organizationId: stateData.organizationId,
+        environmentId: stateData.environmentId,
+        integrationIdentifier: integration.identifier,
+        subscriberId,
+        context: stateData.context,
+        connectionMode: stateData.connectionMode,
+        auth,
+        workspace,
+      })
+    );
+  }
+
+  private async resolveContextKeys(stateData: StateData): Promise<string[]> {
+    if (!stateData.context) {
+      return [];
+    }
+
+    const contexts = await this.contextRepository.findOrCreateContextsFromPayload(
+      stateData.environmentId,
+      stateData.organizationId,
+      stateData.context
+    );
+
+    return contexts.map((context) => context.key);
+  }
+
+  private async findExistingConnection(
+    stateData: StateData,
+    integration: IntegrationEntity,
+    subscriberId: string | undefined,
+    contextKeys: string[]
+  ): Promise<ChannelConnectionEntity | null> {
+    if (stateData.identifier) {
+      const connectionByIdentifier = await this.channelConnectionRepository.findOne({
+        identifier: stateData.identifier,
+        _organizationId: stateData.organizationId,
+        _environmentId: stateData.environmentId,
+      });
+
+      if (connectionByIdentifier) {
+        return connectionByIdentifier;
+      }
+    }
+
+    const contextQuery = this.channelConnectionRepository.buildContextExactMatchQuery(contextKeys);
+
+    return await this.channelConnectionRepository.findOne({
+      _organizationId: stateData.organizationId,
+      _environmentId: stateData.environmentId,
+      integrationIdentifier: integration.identifier,
+      subscriberId,
+      ...contextQuery,
+    });
   }
 
   private async linkUserEndpoint(stateData: StateData, integration: IntegrationEntity, authData: any): Promise<void> {


### PR DESCRIPTION
temp

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Slack workspace reconnection support.
- Existing channel connections can now have their OAuth token and workspace refreshed instead of causing a duplicate-connection conflict.
- Connections are resolved by explicit identifier or by integration, subscriber, and context.
- Slack callback tests are reorganized around a shared harness and extended with reconnect scenarios.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until identifier-based reconnects verify that the matched connection belongs to the OAuth flow's integration, subscriber, and context.

A caller-provided connection identifier can select another connection in the same environment, after which the callback replaces that connection's Slack credentials and workspace without checking resource ownership.

**Files Needing Attention:** apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts

<details open><summary><h3>Security Review</h3></summary>

The identifier-based reconnect path can overwrite another same-environment connection because it does not verify that the matched connection belongs to the callback's integration, subscriber, and context. **How this was verified:** The request-provided identifier was traced from the signed OAuth state through the organization/environment-only lookup to an update that replaces the matched connection's credentials.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts | Adds connection lookup and token refresh behavior, but the identifier path can update a connection outside the callback's integration, subscriber, or context scope. |
| apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.spec.ts | Refactors callback setup into a harness and tests successful reconnects, but does not cover identifiers belonging to a different scoped connection. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Slack OAuth callback] --> B{State has identifier?}
  B -->|Yes| C[Find by identifier, organization, environment]
  B -->|No or not found| D[Find by integration, subscriber, context]
  C --> E{Connection found?}
  D --> E
  E -->|Yes| F[Update token and workspace]
  E -->|No| G[Create channel connection]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fintegrations%2Fusecases%2Fchat-oauth-callback%2Fslack-oauth-callback%2Fslack-oauth-callback.usecase.ts%3A169-177%0A**Reconnect%20bypasses%20connection%20ownership**%0A%0AWhen%20an%20OAuth%20URL%20request%20supplies%20another%20same-environment%20connection's%20identifier%2C%20this%20lookup%20selects%20it%20without%20verifying%20its%20integration%2C%20subscriber%2C%20or%20context%2C%20causing%20the%20subsequent%20update%20to%20overwrite%20that%20connection's%20Slack%20token%20and%20workspace.%20**How%20this%20was%20verified%3A**%20The%20request-provided%20identifier%20was%20traced%20from%20the%20signed%20OAuth%20state%20through%20this%20organization%2Fenvironment-only%20lookup%20to%20the%20credential%20update.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12178&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts:169-177
**Reconnect bypasses connection ownership**

When an OAuth URL request supplies another same-environment connection's identifier, this lookup selects it without verifying its integration, subscriber, or context, causing the subsequent update to overwrite that connection's Slack token and workspace. **How this was verified:** The request-provided identifier was traced from the signed OAuth state through this organization/environment-only lookup to the credential update.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): upsert Slack bot token..."](https://github.com/novuhq/novu/commit/c72a9d4f6768f0b5cea8a9d8f5a3640c9208ff9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49291678)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->