### PR TITLE
fix(api-service): upsert Slack bot token on OAuth reconnect (fixes NV-8088)

### DIFF
--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.spec.ts
@@ -1,11 +1,12 @@
 import { GetNovuProviderCredentials } from '@novu/application-generic';
-import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChannelConnectionRepository, ContextRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
 import { expect } from 'chai';
 import { createHmac } from 'crypto';
 import sinon from 'sinon';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
+import { UpdateChannelConnection } from '../../../../channel-connections/usecases/update-channel-connection/update-channel-connection.usecase';
 import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { encodeOAuthState } from '../../generate-chat-oath-url/chat-oauth-state.util';
 import { SlackOauthCallbackCommand } from './slack-oauth-callback.command';
@@ -21,7 +22,9 @@ const MOCK_SUBSCRIBER_ID = 'subscriber-abc';
 const MOCK_SLACK_USER_ID = 'U012AB3CD';
 const MOCK_TEAM_ID = 'T012AB3CD';
 const MOCK_TEAM_NAME = 'My Workspace';
+const MOCK_CONNECTION_IDENTIFIER = 'connect:user-1:agent:agent-1';
 const MOCK_ACCESS_TOKEN = 'xoxb-mock-access-token';
+const MOCK_REFRESHED_ACCESS_TOKEN = 'xoxb-refreshed-access-token';
 const MOCK_API_ROOT_URL = 'https://api.novu.co';
 
 function buildMockIntegration(overrides: Record<string, unknown> = {}) {
@@ -57,47 +60,67 @@ function buildSlackAuthResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createSlackOauthCallbackHarness() {
+  const integrationRepository = sinon.createStubInstance(IntegrationRepository);
+  const environmentRepository = sinon.createStubInstance(EnvironmentRepository);
+  const channelConnectionRepository = sinon.createStubInstance(ChannelConnectionRepository);
+  const contextRepository = sinon.createStubInstance(ContextRepository);
+  const createChannelConnection = sinon.createStubInstance(CreateChannelConnection);
+  const updateChannelConnection = sinon.createStubInstance(UpdateChannelConnection);
+  const createChannelEndpoint = sinon.createStubInstance(CreateChannelEndpoint);
+  const getNovuProviderCredentials = sinon.createStubInstance(GetNovuProviderCredentials);
+
+  const usecase = new SlackOauthCallback(
+    integrationRepository as any,
+    environmentRepository as any,
+    getNovuProviderCredentials as any,
+    channelConnectionRepository as any,
+    contextRepository as any,
+    createChannelConnection as any,
+    updateChannelConnection as any,
+    createChannelEndpoint as any
+  );
+
+  return {
+    usecase,
+    integrationRepository,
+    environmentRepository,
+    channelConnectionRepository,
+    contextRepository,
+    createChannelConnection,
+    updateChannelConnection,
+    createChannelEndpoint,
+    getNovuProviderCredentials,
+  };
+}
+
 describe('SlackOauthCallback — autoLinkUser', () => {
-  let usecase: SlackOauthCallback;
-  let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
-  let environmentRepository: sinon.SinonStubbedInstance<EnvironmentRepository>;
-  let createChannelConnection: sinon.SinonStubbedInstance<CreateChannelConnection>;
-  let createChannelEndpoint: sinon.SinonStubbedInstance<CreateChannelEndpoint>;
-  let getNovuProviderCredentials: sinon.SinonStubbedInstance<GetNovuProviderCredentials>;
+  let harness: ReturnType<typeof createSlackOauthCallbackHarness>;
   let axiosPost: sinon.SinonStub;
   let originalApiRootUrl: string | undefined;
 
   beforeEach(() => {
-    integrationRepository = sinon.createStubInstance(IntegrationRepository);
-    environmentRepository = sinon.createStubInstance(EnvironmentRepository);
-    createChannelConnection = sinon.createStubInstance(CreateChannelConnection);
-    createChannelEndpoint = sinon.createStubInstance(CreateChannelEndpoint);
-    getNovuProviderCredentials = sinon.createStubInstance(GetNovuProviderCredentials);
-
-    usecase = new SlackOauthCallback(
-      integrationRepository as any,
-      environmentRepository as any,
-      getNovuProviderCredentials as any,
-      createChannelConnection as any,
-      createChannelEndpoint as any
-    );
+    harness = createSlackOauthCallbackHarness();
 
     originalApiRootUrl = process.env.API_ROOT_URL;
     process.env.API_ROOT_URL = MOCK_API_ROOT_URL;
 
-    environmentRepository.findOne.resolves({
+    harness.environmentRepository.findOne.resolves({
       _id: MOCK_ENVIRONMENT_ID,
       apiKeys: [{ key: MOCK_API_KEY }],
     } as any);
 
-    environmentRepository.getApiKeys.resolves([{ key: MOCK_API_KEY }] as any);
+    harness.environmentRepository.getApiKeys.resolves([{ key: MOCK_API_KEY }] as any);
 
-    integrationRepository.findOne.resolves(buildMockIntegration());
+    harness.integrationRepository.findOne.resolves(buildMockIntegration());
+    harness.channelConnectionRepository.findOne.resolves(null);
+    harness.channelConnectionRepository.buildContextExactMatchQuery.returns({});
+    harness.contextRepository.findOrCreateContextsFromPayload.resolves([]);
 
     axiosPost = sinon.stub(axios, 'post').resolves({ data: buildSlackAuthResponse() });
 
-    createChannelConnection.execute.resolves({ identifier: 'conn-abc' } as any);
-    createChannelEndpoint.execute.resolves({} as any);
+    harness.createChannelConnection.execute.resolves({ identifier: 'conn-abc' } as any);
+    harness.createChannelEndpoint.execute.resolves({} as any);
   });
 
   afterEach(() => {
@@ -120,12 +143,12 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.calledOnce).to.be.true;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.calledOnce).to.be.true;
 
-    const endpointArg = createChannelEndpoint.execute.firstCall.args[0];
+    const endpointArg = harness.createChannelEndpoint.execute.firstCall.args[0];
     expect(endpointArg.subscriberId).to.equal(MOCK_SUBSCRIBER_ID);
     expect(endpointArg.type).to.equal(ENDPOINT_TYPES.SLACK_USER);
     expect(endpointArg.endpoint.userId).to.equal(MOCK_SLACK_USER_ID);
@@ -150,10 +173,10 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
   });
 
   it('should create connection but skip endpoint when autoLinkUser=false even if subscriberId and authed_user.id are present', async () => {
@@ -171,10 +194,10 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
   });
 
   it('should create connection but skip endpoint when autoLinkUser is absent (raw API callers default to false)', async () => {
@@ -191,10 +214,10 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
   });
 
   it('should create connection but skip endpoint when autoLinkUser=true but subscriberId is absent', async () => {
@@ -211,9 +234,103 @@ describe('SlackOauthCallback — autoLinkUser', () => {
       state,
     });
 
-    await usecase.execute(command);
+    await harness.usecase.execute(command);
 
-    expect(createChannelConnection.execute.calledOnce).to.be.true;
-    expect(createChannelEndpoint.execute.called).to.be.false;
+    expect(harness.createChannelConnection.execute.calledOnce).to.be.true;
+    expect(harness.createChannelEndpoint.execute.called).to.be.false;
+  });
+});
+
+describe('SlackOauthCallback — reconnect token refresh', () => {
+  let harness: ReturnType<typeof createSlackOauthCallbackHarness>;
+  let originalApiRootUrl: string | undefined;
+
+  beforeEach(() => {
+    harness = createSlackOauthCallbackHarness();
+
+    originalApiRootUrl = process.env.API_ROOT_URL;
+    process.env.API_ROOT_URL = MOCK_API_ROOT_URL;
+
+    harness.environmentRepository.findOne.resolves({
+      _id: MOCK_ENVIRONMENT_ID,
+      apiKeys: [{ key: MOCK_API_KEY }],
+    } as any);
+
+    harness.integrationRepository.findOne.resolves(buildMockIntegration());
+    harness.channelConnectionRepository.buildContextExactMatchQuery.returns({});
+    harness.contextRepository.findOrCreateContextsFromPayload.resolves([]);
+
+    sinon.stub(axios, 'post').resolves({
+      data: buildSlackAuthResponse({ access_token: MOCK_REFRESHED_ACCESS_TOKEN }),
+    });
+
+    harness.updateChannelConnection.execute.resolves({
+      identifier: MOCK_CONNECTION_IDENTIFIER,
+      auth: { accessToken: MOCK_REFRESHED_ACCESS_TOKEN },
+    } as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    process.env.API_ROOT_URL = originalApiRootUrl;
+  });
+
+  it('should update the existing connection token when reconnecting with the same identifier', async () => {
+    harness.channelConnectionRepository.findOne.onFirstCall().resolves({
+      identifier: MOCK_CONNECTION_IDENTIFIER,
+    } as any);
+
+    const state = buildEncodedState({
+      environmentId: MOCK_ENVIRONMENT_ID,
+      organizationId: MOCK_ORGANIZATION_ID,
+      integrationIdentifier: MOCK_INTEGRATION_IDENTIFIER,
+      providerId: ChatProviderIdEnum.Slack,
+      identifier: MOCK_CONNECTION_IDENTIFIER,
+      subscriberId: MOCK_SUBSCRIBER_ID,
+    });
+
+    const command = SlackOauthCallbackCommand.create({
+      providerCode: 'slack-code',
+      state,
+    });
+
+    await harness.usecase.execute(command);
+
+    expect(harness.createChannelConnection.execute.called).to.be.false;
+    expect(harness.updateChannelConnection.execute.calledOnce).to.be.true;
+
+    const updateArg = harness.updateChannelConnection.execute.firstCall.args[0];
+    expect(updateArg.identifier).to.equal(MOCK_CONNECTION_IDENTIFIER);
+    expect(updateArg.auth.accessToken).to.equal(MOCK_REFRESHED_ACCESS_TOKEN);
+    expect(updateArg.workspace.id).to.equal(MOCK_TEAM_ID);
+    expect(updateArg.workspace.name).to.equal(MOCK_TEAM_NAME);
+  });
+
+  it('should update the existing connection token when reconnecting with the same integration, subscriber, and context', async () => {
+    harness.channelConnectionRepository.findOne.resolves({
+      identifier: 'existing-generated-identifier',
+    } as any);
+
+    const state = buildEncodedState({
+      environmentId: MOCK_ENVIRONMENT_ID,
+      organizationId: MOCK_ORGANIZATION_ID,
+      integrationIdentifier: MOCK_INTEGRATION_IDENTIFIER,
+      providerId: ChatProviderIdEnum.Slack,
+      subscriberId: MOCK_SUBSCRIBER_ID,
+    });
+
+    const command = SlackOauthCallbackCommand.create({
+      providerCode: 'slack-code',
+      state,
+    });
+
+    await harness.usecase.execute(command);
+
+    expect(harness.createChannelConnection.execute.called).to.be.false;
+    expect(harness.updateChannelConnection.execute.calledOnce).to.be.true;
+
+    const updateArg = harness.updateChannelConnection.execute.firstCall.args[0];
+    expect(updateArg.identifier).to.equal('existing-generated-identifier');
+    expect(updateArg.auth.accessToken).to.equal(MOCK_REFRESHED_ACCESS_TOKEN);
   });
 });

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -5,7 +5,10 @@ import {
   GetNovuProviderCredentialsCommand,
 } from '@novu/application-generic';
 import {
+  ChannelConnectionEntity,
+  ChannelConnectionRepository,
   ChannelTypeEnum,
+  ContextRepository,
   EnvironmentRepository,
   ICredentialsEntity,
   IntegrationEntity,
@@ -15,6 +18,8 @@ import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
+import { UpdateChannelConnectionCommand } from '../../../../channel-connections/usecases/update-channel-connection/update-channel-connection.command';
+import { UpdateChannelConnection } from '../../../../channel-connections/usecases/update-channel-connection/update-channel-connection.usecase';
 import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
@@ -34,7 +39,10 @@ export class SlackOauthCallback {
     private integrationRepository: IntegrationRepository,
     private environmentRepository: EnvironmentRepository,
     private getNovuProviderCredentials: GetNovuProviderCredentials,
+    private channelConnectionRepository: ChannelConnectionRepository,
+    private contextRepository: ContextRepository,
     private createChannelConnection: CreateChannelConnection,
+    private updateChannelConnection: UpdateChannelConnection,
     private createChannelEndpoint: CreateChannelEndpoint
   ) {}
 
@@ -62,25 +70,7 @@ export class SlackOauthCallback {
        */
       await this.createIncomingWebhookEndpoint(stateData, integration, authData);
     } else {
-      const isSharedMode = stateData.connectionMode === 'shared';
-      const connection = await this.createChannelConnection.execute(
-        CreateChannelConnectionCommand.create({
-          identifier: stateData.identifier,
-          organizationId: stateData.organizationId,
-          environmentId: stateData.environmentId,
-          integrationIdentifier: integration.identifier,
-          subscriberId: isSharedMode ? undefined : stateData.subscriberId,
-          context: stateData.context,
-          connectionMode: stateData.connectionMode,
-          auth: {
-            accessToken: authData.access_token,
-          },
-          workspace: {
-            id: authData.team.id,
-            name: authData.team.name,
-          },
-        })
-      );
+      const connection = await this.upsertWorkspaceConnection(stateData, integration, authData);
       if (stateData.autoLinkUser === true && stateData.subscriberId && authData.authed_user?.id) {
         await this.createChannelEndpoint.execute(
           CreateChannelEndpointCommand.create({
@@ -110,6 +100,93 @@ export class SlackOauthCallback {
         message: 'Your Slack workspace is connected and ready to use.',
       }),
     };
+  }
+
+  private async upsertWorkspaceConnection(
+    stateData: StateData,
+    integration: IntegrationEntity,
+    authData: { access_token: string; team: { id: string; name: string } }
+  ): Promise<ChannelConnectionEntity> {
+    const isSharedMode = stateData.connectionMode === 'shared';
+    const subscriberId = isSharedMode ? undefined : stateData.subscriberId;
+    const contextKeys = await this.resolveContextKeys(stateData);
+    const existingConnection = await this.findExistingConnection(
+      stateData,
+      integration,
+      subscriberId,
+      contextKeys
+    );
+    const auth = { accessToken: authData.access_token };
+    const workspace = { id: authData.team.id, name: authData.team.name };
+
+    if (existingConnection) {
+      return await this.updateChannelConnection.execute(
+        UpdateChannelConnectionCommand.create({
+          identifier: existingConnection.identifier,
+          organizationId: stateData.organizationId,
+          environmentId: stateData.environmentId,
+          auth,
+          workspace,
+        })
+      );
+    }
+
+    return await this.createChannelConnection.execute(
+      CreateChannelConnectionCommand.create({
+        identifier: stateData.identifier,
+        organizationId: stateData.organizationId,
+        environmentId: stateData.environmentId,
+        integrationIdentifier: integration.identifier,
+        subscriberId,
+        context: stateData.context,
+        connectionMode: stateData.connectionMode,
+        auth,
+        workspace,
+      })
+    );
+  }
+
+  private async resolveContextKeys(stateData: StateData): Promise<string[]> {
+    if (!stateData.context) {
+      return [];
+    }
+
+    const contexts = await this.contextRepository.findOrCreateContextsFromPayload(
+      stateData.environmentId,
+      stateData.organizationId,
+      stateData.context
+    );
+
+    return contexts.map((context) => context.key);
+  }
+
+  private async findExistingConnection(
+    stateData: StateData,
+    integration: IntegrationEntity,
+    subscriberId: string | undefined,
+    contextKeys: string[]
+  ): Promise<ChannelConnectionEntity | null> {
+    if (stateData.identifier) {
+      const connectionByIdentifier = await this.channelConnectionRepository.findOne({
+        identifier: stateData.identifier,
+        _organizationId: stateData.organizationId,
+        _environmentId: stateData.environmentId,
+      });
+
+      if (connectionByIdentifier) {
+        return connectionByIdentifier;
+      }
+    }
+
+    const contextQuery = this.channelConnectionRepository.buildContextExactMatchQuery(contextKeys);
+
+    return await this.channelConnectionRepository.findOne({
+      _organizationId: stateData.organizationId,
+      _environmentId: stateData.environmentId,
+      integrationIdentifier: integration.identifier,
+      subscriberId,
+      ...contextQuery,
+    });
   }
 
   private async linkUserEndpoint(stateData: StateData, integration: IntegrationEntity, authData: any): Promise<void> {


### PR DESCRIPTION
Upserts the Slack bot token on OAuth reconnect so the integration does not lose its bot identity.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Slack OAuth callback handling to reuse existing channel connections on reconnect.
- Resolves an existing connection by identifier or by integration, subscriber, and exact context.
- Updates the existing connection’s bot token and workspace instead of attempting to create a duplicate.
- Adds reconnect coverage and consolidates test setup into a shared harness.

<h3>Confidence Score: 4/5</h3>

The ownership scope of identifier-based reconnects must be fixed before merging because the callback can overwrite an unrelated channel connection’s Slack credentials.

The new lookup trusts an independently supplied connection identifier and omits the integration, subscriber, and context constraints used by the fallback path, while the subsequent update replaces credentials without restoring those ownership checks.

**Files Needing Attention:** apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts

<details open><summary><h3>Security Review</h3></summary>

The identifier-first reconnect path does not verify connection ownership fields, allowing a caller-selected identifier to redirect a valid Slack OAuth callback into overwriting another same-environment connection’s credentials.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts | Adds reconnect upsert behavior, but the identifier lookup can select and overwrite a connection outside the state’s integration, subscriber, or context. |
| apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.spec.ts | Refactors the test harness and covers successful reconnect updates, but does not exercise an identifier that belongs to a differently scoped connection. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Slack OAuth API
    participant Slack
    participant DB as Channel Connections
    Client->>API: Request OAuth URL with connection identifier
    API-->>Client: Signed OAuth state
    Client->>Slack: Authorize workspace
    Slack->>API: Callback with code and state
    API->>Slack: Exchange code for bot token
    API->>DB: Find existing connection
    alt Existing connection found
        API->>DB: Update token and workspace
    else No connection found
        API->>DB: Create connection
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fintegrations%2Fusecases%2Fchat-oauth-callback%2Fslack-oauth-callback%2Fslack-oauth-callback.usecase.ts%3A169-178%0A**Reconnect%20lookup%20ignores%20connection%20ownership**%0A%0AWhen%20a%20signed%20OAuth%20state%20contains%20a%20caller-provided%20identifier%20already%20owned%20by%20another%20integration%2C%20subscriber%2C%20or%20context%20in%20the%20same%20environment%2C%20this%20lookup%20selects%20that%20connection%20and%20replaces%20its%20bot%20token%20and%20workspace%2C%20causing%20its%20endpoints%20and%20sends%20to%20use%20the%20wrong%20Slack%20identity.%0A%0A**How%20this%20was%20verified%3A**%20The%20state%20stores%20the%20identifier%20independently%20from%20its%20ownership%20fields%2C%20while%20both%20the%20lookup%20and%20subsequent%20update%20filter%20only%20by%20identifier%2C%20organization%2C%20and%20environment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12179&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts:169-178
**Reconnect lookup ignores connection ownership**

When a signed OAuth state contains a caller-provided identifier already owned by another integration, subscriber, or context in the same environment, this lookup selects that connection and replaces its bot token and workspace, causing its endpoints and sends to use the wrong Slack identity.

**How this was verified:** The state stores the identifier independently from its ownership fields, while both the lookup and subsequent update filter only by identifier, organization, and environment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): upsert Slack bot token..."](https://github.com/novuhq/novu/commit/c72a9d4f6768f0b5cea8a9d8f5a3640c9208ff9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49291783)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->