### PR TITLE
fix(application-generic): improve LaunchDarkly client initialization and error handling

### DIFF
--- a/libs/application-generic/src/services/feature-flags/launch-darkly.service.ts
+++ b/libs/application-generic/src/services/feature-flags/launch-darkly.service.ts
@@ -1,20 +1,27 @@
 import { init, LDClient, LDMultiKindContext } from '@launchdarkly/node-server-sdk';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import type { FeatureFlagContext, FeatureFlagContextBase, IFeatureFlagsService } from './types';
+
+const LOG_CONTEXT = 'LaunchDarklyFeatureFlagsService';
+const INITIALIZATION_TIMEOUT_SECONDS = 10;
 
 @Injectable()
 export class LaunchDarklyFeatureFlagsService implements IFeatureFlagsService {
   private client: LDClient;
-  public isEnabled: boolean;
+  public isEnabled = false;
 
   public async initialize(): Promise<void> {
-    const launchDarklySdkKey = process.env.LAUNCH_DARKLY_SDK_KEY;
-    if (!launchDarklySdkKey) {
-      throw new Error('Missing Launch Darkly SDK key');
+    try {
+      this.client = init(process.env.LAUNCH_DARKLY_SDK_KEY as string);
+      await this.client.waitForInitialization({ timeout: INITIALIZATION_TIMEOUT_SECONDS });
+      this.isEnabled = true;
+    } catch (error) {
+      Logger.error(
+        `Failed to initialize LaunchDarkly client, feature flags will use default values. SDK will retry to initialize in the next tick.`,
+        (error as Error).stack || (error as Error).message,
+        LOG_CONTEXT
+      );
     }
-    this.client = init(launchDarklySdkKey);
-    await this.client.waitForInitialization({ timeout: 10000 });
-    this.isEnabled = true;
   }
 
   public async gracefullyShutdown(): Promise<void> {
@@ -32,10 +39,13 @@ export class LaunchDarklyFeatureFlagsService implements IFeatureFlagsService {
     user,
     component,
   }: FeatureFlagContext<T_Result>): Promise<T_Result> {
-    const context = this.buildLDContext({ user, organization, environment, component });
-    const newVar = await this.client.variation(key, context, defaultValue);
+    if (!this.isEnabled) {
+      return defaultValue;
+    }
 
-    return newVar;
+    const context = this.buildLDContext({ user, organization, environment, component });
+
+    return await this.client.variation(key, context, defaultValue);
   }
 
   private buildLDContext({ user, organization, environment, component }: FeatureFlagContextBase): LDMultiKindContext {


### PR DESCRIPTION
Improves LaunchDarkly client initialization with better timeout and error handling.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves LaunchDarkly startup failure handling.

- Adds a bounded initialization wait and logs initialization failures.
- Returns caller-provided defaults while the LaunchDarkly client is disabled.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until LaunchDarkly evaluation can recover after a transient initialization timeout.

The retained service is initialized only once, and a failed readiness wait leaves `isEnabled` false permanently, causing every subsequent flag lookup to return its default even if the SDK later connects.

**Files Needing Attention:** libs/application-generic/src/services/feature-flags/launch-darkly.service.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/feature-flags/launch-darkly.service.ts | Adds graceful startup fallback, but a transient timeout permanently suppresses remote flag evaluation for the lifetime of the service instance. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Fapplication-generic%2Fsrc%2Fservices%2Ffeature-flags%2Flaunch-darkly.service.ts%3A16%0A**Initialization%20timeout%20becomes%20permanent**%0A%0AWhen%20the%20initial%2010-second%20readiness%20wait%20times%20out%20and%20the%20SDK%20connects%20afterward%2C%20%60isEnabled%60%20remains%20false%20because%20this%20retained%20service%20is%20initialized%20only%20once.%20Every%20subsequent%20flag%20lookup%20therefore%20returns%20its%20default%20until%20restart%2C%20including%20queue-backend%20selection%20falling%20back%20to%20BullMQ%20instead%20of%20its%20configured%20LaunchDarkly%20value.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/application-generic/src/services/feature-flags/launch-darkly.service.ts:16
**Initialization timeout becomes permanent**

When the initial 10-second readiness wait times out and the SDK connects afterward, `isEnabled` remains false because this retained service is initialized only once. Every subsequent flag lookup therefore returns its default until restart, including queue-backend selection falling back to BullMQ instead of its configured LaunchDarkly value.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(application-generic): improve Launch..."](https://github.com/novuhq/novu/commit/5f8eab7220eeecf853331701d866390a6f029e1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49291789)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->