### PR TITLE
fix(js): wrap notification cache entries into Notification instances on event handling

### DIFF
--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -1,7 +1,7 @@
 import { InboxService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { ListNotificationsArgs, ListNotificationsResponse, Notification } from '../notifications';
-import { ChannelType, SeverityLevelEnum } from '../types';
+import { ChannelType, InboxNotification, SeverityLevelEnum } from '../types';
 import { NotificationsCache } from './notifications-cache';
 
 describe('NotificationsCache', () => {
@@ -536,5 +536,49 @@ describe('NotificationsCache', () => {
         notifications: [notification3],
       },
     });
+  });
+
+  it('should wrap plain objects into Notification instances via unshift', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'] };
+    const plainNotification: InboxNotification = {
+      id: 'plain-1',
+      transactionId: 'tx-plain',
+      body: 'plain notification',
+      isRead: false,
+      isArchived: false,
+      isSeen: false,
+      isSnoozed: false,
+      to: { id: '1', subscriberId: '1' },
+      createdAt: new Date().toISOString(),
+      channelType: ChannelType.IN_APP,
+      severity: SeverityLevelEnum.NONE,
+    };
+
+    notificationsCache.unshift(args, plainNotification);
+    const result = notificationsCache.getAll(args);
+
+    expect(result).toBeDefined();
+    expect(result!.notifications).toHaveLength(1);
+    expect(result!.notifications[0]).toBeInstanceOf(Notification);
+    expect(typeof result!.notifications[0].read).toBe('function');
+    expect(typeof result!.notifications[0].archive).toBe('function');
+  });
+
+  it('should wrap plain objects from handleNotificationEvent into Notification instances', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+    notificationsCache.set(args, data);
+
+    const plainObject = JSON.parse(JSON.stringify(notification1));
+    plainObject.body = 'Updated via BroadcastChannel';
+    expect(plainObject).not.toBeInstanceOf(Notification);
+
+    (notificationsCache as any).handleNotificationEvent()({ data: plainObject });
+
+    const result = notificationsCache.getAll(args);
+    expect(result).toBeDefined();
+    expect(result!.notifications[0]).toBeInstanceOf(Notification);
+    expect(typeof result!.notifications[0].read).toBe('function');
+    expect(typeof result!.notifications[0].archive).toBe('function');
   });
 });

--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -211,9 +211,9 @@ export class NotificationsCache {
           Array.isArray(data) &&
           data.every((item): item is Notification => typeof item === 'object' && 'id' in item)
         ) {
-          notifications = data;
+          notifications = this.#normalizeNotifications(data);
         } else if (typeof data === 'object' && 'id' in data) {
-          notifications = [data as Notification];
+          notifications = [this.#toNotificationInstance(data as Notification)];
         }
       } else if (remove && args) {
         if ('notification' in args && args.notification) {

--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -117,10 +117,7 @@ export const CountProvider = (props: ParentProps) => {
     // 1. Cache is nearly empty
     // 2. OR inbox is closed (will be auto-loaded when opened)
     if (hasLessThenMinAmount || !isOpened()) {
-      notificationsCache.update(tabSpecificFilterForCache, {
-        ...cachedData,
-        notifications: [notification, ...cachedData.notifications],
-      });
+      notificationsCache.unshift(tabSpecificFilterForCache, notification);
 
       return;
     }


### PR DESCRIPTION
Wraps notification cache entries into Notification instances on event handling. Fixes NV-8092 related cache instance issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes cross-tab notification handling by restoring serialized cache entries as functional `Notification` instances.
- Normalizes single and bulk event payloads before updating the notification cache.
- Routes count-context insertion through the cache’s normalized `unshift` operation.
- Adds coverage for plain-object insertion and BroadcastChannel-style event payloads.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed paths preserving cache behavior while restoring notification instance methods after cross-tab serialization.

Event payload normalization is idempotent for existing instances, reconstructs serialized plain objects with the cache’s dependencies, and retains ID-based cache matching and existing update emissions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/cache/notifications-cache.ts | Normalizes event payloads through the existing idempotent notification-instance conversion path before updating cached entries. |
| packages/js/src/ui/context/CountContext.tsx | Replaces manual cache reconstruction with the equivalent normalized `unshift` API while preserving pagination boundaries. |
| packages/js/src/cache/notifications-cache.test.ts | Adds focused tests confirming plain notification objects become method-bearing `Notification` instances during insertion and event handling. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js): wrap notification cache entries..."](https://github.com/novuhq/novu/commit/545ade4410c40721f82a504fc8c11647b456a41c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49420142)</sub>

<!-- /greptile_comment -->