### PR TITLE
fix(application-generic): await single-job BullMQ enqueue to prevent silent job loss

### DIFF
--- a/libs/application-generic/src/services/bull-mq/bull-mq.service.spec.ts
+++ b/libs/application-generic/src/services/bull-mq/bull-mq.service.spec.ts
@@ -84,4 +84,75 @@ describe('BullMQ Service', () => {
       expect(queue.opts.prefix).toEqual('{metric-active-jobs}');
     });
   });
+
+  describe('Add job', () => {
+    beforeEach(() => {
+      const mockInMemoryProvider = {
+        providerInUseIsInClusterMode: jest.fn(() => false),
+      };
+
+      bullMqService = new BullMqService(mockInMemoryProvider as unknown as WorkflowInMemoryProviderService);
+    });
+
+    it('should return a Promise<Job> that resolves with the enqueued job', async () => {
+      const queue = {
+        add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+      };
+      (bullMqService as any)._queue = queue;
+
+      const result = bullMqService.add('job-name', { test: true } as any);
+
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result).resolves.toEqual({ id: 'job-1' });
+      expect(queue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not resolve before the underlying enqueue settles', async () => {
+      let settled = false;
+      const queue = {
+        add: jest.fn().mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              setTimeout(() => {
+                settled = true;
+                resolve({ id: 'job-1' });
+              }, 50);
+            })
+        ),
+      };
+      (bullMqService as any)._queue = queue;
+
+      const result = bullMqService.add('job-name', { test: true } as any);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(settled).toBe(false);
+
+      await expect(result).resolves.toEqual({ id: 'job-1' });
+      expect(settled).toBe(true);
+    });
+
+    it('should propagate an enqueue failure to the caller without an unhandled rejection', async () => {
+      const enqueueError = new Error('ECONNREFUSED Redis unavailable');
+      const unhandledRejections: unknown[] = [];
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandledRejection);
+
+      try {
+        const queue = {
+          add: jest.fn().mockRejectedValue(enqueueError),
+        };
+        (bullMqService as any)._queue = queue;
+
+        await expect(bullMqService.add('job-name', { test: true } as any)).rejects.toThrow('ECONNREFUSED');
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(unhandledRejections).toEqual([]);
+      } finally {
+        process.removeListener('unhandledRejection', onUnhandledRejection);
+      }
+    });
+  });
 });

--- a/libs/application-generic/src/services/bull-mq/bull-mq.service.ts
+++ b/libs/application-generic/src/services/bull-mq/bull-mq.service.ts
@@ -160,8 +160,8 @@ export class BullMqService {
     return this._worker;
   }
 
-  public add(name: string, data: BullMqJobData, options: JobsOptions = {}, groupId?: string) {
-    this._queue.add(name, data, {
+  public async add(name: string, data: BullMqJobData, options: JobsOptions = {}, groupId?: string): Promise<Job> {
+    return this._queue.add(name, data, {
       ...options,
       ...(BullMqService.pro && groupId
         ? {


### PR DESCRIPTION
### What changed? Why was the change needed?

What changed

1. libs/application-generic/src/services/bull-mq/bull-mq.service.ts:163 (the fix)

* public add(name: string, data: BullMqJobData, options: JobsOptions = {}, groupId?: string) {
* this.\_queue.add(name, data, { ... });
* public async add(name: string, data: BullMqJobData, options: JobsOptions = {}, groupId?: string): Promise {
* return this.\_queue.add(name, data, { ... });<br>}

2. bull-mq.service.spec.ts — added an Add job test suite with 3 tests:

* add() returns a Promise resolving with the enqueued job
* await add() doesn't resolve before the underlying enqueue settles
* an enqueue failure propagates to the caller with no unhandled rejection<br>Why the change was needed<br>BullMqService.add() called this.\_queue.add(...) but neither returned nor awaited the resulting promise, so it returned undefined. Every caller then awaited void:
* QueueBaseService.addToBullMQ() (await this.bullMqService.add(...), queue-base.service.ts:318)
* ParseEventRequest.dispatchEventToWorkflowQueue() (parse-event-request.usecase.ts:412)<br>Since awaiting void resolves instantly, the /v1/events/trigger endpoint returned acknowledged: true / PROCESSED before Redis accepted the job, and on enqueue failure (Redis down) the dropped promise became an unhandled rejection — apps/api/src/bootstrap.ts:171 handles that with process.exit(1), crashing the whole API process.<br>So the fix has two effects:

1. No silent data loss — the API can no longer confirm a trigger that wasn't durably enqueued; failures now propagate as a caught error (HTTP 500).
2. No crash — awaited callers handle the failure instead of producing an unhandled rejection that tears down the process.<br>The change is confined to BullMqService.add(); the single-job path only. addBulk() already awaited correctly, and all production callers of add() already await it, so no other code needed modification.

### Screenshots

NA

Fixes novuhq/novu#12182

### Greptile Summary

This PR makes single-job BullMQ enqueue operations awaitable and adds tests confirming successful completion, delayed settlement, and rejection propagation.

### Confidence Score: 5/5

The PR appears safe to merge with no actionable defects identified.

The changed method now returns the BullMQ enqueue promise, its declared type matches the queue API, and existing production callers already await the operation.

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| libs/application-generic/src/services/bull-mq/bull-mq.service.ts | Returns the underlying Queue.add promise with a compatible Promise contract, allowing existing awaited callers to observe enqueue completion and failure. |
| libs/application-generic/src/services/bull-mq/bull-mq.service.spec.ts | Adds focused coverage for the returned job, asynchronous settlement, and handled enqueue rejection. |

</details>

Reviews (1): Last reviewed commit: ["fix(application-generic): await single-j..."](<https://github.com/novuhq/novu/commit/2fc33acc431f6f5c8861430ff0a0408456f4113d>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=49469037>)