### PR TITLE
await single-job BullMQ enqueue to prevent silent job loss

### DIFF
--- a/libs/application-generic/src/services/queues/queue-base.service.spec.ts
+++ b/libs/application-generic/src/services/queues/queue-base.service.spec.ts
@@ -1,0 +1,180 @@
+import { CommunityOrganizationRepository } from '@novu/dal';
+import { FeatureFlagsKeysEnum, JobTopicNameEnum, QueueBackendMode } from '@novu/shared';
+import { PinoLogger } from '../../logging';
+import { BullMqService } from '../bull-mq';
+import { FeatureFlagsService } from '../feature-flags';
+import { SqsService } from '../sqs';
+import { QueueBaseService } from './queue-base.service';
+
+const createQueueMock = jest.fn();
+const addToBullMqMock = jest.fn().mockResolvedValue(undefined);
+const addBulkToBullMqMock = jest.fn().mockResolvedValue(undefined);
+
+const sendToSqsMock = jest.fn().mockResolvedValue(undefined);
+const sendBulkToSqsMock = jest.fn().mockResolvedValue(undefined);
+
+const getFlagMock = jest.fn().mockResolvedValue(QueueBackendMode.BULLMQ);
+
+const findOneOrgMock = jest.fn();
+
+const mockBullMqService = {
+  createQueue: createQueueMock,
+  add: addToBullMqMock,
+  addBulk: addBulkToBullMqMock,
+} as unknown as BullMqService;
+
+const mockSqsService = {
+  send: sendToSqsMock,
+  sendBulk: sendBulkToSqsMock,
+} as unknown as SqsService;
+
+const mockFeatureFlagsService = {
+  getFlag: getFlagMock,
+} as unknown as FeatureFlagsService;
+
+const mockOrganizationRepository = {
+  findOne: findOneOrgMock,
+} as unknown as CommunityOrganizationRepository;
+
+const mockLogger = {
+  setContext: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+} as unknown as PinoLogger;
+
+describe('QueueBaseService - organization lookup failure handling', () => {
+  let service: QueueBaseService;
+
+  const organizationId = 'organization-id';
+  const job = {
+    name: 'test-job',
+    data: { _id: 'job-id' },
+    groupId: organizationId,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getFlagMock.mockResolvedValue(QueueBackendMode.BULLMQ);
+
+    service = new QueueBaseService(
+      JobTopicNameEnum.WEB_SOCKETS,
+      mockBullMqService,
+      mockSqsService,
+      mockFeatureFlagsService,
+      mockOrganizationRepository,
+      mockLogger
+    );
+  });
+
+  describe('Transient lookup failure falls back to BullMQ (regression)', () => {
+    it('add() routes the job to BullMQ when the org lookup throws, instead of dropping it', async () => {
+      findOneOrgMock.mockRejectedValueOnce(new Error('Mongo socket timeout'));
+
+      await expect(service.add(job)).resolves.toBeUndefined();
+
+      expect(findOneOrgMock).toHaveBeenCalledWith(
+        { _id: organizationId },
+        'apiServiceLevel',
+        expect.objectContaining({ readPreference: 'primary' })
+      );
+      expect(sendToSqsMock).not.toHaveBeenCalled();
+      expect(addToBullMqMock).toHaveBeenCalledWith(
+        job.name,
+        job.data,
+        expect.objectContaining({ removeOnComplete: true }),
+        organizationId
+      );
+      expect(getFlagMock).not.toHaveBeenCalled();
+    });
+
+    it('addBulk() routes the jobs to BullMQ when the org lookup throws, instead of dropping them', async () => {
+      const secondJob = { name: 'test-job-2', data: { _id: 'job-id-2' }, groupId: organizationId };
+      findOneOrgMock.mockRejectedValueOnce(new Error('Mongo socket timeout'));
+
+      await expect(service.addBulk([job, secondJob])).resolves.toBeUndefined();
+
+      expect(sendBulkToSqsMock).not.toHaveBeenCalled();
+      expect(addBulkToBullMqMock).toHaveBeenCalledWith([
+        expect.objectContaining({ name: job.name, data: job.data, groupId: organizationId }),
+        expect.objectContaining({ name: secondJob.name, data: secondJob.data, groupId: organizationId }),
+      ]);
+      expect(getFlagMock).not.toHaveBeenCalled();
+    });
+
+    it('add() routes the job to BullMQ when the organization repository is unavailable', async () => {
+      service = new QueueBaseService(
+        JobTopicNameEnum.WEB_SOCKETS,
+        mockBullMqService,
+        mockSqsService,
+        mockFeatureFlagsService,
+        undefined,
+        mockLogger
+      );
+
+      await expect(service.add(job)).resolves.toBeUndefined();
+
+      expect(sendToSqsMock).not.toHaveBeenCalled();
+      expect(addToBullMqMock).toHaveBeenCalledWith(
+        job.name,
+        job.data,
+        expect.objectContaining({ removeOnComplete: true }),
+        organizationId
+      );
+      expect(getFlagMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Confirmed missing organization (primary read)', () => {
+    it('uses a primary read before deciding the organization is absent and skips the job', async () => {
+      findOneOrgMock.mockResolvedValueOnce(undefined);
+
+      await expect(service.add(job)).resolves.toBeUndefined();
+
+      expect(findOneOrgMock).toHaveBeenCalledWith(
+        { _id: organizationId },
+        'apiServiceLevel',
+        expect.objectContaining({ readPreference: 'primary' })
+      );
+
+      expect(sendToSqsMock).not.toHaveBeenCalled();
+      expect(addToBullMqMock).not.toHaveBeenCalled();
+      expect(getFlagMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Healthy path (control)', () => {
+    it('add() routes the job to BullMQ when the organization is found', async () => {
+      findOneOrgMock.mockResolvedValueOnce({ _id: organizationId, apiServiceLevel: 'free' });
+      getFlagMock.mockResolvedValueOnce(QueueBackendMode.BULLMQ);
+
+      await service.add(job);
+
+      expect(addToBullMqMock).toHaveBeenCalledWith(
+        job.name,
+        job.data,
+        expect.objectContaining({ removeOnComplete: true }),
+        organizationId
+      );
+    });
+
+    it('add() routes the job to SQS when the backend mode is COMPLETE', async () => {
+      findOneOrgMock.mockResolvedValueOnce({ _id: organizationId, apiServiceLevel: 'free' });
+      getFlagMock.mockResolvedValueOnce(QueueBackendMode.COMPLETE);
+
+      await service.add(job);
+
+      expect(getFlagMock).toHaveBeenCalledWith({
+        key: FeatureFlagsKeysEnum.QUEUE_BACKEND_MODE,
+        defaultValue: QueueBackendMode.BULLMQ,
+        organization: { _id: organizationId, apiServiceLevel: 'free' },
+      });
+
+      expect(sendToSqsMock).toHaveBeenCalledWith(
+        JobTopicNameEnum.WEB_SOCKETS,
+        expect.objectContaining({ groupId: organizationId, body: JSON.stringify(job.data) })
+      );
+    });
+  });
+});

--- a/libs/application-generic/src/services/queues/queue-base.service.ts
+++ b/libs/application-generic/src/services/queues/queue-base.service.ts
@@ -148,22 +148,34 @@ export class QueueBaseService implements OnModuleDestroy {
   }
 
   private async getQueueBackendMode(organizationId: string): Promise<string | null> {
+    if (!this.organizationRepository) {
+      Logger.warn({ topic: this.topic }, 'Organization repository unavailable, routing to BullMQ fallback', LOG_CONTEXT);
+
+      return QueueBackendMode.BULLMQ;
+    }
+
     let organization: { _id: string; apiServiceLevel?: ApiServiceLevelEnum } | undefined;
     try {
-      organization = await this.organizationRepository?.findOne({ _id: organizationId }, 'apiServiceLevel', {
-        readPreference: 'secondaryPreferred',
+      organization = await this.organizationRepository.findOne({ _id: organizationId }, 'apiServiceLevel', {
+        readPreference: 'primary',
       });
     } catch (error) {
-      Logger.warn(
+      /*
+       * A transient lookup failure must not be treated as "organization absent".
+       * Fall back to BullMQ so the job is durably enqueued instead of silently dropped.
+       */
+      Logger.error(
         { organizationId, error: error instanceof Error ? error.message : String(error) },
-        'Failed to fetch organization for queue backend mode flag',
+        'Failed to fetch organization for queue backend mode flag, falling back to BullMQ',
         LOG_CONTEXT
       );
+
+      return QueueBackendMode.BULLMQ;
     }
 
     /*
-     * If the organization is not found, we return null to indicate that the job should be skipped.
-     * There is no point in trying to route the job to SQS or BullMQ if the organization is not found.
+     * The job should only be skipped when the organization is confirmed absent on a primary read.
+     * A stale secondary read can no longer misreport a recently created organization as missing.
      */
 
     if (!organization) {

--- a/libs/application-generic/src/services/queues/standard-queue.service.lookup.spec.ts
+++ b/libs/application-generic/src/services/queues/standard-queue.service.lookup.spec.ts
@@ -1,0 +1,101 @@
+import { CommunityOrganizationRepository } from '@novu/dal';
+import { CloudflareSchedulerMode } from '@novu/shared';
+import { PinoLogger } from '../../logging';
+import { CloudflareSchedulerService } from '../cloudflare-scheduler';
+import { FeatureFlagsService } from '../feature-flags';
+import { WorkflowInMemoryProviderService } from '../in-memory-provider';
+import { SqsService } from '../sqs';
+import { StandardQueueService } from './standard-queue.service';
+
+jest.mock('../in-memory-provider', () => ({
+  WorkflowInMemoryProviderService: jest.fn(() => ({})),
+}));
+
+jest.mock('../bull-mq', () => {
+  const mockBullMqService = {
+    createQueue: jest.fn(),
+    isClientReady: jest.fn().mockReturnValue(true),
+    add: jest.fn().mockResolvedValue(undefined),
+    addBulk: jest.fn().mockResolvedValue(undefined),
+    gracefulShutdown: jest.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    BullMqService: jest.fn(() => mockBullMqService),
+  };
+});
+
+jest.mock('../feature-flags', () => ({ FeatureFlagsService: jest.fn() }));
+
+const findOneOrgMock = jest.fn();
+const getFlagMock = jest.fn();
+const scheduleJobMock = jest.fn();
+
+describe('StandardQueueService - delayed job organization lookup', () => {
+  let service: StandardQueueService;
+
+  const organizationId = 'organization-id';
+  const delayedJob = {
+    name: 'test-delayed-job',
+    groupId: organizationId,
+    data: {
+      _id: 'job-id',
+      _environmentId: 'environment-id',
+      _organizationId: organizationId,
+      _userId: 'user-id',
+    },
+    options: { delay: 60_000 },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    service = new StandardQueueService(
+      new WorkflowInMemoryProviderService(),
+      { scheduleJob: scheduleJobMock } as unknown as CloudflareSchedulerService,
+      { getFlag: getFlagMock } as unknown as FeatureFlagsService,
+      { findOne: findOneOrgMock } as unknown as CommunityOrganizationRepository,
+      {
+        send: jest.fn().mockResolvedValue(undefined),
+        sendBulk: jest.fn().mockResolvedValue(undefined),
+      } as unknown as SqsService,
+      {
+        setContext: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      } as unknown as PinoLogger
+    );
+  });
+
+  it('uses a primary read for delayed jobs so a recently created organization is not misreported as missing', async () => {
+    findOneOrgMock.mockResolvedValueOnce({ _id: organizationId, apiServiceLevel: 'free' });
+    getFlagMock.mockResolvedValueOnce(CloudflareSchedulerMode.OFF);
+
+    await expect(service.add(delayedJob)).resolves.toBeUndefined();
+
+    expect(findOneOrgMock).toHaveBeenCalledWith(
+      { _id: organizationId },
+      'apiServiceLevel',
+      expect.objectContaining({ readPreference: 'primary' })
+    );
+  });
+
+  it('throws only when the organization is confirmed absent on a primary read', async () => {
+    findOneOrgMock.mockResolvedValueOnce(undefined);
+
+    await expect(service.add(delayedJob)).rejects.toThrow(`Organization ${organizationId} not found`);
+  });
+
+  it('routes to the Cloudflare scheduler when scheduler mode is LIVE and the organization is found', async () => {
+    findOneOrgMock.mockResolvedValueOnce({ _id: organizationId, apiServiceLevel: 'free' });
+    getFlagMock.mockResolvedValueOnce(CloudflareSchedulerMode.LIVE);
+
+    await service.add(delayedJob);
+
+    expect(scheduleJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: delayedJob.data._id, mode: CloudflareSchedulerMode.LIVE })
+    );
+  });
+});

--- a/libs/application-generic/src/services/queues/standard-queue.service.ts
+++ b/libs/application-generic/src/services/queues/standard-queue.service.ts
@@ -54,7 +54,7 @@ export class StandardQueueService extends QueueBaseService {
     const organization = await this._organizationRepository.findOne(
       { _id: data.data._organizationId },
       'apiServiceLevel',
-      { readPreference: 'secondaryPreferred' }
+      { readPreference: 'primary' }
     );
     if (!organization) {
       throw new Error(`Organization ${data.data._organizationId} not found`);


### PR DESCRIPTION
Fixes: #12185 
### What changed? Why was the change needed?

QueueBaseService.getQueueBackendMode() (libs/application-generic/src/services/queues/queue-base.service.ts) treated a transient organization lookup failure — and a stale secondaryPreferred read — the same as a confirmed missing organization. Both returned null, which add() and addBulk() interpreted as "skip", silently dropping notification jobs with no error response, retry, or durable record while the trigger path reported success.

# What changed:
- Lookup failure falls back to BullMQ — the catch now logs an error and returns QueueBackendMode.BULLMQ instead of null, so the job is durably enqueued via the existing routing path rather than discarded.
- Consistent absence check — the organization read changed from readPreference: 'secondaryPreferred' to 'primary', so a recently-created organization can no longer be misreported as missing by replica lag. null (skip) is now only returned for an organization confirmed absent on a primary read.
- Repository-unavailable guard — if organizationRepository isn't injected, we fall back to BullMQ instead of dropping every job.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR strengthens queue-delivery reliability:
- Uses primary organization reads in both standard and delayed-job routing.
- Falls back to BullMQ when organization lookup fails or the repository is unavailable.
- Adds regression coverage for lookup failures, confirmed absence, and backend routing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the delayed-job lookup now reads from the primary before deciding that an organization is absent, resolving the previous finding.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/queues/queue-base.service.ts | Organization lookup failures and unavailable repository injection now route jobs to BullMQ, while only primary-confirmed absence skips enqueueing. |
| libs/application-generic/src/services/queues/standard-queue.service.ts | Delayed-job organization validation now reads from the primary, resolving the previously reported replica-lag failure. |
| libs/application-generic/src/services/queues/queue-base.service.spec.ts | Adds regression tests for transient lookup failures, unavailable repository injection, primary-confirmed absence, and healthy backend routing. |
| libs/application-generic/src/services/queues/standard-queue.service.lookup.spec.ts | Verifies delayed jobs use a primary organization read and retain expected scheduler and missing-organization behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(application-generic): use primary re..."](https://github.com/novuhq/novu/commit/13e42437ed8ac61da1c38c1860de2d72d13aa600) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49500187)</sub>

**Context used:**

- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)

<!-- /greptile_comment -->