### PR TITLE
fix(dashboard): align credential values with labels in tool webhook display fixes NV-8505

### DIFF
--- a/apps/dashboard/src/components/subscribers/credentials/tool-webhook-credential-form.tsx
+++ b/apps/dashboard/src/components/subscribers/credentials/tool-webhook-credential-form.tsx
@@ -289,7 +289,7 @@ export function ToolWebhookCredentialFormRow({
       <div className="flex min-w-0 items-start justify-between gap-2">
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <span className={CREDENTIAL_FIELD_LABEL_CLASS}>URL</span>
-          <span className="text-paragraph-xs font-mono text-text-sub truncate">{webhookPayload.url || '-'}</span>
+          <span className="text-paragraph-xs font-mono text-text-sub truncate px-0.5">{webhookPayload.url || '-'}</span>
         </div>
         {!readOnly && (
           <div className="flex shrink-0 items-center gap-1">
@@ -311,14 +311,14 @@ export function ToolWebhookCredentialFormRow({
       {webhookPayload.method && (
         <div className="flex flex-col gap-1">
           <span className={CREDENTIAL_FIELD_LABEL_CLASS}>Method</span>
-          <span className="text-paragraph-xs font-mono text-text-sub">{webhookPayload.method}</span>
+          <span className="text-paragraph-xs font-mono text-text-sub px-0.5">{webhookPayload.method}</span>
         </div>
       )}
       {headerEntries.length > 0 && (
         <div className="flex flex-col gap-1">
           <span className={CREDENTIAL_FIELD_LABEL_CLASS}>Headers</span>
           {headerEntries.map(([key, value]) => (
-            <div key={key} className="flex items-center gap-1 text-paragraph-xs font-mono text-text-sub">
+            <div key={key} className="flex items-center gap-1 px-0.5 text-paragraph-xs font-mono text-text-sub">
               <span className="w-[120px] shrink-0 truncate">{key}</span>
               <span className="min-w-0 flex-1 truncate">{valuesVisible ? value : maskCredentialValue(value)}</span>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Fixed a 2px misalignment in the Tool Webhook subscriber credential read-only view where value text (URL, method, and header rows) started flush at the container edge while their labels were inset by 2px due to `px-0.5` from `CREDENTIAL_FIELD_LABEL_CLASS`.

## Why

The labels use `CREDENTIAL_FIELD_LABEL_CLASS` which includes `px-0.5` (2px horizontal padding), but the value elements had no corresponding padding, causing a visible 1-2px left-alignment offset between labels and their values.

## Fix

Added `px-0.5` to:
- URL value span
- Method value span
- Header key-value row container

This ensures value text starts at the same horizontal position as label text.

## Screenshot (after fix)

![Tool webhook credential alignment after fix](https://cursor.com/artifacts/c/art-9c3dd34b-ef4f-4c00-92b9-caabbbfb6dc3)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8505](https://linear.app/novu/issue/NV-8505/input-alignment-is-a-bit-off-in-the-credentials-section)

<div><a href="https://cursor.com/agents/bc-ea5005c5-4421-43bb-b38d-69b862102987?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea5005c5-4421-43bb-b38d-69b862102987&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds matching horizontal padding to the Tool Webhook credential values so URL, method, and header text align with their labels.
- Applies `px-0.5` to the URL and method value spans.
- Applies the same padding to each header key-value row.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it makes a narrowly scoped visual alignment adjustment without affecting credential behavior.

The changes only add consistent horizontal padding to three existing display elements, and no blocking or independently actionable issue was identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/subscribers/credentials/tool-webhook-credential-form.tsx | The read-only credential display receives consistent horizontal padding without changing data handling or interaction behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): align credential values ..."](https://github.com/novuhq/novu/commit/469ef9c12044f9e183b5565ed600ced16dc65faf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49619873)</sub>

<!-- /greptile_comment -->