### PR TITLE
feat(dashboard): move Format JSON button into Override fields card fixes NV-8503

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-override-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-override-panel.tsx
@@ -1,6 +1,6 @@
 import { type ContentOverrideProviderId } from '@novu/shared';
-import { Braces, Undo2 } from 'lucide-react';
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Undo2 } from 'lucide-react';
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { RiErrorWarningFill } from 'react-icons/ri';
 import { ConfirmationModal } from '@/components/confirmation-modal';
@@ -21,11 +21,7 @@ import {
 } from './content-source';
 import { useContentSource } from './content-source-context';
 import { ContentSourceSelector } from './content-source-selector';
-import {
-  ProviderOverrideEditor,
-  type ProviderOverrideEditorHandle,
-  type ProviderOverrideEditorProps,
-} from './provider-override-editor';
+import { ProviderOverrideEditor, type ProviderOverrideEditorProps } from './provider-override-editor';
 
 /** Per-provider customizations a channel can layer onto the generic override editor. */
 export type ProviderOverrideEditorExtras = Pick<
@@ -57,7 +53,6 @@ export function ContentOverridePanel({
   // Only one override editor is mounted at a time, so at most one provider can have an uncommitted parse error.
   const [draftParseErrorProviderId, setDraftParseErrorProviderId] = useState<string | null>(null);
   const [pendingResetProviderId, setPendingResetProviderId] = useState<ContentOverrideProviderId | null>(null);
-  const overrideEditorRef = useRef<ProviderOverrideEditorHandle>(null);
 
   useEffect(() => {
     if (selectedSource !== DEFAULT_CONTENT_SOURCE && !(selectedSource in (providerOverrides ?? {}))) {
@@ -243,28 +238,12 @@ export function ContentOverridePanel({
             <span>Reset to default</span>
           </button>
         )}
-        {overrideProviderId && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="Format JSON"
-                className="border-stroke-soft bg-bg-white text-text-sub hover:bg-bg-weak flex h-7 items-center justify-center border-r pl-1.5 pr-2 transition-colors"
-                onClick={() => overrideEditorRef.current?.formatJson()}
-              >
-                <Braces className="size-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Format JSON</TooltipContent>
-          </Tooltip>
-        )}
         <div className="h-full flex-1" />
       </div>
 
       <TabsSection className="p-3">
         {overrideProviderId ? (
           <ProviderOverrideEditor
-            ref={overrideEditorRef}
             providerId={overrideProviderId}
             displayName={selectedOption?.displayName ?? getContentSourceLabel(overrideProviderId)}
             onDraftParseValidityChange={handleDraftParseValidityChange}

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/provider-override-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/provider-override-editor.tsx
@@ -1,8 +1,10 @@
 import { type ContentOverrideProviderId, getProviderPrimaryContentKey, setAtPath } from '@novu/shared';
-import { forwardRef, type ReactNode, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
+import { Braces } from 'lucide-react';
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { RiErrorWarningLine, RiLightbulbLine } from 'react-icons/ri';
 import { InputRoot } from '@/components/primitives/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { ControlInput } from '@/components/workflow-editor/control-input';
 import { SectionHeader } from '@/components/workflow-editor/steps/http-request/section-header';
 import { useSaveForm } from '@/components/workflow-editor/steps/save-form-context';
@@ -48,10 +50,6 @@ function formatOverrideJsonDraft(value: string): string {
     return value;
   }
 }
-
-export type ProviderOverrideEditorHandle = {
-  formatJson: () => void;
-};
 
 /**
  * Server issues carry the full control path (e.g. `providerOverrides.slack.blocks.0.status`) in
@@ -128,267 +126,273 @@ export type ProviderOverrideEditorProps = {
   onDraftParseValidityChange?: (providerId: ContentOverrideProviderId, isParseValid: boolean) => void;
 };
 
-export const ProviderOverrideEditor = forwardRef<ProviderOverrideEditorHandle, ProviderOverrideEditorProps>(
-  function ProviderOverrideEditor(
-    {
-      providerId,
-      displayName,
-      notice,
-      headerTooltip,
-      placeholder,
-      rootSchemaOverride,
-      describeField,
-      annotateField,
-      onDraftParseValidityChange,
-    },
-    ref
-  ) {
-    const { control, getValues } = useFormContext();
-    const { saveForm } = useSaveForm();
-    const { step, digestStepBeforeCurrent } = useWorkflow();
-    const { variables, isAllowedVariable } = useParseVariables(step?.variables, digestStepBeforeCurrent?.stepId);
-    const registrySchema = useProviderOverrideSchema(providerId);
-    const rootSchema = rootSchemaOverride ?? registrySchema.rootSchema;
-    // A top-level-keys-only schema has no types or descriptions, so it drives completion but must not
-    // reach the popover, whose rows would list every field as `any` and insert the wrong default.
-    const browsableSchema = rootSchemaOverride ?? (registrySchema.isTopLevelKeysOnly ? undefined : rootSchema);
-    const schemaStatus = registrySchema.isLoading ? `Loading ${displayName} fields…` : undefined;
-    // One resolver per schema, shared by completion and the supported-fields popover so they hit the
-    // same deref cache. Keyed on schema identity: a provider switch or a lazy load swaps the schema
-    // object, which rebuilds it, while a re-render on the same schema reuses it.
-    const resolver = useMemo(() => (rootSchema ? createSchemaResolver(rootSchema) : undefined), [rootSchema]);
-    // `browsableSchema` is either `rootSchema` or nothing, so the same resolver serves both.
-    const browsableResolver = browsableSchema ? resolver : undefined;
-    const primaryKey = getProviderPrimaryContentKey(providerId) ?? undefined;
-    const showEscapeHatchCallout = !notice && isEscapeHatchProvider(providerId);
+export function ProviderOverrideEditor({
+  providerId,
+  displayName,
+  notice,
+  headerTooltip,
+  placeholder,
+  rootSchemaOverride,
+  describeField,
+  annotateField,
+  onDraftParseValidityChange,
+}: ProviderOverrideEditorProps) {
+  const { control, getValues } = useFormContext();
+  const { saveForm } = useSaveForm();
+  const { step, digestStepBeforeCurrent } = useWorkflow();
+  const { variables, isAllowedVariable } = useParseVariables(step?.variables, digestStepBeforeCurrent?.stepId);
+  const registrySchema = useProviderOverrideSchema(providerId);
+  const rootSchema = rootSchemaOverride ?? registrySchema.rootSchema;
+  // A top-level-keys-only schema has no types or descriptions, so it drives completion but must not
+  // reach the popover, whose rows would list every field as `any` and insert the wrong default.
+  const browsableSchema = rootSchemaOverride ?? (registrySchema.isTopLevelKeysOnly ? undefined : rootSchema);
+  const schemaStatus = registrySchema.isLoading ? `Loading ${displayName} fields…` : undefined;
+  // One resolver per schema, shared by completion and the supported-fields popover so they hit the
+  // same deref cache. Keyed on schema identity: a provider switch or a lazy load swaps the schema
+  // object, which rebuilds it, while a re-render on the same schema reuses it.
+  const resolver = useMemo(() => (rootSchema ? createSchemaResolver(rootSchema) : undefined), [rootSchema]);
+  // `browsableSchema` is either `rootSchema` or nothing, so the same resolver serves both.
+  const browsableResolver = browsableSchema ? resolver : undefined;
+  const primaryKey = getProviderPrimaryContentKey(providerId) ?? undefined;
+  const showEscapeHatchCallout = !notice && isEscapeHatchProvider(providerId);
 
-    const [draft, setDraft] = useState(() =>
+  const [draft, setDraft] = useState(() =>
+    formatOverrideJson((getValues(PROVIDER_OVERRIDES_FIELD) as ProviderOverrides | undefined)?.[providerId])
+  );
+
+  useEffect(() => {
+    setDraft(
       formatOverrideJson((getValues(PROVIDER_OVERRIDES_FIELD) as ProviderOverrides | undefined)?.[providerId])
     );
+  }, [getValues, providerId]);
 
-    useEffect(() => {
-      setDraft(
-        formatOverrideJson((getValues(PROVIDER_OVERRIDES_FIELD) as ProviderOverrides | undefined)?.[providerId])
-      );
-    }, [getValues, providerId]);
+  const formatJson = useCallback(() => {
+    setDraft((current) => formatOverrideJsonDraft(current));
+  }, []);
 
-    const formatJson = useCallback(() => {
-      setDraft((current) => formatOverrideJsonDraft(current));
-    }, []);
+  const { parseError, parsedDraft } = useMemo(() => {
+    const { parsed, error } = parseOverrideJson(draft);
+    if (error || !parsed) {
+      return { parseError: error, parsedDraft: undefined };
+    }
 
-    useImperativeHandle(ref, () => ({ formatJson }), [formatJson]);
+    return { parseError: undefined, parsedDraft: parsed };
+  }, [draft]);
 
-    const { parseError, parsedDraft } = useMemo(() => {
-      const { parsed, error } = parseOverrideJson(draft);
-      if (error || !parsed) {
-        return { parseError: error, parsedDraft: undefined };
-      }
+  const issuePathPrefix = `${PROVIDER_OVERRIDES_FIELD}.${providerId}`;
 
-      return { parseError: undefined, parsedDraft: parsed };
-    }, [draft]);
+  // Top-level unsupported keys are detected client-side from the shared override key
+  // list (keystroke-by-keystroke); skip only those server UNSUPPORTED_PROPERTY issues
+  // so the same key is never reported twice. Nested ones (e.g. document.link) are not
+  // covered by the local check and must still render under the editor.
+  const activeServerIssues = useMemo(() => {
+    const controlIssues = step?.issues?.controls ?? {};
 
-    const issuePathPrefix = `${PROVIDER_OVERRIDES_FIELD}.${providerId}`;
+    return Object.entries(controlIssues)
+      .filter(([key]) => key === issuePathPrefix || key.startsWith(`${issuePathPrefix}.`))
+      .flatMap(([path, issueList]) =>
+        issueList
+          .filter((issue) => shouldKeepServerOverrideIssue(issue, path, issuePathPrefix))
+          .map((issue) => ({ ...issue, path }))
+      )
+      .filter((issue) => {
+        if (!parsedDraft) {
+          return true;
+        }
 
-    // Top-level unsupported keys are detected client-side from the shared override key
-    // list (keystroke-by-keystroke); skip only those server UNSUPPORTED_PROPERTY issues
-    // so the same key is never reported twice. Nested ones (e.g. document.link) are not
-    // covered by the local check and must still render under the editor.
-    const activeServerIssues = useMemo(() => {
-      const controlIssues = step?.issues?.controls ?? {};
+        const issuePath = issue.variableName ?? issue.path;
+        if (!issuePath.startsWith(`${issuePathPrefix}.`)) {
+          return true;
+        }
 
-      return Object.entries(controlIssues)
-        .filter(([key]) => key === issuePathPrefix || key.startsWith(`${issuePathPrefix}.`))
-        .flatMap(([path, issueList]) =>
-          issueList
-            .filter((issue) => shouldKeepServerOverrideIssue(issue, path, issuePathPrefix))
-            .map((issue) => ({ ...issue, path }))
-        )
-        .filter((issue) => {
-          if (!parsedDraft) {
-            return true;
-          }
+        const topKey = issuePath.slice(issuePathPrefix.length + 1).split('.')[0];
 
-          const issuePath = issue.variableName ?? issue.path;
-          if (!issuePath.startsWith(`${issuePathPrefix}.`)) {
-            return true;
-          }
+        return topKey in parsedDraft;
+      });
+  }, [step?.issues?.controls, issuePathPrefix, parsedDraft]);
 
-          const topKey = issuePath.slice(issuePathPrefix.length + 1).split('.')[0];
+  const localUnsupportedPropertyMessages = useMemo(() => {
+    if (!parsedDraft) {
+      return [] as string[];
+    }
 
-          return topKey in parsedDraft;
-        });
-    }, [step?.issues?.controls, issuePathPrefix, parsedDraft]);
+    return getUnsupportedOverrideKeys(providerId, parsedDraft).map((key) => `"${key}" is not a supported property`);
+  }, [parsedDraft, providerId]);
 
-    const localUnsupportedPropertyMessages = useMemo(() => {
-      if (!parsedDraft) {
-        return [] as string[];
-      }
+  const usedDraftKeys = useMemo(() => new Set(Object.keys(parsedDraft ?? {})), [parsedDraft]);
 
-      return getUnsupportedOverrideKeys(providerId, parsedDraft).map((key) => `"${key}" is not a supported property`);
-    }, [parsedDraft, providerId]);
+  const completionSources = useMemo(
+    () => [createOverrideCompletionSource({ resolver, describeField })],
+    [describeField, resolver]
+  );
 
-    const usedDraftKeys = useMemo(() => new Set(Object.keys(parsedDraft ?? {})), [parsedDraft]);
+  useEffect(() => {
+    onDraftParseValidityChange?.(providerId, !parseError);
 
-    const completionSources = useMemo(
-      () => [createOverrideCompletionSource({ resolver, describeField })],
-      [describeField, resolver]
+    return () => {
+      onDraftParseValidityChange?.(providerId, true);
+    };
+  }, [onDraftParseValidityChange, parseError, providerId]);
+
+  const resolvedTooltip =
+    headerTooltip ??
+    (primaryKey
+      ? `These fields merge over your default content. "${primaryKey}" falls back to the default message unless set here. Supports Liquid variables inside string values.`
+      : 'These fields are merged into the provider payload as-is. Supports Liquid variables inside string values.');
+
+  const resolvedPlaceholder =
+    placeholder ??
+    JSON.stringify(
+      primaryKey ? setAtPath({}, primaryKey, '{{payload.title}}') : { key: '{{payload.title}}' },
+      null,
+      2
     );
 
-    useEffect(() => {
-      onDraftParseValidityChange?.(providerId, !parseError);
+  const resolvedNotice = typeof notice === 'function' ? notice({ parsedDraft }) : notice;
 
-      return () => {
-        onDraftParseValidityChange?.(providerId, true);
-      };
-    }, [onDraftParseValidityChange, parseError, providerId]);
+  return (
+    <div className="bg-bg-weak flex flex-col gap-1 rounded-lg border border-neutral-100 p-1">
+      <Controller
+        control={control}
+        name={PROVIDER_OVERRIDES_FIELD}
+        render={({ field }) => {
+          const writeProviderOverride = (next: Record<string, unknown>) => {
+            const current = (field.value as ProviderOverrides | undefined) ?? {};
+            field.onChange({
+              ...current,
+              [providerId]: next,
+            });
+            saveForm();
+          };
 
-    const resolvedTooltip =
-      headerTooltip ??
-      (primaryKey
-        ? `These fields merge over your default content. "${primaryKey}" falls back to the default message unless set here. Supports Liquid variables inside string values.`
-        : 'These fields are merged into the provider payload as-is. Supports Liquid variables inside string values.');
+          const handleInsertField = (key: string) => {
+            if (!parsedDraft || usedDraftKeys.has(key)) {
+              return;
+            }
 
-    const resolvedPlaceholder =
-      placeholder ??
-      JSON.stringify(
-        primaryKey ? setAtPath({}, primaryKey, '{{payload.title}}') : { key: '{{payload.title}}' },
-        null,
-        2
-      );
-
-    const resolvedNotice = typeof notice === 'function' ? notice({ parsedDraft }) : notice;
-
-    return (
-      <div className="bg-bg-weak flex flex-col gap-1 rounded-lg border border-neutral-100 p-1">
-        <Controller
-          control={control}
-          name={PROVIDER_OVERRIDES_FIELD}
-          render={({ field }) => {
-            const writeProviderOverride = (next: Record<string, unknown>) => {
-              const current = (field.value as ProviderOverrides | undefined) ?? {};
-              field.onChange({
-                ...current,
-                [providerId]: next,
-              });
-              saveForm();
+            const next = {
+              ...parsedDraft,
+              [key]: browsableResolver?.defaultValue(browsableSchema?.properties?.[key]) ?? '',
             };
+            setDraft(formatOverrideJson(next));
+            writeProviderOverride(next);
+          };
 
-            const handleInsertField = (key: string) => {
-              if (!parsedDraft || usedDraftKeys.has(key)) {
-                return;
-              }
+          return (
+            <>
+              <SectionHeader
+                label="Override fields"
+                tooltip={resolvedTooltip}
+                rightSlot={
+                  <div className="flex items-center gap-2">
+                    {schemaStatus && <span className="text-text-soft text-[11px]">{schemaStatus}</span>}
+                    <OverrideSupportedFields
+                      providerId={providerId}
+                      displayName={displayName}
+                      resolver={browsableResolver}
+                      usedKeys={usedDraftKeys}
+                      canInsert={!parseError}
+                      annotateField={annotateField}
+                      onInsertField={handleInsertField}
+                    />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="Format JSON"
+                          className="text-text-sub hover:text-text-strong flex items-center justify-center transition-colors"
+                          onClick={formatJson}
+                        >
+                          <Braces className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>Format JSON</TooltipContent>
+                    </Tooltip>
+                  </div>
+                }
+              />
+              {showEscapeHatchCallout && (
+                <div className="px-1 pb-1">
+                  <EscapeHatchCallout providerId={providerId} displayName={displayName} />
+                </div>
+              )}
+              <InputRoot className="min-h-[180px]" hasError={!!parseError}>
+                <ControlInput
+                  size="2xs"
+                  multiline={true}
+                  indentWithTab={true}
+                  placeholder={resolvedPlaceholder}
+                  value={draft}
+                  isAllowedVariable={isAllowedVariable}
+                  variables={variables}
+                  completionSources={completionSources}
+                  onChange={(val) => {
+                    const newVal = typeof val === 'string' ? val : '';
+                    setDraft(newVal);
 
-              const next = {
-                ...parsedDraft,
-                [key]: browsableResolver?.defaultValue(browsableSchema?.properties?.[key]) ?? '',
-              };
-              setDraft(formatOverrideJson(next));
-              writeProviderOverride(next);
-            };
+                    const { parsed, error } = parseOverrideJson(newVal);
+                    if (error || !parsed) {
+                      return;
+                    }
 
-            return (
-              <>
-                <SectionHeader
-                  label="Override fields"
-                  tooltip={resolvedTooltip}
-                  rightSlot={
-                    <div className="flex items-center gap-2">
-                      {schemaStatus && <span className="text-text-soft text-[11px]">{schemaStatus}</span>}
-                      <OverrideSupportedFields
-                        providerId={providerId}
-                        displayName={displayName}
-                        resolver={browsableResolver}
-                        usedKeys={usedDraftKeys}
-                        canInsert={!parseError}
-                        annotateField={annotateField}
-                        onInsertField={handleInsertField}
-                      />
-                    </div>
-                  }
+                    writeProviderOverride(parsed);
+                  }}
+                  onBlur={() => {
+                    field.onBlur();
+                  }}
                 />
-                {showEscapeHatchCallout && (
-                  <div className="px-1 pb-1">
-                    <EscapeHatchCallout providerId={providerId} displayName={displayName} />
-                  </div>
-                )}
-                <InputRoot className="min-h-[180px]" hasError={!!parseError}>
-                  <ControlInput
-                    size="2xs"
-                    multiline={true}
-                    indentWithTab={true}
-                    placeholder={resolvedPlaceholder}
-                    value={draft}
-                    isAllowedVariable={isAllowedVariable}
-                    variables={variables}
-                    completionSources={completionSources}
-                    onChange={(val) => {
-                      const newVal = typeof val === 'string' ? val : '';
-                      setDraft(newVal);
+              </InputRoot>
+              {parseError ? (
+                <div className="flex items-center gap-1 px-1">
+                  <RiErrorWarningLine className="text-destructive h-3 w-3 shrink-0" />
+                  <span className="text-destructive text-xs">{parseError}</span>
+                </div>
+              ) : (
+                <>
+                  {activeServerIssues.map((issue) => {
+                    const issuePath = issue.variableName ?? issue.path;
+                    const location = formatIssueLocation(issuePath, issuePathPrefix);
 
-                      const { parsed, error } = parseOverrideJson(newVal);
-                      if (error || !parsed) {
-                        return;
-                      }
-
-                      writeProviderOverride(parsed);
-                    }}
-                    onBlur={() => {
-                      field.onBlur();
-                    }}
-                  />
-                </InputRoot>
-                {parseError ? (
-                  <div className="flex items-center gap-1 px-1">
-                    <RiErrorWarningLine className="text-destructive h-3 w-3 shrink-0" />
-                    <span className="text-destructive text-xs">{parseError}</span>
-                  </div>
-                ) : (
-                  <>
-                    {activeServerIssues.map((issue) => {
-                      const issuePath = issue.variableName ?? issue.path;
-                      const location = formatIssueLocation(issuePath, issuePathPrefix);
-
-                      return (
-                        <div key={`${issuePath}:${issue.message}`} className="flex items-start gap-1 px-1">
-                          <RiErrorWarningLine className="text-destructive mt-0.5 h-3 w-3 shrink-0" />
-                          <span className="text-destructive text-xs">
-                            {location && (
-                              <>
-                                <code className="text-[11px]">{location}</code>
-                                {' — '}
-                              </>
-                            )}
-                            {issue.message}
-                          </span>
-                        </div>
-                      );
-                    })}
-                    {localUnsupportedPropertyMessages.map((message) => (
-                      <div key={message} className="flex items-start gap-1 px-1">
+                    return (
+                      <div key={`${issuePath}:${issue.message}`} className="flex items-start gap-1 px-1">
                         <RiErrorWarningLine className="text-destructive mt-0.5 h-3 w-3 shrink-0" />
-                        <span className="text-destructive text-xs">{message}</span>
-                      </div>
-                    ))}
-                  </>
-                )}
-                {(resolvedNotice || primaryKey) && (
-                  <div className="px-1 py-0.5">
-                    {resolvedNotice ?? (
-                      <div className="text-text-soft flex items-start gap-1">
-                        <RiLightbulbLine className="mt-0.5 size-3 shrink-0" />
-                        <span className="min-w-0 flex-1 text-xs">
-                          Fields merge over default content. <code className="text-[11px]">{primaryKey}</code> falls
-                          back to your default message unless set here.
+                        <span className="text-destructive text-xs">
+                          {location && (
+                            <>
+                              <code className="text-[11px]">{location}</code>
+                              {' — '}
+                            </>
+                          )}
+                          {issue.message}
                         </span>
                       </div>
-                    )}
-                  </div>
-                )}
-              </>
-            );
-          }}
-        />
-      </div>
-    );
-  }
-);
+                    );
+                  })}
+                  {localUnsupportedPropertyMessages.map((message) => (
+                    <div key={message} className="flex items-start gap-1 px-1">
+                      <RiErrorWarningLine className="text-destructive mt-0.5 h-3 w-3 shrink-0" />
+                      <span className="text-destructive text-xs">{message}</span>
+                    </div>
+                  ))}
+                </>
+              )}
+              {(resolvedNotice || primaryKey) && (
+                <div className="px-1 py-0.5">
+                  {resolvedNotice ?? (
+                    <div className="text-text-soft flex items-start gap-1">
+                      <RiLightbulbLine className="mt-0.5 size-3 shrink-0" />
+                      <span className="min-w-0 flex-1 text-xs">
+                        Fields merge over default content. <code className="text-[11px]">{primaryKey}</code> falls back
+                        to your default message unless set here.
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          );
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Moved the Format JSON `{ }` button from the top toolbar header into the "Override fields" section header, since it only affects the override JSON editor. This makes the button's scope clearer and reduces clutter in the toolbar.

**Changes:**
- Removed the Format JSON button from `content-override-panel.tsx` toolbar header
- Added the Format JSON button to the `SectionHeader`'s `rightSlot` in `provider-override-editor.tsx`, next to the "Supported fields" popover
- Cleaned up the now-unused `forwardRef`/`useImperativeHandle` pattern from `ProviderOverrideEditor` since the button now calls `formatJson` directly

This is a shared component used by both Tool and Chat step editors, so the improvement applies to all override editors.

### Screenshots

**After — Format JSON button inside "Override fields" card header:**

![Format JSON button inside Override fields card with tooltip shown](https://cursor.com/artifacts/c/art-6d215991-b7b6-4a4b-a359-cda693fd6d42)

**After formatting — JSON is prettified:**

![Formatted JSON result in Override fields card](https://cursor.com/artifacts/c/art-18420f54-1ce6-4385-b589-953b2d9c98d8)

**Video demo:**

<a href="https://cursor.com/agents/bc-e545d84b-aa77-4848-94b5-8396266898a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fformat_json_button_demo.mp4"><img src="https://cursor.com/artifacts/c/art-442a9047-1d23-41c1-b7e0-2c151fb5f392" alt="format_json_button_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8503](https://linear.app/novu/issue/NV-8503/format-json-button-seem-misplaced)

<div><a href="https://cursor.com/agents/bc-e545d84b-aa77-4848-94b5-8396266898a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e545d84b-aa77-4848-94b5-8396266898a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the Format JSON action into the Override fields card header.
- Removes the toolbar-level formatting button and its imperative ref plumbing.
- Calls the existing formatter directly from the shared provider override editor.
- Applies the relocated action to both Tool and Chat override editors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the formatting behavior preserved in its new location.

The removed ref contract had no remaining consumers, and the relocated type-button directly invokes the same draft-formatting callback from a visible SectionHeader action.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-override-panel.tsx | Removes the old toolbar action and now-unused imperative editor ref without leaving any callers behind. |
| apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/provider-override-editor.tsx | Adds the formatting action to the Override fields header and converts the editor from forwardRef to a plain function component. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): move Format JSON button..."](https://github.com/novuhq/novu/commit/313542215d7d6f1f81f8e0042bd4adfb4e8f7fee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49622692)</sub>

<!-- /greptile_comment -->