### PR TITLE
fix(dashboard): make empty tool preview distinct from loading skeleton fixes NV-8500

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx
@@ -71,8 +71,10 @@ export const ToolPreviewMini = ({ isPreviewPending, previewData }: ToolPreviewPr
               <Skeleton className="h-4 w-1/2" />
             ) : (
               <span
-                className="text-foreground-950 line-clamp-3 min-h-4 whitespace-pre-wrap text-xs font-normal"
-                title={body}
+                className={`line-clamp-3 min-h-4 whitespace-pre-wrap text-xs font-normal ${
+                  body ? 'text-foreground-950' : 'text-foreground-400 italic'
+                }`}
+                title={body || EMPTY_BODY_PLACEHOLDER}
               >
                 {body || EMPTY_BODY_PLACEHOLDER}
               </span>
@@ -138,7 +140,15 @@ export const ToolPreview = ({ isPreviewPending, previewData }: ToolPreviewProps)
       return <AnnotatedOverrideJson {...annotatedPreview} />;
     }
 
-    return <div className={`${PREVIEW_PANEL_CLASS} whitespace-pre-wrap`}>{body || EMPTY_BODY_PLACEHOLDER}</div>;
+    if (!body) {
+      return (
+        <div className="text-foreground-400 flex min-h-16 items-center justify-center rounded-md border border-dashed border-neutral-100 p-2 text-xs italic">
+          {EMPTY_BODY_PLACEHOLDER}
+        </div>
+      );
+    }
+
+    return <div className={`${PREVIEW_PANEL_CLASS} whitespace-pre-wrap`}>{body}</div>;
   };
 
   let previewLabel = 'Default content';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The empty tool preview panel used a solid gray background (`bg-neutral-alpha-50`) with `min-h-16` and solid border that closely resembled the loading skeleton component (`bg-neutral-alpha-100 animate-pulse rounded-md`). Users could confuse the empty state for a stuck loading indicator.

**Changes in `tool-preview.tsx`:**

- **`ToolPreview` (full preview panel):** When body is empty, renders a distinct empty state with a dashed border, centered italic muted placeholder text ("Default content will be delivered to enabled tools"), and no gray background — instead of the previous `PREVIEW_PANEL_CLASS` solid gray box.
- **`ToolPreviewMini` (node/configure preview):** When body is empty, placeholder text now uses `text-foreground-400 italic` styling instead of the same `text-foreground-950` used for actual content.

### Screenshots

**Empty state (after fix) — no skeleton-like gray box:**

![Empty tool preview](https://cursor.com/artifacts/c/art-375246be-94fd-435e-bfc3-f4e8fa3dbe44)

**Filled state — normal preview with content:**

![Filled tool preview](https://cursor.com/artifacts/c/art-c5cf9977-f3b4-4e9c-817e-f797f5034ba6)

**Video demo showing empty → filled transition:**

<a href="https://cursor.com/agents/bc-c8862f31-d2c9-4454-b602-fda3a50623e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftool_preview_empty_vs_filled_demo.mp4"><img src="https://cursor.com/artifacts/c/art-105cce55-d708-4e3b-bc26-bf383f8a76f0" alt="tool_preview_empty_vs_filled_demo.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

Only one file changed (`tool-preview.tsx`). The `PREVIEW_PANEL_CLASS` shared constant is unchanged — the empty state simply uses different styling now.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8500](https://linear.app/novu/issue/NV-8500/empty-tool-preview-kind-of-looks-like-stuck-in-loading-skeleton)

<div><a href="https://cursor.com/agents/bc-c8862f31-d2c9-4454-b602-fda3a50623e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8862f31-d2c9-4454-b602-fda3a50623e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR visually distinguishes empty tool previews from loading states.
- Adds a dashed, background-free placeholder panel to the full preview.
- Gives empty mini previews muted italic text while preserving normal styling for content.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changes are limited to empty-state styling and preserve the existing loading and populated-content rendering paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx | Updates empty-state presentation in both tool preview variants without changing preview data handling. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): make empty tool preview ..."](https://github.com/novuhq/novu/commit/b14b192ca970d65d3914b61795d7181a95472d50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49625971)</sub>

<!-- /greptile_comment -->