### PR TITLE
feat(application-generic): enhance ConditionsFilter with feature flags and logging capabilities

### DIFF
--- a/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
@@ -25,13 +25,22 @@ describe('Message filter matcher', () => {
     add: sinon.stub(),
     execute: sinon.stub().resolves(),
   };
+  const featureFlagsService = {
+    getFlag: sinon.stub().resolves(false),
+  };
+  const logger = {
+    setContext: sinon.stub(),
+    info: sinon.stub(),
+  };
   const conditionsFilter = new ConditionsFilter(
     undefined as any,
     undefined as any,
     undefined as any,
     undefined as any,
     executionLogQueueService as any,
-    new CompileTemplate()
+    new CompileTemplate(),
+    featureFlagsService as any,
+    logger as any
   );
 
   it('should filter correct message by the filter value', async () => {
@@ -911,7 +920,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -947,7 +958,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -977,7 +990,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1001,7 +1016,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1025,7 +1042,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1053,7 +1072,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1090,7 +1111,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1117,7 +1140,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1144,7 +1169,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1171,7 +1198,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1198,7 +1227,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({
@@ -1225,7 +1256,9 @@ describe('Message filter matcher', () => {
           undefined as any,
           undefined as any,
           executionLogQueueService as any,
-          new CompileTemplate()
+          new CompileTemplate(),
+          featureFlagsService as any,
+          logger as any
         );
         const matchedMessage = await filter.filter(
           mapConditionsFilterCommand({

--- a/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -11,6 +11,7 @@ import {
 import {
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
+  FeatureFlagsKeysEnum,
   FILTER_TO_LABEL,
   FieldLogicalOperatorEnum,
   FieldOperatorEnum,
@@ -26,7 +27,8 @@ import {
 } from '@novu/shared';
 import { differenceInDays, differenceInHours, differenceInMinutes, parseISO } from 'date-fns';
 import { decryptApiKey } from '../../encryption';
-import { buildSubscriberKey, CachedResponse, safeOutboundJsonRequest } from '../../services';
+import { PinoLogger } from '../../logging';
+import { buildSubscriberKey, CachedResponse, FeatureFlagsService, safeOutboundJsonRequest } from '../../services';
 import {
   assertSafeOutboundUrl,
   createHash,
@@ -60,9 +62,12 @@ export class ConditionsFilter extends Filter {
     private environmentRepository: EnvironmentRepository,
     @Inject(forwardRef(() => CreateExecutionDetails))
     private createExecutionDetails: CreateExecutionDetails,
-    private compileTemplate: CompileTemplate
+    private compileTemplate: CompileTemplate,
+    private featureFlagsService: FeatureFlagsService,
+    private logger: PinoLogger
   ) {
     super();
+    this.logger.setContext(this.constructor.name);
   }
 
   public async filter(command: ConditionsFilterCommand): Promise<IConditionsFilterResponse> {
@@ -286,6 +291,8 @@ export class ConditionsFilter extends Filter {
         body: payload,
       });
 
+      await this.maybeLogWebhookFilterResponse(command, child.webhookUrl, response);
+
       return response.body;
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
@@ -301,6 +308,44 @@ export class ConditionsFilter extends Filter {
         message,
         data: WEBHOOK_FILTER_REQUEST_FAILED_DATA,
       });
+    }
+  }
+
+  /**
+   * Best-effort pino log of the exact webhook filter POST response. Gated by the
+   * same flag as step-conditions-passed execution details so response bodies are
+   * only emitted when that diagnostics path is intentionally enabled.
+   */
+  private async maybeLogWebhookFilterResponse(
+    command: ConditionsFilterCommand,
+    webhookUrl: string,
+    response: { statusCode: number; statusMessage: string; body: Record<string, unknown> | undefined }
+  ): Promise<void> {
+    try {
+      const isEnabled = await this.featureFlagsService.getFlag({
+        key: FeatureFlagsKeysEnum.IS_STEP_CONDITIONS_PASSED_TRACE_ENABLED,
+        defaultValue: false,
+        organization: { _id: command.organizationId },
+        environment: { _id: command.environmentId },
+      });
+
+      if (!isEnabled) {
+        return;
+      }
+
+      this.logger.info(
+        {
+          webhookUrl,
+          statusCode: response.statusCode,
+          statusMessage: response.statusMessage,
+          body: response.body,
+          jobId: command.job?._id,
+          transactionId: command.job?.transactionId,
+        },
+        'Webhook filter POST response'
+      );
+    } catch {
+      // Logging must never break filter evaluation.
     }
   }
 

--- a/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -26,6 +26,7 @@ import {
   TimeOperatorEnum,
 } from '@novu/shared';
 import { differenceInDays, differenceInHours, differenceInMinutes, parseISO } from 'date-fns';
+import { get as lodashGet } from 'lodash';
 import { decryptApiKey } from '../../encryption';
 import { PinoLogger } from '../../logging';
 import { buildSubscriberKey, CachedResponse, FeatureFlagsService, safeOutboundJsonRequest } from '../../services';
@@ -67,7 +68,7 @@ export class ConditionsFilter extends Filter {
     private logger: PinoLogger
   ) {
     super();
-    this.logger.setContext(this.constructor.name);
+    this.logger?.setContext(this.constructor.name);
   }
 
   public async filter(command: ConditionsFilterCommand): Promise<IConditionsFilterResponse> {
@@ -291,7 +292,7 @@ export class ConditionsFilter extends Filter {
         body: payload,
       });
 
-      await this.maybeLogWebhookFilterResponse(command, child.webhookUrl, response);
+      await this.maybeLogWebhookFilterResponse(command, child, response);
 
       return response.body;
     } catch (err) {
@@ -312,13 +313,14 @@ export class ConditionsFilter extends Filter {
   }
 
   /**
-   * Best-effort pino log of the exact webhook filter POST response. Gated by the
-   * same flag as step-conditions-passed execution details so response bodies are
-   * only emitted when that diagnostics path is intentionally enabled.
+   * Best-effort pino log for webhook filter diagnostics. Gated by the same flag
+   * as step-conditions-passed execution details. Logs only the HTTP status and
+   * the field value used by the filter comparison — never the full response body,
+   * which may contain subscriber PII or credentials outside path-based redaction.
    */
   private async maybeLogWebhookFilterResponse(
     command: ConditionsFilterCommand,
-    webhookUrl: string,
+    child: IWebhookFilterPart,
     response: { statusCode: number; statusMessage: string; body: Record<string, unknown> | undefined }
   ): Promise<void> {
     try {
@@ -335,10 +337,10 @@ export class ConditionsFilter extends Filter {
 
       this.logger.info(
         {
-          webhookUrl,
           statusCode: response.statusCode,
           statusMessage: response.statusMessage,
-          body: response.body,
+          field: child.field,
+          fieldValue: lodashGet(response.body, child.field),
           jobId: command.job?._id,
           transactionId: command.job?.transactionId,
         },

--- a/libs/application-generic/src/usecases/select-integration/select-integration.spec.ts
+++ b/libs/application-generic/src/usecases/select-integration/select-integration.spec.ts
@@ -94,7 +94,9 @@ describe('select integration', () => {
     new JobRepository(),
     new EnvironmentRepository(),
     new CreateExecutionDetails(new ExecutionDetailsRepository(), TraceLogRepository as any, new FeatureFlagsService()),
-    new CompileTemplate()
+    new CompileTemplate(),
+    new FeatureFlagsService(),
+    { setContext: jest.fn(), info: jest.fn() } as any
   );
   beforeEach(async () => {
     // @ts-expect-error

--- a/libs/application-generic/src/usecases/select-variant/select-variant.spec.ts
+++ b/libs/application-generic/src/usecases/select-variant/select-variant.spec.ts
@@ -20,7 +20,7 @@ describe('select variant', () => {
 
   beforeEach(async () => {
     selectVariantUsecase = new SelectVariant(
-      // @ts-ignore
+      // @ts-expect-error test stub — logger/featureFlags are optional at construction
       new ConditionsFilter(),
       new MessageTemplateRepository(),
       new NormalizeVariables(new SubscriberRepository(), new TenantRepository())


### PR DESCRIPTION
…

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances webhook-condition diagnostics and updates affected test construction.
- Adds feature-flag-gated logging of webhook status and the compared response field.
- Makes logger context initialization tolerant of omitted test dependencies.
- Supplies feature-flag and logger stubs to ConditionsFilter tests.

<h3>Confidence Score: 4/5</h3>

This PR is not yet safe to merge because webhook-filter diagnostics can still disclose workflow-selected credentials or PII in worker logs.

Successful webhook-filter responses pass an arbitrary workflow-selected value to Pino under `fieldValue`, while the logger configuration does not redact that key, so the previously reported disclosure remains reachable.

**Files Needing Attention:** libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts

<details open><summary><h3>Security Review</h3></summary>

The diagnostic log still exposes arbitrary webhook response values selected by workflow configuration because `fieldValue` is not redacted.

**How this was verified:** The successful webhook path logs the workflow-selected response value under `fieldValue`, which is absent from the configured Pino redaction paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts | Adds feature-flag-gated webhook diagnostics and optional logger initialization, but the selected response value remains exposed under an unredacted log key. |
| apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts | Updates ConditionsFilter construction with feature-flag and logger stubs. |
| libs/application-generic/src/usecases/select-integration/select-integration.spec.ts | Supplies the newly required ConditionsFilter dependencies in select-integration tests. |
| libs/application-generic/src/usecases/select-variant/select-variant.spec.ts | Replaces the broad TypeScript suppression with an expected constructor-error annotation. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Fapplication-generic%2Fsrc%2Fusecases%2Fconditions-filter%2Fconditions-filter.usecase.ts%3A344%0A**Selected%20webhook%20value%20remains%20exposed**%0A%0AWhen%20diagnostics%20are%20enabled%20and%20a%20webhook%20filter%20selects%20credentials%2C%20subscriber%20PII%2C%20or%20another%20sensitive%20response%20value%2C%20this%20logs%20the%20value%20under%20%60fieldValue%60%2C%20which%20is%20absent%20from%20the%20configured%20Pino%20redaction%20paths%2C%20causing%20the%20data%20to%20be%20stored%20in%20plaintext%20worker%20logs.%0A%0A**How%20this%20was%20verified%3A**%20The%20successful%20webhook%20path%20logs%20the%20workflow-selected%20response%20value%20under%20%60fieldValue%60%2C%20which%20is%20absent%20from%20the%20configured%20Pino%20redaction%20paths.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts:344
**Selected webhook value remains exposed**

When diagnostics are enabled and a webhook filter selects credentials, subscriber PII, or another sensitive response value, this logs the value under `fieldValue`, which is absent from the configured Pino redaction paths, causing the data to be stored in plaintext worker logs.

**How this was verified:** The successful webhook path logs the workflow-selected response value under `fieldValue`, which is absent from the configured Pino redaction paths.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(application-generic): improve loggin..."](https://github.com/novuhq/novu/commit/109f0f5879c2bab07803a26594776eb85c7ba3c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49627252)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)
- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)

<!-- /greptile_comment -->