### PR TITLE
feat(dashboard): implement auth configuration management and enhance authentication flows

### DIFF
--- a/apps/dashboard/src/utils/better-auth/client.ts
+++ b/apps/dashboard/src/utils/better-auth/client.ts
@@ -4,10 +4,11 @@ import { createAuthClient } from 'better-auth/react';
 import { API_HOSTNAME, BETTER_AUTH_BASE_URL } from '@/config';
 
 const baseURL = BETTER_AUTH_BASE_URL || API_HOSTNAME || 'http://localhost:3000';
-const fullBaseURL = `${baseURL}/v1/better-auth`;
+
+export const BETTER_AUTH_API_URL = `${baseURL}/v1/better-auth`;
 
 export const authClient = createAuthClient({
-  baseURL: fullBaseURL,
+  baseURL: BETTER_AUTH_API_URL,
   plugins: [organizationClient(), ssoClient()],
   fetchOptions: {
     credentials: 'include',

--- a/apps/dashboard/src/utils/better-auth/components/forgot-password.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/forgot-password.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { buildSsoSignInPath } from '../sso-redirect';
 import { useAuthConfig } from '../use-auth-config';
 
 export function ForgotPassword() {
@@ -45,7 +46,7 @@ export function ForgotPassword() {
   }
 
   if (!emailPasswordAuthEnabled) {
-    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+    return <Navigate to={buildSsoSignInPath()} replace />;
   }
 
   if (emailSent) {

--- a/apps/dashboard/src/utils/better-auth/components/forgot-password.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/forgot-password.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { useAuthConfig } from '../use-auth-config';
 
 export function ForgotPassword() {
   const navigate = useNavigate();
+  const { emailPasswordAuthEnabled, isLoading: isAuthConfigLoading } = useAuthConfig();
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -37,6 +39,14 @@ export function ForgotPassword() {
       setIsLoading(false);
     }
   };
+
+  if (isAuthConfigLoading) {
+    return null;
+  }
+
+  if (!emailPasswordAuthEnabled) {
+    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+  }
 
   if (emailSent) {
     return (

--- a/apps/dashboard/src/utils/better-auth/components/reset-password.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/reset-password.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { buildSsoSignInPath } from '../sso-redirect';
 import { useAuthConfig } from '../use-auth-config';
 
 export function ResetPassword() {
@@ -73,7 +74,7 @@ export function ResetPassword() {
   }
 
   if (!emailPasswordAuthEnabled) {
-    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+    return <Navigate to={buildSsoSignInPath(searchParams)} replace />;
   }
 
   return (

--- a/apps/dashboard/src/utils/better-auth/components/reset-password.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/reset-password.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { useAuthConfig } from '../use-auth-config';
 
 export function ResetPassword() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { emailPasswordAuthEnabled, isLoading: isAuthConfigLoading } = useAuthConfig();
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -65,6 +67,14 @@ export function ResetPassword() {
       setIsLoading(false);
     }
   };
+
+  if (isAuthConfigLoading) {
+    return null;
+  }
+
+  if (!emailPasswordAuthEnabled) {
+    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+  }
 
   return (
     <div className="mx-auto w-full max-w-md pt-12">

--- a/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
@@ -1,11 +1,12 @@
 import { useId, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { IS_SELF_HOSTED_EE } from '@/config';
 import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { useAuthConfig } from '../use-auth-config';
 
 function resolveSameOriginRedirectUrl(redirectUrl: string | null): string | null {
   if (!redirectUrl) {
@@ -28,6 +29,7 @@ function resolveSameOriginRedirectUrl(redirectUrl: string | null): string | null
 export function SignIn() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { emailPasswordAuthEnabled, isLoading: isAuthConfigLoading } = useAuthConfig();
   const postSignInRedirectUrl = resolveSameOriginRedirectUrl(readClerkRedirectUrlParam(searchParams));
   const emailId = useId();
   const passwordId = useId();
@@ -105,6 +107,14 @@ export function SignIn() {
       setIsLoading(false);
     }
   };
+
+  if (isAuthConfigLoading) {
+    return null;
+  }
+
+  if (!emailPasswordAuthEnabled) {
+    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+  }
 
   return (
     <div className="mx-auto w-full max-w-md pt-12">

--- a/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
@@ -3,28 +3,11 @@ import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { IS_SELF_HOSTED_EE } from '@/config';
-import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
+import { readClerkRedirectUrlParam, resolveSameOriginRedirectUrl } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { buildSsoSignInPath } from '../sso-redirect';
 import { useAuthConfig } from '../use-auth-config';
-
-function resolveSameOriginRedirectUrl(redirectUrl: string | null): string | null {
-  if (!redirectUrl) {
-    return null;
-  }
-
-  try {
-    const parsed = new URL(redirectUrl, window.location.origin);
-
-    if (parsed.origin !== window.location.origin) {
-      return null;
-    }
-
-    return parsed.href;
-  } catch {
-    return null;
-  }
-}
 
 export function SignIn() {
   const navigate = useNavigate();
@@ -113,7 +96,7 @@ export function SignIn() {
   }
 
   if (!emailPasswordAuthEnabled) {
-    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+    return <Navigate to={buildSsoSignInPath(searchParams)} replace />;
   }
 
   return (
@@ -206,7 +189,12 @@ export function SignIn() {
               <span className="bg-white px-2 text-foreground-500">Or</span>
             </div>
           </div>
-          <Button variant="secondary" mode="outline" className="w-full" onClick={() => navigate(ROUTES.SSO_SIGN_IN)}>
+          <Button
+            variant="secondary"
+            mode="outline"
+            className="w-full"
+            onClick={() => navigate(buildSsoSignInPath(searchParams))}
+          >
             Sign in with SSO
           </Button>
         </>

--- a/apps/dashboard/src/utils/better-auth/components/sign-up.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-up.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
 import { useAuth } from '../index';
+import { useAuthConfig } from '../use-auth-config';
 
 function extractInvitationIdFromRedirect(redirectUrl: string | null): string | null {
   if (!redirectUrl) return null;
@@ -28,6 +29,7 @@ export function SignUp() {
 
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { emailPasswordAuthEnabled, isLoading: isAuthConfigLoading } = useAuthConfig();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [firstName, setFirstName] = useState('');
@@ -127,6 +129,15 @@ export function SignUp() {
       setIsLoading(false);
     }
   };
+
+  if (isAuthConfigLoading) {
+    return null;
+  }
+
+  // SSO provisions accounts on first successful login, so there is nothing to sign up for here.
+  if (!emailPasswordAuthEnabled) {
+    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+  }
 
   return (
     <div className="mx-auto max-w-md pt-12">

--- a/apps/dashboard/src/utils/better-auth/components/sign-up.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-up.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/primitives/input';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
 import { useAuth } from '../index';
+import { buildSsoSignInPath } from '../sso-redirect';
 import { useAuthConfig } from '../use-auth-config';
 
 function extractInvitationIdFromRedirect(redirectUrl: string | null): string | null {
@@ -136,7 +137,7 @@ export function SignUp() {
 
   // SSO provisions accounts on first successful login, so there is nothing to sign up for here.
   if (!emailPasswordAuthEnabled) {
-    return <Navigate to={ROUTES.SSO_SIGN_IN} replace />;
+    return <Navigate to={buildSsoSignInPath(searchParams)} replace />;
   }
 
   return (

--- a/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
@@ -2,17 +2,35 @@ import { useEffect, useId, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
-import { readClerkRedirectUrlParam, resolveSameOriginRedirectUrl } from '@/utils/product-auth-urls';
+import { resolveSameOriginRedirectUrl } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
-import { withRedirectUrl } from '../sso-redirect';
+import { readReturnDestination, withRedirectUrl } from '../sso-redirect';
 import { useAuthConfig } from '../use-auth-config';
+
+/**
+ * Resolved before handing off to the identity provider, since the browser leaves the app entirely
+ * and only `callbackURL` decides where it comes back to. Mirrors the email/password sign-in
+ * fallbacks: an explicit destination, then a pending invitation, then the organization picker.
+ */
+function resolvePostSignInUrl(redirectUrl: string | null): string {
+  if (redirectUrl) {
+    return redirectUrl;
+  }
+
+  const pendingInvitationId = sessionStorage.getItem('pendingInvitationId');
+  const path = pendingInvitationId
+    ? `${ROUTES.INVITATION_ACCEPT}?id=${pendingInvitationId}`
+    : ROUTES.SIGNUP_ORGANIZATION_LIST;
+
+  return new URL(path, window.location.origin).href;
+}
 
 export function SSOSignIn() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { emailPasswordAuthEnabled } = useAuthConfig();
-  const postSignInRedirectUrl = resolveSameOriginRedirectUrl(readClerkRedirectUrlParam(searchParams));
+  const postSignInRedirectUrl = resolveSameOriginRedirectUrl(readReturnDestination(searchParams));
   const signInPath = withRedirectUrl(ROUTES.SIGN_IN, postSignInRedirectUrl);
   const ssoRetryPath = withRedirectUrl(ROUTES.SSO_SIGN_IN, postSignInRedirectUrl);
   const ssoEmailId = useId();
@@ -43,15 +61,17 @@ export function SSOSignIn() {
         throw new Error('Please enter a valid email address');
       }
 
+      const postSignInUrl = resolvePostSignInUrl(postSignInRedirectUrl);
+
       await authClient.signIn.sso(
         {
           domain,
-          callbackURL: postSignInRedirectUrl ?? window.location.origin + ROUTES.SIGNUP_ORGANIZATION_LIST,
+          callbackURL: postSignInUrl,
           errorCallbackURL: window.location.origin + ssoRetryPath,
         },
         {
           onSuccess: () => {
-            window.location.href = postSignInRedirectUrl ?? ROUTES.SIGNUP_ORGANIZATION_LIST;
+            window.location.href = postSignInUrl;
           },
           onError: (ctx: any) => {
             throw new Error(ctx.error.message || 'SSO sign in failed');

--- a/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
@@ -2,14 +2,19 @@ import { useEffect, useId, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
+import { readClerkRedirectUrlParam, resolveSameOriginRedirectUrl } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { withRedirectUrl } from '../sso-redirect';
 import { useAuthConfig } from '../use-auth-config';
 
 export function SSOSignIn() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { emailPasswordAuthEnabled } = useAuthConfig();
+  const postSignInRedirectUrl = resolveSameOriginRedirectUrl(readClerkRedirectUrlParam(searchParams));
+  const signInPath = withRedirectUrl(ROUTES.SIGN_IN, postSignInRedirectUrl);
+  const ssoRetryPath = withRedirectUrl(ROUTES.SSO_SIGN_IN, postSignInRedirectUrl);
   const ssoEmailId = useId();
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -41,12 +46,12 @@ export function SSOSignIn() {
       await authClient.signIn.sso(
         {
           domain,
-          callbackURL: window.location.origin + ROUTES.SIGNUP_ORGANIZATION_LIST,
-          errorCallbackURL: window.location.origin + ROUTES.SSO_SIGN_IN,
+          callbackURL: postSignInRedirectUrl ?? window.location.origin + ROUTES.SIGNUP_ORGANIZATION_LIST,
+          errorCallbackURL: window.location.origin + ssoRetryPath,
         },
         {
           onSuccess: () => {
-            window.location.href = ROUTES.SIGNUP_ORGANIZATION_LIST;
+            window.location.href = postSignInRedirectUrl ?? ROUTES.SIGNUP_ORGANIZATION_LIST;
           },
           onError: (ctx: any) => {
             throw new Error(ctx.error.message || 'SSO sign in failed');
@@ -91,9 +96,9 @@ export function SSOSignIn() {
               role="button"
               tabIndex={0}
               className="text-primary-base focus:ring-primary-base/50 cursor-pointer font-medium hover:underline focus:outline-none focus:ring-2"
-              onClick={() => navigate(ROUTES.SIGN_IN)}
+              onClick={() => navigate(signInPath)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') navigate(ROUTES.SIGN_IN);
+                if (e.key === 'Enter' || e.key === ' ') navigate(signInPath);
               }}
             >
               Back to sign in

--- a/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
@@ -4,10 +4,12 @@ import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
+import { useAuthConfig } from '../use-auth-config';
 
 export function SSOSignIn() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { emailPasswordAuthEnabled } = useAuthConfig();
   const ssoEmailId = useId();
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -83,19 +85,21 @@ export function SSOSignIn() {
         <Button type="submit" disabled={isLoading} variant="primary" mode="filled" className="w-full">
           {isLoading ? 'Redirecting...' : 'Continue with SSO'}
         </Button>
-        <p className="mt-4 text-center text-sm text-foreground-600">
-          <span
-            role="button"
-            tabIndex={0}
-            className="text-primary-base focus:ring-primary-base/50 cursor-pointer font-medium hover:underline focus:outline-none focus:ring-2"
-            onClick={() => navigate(ROUTES.SIGN_IN)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') navigate(ROUTES.SIGN_IN);
-            }}
-          >
-            Back to sign in
-          </span>
-        </p>
+        {emailPasswordAuthEnabled && (
+          <p className="mt-4 text-center text-sm text-foreground-600">
+            <span
+              role="button"
+              tabIndex={0}
+              className="text-primary-base focus:ring-primary-base/50 cursor-pointer font-medium hover:underline focus:outline-none focus:ring-2"
+              onClick={() => navigate(ROUTES.SIGN_IN)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') navigate(ROUTES.SIGN_IN);
+              }}
+            >
+              Back to sign in
+            </span>
+          </p>
+        )}
       </form>
     </div>
   );

--- a/apps/dashboard/src/utils/better-auth/components/user-profile.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/user-profile.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/primitives/input';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { authClient } from '../client';
 import { useAuth, useUser } from '../index';
+import { useAuthConfig } from '../use-auth-config';
 
 function getUserInitials(name: string): string {
   return name
@@ -255,6 +256,7 @@ function ProfileSection() {
 
 function SecuritySection() {
   const { user } = useUser();
+  const { emailPasswordAuthEnabled } = useAuthConfig();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -306,6 +308,19 @@ function SecuritySection() {
   };
 
   if (!user) return null;
+
+  if (!emailPasswordAuthEnabled) {
+    return (
+      <div className="space-y-6">
+        <div className="border-b border-neutral-100 pb-4">
+          <h2 className="text-lg font-semibold text-foreground-950">Security</h2>
+          <p className="mt-1 text-sm text-foreground-600">
+            Your credentials are managed by your organization&apos;s identity provider.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/apps/dashboard/src/utils/better-auth/sso-redirect.ts
+++ b/apps/dashboard/src/utils/better-auth/sso-redirect.ts
@@ -1,11 +1,15 @@
-import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
+import { readClerkAuthParamFromLocation, readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 
 /**
- * Flows that bounce through sign-in — CLI authorization, connect claim, deep links — carry their
- * return destination as `redirect_url`. Every hop between the auth screens has to forward it, or the
- * user ends up on the organization list instead of where they started.
+ * Flows that bounce through the auth screens carry a return destination: most use `redirect_url`,
+ * while the invitation flow uses `redirect`. Every hop has to forward it, or the user ends up on the
+ * organization list — which, unlike the rest of the app, has no fallback that resumes the flow.
  */
+export function readReturnDestination(searchParams?: URLSearchParams): string | null {
+  return readClerkRedirectUrlParam(searchParams) ?? readClerkAuthParamFromLocation('redirect', searchParams);
+}
+
 export function withRedirectUrl(path: string, redirectUrl: string | null): string {
   if (!redirectUrl) {
     return path;
@@ -15,5 +19,5 @@ export function withRedirectUrl(path: string, redirectUrl: string | null): strin
 }
 
 export function buildSsoSignInPath(searchParams?: URLSearchParams): string {
-  return withRedirectUrl(ROUTES.SSO_SIGN_IN, readClerkRedirectUrlParam(searchParams));
+  return withRedirectUrl(ROUTES.SSO_SIGN_IN, readReturnDestination(searchParams));
 }

--- a/apps/dashboard/src/utils/better-auth/sso-redirect.ts
+++ b/apps/dashboard/src/utils/better-auth/sso-redirect.ts
@@ -1,0 +1,19 @@
+import { readClerkRedirectUrlParam } from '@/utils/product-auth-urls';
+import { ROUTES } from '@/utils/routes';
+
+/**
+ * Flows that bounce through sign-in — CLI authorization, connect claim, deep links — carry their
+ * return destination as `redirect_url`. Every hop between the auth screens has to forward it, or the
+ * user ends up on the organization list instead of where they started.
+ */
+export function withRedirectUrl(path: string, redirectUrl: string | null): string {
+  if (!redirectUrl) {
+    return path;
+  }
+
+  return `${path}?redirect_url=${encodeURIComponent(redirectUrl)}`;
+}
+
+export function buildSsoSignInPath(searchParams?: URLSearchParams): string {
+  return withRedirectUrl(ROUTES.SSO_SIGN_IN, readClerkRedirectUrlParam(searchParams));
+}

--- a/apps/dashboard/src/utils/better-auth/use-auth-config.ts
+++ b/apps/dashboard/src/utils/better-auth/use-auth-config.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import { BETTER_AUTH_API_URL } from './client';
+
+type AuthConfig = {
+  emailPasswordAuthEnabled: boolean;
+  ssoEnabled: boolean;
+};
+
+/**
+ * Assume the pre-existing defaults when the probe fails, so a transient API hiccup never hides the
+ * only sign-in form a deployment has. The API rejects password requests regardless of what we show.
+ */
+const FALLBACK_AUTH_CONFIG: AuthConfig = {
+  emailPasswordAuthEnabled: true,
+  ssoEnabled: false,
+};
+
+async function fetchAuthConfig(): Promise<AuthConfig> {
+  const response = await fetch(`${BETTER_AUTH_API_URL}/auth-config`, { credentials: 'include' });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load auth config (${response.status})`);
+  }
+
+  const body = await response.json();
+  const payload = body?.data ?? body;
+
+  return {
+    emailPasswordAuthEnabled: payload?.emailPasswordAuthEnabled !== false,
+    ssoEnabled: payload?.ssoEnabled === true,
+  };
+}
+
+/**
+ * Which sign-in methods the backend accepts. Self-hosted deployments can turn off email and password
+ * with `DISABLE_EMAIL_PASSWORD_AUTH` once SSO is configured.
+ */
+export function useAuthConfig(): AuthConfig & { isLoading: boolean } {
+  const { data, isLoading } = useQuery({
+    queryKey: ['betterAuthConfig'],
+    queryFn: fetchAuthConfig,
+    staleTime: Infinity,
+    retry: 1,
+  });
+
+  return { ...(data ?? FALLBACK_AUTH_CONFIG), isLoading };
+}

--- a/apps/dashboard/src/utils/product-auth-urls.ts
+++ b/apps/dashboard/src/utils/product-auth-urls.ts
@@ -49,3 +49,22 @@ export function readClerkAuthParamFromLocation(param: string, searchParams?: URL
 export function readClerkRedirectUrlParam(searchParams?: URLSearchParams): string | null {
   return readClerkAuthParamFromLocation('redirect_url', searchParams);
 }
+
+/** `redirect_url` arrives from an untrusted query string, so only same-origin targets are honored. */
+export function resolveSameOriginRedirectUrl(redirectUrl: string | null): string | null {
+  if (!redirectUrl) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(redirectUrl, window.location.origin);
+
+    if (parsed.origin !== window.location.origin) {
+      return null;
+    }
+
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

- Added `useAuthConfig` hook to fetch and manage authentication configuration.
- Updated authentication components (SignIn, SignUp, ForgotPassword, ResetPassword, SSOSignIn, UserProfile) to conditionally render based on email/password authentication availability.
- Refactored API URL handling in `client.ts` for better clarity.
- Introduced fallback handling for authentication configuration to ensure consistent user experience during API hiccups.
- Updated subproject reference in `.source`.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds backend-driven authentication configuration and adapts dashboard authentication screens for email/password-disabled deployments. It also preserves validated return destinations across sign-in, sign-up, SSO callbacks, retries, and invitation flows.
- Adds a React Query hook for retrieving authentication capabilities with availability-preserving fallback behavior.
- Redirects password-only screens to SSO when email/password authentication is disabled.
- Centralizes return-destination forwarding and same-origin validation for authentication transitions.
- Adjusts profile security controls according to the enabled authentication method.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported return-destination issues are fixed at the current head.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/better-auth/sso-redirect.ts | Centralizes reading and forwarding both standard and invitation return-destination parameters. |
| apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx | Validates forwarded destinations and uses them for successful callbacks, retries, and navigation back to password sign-in. |
| apps/dashboard/src/utils/better-auth/components/sign-in.tsx | Redirects SSO-only deployments while preserving the initiating flow’s return destination. |
| apps/dashboard/src/utils/better-auth/components/sign-up.tsx | Preserves invitation destinations while redirecting SSO-only users to the SSO flow. |
| apps/dashboard/src/utils/better-auth/use-auth-config.ts | Fetches backend authentication capabilities and supplies resilient defaults during request failures. |
| apps/dashboard/src/utils/product-auth-urls.ts | Exposes reusable same-origin validation for untrusted authentication return URLs. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AuthPage as Sign-in / Sign-up
    participant SSO as SSO Sign-in
    participant IdP as Identity Provider
    participant Destination as Return Destination
    User->>AuthPage: Open with redirect_url or redirect
    AuthPage->>SSO: Forward return destination
    SSO->>SSO: Validate same-origin destination
    SSO->>IdP: Start SSO with callbackURL
    IdP-->>Destination: Return after authentication
```

<sub>Reviews (4): Last reviewed commit: ["chore: update subproject reference in .s..."](https://github.com/novuhq/novu/commit/d677f1a32bdee7d9c4a68331ff21f07dbad1d2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49684308)</sub>

<!-- /greptile_comment -->