### PR TITLE
fix(api-service): await websocket enqueue in inbox and widget flows to prevent silent real-time event loss

### DIFF
--- a/apps/api/src/app/inbox/usecases/delete-all-notifications/delete-all-notifications.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/delete-all-notifications/delete-all-notifications.usecase.ts
@@ -5,6 +5,7 @@ import {
   buildMessageCountKey,
   InvalidateCacheService,
   messageWebhookMapper,
+  PinoLogger,
   SendWebhookMessage,
   WebSocketsQueueService,
 } from '@novu/application-generic';
@@ -25,8 +26,11 @@ export class DeleteAllNotifications {
     private messageRepository: MessageRepository,
     private webSocketsQueueService: WebSocketsQueueService,
     private sendWebhookMessage: SendWebhookMessage,
-    private environmentRepository: EnvironmentRepository
-  ) {}
+    private environmentRepository: EnvironmentRepository,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: DeleteAllNotificationsCommand): Promise<void> {
     const subscriber = await this.getSubscriber.execute({
@@ -89,16 +93,20 @@ export class DeleteAllNotifications {
       contextKeys: command.contextKeys,
     });
 
-    this.webSocketsQueueService.add({
-      name: 'sendMessage',
-      data: {
-        event: WebSocketEventEnum.UNREAD,
-        userId: subscriber._id,
-        _environmentId: command.environmentId,
-        contextKeys: command.contextKeys ?? [],
-      },
-      groupId: subscriber._organizationId,
-    });
+    try {
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: WebSocketEventEnum.UNREAD,
+          userId: subscriber._id,
+          _environmentId: command.environmentId,
+          contextKeys: command.contextKeys ?? [],
+        },
+        groupId: subscriber._organizationId,
+      });
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to enqueue delete-all websocket event');
+    }
   }
 
   private async sendWebhookEvents(command: DeleteAllNotificationsCommand, deletedMessages: MessageEntity[]) {

--- a/apps/api/src/app/inbox/usecases/delete-many-notifications/delete-many-notifications.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/delete-many-notifications/delete-many-notifications.usecase.ts
@@ -76,16 +76,20 @@ export class DeleteManyNotifications {
 
     await this.processWebhooksInBatches([WebhookEventEnum.MESSAGE_DELETED], deletedMessages, command, environment);
 
-    this.webSocketsQueueService.add({
-      name: 'sendMessage',
-      data: {
-        event: WebSocketEventEnum.UNREAD,
-        userId: subscriber._id,
-        _environmentId: subscriber._environmentId,
-        contextKeys: command.contextKeys ?? [],
-      },
-      groupId: subscriber._organizationId,
-    });
+    try {
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: WebSocketEventEnum.UNREAD,
+          userId: subscriber._id,
+          _environmentId: subscriber._environmentId,
+          contextKeys: command.contextKeys ?? [],
+        },
+        groupId: subscriber._organizationId,
+      });
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to enqueue delete-many websocket event');
+    }
   }
 
   private async processWebhooksInBatches(

--- a/apps/api/src/app/inbox/usecases/mark-many-notifications-as/mark-many-notifications-as.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/mark-many-notifications-as/mark-many-notifications-as.usecase.ts
@@ -98,16 +98,20 @@ export class MarkManyNotificationsAs {
 
     await this.processWebhooksInBatches(eventTypes, updatedMessages, command, environment);
 
-    this.webSocketsQueueService.add({
-      name: 'sendMessage',
-      data: {
-        event: WebSocketEventEnum.UNREAD,
-        userId: subscriber._id,
-        _environmentId: subscriber._environmentId,
-        contextKeys: command.contextKeys ?? [],
-      },
-      groupId: subscriber._organizationId,
-    });
+    try {
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: WebSocketEventEnum.UNREAD,
+          userId: subscriber._id,
+          _environmentId: subscriber._environmentId,
+          contextKeys: command.contextKeys ?? [],
+        },
+        groupId: subscriber._organizationId,
+      });
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to enqueue mark-many websocket event');
+    }
   }
 
   private async processWebhooksInBatches(

--- a/apps/api/src/app/inbox/usecases/mark-notifications-as-seen/mark-notifications-as-seen.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/mark-notifications-as-seen/mark-notifications-as-seen.usecase.ts
@@ -159,16 +159,20 @@ export class MarkNotificationsAsSeen {
       }),
     ]);
 
-    this.webSocketsQueueService.add({
-      name: 'sendMessage',
-      data: {
-        event: WebSocketEventEnum.UNSEEN,
-        userId: subscriber._id,
-        _environmentId: command.environmentId,
-        contextKeys: contextKeys ?? [],
-      },
-      groupId: subscriber._organizationId,
-    });
+    try {
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: WebSocketEventEnum.UNSEEN,
+          userId: subscriber._id,
+          _environmentId: command.environmentId,
+          contextKeys: contextKeys ?? [],
+        },
+        groupId: subscriber._organizationId,
+      });
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to enqueue mark-as-seen websocket event');
+    }
   }
 
   private async processWebhooksInBatches(

--- a/apps/api/src/app/inbox/usecases/update-all-notifications/update-all-notifications.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-all-notifications/update-all-notifications.usecase.ts
@@ -5,6 +5,7 @@ import {
   buildMessageCountKey,
   InvalidateCacheService,
   messageWebhookMapper,
+  PinoLogger,
   SendWebhookMessage,
   WebSocketsQueueService,
 } from '@novu/application-generic';
@@ -25,8 +26,11 @@ export class UpdateAllNotifications {
     private messageRepository: MessageRepository,
     private webSocketsQueueService: WebSocketsQueueService,
     private sendWebhookMessage: SendWebhookMessage,
-    private environmentRepository: EnvironmentRepository
-  ) {}
+    private environmentRepository: EnvironmentRepository,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: UpdateAllNotificationsCommand): Promise<void> {
     const subscriber = await this.getSubscriber.execute({
@@ -91,16 +95,20 @@ export class UpdateAllNotifications {
       contextKeys: command.contextKeys,
     });
 
-    this.webSocketsQueueService.add({
-      name: 'sendMessage',
-      data: {
-        event: WebSocketEventEnum.UNREAD,
-        userId: subscriber._id,
-        _environmentId: command.environmentId,
-        contextKeys: command.contextKeys ?? [],
-      },
-      groupId: subscriber._organizationId,
-    });
+    try {
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: WebSocketEventEnum.UNREAD,
+          userId: subscriber._id,
+          _environmentId: command.environmentId,
+          contextKeys: command.contextKeys ?? [],
+        },
+        groupId: subscriber._organizationId,
+      });
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to enqueue update-all websocket event');
+    }
   }
 
   private async sendWebhookEvents(command: UpdateAllNotificationsCommand, updatedMessages: MessageEntity[]) {

--- a/apps/api/src/app/widgets/usecases/mark-all-messages-as/mark-all-messages-as.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-all-messages-as/mark-all-messages-as.usecase.ts
@@ -5,6 +5,7 @@ import {
   buildMessageCountKey,
   InvalidateCacheService,
   messageWebhookMapper,
+  PinoLogger,
   SendWebhookMessage,
   WebSocketsQueueService,
 } from '@novu/application-generic';
@@ -23,8 +24,11 @@ export class MarkAllMessagesAs {
     private subscriberRepository: SubscriberRepository,
     private analyticsService: AnalyticsService,
     private sendWebhookMessage: SendWebhookMessage,
-    private environmentRepository: EnvironmentRepository
-  ) {}
+    private environmentRepository: EnvironmentRepository,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: MarkAllMessagesAsCommand): Promise<number> {
     const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
@@ -86,16 +90,20 @@ export class MarkAllMessagesAs {
     const eventMessage = mapMarkMessageToWebSocketEvent(command.markAs);
 
     if (eventMessage !== undefined) {
-      this.webSocketsQueueService.add({
-        name: 'sendMessage',
-        data: {
-          event: eventMessage,
-          userId: subscriber._id,
-          _environmentId: command.environmentId,
-          contextKeys: [],
-        },
-        groupId: subscriber._organizationId,
-      });
+      try {
+        await this.webSocketsQueueService.add({
+          name: 'sendMessage',
+          data: {
+            event: eventMessage,
+            userId: subscriber._id,
+            _environmentId: command.environmentId,
+            contextKeys: [],
+          },
+          groupId: subscriber._organizationId,
+        });
+      } catch (error) {
+        this.logger.error({ err: error }, 'Failed to enqueue mark-all-messages websocket event');
+      }
     }
 
     this.analyticsService.track(

--- a/apps/api/src/app/widgets/usecases/mark-message-as-by-mark/mark-message-as-by-mark.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as-by-mark/mark-message-as-by-mark.usecase.ts
@@ -7,6 +7,7 @@ import {
   CachedResponse,
   InvalidateCacheService,
   messageWebhookMapper,
+  PinoLogger,
   SendWebhookMessage,
   WebSocketsQueueService,
 } from '@novu/application-generic';
@@ -31,8 +32,11 @@ export class MarkMessageAsByMark {
     private analyticsService: AnalyticsService,
     private subscriberRepository: SubscriberRepository,
     private sendWebhookMessage: SendWebhookMessage,
-    private environmentRepository: EnvironmentRepository
-  ) {}
+    private environmentRepository: EnvironmentRepository,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: MarkMessageAsByMarkCommand): Promise<MessageResponseDto[]> {
     const subscriber = await this.fetchSubscriber({
@@ -96,7 +100,7 @@ export class MarkMessageAsByMark {
   }
 
   private async updateServices(command: MarkMessageAsByMarkCommand, subscriber, messages, markAs: MessagesStatusEnum) {
-    this.updateSocketCount(subscriber, markAs);
+    await this.updateSocketCount(subscriber, markAs);
     const analyticMessage =
       command.__source === 'notification_center'
         ? `Mark as ${markAs} - [Notification Center]`
@@ -111,23 +115,27 @@ export class MarkMessageAsByMark {
     }
   }
 
-  private updateSocketCount(subscriber: SubscriberEntity, markAs: MessagesStatusEnum) {
+  private async updateSocketCount(subscriber: SubscriberEntity, markAs: MessagesStatusEnum) {
     const eventMessage = mapMarkMessageToWebSocketEvent(markAs);
 
     if (eventMessage === undefined) {
       return;
     }
 
-    this.webSocketsQueueService.add({
-      name: 'sendMessage',
-      data: {
-        event: eventMessage,
-        userId: subscriber._id,
-        _environmentId: subscriber._environmentId,
-        contextKeys: [],
-      },
-      groupId: subscriber._organizationId,
-    });
+    try {
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: eventMessage,
+          userId: subscriber._id,
+          _environmentId: subscriber._environmentId,
+          contextKeys: [],
+        },
+        groupId: subscriber._organizationId,
+      });
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to enqueue mark-message-as-by-mark websocket event');
+    }
   }
 
   @CachedResponse({

--- a/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
@@ -147,7 +147,7 @@ export class MarkMessageAs {
   }
 
   private async updateServices(command: MarkMessageAsCommand, subscriber, messages, marked: MarkEnum) {
-    this.updateSocketCount(subscriber, marked);
+    await this.updateSocketCount(subscriber, marked);
 
     for (const message of messages) {
       this.analyticsService.mixpanelTrack(`Mark as ${marked} - [Notification Center]`, '', {
@@ -158,19 +158,23 @@ export class MarkMessageAs {
     }
   }
 
-  private updateSocketCount(subscriber: SubscriberEntity, mark: MarkEnum) {
+  private async updateSocketCount(subscriber: SubscriberEntity, mark: MarkEnum) {
     const eventMessage = mark === MarkEnum.READ ? WebSocketEventEnum.UNREAD : WebSocketEventEnum.UNSEEN;
 
-    this.webSocketsQueueService.add({
-      name: 'sendMessage',
-      data: {
-        event: eventMessage,
-        userId: subscriber._id,
-        _environmentId: subscriber._environmentId,
-        contextKeys: [],
-      },
-      groupId: subscriber._organizationId,
-    });
+    try {
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: eventMessage,
+          userId: subscriber._id,
+          _environmentId: subscriber._environmentId,
+          contextKeys: [],
+        },
+        groupId: subscriber._organizationId,
+      });
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to enqueue mark-message-as websocket event');
+    }
   }
 
   private async sendWebhookForMessages(


### PR DESCRIPTION
### What changed? Why was the change needed?

`WebSocketsQueueService.add()` is `async` (feature-flag checks, direct socket-worker delivery, then BullMQ enqueue), but several inbox and widget flows call it **fire-and-forget** — never awaited. This is the same "silent job loss" bug class as #12184.

When the socket-worker path or enqueue throws, these calls produce unhandled promise rejections (process crash risk in modern Node) and real-time events (read/unread/delete/seen) can be silently dropped after the API already returned 200.

Fixed 8 call sites across widgets and inbox mark/delete/update flows to `await` the enqueue:

- `widgets/mark-message-as`, `mark-message-as-by-mark` (via `updateSocketCount` made `async`), `mark-all-messages-as`
- `inbox/update-all-notifications`, `mark-notifications-as-seen`, `mark-many-notifications-as`, `delete-many-notifications`, `delete-all-notifications`

This brings these flows in line with sibling flows that already await (`remove-message`, `remove-all-messages`, `send-message-in-app`, `process-unsnooze-job`). All enclosing methods were already `async`, so this is type-safe with no behavior change beyond observing the enqueue result.

### Screenshots

N/A — no visual changes.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- Verified via ripgrep that no un-awaited `QueueService.add()` call sites remain in `apps/api`, `apps/worker`, or `apps/ws` (excluding the one intentionally wrapped in `await Promise.all`).
- No new unit tests added: these usecases have no existing `*.spec.ts` and require NestJS DI scaffolding; the change is an `await` propagation consistent with the recently merged #12184.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR now observes websocket enqueue completion without turning post-mutation queue failures into failed API mutations.
- Awaits websocket enqueue operations across inbox and widget mark, update, and delete flows.
- Catches and logs enqueue failures after mutations and associated side effects have completed.
- Adds contextual logger injection where the affected use cases did not already have logging support.

<h3>Confidence Score: 4/5</h3>

The websocket delivery-loss path needs to be fixed before merging because enqueue rejection still produces a successful mutation response without the realtime update.

Each changed flow mutates persisted notification state before enqueueing its websocket event, and the new catch blocks only log enqueue rejection, leaving no retry or fallback to deliver the corresponding realtime count update.

**Files Needing Attention:** The changed inbox and widget use cases that catch WebSocketsQueueService.add() failures.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/inbox/usecases/delete-all-notifications/delete-all-notifications.usecase.ts | Awaits websocket enqueue but catches rejection after deletion, leaving the realtime update undelivered while returning success. |
| apps/api/src/app/inbox/usecases/delete-many-notifications/delete-many-notifications.usecase.ts | Handles websocket enqueue rejection after bulk deletion by logging and returning success without retrying delivery. |
| apps/api/src/app/inbox/usecases/mark-many-notifications-as/mark-many-notifications-as.usecase.ts | Awaits the post-update realtime enqueue but drops the side effect when enqueue rejects. |
| apps/api/src/app/inbox/usecases/mark-notifications-as-seen/mark-notifications-as-seen.usecase.ts | Awaits the unseen-count websocket enqueue but returns success when delivery cannot be scheduled. |
| apps/api/src/app/inbox/usecases/update-all-notifications/update-all-notifications.usecase.ts | Adds contextual logging while swallowing websocket enqueue rejection after bulk updates. |
| apps/api/src/app/widgets/usecases/mark-all-messages-as/mark-all-messages-as.usecase.ts | Awaits the realtime count update but logs and drops it when queueing fails. |
| apps/api/src/app/widgets/usecases/mark-message-as-by-mark/mark-message-as-by-mark.usecase.ts | Propagates async execution through updateSocketCount while swallowing enqueue rejection locally. |
| apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts | Propagates async execution through updateSocketCount while swallowing enqueue rejection locally. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Finbox%2Fusecases%2Fdelete-all-notifications%2Fdelete-all-notifications.usecase.ts%3A104-106%0A**Queue%20failure%20still%20drops%20realtime%20updates**%0A%0AWhen%20the%20websocket%20enqueue%20rejects%2C%20this%20catch%20logs%20the%20error%20and%20returns%20success%20after%20the%20mutation%20has%20committed%2C%20causing%20the%20realtime%20unread%20or%20unseen%20update%20to%20be%20permanently%20lost.%20The%20same%20catch-and-continue%20behavior%20remains%20across%20the%20other%20changed%20bulk%20and%20widget%20flows%2C%20so%20fixing%20the%20partial-success%20retry%20response%20does%20not%20ensure%20delivery%20of%20the%20required%20websocket%20side%20effect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12205&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/app/inbox/usecases/delete-all-notifications/delete-all-notifications.usecase.ts:104-106
**Queue failure still drops realtime updates**

When the websocket enqueue rejects, this catch logs the error and returns success after the mutation has committed, causing the realtime unread or unseen update to be permanently lost. The same catch-and-continue behavior remains across the other changed bulk and widget flows, so fixing the partial-success retry response does not ensure delivery of the required websocket side effect.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): await websocket enqueu..."](https://github.com/novuhq/novu/commit/954c8bbfdc440357f6abbf45160965e0c7b3dfb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49720456)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->