### PR TITLE
fix(dashboard): pin personalize title and soften channel pill hover fixes NV-8514

### DIFF
--- a/apps/dashboard/src/components/onboarding/personalize/channel-chip.tsx
+++ b/apps/dashboard/src/components/onboarding/personalize/channel-chip.tsx
@@ -17,9 +17,7 @@ export function ChannelChip({ label, icon, accent, isSelected, onToggle }: Chann
       onClick={onToggle}
       className={cn(
         'text-label-xs inline-flex h-7 cursor-pointer items-center gap-1 rounded-full border px-2 font-medium transition-colors',
-        isSelected
-          ? 'text-text-strong'
-          : 'border-stroke-soft hover:border-stroke-strong text-text-sub bg-white hover:bg-white'
+        isSelected ? 'text-text-strong' : 'border-stroke-weak hover:border-stroke-soft text-text-sub bg-white'
       )}
       style={isSelected ? { backgroundColor: `${accent}1f`, borderColor: `${accent}3d` } : undefined}
     >

--- a/apps/dashboard/src/pages/agents-personalize-page.tsx
+++ b/apps/dashboard/src/pages/agents-personalize-page.tsx
@@ -41,12 +41,17 @@ type SetupHandoffState = {
 
 const PAGE_TITLE = 'Help us personalize your experience';
 
-/** Wraps each question so it rises into place as the previous answer reveals it. */
-function RevealedField({ children }: { children: ReactNode }) {
+/**
+ * Wraps each question so it rises into place as the previous answer reveals it. Hidden questions
+ * stay mounted so the column keeps its full height — otherwise the vertically centered layout would
+ * drag the title and step header upwards every time an answer revealed the next question.
+ */
+function RevealedField({ isRevealed, children }: { isRevealed: boolean; children: ReactNode }) {
   return (
     <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
+      inert={!isRevealed}
+      initial={false}
+      animate={{ opacity: isRevealed ? 1 : 0, y: isRevealed ? 0 : 12 }}
       transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
     >
       {children}
@@ -226,29 +231,23 @@ export function AgentsPersonalizePage() {
           onChange={handleReadinessChange}
         />
 
-        {readiness ? (
-          <RevealedField>
-            <QuestionSelect
-              label="Who should your agent communicate with?"
-              options={AGENT_AUDIENCE_OPTIONS}
-              value={audience}
-              onChange={handleAudienceChange}
-            />
-          </RevealedField>
-        ) : null}
+        <RevealedField isRevealed={Boolean(readiness)}>
+          <QuestionSelect
+            label="Who should your agent communicate with?"
+            options={AGENT_AUDIENCE_OPTIONS}
+            value={audience}
+            onChange={handleAudienceChange}
+          />
+        </RevealedField>
 
-        {audience ? (
-          <RevealedField>
-            <ChannelQuestion selected={channels} onToggle={handleChannelToggle} />
-          </RevealedField>
-        ) : null}
+        <RevealedField isRevealed={Boolean(audience)}>
+          <ChannelQuestion selected={channels} onToggle={handleChannelToggle} />
+        </RevealedField>
       </div>
 
-      {audience ? (
-        <RevealedField>
-          <OnboardingContinueFooter onContinue={handleContinue} />
-        </RevealedField>
-      ) : null}
+      <RevealedField isRevealed={Boolean(audience)}>
+        <OnboardingContinueFooter onContinue={handleContinue} />
+      </RevealedField>
     </>
   );
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Design review follow-up on the personalize onboarding step shipped in #12183.

Linear: [NV-8514](https://linear.app/novu/issue/NV-8514/onboarding-personalize-anchor-title-position-and-soften-channel-pill)

**1. The title no longer moves as questions appear**

The left column is vertically centered, so mounting Q2 / Q3 / the Continue footer grew the column and dragged the step header, title, and subtitle upward on every answer. `RevealedField` now keeps hidden questions mounted (`inert` + animated `opacity`/`y`) instead of conditionally rendering them, so the column reserves its full height from first paint and only the newly revealed question animates.

This matches the design, where `2/3`, the title, and the subtitle sit at the same y in the Q1, Q2, and Q3 frames — and at the same y as the step-1 use-case picker.

**2. Channel pills hover to `stroke-soft`**

The pills hovered to `border-stroke-strong` (`#0e121b`, near-black), which read as a harsh jump on a light survey. Hover is now `stroke-soft`, and the resting border drops to `stroke-weak` so the hover is still perceptible. `stroke-weak` is also what the Figma frame actually uses at rest — sampled `#f2f5f8` on the unselected pill borders, which is `--stroke-weak` (`neutral-100`), not the `#e1e4ea` `stroke-soft` that shipped. The redundant `hover:bg-white` on an already-white pill is gone. Selected pills are untouched.

This mirrors the existing `border-stroke-weak` → `hover:border-stroke-soft` pattern in `step-editor-mode-toggle.tsx`.

### Screenshots

<!-- Add before/after of the personalize step: collapsed (Q1 only) vs expanded (Q1-Q3 + footer), plus a pill hover -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A — dashboard-only

### Special notes for your reviewer

- Presentation only: no telemetry, routing, gating, or answer-handling changes.
- Hidden questions are in the DOM but `inert`, so they take no focus and are not exposed to assistive tech. Their Radix selects cannot be opened while hidden.
- Reserving the full height means a short viewport can show the column's scrollbar from first paint rather than only once expanded — that is the trade-off for a title that does not jump.

</details>

## Test plan
- [ ] Conversations path: answering Q1 then Q2 leaves `2/3`, the title, and the subtitle at a fixed y — only the new question and footer animate in
- [ ] Continue footer still only becomes reachable after Q2 is answered; tabbing from Q1 never lands on a hidden question or "Book a demo"
- [ ] Q2's select cannot be opened before Q1 is answered
- [ ] Unselected channel pills rest on a faint border and hover one step darker; selected pills keep their brand tint
- [ ] Telemetry still fires once per answer and once on submit

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refines the personalize onboarding presentation.

- Keeps later questions and the footer mounted but inert until revealed, preserving the title position.
- Softens the resting and hover borders of unselected channel pills.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The changed fields retain their existing reveal conditions for visibility while inert prevents interaction with hidden controls, and the channel-chip changes are limited to presentation classes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/agents-personalize-page.tsx | Keeps progressive fields mounted in normal flow while using inert, opacity, and translation to preserve layout and prevent premature interaction. |
| apps/dashboard/src/components/onboarding/personalize/channel-chip.tsx | Changes only the unselected channel pill border tokens, leaving selection and click behavior unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): pin personalize title an..."](https://github.com/novuhq/novu/commit/824e6e5fcb3b5869e5d3a2a7716638d6dc33f415) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49731787)</sub>

<!-- /greptile_comment -->