### PR TITLE
fix(dashboard): hide preview provider dropdown when viewing override fixes NV-8508

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview-panel.tsx
@@ -37,7 +37,7 @@ function extractChatPreview(previewData?: GeneratePreviewResponseDto): ChatRende
  */
 function ChatOverridePreview({ isPreviewPending, previewData }: ChatPreviewPanelProps) {
   const { providerOptions, providerOverrides } = useProviderOverrideOptions(ChannelTypeEnum.CHAT);
-  const { previewSource, setPreviewSource } = useContentSource();
+  const { selectedSource, previewSource, setPreviewSource } = useContentSource();
 
   const preview = extractChatPreview(previewData);
   const body = preview?.body ?? '';
@@ -49,6 +49,8 @@ function ChatOverridePreview({ isPreviewPending, previewData }: ChatPreviewPanel
     formOverrides: providerOverrides,
     previewOverrides: preview?.providerOverrides,
   });
+
+  const isViewingOverride = selectedSource !== DEFAULT_CONTENT_SOURCE;
 
   const renderBody = () => {
     if (!activeProviderId || !annotatedPreview) {
@@ -83,15 +85,17 @@ function ChatOverridePreview({ isPreviewPending, previewData }: ChatPreviewPanel
 
   return (
     <div className="-mx-3 -mt-3 flex h-full min-h-0 w-full flex-col">
-      <div className="border-stroke-soft bg-bg-weak flex h-7 shrink-0 items-center border-b">
-        <ContentSourceSelector
-          selectedSource={previewSource}
-          providers={providerOptions}
-          showEscapeHatchBadge
-          onSelectSource={setPreviewSource}
-        />
-        <div className="h-full flex-1" />
-      </div>
+      {!isViewingOverride && (
+        <div className="border-stroke-soft bg-bg-weak flex h-7 shrink-0 items-center border-b">
+          <ContentSourceSelector
+            selectedSource={previewSource}
+            providers={providerOptions}
+            showEscapeHatchBadge
+            onSelectSource={setPreviewSource}
+          />
+          <div className="h-full flex-1" />
+        </div>
+      )}
 
       <div className="flex min-h-0 flex-1 flex-col p-3">{renderBody()}</div>
     </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview-panel.tsx
@@ -8,11 +8,11 @@ import { Skeleton } from '@/components/primitives/skeleton';
 import { AnnotatedOverrideJson } from '@/components/workflow-editor/steps/shared/provider-overrides/annotated-override-json';
 import { DEFAULT_CONTENT_SOURCE } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source';
 import { useContentSource } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source-context';
-import { ContentSourceSelector } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source-selector';
 import {
   getMergedOverrideHint,
   useAnnotatedOverridePreview,
 } from '@/components/workflow-editor/steps/shared/provider-overrides/override-preview';
+import { PreviewSourceBar } from '@/components/workflow-editor/steps/shared/provider-overrides/preview-source-bar';
 import { useProviderOverrideOptions } from '@/components/workflow-editor/steps/shared/provider-overrides/use-provider-override-options';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { ChatPreview } from './chat-preview';
@@ -85,17 +85,13 @@ function ChatOverridePreview({ isPreviewPending, previewData }: ChatPreviewPanel
 
   return (
     <div className="-mx-3 -mt-3 flex h-full min-h-0 w-full flex-col">
-      {!isViewingOverride && (
-        <div className="border-stroke-soft bg-bg-weak flex h-7 shrink-0 items-center border-b">
-          <ContentSourceSelector
-            selectedSource={previewSource}
-            providers={providerOptions}
-            showEscapeHatchBadge
-            onSelectSource={setPreviewSource}
-          />
-          <div className="h-full flex-1" />
-        </div>
-      )}
+      <PreviewSourceBar
+        visible={!isViewingOverride}
+        selectedSource={previewSource}
+        providers={providerOptions}
+        showEscapeHatchBadge
+        onSelectSource={setPreviewSource}
+      />
 
       <div className="flex min-h-0 flex-1 flex-col p-3">{renderBody()}</div>
     </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/preview-source-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/preview-source-bar.tsx
@@ -1,0 +1,48 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { type ContentSource, type ProviderOverrideOption } from './content-source';
+import { ContentSourceSelector } from './content-source-selector';
+
+type PreviewSourceBarProps = {
+  visible: boolean;
+  selectedSource: ContentSource;
+  providers: ProviderOverrideOption[];
+  showEscapeHatchBadge?: boolean;
+  onSelectSource: (source: ContentSource) => void;
+};
+
+/**
+ * Collapsible preview provider picker. Animates height/opacity so switching the editor between
+ * default content and a provider override doesn't hard-cut the bar in/out.
+ */
+export function PreviewSourceBar({
+  visible,
+  selectedSource,
+  providers,
+  showEscapeHatchBadge,
+  onSelectSource,
+}: PreviewSourceBarProps) {
+  return (
+    <AnimatePresence initial={false}>
+      {visible ? (
+        <motion.div
+          key="preview-source-bar"
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: 'auto', opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.2, ease: 'easeInOut' }}
+          className="shrink-0 overflow-hidden"
+        >
+          <div className="border-stroke-soft bg-bg-weak flex h-7 items-center border-b">
+            <ContentSourceSelector
+              selectedSource={selectedSource}
+              providers={providers}
+              showEscapeHatchBadge={showEscapeHatchBadge}
+              onSelectSource={onSelectSource}
+            />
+            <div className="h-full flex-1" />
+          </div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx
@@ -92,7 +92,7 @@ export const ToolPreview = ({ isPreviewPending, previewData }: ToolPreviewProps)
   const body = preview?.body ?? '';
 
   const { providerOptions, providerOverrides } = useToolOverrideProviderOptions();
-  const { previewSource, setPreviewSource } = useContentSource();
+  const { selectedSource, previewSource, setPreviewSource } = useContentSource();
   const activeProviderId = previewSource === DEFAULT_CONTENT_SOURCE ? undefined : previewSource;
   const isWebhookPreview = activeProviderId === ToolProviderIdEnum.Webhook;
 
@@ -159,16 +159,20 @@ export const ToolPreview = ({ isPreviewPending, previewData }: ToolPreviewProps)
     previewLabel = 'Rendered override JSON';
   }
 
+  const isViewingOverride = selectedSource !== DEFAULT_CONTENT_SOURCE;
+
   return (
     <div className="-mx-3 -mt-3 flex h-full min-h-0 w-full flex-col">
-      <div className="border-stroke-soft bg-bg-weak flex h-7 shrink-0 items-center border-b">
-        <ContentSourceSelector
-          selectedSource={previewSource}
-          providers={providerOptions}
-          onSelectSource={setPreviewSource}
-        />
-        <div className="h-full flex-1" />
-      </div>
+      {!isViewingOverride && (
+        <div className="border-stroke-soft bg-bg-weak flex h-7 shrink-0 items-center border-b">
+          <ContentSourceSelector
+            selectedSource={previewSource}
+            providers={providerOptions}
+            onSelectSource={setPreviewSource}
+          />
+          <div className="h-full flex-1" />
+        </div>
+      )}
 
       <div className="relative flex min-h-0 flex-1 flex-col gap-3 p-3">
         <div className="flex h-full min-h-0 w-full flex-col gap-3 rounded-xl border border-dashed border-[#E1E4EA] p-3">

--- a/apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx
@@ -13,12 +13,12 @@ import {
   type ProviderOverrideOption,
 } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source';
 import { useContentSource } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source-context';
-import { ContentSourceSelector } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source-selector';
 import {
   getMergedOverrideHint,
   PREVIEW_PANEL_CLASS,
   useAnnotatedOverridePreview,
 } from '@/components/workflow-editor/steps/shared/provider-overrides/override-preview';
+import { PreviewSourceBar } from '@/components/workflow-editor/steps/shared/provider-overrides/preview-source-bar';
 import { useToolOverrideProviderOptions } from './use-tool-override-provider-options';
 
 type ToolPreviewResult = {
@@ -163,16 +163,12 @@ export const ToolPreview = ({ isPreviewPending, previewData }: ToolPreviewProps)
 
   return (
     <div className="-mx-3 -mt-3 flex h-full min-h-0 w-full flex-col">
-      {!isViewingOverride && (
-        <div className="border-stroke-soft bg-bg-weak flex h-7 shrink-0 items-center border-b">
-          <ContentSourceSelector
-            selectedSource={previewSource}
-            providers={providerOptions}
-            onSelectSource={setPreviewSource}
-          />
-          <div className="h-full flex-1" />
-        </div>
-      )}
+      <PreviewSourceBar
+        visible={!isViewingOverride}
+        selectedSource={previewSource}
+        providers={providerOptions}
+        onSelectSource={setPreviewSource}
+      />
 
       <div className="relative flex min-h-0 flex-1 flex-col gap-3 p-3">
         <div className="flex h-full min-h-0 w-full flex-col gap-3 rounded-xl border border-dashed border-[#E1E4EA] p-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

When the Chat/Tool step editor is viewing a provider-specific override (e.g. Slack), both the **editor** and **preview** panels displayed their own provider selector dropdown — the "double Slack dropdown" issue reported in [NV-8508](https://linear.app/novu/issue/NV-8508).

This was confusing because switching the preview dropdown while editing an override serves no useful purpose. As agreed in the issue discussion:

1. Default to provider preview when the user switches to a specific provider (already worked)
2. **No toggle on the provider-specific override** in the preview panel
3. User can only view other previews when in the default editor

The fix conditionally hides the `ContentSourceSelector` bar in the preview panel when `selectedSource !== DEFAULT_CONTENT_SOURCE` (i.e., the editor is on a provider override tab). Applied to both `ChatOverridePreview` and `ToolPreview` components.

### Screenshots

**Default content — Preview shows provider dropdown:**

![Default content with dropdown visible](https://cursor.com/artifacts/c/art-c2a25b0d-502d-45c7-b737-e9ea7e94e19d)

**Slack override — Preview dropdown hidden:**

![Override view with dropdown hidden](https://cursor.com/artifacts/c/art-7d3c5524-4301-4033-b840-c62ddf20ddf4)

**Video demo:**

<a href="https://cursor.com/agents/bc-539b0405-88ab-4879-8117-87ee99d05ba0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_preview_dropdown_fix_demo.mp4"><img src="https://cursor.com/artifacts/c/art-e3952f9c-8887-423b-a077-40479d4b8fc3" alt="chat_preview_dropdown_fix_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8508](https://linear.app/novu/issue/NV-8508/the-double-slack-dropdown-in-preview-is-a-little-strange)

<div><a href="https://cursor.com/agents/bc-539b0405-88ab-4879-8117-87ee99d05ba0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539b0405-88ab-4879-8117-87ee99d05ba0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hides the preview provider selector while a Chat or Tool provider override is being edited, keeping it available for default-content previews.
- Adds a reusable animated `PreviewSourceBar`.
- Uses the editor’s selected content source to control selector visibility in Chat and Tool previews.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview-panel.tsx | Replaces the always-visible Chat preview selector with a source-aware preview bar hidden for override editing. |
| apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/preview-source-bar.tsx | Introduces a reusable animated wrapper around the existing preview content-source selector. |
| apps/dashboard/src/components/workflow-editor/steps/tool/tool-preview.tsx | Applies the same source-aware selector visibility behavior to Tool previews. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): animate preview picker w..."](https://github.com/novuhq/novu/commit/82fd741668aa8d89fb205a5e2a1ab40bfdc21afb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49757181)</sub>

<!-- /greptile_comment -->