### PR TITLE
feat(worker, application-generic): implement job deduplication and scheduling extensions in standard queue service tests fixes NV-8517

### DIFF
--- a/apps/worker/src/app/workflow/services/standard.worker.spec.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import {
   CloudflareSchedulerService,
   FeatureFlagsService,
+  JobsOptions,
   PinoLogger,
   SqsService,
   StandardQueueService,
@@ -721,6 +722,71 @@ describe('Standard Worker', () => {
       const result = await jobRepository.releaseStaleQueuedChildToPending(parent._environmentId, parent._id);
 
       expect(result).to.equal(null);
+    });
+  });
+
+  describe('queue entry dedup', () => {
+    // A long delay parks the entry in the delayed set, where the running worker cannot consume it.
+    const DELAY_MS = 60_000;
+
+    const enqueue = async (job: JobEntity, options: JobsOptions = {}) =>
+      standardQueueService.add({
+        name: job._id,
+        data: {
+          _environmentId: job._environmentId,
+          _id: job._id,
+          _organizationId: job._organizationId,
+          _userId: job._userId,
+        },
+        groupId: '0',
+        options: { delay: DELAY_MS, ...options },
+      });
+
+    /*
+     * Nothing else in this suite enqueues with a delay and afterEach empties the set, so every
+     * delayed entry belongs to the test at hand - including one BullMQ numbered itself because a
+     * caller-supplied id went missing.
+     */
+    const delayedEntryIds = async (): Promise<(string | undefined)[]> => {
+      const delayed = await standardQueueService.queue.getDelayed();
+
+      return delayed.map((entry) => entry.id);
+    };
+
+    afterEach(async () => {
+      const delayed = await standardQueueService.queue.getDelayed();
+      await Promise.all(delayed.map((entry) => entry.remove()));
+    });
+
+    it('collapses a repeated enqueue of the same job onto the live entry', async () => {
+      const created = await jobRepository.create(buildJob(JobStatusEnum.QUEUED));
+
+      await enqueue(created);
+      await enqueue(created);
+
+      expect(await delayedEntryIds()).to.deep.equal([created._id]);
+    });
+
+    it('still dedups when a caller passes an explicitly undefined job id', async () => {
+      const created = await jobRepository.create(buildJob(JobStatusEnum.QUEUED));
+
+      await enqueue(created);
+      await enqueue(created, { jobId: undefined });
+
+      expect(await delayedEntryIds()).to.deep.equal([created._id]);
+    });
+
+    it('keeps a schedule extension re-queue alongside the entry it extends', async () => {
+      const created = await jobRepository.create(buildJob(JobStatusEnum.QUEUED));
+
+      // Mirrors the ids AddJob.queueJob derives before and after an extension.
+      await enqueue(created, { jobId: created._id });
+      await enqueue(created, { jobId: `${created._id}-ext1` });
+
+      const ids = await delayedEntryIds();
+      expect(ids.length).to.equal(2);
+      expect(ids).to.include(created._id);
+      expect(ids).to.include(`${created._id}-ext1`);
     });
   });
 

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -1095,6 +1095,15 @@ export class AddJob {
       options.attempts = this.standardQueueService.DEFAULT_ATTEMPTS;
     }
 
+    /*
+     * The standard queue dedups on the job id, so a re-enqueue of a job that is still queued or
+     * running collapses onto the live entry. A schedule extension re-queues a job whose entry is
+     * the one currently being processed, so it needs an id of its own or the step would never be
+     * delivered. The counter advances on every extension, so an extended job carries no dedup
+     * protection - the atomic claim in JobRepository is what keeps that case correct.
+     */
+    options.jobId = job.scheduleExtensionsCount ? `${job._id}-ext${job.scheduleExtensionsCount}` : job._id;
+
     await this.standardQueueService.add({
       name: job._id,
       data: {

--- a/libs/application-generic/src/services/queues/standard-queue.service.spec.ts
+++ b/libs/application-generic/src/services/queues/standard-queue.service.spec.ts
@@ -1,4 +1,5 @@
 import { CommunityOrganizationRepository } from '@novu/dal';
+import { ApiServiceLevelEnum, QueueBackendMode } from '@novu/shared';
 import { PinoLogger } from '../../logging';
 import { CloudflareSchedulerService } from '../cloudflare-scheduler';
 import { FeatureFlagsService } from '../feature-flags';
@@ -12,12 +13,14 @@ const mockCloudflareSchedulerService = {
   scheduleJob: jest.fn(),
 } as unknown as CloudflareSchedulerService;
 
+const ORGANIZATION_ID = 'standard-organization-id';
+
 const mockFeatureFlagsService = {
-  getFlag: jest.fn(),
+  getFlag: jest.fn().mockResolvedValue(QueueBackendMode.BULLMQ),
 } as unknown as FeatureFlagsService;
 
 const mockOrganizationRepository = {
-  findOne: jest.fn(),
+  findOne: jest.fn().mockResolvedValue({ _id: ORGANIZATION_ID, apiServiceLevel: ApiServiceLevelEnum.FREE }),
 } as unknown as CommunityOrganizationRepository;
 
 const mockSqsService = {
@@ -58,9 +61,7 @@ describe('Standard Queue service', () => {
 
     it('should be initialised properly', async () => {
       expect(standardQueueService).toBeDefined();
-      expect(Object.keys(standardQueueService)).toEqual(
-        expect.arrayContaining(['topic', 'DEFAULT_ATTEMPTS', 'instance', 'queue'])
-      );
+      expect(Object.keys(standardQueueService)).toEqual(expect.arrayContaining(['topic', 'DEFAULT_ATTEMPTS', 'queue']));
       expect(standardQueueService.DEFAULT_ATTEMPTS).toEqual(3);
       expect(standardQueueService.topic).toEqual('standard');
       expect(await standardQueueService.getStatus()).toEqual({
@@ -112,7 +113,7 @@ describe('Standard Queue service', () => {
       const [standardQueueJob] = standardQueueJobs;
       expect(standardQueueJob).toMatchObject(
         expect.objectContaining({
-          id: '1',
+          id: jobId,
           name: jobId,
           data: jobData,
           attemptsMade: 0,
@@ -147,7 +148,7 @@ describe('Standard Queue service', () => {
       const [standardQueueJob] = standardQueueJobs;
       expect(standardQueueJob).toMatchObject(
         expect.objectContaining({
-          id: '2',
+          id: jobId,
           name: jobId,
           data: {
             _id: jobId,
@@ -158,6 +159,49 @@ describe('Standard Queue service', () => {
           attemptsMade: 0,
         })
       );
+    });
+
+    it('should not add the same job twice', async () => {
+      const jobId = 'standard-job-id-duplicated';
+      const jobData = {
+        _id: jobId,
+        _environmentId: 'standard-environment-id',
+        _organizationId: ORGANIZATION_ID,
+        _userId: 'standard-user-id',
+      };
+
+      await standardQueueService.add({ name: jobId, data: jobData, groupId: ORGANIZATION_ID });
+      await standardQueueService.add({ name: jobId, data: jobData, groupId: ORGANIZATION_ID });
+
+      expect(await standardQueueService.queue.getWaitingCount()).toEqual(1);
+
+      const standardQueueJobs = await standardQueueService.queue.getJobs();
+      expect(standardQueueJobs.length).toEqual(1);
+      expect(standardQueueJobs[0].id).toEqual(jobId);
+    });
+
+    it('should honour a job id provided by the caller', async () => {
+      const jobId = 'standard-job-id-with-custom-id';
+      const customJobId = `${jobId}-ext1`;
+      const jobData = {
+        _id: jobId,
+        _environmentId: 'standard-environment-id',
+        _organizationId: ORGANIZATION_ID,
+        _userId: 'standard-user-id',
+      };
+
+      await standardQueueService.add({ name: jobId, data: jobData, groupId: ORGANIZATION_ID });
+      await standardQueueService.add({
+        name: jobId,
+        data: jobData,
+        groupId: ORGANIZATION_ID,
+        options: { jobId: customJobId },
+      });
+
+      expect(await standardQueueService.queue.getWaitingCount()).toEqual(2);
+
+      const standardQueueJobs = await standardQueueService.queue.getJobs();
+      expect(standardQueueJobs.map((job) => job.id).sort()).toEqual([customJobId, jobId]);
     });
   });
 

--- a/libs/application-generic/src/services/queues/standard-queue.service.ts
+++ b/libs/application-generic/src/services/queues/standard-queue.service.ts
@@ -38,16 +38,30 @@ export class StandardQueueService extends QueueBaseService {
   }
 
   public async add(data: IStandardJobDto) {
-    const delay = data.options?.delay || 0;
+    /*
+     * The job name is the Mongo job id, so defaulting the BullMQ job id to it makes a repeated
+     * insertion of the same job a no-op while it is queued, delayed or active. BullMQ only - the
+     * SQS route derives its own message id. Reusing an id later depends on the entry being dropped
+     * once it settles: addToBullMQ defaults removeOnComplete and removeOnFail to true but lets
+     * caller options override them, so a caller passing removeOnFail: false would leave a tombstone
+     * that blocks every later insert of that job. Callers that deliberately need a second live
+     * entry for one job (schedule extensions) pass an id of their own.
+     */
+    const jobData: IStandardJobDto = {
+      ...data,
+      options: { ...data.options, jobId: data.options?.jobId ?? data.name },
+    };
+
+    const delay = jobData.options?.delay || 0;
     const hasDelay = delay > 0;
 
     // For delayed jobs, use existing BullMQ + CF Scheduler system
     if (hasDelay) {
-      return await this.handleDelayedJob(data, delay);
+      return await this.handleDelayedJob(jobData, delay);
     }
 
     // For immediate jobs (delay = 0), let QueueBaseService handle SQS/BullMQ routing
-    return await super.add(data);
+    return await super.add(jobData);
   }
 
   private async handleDelayedJob(data: IStandardJobDto, delay: number) {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds deterministic BullMQ IDs to deduplicate standard-queue jobs and gives schedule extensions count-based IDs.
- Defaults standard queue entries to their job name as the BullMQ job ID.
- Assigns distinct IDs to schedule-extension requeues.
- Adds unit and worker coverage for duplicate and extension enqueues.

<h3>Confidence Score: 4/5</h3>

The scheduler callback collision must be fixed before merging because it can drop scheduled notification steps in Cloudflare Scheduler LIVE mode.

The new default job ID causes the executable callback enqueue and its non-executable BullMQ shadow to share an identity, allowing BullMQ deduplication to retain only the copy that workers intentionally skip.

**Files Needing Attention:** libs/application-generic/src/services/queues/standard-queue.service.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/services/queues/standard-queue.service.ts | Adds queue-entry deduplication but makes scheduler callback jobs collide with LIVE-mode BullMQ shadow entries. |
| apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts | Assigns base IDs to normal jobs and count-suffixed IDs to schedule-extension requeues. |
| libs/application-generic/src/services/queues/standard-queue.service.spec.ts | Covers direct BullMQ deduplication and explicit custom IDs but not the Cloudflare Scheduler callback collision. |
| apps/worker/src/app/workflow/services/standard.worker.spec.ts | Adds integration coverage for repeated and extension enqueues in the direct delayed BullMQ path. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Fapplication-generic%2Fsrc%2Fservices%2Fqueues%2Fstandard-queue.service.ts%3A52%0A**Scheduler%20callback%20identity%20collision**%0A%0AWhen%20Cloudflare%20Scheduler%20LIVE%20mode%20retains%20a%20delayed%20BullMQ%20shadow%20marked%20%60skipProcessing%60%2C%20this%20fallback%20assigns%20the%20scheduler%20callback%20the%20same%20base%20job%20ID.%20BullMQ%20treats%20the%20executable%20callback%20as%20a%20duplicate%20while%20the%20shadow%20still%20exists%2C%20so%20the%20worker%20skips%20the%20retained%20entry%20and%20the%20scheduled%20notification%20step%20is%20lost.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12214&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/application-generic/src/services/queues/standard-queue.service.ts:52
**Scheduler callback identity collision**

When Cloudflare Scheduler LIVE mode retains a delayed BullMQ shadow marked `skipProcessing`, this fallback assigns the scheduler callback the same base job ID. BullMQ treats the executable callback as a duplicate while the shadow still exists, so the worker skips the retained entry and the scheduled notification step is lost.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker, application-generic): imple..."](https://github.com/novuhq/novu/commit/d03b384102e96990f11a1a1cce03998fdc3e4c2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50024237)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
</details>

<!-- /greptile_comment -->