### PR TITLE
chore(dashboard): rich chat editor - default preview fixes NV-8516

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview-panel.tsx
@@ -98,6 +98,11 @@ function ChatOverridePreview({ isPreviewPending, previewData }: ChatPreviewPanel
   );
 }
 
+/**
+ * Chat step preview router. The rich default-preview shell, platform selector, warning banners,
+ * and editor content-source sync live exclusively in `ChatBlockEditorPreview` and are only mounted
+ * when `IS_CHAT_BLOCK_EDITOR_ENABLED` is on.
+ */
 export const ChatPreviewPanel = (props: ChatPreviewPanelProps) => {
   const isBlockEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CHAT_BLOCK_EDITOR_ENABLED);
   const areProviderOverridesEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CHAT_PROVIDER_OVERRIDES_ENABLED);

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/chat-block-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/chat-block-editor-preview.tsx
@@ -1,20 +1,46 @@
-import { ChannelTypeEnum, type ChatRenderOutput, type GeneratePreviewResponseDto } from '@novu/shared';
-import { useState } from 'react';
+import {
+  ChannelTypeEnum,
+  type ChatRenderOutput,
+  FeatureFlagsKeysEnum,
+  type GeneratePreviewResponseDto,
+} from '@novu/shared';
+import { type ReactNode, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 import { Skeleton } from '@/components/primitives/skeleton';
 import { AnnotatedOverrideJson } from '@/components/workflow-editor/steps/shared/provider-overrides/annotated-override-json';
 import {
+  type ContentSource,
+  DEFAULT_CONTENT_SOURCE,
   PROVIDER_OVERRIDES_FIELD,
   type ProviderOverrides,
 } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source';
+import { useOptionalContentSource } from '@/components/workflow-editor/steps/shared/provider-overrides/content-source-context';
 import {
   getMergedOverrideHint,
   useAnnotatedOverridePreview,
 } from '@/components/workflow-editor/steps/shared/provider-overrides/override-preview';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { buildRoute, ROUTES } from '@/utils/routes';
 import { ChatShellContent } from './chat-shell-content';
 import { PlatformSelector } from './platform-selector';
-import { useConfiguredChatProviders } from './use-configured-chat-providers';
+import { PreviewInfoHint } from './preview-info-hint';
+import { PreviewWarningBanner } from './preview-warning-banner';
+import { isChatPreviewSupported } from './shells/shell-registry';
+import {
+  type ChatPreviewProviderOption,
+  DEFAULT_PREVIEW_PROVIDER_ID,
+  useConfiguredChatProviders,
+} from './use-configured-chat-providers';
+
+function contentSourceToPreviewProviderId(source: ContentSource): string {
+  return source === DEFAULT_CONTENT_SOURCE ? DEFAULT_PREVIEW_PROVIDER_ID : source;
+}
+
+function previewProviderIdToContentSource(providerId: string): ContentSource {
+  return providerId === DEFAULT_PREVIEW_PROVIDER_ID ? DEFAULT_CONTENT_SOURCE : (providerId as ContentSource);
+}
 
 type ChatBlockEditorPreviewProps = {
   isPreviewPending: boolean;
@@ -27,16 +53,120 @@ function extractChatPreview(previewData?: GeneratePreviewResponseDto): ChatRende
   return result?.type === ChannelTypeEnum.CHAT ? (result.preview as ChatRenderOutput) : undefined;
 }
 
+type ShellBodyProps = {
+  providerId: string;
+  card?: ChatRenderOutput['card'];
+  body: string;
+  isPreviewPending: boolean;
+  isPreviewSupported: boolean;
+};
+
+function ShellBody({ providerId, card, body, isPreviewPending, isPreviewSupported }: ShellBodyProps) {
+  if (!isPreviewSupported) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <ChatShellContent
+          providerId={providerId}
+          variant="default"
+          card={card}
+          body={body}
+          isPreviewPending={isPreviewPending}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-col gap-3">
+      <ChatShellContent
+        providerId={providerId}
+        variant="default"
+        card={card}
+        body={body}
+        isPreviewPending={isPreviewPending}
+      />
+      <PreviewInfoHint />
+    </div>
+  );
+}
+
+type PreviewFrameProps = {
+  activeOption?: ChatPreviewProviderOption;
+  options: ChatPreviewProviderOption[];
+  onSelectProvider: (providerId: string) => void;
+  warningBanner: ReactNode;
+  children: ReactNode;
+};
+
+function PreviewFrame({ activeOption, options, onSelectProvider, warningBanner, children }: PreviewFrameProps) {
+  return (
+    <div className="-m-3 flex h-full min-h-0 flex-col">
+      <PlatformSelector activeOption={activeOption} options={options} onSelect={onSelectProvider} />
+      {warningBanner}
+      <div className="flex min-h-0 flex-1 flex-col p-3">{children}</div>
+    </div>
+  );
+}
+
+function usePreviewWarningBanner({
+  activeProviderId,
+  activeOption,
+  hasConnectedIntegrations,
+  hideBanner,
+}: {
+  activeProviderId: string;
+  activeOption?: ChatPreviewProviderOption;
+  hasConnectedIntegrations: boolean;
+  hideBanner?: boolean;
+}) {
+  const navigate = useNavigate();
+  const isDefaultPreview = activeProviderId === DEFAULT_PREVIEW_PROVIDER_ID;
+  const showProviderWarning = !isDefaultPreview && activeOption?.isConnected === false;
+
+  const handleConnect = () => {
+    if (isDefaultPreview) {
+      void navigate(ROUTES.INTEGRATIONS_CONNECT);
+
+      return;
+    }
+
+    void navigate(buildRoute(ROUTES.INTEGRATIONS_CONNECT_PROVIDER, { providerId: activeProviderId }));
+  };
+
+  if (hideBanner) {
+    return null;
+  }
+
+  if (isDefaultPreview && !hasConnectedIntegrations) {
+    return (
+      <PreviewWarningBanner
+        message="Formatting may vary across providers."
+        ctaLabel="Connect a provider →"
+        onConnect={handleConnect}
+      />
+    );
+  }
+
+  if (showProviderWarning) {
+    return (
+      <PreviewWarningBanner
+        message="No integration available for this provider."
+        ctaLabel={`Connect ${activeOption?.displayName ?? activeProviderId} →`}
+        onConnect={handleConnect}
+      />
+    );
+  }
+
+  return null;
+}
+
 /**
- * Rich-chat preview (behind `IS_CHAT_BLOCK_EDITOR_ENABLED`). A provider dropdown scoped to the
- * environment's active chat integrations drives which shell renders. For the selected provider we
- * show its override preview when one is authored, otherwise the compiled card, otherwise the body.
+ * Rich preview without provider-override coupling. Platform selection is local; the
+ * `providerOverrides` form field is never watched.
  */
-export function ChatBlockEditorPreview({ isPreviewPending, previewData }: ChatBlockEditorPreviewProps) {
-  const { options, defaultProviderId } = useConfiguredChatProviders();
+function ChatBlockEditorPreviewBase({ isPreviewPending, previewData }: ChatBlockEditorPreviewProps) {
+  const { options, defaultProviderId, isLoading } = useConfiguredChatProviders();
   const [selectedProviderId, setSelectedProviderId] = useState<string | undefined>();
-  const { watch } = useFormContext();
-  const providerOverrides = watch(PROVIDER_OVERRIDES_FIELD) as ProviderOverrides | undefined;
 
   const activeProviderId =
     selectedProviderId && options.some((option) => option.providerId === selectedProviderId)
@@ -45,10 +175,61 @@ export function ChatBlockEditorPreview({ isPreviewPending, previewData }: ChatBl
   const activeOption = options.find((option) => option.providerId === activeProviderId);
 
   const preview = extractChatPreview(previewData);
-  const card = preview?.card;
-  const body = preview?.body ?? '';
+  const isPreviewSupported = isChatPreviewSupported(activeProviderId);
+  const hasConnectedIntegrations = options.some(
+    (option) => option.providerId !== DEFAULT_PREVIEW_PROVIDER_ID && option.isConnected
+  );
 
+  const warningBanner = usePreviewWarningBanner({
+    activeProviderId,
+    activeOption,
+    hasConnectedIntegrations,
+    hideBanner: isLoading,
+  });
+
+  return (
+    <PreviewFrame
+      activeOption={activeOption}
+      options={options}
+      onSelectProvider={setSelectedProviderId}
+      warningBanner={warningBanner}
+    >
+      <ShellBody
+        providerId={activeProviderId}
+        card={preview?.card}
+        body={preview?.body ?? ''}
+        isPreviewPending={isPreviewPending}
+        isPreviewSupported={isPreviewSupported}
+      />
+    </PreviewFrame>
+  );
+}
+
+/**
+ * Rich preview with editor content-source sync and override JSON. Split out so the
+ * overrides-flag-off path never subscribes to `providerOverrides` or `ContentSourceContext`.
+ */
+function ChatBlockEditorPreviewWithOverrides({ isPreviewPending, previewData }: ChatBlockEditorPreviewProps) {
+  const { options, defaultProviderId, isLoading } = useConfiguredChatProviders();
+  const contentSource = useOptionalContentSource();
+  const { watch } = useFormContext();
+  const providerOverrides = watch(PROVIDER_OVERRIDES_FIELD) as ProviderOverrides | undefined;
+
+  const resolvedProviderId = contentSource
+    ? contentSourceToPreviewProviderId(contentSource.previewSource)
+    : defaultProviderId;
+  const activeProviderId = options.some((option) => option.providerId === resolvedProviderId)
+    ? resolvedProviderId
+    : defaultProviderId;
+  const activeOption = options.find((option) => option.providerId === activeProviderId);
+
+  const preview = extractChatPreview(previewData);
+  const body = preview?.body ?? '';
+  const isPreviewSupported = isChatPreviewSupported(activeProviderId);
   const hasOverride = !!providerOverrides && activeProviderId in providerOverrides;
+  const hasConnectedIntegrations = options.some(
+    (option) => option.providerId !== DEFAULT_PREVIEW_PROVIDER_ID && option.isConnected
+  );
 
   const annotatedPreview = useAnnotatedOverridePreview({
     body,
@@ -57,9 +238,18 @@ export function ChatBlockEditorPreview({ isPreviewPending, previewData }: ChatBl
     previewOverrides: preview?.providerOverrides,
   });
 
+  const warningBanner = usePreviewWarningBanner({
+    activeProviderId,
+    activeOption,
+    hasConnectedIntegrations,
+    hideBanner: isLoading || hasOverride,
+  });
+
+  const handleSelectProvider = (providerId: string) => {
+    contentSource?.setPreviewSource(previewProviderIdToContentSource(providerId));
+  };
+
   const renderContent = () => {
-    // An authored override always wins over the shell/card/body — including the
-    // "preview not supported" state for providers without a dedicated shell.
     if (hasOverride) {
       if (isPreviewPending || !annotatedPreview) {
         return <Skeleton className="h-24 w-full shrink-0 rounded-md" />;
@@ -87,20 +277,39 @@ export function ChatBlockEditorPreview({ isPreviewPending, previewData }: ChatBl
     }
 
     return (
-      <ChatShellContent
+      <ShellBody
         providerId={activeProviderId}
-        variant="default"
-        card={card}
+        card={preview?.card}
         body={body}
         isPreviewPending={isPreviewPending}
+        isPreviewSupported={isPreviewSupported}
       />
     );
   };
 
   return (
-    <div className="-m-3 flex h-full min-h-0 flex-col">
-      <PlatformSelector activeOption={activeOption} options={options} onSelect={setSelectedProviderId} />
-      <div className="flex min-h-0 flex-1 flex-col p-3">{renderContent()}</div>
-    </div>
+    <PreviewFrame
+      activeOption={activeOption}
+      options={options}
+      onSelectProvider={handleSelectProvider}
+      warningBanner={warningBanner}
+    >
+      {renderContent()}
+    </PreviewFrame>
   );
+}
+
+/**
+ * Rich-chat preview. Only mounted when `IS_CHAT_BLOCK_EDITOR_ENABLED` is on
+ * (see `ChatPreviewPanel`). When `IS_CHAT_PROVIDER_OVERRIDES_ENABLED` is also on, platform
+ * selection syncs with the editor content-source dropdown and authored overrides win over the shell.
+ */
+export function ChatBlockEditorPreview(props: ChatBlockEditorPreviewProps) {
+  const areProviderOverridesEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CHAT_PROVIDER_OVERRIDES_ENABLED);
+
+  if (areProviderOverridesEnabled) {
+    return <ChatBlockEditorPreviewWithOverrides {...props} />;
+  }
+
+  return <ChatBlockEditorPreviewBase {...props} />;
 }

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/platform-selector.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/platform-selector.tsx
@@ -1,4 +1,4 @@
-import { RiCheckLine, RiExpandUpDownLine } from 'react-icons/ri';
+import { RiChat3Line, RiCheckLine, RiExpandUpDownLine } from 'react-icons/ri';
 
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import {
@@ -8,13 +8,21 @@ import {
   DropdownMenuTrigger,
 } from '@/components/primitives/dropdown-menu';
 import { cn } from '@/utils/ui';
-import type { ChatPreviewProviderOption } from './use-configured-chat-providers';
+import { type ChatPreviewProviderOption, DEFAULT_PREVIEW_PROVIDER_ID } from './use-configured-chat-providers';
 
 type PlatformSelectorProps = {
   activeOption?: ChatPreviewProviderOption;
   options: ChatPreviewProviderOption[];
   onSelect: (providerId: string) => void;
 };
+
+function PlatformIcon({ option, className }: { option: ChatPreviewProviderOption; className: string }) {
+  if (option.providerId === DEFAULT_PREVIEW_PROVIDER_ID) {
+    return <RiChat3Line className={cn('text-text-sub', className)} />;
+  }
+
+  return <ProviderIcon providerId={option.providerId} providerDisplayName={option.displayName} className={className} />;
+}
 
 export function PlatformSelector({ activeOption, options, onSelect }: PlatformSelectorProps) {
   const activeProviderId = activeOption?.providerId;
@@ -28,13 +36,7 @@ export function PlatformSelector({ activeOption, options, onSelect }: PlatformSe
             aria-label="Select preview platform"
             className="border-stroke-soft bg-bg-white hover:bg-bg-weak flex h-full items-center gap-1 border-r pl-2 pr-1 transition-colors"
           >
-            {activeOption && (
-              <ProviderIcon
-                providerId={activeOption.providerId}
-                providerDisplayName={activeOption.displayName}
-                className="size-3.5 shrink-0"
-              />
-            )}
+            {activeOption && <PlatformIcon option={activeOption} className="size-3.5 shrink-0" />}
             <span className="text-label-xs text-text-sub">{activeOption?.displayName ?? activeProviderId}</span>
             <RiExpandUpDownLine className="text-text-sub size-3" />
           </button>
@@ -53,11 +55,7 @@ export function PlatformSelector({ activeOption, options, onSelect }: PlatformSe
                 onSelect={() => onSelect(option.providerId)}
               >
                 <span className="flex min-w-0 items-center gap-1.5">
-                  <ProviderIcon
-                    providerId={option.providerId}
-                    providerDisplayName={option.displayName}
-                    className="size-4 shrink-0"
-                  />
+                  <PlatformIcon option={option} className="size-4 shrink-0" />
                   <span className="text-foreground-950 truncate text-xs font-medium">{option.displayName}</span>
                 </span>
                 {isSelected && <RiCheckLine className="text-foreground-600 size-3.5 shrink-0" />}

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/preview-info-hint.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/preview-info-hint.tsx
@@ -1,0 +1,16 @@
+import { RiInformation2Line } from 'react-icons/ri';
+
+/**
+ * Static hint under the chat preview clarifying it is an approximation. Matches Figma `10980:12903`:
+ * `information-2-line` icon with `text-sub` copy, no background.
+ */
+export function PreviewInfoHint() {
+  return (
+    <div className="flex items-start gap-0.5 pt-0.5 pb-6">
+      <RiInformation2Line className="text-text-sub size-4 shrink-0" />
+      <p className="text-text-sub text-[12px] font-normal leading-4">
+        This preview shows how your message will appear. Actual rendering may vary by provider.
+      </p>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/preview-warning-banner.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/preview-warning-banner.tsx
@@ -1,0 +1,29 @@
+import { RiAlertFill } from 'react-icons/ri';
+
+/**
+ * Full-width warning band shown above the chat preview when the selected provider has no integration
+ * (or on the provider-agnostic default preview). Matches Figma `10980:12895`/`10980:12896`: a
+ * warning-tinted band bordered top and bottom, a `warning-fill` icon, warning-dark text, and an
+ * inline "Connect ..." call to action.
+ */
+type PreviewWarningBannerProps = {
+  message: string;
+  ctaLabel: string;
+  onConnect: () => void;
+};
+
+export function PreviewWarningBanner({ message, ctaLabel, onConnect }: PreviewWarningBannerProps) {
+  return (
+    <div className="border-stroke-soft bg-warning/10 flex w-full items-start gap-0.5 border-y px-1.5 py-1.75">
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        <RiAlertFill className="text-warning min-w-2.5 size-2.5" />
+      </span>
+      <p className="flex flex-wrap items-center gap-1 text-[12px] font-medium leading-4 text-[#682f12]">
+        <span>{message}</span>
+        <button type="button" onClick={onConnect} className="underline-offset-2 hover:underline">
+          {ctaLabel}
+        </button>
+      </p>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/shells/default-preview-shell.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/shells/default-preview-shell.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+
+import { CardRenderer } from '../card-renderer';
+import type { ChatShellProps } from './shell-types';
+
+/**
+ * Provider-agnostic default preview chrome (Figma `10980:11321`): a bordered card with a
+ * weak-background header bar (Novu sender line + a right-aligned "DEFAULT PREVIEW" pill) over a
+ * white message body. No avatar and no composer, so the preview reads as a neutral approximation
+ * rather than any one platform's rendering.
+ */
+function DefaultPreviewFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="border-stroke-soft pointer-events-none flex w-full flex-col overflow-clip rounded-md border">
+      <div className="border-stroke-weak bg-bg-weak flex w-full items-center justify-between border-b px-2.5 py-2">
+        <div className="flex items-center gap-1">
+          <span className="text-text-strong text-[14px] font-medium leading-5 tracking-[-0.084px]">Novu</span>
+          <span className="text-text-sub rounded-[3px] bg-[#f4f5f6] px-1 py-px text-[10px] font-normal leading-3.5 opacity-70">
+            APP
+          </span>
+          <span className="text-text-sub text-[10px] font-normal leading-3.5 opacity-70">12:45</span>
+        </div>
+        <span className="text-text-sub rounded-[3px] bg-[#f4f5f6] px-1 py-px text-[10px] font-normal leading-3.5 opacity-70">
+          DEFAULT PREVIEW
+        </span>
+      </div>
+      <div className="bg-bg-white flex w-full flex-col p-2.5">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Neutral chrome around the DSL content used for the "Default preview" option.
+ */
+export const DefaultPreviewShell = ({ card, children }: ChatShellProps) => {
+  return <DefaultPreviewFrame>{card ? <CardRenderer card={card} /> : children}</DefaultPreviewFrame>;
+};

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/shells/shell-registry.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/shells/shell-registry.tsx
@@ -1,6 +1,8 @@
 import { ChatProviderIdEnum } from '@novu/shared';
 import type { ComponentType } from 'react';
 
+import { DEFAULT_PREVIEW_PROVIDER_ID } from '../use-configured-chat-providers';
+import { DefaultPreviewShell } from './default-preview-shell';
 import { GenericContentSkeleton } from './generic-content-skeleton';
 import { GenericShell } from './generic-shell';
 import { MsTeamsShell } from './ms-teams-shell';
@@ -23,7 +25,12 @@ type ChatPreviewSkin = {
  * Per-provider preview skin (shell chrome + loading body). Add WhatsApp / Telegram entries here
  * when those shells land; unregistered providers use the generic markdown fallback.
  */
-const PREVIEW_SKIN_BY_PROVIDER: Partial<Record<ChatProviderIdEnum, ChatPreviewSkin>> = {
+const PREVIEW_SKIN_BY_PROVIDER: Record<string, ChatPreviewSkin> = {
+  [DEFAULT_PREVIEW_PROVIDER_ID]: {
+    Shell: DefaultPreviewShell,
+    ContentSkeleton: GenericContentSkeleton,
+    isSupported: true,
+  },
   [ChatProviderIdEnum.Slack]: { Shell: SlackShell, ContentSkeleton: SlackContentSkeleton, isSupported: true },
   [ChatProviderIdEnum.Novu]: { Shell: SlackShell, ContentSkeleton: SlackContentSkeleton, isSupported: true },
   [ChatProviderIdEnum.MsTeams]: { Shell: MsTeamsShell, ContentSkeleton: GenericContentSkeleton, isSupported: true },
@@ -36,7 +43,7 @@ const GENERIC_PREVIEW_SKIN: ChatPreviewSkin = {
 };
 
 export function getChatPreviewSkin(providerId: string): ChatPreviewSkin {
-  return PREVIEW_SKIN_BY_PROVIDER[providerId as ChatProviderIdEnum] ?? GENERIC_PREVIEW_SKIN;
+  return PREVIEW_SKIN_BY_PROVIDER[providerId] ?? GENERIC_PREVIEW_SKIN;
 }
 
 /** Whether the provider has a platform-accurate shell (vs. the generic markdown fallback). */

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/use-configured-chat-providers.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/use-configured-chat-providers.ts
@@ -7,11 +7,27 @@ import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 export type ChatPreviewProviderOption = {
   providerId: string;
   displayName: string;
+  /** Whether an active chat integration exists for this provider in the current environment. */
+  isConnected: boolean;
 };
 
 export type ChatPreviewProviders = {
   options: ChatPreviewProviderOption[];
   defaultProviderId: string;
+  /** True until the environment's integrations have been fetched at least once. */
+  isLoading: boolean;
+};
+
+/**
+ * Sentinel option that renders a provider-agnostic "Default preview" shell. Always the first option
+ * and the default selection, so the preview never assumes a specific platform before one is picked.
+ */
+export const DEFAULT_PREVIEW_PROVIDER_ID = 'default-preview';
+
+const DEFAULT_PREVIEW_OPTION: ChatPreviewProviderOption = {
+  providerId: DEFAULT_PREVIEW_PROVIDER_ID,
+  displayName: 'Default preview',
+  isConnected: true,
 };
 
 /** Preferred provider ordering in the preview dropdown; everything else follows alphabetically. */
@@ -49,6 +65,7 @@ function buildChatPreviewProviders(
   integrations: IIntegration[] | undefined,
   environmentId: string | undefined
 ): ChatPreviewProviders {
+  const connectedProviderIds = new Set<string>();
   const seen = new Set<string>();
   const options: ChatPreviewProviderOption[] = [];
 
@@ -57,43 +74,50 @@ function buildChatPreviewProviders(
       integration.active &&
       !integration.deleted &&
       integration.channel === ChannelTypeEnum.CHAT &&
-      integration._environmentId === environmentId &&
-      !seen.has(integration.providerId)
+      integration._environmentId === environmentId
     ) {
-      seen.add(integration.providerId);
-      options.push({
-        providerId: integration.providerId,
-        displayName: getProviderDisplayName(integration.providerId),
-      });
+      connectedProviderIds.add(integration.providerId);
+
+      if (!seen.has(integration.providerId)) {
+        seen.add(integration.providerId);
+        options.push({
+          providerId: integration.providerId,
+          displayName: getProviderDisplayName(integration.providerId),
+          isConnected: true,
+        });
+      }
     }
   }
 
   for (const providerId of ALWAYS_AVAILABLE_PROVIDER_IDS) {
     if (!seen.has(providerId)) {
       seen.add(providerId);
-      options.push({ providerId, displayName: getProviderDisplayName(providerId) });
+      options.push({
+        providerId,
+        displayName: getProviderDisplayName(providerId),
+        isConnected: connectedProviderIds.has(providerId),
+      });
     }
   }
 
   options.sort(compareProviderOptions);
 
-  const defaultProviderId =
-    options.find((option) => option.providerId === ChatProviderIdEnum.Slack)?.providerId ?? options[0].providerId;
-
-  return { options, defaultProviderId };
+  // "Default preview" always leads and is the default selection, regardless of connected providers.
+  return { options: [DEFAULT_PREVIEW_OPTION, ...options], defaultProviderId: DEFAULT_PREVIEW_PROVIDER_ID };
 }
 
 /**
  * Chat providers configured on the current environment, scoping the preview platform dropdown to
- * what the environment actually delivers to. Falls back to Slack so the preview still renders before
- * any chat integration is connected, and prefers Slack as the default when available.
+ * what the environment actually delivers to. Always leads with a provider-agnostic "Default preview"
+ * option (the default selection) and flags whether each provider has an active integration.
  */
 export function useConfiguredChatProviders(): ChatPreviewProviders {
   const { currentEnvironment } = useEnvironment();
-  const { integrations } = useFetchIntegrations();
+  const { integrations, isPending } = useFetchIntegrations();
 
-  return useMemo(
-    () => buildChatPreviewProviders(integrations, currentEnvironment?._id),
-    [integrations, currentEnvironment?._id]
-  );
+  return useMemo(() => {
+    const providers = buildChatPreviewProviders(integrations, currentEnvironment?._id);
+
+    return { ...providers, isLoading: isPending };
+  }, [integrations, currentEnvironment?._id, isPending]);
 }

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/use-configured-chat-providers.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/use-configured-chat-providers.ts
@@ -64,7 +64,7 @@ function compareProviderOptions(left: ChatPreviewProviderOption, right: ChatPrev
 function buildChatPreviewProviders(
   integrations: IIntegration[] | undefined,
   environmentId: string | undefined
-): ChatPreviewProviders {
+): Omit<ChatPreviewProviders, 'isLoading'> {
   const connectedProviderIds = new Set<string>();
   const seen = new Set<string>();
   const options: ChatPreviewProviderOption[] = [];

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-source-context.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-source-context.tsx
@@ -36,3 +36,8 @@ export const useContentSource = (): ContentSourceContextValue => {
 
   return context;
 };
+
+/** Soft read for call sites that may render outside `ContentSourceProvider`. */
+export const useOptionalContentSource = (): ContentSourceContextValue | null => {
+  return useContext(ContentSourceContext);
+};


### PR DESCRIPTION
### What changed? Why was the change needed?

Rich Chat Editor - default preview, behaviour and UI adjustments.

### Screenshots


https://github.com/user-attachments/assets/44026fdb-8e7c-4d58-8351-5ce7467ff839


https://github.com/user-attachments/assets/77ca4ca6-8d67-4573-823b-95eeff8d3ec6

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a provider-agnostic default chat preview and adjusts platform selection, integration warnings, shell rendering, and content-source synchronization.
- Adds a neutral default-preview shell and selector option.
- Splits rich-preview behavior according to the provider-overrides feature flag.
- Adds connection warnings and provider-specific integration navigation.
- Synchronizes preview platform selection with the editor content source when overrides are enabled.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge based on the available follow-up review evidence.

No blocking failure remains in the eligible follow-up scope.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/workflow-editor/steps/chat/preview/chat-block-editor-preview.tsx | Reorganizes rich chat preview rendering into override-aware and independent paths while adding content-source synchronization and warning banners. |
| apps/dashboard/src/components/workflow-editor/steps/chat/preview/use-configured-chat-providers.ts | Adds the provider-agnostic default option and connection/loading metadata to the preview provider list. |
| apps/dashboard/src/components/workflow-editor/steps/chat/preview/shells/default-preview-shell.tsx | Introduces neutral chrome for rendering chat content without assuming a provider. |
| apps/dashboard/src/components/workflow-editor/steps/chat/preview/shells/shell-registry.tsx | Registers the default-preview shell while preserving generic fallback behavior for unsupported providers. |
| apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-source-context.tsx | Adds a non-throwing context hook for preview call sites that may render without the provider. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Panel[ChatPreviewPanel] -->|Block editor enabled| Rich[ChatBlockEditorPreview]
    Rich --> Flags{Provider overrides enabled?}
    Flags -->|No| Local[Local platform selection]
    Flags -->|Yes| Synced[Content-source synchronized selection]
    Local --> Frame[PreviewFrame]
    Synced --> Override{Authored override exists?}
    Override -->|Yes| JSON[Annotated override JSON]
    Override -->|No| Frame
    Frame --> Default{Default preview selected?}
    Default -->|Yes| Neutral[DefaultPreviewShell]
    Default -->|No| Provider[Provider shell or generic fallback]
    Frame --> Warning[Optional integration warning]
```

<sub>Reviews (2): Last reviewed commit: ["chore(dashboard): fixing ts issue"](https://github.com/novuhq/novu/commit/96970d963c23b36f850dc00b61f4c67e9a93c8d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50024881)</sub>

<!-- /greptile_comment -->