### PR TITLE
ci(root): add concurrency settings to deployment and push trigger workflows for improved deployment management

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,27 @@ description: |
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
+# One deploy per environment + service combination at a time, so deploys of
+# unrelated services don't block each other. Staging cancels the in-flight
+# run so only the latest commit deploys; production queues instead of
+# cancelling to never interrupt an in-progress production deploy.
+concurrency:
+  group: >-
+    deploy-${{ github.event.inputs.environment }}${{
+      github.event.inputs.deploy_api == 'true' && '-api' || ''
+    }}${{
+      github.event.inputs.deploy_worker == 'true' && '-worker' || ''
+    }}${{
+      github.event.inputs.deploy_ws == 'true' && '-ws' || ''
+    }}${{
+      github.event.inputs.deploy_webhook == 'true' && '-webhook' || ''
+    }}${{
+      github.event.inputs.deploy_inbound_mail == 'true' && '-inbound-mail' || ''
+    }}${{
+      github.event.inputs.deploy_thalamus_observer == 'true' && '-thalamus-observer' || ''
+    }}
+  cancel-in-progress: ${{ startsWith(github.event.inputs.environment, 'staging') }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/on-push-trigger.yml
+++ b/.github/workflows/on-push-trigger.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - next
 
+# A newer push to next cancels any in-flight run so only the latest commit triggers a deploy
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: write


### PR DESCRIPTION
…
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds workflow concurrency controls intended to cancel superseded staging-trigger runs while queueing production deployments.
- Builds deployment concurrency keys from the target environment and selected services.
- Cancels an in-progress next-branch trigger when a newer push arrives.
- The new grouping permits overlapping deployment runs with different service sets, while push cancellation can omit deployment work from the canceled PR.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until overlapping deployments are serialized and canceled push-trigger runs preserve all pending service deployments.

Different service-set keys permit last-writer deployment races on shared ECS services, and replacing a trigger run can permanently omit services selected by the canceled PR.

**Files Needing Attention:** .github/workflows/deploy.yml, .github/workflows/on-push-trigger.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.yml | Adds environment-and-service-set concurrency, but overlapping service combinations can still concurrently deploy the same ECS service. |
| .github/workflows/on-push-trigger.yml | Cancels superseded push triggers without carrying the canceled PR's selected services into the replacement run. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as PR A push
    participant TA as Trigger run A
    participant B as PR B push
    participant TB as Trigger run B
    participant D as deploy.yml
    A->>TA: Select API from PR A labels
    B->>TA: Cancel via shared concurrency key
    B->>TB: Select Worker from PR B labels
    TB->>D: Dispatch Worker only
    Note over D: API changes from PR A remain undeployed
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fdeploy.yml%3A32-44%0A**Overlapping%20service%20deployments%20remain%20concurrent**%0A%0AWhen%20two%20runs%20target%20the%20same%20environment%20and%20share%20a%20service%20but%20select%20different%20overall%20service%20combinations%2C%20this%20key%20assigns%20them%20different%20concurrency%20groups%2C%20allowing%20both%20runs%20to%20update%20the%20same%20ECS%20service%20and%20an%20older%20task%20definition%20to%20supersede%20the%20newer%20deployment.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fon-push-trigger.yml%3A9-11%0A**Cancellation%20drops%20pending%20service%20deployments**%0A%0AWhen%20two%20differently%20labeled%20PRs%20merge%20before%20the%20first%20trigger%20dispatches%2C%20the%20second%20push%20cancels%20that%20run%20and%20derives%20services%20only%20from%20the%20newest%20PR%2C%20causing%20services%20changed%20by%20the%20canceled%20PR%20to%20remain%20stale%20in%20staging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/deploy.yml:32-44
**Overlapping service deployments remain concurrent**

When two runs target the same environment and share a service but select different overall service combinations, this key assigns them different concurrency groups, allowing both runs to update the same ECS service and an older task definition to supersede the newer deployment.

### Issue 2
.github/workflows/on-push-trigger.yml:9-11
**Cancellation drops pending service deployments**

When two differently labeled PRs merge before the first trigger dispatches, the second push cancels that run and derives services only from the newest PR, causing services changed by the canceled PR to remain stale in staging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(root): add concurrency settings to de..."](https://github.com/novuhq/novu/commit/ff3c6e39371638ed9607b63ecdc8f56077d5885a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50044121)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->