### PR TITLE
fix(dashboard): hide web chat channel unless IS_AGENT_WEB_CHAT_ENABLED fixes NV-8520

### DIFF
--- a/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
@@ -8,7 +8,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { AnalyticsService, encryptSecret, FeatureFlagsService, isAgentEmailEnabled } from '@novu/application-generic';
+import { AnalyticsService, encryptSecret, isAgentEmailEnabled } from '@novu/application-generic';
 import {
   type AgentEntity,
   AgentIntegrationRepository,
@@ -23,7 +23,6 @@ import {
   ChatProviderIdEnum,
   EmailProviderIdEnum,
   EnvironmentTypeEnum,
-  FeatureFlagsKeysEnum,
   FeatureNameEnum,
   getFeatureForTierAsBoolean,
 } from '@novu/shared';
@@ -44,8 +43,7 @@ export class AddAgentIntegration {
     private readonly environmentRepository: EnvironmentRepository,
     private readonly findOrCreateNovuEmail: NovuEmailProvisioningService,
     private readonly findOrCreateNovuWebChat: NovuWebChatProvisioningService,
-    private readonly analyticsService: AnalyticsService,
-    private readonly featureFlagsService: FeatureFlagsService
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: AddAgentIntegrationCommand): Promise<AgentIntegrationResponseDto> {
@@ -98,8 +96,6 @@ export class AddAgentIntegration {
     }
 
     if (command.providerId === ChatProviderIdEnum.NovuWebChat) {
-      await this.enforceWebChatFlag(command.environmentId, command.organizationId);
-
       const { response, provisionedNewLink } = await this.findOrCreateNovuWebChat.execute(
         agent._id,
         command.environmentId,
@@ -216,24 +212,6 @@ export class AddAgentIntegration {
     });
 
     return response;
-  }
-
-  /**
-   * Web chat is still pre-release: the channel is only provisionable once
-   * `IS_AGENT_WEB_CHAT_ENABLED` is on for the org/env, matching the gate on the subscriber
-   * `/v1/web-chat/*` API. Defaults to off so an LD outage cannot open the channel.
-   */
-  private async enforceWebChatFlag(environmentId: string, organizationId: string): Promise<void> {
-    const enabled = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_AGENT_WEB_CHAT_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-      environment: { _id: environmentId },
-    });
-
-    if (!enabled) {
-      throw new ForbiddenException('Agent web chat is not enabled for this organization.');
-    }
   }
 
   private async enforceEmailTier(organizationId: string): Promise<void> {

--- a/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/channels/integrations/add-agent-integration/add-agent-integration.usecase.ts
@@ -8,7 +8,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { AnalyticsService, encryptSecret, isAgentEmailEnabled } from '@novu/application-generic';
+import { AnalyticsService, encryptSecret, FeatureFlagsService, isAgentEmailEnabled } from '@novu/application-generic';
 import {
   type AgentEntity,
   AgentIntegrationRepository,
@@ -23,6 +23,7 @@ import {
   ChatProviderIdEnum,
   EmailProviderIdEnum,
   EnvironmentTypeEnum,
+  FeatureFlagsKeysEnum,
   FeatureNameEnum,
   getFeatureForTierAsBoolean,
 } from '@novu/shared';
@@ -43,7 +44,8 @@ export class AddAgentIntegration {
     private readonly environmentRepository: EnvironmentRepository,
     private readonly findOrCreateNovuEmail: NovuEmailProvisioningService,
     private readonly findOrCreateNovuWebChat: NovuWebChatProvisioningService,
-    private readonly analyticsService: AnalyticsService
+    private readonly analyticsService: AnalyticsService,
+    private readonly featureFlagsService: FeatureFlagsService
   ) {}
 
   async execute(command: AddAgentIntegrationCommand): Promise<AgentIntegrationResponseDto> {
@@ -96,6 +98,8 @@ export class AddAgentIntegration {
     }
 
     if (command.providerId === ChatProviderIdEnum.NovuWebChat) {
+      await this.enforceWebChatFlag(command.environmentId, command.organizationId);
+
       const { response, provisionedNewLink } = await this.findOrCreateNovuWebChat.execute(
         agent._id,
         command.environmentId,
@@ -212,6 +216,24 @@ export class AddAgentIntegration {
     });
 
     return response;
+  }
+
+  /**
+   * Web chat is still pre-release: the channel is only provisionable once
+   * `IS_AGENT_WEB_CHAT_ENABLED` is on for the org/env, matching the gate on the subscriber
+   * `/v1/web-chat/*` API. Defaults to off so an LD outage cannot open the channel.
+   */
+  private async enforceWebChatFlag(environmentId: string, organizationId: string): Promise<void> {
+    const enabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_AGENT_WEB_CHAT_ENABLED,
+      defaultValue: false,
+      organization: { _id: organizationId },
+      environment: { _id: environmentId },
+    });
+
+    if (!enabled) {
+      throw new ForbiddenException('Agent web chat is not enabled for this organization.');
+    }
   }
 
   private async enforceEmailTier(organizationId: string): Promise<void> {

--- a/apps/dashboard/.example.env
+++ b/apps/dashboard/.example.env
@@ -14,6 +14,8 @@ VITE_NOVU_WHATSAPP_CONFIG_ID=
 # VITE_IS_AGENT_MSTEAMS_WHATS_NEXT_ENABLED=true
 # Email agent production-readiness "What's next" guide + simplified out-of-box setup. Vite env fallback when LD client id is unset.
 # VITE_IS_AGENT_EMAIL_WHATS_NEXT_ENABLED=true
+# Agent web chat channel (pre-release). Keep off to hide the Web Chat channel from every picker. Vite env fallback when LD client id is unset.
+# VITE_IS_AGENT_WEB_CHAT_ENABLED=true
 # Workflow agent assignment ("Send & reply via agent"). Vite env fallback when LD client id is unset.
 # VITE_IS_WORKFLOW_AGENT_ASSIGNMENT_ENABLED=true
 VITE_HUBSPOT_EMBED=

--- a/apps/dashboard/src/components/agents/provider-cards.tsx
+++ b/apps/dashboard/src/components/agents/provider-cards.tsx
@@ -1,6 +1,5 @@
 import {
   ChatProviderIdEnum,
-  CONVERSATIONAL_PROVIDERS,
   type ConversationalProvider,
   EmailProviderIdEnum,
   type IIntegration,
@@ -19,6 +18,7 @@ import type { AgentIntegrationLink } from '@/api/agents';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { IS_SELF_HOSTED, IS_SELF_HOSTED_CE, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
+import { useConversationalProviders } from '@/hooks/use-conversational-providers';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { buildEdgeFadeMask, useHorizontalScrollEdges } from '@/hooks/use-horizontal-scroll-edges';
 import { useIsAgentEmailAvailable } from '@/hooks/use-is-agent-email-available';
@@ -446,12 +446,13 @@ export function ProviderCards({
 }: ProviderCardsProps) {
   const { integrations } = useFetchIntegrations();
   const isAgentEmailAvailable = useIsAgentEmailAvailable();
+  const conversationalProviders = useConversationalProviders();
   const navigate = useNavigate();
 
   // Email (NovuAgent) renders like every other connectable channel card; its integration + link
   // are only provisioned when the user clicks Connect.
   const items = useMemo(() => {
-    const built = buildCardItems(CONVERSATIONAL_PROVIDERS, integrations).filter(
+    const built = buildCardItems(conversationalProviders, integrations).filter(
       // Agent email is Enterprise/Cloud-only — never surface the card on Community.
       (item) => !(IS_SELF_HOSTED_CE && item.providerId === EmailProviderIdEnum.NovuAgent)
     );
@@ -462,7 +463,7 @@ export function ProviderCards({
 
       return 0;
     });
-  }, [integrations]);
+  }, [conversationalProviders, integrations]);
 
   const linkedIntegrationIds = useMemo(
     () => new Set(existingLinks?.map((link) => link.integration._id) ?? []),

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -1,6 +1,5 @@
 import {
   ChannelTypeEnum,
-  CONVERSATIONAL_PROVIDERS,
   type ConversationalProvider,
   EmailProviderIdEnum,
   type IIntegration,
@@ -31,6 +30,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { IS_SELF_HOSTED, IS_SELF_HOSTED_CE, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
+import { useConversationalProviders } from '@/hooks/use-conversational-providers';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useIsAgentEmailAvailable } from '@/hooks/use-is-agent-email-available';
 import { useLinkAgentIntegration } from '@/hooks/use-link-agent-integration';
@@ -188,6 +188,7 @@ export function ProviderDropdown({
   const { integrations } = useFetchIntegrations();
   const navigate = useNavigate();
   const isAgentEmailAvailable = useIsAgentEmailAvailable();
+  const conversationalProviders = useConversationalProviders();
 
   const closeDropdown = () => {
     setOpen(false);
@@ -204,8 +205,8 @@ export function ProviderDropdown({
   });
 
   const { supported: allSupported, comingSoon } = useMemo(
-    () => buildDropdownItems(CONVERSATIONAL_PROVIDERS, integrations),
-    [integrations]
+    () => buildDropdownItems(conversationalProviders, integrations),
+    [conversationalProviders, integrations]
   );
 
   const supported = useMemo(() => {

--- a/apps/dashboard/src/components/conversations/constants.ts
+++ b/apps/dashboard/src/components/conversations/constants.ts
@@ -1,11 +1,19 @@
-import { CONVERSATIONAL_PROVIDERS } from '@novu/shared';
+import type { ConversationalProvider } from '@novu/shared';
 import { ConversationFiltersData } from '@/types/conversation';
 import { getAgentChannelDisplayName } from '@/utils/agent-email-provider-display';
 
-export const PROVIDER_OPTIONS = CONVERSATIONAL_PROVIDERS.filter((p) => !p.comingSoon).map((p) => ({
-  label: getAgentChannelDisplayName(p.providerId, p.displayName),
-  value: p.providerId,
-}));
+/**
+ * Provider filter options for the conversations table. Callers pass the channels the org is
+ * allowed to see (see `useConversationalProviders`) so unreleased channels stay hidden.
+ */
+export function buildProviderFilterOptions(providers: readonly ConversationalProvider[]) {
+  return providers
+    .filter((p) => !p.comingSoon)
+    .map((p) => ({
+      label: getAgentChannelDisplayName(p.providerId, p.displayName),
+      value: p.providerId,
+    }));
+}
 
 export const defaultConversationFilters: ConversationFiltersData = {
   dateRange: '24h',

--- a/apps/dashboard/src/components/conversations/conversations-filters.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-filters.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { getAgentsListQueryKey, listAgents } from '@/api/agents';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useConversationalProviders } from '@/hooks/use-conversational-providers';
 import { useDebouncedForm } from '@/hooks/use-debounced-form';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { useHasPermission } from '@/hooks/use-has-permission';
@@ -16,7 +17,7 @@ import { IS_CLOUD } from '../../config';
 import { Button } from '../primitives/button';
 import { FacetedFormFilter } from '../primitives/form/faceted-filter/facated-form-filter';
 import { Form, FormField, FormItem, FormRoot } from '../primitives/form/form';
-import { PROVIDER_OPTIONS } from './constants';
+import { buildProviderFilterOptions } from './constants';
 
 const AGENT_FILTER_LIMIT = 100;
 const AGENT_FILTER_PARAMS = { after: undefined, before: undefined, limit: AGENT_FILTER_LIMIT, identifier: '' };
@@ -41,6 +42,8 @@ export function ConversationFilters({
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
   const canReadAgents = has({ permission: PermissionsEnum.AGENT_READ });
+  const conversationalProviders = useConversationalProviders();
+  const providerOptions = useMemo(() => buildProviderFilterOptions(conversationalProviders), [conversationalProviders]);
 
   const form = useForm<ConversationFiltersData>({
     values: filters,
@@ -125,7 +128,7 @@ export function ConversationFilters({
                 type="multi"
                 title="Provider"
                 hideSearch
-                options={PROVIDER_OPTIONS}
+                options={providerOptions}
                 selected={field.value}
                 onSelect={(values) => setValue('provider', values)}
               />

--- a/apps/dashboard/src/hooks/use-conversational-providers.ts
+++ b/apps/dashboard/src/hooks/use-conversational-providers.ts
@@ -1,0 +1,28 @@
+import {
+  ChatProviderIdEnum,
+  CONVERSATIONAL_PROVIDERS,
+  type ConversationalProvider,
+  FeatureFlagsKeysEnum,
+} from '@novu/shared';
+import { useMemo } from 'react';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
+
+/**
+ * Conversational channels the current organization is allowed to see.
+ *
+ * Web chat is not launched yet, so it stays out of every channel picker until
+ * `IS_AGENT_WEB_CHAT_ENABLED` is on — the same flag that gates the subscriber `/v1/web-chat/*`
+ * API. Read the list through this hook instead of `CONVERSATIONAL_PROVIDERS` directly so a
+ * pre-release channel can never leak into the UI.
+ */
+export function useConversationalProviders(): ConversationalProvider[] {
+  const isWebChatEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_AGENT_WEB_CHAT_ENABLED);
+
+  return useMemo(
+    () =>
+      CONVERSATIONAL_PROVIDERS.filter(
+        (provider) => isWebChatEnabled || provider.providerId !== ChatProviderIdEnum.NovuWebChat
+      ),
+    [isWebChatEnabled]
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Novu Web Chat was listed in `CONVERSATIONAL_PROVIDERS` and rendered in agent channel pickers with no check for `IS_AGENT_WEB_CHAT_ENABLED`, even though the feature is not launched.

Dashboard channel lists now read through `useConversationalProviders()`, which drops `novu-web-chat` unless the flag is on (LaunchDarkly or `VITE_IS_AGENT_WEB_CHAT_ENABLED` when LD is unset).

## Surfaces

- Agent setup provider cards (`ProviderCards`)
- Agent provider dropdown
- Conversations provider filter

## Notes

No API changes. Subscriber web-chat routes were already gated on the same flag.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d27e8e3-250e-4b32-9443-13ce3d5a781c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d27e8e3-250e-4b32-9443-13ce3d5a781c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes feature-aware conversational provider selection so the unreleased Novu Web Chat channel is hidden unless its feature flag is enabled.
- Adds `useConversationalProviders()` to filter Web Chat using `IS_AGENT_WEB_CHAT_ENABLED`.
- Applies the filtered provider list to agent provider cards, the provider dropdown, and conversation filters.
- Documents the dashboard environment-variable fallback.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The new hook consistently applies the existing feature flag to all three specified dashboard surfaces, and the removed static provider-options export has no stale repository importers.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/hooks/use-conversational-providers.ts | Adds a memoized, feature-aware provider list that excludes Novu Web Chat by default. |
| apps/dashboard/src/components/agents/provider-cards.tsx | Builds agent setup cards from the feature-filtered conversational provider list. |
| apps/dashboard/src/components/agents/provider-dropdown.tsx | Builds provider dropdown entries from the feature-filtered provider list. |
| apps/dashboard/src/components/conversations/constants.ts | Replaces the static provider options export with a provider-list-driven builder. |
| apps/dashboard/src/components/conversations/conversations-filters.tsx | Derives conversation provider filter options from currently visible conversational providers. |
| apps/dashboard/.example.env | Documents the Vite fallback for enabling the pre-release Web Chat channel. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Flag[IS_AGENT_WEB_CHAT_ENABLED] --> Hook[useConversationalProviders]
    Providers[CONVERSATIONAL_PROVIDERS] --> Hook
    Hook -->|Web Chat enabled or other provider| Visible[Visible providers]
    Hook -->|Web Chat disabled| Hidden[Exclude Novu Web Chat]
    Visible --> Cards[Agent provider cards]
    Visible --> Dropdown[Agent provider dropdown]
    Visible --> Filters[Conversation provider filter]
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): hide web chat channel un..."](https://github.com/novuhq/novu/commit/e3fd0dfbc5c6947d16a5afd8a57dc651a92a6f33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50053747)</sub>

<!-- /greptile_comment -->