### PR TITLE
fix(dashboard): restore subscriber credentials scroll in nested drawers fixes NV-8504

### DIFF
--- a/apps/dashboard/src/components/activity/components/activity-overview.tsx
+++ b/apps/dashboard/src/components/activity/components/activity-overview.tsx
@@ -149,6 +149,7 @@ export function ActivityOverview({ activity }: ActivityOverviewProps) {
           disabled={!activity.subscriber}
           className="text-start"
           subscriberId={activity.subscriber?.subscriberId || activity._subscriberId}
+          modal
         >
           <OverviewItem
             label="Subscriber ID"

--- a/apps/dashboard/src/components/subscribers/credentials/subscriber-credentials.tsx
+++ b/apps/dashboard/src/components/subscribers/credentials/subscriber-credentials.tsx
@@ -269,8 +269,8 @@ export function SubscriberCredentials({
   };
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex flex-1 flex-col gap-6 overflow-y-auto">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto">
         {groups.length > 0 ? (
           <div className="flex flex-col gap-2">
             {groups.map((group) => (
@@ -293,8 +293,8 @@ export function SubscriberCredentials({
         )}
       </div>
 
-      <Separator />
-      <div className="flex flex-col gap-2.5 px-5 py-3">
+      <Separator className="shrink-0" />
+      <div className="flex shrink-0 flex-col gap-2.5 px-5 py-3">
         {subscriber?.updatedAt && (
           <span className="text-2xs text-text-soft">
             Last updated {formatDistanceToNow(new Date(subscriber.updatedAt), { addSuffix: true })}

--- a/apps/dashboard/src/components/subscribers/subscriber-activity-list.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-activity-list.tsx
@@ -66,7 +66,7 @@ export const SubscriberActivityList = ({
         initial="hidden"
         animate="visible"
         variants={listVariants}
-        className="flex flex-1 flex-col overflow-y-auto border-t border-t-neutral-200"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto border-t border-t-neutral-200"
       >
         {Array.from({ length: 10 }).map((_, index) => (
           <motion.div
@@ -105,7 +105,7 @@ export const SubscriberActivityList = ({
           },
         },
       }}
-      className="flex flex-1 flex-col overflow-y-auto border-t border-t-neutral-200"
+      className="flex min-h-0 flex-1 flex-col overflow-y-auto border-t border-t-neutral-200"
     >
       {activities.map((activity) => {
         const status = getActivityStatus(activity.jobs);

--- a/apps/dashboard/src/components/subscribers/subscriber-activity.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-activity.tsx
@@ -112,14 +112,14 @@ export const SubscriberActivity = ({ subscriberId }: { subscriberId: string }) =
 
   return (
     <AnimatePresence mode="wait">
-      <div className="flex h-full flex-col">
+      <div className="flex h-full min-h-0 flex-col">
         <ActivityFilters
           filters={filters}
           showReset={hasChangesInFilters}
           onFiltersChange={setFilters}
           onReset={handleClearFilters}
           hide={['dateRange', 'subscriberId']}
-          className="py-2 px-2"
+          className="shrink-0 py-2 px-2"
         />
         <SubscriberActivityList
           isLoading={isLoading}
@@ -128,7 +128,7 @@ export const SubscriberActivity = ({ subscriberId }: { subscriberId: string }) =
           onClearFilters={handleClearFilters}
           onActivitySelect={handleActivitySelect}
         />
-        <span className="text-paragraph-2xs text-text-soft border-border-soft mt-auto border-t p-3 text-center">
+        <span className="text-paragraph-2xs text-text-soft border-border-soft mt-auto shrink-0 border-t p-3 text-center">
           To view more detailed activity, View{' '}
           <Link
             className="underline"

--- a/apps/dashboard/src/components/subscribers/subscriber-drawer.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-drawer.tsx
@@ -61,10 +61,11 @@ type SubscriberDrawerButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>
   subscriberId: string;
   readOnly?: boolean;
   closeOnSave?: boolean;
+  modal?: boolean;
 };
 
 export const SubscriberDrawerButton = (props: SubscriberDrawerButtonProps) => {
-  const { subscriberId, onClick, readOnly = false, closeOnSave = false, ...rest } = props;
+  const { subscriberId, onClick, readOnly = false, closeOnSave = false, modal = false, ...rest } = props;
   const [open, setOpen] = useState(false);
 
   return (
@@ -77,6 +78,7 @@ export const SubscriberDrawerButton = (props: SubscriberDrawerButtonProps) => {
         }}
       />
       <SubscriberDrawer
+        modal={modal}
         open={open}
         onOpenChange={setOpen}
         subscriberId={subscriberId}

--- a/apps/dashboard/src/components/subscribers/subscriber-overview-form.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-overview-form.tsx
@@ -19,7 +19,6 @@ import { useTelemetry } from '@/hooks/use-telemetry';
 import { formatDateSimple } from '@/utils/format-date';
 import { QueryKeys } from '@/utils/query-keys';
 import { TelemetryEvent } from '@/utils/telemetry';
-import { cn } from '@/utils/ui';
 import { ConfirmationModal } from '../confirmation-modal';
 import { Avatar, AvatarFallback, AvatarImage } from '../primitives/avatar';
 import { Button } from '../primitives/button';
@@ -196,10 +195,15 @@ export function SubscriberOverviewForm(props: SubscriberOverviewFormProps) {
   const lastNameChar = form.getValues('lastName')?.charAt(0) || '';
 
   return (
-    <div className={cn('flex h-full flex-col')}>
+    <div className="flex h-full min-h-0 flex-col">
       <Form {...form}>
-        <FormRoot autoComplete="off" noValidate onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col">
-          <div className="flex flex-1 flex-col items-stretch overflow-y-auto">
+        <FormRoot
+          autoComplete="off"
+          noValidate
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex h-full min-h-0 flex-col"
+        >
+          <div className="flex min-h-0 flex-1 flex-col items-stretch overflow-y-auto">
             <div className="flex flex-col items-stretch gap-6 p-5">
               <div className="flex items-center gap-3">
                 <Tooltip>
@@ -450,7 +454,7 @@ export function SubscriberOverviewForm(props: SubscriberOverviewFormProps) {
           </div>
 
           {!readOnly && (
-            <div className="mt-auto">
+            <div className="mt-auto shrink-0">
               <Separator />
               <div className="flex justify-between gap-3 p-3.5">
                 <Button

--- a/apps/dashboard/src/components/subscribers/subscriber-tabs.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-tabs.tsx
@@ -79,6 +79,9 @@ const SubscriberPreferences = (props: SubscriberPreferencesProps) => {
 const tabTriggerClasses =
   'hover:data-[state=inactive]:text-foreground-950 py-3 rounded-none [&>span]:h-5 px-0 relative';
 
+const tabContentPanelClasses = 'min-h-0 w-full flex-1 overflow-hidden';
+const tabContentScrollClasses = 'min-h-0 w-full flex-1 overflow-y-auto';
+
 type SubscriberTabsProps = {
   subscriberId: string;
   readOnly?: boolean;
@@ -99,15 +102,15 @@ export function SubscriberTabs(props: SubscriberTabsProps) {
   const clearOverviewFocusField = useCallback(() => setOverviewFocusField(undefined), []);
 
   return (
-    <Tabs className="flex h-full w-full flex-col" value={tab} onValueChange={setTab}>
-      <header className="border-bg-soft flex h-12 w-full flex-row items-center gap-3 border-b px-3 py-4">
+    <Tabs className="flex h-full min-h-0 w-full flex-col" value={tab} onValueChange={setTab}>
+      <header className="border-bg-soft flex h-12 w-full shrink-0 flex-row items-center gap-3 border-b px-3 py-4">
         <div className="flex flex-1 items-center gap-1 overflow-hidden text-sm font-medium">
           <RiGroup2Line className="size-5 p-0.5" />
           <TruncatedText className="flex-1">Subscriber Profile - {subscriberId}</TruncatedText>
         </div>
       </header>
 
-      <TabsList className="border-bg-soft h-auto w-full items-center gap-6 rounded-none border-b bg-transparent px-3 py-0">
+      <TabsList className="border-bg-soft h-auto w-full shrink-0 items-center gap-6 rounded-none border-b bg-transparent px-3 py-0">
         <TabsTrigger value="overview" className={tabTriggerClasses} variant="regular" size="lg">
           <span>Overview</span>
           {tab === 'overview' && <ActiveTabIndicator />}
@@ -129,7 +132,7 @@ export function SubscriberTabs(props: SubscriberTabsProps) {
           {tab === 'activity-feed' && <ActiveTabIndicator />}
         </TabsTrigger>
       </TabsList>
-      <TabsContent value="overview" className="h-full w-full overflow-y-auto">
+      <TabsContent value="overview" className={tabContentPanelClasses}>
         <SubscriberOverview
           subscriberId={subscriberId}
           readOnly={readOnly}
@@ -139,19 +142,19 @@ export function SubscriberTabs(props: SubscriberTabsProps) {
           onFocusHandled={clearOverviewFocusField}
         />
       </TabsContent>
-      <TabsContent value="credentials" className="h-full w-full overflow-y-auto">
+      <TabsContent value="credentials" className={tabContentPanelClasses}>
         <SubscriberCredentials subscriberId={subscriberId} readOnly={readOnly} onEditInOverview={focusOverviewField} />
       </TabsContent>
-      <TabsContent value="preferences" className="h-full w-full overflow-y-auto">
+      <TabsContent value="preferences" className={tabContentScrollClasses}>
         <SubscriberPreferences subscriberId={subscriberId} readOnly={readOnly} />
       </TabsContent>
-      <TabsContent value="subscriptions" className="h-full w-full overflow-y-auto">
+      <TabsContent value="subscriptions" className={tabContentScrollClasses}>
         <SubscriberSubscriptions subscriberId={subscriberId} />
       </TabsContent>
-      <TabsContent value="activity-feed" className="h-full w-full overflow-y-auto">
+      <TabsContent value="activity-feed" className={tabContentPanelClasses}>
         <SubscriberActivity subscriberId={subscriberId} />
       </TabsContent>
-      <Separator />
+      <Separator className="shrink-0" />
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary

- Opens the subscriber drawer as a **modal** from `ActivityOverview`, so parent modal sheets (test workflow → workflow run) no longer scroll-lock wheel events over the credentials tab ([NV-8504](https://linear.app/novu/issue/NV-8504/openning-credentials-tab-from-activity-details-tab-is-not-scrollable)).
- Fixes the subscriber drawer tab flex overflow chain (`min-h-0` / `flex-1` / `shrink-0`) so overview, credentials, and activity feed keep sticky footers while content scrolls.

```mermaid
sequenceDiagram
  participant Editor as Workflow editor
  participant Test as Test workflow sheet (modal)
  participant Run as Workflow run sheet (modal)
  participant Sub as Subscriber drawer
  Editor->>Test: Test workflow
  Test->>Run: Trigger → activity drawer
  Run->>Sub: Subscriber ID click
  Note over Sub: modal=true so wheel is not blocked by parent RemoveScroll
  Sub->>Sub: Credentials tab scrolls
```

## Test plan

- [ ] Workflow editor → Test workflow → trigger → click Subscriber ID → Credentials tab → mouse wheel scrolls the list; tip footer stays pinned
- [ ] Same path for Overview / Activity Feed tabs (sticky footers still work)
- [ ] Subscribers page → open subscriber → Credentials still scrolls
- [ ] Activity feed page → open run details → Subscriber ID → Credentials scrolls

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores scrolling in subscriber credentials opened from nested activity drawers and tightens the subscriber tabs’ flex-overflow chain.
- Opens the subscriber drawer modally from `ActivityOverview` to avoid the parent sheet’s wheel-event scroll lock.
- Adds `min-h-0`, `flex-1`, and `shrink-0` constraints so tab content scrolls while headers and footers remain fixed.
- Applies the corrected sizing consistently across overview, credentials, preferences, subscriptions, and activity-feed tabs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The modality change is correctly forwarded to the underlying drawer, and the revised tab layouts consistently establish bounded scroll regions with non-shrinking headers and footers.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/activity/components/activity-overview.tsx | Opens subscriber details as a modal from activity views, addressing nested-sheet wheel-event blocking. |
| apps/dashboard/src/components/subscribers/subscriber-drawer.tsx | Adds a modal option to the drawer button and forwards it through the existing subscriber drawer abstraction. |
| apps/dashboard/src/components/subscribers/subscriber-tabs.tsx | Establishes a bounded flex layout for tab panels and prevents shared headers, tabs, and separators from shrinking. |
| apps/dashboard/src/components/subscribers/credentials/subscriber-credentials.tsx | Makes credentials content the bounded scroll region while keeping metadata and tip content pinned. |
| apps/dashboard/src/components/subscribers/subscriber-overview-form.tsx | Completes the overview form’s flex-height chain and keeps action controls outside the scrolling region. |
| apps/dashboard/src/components/subscribers/subscriber-activity.tsx | Prevents activity filters and the activity-page link from shrinking while allowing the list to consume remaining space. |
| apps/dashboard/src/components/subscribers/subscriber-activity-list.tsx | Allows loading and populated activity lists to shrink within the panel and scroll vertically. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Parent as Activity sheet
  participant Overview as ActivityOverview
  participant Subscriber as Subscriber drawer
  participant Tabs as Subscriber tabs
  User->>Parent: Open activity details
  User->>Overview: Click subscriber ID
  Overview->>Subscriber: "Open with modal=true"
  Subscriber->>Tabs: Render bounded flex panels
  User->>Tabs: Open credentials
  Tabs-->>User: Scroll content while footer stays fixed
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): restore subscriber crede..."](https://github.com/novuhq/novu/commit/4611d271a1ed7d0b71930562f28ed43f0faab7f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50111594)</sub>

<!-- /greptile_comment -->