### PR TITLE
fix(dashboard): stop credential draft flicker on save fixes NV-8511

### DIFF
--- a/apps/dashboard/src/components/subscribers/credentials/credential-form-row.tsx
+++ b/apps/dashboard/src/components/subscribers/credentials/credential-form-row.tsx
@@ -40,11 +40,17 @@ export function CredentialFormRow({
   const baseId = useId();
   const [isEditing, setIsEditing] = useState(false);
 
-  const { draft, setField, showErrors, isSaving, hasUnsavedCredential, save, cancel } = useCredentialFormDraft({
-    fields,
-    onSave,
-    onCancel: () => setIsEditing(false),
-  });
+  const { draft, setField, showErrors, isSaving, hasUnsavedCredential, save, cancel, resetDraft } =
+    useCredentialFormDraft({
+      fields,
+      onSave,
+      onCancel: () => setIsEditing(false),
+    });
+
+  const handleEdit = () => {
+    resetDraft(fields);
+    setIsEditing(true);
+  };
 
   const handleCancel = () => cancel();
 
@@ -104,7 +110,7 @@ export function CredentialFormRow({
                       copyLabel={field.label}
                       ariaEntity={ariaEntity}
                       isSaving={isSaving}
-                      onEdit={isEditing ? undefined : () => setIsEditing(true)}
+                      onEdit={isEditing ? undefined : handleEdit}
                       onDelete={isEditing ? undefined : onDelete}
                       onConfirm={isEditing ? save : undefined}
                       onCancel={isEditing ? handleCancel : undefined}

--- a/apps/dashboard/src/components/subscribers/credentials/use-credential-form-draft.ts
+++ b/apps/dashboard/src/components/subscribers/credentials/use-credential-form-draft.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import type { CredentialField } from './credential-fields';
 
 function toValues(fields: CredentialField[]): Record<string, string> {
@@ -15,25 +15,33 @@ type UseCredentialFormDraftArgs = {
   onCancel: () => void;
 };
 
+/**
+ * Local draft for credential create/edit. Call {@link resetDraft} when entering
+ * edit to snapshot server values. Do not sync from `fields` during edit: parents
+ * often pass a new fields array each render, which would flash stale credentials
+ * while a save is in flight.
+ */
 export function useCredentialFormDraft({ fields, onSave, onCancel }: UseCredentialFormDraftArgs) {
-  const initialValues = useMemo(() => toValues(fields), [fields]);
-  const [draft, setDraft] = useState<Record<string, string>>(initialValues);
+  const [draft, setDraft] = useState<Record<string, string>>(() => toValues(fields));
+  const [baseline, setBaseline] = useState<Record<string, string>>(() => toValues(fields));
   const [showErrors, setShowErrors] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  useEffect(() => {
-    setDraft(toValues(fields));
-    setShowErrors(false);
-  }, [fields]);
-
   const hasMissingRequired = fields.some((field) => !field.optional && (draft[field.key] ?? '').trim().length === 0);
-  const hasChanges = fields.some((field) => (draft[field.key] ?? '') !== (initialValues[field.key] ?? ''));
+  const hasChanges = fields.some((field) => (draft[field.key] ?? '') !== (baseline[field.key] ?? ''));
   const hasUnsavedCredential = !isSaving && hasChanges;
 
   const setField = (key: string, value: string) => setDraft((prev) => ({ ...prev, [key]: value }));
 
+  const resetDraft = (nextFields: CredentialField[] = fields) => {
+    const values = toValues(nextFields);
+    setDraft(values);
+    setBaseline(values);
+    setShowErrors(false);
+  };
+
   const cancel = () => {
-    setDraft(initialValues);
+    setDraft(baseline);
     setShowErrors(false);
     onCancel();
   };
@@ -63,7 +71,9 @@ export function useCredentialFormDraft({ fields, onSave, onCancel }: UseCredenti
     setIsSaving(false);
 
     if (succeeded) {
-      cancel();
+      // Exit without resetting to the pre-edit baseline; display uses refreshed props.
+      setShowErrors(false);
+      onCancel();
     }
   };
 
@@ -75,5 +85,6 @@ export function useCredentialFormDraft({ fields, onSave, onCancel }: UseCredenti
     hasUnsavedCredential,
     save,
     cancel,
+    resetDraft,
   };
 }


### PR DESCRIPTION
## Summary

- Fixes a flicker on the subscriber Credentials tab where saving PagerDuty (and other shared credential-row) values briefly showed the previous secret.
- Root cause: `useCredentialFormDraft` reset draft state whenever the `fields` prop identity changed; parents pass `payloadToFields(...)` inline, so mutation/refetch re-renders re-seeded the input with stale server values mid-save.
- Aligns with the tool-webhook row pattern: snapshot values via `resetDraft` when entering edit, and do not prop-sync during edit/save.

## Test plan

- [ ] Open a subscriber → Credentials tab with an existing PagerDuty (or Opsgenie/Grafana) credential
- [ ] Edit the routing key / secret and save
- [ ] Confirm the input does not briefly flash the previous value while saving
- [ ] Confirm cancel still restores the pre-edit values
- [ ] Confirm add-credential form still saves and cancels correctly
- [ ] Confirm tool-webhook credentials still edit/save without regression

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes credential draft synchronization so inline editing snapshots current server values when editing begins rather than continuously reseeding the draft from identity-unstable props.
- Adds an explicit `resetDraft` operation and a stable edit-session baseline.
- Calls `resetDraft` when an existing credential enters edit mode.
- Preserves the submitted draft through save completion while display mode continues to use refreshed credential props.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code regression identified.

Existing credential rows now initialize their drafts at the edit boundary, while add forms mount with fresh initial state and successful saves continue to transition back to prop-backed display mode.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/subscribers/credentials/credential-form-row.tsx | Snapshots the latest credential fields before entering edit mode, preventing parent rerenders from replacing an active draft. |
| apps/dashboard/src/components/subscribers/credentials/use-credential-form-draft.ts | Replaces prop-driven draft synchronization with an explicit edit-session baseline while retaining validation, save, and cancel behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): stop credential draft fl..."](https://github.com/novuhq/novu/commit/21a9a6dde0a0d2ebbc848eaf471c40b2d6b3ca20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50113649)</sub>

<!-- /greptile_comment -->