### PR TITLE
feat(dashboard): replace onboarding connector dropdown with card grid fixes NV-8522

### DIFF
--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-demo-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-demo-form.tsx
@@ -113,7 +113,7 @@ export function ConnectAgentDemoForm({
       title="Where your agent runs?"
       description="The platform or framework that hosts and runs your agent today. Novu supports both custom-code and managed-runtime agents."
       fullWidthContent={
-        <div className="mt-1 flex w-full max-w-[560px] flex-col gap-2">
+        <div className="mt-1 flex w-full max-w-[719px] flex-col gap-2">
           <ConnectorIntegrationCards
             selectedConnectorId={connectorId}
             selectedIntegrationId={selectedIntegrationId}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-demo-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-demo-form.tsx
@@ -3,10 +3,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import type { ReactNode } from 'react';
 import { RiCloseLine, RiInformation2Line, RiLoopLeftLine } from 'react-icons/ri';
 import { isDemoManagedClaudeIntegrationSelected } from '@/components/agents/connectors/claude-managed-integrations';
-import {
-  ConnectorIntegrationDropdown,
-  type ConnectorIntegrationStatus,
-} from '@/components/agents/connectors/connector-integration-dropdown';
+import { type ConnectorIntegrationStatus } from '@/components/agents/connectors/connector-integration-dropdown';
 import { type ConnectorOption, getConnectorById } from '@/components/agents/connectors/connector-options';
 import {
   ConfigureCredentialsSection,
@@ -18,6 +15,7 @@ import { SetupStep } from '@/components/agents/setup-guide-primitives';
 import { Button } from '@/components/primitives/button';
 import { AgentSuggestionPills } from './agent-suggestion-pills';
 import type { AgentGenerationBindings } from './connect-agent-form';
+import { ConnectorIntegrationCards } from './connector-integration-cards';
 import type { ConnectorId } from './connector-options';
 import { GenerationStatus } from './generation-status';
 import { PromptInput } from './prompt-input';
@@ -78,8 +76,6 @@ export function ConnectAgentDemoForm({
   disabled,
   integrations,
   selectedIntegrationId,
-  dropdownStatus,
-  showSavedBadge,
   credentialsPanelVisible,
   credentialsPanelExpanded,
   integrationName,
@@ -117,13 +113,11 @@ export function ConnectAgentDemoForm({
       title="Where your agent runs?"
       description="The platform or framework that hosts and runs your agent today. Novu supports both custom-code and managed-runtime agents."
       fullWidthContent={
-        <div className="mt-1 flex w-full max-w-[500px] flex-col gap-2">
-          <ConnectorIntegrationDropdown
+        <div className="mt-1 flex w-full max-w-[560px] flex-col gap-2">
+          <ConnectorIntegrationCards
             selectedConnectorId={connectorId}
             selectedIntegrationId={selectedIntegrationId}
             integrations={integrations}
-            status={dropdownStatus}
-            showStatusBadge={showSavedBadge}
             disabled={disabled}
             onSelectConnector={onConnectorChange}
             onSelectIntegration={onSelectIntegration}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
@@ -89,7 +89,7 @@ function ConnectAction({ isVisible }: { isVisible: boolean }) {
   return (
     <div
       className={cn(
-        'text-text-sub flex items-center justify-center py-1 transition-opacity',
+        'text-text-sub absolute right-2 top-2 flex items-center justify-center py-1 transition-opacity',
         isVisible ? 'opacity-100' : 'opacity-0'
       )}
     >
@@ -131,19 +131,31 @@ function ConnectorCard({
       onFocus={() => setIsHovered(true)}
       onBlur={() => setIsHovered(false)}
       className={cn(
-        'group bg-bg-white border-stroke-weak relative flex h-16 w-[150px] flex-col items-start gap-2 overflow-hidden rounded-lg border p-2 text-left shadow-xs transition-colors',
+        'group bg-bg-white border-stroke-weak relative flex h-[68px] w-40 flex-col items-start gap-2 overflow-hidden rounded-lg border p-2 text-left shadow-xs transition-colors',
         'hover:border-stroke-soft focus-visible:border-stroke-soft focus-visible:outline-none',
-        isSelected && 'border-stroke-strong',
+        isSelected && 'border-stroke-sub',
         comingSoon && 'cursor-not-allowed',
         isDisabled && !comingSoon && 'cursor-default opacity-60',
         !isDisabled && 'cursor-pointer!'
       )}
     >
-      <div className="flex h-6 w-full items-center justify-between">
+      <div className="flex h-6 w-full items-center">
         <div className="flex size-6 shrink-0 items-center justify-center">{icon}</div>
-        {isSelected ? <RiCheckboxCircleFill className="text-success-base size-4 shrink-0" aria-hidden /> : badge}
-        {!isSelected && !comingSoon ? <ConnectAction isVisible={isConnectVisible} /> : null}
       </div>
+      {isSelected ? (
+        <RiCheckboxCircleFill className="text-success-base absolute right-2 top-2 size-4" aria-hidden />
+      ) : null}
+      {badge ? (
+        <div
+          className={cn(
+            'absolute right-2 top-2 transition-opacity',
+            isHovered && !comingSoon ? 'opacity-0' : 'opacity-100'
+          )}
+        >
+          {badge}
+        </div>
+      ) : null}
+      {!isSelected && !comingSoon ? <ConnectAction isVisible={isConnectVisible} /> : null}
       <span
         className={cn(
           'text-text-sub min-w-0 text-label-xs font-medium leading-4',
@@ -228,7 +240,7 @@ export function ConnectorIntegrationCards({
   }
 
   return (
-    <div className="grid w-full grid-cols-2 gap-x-3 gap-y-3.5 sm:grid-cols-3 md:grid-cols-[repeat(4,150px)]">
+    <div className="grid w-full grid-cols-2 gap-x-3 gap-y-3.5 sm:grid-cols-3 md:grid-cols-[repeat(4,160px)]">
       {items.map((item) => {
         if (item.kind === 'demo') {
           return (
@@ -237,7 +249,7 @@ export function ConnectorIntegrationCards({
               label="Demo agent"
               icon={<DemoCardIcon />}
               badge={
-                <Badge color="yellow" variant="lighter" size="sm" className="shrink-0 rounded-sm uppercase">
+                <Badge color="yellow" variant="lighter" size="sm" className="shrink-0 rounded-sm px-1 uppercase">
                   DEMO
                 </Badge>
               }
@@ -259,7 +271,7 @@ export function ConnectorIntegrationCards({
             icon={<ConnectorCardIcon connectorId={option.id} />}
             badge={
               isComingSoon ? (
-                <Badge color="gray" variant="lighter" size="sm" className="shrink-0 rounded-sm uppercase">
+                <Badge color="gray" variant="lighter" size="sm" className="shrink-0 rounded-sm px-1 uppercase">
                   Coming soon
                 </Badge>
               ) : undefined

--- a/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
@@ -145,7 +145,7 @@ function ConnectorCard({
       {isSelected ? (
         <RiCheckboxCircleFill className="text-success-base absolute right-2 top-2 size-4" aria-hidden />
       ) : null}
-      {badge ? (
+      {badge && !isSelected ? (
         <div
           className={cn(
             'absolute right-2 top-2 transition-opacity',

--- a/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
@@ -272,7 +272,7 @@ export function ConnectorIntegrationCards({
             badge={
               isComingSoon ? (
                 <Badge color="gray" variant="lighter" size="sm" className="shrink-0 rounded-sm px-1 uppercase">
-                  Coming soon
+                  Soon
                 </Badge>
               ) : undefined
             }

--- a/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
@@ -54,36 +54,16 @@ type CardItem =
 function ConnectorCardIcon({ connectorId }: { connectorId: ConnectorId }) {
   switch (connectorId) {
     case 'ai-sdk':
-      return (
-        <div className="bg-bg-weak text-text-strong flex size-6 items-center justify-center rounded-full">
-          <AiSdkIcon className="size-3.5" />
-        </div>
-      );
+      return <AiSdkIcon className="text-text-strong h-4 w-[18.5px]" />;
     case 'langchain':
-      return (
-        <div className="bg-bg-weak flex size-6 items-center justify-center rounded-full">
-          <LangChainIcon className="size-4" />
-        </div>
-      );
+      return <LangChainIcon className="size-[18px]" />;
     case 'custom-code':
-      return (
-        <div className="bg-bg-weak text-text-sub flex size-6 items-center justify-center rounded-full">
-          <RiFileCodeLine className="size-4" />
-        </div>
-      );
+      return <RiFileCodeLine className="text-text-sub size-4" />;
     case 'claude':
-      return (
-        <div className="bg-primary-base/10 text-primary-base flex size-6 items-center justify-center rounded-full">
-          <ClaudeIcon className="size-3.5" />
-        </div>
-      );
+      return <ClaudeIcon className="text-primary-base size-5" />;
     case 'claude-aws':
     case 'bedrock':
-      return (
-        <div className="bg-bg-weak text-text-sub flex size-6 items-center justify-center rounded-full">
-          <AwsIcon className="size-4" />
-        </div>
-      );
+      return <AwsIcon className="size-6" />;
     default: {
       const _exhaustive: never = connectorId;
 
@@ -95,31 +75,21 @@ function ConnectorCardIcon({ connectorId }: { connectorId: ConnectorId }) {
 function DemoCardIcon() {
   return (
     <div
-      className="flex size-6 items-center justify-center rounded-full text-white"
+      className="flex size-[18px] items-center justify-center rounded-full text-white"
       style={{
         background: 'linear-gradient(135deg, #FF884D 0%, #E300BD 55%, #7B61FF 100%)',
       }}
     >
-      <NovuIcon className="size-3.5" />
+      <NovuIcon className="size-2.5" />
     </div>
   );
 }
 
-function ConnectPill() {
+function ConnectAction() {
   return (
-    <div
-      className={cn(
-        'flex h-full w-full items-center justify-center rounded-[4px] text-text-sub',
-        'shadow-[0px_1px_3px_0px_rgba(14,18,27,0.12),0px_0px_0px_1px_#e1e4ea]'
-      )}
-      style={{
-        backgroundImage:
-          'linear-gradient(180deg, transparent 30%, rgba(0,0,0,0.02) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
-      }}
-      aria-hidden
-    >
-      <span className="px-1 text-label-xs font-medium leading-4">Connect</span>
-      <RiArrowRightSLine className="size-3.5 shrink-0 text-text-soft" />
+    <div className="text-text-sub flex items-center justify-center py-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100">
+      <span className="px-0.5 text-label-xs font-medium leading-4">Connect</span>
+      <RiArrowRightSLine className="size-4 shrink-0" aria-hidden />
     </div>
   );
 }
@@ -149,23 +119,27 @@ function ConnectorCard({
       aria-disabled={isDisabled || undefined}
       aria-pressed={isSelected || undefined}
       className={cn(
-        'relative flex min-h-[92px] flex-col items-start gap-1.5 overflow-hidden rounded-[8px] border bg-bg-white p-2 text-left shadow-xs transition-colors',
-        isSelected ? 'border-stroke-strong' : 'border-stroke-weak hover:border-stroke-soft',
-        comingSoon && 'cursor-not-allowed opacity-60',
+        'group bg-bg-white border-stroke-weak relative flex h-16 w-[150px] flex-col items-start gap-2 overflow-hidden rounded-lg border p-2 text-left shadow-xs transition-colors',
+        'hover:border-stroke-soft focus-visible:border-stroke-soft focus-visible:outline-none',
+        isSelected && 'border-stroke-strong',
+        comingSoon && 'cursor-not-allowed',
         isDisabled && !comingSoon && 'cursor-default opacity-60',
         !isDisabled && 'cursor-pointer!'
       )}
     >
-      <div className="flex w-full items-start justify-between gap-1">
+      <div className="flex h-6 w-full items-center justify-between">
         <div className="flex size-6 shrink-0 items-center justify-center">{icon}</div>
-        {isSelected ? (
-          <RiCheckboxCircleFill className="text-success-base size-4 shrink-0" aria-hidden />
-        ) : (
-          (badge ?? null)
-        )}
+        {isSelected ? <RiCheckboxCircleFill className="text-success-base size-4 shrink-0" aria-hidden /> : badge}
+        {!isSelected && !comingSoon ? <ConnectAction /> : null}
       </div>
-      <span className="text-label-xs text-text-sub min-w-0 font-medium leading-4">{label}</span>
-      <div className="mt-auto h-7 w-full shrink-0">{isSelected || comingSoon ? null : <ConnectPill />}</div>
+      <span
+        className={cn(
+          'text-text-sub min-w-0 text-label-xs font-medium leading-4',
+          !isDisabled && 'group-hover:text-text-strong group-focus-visible:text-text-strong'
+        )}
+      >
+        {label}
+      </span>
     </button>
   );
 }
@@ -242,7 +216,7 @@ export function ConnectorIntegrationCards({
   }
 
   return (
-    <div className="grid w-full grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+    <div className="grid w-full grid-cols-2 gap-x-3 gap-y-3.5 sm:grid-cols-3 md:grid-cols-[repeat(4,150px)]">
       {items.map((item) => {
         if (item.kind === 'demo') {
           return (

--- a/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
@@ -1,0 +1,290 @@
+import { type IIntegration } from '@novu/shared';
+import { type ReactNode, useMemo } from 'react';
+import { RiArrowRightSLine, RiCheckboxCircleFill, RiFileCodeLine } from 'react-icons/ri';
+import {
+  getClaudeManagedAgentIntegrations,
+  partitionClaudeManagedIntegrations,
+} from '@/components/agents/connectors/claude-managed-integrations';
+import {
+  CONNECTOR_OPTIONS,
+  type ConnectorId,
+  type ConnectorOption,
+} from '@/components/agents/connectors/connector-options';
+import { AiSdkIcon } from '@/components/icons/ai-sdk';
+import { AwsIcon } from '@/components/icons/aws';
+import { ClaudeIcon } from '@/components/icons/claude';
+import { LangChainIcon } from '@/components/icons/langchain';
+import { NovuIcon } from '@/components/icons/novu-icon';
+import { isDemoIntegration } from '@/components/integrations/components/utils/helpers';
+import { Badge } from '@/components/primitives/badge';
+import { useManagedAgentRuntimeEnabled } from '@/hooks/use-managed-agent-runtime-enabled';
+import { cn } from '@/utils/ui';
+
+const CARD_LABELS: Record<ConnectorId, string> = {
+  'ai-sdk': 'Vercel AI SDK',
+  langchain: 'Langchain',
+  'custom-code': 'Custom code',
+  claude: 'Claude Managed',
+  'claude-aws': 'AWS Claude Managed',
+  bedrock: 'AWS Bedrock',
+};
+
+type ConnectorIntegrationCardsProps = {
+  selectedConnectorId?: ConnectorId;
+  selectedIntegrationId?: string;
+  integrations: IIntegration[] | undefined;
+  disabled?: boolean;
+  /** Test/Storybook override; production reads `IS_MANAGED_AGENT_RUNTIME_ENABLED`. */
+  showManagedOptionsOverride?: boolean;
+  onSelectConnector: (id: ConnectorId) => void;
+  onSelectIntegration: (integration: IIntegration) => void;
+  onRequestSetupCredentials: (option: ConnectorOption) => void;
+};
+
+type CardItem =
+  | {
+      kind: 'connector';
+      option: ConnectorOption;
+    }
+  | {
+      kind: 'demo';
+      integration: IIntegration;
+    };
+
+function ConnectorCardIcon({ connectorId }: { connectorId: ConnectorId }) {
+  switch (connectorId) {
+    case 'ai-sdk':
+      return (
+        <div className="bg-bg-weak text-text-strong flex size-6 items-center justify-center rounded-full">
+          <AiSdkIcon className="size-3.5" />
+        </div>
+      );
+    case 'langchain':
+      return (
+        <div className="bg-bg-weak flex size-6 items-center justify-center rounded-full">
+          <LangChainIcon className="size-4" />
+        </div>
+      );
+    case 'custom-code':
+      return (
+        <div className="bg-bg-weak text-text-sub flex size-6 items-center justify-center rounded-full">
+          <RiFileCodeLine className="size-4" />
+        </div>
+      );
+    case 'claude':
+      return (
+        <div className="bg-primary-base/10 text-primary-base flex size-6 items-center justify-center rounded-full">
+          <ClaudeIcon className="size-3.5" />
+        </div>
+      );
+    case 'claude-aws':
+    case 'bedrock':
+      return (
+        <div className="bg-bg-weak text-text-sub flex size-6 items-center justify-center rounded-full">
+          <AwsIcon className="size-4" />
+        </div>
+      );
+    default: {
+      const _exhaustive: never = connectorId;
+
+      return _exhaustive;
+    }
+  }
+}
+
+function DemoCardIcon() {
+  return (
+    <div
+      className="flex size-6 items-center justify-center rounded-full text-white"
+      style={{
+        background: 'linear-gradient(135deg, #FF884D 0%, #E300BD 55%, #7B61FF 100%)',
+      }}
+    >
+      <NovuIcon className="size-3.5" />
+    </div>
+  );
+}
+
+function ConnectPill() {
+  return (
+    <div
+      className={cn(
+        'flex h-full w-full items-center justify-center rounded-[4px] text-text-sub',
+        'shadow-[0px_1px_3px_0px_rgba(14,18,27,0.12),0px_0px_0px_1px_#e1e4ea]'
+      )}
+      style={{
+        backgroundImage:
+          'linear-gradient(180deg, transparent 30%, rgba(0,0,0,0.02) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
+      }}
+      aria-hidden
+    >
+      <span className="px-1 text-label-xs font-medium leading-4">Connect</span>
+      <RiArrowRightSLine className="size-3.5 shrink-0 text-text-soft" />
+    </div>
+  );
+}
+
+function ConnectorCard({
+  label,
+  icon,
+  badge,
+  isSelected,
+  isDisabled,
+  comingSoon,
+  onClick,
+}: {
+  label: string;
+  icon: ReactNode;
+  badge?: ReactNode;
+  isSelected: boolean;
+  isDisabled?: boolean;
+  comingSoon?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isDisabled}
+      aria-disabled={isDisabled || undefined}
+      aria-pressed={isSelected || undefined}
+      className={cn(
+        'relative flex min-h-[92px] flex-col items-start gap-1.5 overflow-hidden rounded-[8px] border bg-bg-white p-2 text-left shadow-xs transition-colors',
+        isSelected ? 'border-stroke-strong' : 'border-stroke-weak hover:border-stroke-soft',
+        comingSoon && 'cursor-not-allowed opacity-60',
+        isDisabled && !comingSoon && 'cursor-default opacity-60',
+        !isDisabled && 'cursor-pointer!'
+      )}
+    >
+      <div className="flex w-full items-start justify-between gap-1">
+        <div className="flex size-6 shrink-0 items-center justify-center">{icon}</div>
+        {isSelected ? (
+          <RiCheckboxCircleFill className="text-success-base size-4 shrink-0" aria-hidden />
+        ) : (
+          (badge ?? null)
+        )}
+      </div>
+      <span className="text-label-xs text-text-sub min-w-0 font-medium leading-4">{label}</span>
+      <div className="mt-auto h-7 w-full shrink-0">{isSelected || comingSoon ? null : <ConnectPill />}</div>
+    </button>
+  );
+}
+
+export function ConnectorIntegrationCards({
+  selectedConnectorId,
+  selectedIntegrationId,
+  integrations,
+  disabled,
+  showManagedOptionsOverride,
+  onSelectConnector,
+  onSelectIntegration,
+  onRequestSetupCredentials,
+}: ConnectorIntegrationCardsProps) {
+  const isManagedRuntimeEnabled = useManagedAgentRuntimeEnabled(showManagedOptionsOverride);
+
+  const demoIntegration = useMemo(() => {
+    const allClaude = getClaudeManagedAgentIntegrations(integrations);
+    const { demoIntegrations } = partitionClaudeManagedIntegrations(allClaude);
+
+    return demoIntegrations[0];
+  }, [integrations]);
+
+  const selectedIntegration = useMemo(
+    () => (integrations ?? []).find((integration) => integration._id === selectedIntegrationId),
+    [integrations, selectedIntegrationId]
+  );
+  const isDemoSelected = Boolean(selectedIntegration && isDemoIntegration(selectedIntegration.providerId));
+
+  const items = useMemo((): CardItem[] => {
+    const customOptions = CONNECTOR_OPTIONS.filter((option) => option.group === 'custom');
+    const externalOptions = isManagedRuntimeEnabled
+      ? CONNECTOR_OPTIONS.filter((option) => option.group === 'external')
+      : [];
+
+    const next: CardItem[] = customOptions.map((option) => ({ kind: 'connector', option }));
+
+    if (demoIntegration) {
+      next.push({ kind: 'demo', integration: demoIntegration });
+    }
+
+    for (const option of externalOptions) {
+      next.push({ kind: 'connector', option });
+    }
+
+    return next;
+  }, [demoIntegration, isManagedRuntimeEnabled]);
+
+  function handleConnectorClick(option: ConnectorOption) {
+    if (disabled || option.comingSoon || !option.runtime) return;
+
+    onSelectConnector(option.id);
+
+    if (!option.providerId) return;
+
+    const matching = getClaudeManagedAgentIntegrations(integrations, option.providerId);
+    const { userIntegrations } = partitionClaudeManagedIntegrations(matching);
+
+    if (userIntegrations.length > 0) {
+      onSelectIntegration(userIntegrations[0]);
+
+      return;
+    }
+
+    onRequestSetupCredentials(option);
+  }
+
+  function handleDemoClick(integration: IIntegration) {
+    if (disabled) return;
+
+    const connectorId: ConnectorId = 'claude';
+    onSelectConnector(connectorId);
+    onSelectIntegration(integration);
+  }
+
+  return (
+    <div className="grid w-full grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+      {items.map((item) => {
+        if (item.kind === 'demo') {
+          return (
+            <ConnectorCard
+              key={`demo-${item.integration._id}`}
+              label="Demo agent"
+              icon={<DemoCardIcon />}
+              badge={
+                <Badge color="yellow" variant="lighter" size="sm" className="shrink-0 rounded-sm uppercase">
+                  DEMO
+                </Badge>
+              }
+              isSelected={isDemoSelected}
+              isDisabled={disabled}
+              onClick={() => handleDemoClick(item.integration)}
+            />
+          );
+        }
+
+        const { option } = item;
+        const isComingSoon = option.comingSoon || !option.runtime;
+        const isSelected = !isDemoSelected && selectedConnectorId === option.id && !isComingSoon;
+
+        return (
+          <ConnectorCard
+            key={option.id}
+            label={CARD_LABELS[option.id]}
+            icon={<ConnectorCardIcon connectorId={option.id} />}
+            badge={
+              isComingSoon ? (
+                <Badge color="gray" variant="lighter" size="sm" className="shrink-0 rounded-sm uppercase">
+                  Coming soon
+                </Badge>
+              ) : undefined
+            }
+            isSelected={isSelected}
+            isDisabled={disabled || isComingSoon}
+            comingSoon={isComingSoon}
+            onClick={() => handleConnectorClick(option)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx
@@ -1,5 +1,5 @@
 import { type IIntegration } from '@novu/shared';
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { RiArrowRightSLine, RiCheckboxCircleFill, RiFileCodeLine } from 'react-icons/ri';
 import {
   getClaudeManagedAgentIntegrations,
@@ -85,9 +85,14 @@ function DemoCardIcon() {
   );
 }
 
-function ConnectAction() {
+function ConnectAction({ isVisible }: { isVisible: boolean }) {
   return (
-    <div className="text-text-sub flex items-center justify-center py-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100">
+    <div
+      className={cn(
+        'text-text-sub flex items-center justify-center py-1 transition-opacity',
+        isVisible ? 'opacity-100' : 'opacity-0'
+      )}
+    >
       <span className="px-0.5 text-label-xs font-medium leading-4">Connect</span>
       <RiArrowRightSLine className="size-4 shrink-0" aria-hidden />
     </div>
@@ -111,6 +116,9 @@ function ConnectorCard({
   comingSoon?: boolean;
   onClick: () => void;
 }) {
+  const [isHovered, setIsHovered] = useState(false);
+  const isConnectVisible = isHovered && !isSelected && !comingSoon;
+
   return (
     <button
       type="button"
@@ -118,6 +126,10 @@ function ConnectorCard({
       disabled={isDisabled}
       aria-disabled={isDisabled || undefined}
       aria-pressed={isSelected || undefined}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onFocus={() => setIsHovered(true)}
+      onBlur={() => setIsHovered(false)}
       className={cn(
         'group bg-bg-white border-stroke-weak relative flex h-16 w-[150px] flex-col items-start gap-2 overflow-hidden rounded-lg border p-2 text-left shadow-xs transition-colors',
         'hover:border-stroke-soft focus-visible:border-stroke-soft focus-visible:outline-none',
@@ -130,7 +142,7 @@ function ConnectorCard({
       <div className="flex h-6 w-full items-center justify-between">
         <div className="flex size-6 shrink-0 items-center justify-center">{icon}</div>
         {isSelected ? <RiCheckboxCircleFill className="text-success-base size-4 shrink-0" aria-hidden /> : badge}
-        {!isSelected && !comingSoon ? <ConnectAction /> : null}
+        {!isSelected && !comingSoon ? <ConnectAction isVisible={isConnectVisible} /> : null}
       </div>
       <span
         className={cn(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the connector dropdown on the `/onboarding/agents` “Where your agent runs?” step with a **2-row clickable card grid** so every option is visible without scrolling.

Motivation (from #proj-maga-activation): high drop-off on this screen — users open the dropdown, browse, and leave without selecting. Cards make the available runtimes obvious while the hover state provides a clear Connect CTA.

## Changes

- New `ConnectorIntegrationCards` component: compact grid of connector cards (custom + managed + demo when available)
- Wired into `ConnectAgentDemoForm` in place of `ConnectorIntegrationDropdown`
- Matches Figma regular and hover treatment: 8px padding, 8px content gap, weak default border, soft hover border, top-right hover Connect action, and stronger hover label
- Increased cards slightly to 160×68 for better visual weight in the live onboarding composition
- Selected cards use `stroke-sub`
- Demo and availability badges are pinned to the top-right corner; Demo swaps cleanly to Connect on hover
- Selected Demo cards replace the DEMO badge with the success checkmark, avoiding overlap
- AWS Bedrock uses the compact `SOON` badge
- Matched icon geometry per connector with no circular icon backgrounds
- Coming-soon connectors (e.g. AWS Bedrock) remain disabled
- Demo agent card appears when a Novu demo Claude integration exists

## Screenshots

Regular state:

![Refined connector cards regular state](https://cursor.com/artifacts/c/art-e194a0b9-e0ac-4442-963e-df2772cb8d00)

Hover state:

![Refined Vercel connector hover state](https://cursor.com/artifacts/c/art-554d1819-46fe-4ca5-b49d-3f908731b37d)

Selected state:

![Refined Custom code selected state](https://cursor.com/artifacts/c/art-51aa7c8f-3305-4554-9f36-4f1f1d2381a0)

Bedrock availability badge:

![AWS Bedrock SOON badge](https://cursor.com/artifacts/c/art-bf10fae6-146e-4c40-9878-167f23e2fcb6)

## Video

<a href="https://cursor.com/agents/bc-9d4a2ed4-4709-5fcd-a65a-7268e0f4e5e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_connector_refined_proportions.mp4"><img src="https://cursor.com/artifacts/c/art-df3a03a0-608f-4d87-9dde-8ce5c2c23682" alt="onboarding_connector_refined_proportions.mp4" /></a>

<a href="https://cursor.com/agents/bc-9d4a2ed4-4709-5fcd-a65a-7268e0f4e5e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_bedrock_soon_badge.mp4"><img src="https://cursor.com/artifacts/c/art-a54f7b56-d661-4574-86fd-5bb73e191fb8" alt="onboarding_bedrock_soon_badge.mp4" /></a>

## Notes

- The seeded environment does not currently expose a Demo integration, so the Demo card is not present in the walkthrough. Demo and availability badges share the same absolute top-right slot; AWS Bedrock validates that placement.
- Non-onboarding agent create flow still uses the dropdown.

Linear: [NV-8522](https://linear.app/novu/issue/NV-8522/replace-onboarding-agent-connector-dropdown-with-clickable-card-grid)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0BM0C98WLC/p1785908710722859?thread_ts=1785908710.722859&cid=C0BM0C98WLC)

<div><a href="https://cursor.com/agents/bc-9d4a2ed4-4709-5fcd-a65a-7268e0f4e5e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d4a2ed4-4709-5fcd-a65a-7268e0f4e5e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the onboarding connector dropdown with a responsive card grid while retaining connector, demo-integration, disabled, and coming-soon states.

- Adds connector cards with hover, selected, demo, and coming-soon treatments.
- Integrates the card grid into the onboarding agent form.
- Leaves the non-onboarding connector dropdown unchanged.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because managed-runtime cards still silently bind the first matching integration when multiple credentials are available.

The current click handler selects `userIntegrations[0]` and bypasses both explicit integration choice and credential setup whenever an existing managed integration is present, so the previously reported incorrect-binding path remains reachable.

**Files Needing Attention:** apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/onboarding/connect-agent/connect-agent-demo-form.tsx | Replaces the onboarding dropdown with the new card-grid component and expands the available content width. |
| apps/dashboard/src/components/onboarding/connect-agent/connector-integration-cards.tsx | Adds the responsive connector-card UI and its connector, integration, demo, disabled, and coming-soon selection behavior. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(dashboard): shorten Bedrock availabi..."](https://github.com/novuhq/novu/commit/743b77fdc796173b1c8e37c587e7fde016d4beb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50361434)</sub>

<!-- /greptile_comment -->