### PR TITLE
feat(dashboard): show agent use cases in contextual help drawer fixes NV-8523

### DIFF
--- a/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
+++ b/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
@@ -7,6 +7,7 @@ import {
   RiKey2Line,
   RiLayoutGridLine,
   RiMailLine,
+  RiMessage3Line,
   RiRouteFill,
   RiSettings3Line,
   RiStore3Line,
@@ -15,6 +16,7 @@ import {
 } from 'react-icons/ri';
 import { useLocation } from 'react-router-dom';
 import { Bell, NovuIcon } from '@/components/icons';
+import { BotIcon } from '@/components/icons/bot';
 
 export const DRAWER_WIDTH_DEFAULT = 350;
 export const DRAWER_WIDTH_EXPANDED = 700;
@@ -77,9 +79,68 @@ type RouteContext =
   | 'settings'
   | 'environments'
   | 'contexts'
+  | 'agents'
+  | 'conversations'
   | 'default';
 
+const AGENT_SUGGESTIONS: SuggestionItem[] = [
+  {
+    icon: BotIcon,
+    title: 'What is ACI?',
+    description: 'Connect AI agents to Slack, Teams, WhatsApp, Telegram, and email.',
+    url: docsUrl('/agents/get-started/what-is-aci'),
+  },
+  {
+    icon: RiCodeLine,
+    title: 'Connect AI SDK to Slack',
+    description: 'Example: wire Vercel AI SDK to Slack and reply from onMessage.',
+    url: docsUrl('/agents/get-started/ai-sdk'),
+  },
+  {
+    icon: RiStore3Line,
+    title: 'Claude managed agent',
+    description: 'Example: launch a managed agent with no bridge server required.',
+    url: docsUrl('/agents/get-started/claude-managed'),
+  },
+];
+
+const AGENT_GETTING_STARTED: SuggestionItem[] = [
+  {
+    icon: BotIcon,
+    title: 'Mental model',
+    description: 'Trace how messages flow from a channel to your agent and back.',
+    url: docsUrl('/agents/get-started/mental-model'),
+  },
+  {
+    icon: RiStore3Line,
+    title: 'Agents and providers',
+    description: 'Connect Slack, Teams, WhatsApp, and more to one agent.',
+    url: docsUrl('/agents/get-started/agents-and-providers'),
+  },
+  {
+    icon: RiMessage3Line,
+    title: 'Agent conversations',
+    description: 'Inspect threads, history, and lifecycle across providers.',
+    url: docsUrl('/agents/conversations'),
+  },
+];
+
 const CONTEXTUAL_SUGGESTIONS: Record<RouteContext, SuggestionItem[]> = {
+  agents: AGENT_SUGGESTIONS,
+  conversations: [
+    {
+      icon: RiMessage3Line,
+      title: 'Agent conversations',
+      description: 'View, inspect, and manage agent threads across providers.',
+      url: docsUrl('/agents/conversations'),
+    },
+    {
+      icon: BotIcon,
+      title: 'What is ACI?',
+      description: 'Connect AI agents to Slack, Teams, WhatsApp, Telegram, and email.',
+      url: docsUrl('/agents/get-started/what-is-aci'),
+    },
+  ],
   workflows: [
     {
       icon: RiRouteFill,
@@ -261,6 +322,8 @@ function getRouteContext(pathname: string): RouteContext {
   if (pathname.includes('/environments')) return 'environments';
   if (pathname.includes('/contexts')) return 'contexts';
   if (pathname.includes('/settings')) return 'settings';
+  if (pathname.includes('/agents')) return 'agents';
+  if (pathname.includes('/conversations')) return 'conversations';
 
   return 'default';
 }
@@ -275,7 +338,7 @@ export function useContextualSuggestions(): SuggestionItem[] {
   }, [location.pathname]);
 }
 
-export const GETTING_STARTED: SuggestionItem[] = [
+const DEFAULT_GETTING_STARTED: SuggestionItem[] = [
   {
     icon: NovuIcon,
     title: 'Learn the basics',
@@ -295,3 +358,21 @@ export const GETTING_STARTED: SuggestionItem[] = [
     url: docsUrl('/platform/integrations'),
   },
 ];
+
+const CONTEXTUAL_GETTING_STARTED: Partial<Record<RouteContext, SuggestionItem[]>> = {
+  agents: AGENT_GETTING_STARTED,
+  conversations: AGENT_GETTING_STARTED,
+};
+
+/** Default getting-started links shown outside agent surfaces. */
+export const GETTING_STARTED = DEFAULT_GETTING_STARTED;
+
+export function useContextualGettingStarted(): SuggestionItem[] {
+  const location = useLocation();
+
+  return useMemo(() => {
+    const context = getRouteContext(location.pathname);
+
+    return CONTEXTUAL_GETTING_STARTED[context] ?? DEFAULT_GETTING_STARTED;
+  }, [location.pathname]);
+}

--- a/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
+++ b/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
@@ -8,6 +8,7 @@ import {
   RiLayoutGridLine,
   RiMailLine,
   RiMessage3Line,
+  RiRobot2Line,
   RiRouteFill,
   RiSettings3Line,
   RiStore3Line,
@@ -97,7 +98,7 @@ const AGENT_SUGGESTIONS: SuggestionItem[] = [
     url: docsUrl('/agents/get-started/ai-sdk'),
   },
   {
-    icon: RiStore3Line,
+    icon: RiRobot2Line,
     title: 'Claude managed agent',
     description: 'Example: launch a managed agent with no bridge server required.',
     url: docsUrl('/agents/get-started/claude-managed'),

--- a/apps/dashboard/src/components/header-navigation/support-drawer.tsx
+++ b/apps/dashboard/src/components/header-navigation/support-drawer.tsx
@@ -15,8 +15,8 @@ import {
   DRAWER_WIDTH_DEFAULT,
   DRAWER_WIDTH_EXPANDED,
   docsUrl,
-  GETTING_STARTED,
   ROADMAP_URL,
+  useContextualGettingStarted,
   useContextualSuggestions,
 } from './support-drawer-constants';
 
@@ -36,6 +36,7 @@ function SupportDrawerContent({
   const telemetry = useTelemetry();
   const { showPlainLiveChat, isLiveChatVisible } = usePlainChat();
   const suggestions = useContextualSuggestions();
+  const gettingStarted = useContextualGettingStarted();
   const searchFunctionsRef = useRef(null);
   const [hasSearchQuery, setHasSearchQuery] = useState(false);
 
@@ -174,13 +175,13 @@ function SupportDrawerContent({
                 </div>
               )}
 
-              {GETTING_STARTED.length > 0 && (
+              {gettingStarted.length > 0 && (
                 <div className="flex flex-col gap-2">
                   <span className="text-foreground-600 px-1 text-sm font-medium leading-5 tracking-[-0.084px]">
                     Getting started
                   </span>
                   <div className="flex flex-col gap-2">
-                    {GETTING_STARTED.map((item) => (
+                    {gettingStarted.map((item) => (
                       <SuggestionCard
                         key={item.title}
                         item={item}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed? Why was the change needed?

On Agents (and Conversations) routes, the contextual help drawer fell through to generic defaults — “Understand Novu”, “Introduction to Inbox”, and Inbox-focused Getting started links. That mismatched user intent on agent surfaces (NV-8523).

This PR adds an `agents` / `conversations` route context so the drawer surfaces ACI guidance plus concrete examples (AI SDK → Slack, Claude managed agent), and swaps Getting started to agent mental model / providers / conversations docs.

### Screenshots

![Agents help drawer with contextual suggestions](https://cursor.com/artifacts/c/art-22b5165b-80e9-4a54-a33e-1007fa370037)

### Test plan

- [x] Code: route context maps `/agents` and `/conversations` to agent content
- [x] Manual: open Help on Agents page → Suggestions show ACI / AI SDK / Claude managed; Getting started shows Mental model / Providers / Conversations
- [ ] Manual: open Help on Workflows → still shows workflow suggestions + default Getting started
- [ ] Manual: docs cards open embed view for agent docs URLs

### Special notes for your reviewer

Builds on the NV-6927 contextual help drawer. No feature-flag or API changes — content only when `IS_CONTEXTUAL_HELP_DRAWER_ENABLED` is already on.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8523](https://linear.app/novu/issue/NV-8523/update-help-drawer-to-show-contextual-agent-use-cases-and-examples)

<div><a href="https://cursor.com/agents/bc-9e54b73a-8f50-48ef-9a6b-621853ccea88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e54b73a-8f50-48ef-9a6b-621853ccea88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds agent- and conversation-specific documentation cards to the contextual support drawer.
- Adds tailored suggestions and getting-started links for agent surfaces.
- Selects support content from the current dashboard route.
- Updates the drawer to render context-specific getting-started cards.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the canonical Conversations page still receives generic activity help instead of the newly added conversation content.

The `/env/:environmentSlug/activity/conversations` route matches the earlier `/activity` condition, so both contextual hooks receive `activity` and the intended Conversations help remains unreachable.

**Files Needing Attention:** apps/dashboard/src/components/header-navigation/support-drawer-constants.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/header-navigation/support-drawer-constants.ts | Adds agent and conversation help content, route-context selection, and contextual getting-started data. |
| apps/dashboard/src/components/header-navigation/support-drawer.tsx | Replaces the static getting-started list with the route-aware hook result. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(dashboard): use robot icon for Cla..."](https://github.com/novuhq/novu/commit/ec9b7693667c45f206f77c95345301b4ca5cfc82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50392720)</sub>

<!-- /greptile_comment -->