### PR TITLE
feat(shared): onboard Novu MCP with DCR OAuth fixes NV-8524

### DIFF
--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-issuer-match.spec.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-issuer-match.spec.ts
@@ -26,6 +26,12 @@ const NEW_RELIC_OPTS: IssuerMatchOpts = {
   registrationEndpoint: 'https://mcp.newrelic.com/register',
 };
 
+const NOVU_OPTS: IssuerMatchOpts = {
+  authorizationEndpoint: 'https://clerk.dashboard.novu.co/oauth/authorize',
+  tokenEndpoint: 'https://clerk.dashboard.novu.co/oauth/token',
+  registrationEndpoint: 'https://mcp.novu.co/oauth/register',
+};
+
 describe('isAcceptableIssuerMatch', () => {
   it('accepts exact issuer match', () => {
     expect(isAcceptableIssuerMatch('https://auth.example.com', 'https://auth.example.com')).to.equal(true);
@@ -57,6 +63,10 @@ describe('isAcceptableIssuerMatch', () => {
     expect(isAcceptableIssuerMatch('https://mcp.newrelic.com', 'https://login.newrelic.com', NEW_RELIC_OPTS)).to.equal(
       true
     );
+  });
+
+  it('accepts the sibling-subdomain MCP gateway pattern (Novu / Clerk)', () => {
+    expect(isAcceptableIssuerMatch('https://mcp.novu.co', 'https://clerk.dashboard.novu.co', NOVU_OPTS)).to.equal(true);
   });
 
   it('rejects gateway pattern when OAuth endpoints leave the advertised domain', () => {

--- a/packages/shared/src/consts/providers/mcp-servers.ts
+++ b/packages/shared/src/consts/providers/mcp-servers.ts
@@ -1748,6 +1748,15 @@ export const MCP_SERVERS: McpServer[] = [
     oauth: { mode: McpConnectionAuthModeEnum.Dcr },
   },
   {
+    id: 'novu',
+    name: 'Novu',
+    description: 'Manage Novu workflows, subscribers, preferences, integrations, and delivery activity.',
+    url: 'https://mcp.novu.co/',
+    category: 'communication',
+    popular: false,
+    oauth: { mode: McpConnectionAuthModeEnum.Dcr },
+  },
+  {
     id: 'omni-analytics',
     name: 'Omni Analytics',
     description: 'Query Omni Analytics data, models, and dashboards through your agent.',


### PR DESCRIPTION
## Summary
- Add catalog entry `novu` (`https://mcp.novu.co/`) with `oauth.mode: dcr` so managed agents can connect to Novu MCP via Novu-handled OAuth.
- Add issuer-match regression coverage for the Clerk sibling-domain pattern (`mcp.novu.co` ↔ `clerk.dashboard.novu.co`).

Linear: https://linear.app/novu/issue/NV-8524/onboard-novu-mcp-to-catalog-dcr-oauth

## DCR onboarding evidence

- MCP id: `novu`
- MCP URL: `https://mcp.novu.co/`
- Issuer: `https://clerk.dashboard.novu.co` (PRM authorization server hint: `https://mcp.novu.co`)

### PRM
```json
{"authorization_servers":["https://mcp.novu.co"],"bearer_methods_supported":["header"],"resource":"https://mcp.novu.co","scopes_supported":["user:org:read","email","profile","offline_access"]}
```

### AS metadata
```json
{"issuer":"https://clerk.dashboard.novu.co","authorization_endpoint":"https://clerk.dashboard.novu.co/oauth/authorize","token_endpoint":"https://clerk.dashboard.novu.co/oauth/token","registration_endpoint":"https://mcp.novu.co/oauth/register","code_challenge_methods_supported":["S256"],"token_endpoint_auth_methods_supported":["client_secret_basic","none","client_secret_post"],"scopes_supported":["user:org:read","email","profile","offline_access"]}
```

### DCR register probe
```json
{"client_id":"t2Y0d2rGWDTNJVq9","client_id_issued_at":1785926563128,"client_secret_expires_at":0,"client_name":"Novu probe","redirect_uris":["https://api.novu.co/v1/agents/mcp/oauth/callback"],"grant_types":["authorization_code"],"response_types":["code"],"scope":"email offline_access profile user:org:read","token_endpoint_auth_method":"none"}
```
HTTP 201

### Scope notes
PRM advertises `user:org:read email profile offline_access` — small enough that catalog does not pin `oauth.scopes`. DCR response downgraded auth method to `none` (public client); generic RFC 7591 §3.2.1 handling applies.

### Code changes beyond catalog?
- [x] No — catalog entry only (plus issuer-match regression test)
- [ ] Yes — discovery issuer matching because ...
- [ ] Yes — token-exchange-outcome because ...

Existing sibling-registrable-domain issuer relaxation already accepts Novu/Clerk; no production discovery change required.

## Test plan
- [x] `pnpm --filter @novu/shared build`
- [x] `vitest run src/consts/providers/mcp-servers.spec.ts`
- [x] `mocha` issuer-match unit spec (`NODE_ENV=test`, `--no-config`)
- [ ] Connect Novu MCP from a managed agent in staging and complete OAuth consent
- [ ] Confirm tool calls succeed after authorize (e.g. `whoami` / `get_workflows`)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Novu MCP to the shared server catalog using dynamic client registration and adds regression coverage for Novu's sibling-domain Clerk issuer.
- Registers `https://mcp.novu.co/` as a communication MCP server with DCR OAuth.
- Verifies that OAuth discovery accepts the `mcp.novu.co` and `clerk.dashboard.novu.co` issuer arrangement when all OAuth endpoints remain under `novu.co`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The catalog entry satisfies existing validation and DCR scope-discovery behavior, while the regression test directly exercises the production issuer matcher with the argument shape used by OAuth discovery.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/consts/providers/mcp-servers.ts | Adds a schema-compliant, uniquely identified Novu MCP catalog entry configured for DCR OAuth. |
| apps/api/src/app/agents/mcp/oauth/mcp-oauth-issuer-match.spec.ts | Adds focused regression coverage for the existing sibling-registrable-domain issuer relaxation using Novu's production endpoint arrangement. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Managed Agent
    participant MCP as mcp.novu.co
    participant Clerk as clerk.dashboard.novu.co
    Agent->>MCP: Discover protected-resource metadata
    MCP-->>Agent: Authorization server hint and scopes
    Agent->>Clerk: Discover authorization-server metadata
    Clerk-->>Agent: Issuer and authorization/token endpoints
    Agent->>MCP: Dynamically register OAuth client
    MCP-->>Agent: Public client registration
    Agent->>Clerk: Begin authorization flow
```

<sub>Reviews (1): Last reviewed commit: ["feat(shared): onboard Novu MCP with DCR ..."](https://github.com/novuhq/novu/commit/1fb3aea3cc16d4569058d2c2270df39c510b0eb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50396603)</sub>

<!-- /greptile_comment -->