### PR TITLE
fix(dashboard): open support drawer docs in new tab fixes NV-8525

### DIFF
--- a/apps/dashboard/src/components/header-navigation/support-drawer-components.tsx
+++ b/apps/dashboard/src/components/header-navigation/support-drawer-components.tsx
@@ -1,22 +1,19 @@
-import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useState } from 'react';
-import { RiArrowLeftLine, RiExternalLinkLine, RiLoaderLine } from 'react-icons/ri';
-import { SuggestionItem, toEmbedUrl } from './support-drawer-constants';
+import { SuggestionItem } from './support-drawer-constants';
 
 type SuggestionCardProps = {
   item: SuggestionItem;
-  onOpenDocs: (url: string) => void;
+  onOpenUrl: (url: string) => void;
   onTrack: (title: string) => void;
 };
 
-export function SuggestionCard({ item, onOpenDocs, onTrack }: SuggestionCardProps) {
+export function SuggestionCard({ item, onOpenUrl, onTrack }: SuggestionCardProps) {
   const Icon = item.icon;
 
   return (
     <button
       onClick={() => {
         onTrack(item.title);
-        onOpenDocs(item.url);
+        onOpenUrl(item.url);
       }}
       className="bg-background hover:bg-neutral-50 border-stroke-soft group flex w-full items-center gap-2 rounded-xl border p-2 transition-colors text-left"
     >
@@ -30,90 +27,6 @@ export function SuggestionCard({ item, onOpenDocs, onTrack }: SuggestionCardProp
         <span className="text-foreground-400 text-xs leading-4">{item.description}</span>
       </div>
     </button>
-  );
-}
-
-type DocsIframeViewProps = {
-  url: string;
-  onBack: () => void;
-  onTrackBack: () => void;
-  onTrackExternal: () => void;
-};
-
-export function DocsIframeView({ url, onBack, onTrackBack, onTrackExternal }: DocsIframeViewProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const embedUrl = toEmbedUrl(url);
-
-  useEffect(() => {
-    const ensurePrefetch = () => {
-      const existingPrefetch = document.querySelector('link[rel="dns-prefetch"][href="https://docs.novu.co"]');
-      const existingPreconnect = document.querySelector('link[rel="preconnect"][href="https://docs.novu.co"]');
-
-      if (!existingPrefetch) {
-        const prefetchLink = document.createElement('link');
-        prefetchLink.rel = 'dns-prefetch';
-        prefetchLink.href = 'https://docs.novu.co';
-        document.head.appendChild(prefetchLink);
-      }
-
-      if (!existingPreconnect) {
-        const preconnectLink = document.createElement('link');
-        preconnectLink.rel = 'preconnect';
-        preconnectLink.href = 'https://docs.novu.co';
-        document.head.appendChild(preconnectLink);
-      }
-    };
-
-    ensurePrefetch();
-  }, []);
-
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex items-center gap-1 px-3 py-3.5 pr-14">
-        <button
-          onClick={() => {
-            onTrackBack();
-            onBack();
-          }}
-          className="hover:bg-neutral-100 -ml-1.5 flex size-5 items-center justify-center rounded transition-colors"
-        >
-          <RiArrowLeftLine className="text-foreground-600 size-3.5" />
-        </button>
-        <span className="text-foreground-600 flex-1 text-sm font-medium leading-5 tracking-[-0.084px]">
-          Documentation
-        </span>
-        <button
-          onClick={() => {
-            onTrackExternal();
-            window.open(url, '_blank noopener noreferrer');
-          }}
-          className="hover:bg-neutral-100 flex size-5 items-center justify-center rounded transition-colors"
-          title="Open in new tab"
-        >
-          <RiExternalLinkLine className="text-foreground-600 size-3.5" />
-        </button>
-      </div>
-      <div className="relative flex-1 overflow-hidden rounded-b-xl">
-        <AnimatePresence>
-          {isLoading && (
-            <motion.div
-              initial={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
-              className="absolute inset-0 flex items-center justify-center bg-neutral-50"
-            >
-              <RiLoaderLine className="text-foreground-400 size-6 animate-spin" />
-            </motion.div>
-          )}
-        </AnimatePresence>
-        <iframe
-          src={embedUrl}
-          className="h-full w-full border-0"
-          onLoad={() => setIsLoading(false)}
-          title="Documentation"
-        />
-      </div>
-    </div>
   );
 }
 

--- a/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
+++ b/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
@@ -20,7 +20,6 @@ import { Bell, NovuIcon } from '@/components/icons';
 import { BotIcon } from '@/components/icons/bot';
 
 export const DRAWER_WIDTH_DEFAULT = 350;
-export const DRAWER_WIDTH_EXPANDED = 700;
 
 const DOCS_BASE_URL = 'https://docs.novu.co';
 const UTM_SUFFIX = '?utm_campaign=support_drawer';
@@ -34,13 +33,6 @@ export function docsUrl(path = '') {
   const url = `${DOCS_BASE_URL}${basePath}${UTM_SUFFIX}`;
 
   return hash ? `${url}#${hash}` : url;
-}
-
-export function toEmbedUrl(url: string) {
-  const [baseWithParams, hash] = url.split('#');
-  const embedUrl = `${baseWithParams}&full=true`;
-
-  return hash ? `${embedUrl}#${hash}` : embedUrl;
 }
 
 export type SuggestionItem = {

--- a/apps/dashboard/src/components/header-navigation/support-drawer.tsx
+++ b/apps/dashboard/src/components/header-navigation/support-drawer.tsx
@@ -8,12 +8,11 @@ import { IS_AI_FEATURES_ENABLED } from '@/config';
 import { usePlainChat } from '@/hooks/use-plain-chat';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
-import { DocsIframeView, FooterLink, SuggestionCard } from './support-drawer-components';
+import { FooterLink, SuggestionCard } from './support-drawer-components';
 import {
   BOOK_DEMO_URL,
   CHANGELOG_URL,
   DRAWER_WIDTH_DEFAULT,
-  DRAWER_WIDTH_EXPANDED,
   docsUrl,
   ROADMAP_URL,
   useContextualGettingStarted,
@@ -22,17 +21,9 @@ import {
 
 type SupportDrawerContentProps = {
   onClose: () => void;
-  docsUrl: string | null;
-  onOpenDocs: (url: string) => void;
-  onCloseDocs: () => void;
 };
 
-function SupportDrawerContent({
-  onClose,
-  docsUrl: currentDocsUrl,
-  onOpenDocs,
-  onCloseDocs,
-}: SupportDrawerContentProps) {
+function SupportDrawerContent({ onClose }: SupportDrawerContentProps) {
   const telemetry = useTelemetry();
   const { showPlainLiveChat, isLiveChatVisible } = usePlainChat();
   const suggestions = useContextualSuggestions();
@@ -41,7 +32,6 @@ function SupportDrawerContent({
   const [hasSearchQuery, setHasSearchQuery] = useState(false);
 
   const hasInkeep = IS_AI_FEATURES_ENABLED && !!import.meta.env.VITE_INKEEP_API_KEY;
-  const isViewingDocs = currentDocsUrl !== null;
 
   const inkeepConfig: InkeepEmbeddedSearchProps = {
     baseSettings: {
@@ -100,14 +90,6 @@ function SupportDrawerContent({
     telemetry(TelemetryEvent.SUPPORT_DRAWER_SUGGESTION_CLICKED, { suggestionTitle: title });
   }
 
-  function handleTrackDocsBack() {
-    telemetry(TelemetryEvent.SUPPORT_DRAWER_DOCS_BACK_CLICKED);
-  }
-
-  function handleTrackDocsExternal() {
-    telemetry(TelemetryEvent.SUPPORT_DRAWER_DOCS_EXTERNAL_CLICKED);
-  }
-
   function handleShareFeedback() {
     if (isLiveChatVisible) {
       showPlainLiveChat();
@@ -120,17 +102,6 @@ function SupportDrawerContent({
   function handleOpenExternalLink(url: string) {
     window.open(url, '_blank noopener noreferrer');
     onClose();
-  }
-
-  if (isViewingDocs) {
-    return (
-      <DocsIframeView
-        url={currentDocsUrl}
-        onBack={onCloseDocs}
-        onTrackBack={handleTrackDocsBack}
-        onTrackExternal={handleTrackDocsExternal}
-      />
-    );
   }
 
   return (
@@ -167,7 +138,7 @@ function SupportDrawerContent({
                       <SuggestionCard
                         key={item.title}
                         item={item}
-                        onOpenDocs={onOpenDocs}
+                        onOpenUrl={handleOpenExternalLink}
                         onTrack={handleTrackSuggestion}
                       />
                     ))}
@@ -185,7 +156,7 @@ function SupportDrawerContent({
                       <SuggestionCard
                         key={item.title}
                         item={item}
-                        onOpenDocs={onOpenDocs}
+                        onOpenUrl={handleOpenExternalLink}
                         onTrack={handleTrackSuggestion}
                       />
                     ))}
@@ -257,27 +228,12 @@ type SupportDrawerProps = {
 export function SupportDrawer({ children }: SupportDrawerProps) {
   const telemetry = useTelemetry();
   const [isOpen, setIsOpen] = useState(false);
-  const [docsUrl, setDocsUrl] = useState<string | null>(null);
-
-  const isViewingDocs = docsUrl !== null;
-  const drawerWidth = isViewingDocs ? DRAWER_WIDTH_EXPANDED : DRAWER_WIDTH_DEFAULT;
 
   function handleOpenChange(open: boolean) {
     setIsOpen(open);
     if (open) {
       telemetry(TelemetryEvent.SUPPORT_DRAWER_OPENED);
     }
-    if (!open) {
-      setDocsUrl(null);
-    }
-  }
-
-  function handleOpenDocs(url: string) {
-    setDocsUrl(url);
-  }
-
-  function handleCloseDocs() {
-    setDocsUrl(null);
   }
 
   const trigger = isValidElement(children)
@@ -289,15 +245,10 @@ export function SupportDrawer({ children }: SupportDrawerProps) {
       {trigger}
       <Sheet open={isOpen} onOpenChange={handleOpenChange}>
         <SheetContent
-          className="border-stroke-soft m-[10px] h-[calc(100%-20px)] rounded-xl border bg-neutral-50 p-0 shadow-[0px_18px_88px_-4px_rgba(24,39,75,0.16)] transition-[width,max-width] duration-300 ease-[cubic-bezier(0.25,0.1,0.25,1)]"
-          style={{ width: drawerWidth, maxWidth: drawerWidth }}
+          className="border-stroke-soft m-[10px] h-[calc(100%-20px)] rounded-xl border bg-neutral-50 p-0 shadow-[0px_18px_88px_-4px_rgba(24,39,75,0.16)]"
+          style={{ width: DRAWER_WIDTH_DEFAULT, maxWidth: DRAWER_WIDTH_DEFAULT }}
         >
-          <SupportDrawerContent
-            onClose={() => handleOpenChange(false)}
-            docsUrl={docsUrl}
-            onOpenDocs={handleOpenDocs}
-            onCloseDocs={handleCloseDocs}
-          />
+          <SupportDrawerContent onClose={() => handleOpenChange(false)} />
         </SheetContent>
       </Sheet>
     </>

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -107,8 +107,6 @@ export enum TelemetryEvent {
   SUPPORT_DRAWER_ROADMAP_CLICKED = 'Support drawer roadmap clicked - [Support]',
   SUPPORT_DRAWER_CHAT_CLICKED = 'Support drawer chat clicked - [Support]',
   SUPPORT_DRAWER_BOOK_DEMO_CLICKED = 'Support drawer book demo clicked - [Support]',
-  SUPPORT_DRAWER_DOCS_BACK_CLICKED = 'Support drawer docs back clicked - [Support]',
-  SUPPORT_DRAWER_DOCS_EXTERNAL_CLICKED = 'Support drawer docs external link clicked - [Support]',
 
   COPILOT_MESSAGE_SENT = 'Copilot message sent - [AI Copilot]',
   COPILOT_GENERATION_COMPLETED = 'Copilot generation completed - [AI Copilot]',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Suggestion and Getting started cards in the support/help drawer now open `docs.novu.co` links in a **new browser tab** instead of loading them in an in-drawer iframe.

The iframe docs view (`DocsIframeView`), expand-to-700px width, embed URL helper, and related telemetry events were removed since they are unused.

## Why

`docs.novu.co` cannot be framed (X-Frame-Options / CSP), so the previous embed experience failed. Opening docs externally matches the existing Documentation footer link behavior.

## Test plan

- [ ] Open the help/support drawer from the header
- [ ] Click a Suggestions or Getting started card → docs open in a new tab; drawer closes
- [ ] Click Documentation in the footer → same new-tab behavior
- [ ] Confirm the drawer no longer expands or shows an iframe docs view

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b29ad7f7-9f9e-4eae-a562-8ca4c4c82ba2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b29ad7f7-9f9e-4eae-a562-8ca4c4c82ba2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the broken in-drawer documentation iframe with the support drawer’s existing external-link behavior.
- Suggestion and getting-started documentation links now open in a new tab and close the drawer.
- The iframe view, expanded drawer state, embed URL helper, and iframe-specific telemetry events are removed.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the documentation links consistently routed through the existing external-link behavior.

The changed suggestion click path opens valid HTTPS documentation URLs synchronously from user activation before closing the drawer, and repository searches found no remaining references to the removed iframe APIs or telemetry events.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/header-navigation/support-drawer-components.tsx | Renames the suggestion callback for generic URL opening and removes the unused iframe documentation view. |
| apps/dashboard/src/components/header-navigation/support-drawer-constants.ts | Removes the expanded-width constant and documentation embed URL helper while preserving external documentation URLs. |
| apps/dashboard/src/components/header-navigation/support-drawer.tsx | Routes suggestion cards through the existing synchronous new-tab-and-close handler and removes iframe-related state. |
| apps/dashboard/src/utils/telemetry.ts | Removes telemetry events that were exclusive to the deleted iframe view. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Click[Click suggestion or getting-started card] --> Track[Record suggestion telemetry]
    Track --> Open[Open documentation in new tab]
    Open --> Close[Close support drawer]
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): open support drawer docs..."](https://github.com/novuhq/novu/commit/9be017158615c5fecd81f8225d9286b330df6a93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50406261)</sub>

<!-- /greptile_comment -->