### PR TITLE
fix(dashboard): query topic subscription details by identifier fixes NV-8527

### DIFF
--- a/apps/api/src/app/subscriptions/usecases/get-subscription/get-subscription.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/get-subscription/get-subscription.usecase.ts
@@ -61,26 +61,14 @@ export class GetSubscription {
             enabled: useContextFiltering,
           });
 
-    const scopeQuery = {
+    const subscription = await this.topicSubscribersRepository.findOne({
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
       topicKey: command.topicKey,
+      identifier: command.identifier,
       ...(command._subscriberId && { _subscriberId: command._subscriberId }),
       ...contextQuery,
-    };
-
-    let subscription = await this.topicSubscribersRepository.findOne({
-      ...scopeQuery,
-      identifier: command.identifier,
     });
-
-    // Subscriptions created before identifiers existed may have none, so also accept the internal id
-    if (!subscription && BaseRepository.isInternalId(command.identifier)) {
-      subscription = await this.topicSubscribersRepository.findOne({
-        ...scopeQuery,
-        _id: command.identifier,
-      });
-    }
 
     if (!subscription) {
       return null;

--- a/apps/api/src/app/subscriptions/usecases/get-subscription/get-subscription.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/get-subscription/get-subscription.usecase.ts
@@ -61,14 +61,26 @@ export class GetSubscription {
             enabled: useContextFiltering,
           });
 
-    const subscription = await this.topicSubscribersRepository.findOne({
+    const scopeQuery = {
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
       topicKey: command.topicKey,
-      identifier: command.identifier,
       ...(command._subscriberId && { _subscriberId: command._subscriberId }),
       ...contextQuery,
+    };
+
+    let subscription = await this.topicSubscribersRepository.findOne({
+      ...scopeQuery,
+      identifier: command.identifier,
     });
+
+    // Subscriptions created before identifiers existed may have none, so also accept the internal id
+    if (!subscription && BaseRepository.isInternalId(command.identifier)) {
+      subscription = await this.topicSubscribersRepository.findOne({
+        ...scopeQuery,
+        _id: command.identifier,
+      });
+    }
 
     if (!subscription) {
       return null;

--- a/apps/api/src/app/topics-v2/e2e/get-topic-subscription.e2e.ts
+++ b/apps/api/src/app/topics-v2/e2e/get-topic-subscription.e2e.ts
@@ -78,7 +78,7 @@ describe('Get topic subscription - /v2/topics/:topicKey/subscriptions/:identifie
     expect(response.body.data.preferences[0].enabled).to.equal(false);
   });
 
-  it('should return the subscription when queried by its internal id', async () => {
+  it('should return 204 when queried by the internal subscription id', async () => {
     const topicKey = `topic-key-get-by-internal-id-${Date.now()}`;
     const subscription = await createSubscription(topicKey);
 
@@ -90,37 +90,7 @@ describe('Get topic subscription - /v2/topics/:topicKey/subscriptions/:identifie
 
     const response = await session.testAgent.get(`/v2/topics/${topicKey}/subscriptions/${subscriptionEntity?._id}`);
 
-    expect(response.status).to.equal(200);
-    expect(response.body.data.id).to.equal(subscriptionEntity?._id);
-    expect(response.body.data.identifier).to.equal(subscription.identifier);
-  });
-
-  it('should return the subscription by internal id when it has no identifier', async () => {
-    const topicKey = `topic-key-get-legacy-${Date.now()}`;
-    const topicResponse = await novuClient.topics.create({ key: topicKey, name: 'Legacy Topic' });
-
-    await topicSubscribersRepository.createSubscriptions([
-      {
-        _environmentId: session.environment._id,
-        _organizationId: session.organization._id,
-        _subscriberId: subscriber._id,
-        _topicId: topicResponse.result.id,
-        topicKey,
-        externalSubscriberId: subscriber.subscriberId,
-        identifier: '',
-      },
-    ]);
-
-    const subscriptionEntity = await topicSubscribersRepository.findOne({
-      _environmentId: session.environment._id,
-      _organizationId: session.organization._id,
-      topicKey,
-    });
-
-    const response = await session.testAgent.get(`/v2/topics/${topicKey}/subscriptions/${subscriptionEntity?._id}`);
-
-    expect(response.status).to.equal(200);
-    expect(response.body.data.id).to.equal(subscriptionEntity?._id);
+    expect(response.status).to.equal(204);
   });
 
   it('should return 204 when the subscription does not exist', async () => {

--- a/apps/api/src/app/topics-v2/e2e/get-topic-subscription.e2e.ts
+++ b/apps/api/src/app/topics-v2/e2e/get-topic-subscription.e2e.ts
@@ -1,0 +1,134 @@
+import { Novu } from '@novu/api';
+import { SubscriberEntity, TopicSubscribersRepository } from '@novu/dal';
+import { CreateWorkflowDto, StepTypeEnum, WorkflowCreationSourceEnum } from '@novu/shared';
+import { SubscribersService, UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import { initNovuClassSdk } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
+
+describe('Get topic subscription - /v2/topics/:topicKey/subscriptions/:identifier (GET) #novu-v2', async () => {
+  let session: UserSession;
+  let novuClient: Novu;
+  let subscriber: SubscriberEntity;
+  let topicSubscribersRepository: TopicSubscribersRepository;
+
+  before(async () => {
+    session = new UserSession();
+    await session.initialize();
+    novuClient = initNovuClassSdk(session);
+    topicSubscribersRepository = new TopicSubscribersRepository();
+
+    const subscribersService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscribersService.createSubscriber();
+
+    const workflowDto: CreateWorkflowDto = {
+      name: 'Workflow 1',
+      workflowId: 'get-subscription-workflow-1',
+      __source: WorkflowCreationSourceEnum.DASHBOARD,
+      tags: ['tag1'],
+      active: true,
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          name: 'Test Step',
+          controlValues: {
+            body: 'Test content',
+          },
+        },
+      ],
+    };
+
+    await session.testAgent.post('/v2/workflows').send(workflowDto);
+  });
+
+  const createSubscription = async (topicKey: string) => {
+    await novuClient.topics.create({ key: topicKey, name: 'Test Topic' });
+
+    const subscriptionResponse = await novuClient.topics.subscriptions.create(
+      {
+        subscriberIds: [subscriber.subscriberId],
+        preferences: [
+          {
+            filter: { workflowIds: ['get-subscription-workflow-1'] },
+            enabled: false,
+          },
+        ],
+      },
+      topicKey
+    );
+
+    expect(subscriptionResponse.result.data.length, 'Should have created a subscription').to.equal(1);
+
+    const identifier = subscriptionResponse.result.data[0].identifier;
+    expect(identifier, 'Should have an identifier').to.be.a('string');
+
+    return { identifier: identifier as string };
+  };
+
+  it('should return the subscription with its preferences when queried by identifier', async () => {
+    const topicKey = `topic-key-get-by-identifier-${Date.now()}`;
+    const subscription = await createSubscription(topicKey);
+
+    const response = await session.testAgent.get(
+      `/v2/topics/${topicKey}/subscriptions/${encodeURIComponent(subscription.identifier)}`
+    );
+
+    expect(response.status).to.equal(200);
+    expect(response.body.data.identifier).to.equal(subscription.identifier);
+    expect(response.body.data.preferences?.length).to.be.greaterThan(0);
+    expect(response.body.data.preferences[0].enabled).to.equal(false);
+  });
+
+  it('should return the subscription when queried by its internal id', async () => {
+    const topicKey = `topic-key-get-by-internal-id-${Date.now()}`;
+    const subscription = await createSubscription(topicKey);
+
+    const subscriptionEntity = await topicSubscribersRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      identifier: subscription.identifier,
+    });
+
+    const response = await session.testAgent.get(`/v2/topics/${topicKey}/subscriptions/${subscriptionEntity?._id}`);
+
+    expect(response.status).to.equal(200);
+    expect(response.body.data.id).to.equal(subscriptionEntity?._id);
+    expect(response.body.data.identifier).to.equal(subscription.identifier);
+  });
+
+  it('should return the subscription by internal id when it has no identifier', async () => {
+    const topicKey = `topic-key-get-legacy-${Date.now()}`;
+    const topicResponse = await novuClient.topics.create({ key: topicKey, name: 'Legacy Topic' });
+
+    await topicSubscribersRepository.createSubscriptions([
+      {
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        _subscriberId: subscriber._id,
+        _topicId: topicResponse.result.id,
+        topicKey,
+        externalSubscriberId: subscriber.subscriberId,
+        identifier: '',
+      },
+    ]);
+
+    const subscriptionEntity = await topicSubscribersRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      topicKey,
+    });
+
+    const response = await session.testAgent.get(`/v2/topics/${topicKey}/subscriptions/${subscriptionEntity?._id}`);
+
+    expect(response.status).to.equal(200);
+    expect(response.body.data.id).to.equal(subscriptionEntity?._id);
+  });
+
+  it('should return 204 when the subscription does not exist', async () => {
+    const topicKey = `topic-key-get-missing-${Date.now()}`;
+    await createSubscription(topicKey);
+
+    const response = await session.testAgent.get(`/v2/topics/${topicKey}/subscriptions/does-not-exist`);
+
+    expect(response.status).to.equal(204);
+  });
+});

--- a/apps/dashboard/src/api/topics.ts
+++ b/apps/dashboard/src/api/topics.ts
@@ -220,7 +220,7 @@ export type TopicSubscriptionDetailsResponse = {
   id: string;
   identifier?: string;
   name?: string;
-  preferences: TopicSubscriptionPreference[];
+  preferences?: TopicSubscriptionPreference[];
 };
 
 export const getTopicSubscriptions = async ({
@@ -268,18 +268,19 @@ export const getTopicSubscriptions = async ({
 export const getTopicSubscription = async ({
   environment,
   topicKey,
-  subscriptionId,
+  subscriptionIdentifier,
 }: {
   environment: IEnvironment;
   topicKey: string;
-  subscriptionId: string;
-}): Promise<TopicSubscriptionDetailsResponse> => {
-  const response = await getV2<{ data: TopicSubscriptionDetailsResponse }>(
-    `/topics/${encodeURIComponent(topicKey)}/subscriptions/${subscriptionId}`,
+  subscriptionIdentifier: string;
+}): Promise<TopicSubscriptionDetailsResponse | null> => {
+  const response = await getV2<{ data?: TopicSubscriptionDetailsResponse }>(
+    `/topics/${encodeURIComponent(topicKey)}/subscriptions/${encodeURIComponent(subscriptionIdentifier)}`,
     {
       environment,
     }
   );
 
-  return response.data;
+  // The endpoint replies with 204 No Content when the subscription does not exist
+  return response.data ?? null;
 };

--- a/apps/dashboard/src/components/subscribers/hooks/use-get-subscription.ts
+++ b/apps/dashboard/src/components/subscribers/hooks/use-get-subscription.ts
@@ -4,26 +4,26 @@ import { useEnvironment } from '@/context/environment/hooks';
 
 export const useGetSubscription = ({
   topicKey,
-  subscriptionId,
+  subscriptionIdentifier,
   options,
 }: {
   topicKey?: string;
-  subscriptionId?: string;
-  options?: Omit<UseQueryOptions<TopicSubscriptionDetailsResponse, Error>, 'queryKey' | 'queryFn'>;
-}): UseQueryResult<TopicSubscriptionDetailsResponse, Error> => {
+  subscriptionIdentifier?: string;
+  options?: Omit<UseQueryOptions<TopicSubscriptionDetailsResponse | null, Error>, 'queryKey' | 'queryFn'>;
+}): UseQueryResult<TopicSubscriptionDetailsResponse | null, Error> => {
   const { enabled = true } = options || {};
   const { currentEnvironment } = useEnvironment();
 
   return useQuery({
-    queryKey: ['subscription-preferences', currentEnvironment?._id, topicKey, subscriptionId],
+    queryKey: ['subscription-preferences', currentEnvironment?._id, topicKey, subscriptionIdentifier],
     queryFn: () => {
-      if (!currentEnvironment || !topicKey || !subscriptionId) {
-        throw new Error('Environment, topicKey, subscriberId, and subscriptionId are required');
+      if (!currentEnvironment || !topicKey || !subscriptionIdentifier) {
+        throw new Error('Environment, topicKey, and subscriptionIdentifier are required');
       }
 
-      return getTopicSubscription({ environment: currentEnvironment, topicKey, subscriptionId });
+      return getTopicSubscription({ environment: currentEnvironment, topicKey, subscriptionIdentifier });
     },
-    enabled: enabled && !!currentEnvironment && !!topicKey && !!subscriptionId,
+    enabled: enabled && !!currentEnvironment && !!topicKey && !!subscriptionIdentifier,
     ...options,
   });
 };

--- a/apps/dashboard/src/components/subscribers/subscriptions/subscriber-subscriptions.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriptions/subscriber-subscriptions.tsx
@@ -141,8 +141,7 @@ export function SubscriberSubscriptions({ subscriberId }: SubscriberSubscription
           }
         }}
         topicKey={selectedSubscription?.topic.key}
-        // legacy subscriptions may not have an identifier, the API also resolves them by internal id
-        subscriptionIdentifier={selectedSubscription?.identifier || selectedSubscription?._id}
+        subscriptionIdentifier={selectedSubscription?.identifier}
         subscriberId={selectedSubscription?.subscriber.subscriberId}
       />
       <ConfirmationModal

--- a/apps/dashboard/src/components/subscribers/subscriptions/subscriber-subscriptions.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriptions/subscriber-subscriptions.tsx
@@ -141,7 +141,8 @@ export function SubscriberSubscriptions({ subscriberId }: SubscriberSubscription
           }
         }}
         topicKey={selectedSubscription?.topic.key}
-        subscriptionId={selectedSubscription?._id}
+        // legacy subscriptions may not have an identifier, the API also resolves them by internal id
+        subscriptionIdentifier={selectedSubscription?.identifier || selectedSubscription?._id}
         subscriberId={selectedSubscription?.subscriber.subscriberId}
       />
       <ConfirmationModal

--- a/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences-drawer.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences-drawer.tsx
@@ -27,7 +27,11 @@ export const SubscriptionPreferencesDrawer = forwardRef<HTMLDivElement, Subscrip
       }
     };
 
-    const { data: subscription, isLoading } = useGetSubscription({
+    const {
+      data: subscription,
+      isLoading,
+      isError,
+    } = useGetSubscription({
       topicKey,
       subscriptionIdentifier,
       options: { enabled: open },
@@ -53,6 +57,7 @@ export const SubscriptionPreferencesDrawer = forwardRef<HTMLDivElement, Subscrip
           </VisuallyHidden>
           <SubscriptionPreferences
             isLoading={isLoading}
+            isError={isError}
             topicKey={topicKey}
             subscription={subscription ?? undefined}
             subscriberId={subscriberId}

--- a/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences-drawer.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences-drawer.tsx
@@ -9,13 +9,13 @@ type SubscriptionPreferencesDrawerProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   topicKey?: string;
-  subscriptionId?: string;
+  subscriptionIdentifier?: string;
   subscriberId?: string;
   className?: string;
 };
 
 export const SubscriptionPreferencesDrawer = forwardRef<HTMLDivElement, SubscriptionPreferencesDrawerProps>(
-  ({ open, onOpenChange, topicKey, subscriptionId, subscriberId, className }, forwardedRef) => {
+  ({ open, onOpenChange, topicKey, subscriptionIdentifier, subscriberId, className }, forwardedRef) => {
     const overlayRef = useRef<HTMLDivElement>(null);
 
     const handleInteractOutside = (e: Event) => {
@@ -29,7 +29,7 @@ export const SubscriptionPreferencesDrawer = forwardRef<HTMLDivElement, Subscrip
 
     const { data: subscription, isLoading } = useGetSubscription({
       topicKey,
-      subscriptionId,
+      subscriptionIdentifier,
       options: { enabled: open },
     });
 
@@ -54,7 +54,7 @@ export const SubscriptionPreferencesDrawer = forwardRef<HTMLDivElement, Subscrip
           <SubscriptionPreferences
             isLoading={isLoading}
             topicKey={topicKey}
-            subscription={subscription}
+            subscription={subscription ?? undefined}
             subscriberId={subscriberId}
           />
         </SheetContent>

--- a/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences.tsx
@@ -13,6 +13,7 @@ import { SubscriptionPreferenceRule } from './subscription-preference-rule';
 
 type SubscriptionPreferencesProps = {
   isLoading: boolean;
+  isError?: boolean;
   topicKey?: string;
   subscription?: TopicSubscriptionDetailsResponse;
   subscriberId?: string;
@@ -53,6 +54,7 @@ const SubscriptionOverview = ({ children, className, isCopyable, label, value }:
 
 export const SubscriptionPreferences = ({
   isLoading,
+  isError,
   topicKey,
   subscription,
   subscriberId,
@@ -111,6 +113,18 @@ export const SubscriptionPreferences = ({
               View subscription activity
             </Button>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex h-full flex-col">
+        <SubscriptionPreferencesHeader />
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-1 p-6 text-center">
+          <span className="text-foreground-600 text-sm font-medium">Couldn't load subscription preferences</span>
+          <span className="text-text-soft text-xs">Close the panel and try again.</span>
         </div>
       </div>
     );

--- a/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences.tsx
@@ -26,6 +26,17 @@ interface SubscriptionOverviewProps {
   value?: string;
 }
 
+const SubscriptionPreferencesHeader = () => {
+  return (
+    <header className="border-bg-soft flex h-12 w-full shrink-0 flex-row items-center gap-3 border-b px-3 py-4">
+      <div className="flex flex-1 items-center gap-1 overflow-hidden text-sm font-medium">
+        <RiMindMap className="size-5 p-0.5" />
+        <TruncatedText className="flex-1 pr-10">Subscription preferences</TruncatedText>
+      </div>
+    </header>
+  );
+};
+
 const SubscriptionOverview = ({ children, className, isCopyable, label, value }: SubscriptionOverviewProps) => {
   return (
     <div className={cn('flex items-center justify-between gap-2 overflow-hidden', className)}>
@@ -48,15 +59,10 @@ export const SubscriptionPreferences = ({
 }: SubscriptionPreferencesProps) => {
   const [openTopicDrawer, setOpenTopicDrawer] = useState(false);
 
-  if (isLoading || !subscription || !topicKey || !subscriberId) {
+  if (isLoading) {
     return (
       <div className="flex h-full flex-col">
-        <header className="border-bg-soft flex h-12 w-full shrink-0 flex-row items-center gap-3 border-b px-3 py-4">
-          <div className="flex flex-1 items-center gap-1 overflow-hidden text-sm font-medium">
-            <RiMindMap className="size-5 p-0.5" />
-            <TruncatedText className="flex-1 pr-10">Subscription preferences</TruncatedText>
-          </div>
-        </header>
+        <SubscriptionPreferencesHeader />
         <div className="flex min-h-0 flex-1 flex-col overflow-auto">
           <div className="flex flex-col gap-2 border-b border-bg-soft p-4">
             <motion.div {...fadeIn}>
@@ -110,15 +116,24 @@ export const SubscriptionPreferences = ({
     );
   }
 
+  if (!subscription || !topicKey || !subscriberId) {
+    return (
+      <div className="flex h-full flex-col">
+        <SubscriptionPreferencesHeader />
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-1 p-6 text-center">
+          <span className="text-foreground-600 text-sm font-medium">Subscription not found</span>
+          <span className="text-text-soft text-xs">
+            It may have been removed, or it is no longer available in this environment.
+          </span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <div className="flex h-full flex-col">
-        <header className="border-bg-soft flex h-12 w-full shrink-0 flex-row items-center gap-3 border-b px-3 py-4">
-          <div className="flex flex-1 items-center gap-1 overflow-hidden text-sm font-medium">
-            <RiMindMap className="size-5 p-0.5" />
-            <TruncatedText className="flex-1 pr-10">Subscription preferences</TruncatedText>
-          </div>
-        </header>
+        <SubscriptionPreferencesHeader />
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="flex flex-col gap-2 border-b border-bg-soft p-4">
             <motion.div {...fadeIn}>
@@ -137,9 +152,13 @@ export const SubscriptionPreferences = ({
             <span className="text-xs font-medium">Preference rules</span>
           </div>
           <div className="flex flex-col gap-2 p-3 overflow-auto">
-            {subscription.preferences.map((preference) => (
-              <SubscriptionPreferenceRule key={preference.workflow.id} preference={preference} />
-            ))}
+            {subscription.preferences?.length ? (
+              subscription.preferences.map((preference) => (
+                <SubscriptionPreferenceRule key={preference.workflow.id} preference={preference} />
+              ))
+            ) : (
+              <span className="text-text-soft text-xs">No preference rules are defined for this subscription.</span>
+            )}
           </div>
         </div>
         <div className="flex shrink-0 flex-col gap-2 border-t border-bg-soft p-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Linear: [NV-8527](https://linear.app/novu/issue/NV-8527/dashboard-subscription-preferences-drawer-errors-because-it-queries)

Opening **View subscription preferences** on a topic subscription showed a non-descriptive error instead of the preference rules.

The drawer called `GET /v2/topics/:topicKey/subscriptions/:identifier` with the subscription's internal Mongo `_id`, but that endpoint resolves subscriptions by their external `identifier`. The lookup missed, the API replied `204 No Content`, the dashboard fetcher returned `undefined`, and TanStack Query surfaced its generic `data is undefined` error keyed by the query cache key.

Changes:

- **Dashboard** — pass the subscription `identifier` instead of `_id`, URL-encoded since identifiers contain `:` and may contain `,` when context keys are involved.
- **Dashboard** — treat `204 No Content` as `null` rather than `undefined` so the query resolves cleanly, and render a readable "Subscription not found" state. A failed request renders a separate error state instead, so a network or API failure is not reported as a missing subscription. The preference list also tolerates an absent `preferences` array, which the API DTO marks optional.
- **API** — new e2e suite `get-topic-subscription.e2e.ts` covering lookup by identifier, plus the `204` responses for an internal id and for an unknown identifier.

The API is unchanged: it resolves subscriptions by identifier only, with no internal-id compatibility path.

### Screenshots

Before — the drawer stays on skeletons and a toast reports `[...] data is undefined`:

![Subscription preferences drawer stuck on skeletons with a data is undefined error toast](https://cursor.com/artifacts/c/art-719a7128-b136-48fe-91e1-521b0153f7b0)

After — the drawer renders the subscription details and its preference rules:

<a href="https://cursor.com/agents/bc-81efb141-5e0c-48d0-9a27-6c28706f59fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsubscription_preferences_drawer_identifier_only_lookup.mp4"><img src="https://cursor.com/artifacts/c/art-3d643362-7e0b-4be9-a586-ccec7ac2143b" alt="subscription_preferences_drawer_identifier_only_lookup.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

`GET /v2/topics/:topicKey/subscriptions/:identifier` returns `204 No Content` rather than `404` for a miss, which is why the dashboard needed an explicit `null` mapping — returning `undefined` from a TanStack Query `queryFn` is always an error.

Verification: 84 e2e tests pass across `src/app/topics-v2/e2e` and the inbox topic suites, including the 3 new ones, plus a manual reproduce-then-fix pass in the dashboard shown above.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81efb141-5e0c-48d0-9a27-6c28706f59fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81efb141-5e0c-48d0-9a27-6c28706f59fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The dashboard now queries topic subscriptions by their external identifier and distinguishes loading, missing-subscription, and request-error states.
- URL-encodes topic and subscription identifiers before requesting subscription details.
- Maps empty API responses to `null` and supports optional preference arrays.
- Adds focused API coverage for identifier lookup, internal-ID misses, and nonexistent subscriptions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported conflation of query errors with missing subscriptions is resolved by the dedicated error state.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/api/topics.ts | Uses the encoded external subscription identifier and normalizes an empty response to null. |
| apps/dashboard/src/components/subscribers/hooks/use-get-subscription.ts | Updates the query contract and cache key to use the subscription identifier and nullable response. |
| apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences-drawer.tsx | Forwards query failures separately from absent subscription data. |
| apps/dashboard/src/components/subscribers/subscriptions/subscription-preferences.tsx | Renders distinct loading, request-error, missing-subscription, and successful preference states. |
| apps/api/src/app/topics-v2/e2e/get-topic-subscription.e2e.ts | Adds endpoint coverage for identifier lookup and empty responses for internal or nonexistent identifiers. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Drawer as Preferences drawer
    participant Query as TanStack Query
    participant API as Topics API
    User->>Drawer: Open subscription preferences
    Drawer->>Query: Fetch by encoded identifier
    Query->>API: GET /topics/:key/subscriptions/:identifier
    alt Subscription exists
        API-->>Query: 200 subscription details
        Query-->>Drawer: Render preference rules
    else Subscription missing
        API-->>Query: 204 No Content
        Query-->>Drawer: null
        Drawer-->>User: Subscription not found
    else Request fails
        API--xQuery: Network/API error
        Query-->>Drawer: Error state
        Drawer-->>User: Couldn't load preferences
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): drop internal-id compati..."](https://github.com/novuhq/novu/commit/7dd6bf310f832ff77ea930f593f6405f018c09d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50421410)</sub>

<!-- /greptile_comment -->