### PR TITLE
fix(worker): keep trigger attachments until the job chain ends fixes NV-8533

### DIFF
--- a/apps/worker/src/app/workflow/specs/run-job-attachments.spec.ts
+++ b/apps/worker/src/app/workflow/specs/run-job-attachments.spec.ts
@@ -1,0 +1,86 @@
+import { JobEntity, NotificationEntity } from '@novu/dal';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { RunJob } from '../usecases/run-job';
+
+/**
+ * Attachments are uploaded once per trigger and downloaded again by every job that
+ * needs them, so they may only be released after the last job of the chain. Under
+ * payload-dedup a job's payload is the parent notification's payload object, which the
+ * already-executed job hydrates with the downloaded file — deleting on that hydrated
+ * payload used to wipe the file before the next step could send it.
+ */
+describe('RunJob - stored attachment cleanup', () => {
+  const buildNotification = () =>
+    ({
+      _id: 'notification-id',
+      payload: {
+        attachments: [
+          {
+            name: 'invoice.pdf',
+            mime: 'application/pdf',
+            storagePath: 'org/env/random/invoice.pdf',
+            file: Buffer.from('%PDF-1.7'),
+          },
+        ],
+      },
+    }) as unknown as NotificationEntity;
+
+  const buildJob = (payload?: Record<string, unknown>) =>
+    ({
+      _id: 'job-id',
+      _environmentId: 'env-id',
+      _organizationId: 'org-id',
+      _subscriberId: 'subscriber-id',
+      _notificationId: 'notification-id',
+      _userId: 'user-id',
+      type: 'trigger',
+      payload,
+    }) as unknown as JobEntity;
+
+  const buildRunJob = (overrides: Record<string, unknown>) => {
+    const runJob = Object.create(RunJob.prototype);
+
+    Object.assign(runJob, {
+      workflowRunService: { updateDeliveryLifecycle: sinon.stub().resolves() },
+      addJobUsecase: { execute: sinon.stub().resolves({ stepStatus: 'queued' }) },
+      stepRunRepository: { create: sinon.stub().resolves(), createMany: sinon.stub().resolves() },
+      createExecutionDetails: { execute: sinon.stub().resolves() },
+      logger: { error: sinon.stub(), info: sinon.stub() },
+      ...overrides,
+    });
+
+    return runJob;
+  };
+
+  it('keeps the stored attachments while the next job is queued', async () => {
+    const notification = buildNotification();
+    const deleteAttachments = sinon.stub().resolves();
+    const runJob = buildRunJob({
+      jobRepository: {
+        claimNextChildAsQueued: sinon.stub().resolves(buildJob()),
+      },
+      storageHelperService: { deleteAttachments },
+    });
+
+    await runJob.tryQueueNextJobs(buildJob(), notification, false);
+
+    expect(deleteAttachments.called).to.equal(false);
+  });
+
+  it('releases the stored attachments once no job is left in the chain', async () => {
+    const notification = buildNotification();
+    const deleteAttachments = sinon.stub().resolves();
+    const runJob = buildRunJob({
+      jobRepository: {
+        claimNextChildAsQueued: sinon.stub().resolves(null),
+      },
+      storageHelperService: { deleteAttachments },
+    });
+
+    await runJob.tryQueueNextJobs(buildJob(), notification, false);
+
+    expect(deleteAttachments.calledOnce).to.equal(true);
+    expect(deleteAttachments.firstCall.args[0]).to.equal(notification.payload.attachments);
+  });
+});

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -615,6 +615,8 @@ export class RunJob {
     let shouldContinueQueueNextJob = true;
 
     while (shouldContinueQueueNextJob) {
+      let isWorkflowHaltedForNextJob = false;
+
       try {
         if (!currentJob) {
           return;
@@ -635,6 +637,10 @@ export class RunJob {
               currentJob: { type: currentJob.type, _id: currentJob._id },
             });
           }
+
+          // No job left in the chain, so the stored attachments can be released.
+          currentJob.payload = getEffectiveJobPayload(currentJob, notification);
+          await this.storageHelperService.deleteAttachments(currentJob.payload?.attachments);
 
           return;
         }
@@ -724,6 +730,7 @@ export class RunJob {
 
         const isHaltingWorkflow = shouldHaltOnStepFailure(nextJob) && !this.shouldBackoff(error as Error);
         const isLastJobFailed = !jobAfterNext || isHaltingWorkflow;
+        isWorkflowHaltedForNextJob = isHaltingWorkflow;
 
         await this.setJobAsFailed.execute(
           SetJobAsFailedCommand.create({
@@ -768,7 +775,13 @@ export class RunJob {
           // when the job doesn't carry its own. nextJob shares the same
           // notification as the current workflow execution.
           nextJob.payload = getEffectiveJobPayload(nextJob, notification);
-          await this.storageHelperService.deleteAttachments(nextJob.payload?.attachments);
+
+          // Only release the stored attachments once nothing is left to run. A queued
+          // job still has to download them, and a job that will be retried after a
+          // backoff needs them on its next attempt.
+          if (isWorkflowHaltedForNextJob) {
+            await this.storageHelperService.deleteAttachments(nextJob.payload?.attachments);
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Email (and other channel) steps were sending **zero-byte attachments**: the recipient gets an `invoice.pdf` of 0 bytes, which every PDF reader reports as corrupt. Reported for SES, but the bug is provider-independent — the attachment is already gone before the provider is reached.

## Root cause

Attachments are uploaded to storage once at trigger time (the binary is stripped from the queued payload) and re-downloaded by each job that needs them.

`#11976` (payload-dedup, NV-8320) added this line to `tryQueueNextJobs`:

```ts
nextJob.payload = getEffectiveJobPayload(nextJob, notification);
await this.storageHelperService.deleteAttachments(nextJob.payload?.attachments);
```

With payload-dedup on, a job no longer persists its own payload, so `getEffectiveJobPayload` returns **the parent notification's payload object itself**. Every workflow starts with an ad-hoc `trigger` job whose `run-job` run calls `getAttachments(...)`, which hydrates `attachments[0].file` with the downloaded `Buffer` **on that shared object**.

So when the `trigger` job finishes and queues the email job, `deleteAttachments` sees a truthy `file` and deletes the stored object — before the email job ever runs. The email job's own `getAttachments` then hits `NoSuchKey`, swallows it as `file = null`, and nodemailer emits an attachment part with an empty body.

Before payload-dedup this call was a silent no-op (payloads loaded from Mongo never carry `file`), which is why it went unnoticed.

```mermaid
sequenceDiagram
    participant T as trigger job
    participant S as storage
    participant E as email job
    participant P as email provider
    T->>S: getAttachments -> file = Buffer (on notification.payload)
    T->>E: queue next job
    T->>S: deleteAttachments (sees truthy file) ❌
    E->>S: getAttachments -> NoSuchKey -> file = null
    E->>P: attachment with empty content
```

## Fix

Release stored attachments only when nothing is left to run:

- delete them when `claimNextChildAsQueued` returns no next job (chain complete) — this also closes a pre-existing leak where the normal completion path never cleaned up;
- in the `finally`, delete only when the workflow was halted for the next job, so a queued job still has its files and a job awaiting a backoff retry keeps them for its next attempt.

## Verification

End-to-end against the local stack, with the SES endpoint pointed at a capture sink so the exact `SendEmail` raw MIME could be inspected.

Before the fix — attachment part is empty:

```
Content-Type: application/pdf; name=invoice.pdf
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename=invoice.pdf

----_NmP-bc48cc554e94e2cd-Part_1--
```

After the fix, single email step:

```
attachment: invoice.pdf bytes: 120016
  sha256: 83be0d761dcd3c34f2c545734ea2ee0796ece842bbe00271155a67032c20d9dc
  matches original: True
```

After the fix, two email steps (both intact, storage cleaned up afterwards):

```
subject: First  | attachment invoice.pdf 120016 matches: True
subject: Second | attachment invoice.pdf 120016 matches: True
s3 objects after workflow: []
```

Also added `apps/worker/src/app/workflow/specs/run-job-attachments.spec.ts`, which fails on the current `next` and passes with this change.

## Breaking changes

None.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1785998002626359?thread_ts=1785998002.626359&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-b83699f7-dd4a-533d-b4c9-e934ba6f6815?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b83699f7-dd4a-533d-b4c9-e934ba6f6815&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers stored-attachment deletion until a workflow chain ends or is deliberately halted, preventing later steps and retries from receiving empty files.

- Moves normal attachment cleanup to the no-next-job completion path.
- Preserves attachments while another job is queued or awaiting backoff.
- Adds focused tests for retention during chaining and cleanup at chain completion.

<h3>Confidence Score: 4/5</h3>

The attachment-lifetime fix should not merge until cleanup failures are prevented from marking successfully delivered final jobs as failed.

The new completion-path deletion is awaited after delivery and completion are persisted, so an S3 deletion error escapes job execution and causes failure handling to overwrite the successful job state.

**Files Needing Attention:** apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Correctly delays attachment cleanup, but a storage deletion failure can convert an already successful final job into a failed job. |
| apps/worker/src/app/workflow/specs/run-job-attachments.spec.ts | Covers retention while chaining and deletion at completion, but does not exercise deletion failure behavior. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Job as Final RunJob
    participant Provider as Channel Provider
    participant DB as Job Repository
    participant Storage as S3 Storage
    participant Worker as StandardWorker
    Job->>Provider: Send message with attachment
    Provider-->>Job: Delivered
    Job->>DB: Mark COMPLETED
    Job->>Storage: Delete stored attachment
    Storage--xJob: Transient deletion error
    Job--xWorker: RunJob rejects
    Worker->>DB: Mark already-delivered job FAILED
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Frun-job%2Frun-job.usecase.ts%3A643%0A**Cleanup%20overwrites%20completed%20job%20state**%0A%0AWhen%20the%20default%20S3%20provider%20returns%20a%20transient%20deletion%20error%2C%20this%20awaited%20cleanup%20rejects%20after%20the%20message%20was%20delivered%20and%20the%20job%20was%20marked%20completed.%20The%20rejection%20enters%20the%20worker%20failure%20handler%2C%20which%20overwrites%20the%20successfully%20delivered%20job%20as%20failed%20and%20records%20an%20incorrect%20failure%20lifecycle.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12247&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts:643
**Cleanup overwrites completed job state**

When the default S3 provider returns a transient deletion error, this awaited cleanup rejects after the message was delivered and the job was marked completed. The rejection enters the worker failure handler, which overwrites the successfully delivered job as failed and records an incorrect failure lifecycle.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): keep trigger attachments un..."](https://github.com/novuhq/novu/commit/c8b867d6f350ffb40c79a7873b2721078ae0fe77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50736793)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)

<!-- /greptile_comment -->