### PR TITLE
fix(worker): enhance job handling by adding attachment management for failing jobs and updating test cases

### DIFF
--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.spec.ts
@@ -2,6 +2,7 @@ import {
   getEffectiveJobPayload,
   StorageHelperService,
   StorageService,
+  WEBHOOK_FILTER_REQUEST_FAILED_DATA,
   WorkflowRunStatusEnum,
 } from '@novu/application-generic';
 import { JobEntity, JobStatusEnum } from '@novu/dal';
@@ -21,13 +22,19 @@ type RunJobTestDouble = {
     notification?: PartialNotificationEntity | null,
     hasCurrentJobError?: boolean
   ) => Promise<void>;
-  jobRepository: { claimNextChildAsQueued: sinon.SinonStub; updateOne: sinon.SinonStub };
+  jobRepository: {
+    claimNextChildAsQueued: sinon.SinonStub;
+    updateOne: sinon.SinonStub;
+    findOne: sinon.SinonStub;
+    cancelPendingJobs: sinon.SinonStub;
+  };
   addJobUsecase: { execute: sinon.SinonStub };
+  setJobAsFailed: { execute: sinon.SinonStub };
   storageHelperService: StorageHelperService;
   workflowRunService: { updateDeliveryLifecycle: sinon.SinonStub };
-  stepRunRepository: { create: sinon.SinonStub };
+  stepRunRepository: { create: sinon.SinonStub; createMany: sinon.SinonStub };
   createExecutionDetails: { execute: sinon.SinonStub };
-  logger: { debug: sinon.SinonStub; warn: sinon.SinonStub };
+  logger: { debug: sinon.SinonStub; warn: sinon.SinonStub; error: sinon.SinonStub };
 };
 
 const ATTACHMENT_STORAGE_PATH = 'environment-id/attachment.pdf';
@@ -35,12 +42,18 @@ const PDF_BYTES = Buffer.from('%PDF-1.7 pdf-bytes');
 
 function buildUsecase(sandbox: sinon.SinonSandbox): RunJobTestDouble {
   const usecase = Object.create(RunJob.prototype) as RunJobTestDouble;
-  usecase.jobRepository = { claimNextChildAsQueued: sandbox.stub(), updateOne: sandbox.stub().resolves() };
+  usecase.jobRepository = {
+    claimNextChildAsQueued: sandbox.stub(),
+    updateOne: sandbox.stub().resolves(),
+    findOne: sandbox.stub().resolves(null),
+    cancelPendingJobs: sandbox.stub().resolves([]),
+  };
   usecase.addJobUsecase = { execute: sandbox.stub() };
+  usecase.setJobAsFailed = { execute: sandbox.stub().resolves() };
   usecase.workflowRunService = { updateDeliveryLifecycle: sandbox.stub().resolves() };
-  usecase.stepRunRepository = { create: sandbox.stub().resolves() };
+  usecase.stepRunRepository = { create: sandbox.stub().resolves(), createMany: sandbox.stub().resolves() };
   usecase.createExecutionDetails = { execute: sandbox.stub().resolves() };
-  usecase.logger = { debug: sandbox.stub(), warn: sandbox.stub() };
+  usecase.logger = { debug: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() };
 
   return usecase;
 }
@@ -148,6 +161,38 @@ describe('RunJob - attachment cleanup ordering', () => {
 
     sinon.assert.calledOnceWithExactly(deleteAttachments, notification.payload.attachments);
     expect(dedupJob.payload).to.equal(undefined);
+  });
+
+  it('deletes the attachments when a failing child halts the workflow', async () => {
+    const haltingJob = buildJob({
+      _id: 'email-job-id',
+      type: StepTypeEnum.EMAIL,
+      payload: undefined,
+      step: { _id: 'step-id', shouldStopOnFail: true },
+    } as unknown as Partial<JobEntity>);
+    usecase.jobRepository.claimNextChildAsQueued.resolves(haltingJob);
+    usecase.addJobUsecase.execute.rejects(new Error('failed to add the job'));
+
+    await usecase.tryQueueNextJobs(triggerJob, notification);
+
+    sinon.assert.calledOnce(usecase.jobRepository.cancelPendingJobs);
+    sinon.assert.calledOnceWithExactly(deleteAttachments, notification.payload.attachments);
+  });
+
+  it('keeps the attachments when a failing child will be retried', async () => {
+    const retryingJob = buildJob({
+      _id: 'email-job-id',
+      type: StepTypeEnum.EMAIL,
+      payload: undefined,
+      step: { _id: 'step-id', shouldStopOnFail: true },
+    } as unknown as Partial<JobEntity>);
+    usecase.jobRepository.claimNextChildAsQueued.resolves(retryingJob);
+    usecase.addJobUsecase.execute.rejects(new Error(WEBHOOK_FILTER_REQUEST_FAILED_DATA));
+
+    await usecase.tryQueueNextJobs(triggerJob, notification);
+
+    sinon.assert.notCalled(usecase.jobRepository.cancelPendingJobs);
+    sinon.assert.notCalled(deleteAttachments);
   });
 
   it('deletes the executed job attachments when the chain ends on a skipped step', async () => {

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -764,6 +764,11 @@ export class RunJob {
               'Failed to cancel pending jobs after next job failure'
             );
           }
+
+          // The remaining steps were just cancelled, so this chain is over and
+          // nothing will read the attachments again. The retryable case below
+          // deliberately keeps them for the retry.
+          await this.deleteChainAttachments(job, notification);
         }
 
         if (shouldHaltOnStepFailure(nextJob) || this.shouldBackoff(error as Error)) {


### PR DESCRIPTION
…

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR cleans up stored attachments when a non-retryable child-job failure halts a workflow, while preserving attachments for retryable failures.

- Adds attachment deletion after pending jobs are cancelled on a halting failure.
- Adds tests covering cleanup for terminal failures and retention for webhook-filter retries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with terminal and retryable attachment lifecycles handled consistently.

The new cleanup runs only after a halting, non-retryable child failure, while retryable failures retain their attachments and storage deletion errors are caught by the existing cleanup helper.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Adds guarded chain-attachment cleanup after terminal next-job failure; storage cleanup errors remain contained by the existing helper. |
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.spec.ts | Extends test doubles and verifies attachments are deleted for terminal halting failures but retained for retryable failures. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): enhance job handling by add..."](https://github.com/novuhq/novu/commit/829e3857c52a7b5fffc241ec803bac58502cf0b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50759210)</sub>

**Context used:**

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)

<!-- /greptile_comment -->