### PR TITLE
feat(docs): add sinch sms docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -282,6 +282,7 @@
                   "platform/integrations/sms/nexmo",
                   "platform/integrations/sms/plivo",
                   "platform/integrations/sms/sendchamp",
+                  "platform/integrations/sms/sinch",
                   "platform/integrations/sms/simpletexting",
                   "platform/integrations/sms/sms-central",
                   "platform/integrations/sms/sms-webhook",

--- a/docs/platform/integrations/email.mdx
+++ b/docs/platform/integrations/email.mdx
@@ -1283,7 +1283,7 @@ Here are the email providers that are currently supported by Novu. Select any pr
   <Card title="Postmark" href="/platform/integrations/email/postmark"> Learn how to use the Postmark provider to send emails using Novu.</Card>
   <Card title="Resend" href="/platform/integrations/email/resend"> Learn how to use the Resend provider to send emails using Novu.</Card> 
   <Card title="Brevo" href="/platform/integrations/email/brevo"> Learn how to use the Brevo provider to send emails using Novu.</Card>
-  <Card title="Mailgun" href="/platform/integrations/email/mailgun"> Learn how to use the Mailgun provider to send emails using Novu.</Card>
+  <Card title="Sinch Mailgun" href="/platform/integrations/email/mailgun"> Learn how to use Sinch Mailgun to send emails using Novu.</Card>
   <Card title="Mailjet" href="/platform/integrations/email/mailjet"> Learn how to use the Mailjet provider to send emails using Novu.</Card>
   <Card title="Braze" href="/platform/integrations/email/braze"> Learn how to use the Braze provider to send emails using Novu.</Card> 
   <Card title="Infobip" href="/platform/integrations/email/infobip"> Learn how to use the Infobip provider to send emails using Novu.</Card> 

--- a/docs/platform/integrations/email/mailgun.mdx
+++ b/docs/platform/integrations/email/mailgun.mdx
@@ -1,47 +1,49 @@
 ---
-title: "Mailgun Email Integration with Novu"
-sidebarTitle: 'Mailgun'
-description: "Connect Mailgun to Novu to send transactional emails through workflows. Configure your Mailgun API key, sending domain, and region for reliable email delivery."
+title: "Sinch Mailgun Email Integration with Novu"
+sidebarTitle: "Sinch Mailgun"
+description: "Connect Sinch Mailgun to Novu to send transactional emails through workflows. Configure your Mailgun API key, sending domain, and region for reliable email delivery."
 ---
 
-You can use the [Mailgun](https://mailgun.com/) provider to send transactional emails to your customers using the Novu Platform with a single API to create multi-channel experiences.
+You can use [Sinch Mailgun](https://www.mailgun.com/) to send transactional emails to your customers through Novu.
+
+Mailgun is Sinch's email product. In the Novu Integrations Store it still appears as **Mailgun**. Use the same credentials from your Sinch Mailgun account.
 
 ## Getting Started
 
-To use the Mailgun provider in the email channel, you will need to create a Mailgun account and add your API key and domain name to the Mailgun integration on the Novu platform.
+To use Sinch Mailgun in the email channel, create a Mailgun account and add your API key and domain name to the Mailgun integration on the Novu platform.
 
 ## Generating an API Key
 
-To generate a new API key in Mailgun, you can follow these steps:
+To generate a new API key in Mailgun:
 
-- [Sign up](https://signup.mailgun.com/new/signup) or [Log in](https://login.mailgun.com/login/) to your Mailgun account.
-- Click on the **Profile** section in the top right corner of the screen, and then click "API Keys" from the drop-down menu.
-- On the [API Keys](https://app.mailgun.com/app/account/security/api_keys) page, copy the generated **Private API Key**
+- [Sign up](https://signup.mailgun.com/new/signup) or [Log in](https://login.mailgun.com/login/) to your Mailgun account.
+- Click on the **Profile** section in the top right corner of the screen, and then click "API Keys" from the drop-down menu.
+- On the [API Keys](https://app.mailgun.com/app/account/security/api_keys) page, copy the generated **Private API Key**
 
 ## Adding a new domain name
 
 Mailgun recommends that you add a subdomain as a domain name. To do so:
 
-- Visit the page to add a [domain name](https://app.mailgun.com/app/sending/domains/new).
-  - During this process, you will need to choose a region for the domain name which is between `US` and `EU`. The default is `US`.
-- Follow the [instructions](https://documentation.mailgun.com/en/latest/user_manual.html#verifying-your-domain-1) to verify the domain name.
+- Visit the page to add a [domain name](https://app.mailgun.com/app/sending/domains/new).
+  - During this process, you will need to choose a region for the domain name which is between `US` and `EU`. The default is `US`.
+- Follow the [instructions](https://documentation.mailgun.com/en/latest/user_manual.html#verifying-your-domain-1) to verify the domain name.
 
-## Creating a Mailgun integration with Novu
+## Creating a Sinch Mailgun integration with Novu
 
-- Visit the [Integrations](https://dashboard.novu.co/integrations?utm_campaign=docs-mailgun) page on Novu.
+- Visit the [Integrations](https://dashboard.novu.co/integrations?utm_campaign=docs-mailgun) page on Novu.
 - Click on Add a Provider.
-- Select Mailgun service.
+- Select **Mailgun**.
 - Enter your Mailgun API Key.
 - Enter your Base URL.
-  - For domains created in the EU region, the base URL is: `https://api.eu.mailgun.net/`
+  - For domains created in the EU region, the base URL is: `https://api.eu.mailgun.net/`
   - Otherwise, leave the base URL blank.
-- Fill in the `Username`.
-- Fill in the `Domain name` registered on Mailgun.
-- Fill in the `From email address` field using the authenticated email from the previous step.
-- Fill in the `Sender's name`.
-- Click on the `Disabled` button and mark it as `Active`.
-- Click on the **Update** button.
-- You should now be able to send notifications using Mailgun in Novu.
+- Fill in the `Username`.
+- Fill in the `Domain name` registered on Mailgun.
+- Fill in the `From email address` field using the authenticated email from the previous step.
+- Fill in the `Sender's name`.
+- Click on the `Disabled` button and mark it as `Active`.
+- Click on the **Update** button.
+- You should now be able to send notifications using Sinch Mailgun in Novu.
 
 ## Next Steps
 

--- a/docs/platform/integrations/sms.mdx
+++ b/docs/platform/integrations/sms.mdx
@@ -430,6 +430,7 @@ Here are the SMS providers that are currently supported by Novu. Select any prov
 <Card title="Nexmo" href="/platform/integrations/sms/nexmo"> Learn how to use the Nexmo provider to send SMS notifications using Novu.</Card>
 <Card title="Plivo" href="/platform/integrations/sms/plivo"> Learn how to use the Plivo provider to send SMS notifications using Novu.</Card>
 <Card title="Sendchamp" href="/platform/integrations/sms/sendchamp"> Learn how to use the Sendchamp provider to send SMS notifications using Novu.</Card>
+<Card title="Sinch" href="/platform/integrations/sms/sinch"> Learn how to use the Sinch provider to send SMS notifications using Novu.</Card>
 <Card title="SimpleTexting" href="/platform/integrations/sms/simpletexting"> Learn how to use the SimpleTexting provider to send SMS notifications using Novu.</Card>
 <Card title="SMS Central" href="/platform/integrations/sms/sms-central"> Learn how to use the SMS Central provider to send SMS notifications using Novu.</Card>
 <Card title="SMS Webhook" href="/platform/integrations/sms/sms-webhook"> Learn how to send SMS through your own HTTP API using Novu.</Card>

--- a/docs/platform/integrations/sms/sinch.mdx
+++ b/docs/platform/integrations/sms/sinch.mdx
@@ -49,8 +49,8 @@ For the **From** field, use a Sinch virtual number assigned to your service plan
    - **API Token**
    - **Region** (must match your Sinch service plan)
    - **From** (your Sinch sender number or sender ID)
-5. Click the **Disabled** toggle and mark the integration as **Active**.
-6. Click **Connect**.
+5. Confirm **Active Integration** is on. New integrations start active by default.
+6. Click **Create Integration**.
 </Step>
 </Steps>
 

--- a/docs/platform/integrations/sms/sinch.mdx
+++ b/docs/platform/integrations/sms/sinch.mdx
@@ -1,0 +1,67 @@
+---
+title: "Sinch SMS Integration with Novu"
+sidebarTitle: "Sinch"
+description: "Connect Sinch to Novu to send SMS notifications through workflows. Store your Service Plan ID, API token, sender, and region in the Novu dashboard."
+---
+
+You can use the [Sinch SMS API](https://developers.sinch.com/docs/sms/getting-started) to send SMS messages to your customers through Novu.
+
+## Setting up Sinch
+
+<Steps>
+<Step title="Create a Sinch account">
+1. Go to the [Sinch Build Dashboard](https://dashboard.sinch.com/) and create an account, or log in if you already have one.
+2. Open the SMS product and confirm you have a virtual number for sending. New accounts usually get a free test number. You can buy more numbers later from the dashboard.
+</Step>
+
+<Step title="Get your Service Plan ID and API token">
+1. In the Sinch Build Dashboard, go to **SMS** then **APIs**.
+2. Under **REST configuration**, copy your **Service Plan ID**.
+3. Click **Show** next to the API token and copy it.
+
+Keep these values handy. Novu needs both to authenticate with Sinch.
+</Step>
+
+<Step title="Note your region and sender">
+Sinch hosts SMS APIs in several regions. Use the same region as your service plan:
+
+| Region value in Novu | Sinch API host |
+| --- | --- |
+| `eu` | `eu.sms.api.sinch.com` (Ireland, Sweden) |
+| `us` | `us.sms.api.sinch.com` |
+| `au` | `au.sms.api.sinch.com` |
+| `br` | `br.sms.api.sinch.com` |
+| `ca` | `ca.sms.api.sinch.com` |
+
+For the **From** field, use a Sinch virtual number assigned to your service plan, or another sender ID Sinch allows for your account and destination country.
+</Step>
+</Steps>
+
+## Creating a Sinch integration with Novu
+
+<Steps>
+<Step title="Connect Sinch to Novu">
+1. Visit the [Integrations](https://dashboard.novu.co/integrations?utm_campaign=docs-sms-sinch) page on Novu.
+2. Click **Add a provider**.
+3. Locate **Sinch** under the SMS section and click **Connect**.
+4. Enter your:
+   - **Service Plan ID**
+   - **API Token**
+   - **Region** (must match your Sinch service plan)
+   - **From** (your Sinch sender number or sender ID)
+5. Click the **Disabled** toggle and mark the integration as **Active**.
+6. Click **Connect**.
+</Step>
+</Steps>
+
+You can now send SMS notifications with Sinch through Novu.
+
+<Note>
+  Some countries restrict which sender IDs you can use. Check Sinch and local regulations for the destinations you send to.
+</Note>
+
+## Next steps
+
+<Card title="Adding SMS Channel" href="/platform/integrations/sms/adding-sms">
+  Learn how to add an SMS step to a workflow and test delivery.
+</Card>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Sinch SMS integration documentation and updates Mailgun branding to Sinch Mailgun.
- Registers Sinch in the SMS navigation and provider catalog.
- Documents Sinch credentials, regions, sender configuration, and the dashboard setup flow.
- Updates Mailgun integration copy and metadata to use Sinch Mailgun branding.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/integrations/sms/sinch.mdx | Adds the Sinch SMS setup guide and now accurately reflects the dashboard’s integration state and submission controls. |
| docs/docs.json | Registers the new Sinch SMS guide in documentation navigation. |
| docs/platform/integrations/sms.mdx | Adds Sinch to the supported SMS provider catalog. |
| docs/platform/integrations/email/mailgun.mdx | Rebrands the Mailgun documentation as Sinch Mailgun while retaining the existing setup flow. |
| docs/platform/integrations/email.mdx | Updates the email provider card to use Sinch Mailgun branding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(sinch): update integration steps fo..."](https://github.com/novuhq/novu/commit/685f19ef286c931ebd59164f46bf56b77c4dea21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50769308)</sub>

<!-- /greptile_comment -->