### PR TITLE
fix(dashboard): support text+variable in chat button link fields fixes NV-8543

### DIFF
--- a/libs/maily-core/src/editor/bubble-suggestions/index.ts
+++ b/libs/maily-core/src/editor/bubble-suggestions/index.ts
@@ -8,6 +8,8 @@ export type {
   SuggestionProvider,
   SuggestionProviderFactory,
 } from './suggestion-provider';
+export { resolveSuggestionInsertValue } from './resolve-suggestion-value';
+export type { ResolveSuggestionValueParams, ResolvedSuggestionValue } from './resolve-suggestion-value';
 // Registry functions
 export {
   detectActiveProvider,

--- a/libs/maily-core/src/editor/bubble-suggestions/resolve-suggestion-value.spec.ts
+++ b/libs/maily-core/src/editor/bubble-suggestions/resolve-suggestion-value.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSuggestionInsertValue } from './resolve-suggestion-value';
+
+const variableProvider = { name: 'variable', triggerPattern: '{{' };
+
+describe('resolveSuggestionInsertValue', () => {
+  it('stores a whole-field variable pick as a bare path for pill mode', () => {
+    const result = resolveSuggestionInsertValue({
+      currentValue: '{{payload.foo',
+      triggerIndex: 0,
+      formattedValue: 'payload.foo',
+      provider: variableProvider,
+    });
+
+    expect(result).toEqual({
+      value: 'payload.foo',
+      isWholeFieldSuggestion: true,
+    });
+  });
+
+  it('keeps free-text prefix and inserts liquid braces for mixed text + variable', () => {
+    const result = resolveSuggestionInsertValue({
+      currentValue: 'https://example.com/{{payload.foo',
+      triggerIndex: 'https://example.com/'.length,
+      formattedValue: 'payload.foo',
+      provider: variableProvider,
+    });
+
+    expect(result).toEqual({
+      value: 'https://example.com/{{payload.foo}}',
+      isWholeFieldSuggestion: false,
+    });
+  });
+
+  it('supports label-style text + variable combinations', () => {
+    const result = resolveSuggestionInsertValue({
+      currentValue: 'Open {{payload.name',
+      triggerIndex: 'Open '.length,
+      formattedValue: 'payload.name',
+      provider: variableProvider,
+    });
+
+    expect(result).toEqual({
+      value: 'Open {{payload.name}}',
+      isWholeFieldSuggestion: false,
+    });
+  });
+
+  it('does not double-wrap values that already include liquid braces', () => {
+    const result = resolveSuggestionInsertValue({
+      currentValue: 'https://example.com/{{',
+      triggerIndex: 'https://example.com/'.length,
+      formattedValue: '{{payload.foo}}',
+      provider: variableProvider,
+    });
+
+    expect(result).toEqual({
+      value: 'https://example.com/{{payload.foo}}',
+      isWholeFieldSuggestion: false,
+    });
+  });
+
+  it('preserves prefix for non-variable providers without wrapping', () => {
+    const result = resolveSuggestionInsertValue({
+      currentValue: 'Hello #welcome',
+      triggerIndex: 'Hello '.length,
+      formattedValue: '#welcome',
+      provider: { name: 'inlineDecorator', triggerPattern: '#' },
+    });
+
+    expect(result).toEqual({
+      value: 'Hello #welcome',
+      isWholeFieldSuggestion: false,
+    });
+  });
+});

--- a/libs/maily-core/src/editor/bubble-suggestions/resolve-suggestion-value.ts
+++ b/libs/maily-core/src/editor/bubble-suggestions/resolve-suggestion-value.ts
@@ -1,0 +1,50 @@
+import { SuggestionProvider } from './suggestion-provider';
+
+export type ResolveSuggestionValueParams = {
+  currentValue: string;
+  triggerIndex: number;
+  formattedValue: string;
+  provider: Pick<SuggestionProvider, 'name' | 'triggerPattern'>;
+};
+
+export type ResolvedSuggestionValue = {
+  /** Value to write into the field after accepting a suggestion. */
+  value: string;
+  /**
+   * True when the suggestion replaces the entire field (no free-text prefix).
+   * Callers use this for pill mode (`isUrlVariable` / `isLabelVariable`).
+   * Mixed text + variable stays as editable free text with liquid `{{ }}`.
+   */
+  isWholeFieldSuggestion: boolean;
+};
+
+/**
+ * Builds the next field value when a bubble-menu suggestion is accepted.
+ *
+ * - Whole-field variable pick → bare path (`payload.foo`) so the field can collapse to a pill.
+ * - Mixed text + variable → keep the prefix and insert `{{payload.foo}}` (in-app subject style).
+ * - Other providers keep `formatValue` as-is, always preserving any prefix.
+ */
+export function resolveSuggestionInsertValue({
+  currentValue,
+  triggerIndex,
+  formattedValue,
+  provider,
+}: ResolveSuggestionValueParams): ResolvedSuggestionValue {
+  const beforeTrigger = currentValue.slice(0, triggerIndex);
+  const hasPrefix = beforeTrigger.length > 0;
+
+  let insertedValue = formattedValue;
+
+  if (provider.name === 'variable' && hasPrefix) {
+    const triggerChar = typeof provider.triggerPattern === 'string' ? provider.triggerPattern : '{{';
+    const alreadyWrapped = formattedValue.startsWith(triggerChar) && formattedValue.endsWith('}}');
+
+    insertedValue = alreadyWrapped ? formattedValue : `${triggerChar}${formattedValue}}}`;
+  }
+
+  return {
+    value: beforeTrigger + insertedValue,
+    isWholeFieldSuggestion: !hasPrefix,
+  };
+}

--- a/libs/maily-core/src/editor/bubble-suggestions/suggestion-input.tsx
+++ b/libs/maily-core/src/editor/bubble-suggestions/suggestion-input.tsx
@@ -6,13 +6,19 @@ import { cn } from '@/editor/utils/classname';
 import { AUTOCOMPLETE_PASSWORD_MANAGERS_OFF } from '@/editor/utils/constants';
 import { useInlineDecoratorOptions, useVariableOptions } from '@/editor/utils/node-options';
 import { useOutsideClick } from '@/editor/utils/use-outside-click';
+import { resolveSuggestionInsertValue } from './resolve-suggestion-value';
 import { SuggestionItem, SuggestionProvider } from './suggestion-provider';
 import { useActiveSuggestion, useSuggestionProviders } from './use-suggestion-providers';
 
 type SuggestionInputProps = HTMLAttributes<HTMLInputElement> & {
   value: string;
   onValueChange: (value: string) => void;
-  onSelectSuggestion?: (provider: SuggestionProvider, item: SuggestionItem, formattedValue: string) => void;
+  onSelectSuggestion?: (
+    provider: SuggestionProvider,
+    item: SuggestionItem,
+    formattedValue: string,
+    isWholeFieldSuggestion: boolean
+  ) => void;
   enabledProviders?: string[];
   onOutsideClick?: () => void;
   placeholder?: string;
@@ -124,13 +130,21 @@ export const SuggestionInput = forwardRef<HTMLInputElement, SuggestionInputProps
     activeSuggestion.provider.onSelect?.(item, editor);
 
     const formattedValue = activeSuggestion.provider.formatValue(item);
+    const { value: newValue, isWholeFieldSuggestion } = resolveSuggestionInsertValue({
+      currentValue: value,
+      triggerIndex: activeSuggestion.triggerIndex,
+      formattedValue,
+      provider: activeSuggestion.provider,
+    });
 
-    // Replace the trigger + query with the formatted value
-    const beforeTrigger = value.slice(0, activeSuggestion.triggerIndex);
-    const newValue = beforeTrigger + formattedValue;
-
-    onValueChange(newValue);
-    onSelectSuggestion?.(activeSuggestion.provider, item, newValue);
+    // Single update path: when a suggestion callback is provided it owns the write
+    // (including isVariable). Calling onValueChange first used to force isVariable=false
+    // and could leave button URL/label fields as bare text after a mouse pick.
+    if (onSelectSuggestion) {
+      onSelectSuggestion(activeSuggestion.provider, item, newValue, isWholeFieldSuggestion);
+    } else {
+      onValueChange(newValue);
+    }
   };
 
   const isTriggering = !!activeSuggestion && suggestions.length > 0;
@@ -195,7 +209,18 @@ export const SuggestionInput = forwardRef<HTMLInputElement, SuggestionInputProps
               };
             })}
             onSelectItem={(item) => {
-              const suggestion = suggestions.find((s) => s.id === item.name);
+              // Digest variables rewrite `name` before select; fall back to the rewritten id
+              // so mouse picks still resolve instead of silently no-oping.
+              const suggestion =
+                suggestions.find((s) => s.id === item.name) ??
+                (item.name
+                  ? {
+                      id: item.name,
+                      label: item.displayLabel ?? item.name,
+                      data: item,
+                    }
+                  : undefined);
+
               if (suggestion) {
                 handleSelectItem(suggestion);
               }

--- a/libs/maily-core/src/editor/nodes/button/button-label-input.tsx
+++ b/libs/maily-core/src/editor/nodes/button/button-label-input.tsx
@@ -83,9 +83,14 @@ export function ButtonLabelInput(props: ButtonLabelInputProps) {
           'mly-box-border mly-h-6 mly-max-h-6 mly-w-40 mly-rounded-md mly-px-2 mly-pr-6 mly-text-sm mly-text-midnight-gray hover:mly-bg-soft-gray focus:mly-bg-soft-gray focus:mly-outline-none',
           className
         )}
-        onSelectSuggestion={(_provider, _item, formattedValue) => {
-          setIsEditing(false);
-          onValueChange?.(formattedValue, true);
+        onSelectSuggestion={(_provider, _item, formattedValue, isWholeFieldSuggestion) => {
+          // Whole-field variable → pill + is*Variable. Mixed text + `{{var}}` stays free text
+          // (same model as the in-app subject field / NV-8543).
+          if (isWholeFieldSuggestion) {
+            setIsEditing(false);
+          }
+
+          onValueChange?.(formattedValue, isWholeFieldSuggestion);
         }}
         onOutsideClick={() => {
           if (matchingProvider && isVariable) {

--- a/libs/maily-core/src/editor/nodes/variable/variable-suggestions-popover.tsx
+++ b/libs/maily-core/src/editor/nodes/variable/variable-suggestions-popover.tsx
@@ -91,8 +91,14 @@ export const VariableSuggestionsPopover: VariableSuggestionsPopoverType = forwar
             items?.map((item, index: number) => (
               <button
                 key={index}
+                type="button"
                 ref={(el) => {
                   itemRefs.current[index] = el;
+                }}
+                // Keep the parent SuggestionInput focused so mouse picks don't blur/dismiss
+                // the bubble field before onClick runs (NV-8543).
+                onMouseDown={(e) => {
+                  e.preventDefault();
                 }}
                 onClick={() => onSelectItem(item)}
                 className={cn(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Rich Chat Actions Label/URL fields could not reliably accept variables:

1. **Mouse pick bug** — Typing `{{payload.foo` and clicking a suggestion could leave a bare path as regular text (double `onValueChange` forced `isUrlVariable=false`, and digest-rewritten ids could silently miss the suggestion lookup).
2. **Mixed text + variable** — Autocomplete always treated the whole field as a variable (`isUrlVariable=true`) and stored a bare path, so `https://example.com/{{payload.foo}}` became `https://example.com/payload.foo` marked as a variable.

This aligns button Label/URL with the in-app subject model:

- free text
- whole-field variable (pill + `is*Variable`)
- text + `{{variable}}` (stored as liquid in the string, flag false)

```mermaid
flowchart TD
  A["User accepts suggestion in Label/URL"] --> B{"Prefix before {{ ?"}
  B -->|No| C["Store bare path + isVariable=true → pill"]
  B -->|Yes| D["Keep prefix + insert {{path}} + isVariable=false"]
  C --> E["Delivery wraps via wrapMailyInLiquid"]
  D --> F["Delivery leaves embedded liquid as-is"]
```

### Special notes for your reviewer

- Changes are in `@novu/maily-core` (`SuggestionInput`, `ButtonLabelInput`, default suggestions popover).
- Unit tests cover `resolveSuggestionInsertValue` (whole-field vs mixed insert).
- Complements NV-8544 validation, which already expects embedded `{{ }}` in URLs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-120dc613-3cd7-41e7-b9fa-753326f06e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-120dc613-3cd7-41e7-b9fa-753326f06e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates chat button label and URL autocomplete so whole-field variables remain pill values while mixed text and variables are stored as Liquid expressions.
- Adds a shared suggestion-value resolver with unit coverage for whole-field and mixed-content insertion.
- Routes suggestion selection through a single state update and handles rewritten variable identifiers.
- Prevents mouse selection from blurring the suggestions input before the click is processed.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The changed selection flow preserves the expected persisted representations for both whole-field and embedded variables, and all current callback consumers continue to update their values correctly.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/maily-core/src/editor/bubble-suggestions/resolve-suggestion-value.ts | Introduces the shared distinction between whole-field suggestion values and mixed text-plus-variable values. |
| libs/maily-core/src/editor/bubble-suggestions/suggestion-input.tsx | Uses the resolver, avoids duplicate writes, and recovers selections whose displayed identifiers were rewritten. |
| libs/maily-core/src/editor/nodes/button/button-label-input.tsx | Propagates whole-field status into button variable state while leaving mixed content editable. |
| libs/maily-core/src/editor/nodes/variable/variable-suggestions-popover.tsx | Preserves input focus during mouse selection and explicitly marks suggestion controls as non-submit buttons. |
| libs/maily-core/src/editor/bubble-suggestions/resolve-suggestion-value.spec.ts | Covers whole-field variables, mixed URL and label content, pre-wrapped Liquid values, and non-variable providers. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[User selects a suggestion] --> B{Text before trigger?}
  B -->|No| C[Store bare variable path]
  C --> D[Set variable flag and show pill]
  B -->|Yes| E[Preserve prefix and insert Liquid expression]
  E --> F[Keep variable flag false and remain editable]
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): support text+variable in..."](https://github.com/novuhq/novu/commit/b5d90702285a155eb8400500250ab3785952f616) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50807022)</sub>

<!-- /greptile_comment -->