### PR TITLE
chore(docs): clarify global preferences behavior and priority resolution in workflows

### DIFF
--- a/docs/platform/concepts/preferences.mdx
+++ b/docs/platform/concepts/preferences.mdx
@@ -56,7 +56,9 @@ In those cases, you can mark a workflow as `critical` in the workflow channel pr
 
 ## Subscriber global preferences
 
-Subscribers can set global channel preferences, which override individual settings. For instance, if there are 10 workflows, and a subscriber wants to disable SMS notifications for all of them, they can do so with via global preferences.
+Subscribers can set global channel preferences, which apply across every workflow. For instance, if there are 10 workflows and a subscriber wants to disable SMS notifications for all of them, they can do so with global preferences instead of changing each workflow.
+
+Global preferences act as the subscriber's baseline. If the same subscriber later sets a preference for one specific workflow, that more specific choice wins for that workflow. See [Priority of preferences](#priority-of-preferences).
 
 ![Preferences](/images/inbox/preferences@2x.png)
 
@@ -72,28 +74,42 @@ For each workflow, each subscriber has their own channel preferences. Subscriber
 
 ## Priority of preferences
 
-Since there are three types of preferences, the priority order is as follows:
+Novu resolves preferences per channel. It layers each type of preference on top of the previous one, from the most general to the most specific, and **the most specific layer that defines a channel wins**:
 
-Workflow channel preferences > Subscriber global preferences > Subscriber channel preferences per workflow
+1. Workflow channel preferences defined in code with the [Framework](/framework/overview)
+2. Workflow channel preferences set in the dashboard
+3. Subscriber global preferences
+4. Subscriber channel preferences per workflow
+
+So a subscriber's per-workflow choice takes precedence over their global choice, and both take precedence over the workflow defaults.
+
+The one exception is [critical workflows](#critical-workflows). When a workflow is marked as critical, both subscriber layers are discarded and the workflow channel preferences decide on their own.
 
 ```mermaid
 flowchart TD
-    startNode([Should notification send?]) --> workflowDisabled{Channel disabled in workflow preferences?}
-    workflowDisabled -->|Yes| blockWorkflow[Do not send]
-    workflowDisabled -->|No| isCritical{Workflow marked as critical?}
-    isCritical -->|Yes| sendCritical[Send notification]
-    isCritical -->|No| globalDisabled{Channel disabled in subscriber global preferences?}
-    globalDisabled -->|Yes| blockGlobal[Do not send]
-    globalDisabled -->|No| subscriberDisabled{Subscriber disabled channel for this workflow?}
-    subscriberDisabled -->|Yes| blockSubscriber[Do not send]
-    subscriberDisabled -->|No| sendAllowed[Send notification]
+    startNode([Should this channel send?]) --> isCritical{Workflow marked as critical?}
+    isCritical -->|Yes| useWorkflow[Use the workflow channel preference]
+    isCritical -->|No| hasWorkflowPref{Subscriber set a preference for this workflow?}
+    hasWorkflowPref -->|Yes| useSubscriberWorkflow[Use the subscriber preference for this workflow]
+    hasWorkflowPref -->|No| hasGlobalPref{Subscriber set a global preference for this channel?}
+    hasGlobalPref -->|Yes| useSubscriberGlobal[Use the subscriber global preference]
+    hasGlobalPref -->|No| useWorkflow
+    useWorkflow --> resolved{Resolved value enabled?}
+    useSubscriberWorkflow --> resolved
+    useSubscriberGlobal --> resolved
+    resolved -->|Yes| sendAllowed[Send notification]
+    resolved -->|No| blocked[Do not send]
 ```
 
 Examples:
 
-1. If the `email` channel is disabled in workflow channel preferences, global and subscriber preferences are ignored, and subscribers will not receive email notifications for this workflow.
-2. If the `in-app` channel is enabled in workflow channel preferences but the workflow is marked as critical, subscribers cannot change their preferences and will always receive in-app notifications.
-3. If both `chat` and `email` channels are enabled in the workflow but `email` is disabled in subscriber global preferences, the subscriber will receive only chat notifications for this workflow.
+1. If the `email` channel is enabled in workflow channel preferences but the subscriber disabled `email` globally, they will not receive email notifications for this workflow.
+2. If the subscriber disabled `email` globally but enabled `email` for this specific workflow, they will receive email notifications for this workflow. The per-workflow preference is more specific than the global one.
+3. If the `in-app` channel is enabled in workflow channel preferences and the workflow is marked as critical, subscribers cannot change their preferences and will always receive in-app notifications.
+
+<Note>
+  Only channels that exist as active steps in the workflow are considered. A channel that the workflow does not use is never resolved, whatever the subscriber set for it globally.
+</Note>
 
 ## Subscriber preferences APIs
 

--- a/docs/platform/inbox/configuration/preferences.mdx
+++ b/docs/platform/inbox/configuration/preferences.mdx
@@ -17,11 +17,11 @@ The Preferences interface in the Inbox component lets subscribers customize how 
 
 ## Global preferences
 
-Global preferences apply across all workflows. For example, a subscriber can turn off an email or SMS channels globally, ensuring that they don’t receive notifications through that channel from any workflow.
+Global preferences act as the subscriber's baseline across all workflows. For example, a subscriber can turn the email or SMS channel off globally rather than turning it off workflow by workflow.
 
 ![Global preferences](/images/inbox/global-preferences.png)
 
-Global preferences override individual workflow preferences. If a channel is turned off (disabled) globally, notifications for that channel will not be sent even if it is enabled for a specific workflow.
+Turning a channel off globally disables it for every workflow the subscriber has not configured individually. If the subscriber then sets a preference for one specific workflow, that more specific choice wins for that workflow — so they can disable `email` globally and re-enable it for the single workflow they care about. See [Priority of preferences](/platform/concepts/preferences#priority-of-preferences) for the full resolution order.
 
 ### Hide global preferences UI
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This assumed code as source of truth
### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR clarifies how global, workflow-specific, and critical-workflow preferences are resolved.
- Explains that subscriber global preferences are a baseline overridden by subscriber per-workflow choices.
- Documents the complete preference precedence order and critical-workflow exception.
- Replaces the previous decision diagram and examples with behavior matching the current implementation.
- Aligns the Inbox configuration guide with the clarified resolution semantics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the revised documentation matches the current preference-resolution behavior.

The documented layer ordering, subscriber override behavior, critical-workflow exception, and active-channel scope are consistent with the implementation and focused preference tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/concepts/preferences.mdx | Clarifies channel-level preference precedence, critical-workflow behavior, active-channel scope, examples, and the resolution diagram consistently with the implementation. |
| docs/platform/inbox/configuration/preferences.mdx | Corrects the description of global preferences to explain that workflow-specific subscriber preferences can override the global baseline. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(preferences): clarify global prefer..."](https://github.com/novuhq/novu/commit/f54fb0604aa89756b0668807b89dade99a9d61a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50911855)</sub>

<!-- /greptile_comment -->