### PR TITLE
feat(js,react,api): headless useAgentChat send + open/resume fixes NV-8445

### DIFF
--- a/apps/api/src/app/agents/e2e/agent-events-ingest.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-events-ingest.e2e.ts
@@ -61,7 +61,7 @@ describe('Agent Events Ingest - /agents/events/ingest #novu-v2', () => {
   ): AgentEventEnvelope {
     return buildEnvelope(
       conversationId,
-      { type: 'message', messageId, content: { markdown: `Content for ${messageId}` } },
+      { type: 'message', role: 'assistant', messageId, content: { markdown: `Content for ${messageId}` } },
       overrides
     );
   }

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -104,7 +104,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
   function getEvents(
     conversationIdentifier: string,
     token = subscriberToken,
-    query: { after?: string; before?: string; afterSequence?: number; limit?: number } = {}
+    query: { before?: string; limit?: number } = {}
   ) {
     return ctx.session.testAgent
       .get(`/v1/web-chat/conversations/${conversationIdentifier}/events`)
@@ -286,8 +286,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
 
     const eventsRes = await getEvents(createRes.body.data.identifier);
     expect(eventsRes.status).to.equal(200);
-    expect(eventsRes.body.data.hasMore).to.equal(false);
-    expect(eventsRes.body.data.next).to.equal(null);
+    expect(eventsRes.body.data.olderCursor).to.equal(null);
     expect(eventsRes.body.data.events.length).to.be.greaterThan(0);
 
     const agentMessageEvent = eventsRes.body.data.events.find(
@@ -337,18 +336,27 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     const newestPage = await getEvents(createRes.body.data.identifier, subscriberToken, { limit: 1 });
     expect(newestPage.status).to.equal(200);
     expect(newestPage.body.data.events).to.have.length(1);
-    expect(newestPage.body.data.hasMore).to.equal(true);
-    expect(newestPage.body.data.previous).to.be.a('string');
+    expect(newestPage.body.data.olderCursor).to.be.a('string');
 
-    const olderPage = await ctx.session.testAgent
-      .get(`/v1/web-chat/conversations/${createRes.body.data.identifier}/events`)
-      .query({ before: newestPage.body.data.previous, limit: 50 })
-      .set('Authorization', `Bearer ${subscriberToken}`);
+    const newestSequences = newestPage.body.data.events.map((event: AgentEventEnvelope) => event.sequence);
+    for (let index = 1; index < newestSequences.length; index += 1) {
+      expect(newestSequences[index]).to.be.greaterThan(newestSequences[index - 1]);
+    }
+
+    const olderPage = await getEvents(createRes.body.data.identifier, subscriberToken, {
+      before: newestPage.body.data.olderCursor,
+      limit: 50,
+    });
     expect(olderPage.status).to.equal(200);
     expect(olderPage.body.data.events.length).to.be.greaterThan(0);
     expect(olderPage.body.data.events[olderPage.body.data.events.length - 1].sequence).to.be.lessThan(
       newestPage.body.data.events[0].sequence
     );
+
+    const olderSequences = olderPage.body.data.events.map((event: AgentEventEnvelope) => event.sequence);
+    for (let index = 1; index < olderSequences.length; index += 1) {
+      expect(olderSequences[index]).to.be.greaterThan(olderSequences[index - 1]);
+    }
   });
 
   it('should reject GET events for another subscriber', async () => {
@@ -550,37 +558,6 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(second.status).to.equal(201);
     expect(second.body.data.identifier).to.not.equal(first.body.data.identifier);
     expect(second.body.data.identifier).to.match(/^conv_/);
-  });
-
-  it('should paginate durable history with afterSequence', async () => {
-    await linkWebChat();
-
-    const createRes = await createConversation({
-      agentId: ctx.agentIdentifier,
-      text: 'Sequence start',
-    });
-    expect(createRes.status).to.equal(201);
-
-    const conversation = await waitForConversation(createRes.body.data.identifier);
-
-    await ctx.session.testAgent.post('/v1/agents/events/ingest').send({
-      events: [messageEnvelope(conversation._id, `msg-seq-${Date.now()}`)],
-    });
-
-    const fullPage = await getEvents(createRes.body.data.identifier);
-    expect(fullPage.status).to.equal(200);
-    expect(fullPage.body.data.events.length).to.be.greaterThan(1);
-
-    const firstSequence = fullPage.body.data.events[0].sequence as number;
-    const gapFill = await getEvents(createRes.body.data.identifier, subscriberToken, {
-      afterSequence: firstSequence,
-      limit: 50,
-    });
-    expect(gapFill.status).to.equal(200);
-    expect(gapFill.body.data.events.length).to.be.greaterThan(0);
-    for (const envelope of gapFill.body.data.events) {
-      expect(envelope.sequence).to.be.greaterThan(firstSequence);
-    }
   });
 
   it('should emit exactly one live AGENT_EVENT per post/edit/delete/typing via adapter callbacks', async () => {
@@ -877,22 +854,15 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     );
     expect(agentActivity.sequence).to.be.greaterThan(1);
 
+    // Unsequenced legacy rows are excluded; only sequenced events appear, ascending.
     const eventsRes = await getEvents(createRes.body.data.identifier);
     expect(eventsRes.status).to.equal(200);
-    const sequences = eventsRes.body.data.events.map((event: AgentEventEnvelope) => event.sequence);
-    expect(new Set(sequences).size).to.equal(sequences.length);
-
-    const gapFillRes = await getEvents(createRes.body.data.identifier, subscriberToken, {
-      afterSequence: 1,
-      limit: 1,
-    });
-    expect(gapFillRes.status).to.equal(200);
-    expect(gapFillRes.body.data.events.map((event: AgentEventEnvelope) => event.sequence)).to.deep.equal([
-      agentActivity.sequence,
-    ]);
+    expect(eventsRes.body.data.events).to.have.length(1);
+    expect(eventsRes.body.data.events[0].sequence).to.equal(agentActivity.sequence);
+    expect(eventsRes.body.data.olderCursor).to.equal(null);
   });
 
-  it('should return concurrent durable events in sequence order during gap-fill', async () => {
+  it('should return concurrent durable events in sequence order on the newest page', async () => {
     await linkWebChat();
     const createRes = await createConversation({
       agentId: ctx.agentIdentifier,
@@ -924,23 +894,13 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     await new Promise((resolve) => setTimeout(resolve, 5));
     await createActivity(2);
 
-    const firstGapPage = await getEvents(createRes.body.data.identifier, subscriberToken, {
-      afterSequence: 1,
-      limit: 1,
-    });
-    expect(firstGapPage.status).to.equal(200);
-    expect(firstGapPage.body.data.events.map((event: AgentEventEnvelope) => event.sequence)).to.deep.equal([2]);
-    expect(firstGapPage.body.data.hasMore).to.equal(true);
-
-    const secondGapPage = await getEvents(createRes.body.data.identifier, subscriberToken, {
-      afterSequence: 2,
-      limit: 1,
-    });
-    expect(secondGapPage.status).to.equal(200);
-    expect(secondGapPage.body.data.events.map((event: AgentEventEnvelope) => event.sequence)).to.deep.equal([3]);
+    const newestPage = await getEvents(createRes.body.data.identifier, subscriberToken, { limit: 2 });
+    expect(newestPage.status).to.equal(200);
+    // Newest page is chronological within the page (seq 2 then 3), not insert order.
+    expect(newestPage.body.data.events.map((event: AgentEventEnvelope) => event.sequence)).to.deep.equal([2, 3]);
   });
 
-  it('should support ephemeral sequence gaps in durable afterSequence gap-fill', async () => {
+  it('should omit ephemeral sequence gaps from durable history', async () => {
     await linkWebChat();
     const createRes = await createConversation({
       agentId: ctx.agentIdentifier,
@@ -987,16 +947,5 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(agentMsg.sequence).to.be.a('number');
     // Durable history has fewer events than the high-watermark (ephemeral left a gap).
     expect(eventsRes.body.data.events.length).to.be.lessThan(refreshed!.eventSequence!);
-
-    const afterUser = await getEvents(createRes.body.data.identifier, subscriberToken, {
-      afterSequence: 1,
-      limit: 50,
-    });
-    expect(afterUser.status).to.equal(200);
-    expect(
-      afterUser.body.data.events.some(
-        (e: AgentEventEnvelope) => e.event.type === 'message' && e.event.messageId === agentActivity.platformMessageId
-      )
-    ).to.equal(true);
   });
 });

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -146,6 +146,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       timestamp: new Date().toISOString(),
       event: {
         type: 'message',
+        role: 'assistant',
         messageId,
         content: { markdown: `Agent reply ${messageId}` },
       },
@@ -162,6 +163,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
 
     expect(res.status).to.equal(201);
     expect(res.body.data.identifier).to.match(/^conv_/);
+    expect(res.body.data.messageId).to.match(/^msg_/);
 
     const conversation = await pollFor(() =>
       conversationRepository.findOne(
@@ -189,7 +191,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       return subscriberMessage ?? null;
     });
     expect(activities.content).to.equal('Hello from web chat');
-    expect(activities.identifier).to.match(/^msg_/);
+    expect(activities.identifier).to.equal(res.body.data.messageId);
     expect(conversation.channels.some((channel) => channel.platform === 'web_chat')).to.equal(true);
     expect(conversation.channels[0]?.platformThreadId).to.equal(`web_chat:${res.body.data.identifier}`);
   });
@@ -296,19 +298,20 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(agentMessageEvent.event.content.markdown).to.equal(`Agent reply ${messageId}`);
 
     const subscriberMessageEvent = eventsRes.body.data.events.find((envelope: AgentEventEnvelope) => {
-      if (envelope.event.type !== 'custom' || envelope.event.name !== 'subscriber.message') {
-        return false;
-      }
-      const data = envelope.event.data as { content?: { markdown?: string }; messageId?: string };
-
-      return data.content?.markdown === 'Start thread';
+      return (
+        envelope.event.type === 'message' &&
+        envelope.event.role === 'user' &&
+        envelope.event.content?.markdown === 'Start thread'
+      );
     });
     expect(subscriberMessageEvent).to.exist;
-    const subscriberData = subscriberMessageEvent.event.data as { messageId?: string };
-    expect(subscriberData.messageId).to.match(/^msg_/);
+    expect(subscriberMessageEvent.event.type).to.equal('message');
+    if (subscriberMessageEvent.event.type === 'message') {
+      expect(subscriberMessageEvent.event.messageId).to.match(/^msg_/);
+    }
   });
 
-  it('should paginate events with activity cursor', async () => {
+  it('should return the newest page by default and paginate older with before', async () => {
     await linkWebChat();
 
     const createRes = await createConversation({
@@ -331,19 +334,21 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       events: [messageEnvelope(conversation._id, `msg-page-${Date.now()}`)],
     });
 
-    const firstPage = await getEvents(createRes.body.data.identifier, subscriberToken, { limit: 1 });
-    expect(firstPage.status).to.equal(200);
-    expect(firstPage.body.data.events).to.have.length(1);
-    expect(firstPage.body.data.hasMore).to.equal(true);
-    expect(firstPage.body.data.next).to.be.a('string');
+    const newestPage = await getEvents(createRes.body.data.identifier, subscriberToken, { limit: 1 });
+    expect(newestPage.status).to.equal(200);
+    expect(newestPage.body.data.events).to.have.length(1);
+    expect(newestPage.body.data.hasMore).to.equal(true);
+    expect(newestPage.body.data.previous).to.be.a('string');
 
-    const secondPage = await ctx.session.testAgent
+    const olderPage = await ctx.session.testAgent
       .get(`/v1/web-chat/conversations/${createRes.body.data.identifier}/events`)
-      .query({ after: firstPage.body.data.next, limit: 50 })
+      .query({ before: newestPage.body.data.previous, limit: 50 })
       .set('Authorization', `Bearer ${subscriberToken}`);
-    expect(secondPage.status).to.equal(200);
-    expect(secondPage.body.data.events.length).to.be.greaterThan(0);
-    expect(secondPage.body.data.events[0].sequence).to.be.greaterThan(firstPage.body.data.events[0].sequence);
+    expect(olderPage.status).to.equal(200);
+    expect(olderPage.body.data.events.length).to.be.greaterThan(0);
+    expect(olderPage.body.data.events[olderPage.body.data.events.length - 1].sequence).to.be.lessThan(
+      newestPage.body.data.events[0].sequence
+    );
   });
 
   it('should reject GET events for another subscriber', async () => {
@@ -682,7 +687,11 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(byType('channel.delete')).to.have.length(1);
 
     const liveMessage = byType('message')[0].data.payload as AgentEventEnvelope;
-    expect(liveMessage.event).to.deep.include({ type: 'message', messageId: platformMessageId });
+    expect(liveMessage.event).to.deep.include({
+      type: 'message',
+      role: 'assistant',
+      messageId: platformMessageId,
+    });
 
     const historyRes = await getEvents(createRes.body.data.identifier);
     expect(historyRes.status).to.equal(200);
@@ -754,6 +763,7 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(liveMessages).to.have.length(1);
     expect((liveMessages[0].data.payload as AgentEventEnvelope).event).to.deep.include({
       type: 'message',
+      role: 'assistant',
       messageId: activity.platformMessageId,
     });
   });

--- a/apps/api/src/app/agents/managed-runtime/stream-part-mapper.ts
+++ b/apps/api/src/app/agents/managed-runtime/stream-part-mapper.ts
@@ -26,6 +26,7 @@ export function mapStreamPart(part: StreamPart): AgentEvent[] {
       return [
         {
           type: 'message',
+          role: 'assistant',
           messageId: randomUUID(),
           content: { markdown: part.text },
         },
@@ -41,6 +42,7 @@ export function mapStreamPart(part: StreamPart): AgentEvent[] {
       return [
         {
           type: 'message',
+          role: 'assistant',
           messageId: randomUUID(),
           content: { markdown: part.text },
         },

--- a/apps/api/src/app/agents/shared/agent-event-sink.service.ts
+++ b/apps/api/src/app/agents/shared/agent-event-sink.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { type AgentEvent, type AgentEventEnvelope, isDeltaEvent } from '@novu/agent-event-protocol';
 import { PinoLogger } from '@novu/application-generic';
 import { ConversationActivityEntity, ConversationActivityRepository, ConversationRepository } from '@novu/dal';
@@ -270,6 +270,14 @@ export class AgentEventSink {
     context: AgentEventContext,
     runId: string
   ): Promise<IngestOutcome> {
+    // Runtime ingest accepts assistant messages only. Subscriber turns arrive
+    // through the inbound HTTP endpoint, not through this path.
+    if (event.role !== 'assistant') {
+      throw new BadRequestException(
+        `Rejecting durable message with role "${event.role}": ingest accepts assistant messages only`
+      );
+    }
+
     if (context.suppressReply) {
       return 'accepted';
     }

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -42,6 +42,7 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
       if (activity.senderType === ConversationActivitySenderTypeEnum.AGENT) {
         return {
           type: 'message',
+          role: 'assistant',
           // Browser-visible id is platformMessageId (aligned with live WS envelopes).
           messageId: activity.platformMessageId ?? activity.identifier,
           content: { markdown: activity.content },
@@ -51,12 +52,11 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
 
       if (activity.senderType === ConversationActivitySenderTypeEnum.SUBSCRIBER) {
         return {
-          type: 'custom',
-          name: 'subscriber.message',
-          data: {
-            messageId: activity.identifier,
-            content: { markdown: activity.content },
-          },
+          type: 'message',
+          role: 'user',
+          messageId: activity.platformMessageId ?? activity.identifier,
+          content: { markdown: activity.content },
+          files: filesFromRichContent(activity.richContent),
         };
       }
 

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -125,11 +125,12 @@ function buildEnvelope(
   activity: ConversationActivityEntity,
   event: AgentEvent,
   sequence: number,
-  context: { conversationId: string; agentIdentifier: string }
+  context: { conversationId: string; conversationIdentifier: string; agentIdentifier: string }
 ): AgentEventEnvelope {
   return {
     version: AGENT_EVENT_PROTOCOL_VERSION,
     conversationId: context.conversationId,
+    conversationIdentifier: context.conversationIdentifier,
     agentId: context.agentIdentifier,
     runId: 'history',
     turnId: activity.identifier,
@@ -151,7 +152,7 @@ export function isMappableActivity(activity: ConversationActivityEntity): boolea
 
 export function mapActivitiesToEventPage(
   activities: ConversationActivityEntity[],
-  context: { conversationId: string; agentIdentifier: string },
+  context: { conversationId: string; conversationIdentifier: string; agentIdentifier: string },
   options: {
     sequenceOffset?: number;
     afterSequence?: number;

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -36,31 +36,28 @@ function filesFromRichContent(richContent?: Record<string, unknown>) {
   return files as AgentFileRef[];
 }
 
+const MESSAGE_ROLE_BY_SENDER = {
+  [ConversationActivitySenderTypeEnum.AGENT]: 'assistant',
+  [ConversationActivitySenderTypeEnum.SUBSCRIBER]: 'user',
+} as const;
+
 function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | null {
   switch (activity.type) {
-    case ConversationActivityTypeEnum.MESSAGE:
-      if (activity.senderType === ConversationActivitySenderTypeEnum.AGENT) {
-        return {
-          type: 'message',
-          role: 'assistant',
-          // Browser-visible id is platformMessageId (aligned with live WS envelopes).
-          messageId: activity.platformMessageId ?? activity.identifier,
-          content: { markdown: activity.content },
-          files: filesFromRichContent(activity.richContent),
-        };
+    case ConversationActivityTypeEnum.MESSAGE: {
+      const role = MESSAGE_ROLE_BY_SENDER[activity.senderType as keyof typeof MESSAGE_ROLE_BY_SENDER];
+      if (!role) {
+        return null;
       }
 
-      if (activity.senderType === ConversationActivitySenderTypeEnum.SUBSCRIBER) {
-        return {
-          type: 'message',
-          role: 'user',
-          messageId: activity.platformMessageId ?? activity.identifier,
-          content: { markdown: activity.content },
-          files: filesFromRichContent(activity.richContent),
-        };
-      }
-
-      return null;
+      return {
+        type: 'message',
+        role,
+        // Browser-visible id is platformMessageId (aligned with live WS envelopes).
+        messageId: activity.platformMessageId ?? activity.identifier,
+        content: { markdown: activity.content },
+        files: filesFromRichContent(activity.richContent),
+      };
+    }
 
     case ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST: {
       const toolData = activity.toolData;
@@ -121,11 +118,17 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
   }
 }
 
+export interface EventMapContext {
+  conversationId: string;
+  conversationIdentifier: string;
+  agentIdentifier: string;
+}
+
 function buildEnvelope(
   activity: ConversationActivityEntity,
   event: AgentEvent,
   sequence: number,
-  context: { conversationId: string; conversationIdentifier: string; agentIdentifier: string }
+  context: EventMapContext
 ): AgentEventEnvelope {
   return {
     version: AGENT_EVENT_PROTOCOL_VERSION,
@@ -140,70 +143,48 @@ function buildEnvelope(
   };
 }
 
-function resolveSequence(activity: ConversationActivityEntity, computed: number): number {
-  return typeof activity.sequence === 'number' ? activity.sequence : computed;
-}
+/**
+ * Sequence allocation happens at write time. Activities without a stored
+ * sequence are dev-only legacy rows and are not part of the event history.
+ */
+function toMappableActivity(
+  activity: ConversationActivityEntity
+): { activity: ConversationActivityEntity; event: AgentEvent; sequence: number } | null {
+  if (typeof activity.sequence !== 'number') {
+    return null;
+  }
 
-export function isMappableActivity(activity: ConversationActivityEntity): boolean {
   const event = mapActivityToEvent(activity);
+  if (!event || isDeltaEvent(event)) {
+    return null;
+  }
 
-  return event !== null && !isDeltaEvent(event);
+  return { activity, event, sequence: activity.sequence };
 }
 
-export function mapActivitiesToEventPage(
+/**
+ * Map a newest-first, already-filtered activity page to chronological envelopes.
+ * The repository owns type/sequence filtering; this only builds wire envelopes.
+ */
+export function mapNewestFirstEventActivities(
   activities: ConversationActivityEntity[],
-  context: { conversationId: string; conversationIdentifier: string; agentIdentifier: string },
-  options: {
-    sequenceOffset?: number;
-    afterSequence?: number;
-    limit: number;
-  }
-): {
-  events: AgentEventEnvelope[];
-  lastActivityId?: string;
-  hasMoreActivities: boolean;
-  nextSequence: number;
-} {
+  context: EventMapContext
+): AgentEventEnvelope[] {
   const events: AgentEventEnvelope[] = [];
-  let computed = options.sequenceOffset ?? 0;
-  let lastActivityId: string | undefined;
-  let lastSequence = computed;
 
-  for (const activity of activities) {
-    const event = mapActivityToEvent(activity);
-    if (!event || isDeltaEvent(event)) {
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (!activity) {
       continue;
     }
 
-    computed += 1;
-    const sequence = resolveSequence(activity, computed);
-    if (typeof activity.sequence === 'number') {
-      computed = Math.max(computed, activity.sequence);
-    }
-    lastSequence = sequence;
-
-    if (options.afterSequence !== undefined && sequence <= options.afterSequence) {
-      lastActivityId = activity._id;
+    const mappable = toMappableActivity(activity);
+    if (!mappable) {
       continue;
     }
 
-    if (events.length >= options.limit) {
-      return {
-        events,
-        lastActivityId,
-        hasMoreActivities: true,
-        nextSequence: lastSequence,
-      };
-    }
-
-    events.push(buildEnvelope(activity, event, sequence, context));
-    lastActivityId = activity._id;
+    events.push(buildEnvelope(mappable.activity, mappable.event, mappable.sequence, context));
   }
 
-  return {
-    events,
-    lastActivityId,
-    hasMoreActivities: false,
-    nextSequence: lastSequence,
-  };
+  return events;
 }

--- a/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
@@ -3,25 +3,10 @@ import { Type } from 'class-transformer';
 import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class ListWebChatConversationEventsQueryDto {
-  /**
-   * Cursor: activity `_id` for forward pagination (older → newer).
-   * Omit both `after` and `before` to get the newest page (open/resume).
-   */
-  @IsOptional()
-  @IsString()
-  after?: string;
-
-  /** Cursor: activity `_id` for reverse pagination (load older history). */
+  /** Activity `_id` cursor that loads older history. Omit it to get the newest page. */
   @IsOptional()
   @IsString()
   before?: string;
-
-  /** Gap-fill replay cursor — events with sequence strictly greater than this value. */
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(0)
-  afterSequence?: number;
 
   @IsOptional()
   @Type(() => Number)
@@ -33,7 +18,6 @@ export class ListWebChatConversationEventsQueryDto {
 
 export class ListWebChatConversationEventsResponseDto {
   events: AgentEventEnvelope[];
-  hasMore: boolean;
-  next: string | null;
-  previous: string | null;
+  /** Cursor toward older history. Send it as `before`. Null when the beginning is reached. */
+  olderCursor: string | null;
 }

--- a/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/list-web-chat-conversation-events.dto.ts
@@ -3,12 +3,15 @@ import { Type } from 'class-transformer';
 import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class ListWebChatConversationEventsQueryDto {
-  /** Cursor: activity `_id` for forward pagination. */
+  /**
+   * Cursor: activity `_id` for forward pagination (older → newer).
+   * Omit both `after` and `before` to get the newest page (open/resume).
+   */
   @IsOptional()
   @IsString()
   after?: string;
 
-  /** Cursor: activity `_id` for reverse pagination. */
+  /** Cursor: activity `_id` for reverse pagination (load older history). */
   @IsOptional()
   @IsString()
   before?: string;

--- a/apps/api/src/app/agents/web-chat/dtos/web-chat-conversation.dto.ts
+++ b/apps/api/src/app/agents/web-chat/dtos/web-chat-conversation.dto.ts
@@ -1,5 +1,5 @@
-import { Type } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { withCursorPagination } from '../../../shared/dtos/cursor-paginated-response';
+import { CursorPaginationQueryDto } from '../../shared/dtos/cursor-pagination-query.dto';
 
 export class WebChatConversationMetadataDto {
   identifier: string;
@@ -10,29 +10,11 @@ export class WebChatConversationMetadataDto {
   createdAt: string;
 }
 
-export class ListWebChatConversationsQueryDto {
-  /** Cursor: conversation `_id` for forward pagination. */
-  @IsOptional()
-  @IsString()
-  after?: string;
+export class ListWebChatConversationsQueryDto extends CursorPaginationQueryDto<
+  WebChatConversationMetadataDto,
+  'lastActivityAt' | 'createdAt'
+> {}
 
-  /** Cursor: conversation `_id` for reverse pagination. */
-  @IsOptional()
-  @IsString()
-  before?: string;
-
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(100)
-  limit?: number;
-}
-
-export class ListWebChatConversationsResponseDto {
-  data: WebChatConversationMetadataDto[];
-  next: string | null;
-  previous: string | null;
-  totalCount: number;
-  totalCountCapped: boolean;
-}
+export class ListWebChatConversationsResponseDto extends withCursorPagination(WebChatConversationMetadataDto, {
+  description: 'List of web-chat conversations for the subscriber',
+}) {}

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.command.ts
@@ -7,21 +7,10 @@ export class ListWebChatConversationEventsCommand extends EnvironmentWithSubscri
   @IsNotEmpty()
   conversationIdentifier: string;
 
-  /** Cursor: activity `_id` — fetch events after this activity (forward pagination). */
-  @IsOptional()
-  @IsString()
-  after?: string;
-
-  /** Cursor: activity `_id` — fetch events before this activity (reverse pagination). */
+  /** Activity `_id` cursor that loads older history. Omit it to get the newest page. */
   @IsOptional()
   @IsString()
   before?: string;
-
-  /** Gap-fill replay cursor — events with sequence strictly greater than this value. */
-  @IsOptional()
-  @IsInt()
-  @Min(0)
-  afterSequence = 0;
 
   @IsOptional()
   @IsInt()

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
@@ -86,6 +86,8 @@ export class ListWebChatConversationEvents {
       return this.fetchAfterSequenceEventPage(command, conversation._id, mapContext);
     }
 
+    // No cursor → newest page (chat open/resume). Explicit `after` stays oldest→newer.
+    const reverse = Boolean(command.before) || (!command.after && !command.before);
     const sequenceOffset = command.after
       ? await this.countMappableEventsUpToActivity(
           command.environmentId,
@@ -97,7 +99,7 @@ export class ListWebChatConversationEvents {
 
     return this.fetchEventPage(command, conversation._id, mapContext, {
       activityCursor: command.after ?? command.before,
-      before: command.before,
+      reverse,
       sequenceOffset,
     });
   }
@@ -134,11 +136,13 @@ export class ListWebChatConversationEvents {
     mapContext: { conversationId: string; conversationIdentifier: string; agentIdentifier: string },
     options: {
       activityCursor?: string;
-      before?: string;
+      /** Newest-first DB walk (`before` cursor or default open/resume page). */
+      reverse?: boolean;
       sequenceOffset?: number;
     }
   ): Promise<EventPageResult> {
-    const sortDirection = options.before ? -1 : 1;
+    const reverse = Boolean(options.reverse);
+    const sortDirection = reverse ? -1 : 1;
     let activityCursor = options.activityCursor;
     let dbNext: string | null = null;
     let dbPrevious: string | null = null;
@@ -149,8 +153,8 @@ export class ListWebChatConversationEvents {
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         conversationId,
-        after: options.before ? undefined : activityCursor,
-        before: options.before ? activityCursor : undefined,
+        after: reverse ? undefined : activityCursor,
+        before: reverse ? activityCursor : undefined,
         limit: ACTIVITY_FETCH_BATCH_SIZE,
         sortDirection,
       });
@@ -169,17 +173,13 @@ export class ListWebChatConversationEvents {
       });
 
       if (mapped.events.length >= command.limit || mapped.hasMoreActivities || !page.next) {
-        const events = options.before ? [...mapped.events].reverse() : mapped.events;
+        const events = reverse ? [...mapped.events].reverse() : mapped.events;
 
         return {
           events,
           hasMore: mapped.hasMoreActivities || Boolean(page.next),
-          next: options.before ? dbPrevious : mapped.hasMoreActivities ? (mapped.lastActivityId ?? dbNext) : dbNext,
-          previous: options.before
-            ? mapped.hasMoreActivities
-              ? (mapped.lastActivityId ?? dbNext)
-              : dbNext
-            : dbPrevious,
+          next: reverse ? dbPrevious : mapped.hasMoreActivities ? (mapped.lastActivityId ?? dbNext) : dbNext,
+          previous: reverse ? (mapped.hasMoreActivities ? (mapped.lastActivityId ?? dbNext) : dbNext) : dbPrevious,
         };
       }
 

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
@@ -78,6 +78,7 @@ export class ListWebChatConversationEvents {
 
     const mapContext = {
       conversationId: conversation._id,
+      conversationIdentifier: conversation.identifier,
       agentIdentifier: agent.identifier,
     };
 
@@ -104,7 +105,7 @@ export class ListWebChatConversationEvents {
   private async fetchAfterSequenceEventPage(
     command: ListWebChatConversationEventsCommand,
     conversationId: string,
-    mapContext: { conversationId: string; agentIdentifier: string }
+    mapContext: { conversationId: string; conversationIdentifier: string; agentIdentifier: string }
   ): Promise<EventPageResult> {
     const page = await this.activityRepository.listEventActivitiesAfterSequence({
       environmentId: command.environmentId,
@@ -130,7 +131,7 @@ export class ListWebChatConversationEvents {
   private async fetchEventPage(
     command: ListWebChatConversationEventsCommand,
     conversationId: string,
-    mapContext: { conversationId: string; agentIdentifier: string },
+    mapContext: { conversationId: string; conversationIdentifier: string; agentIdentifier: string },
     options: {
       activityCursor?: string;
       before?: string;

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
@@ -1,24 +1,24 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import {
   AgentRepository,
-  ConversationActivityEntity,
   ConversationActivityRepository,
   ConversationParticipantTypeEnum,
   ConversationRepository,
 } from '@novu/dal';
 import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
-import { isMappableActivity, mapActivitiesToEventPage, WEB_CHAT_EVENT_ACTIVITY_FILTER } from '../../activity-to-events';
+import {
+  type EventMapContext,
+  mapNewestFirstEventActivities,
+  WEB_CHAT_EVENT_ACTIVITY_FILTER,
+} from '../../activity-to-events';
 import { ListWebChatConversationEventsCommand } from './list-web-chat-conversation-events.command';
 
-const ACTIVITY_FETCH_BATCH_SIZE = 100;
-
-type EventPageResult = {
+interface EventPageResult {
   events: AgentEventEnvelope[];
-  hasMore: boolean;
-  next: string | null;
-  previous: string | null;
-};
+  /** Cursor toward older history. Send it as `before`. Null when the beginning is reached. */
+  olderCursor: string | null;
+}
 
 @Injectable()
 export class ListWebChatConversationEvents {
@@ -29,14 +29,6 @@ export class ListWebChatConversationEvents {
   ) {}
 
   async execute(command: ListWebChatConversationEventsCommand): Promise<EventPageResult> {
-    if (command.after && command.before) {
-      throw new BadRequestException('Cannot specify both "before" and "after" cursors at the same time.');
-    }
-
-    if ((command.after || command.before) && command.afterSequence > 0) {
-      throw new BadRequestException('Use either cursor pagination (after/before) or afterSequence, not both.');
-    }
-
     const conversation = await this.conversationRepository.findOne(
       {
         identifier: command.conversationIdentifier,
@@ -76,157 +68,28 @@ export class ListWebChatConversationEvents {
       throw new NotFoundException('Conversation not found');
     }
 
-    const mapContext = {
+    const mapContext: EventMapContext = {
       conversationId: conversation._id,
       conversationIdentifier: conversation.identifier,
       agentIdentifier: agent.identifier,
     };
 
-    if (command.afterSequence > 0) {
-      return this.fetchAfterSequenceEventPage(command, conversation._id, mapContext);
-    }
-
-    // No cursor → newest page (chat open/resume). Explicit `after` stays oldest→newer.
-    const reverse = Boolean(command.before) || (!command.after && !command.before);
-    const sequenceOffset = command.after
-      ? await this.countMappableEventsUpToActivity(
-          command.environmentId,
-          command.organizationId,
-          conversation._id,
-          command.after
-        )
-      : 0;
-
-    return this.fetchEventPage(command, conversation._id, mapContext, {
-      activityCursor: command.after ?? command.before,
-      reverse,
-      sequenceOffset,
-    });
-  }
-
-  private async fetchAfterSequenceEventPage(
-    command: ListWebChatConversationEventsCommand,
-    conversationId: string,
-    mapContext: { conversationId: string; conversationIdentifier: string; agentIdentifier: string }
-  ): Promise<EventPageResult> {
-    const page = await this.activityRepository.listEventActivitiesAfterSequence({
+    const page = await this.activityRepository.listEventActivities({
       environmentId: command.environmentId,
       organizationId: command.organizationId,
-      conversationId,
-      afterSequence: command.afterSequence,
+      conversationId: conversation._id,
+      before: command.before,
       limit: command.limit,
       filter: WEB_CHAT_EVENT_ACTIVITY_FILTER,
     });
-    const events = mapActivitiesToEventPage(page.data, mapContext, {
-      sequenceOffset: command.afterSequence,
-      limit: command.limit,
-    }).events;
+
+    // Repo returns newest-first; mapper flips to chronological for the client.
+    const events = mapNewestFirstEventActivities(page.data, mapContext);
+    const oldestInPage = page.data[page.data.length - 1];
 
     return {
       events,
-      hasMore: page.hasMore,
-      next: null,
-      previous: null,
+      olderCursor: page.hasMore && oldestInPage ? oldestInPage._id : null,
     };
-  }
-
-  private async fetchEventPage(
-    command: ListWebChatConversationEventsCommand,
-    conversationId: string,
-    mapContext: { conversationId: string; conversationIdentifier: string; agentIdentifier: string },
-    options: {
-      activityCursor?: string;
-      /** Newest-first DB walk (`before` cursor or default open/resume page). */
-      reverse?: boolean;
-      sequenceOffset?: number;
-    }
-  ): Promise<EventPageResult> {
-    const reverse = Boolean(options.reverse);
-    const sortDirection = reverse ? -1 : 1;
-    let activityCursor = options.activityCursor;
-    let dbNext: string | null = null;
-    let dbPrevious: string | null = null;
-    const collected: ConversationActivityEntity[] = [];
-
-    while (true) {
-      const page = await this.activityRepository.listActivities({
-        environmentId: command.environmentId,
-        organizationId: command.organizationId,
-        conversationId,
-        after: reverse ? undefined : activityCursor,
-        before: reverse ? activityCursor : undefined,
-        limit: ACTIVITY_FETCH_BATCH_SIZE,
-        sortDirection,
-      });
-
-      if (page.data.length === 0) {
-        break;
-      }
-
-      collected.push(...page.data);
-      dbNext = page.next;
-      dbPrevious = page.previous;
-
-      const mapped = mapActivitiesToEventPage(collected, mapContext, {
-        sequenceOffset: options.sequenceOffset ?? 0,
-        limit: command.limit,
-      });
-
-      if (mapped.events.length >= command.limit || mapped.hasMoreActivities || !page.next) {
-        const events = reverse ? [...mapped.events].reverse() : mapped.events;
-
-        return {
-          events,
-          hasMore: mapped.hasMoreActivities || Boolean(page.next),
-          next: reverse ? dbPrevious : mapped.hasMoreActivities ? (mapped.lastActivityId ?? dbNext) : dbNext,
-          previous: reverse ? (mapped.hasMoreActivities ? (mapped.lastActivityId ?? dbNext) : dbNext) : dbPrevious,
-        };
-      }
-
-      activityCursor = page.next ?? undefined;
-    }
-
-    return { events: [], hasMore: false, next: null, previous: dbPrevious };
-  }
-
-  private async countMappableEventsUpToActivity(
-    environmentId: string,
-    organizationId: string,
-    conversationId: string,
-    activityId: string
-  ): Promise<number> {
-    let offset = 0;
-    let cursor: string | undefined;
-
-    while (true) {
-      const page = await this.activityRepository.listActivities({
-        environmentId,
-        organizationId,
-        conversationId,
-        after: cursor,
-        limit: ACTIVITY_FETCH_BATCH_SIZE,
-        sortDirection: 1,
-      });
-
-      if (page.data.length === 0) {
-        return offset;
-      }
-
-      for (const activity of page.data) {
-        if (activity._id === activityId) {
-          return isMappableActivity(activity) ? offset + 1 : offset;
-        }
-
-        if (isMappableActivity(activity)) {
-          offset += 1;
-        }
-      }
-
-      if (!page.next) {
-        return offset;
-      }
-
-      cursor = page.next;
-    }
   }
 }

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.command.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.command.ts
@@ -1,14 +1,15 @@
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { DirectionEnum } from '@novu/shared';
+import { IsBoolean, IsEnum, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 import { EnvironmentWithSubscriber } from '../../../../shared/commands/project.command';
 
 export class ListWebChatConversationsCommand extends EnvironmentWithSubscriber {
-  /** Cursor: conversation `_id` — fetch conversations after this id (forward pagination). */
+  /** Conversation `_id` cursor for forward pagination. */
   @IsOptional()
   @IsString()
   after?: string;
 
-  /** Cursor: conversation `_id` — fetch conversations before this id (reverse pagination). */
+  /** Conversation `_id` cursor for reverse pagination. */
   @IsOptional()
   @IsString()
   before?: string;
@@ -18,4 +19,15 @@ export class ListWebChatConversationsCommand extends EnvironmentWithSubscriber {
   @Min(1)
   @Max(100)
   limit = 50;
+
+  @IsIn(['lastActivityAt', 'createdAt'])
+  orderBy: 'lastActivityAt' | 'createdAt' = 'lastActivityAt';
+
+  @IsOptional()
+  @IsEnum(DirectionEnum)
+  orderDirection?: DirectionEnum;
+
+  @IsOptional()
+  @IsBoolean()
+  includeCursor?: boolean;
 }

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts
@@ -1,16 +1,12 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { AgentRepository, ConversationEntity, ConversationRepository } from '@novu/dal';
+import { DirectionEnum } from '@novu/shared';
 import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
-import type { WebChatConversationMetadataDto } from '../../dtos/web-chat-conversation.dto';
+import type {
+  ListWebChatConversationsResponseDto,
+  WebChatConversationMetadataDto,
+} from '../../dtos/web-chat-conversation.dto';
 import { ListWebChatConversationsCommand } from './list-web-chat-conversations.command';
-
-type ListResult = {
-  data: WebChatConversationMetadataDto[];
-  next: string | null;
-  previous: string | null;
-  totalCount: number;
-  totalCountCapped: boolean;
-};
 
 @Injectable()
 export class ListWebChatConversations {
@@ -19,7 +15,7 @@ export class ListWebChatConversations {
     private readonly agentRepository: AgentRepository
   ) {}
 
-  async execute(command: ListWebChatConversationsCommand): Promise<ListResult> {
+  async execute(command: ListWebChatConversationsCommand): Promise<ListWebChatConversationsResponseDto> {
     if (command.after && command.before) {
       throw new BadRequestException('Cannot specify both "before" and "after" cursors at the same time.');
     }
@@ -32,8 +28,9 @@ export class ListWebChatConversations {
       after: command.after,
       before: command.before,
       limit: command.limit,
-      sortBy: 'lastActivityAt',
-      sortDirection: -1,
+      sortBy: command.orderBy,
+      sortDirection: command.orderDirection === DirectionEnum.ASC ? 1 : -1,
+      includeCursor: command.includeCursor,
     });
 
     const agentIdentifierById = await this.resolveAgentIdentifiers(

--- a/apps/api/src/app/agents/web-chat/web-chat-event.factory.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-event.factory.ts
@@ -4,6 +4,7 @@ import { shortId } from '@novu/application-generic';
 
 type WebChatFactoryBaseInput = {
   conversationId: string;
+  conversationIdentifier: string;
   agentId: string;
   sequence: number;
   runId?: string;
@@ -68,20 +69,11 @@ export class WebChatEventFactory {
     });
   }
 
-  private build(
-    input: {
-      conversationId: string;
-      agentId: string;
-      sequence: number;
-      runId?: string;
-      turnId?: string;
-      timestamp?: string;
-    },
-    event: AgentEvent
-  ): AgentEventEnvelope {
+  private build(input: WebChatFactoryBaseInput, event: AgentEvent): AgentEventEnvelope {
     return {
       version: AGENT_EVENT_PROTOCOL_VERSION,
       conversationId: input.conversationId,
+      conversationIdentifier: input.conversationIdentifier,
       agentId: input.agentId,
       runId: input.runId ?? `web_${shortId(12)}`,
       turnId: input.turnId ?? `turn_${shortId(12)}`,

--- a/apps/api/src/app/agents/web-chat/web-chat-event.factory.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-event.factory.ts
@@ -41,6 +41,7 @@ export class WebChatEventFactory {
   createMessageEnvelope(input: WebChatFactoryMessageInput): AgentEventEnvelope {
     return this.build(input, {
       type: 'message',
+      role: 'assistant',
       messageId: input.platformMessageId,
       content: input.content,
     });

--- a/apps/api/src/app/agents/web-chat/web-chat-platform-delivery.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-platform-delivery.service.ts
@@ -64,6 +64,7 @@ export class WebChatPlatformDeliveryService {
         const markdown = this.markdownForLiveEnvelope(content, richContent);
         const envelope = this.eventFactory.createMessageEnvelope({
           conversationId: conversation._id,
+          conversationIdentifier: conversation.identifier,
           agentId: context.config.agentIdentifier,
           platformMessageId,
           content: { markdown },
@@ -91,6 +92,7 @@ export class WebChatPlatformDeliveryService {
         const markdown = this.markdownForLiveEnvelope(content, richContent);
         const envelope = this.eventFactory.createEditEnvelope({
           conversationId: conversation._id,
+          conversationIdentifier: conversation.identifier,
           agentId: context.config.agentIdentifier,
           platformMessageId: messageId,
           content: { markdown },
@@ -112,6 +114,7 @@ export class WebChatPlatformDeliveryService {
       if (conversation && sequence !== undefined) {
         const envelope = this.eventFactory.createDeleteEnvelope({
           conversationId: conversation._id,
+          conversationIdentifier: conversation.identifier,
           agentId: context.config.agentIdentifier,
           platformMessageId: messageId,
           sequence,
@@ -135,6 +138,7 @@ export class WebChatPlatformDeliveryService {
       const typingState = status?.trim() ? 'on' : 'off';
       const envelope = this.eventFactory.createTypingEnvelope({
         conversationId: conversation._id,
+        conversationIdentifier: conversation.identifier,
         agentId: context.config.agentIdentifier,
         sequence,
         state: typingState,

--- a/apps/api/src/app/agents/web-chat/web-chat.controller.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat.controller.ts
@@ -13,6 +13,7 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { FeatureFlagsService } from '@novu/application-generic';
+import { DirectionEnum } from '@novu/shared';
 import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import {
   SubscriberSession,
@@ -109,6 +110,9 @@ export class WebChatController {
         after: query.after,
         before: query.before,
         limit: query.limit ?? 50,
+        orderBy: query.orderBy || 'lastActivityAt',
+        orderDirection: query.orderDirection || DirectionEnum.DESC,
+        includeCursor: query.includeCursor,
       })
     );
   }
@@ -142,9 +146,7 @@ export class WebChatController {
         organizationId: subscriberSession.organizationId,
         subscriberId: subscriberSession.subscriberId,
         conversationIdentifier: identifier,
-        after: query.after,
         before: query.before,
-        afterSequence: query.afterSequence ?? 0,
         limit: query.limit ?? 50,
       })
     );

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -105,46 +105,54 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     });
   }
 
-  async listEventActivitiesAfterSequence(params: {
+  /**
+   * Newest-first page of event-capable activities that already carry a stored
+   * sequence. Used by web-chat history open/resume (`before` = older cursor).
+   */
+  async listEventActivities(params: {
     environmentId: string;
     organizationId: string;
     conversationId: string;
-    afterSequence: number;
+    /** Activity `_id` from the previous page's oldest row — fetch older history. */
+    before?: string;
     limit: number;
     filter: ConversationEventActivityFilter;
   }): Promise<{ data: ConversationActivityEntity[]; hasMore: boolean }> {
-    const baseQuery = {
+    const query: FilterQuery<ConversationActivityDBModel> & EnforceEnvOrOrgIds = {
       _environmentId: params.environmentId,
       _organizationId: params.organizationId,
       _conversationId: params.conversationId,
+      sequence: { $type: 'number' },
       ...eventActivityQuery(params.filter),
     };
+
+    if (params.before) {
+      const cursor = await this.findOne(
+        {
+          _environmentId: params.environmentId,
+          _organizationId: params.organizationId,
+          _conversationId: params.conversationId,
+          _id: params.before,
+        },
+        '*'
+      );
+
+      if (!cursor || typeof cursor.sequence !== 'number') {
+        return { data: [], hasMore: false };
+      }
+
+      query.$and = [
+        {
+          $or: [{ sequence: { $lt: cursor.sequence } }, { sequence: cursor.sequence, _id: { $lt: cursor._id } }],
+        },
+      ];
+    }
+
     const fetchLimit = params.limit + 1;
-    const legacyCount = await this.count({ ...baseQuery, sequence: { $exists: false } });
-    const legacy =
-      params.afterSequence < legacyCount
-        ? await this.find({ ...baseQuery, sequence: { $exists: false } }, '*', {
-            sort: { createdAt: 1, _id: 1 },
-            skip: params.afterSequence,
-            limit: fetchLimit,
-          })
-        : [];
-    const remaining = fetchLimit - legacy.length;
-    const sequenced =
-      remaining > 0
-        ? await this.find(
-            {
-              ...baseQuery,
-              sequence: { $gt: Math.max(params.afterSequence, legacyCount) },
-            },
-            '*',
-            {
-              sort: { sequence: 1, _id: 1 },
-              limit: remaining,
-            }
-          )
-        : [];
-    const data = [...legacy, ...sequenced];
+    const data = await this.find(query, '*', {
+      sort: { sequence: -1, _id: -1 },
+      limit: fetchLimit,
+    });
 
     return {
       data: data.slice(0, params.limit),

--- a/packages/agent-event-protocol/src/agent-event.types.ts
+++ b/packages/agent-event-protocol/src/agent-event.types.ts
@@ -1,3 +1,4 @@
+import type { AgentMessageRole } from './agent-message.types';
 import type { AgentFileRef, AgentMessageContent, AgentToolResultContent, AgentToolSource } from './wire-content.types';
 
 export const AGENT_EVENT_PROTOCOL_VERSION = 1 as const;
@@ -39,7 +40,14 @@ export type AgentEvent =
   | { type: 'step-start'; name?: string; index?: number }
   | { type: 'step-end'; name?: string; index?: number; usage?: AgentEventUsage }
   // Content
-  | { type: 'message'; messageId: string; content: AgentMessageContent; files?: AgentFileRef[] }
+  | {
+      type: 'message';
+      messageId: string;
+      /** Who authored this durable message. Streaming events stay assistant-only and omit role. */
+      role: AgentMessageRole;
+      content: AgentMessageContent;
+      files?: AgentFileRef[];
+    }
   | { type: 'message-start'; messageId: string }
   | { type: 'message-delta'; messageId: string; delta: string }
   | { type: 'message-end'; messageId: string; content?: AgentMessageContent; files?: AgentFileRef[] }

--- a/packages/agent-event-protocol/src/agent-event.types.ts
+++ b/packages/agent-event-protocol/src/agent-event.types.ts
@@ -75,7 +75,7 @@ export type AgentEvent =
   | { type: 'tool-use-result'; toolUseId: string; content: AgentToolResultContent[]; isError?: boolean }
   | ({
       type: 'tool-approval-request';
-      /** When true, no companion message carries the approval UI — the consumer should render its default approval card. */
+      /** When true, no companion message carries the approval UI. The consumer should render its default approval card. */
       deliverCard?: boolean;
     } & AgentApprovalRequest)
   | {
@@ -88,7 +88,7 @@ export type AgentEvent =
   // Conversation ops
   | { type: 'resolve'; summary?: string }
   | { type: 'signal'; signal: AgentSignal }
-  // Channel ops (imperative — emitted only by the framework SDK)
+  // Channel operations: imperative events that only the framework SDK emits.
   | { type: 'channel.typing'; state: 'on' | 'off'; status?: string }
   | { type: 'channel.edit'; messageId: string; content: AgentMessageContent; files?: AgentFileRef[] }
   | { type: 'channel.delete'; messageId: string }
@@ -130,16 +130,25 @@ export function isAgentEventEnvelope(value: unknown): value is AgentEventEnvelop
   const candidate = value as Record<string, unknown>;
   const event = candidate.event as Record<string, unknown> | undefined;
 
-  return (
-    candidate.version === AGENT_EVENT_PROTOCOL_VERSION &&
-    typeof candidate.conversationId === 'string' &&
-    typeof candidate.agentId === 'string' &&
-    typeof candidate.runId === 'string' &&
-    typeof candidate.turnId === 'string' &&
-    typeof candidate.sequence === 'number' &&
-    typeof candidate.timestamp === 'string' &&
-    typeof event === 'object' &&
-    event !== null &&
-    typeof event.type === 'string'
-  );
+  if (
+    candidate.version !== AGENT_EVENT_PROTOCOL_VERSION ||
+    typeof candidate.conversationId !== 'string' ||
+    typeof candidate.agentId !== 'string' ||
+    typeof candidate.runId !== 'string' ||
+    typeof candidate.turnId !== 'string' ||
+    typeof candidate.sequence !== 'number' ||
+    typeof candidate.timestamp !== 'string' ||
+    typeof event !== 'object' ||
+    event === null ||
+    typeof event.type !== 'string'
+  ) {
+    return false;
+  }
+
+  // Durable message requires an explicit role — no default.
+  if (event.type === 'message' && event.role !== 'user' && event.role !== 'assistant') {
+    return false;
+  }
+
+  return true;
 }

--- a/packages/agent-event-protocol/src/agent-event.types.ts
+++ b/packages/agent-event-protocol/src/agent-event.types.ts
@@ -99,6 +99,8 @@ export type AgentEvent =
 export interface AgentEventEnvelope {
   version: typeof AGENT_EVENT_PROTOCOL_VERSION;
   conversationId: string;
+  /** Public `conv_*` identifier. Clients receive only this id, never `conversationId`. */
+  conversationIdentifier?: string;
   agentId: string;
   runId: string;
   turnId: string;

--- a/packages/agent-event-protocol/src/apply-envelope.spec.ts
+++ b/packages/agent-event-protocol/src/apply-envelope.spec.ts
@@ -39,13 +39,13 @@ describe('applyEnvelope', () => {
       envelope(2, { type: 'message-start', messageId: 'm1' }),
       envelope(3, { type: 'message-delta', messageId: 'm1', delta: 'Hel' }),
       envelope(4, { type: 'message-delta', messageId: 'm1', delta: 'lo' }),
-      envelope(5, { type: 'message', messageId: 'm1', content: { markdown: 'Hello' } }),
+      envelope(5, { type: 'message', role: 'assistant', messageId: 'm1', content: { markdown: 'Hello' } }),
       envelope(6, { type: 'run-finish', outcome: 'completed' }),
     ]);
 
     const history = applyEnvelopes(createInitialAgentConversationState(), [
       envelope(1, { type: 'run-start' }),
-      envelope(2, { type: 'message', messageId: 'm1', content: { markdown: 'Hello' } }),
+      envelope(2, { type: 'message', role: 'assistant', messageId: 'm1', content: { markdown: 'Hello' } }),
       envelope(3, { type: 'run-finish', outcome: 'completed' }),
     ]);
 
@@ -76,14 +76,29 @@ describe('applyEnvelope', () => {
         content: [{ type: 'text', text: 'Ships Friday' }],
       }),
       envelope(12, { type: 'message-delta', messageId: 'm1', delta: ' your order' }),
-      envelope(13, { type: 'message', messageId: 'm1', content: { markdown: 'Checking your order' } }),
-      envelope(14, { type: 'message', messageId: 'm1', content: { markdown: 'It ships Friday' } }),
+      envelope(13, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'm1',
+        content: { markdown: 'Checking your order' },
+      }),
+      envelope(14, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'm1',
+        content: { markdown: 'It ships Friday' },
+      }),
       envelope(15, { type: 'run-finish', outcome: 'completed' }),
     ];
 
     const historyEnvelopes: AgentEventEnvelope[] = [
       envelope(1, { type: 'run-start' }),
-      envelope(2, { type: 'message', messageId: 'm1', content: { markdown: 'Checking your order' } }),
+      envelope(2, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'm1',
+        content: { markdown: 'Checking your order' },
+      }),
       envelope(3, { type: 'thinking-start', thinkingId: 't1' }),
       envelope(4, { type: 'thinking-delta', thinkingId: 't1', delta: 'Looking up order' }),
       envelope(5, { type: 'thinking-end', thinkingId: 't1' }),
@@ -99,7 +114,12 @@ describe('applyEnvelope', () => {
         toolUseId: 'tu1',
         content: [{ type: 'text', text: 'Ships Friday' }],
       }),
-      envelope(9, { type: 'message', messageId: 'm1', content: { markdown: 'It ships Friday' } }),
+      envelope(9, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'm1',
+        content: { markdown: 'It ships Friday' },
+      }),
       envelope(10, { type: 'run-finish', outcome: 'completed' }),
     ];
 
@@ -184,5 +204,36 @@ describe('applyEnvelope', () => {
 
     const approval = state.messages[0]?.parts.find((part) => part.type === 'approval');
     expect(approval).toMatchObject({ type: 'approval', approvalId: 'a1', state: 'approved' });
+  });
+
+  it('folds durable user messages when role is user', () => {
+    const state = applyEnvelopes(createInitialAgentConversationState(), [
+      envelope(1, {
+        type: 'message',
+        role: 'user',
+        messageId: 'msg_user0000001',
+        content: { markdown: 'Hello agent' },
+      }),
+      envelope(2, {
+        type: 'message',
+        role: 'assistant',
+        messageId: 'msg_asst0000001',
+        content: { markdown: 'Hello human' },
+      }),
+    ]);
+
+    expect(state.messages).toHaveLength(2);
+    expect(state.messages[0]).toMatchObject({
+      id: 'msg_user0000001',
+      role: 'user',
+      status: 'sent',
+      parts: [{ type: 'text', text: 'Hello agent', state: 'done' }],
+    });
+    expect(state.messages[1]).toMatchObject({
+      id: 'msg_asst0000001',
+      role: 'assistant',
+      status: 'sent',
+      parts: [{ type: 'text', text: 'Hello human', state: 'done' }],
+    });
   });
 });

--- a/packages/agent-event-protocol/src/apply-envelope.ts
+++ b/packages/agent-event-protocol/src/apply-envelope.ts
@@ -70,21 +70,12 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
         parts: finalizeMessageEndParts(message.parts, event.content, event.files),
       }));
 
-    case 'message': {
-      if (event.role === 'user') {
-        return withUserMessage(state, envelope, event.messageId, (message) => ({
-          ...message,
-          parts: applyDurableMessageParts(message.parts, event.content, event.files),
-          status: 'sent',
-        }));
-      }
-
-      return withAssistantMessage(state, envelope, event.messageId, (message) => ({
+    case 'message':
+      return withMessage(state, envelope, event.messageId, event.role, (message) => ({
         ...message,
         parts: applyDurableMessageParts(message.parts, event.content, event.files),
         status: 'sent',
       }));
-    }
 
     case 'thinking-start':
       return withActiveAssistantMessage(state, envelope, (message) => ({
@@ -186,67 +177,35 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
   }
 }
 
+function withMessage(
+  state: AgentConversationState,
+  envelope: AgentEventEnvelope,
+  messageId: string,
+  role: AgentMessageRole,
+  update: (message: AgentMessage) => AgentMessage
+): AgentConversationState {
+  const { messages, index } = ensureMessage(state, envelope, messageId, role);
+  const existing = messages[index];
+  if (!existing) {
+    return state;
+  }
+  const nextMessages = messages.slice();
+  nextMessages[index] = update(existing);
+
+  return {
+    ...state,
+    messages: nextMessages,
+    ...(role === 'assistant' ? { activeAssistantMessageId: messageId } : {}),
+  };
+}
+
 function withAssistantMessage(
   state: AgentConversationState,
   envelope: AgentEventEnvelope,
   messageId: string,
   update: (message: AgentMessage) => AgentMessage
 ): AgentConversationState {
-  const { messages, index } = ensureAssistantMessage(state, envelope, messageId);
-  const existing = messages[index];
-  if (!existing) {
-    return state;
-  }
-  const nextMessages = messages.slice();
-  nextMessages[index] = update(existing);
-
-  return {
-    ...state,
-    messages: nextMessages,
-    activeAssistantMessageId: messageId,
-  };
-}
-
-function withUserMessage(
-  state: AgentConversationState,
-  envelope: AgentEventEnvelope,
-  messageId: string,
-  update: (message: AgentMessage) => AgentMessage
-): AgentConversationState {
-  const { messages, index } = ensureUserMessage(state, envelope, messageId);
-  const existing = messages[index];
-  if (!existing) {
-    return state;
-  }
-  const nextMessages = messages.slice();
-  nextMessages[index] = update(existing);
-
-  return {
-    ...state,
-    messages: nextMessages,
-  };
-}
-
-function ensureUserMessage(
-  state: AgentConversationState,
-  envelope: AgentEventEnvelope,
-  messageId: string
-): { messages: AgentMessage[]; index: number } {
-  const existingIndex = state.messages.findIndex((message) => message.id === messageId && message.role === 'user');
-
-  if (existingIndex >= 0) {
-    return { messages: state.messages, index: existingIndex };
-  }
-
-  const message: AgentMessage = {
-    id: messageId,
-    role: 'user',
-    parts: [],
-    createdAt: envelope.timestamp,
-    status: 'sent',
-  };
-
-  return { messages: [...state.messages, message], index: state.messages.length };
+  return withMessage(state, envelope, messageId, 'assistant', update);
 }
 
 function withActiveAssistantMessage(
@@ -255,27 +214,17 @@ function withActiveAssistantMessage(
   update: (message: AgentMessage) => AgentMessage
 ): AgentConversationState {
   const messageId = state.activeAssistantMessageId ?? envelope.runId;
-  const { messages, index } = ensureAssistantMessage(state, envelope, messageId);
-  const existing = messages[index];
-  if (!existing) {
-    return state;
-  }
-  const nextMessages = messages.slice();
-  nextMessages[index] = update(existing);
 
-  return {
-    ...state,
-    messages: nextMessages,
-    activeAssistantMessageId: messageId,
-  };
+  return withMessage(state, envelope, messageId, 'assistant', update);
 }
 
-function ensureAssistantMessage(
+function ensureMessage(
   state: AgentConversationState,
   envelope: AgentEventEnvelope,
-  messageId: string
+  messageId: string,
+  role: AgentMessageRole
 ): { messages: AgentMessage[]; index: number } {
-  const existingIndex = state.messages.findIndex((message) => message.id === messageId && message.role === 'assistant');
+  const existingIndex = state.messages.findIndex((message) => message.id === messageId && message.role === role);
 
   if (existingIndex >= 0) {
     return { messages: state.messages, index: existingIndex };
@@ -283,7 +232,7 @@ function ensureAssistantMessage(
 
   const message: AgentMessage = {
     id: messageId,
-    role: 'assistant',
+    role,
     parts: [],
     createdAt: envelope.timestamp,
     status: 'sent',

--- a/packages/agent-event-protocol/src/apply-envelope.ts
+++ b/packages/agent-event-protocol/src/apply-envelope.ts
@@ -70,12 +70,21 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
         parts: finalizeMessageEndParts(message.parts, event.content, event.files),
       }));
 
-    case 'message':
+    case 'message': {
+      if (event.role === 'user') {
+        return withUserMessage(state, envelope, event.messageId, (message) => ({
+          ...message,
+          parts: applyDurableMessageParts(message.parts, event.content, event.files),
+          status: 'sent',
+        }));
+      }
+
       return withAssistantMessage(state, envelope, event.messageId, (message) => ({
         ...message,
         parts: applyDurableMessageParts(message.parts, event.content, event.files),
         status: 'sent',
       }));
+    }
 
     case 'thinking-start':
       return withActiveAssistantMessage(state, envelope, (message) => ({
@@ -196,6 +205,48 @@ function withAssistantMessage(
     messages: nextMessages,
     activeAssistantMessageId: messageId,
   };
+}
+
+function withUserMessage(
+  state: AgentConversationState,
+  envelope: AgentEventEnvelope,
+  messageId: string,
+  update: (message: AgentMessage) => AgentMessage
+): AgentConversationState {
+  const { messages, index } = ensureUserMessage(state, envelope, messageId);
+  const existing = messages[index];
+  if (!existing) {
+    return state;
+  }
+  const nextMessages = messages.slice();
+  nextMessages[index] = update(existing);
+
+  return {
+    ...state,
+    messages: nextMessages,
+  };
+}
+
+function ensureUserMessage(
+  state: AgentConversationState,
+  envelope: AgentEventEnvelope,
+  messageId: string
+): { messages: AgentMessage[]; index: number } {
+  const existingIndex = state.messages.findIndex((message) => message.id === messageId && message.role === 'user');
+
+  if (existingIndex >= 0) {
+    return { messages: state.messages, index: existingIndex };
+  }
+
+  const message: AgentMessage = {
+    id: messageId,
+    role: 'user',
+    parts: [],
+    createdAt: envelope.timestamp,
+    status: 'sent',
+  };
+
+  return { messages: [...state.messages, message], index: state.messages.length };
 }
 
 function withActiveAssistantMessage(

--- a/packages/chat-adapter-web/src/adapter.spec.ts
+++ b/packages/chat-adapter-web/src/adapter.spec.ts
@@ -120,9 +120,10 @@ describe('NovuWebChatAdapterImpl', () => {
 
     expect(response.status).toBe(201);
     expect(body.data.identifier).toMatch(/^conv_[0-9a-z]{12}$/);
+    expect(body.data.messageId).toMatch(/^msg_[0-9a-z]{12}$/);
     expect(processMessage).toHaveBeenCalledOnce();
     expect(processMessage.mock.calls[0]?.[1]).toBe(`web_chat:${body.data.identifier}`);
-    expect(processMessage.mock.calls[0]?.[2].id).toMatch(/^msg_[0-9a-z]{12}$/);
+    expect(processMessage.mock.calls[0]?.[2].id).toBe(body.data.messageId);
   });
 
   it('ignores client messageId and always mints server message id', async () => {

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -201,8 +201,9 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
     // Always mint message ids. Client `messageId` idempotency would ack a ghost
     // turn if checked before durable create; keep server-minted ids for now.
     const threadId = this.encodeThreadId({ conversationId });
+    const messageId = mintMessageId();
     const message = this.parseMessage({
-      id: mintMessageId(),
+      id: messageId,
       text: kind.text,
       subscriberId: session.subscriberId,
       createdAt: new Date().toISOString(),
@@ -212,7 +213,8 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
 
     // Public conversation identifier stays bare `conv_*`; chat-sdk thread ids are
     // `web_chat:conv_*` so `chat.thread()` can resolve this adapter by prefix.
-    return jsonResponse({ data: { identifier: conversationId } }, 201);
+    // `messageId` lets the client reconcile optimistic bubbles with history/live.
+    return jsonResponse({ data: { identifier: conversationId, messageId } }, 201);
   }
 
   /** Button / approval click — mirrors Telegram `handleCallbackQuery`. */

--- a/packages/framework/src/resources/agent/agent-event-mode.test.ts
+++ b/packages/framework/src/resources/agent/agent-event-mode.test.ts
@@ -76,6 +76,7 @@ describe('event mode (AgentEvent protocol)', () => {
     expect(eventBatches[0][0].event).toEqual({ type: 'run-start' });
     expect(eventBatches[0][1].event).toEqual({
       type: 'message',
+      role: 'assistant',
       messageId: 'msg_00000000-0000-4000-8000-000000000001',
       content: { markdown: 'Hello from event mode' },
     });
@@ -102,6 +103,7 @@ describe('event mode (AgentEvent protocol)', () => {
 
     expect(eventBatches[0][1].event).toEqual({
       type: 'message',
+      role: 'assistant',
       messageId: 'msg_00000000-0000-4000-8000-000000000001',
       content: { markdown: 'Here is the report' },
       files: [

--- a/packages/framework/src/resources/agent/agent-event-outbox.test.ts
+++ b/packages/framework/src/resources/agent/agent-event-outbox.test.ts
@@ -36,7 +36,7 @@ describe('AgentEventOutbox', () => {
     const outbox = new AgentEventOutbox({ ...BASE_OPTIONS, fetchFn });
 
     outbox.enqueue({ type: 'run-start' });
-    outbox.enqueue({ type: 'message', messageId: 'msg-1', content: { markdown: 'a' } });
+    outbox.enqueue({ type: 'message', role: 'assistant', messageId: 'msg-1', content: { markdown: 'a' } });
     outbox.enqueue({ type: 'run-finish', outcome: 'completed' });
     await outbox.flush();
 

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -459,6 +459,7 @@ class EventOutboxTransport implements TurnTransport {
     const events = toSideEffectEvents(sideEffects);
     events.push({
       type: 'message',
+      role: 'assistant',
       messageId,
       content: toAgentMessageContent(reply),
       files: toAgentFileRefs(reply.files),

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -98,6 +98,7 @@
     ]
   },
   "devDependencies": {
+    "@novu/agent-event-protocol": "workspace:*",
     "@arethetypeswrong/cli": "^0.17.4",
     "@types/jest": "^29.2.3",
     "@types/node": "^22.0.0",

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -13,9 +13,22 @@ import {
  */
 export type ConversationEntry = AgentConversationState & {
   agentId: string;
-  /** Public `conv_*` id once assigned (uncontrolled send) or when resuming. */
+  /** Public `conv_*` id once the draft is claimed, or when resuming. */
   conversationId?: string;
+  /**
+   * Immutable subscription key for emits.
+   * Draft holders stay `agent:<agentId>` after claim; resumed holders are `conv:<id>`.
+   */
+  key: string;
 };
+
+export function draftKey(agentId: string): string {
+  return `agent:${agentId}`;
+}
+
+export function resumeKey(conversationId: string): string {
+  return `conv:${conversationId}`;
+}
 
 function createOptimisticMessageId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -41,18 +54,23 @@ function applyState(entry: ConversationEntry, next: AgentConversationState): voi
  * HTTP calls; the hook listens via `onUpdate` → `agent_chat.messages.updated`.
  *
  * Dual index — same stable holder, two lookup keys:
- * - `#byAgentId` — uncontrolled draft for that agent (omit conversationId on send)
+ * - `#byAgentId` — agent draft (omit conversationId on send / sticky resume)
  * - `#byConversationId` — alias added once the public `conv_*` id is known
  *
  * Holders are never swapped. `conversationId` is an alias on the existing object.
  * Resume/`loadConversation` indexes by conversationId only and does not claim the
- * agent draft key (so uncontrolled sends stay on the draft, not a resumed chat).
+ * agent draft key (so draft sends stay on the draft, not a resumed chat).
  */
 export class AgentChatStore {
-  /** Uncontrolled draft (and sticky resume) keyed by agent. */
+  /** Agent draft (and sticky resume after claim) keyed by agent. */
   #byAgentId = new Map<string, ConversationEntry>();
   /** Same holders keyed by public conversation id once known. */
   #byConversationId = new Map<string, ConversationEntry>();
+  /**
+   * In-flight draft claim per agent (server mint of `conv_*`).
+   * Waiters reuse the claimed id; concurrent posts after claim are not gated.
+   */
+  #pendingDraftClaims = new Map<string, Promise<string | undefined>>();
   /** Fired after every mutation so AgentChat can emit to React. */
   #onUpdate: (entry: ConversationEntry) => void;
 
@@ -64,6 +82,7 @@ export class AgentChatStore {
   clear(): void {
     this.#byAgentId.clear();
     this.#byConversationId.clear();
+    this.#pendingDraftClaims.clear();
   }
 
   /**
@@ -85,8 +104,8 @@ export class AgentChatStore {
 
   /**
    * Return the entry if it exists; otherwise create an empty holder.
-   * With `conversationId`: conversation index only (resume / controlled).
-   * Without: agent draft slot (uncontrolled send / sticky resume).
+   * With `conversationId`: conversation index only (resume).
+   * Without: agent draft slot (first send claims; later sends sticky-resume).
    */
   getOrCreate(agentId: string, conversationId?: string): ConversationEntry {
     const existing = this.get(agentId, conversationId);
@@ -98,6 +117,7 @@ export class AgentChatStore {
       ...createInitialAgentConversationState(),
       agentId,
       conversationId,
+      key: conversationId ? resumeKey(conversationId) : draftKey(agentId),
     };
 
     if (conversationId) {
@@ -131,7 +151,8 @@ export class AgentChatStore {
 
   /**
    * Mark an optimistic message `sent`, swap in the server message id, and adopt
-   * conversationId as an alias on this same holder (sticky uncontrolled resume).
+   * conversationId as an alias on this same holder (sticky draft resume).
+   * Does not change `entry.key` — draft listeners keep matching after claim.
    */
   markSent(
     entry: ConversationEntry,
@@ -184,5 +205,37 @@ export class AgentChatStore {
     this.#onUpdate(entry);
 
     return entry;
+  }
+
+  /**
+   * Run an HTTP post for this entry.
+   * Unclaimed drafts: only one create in flight; waiters reuse the claimed `conv_*`.
+   * After claim (or resume / explicit id): posts run immediately with no gating.
+   */
+  withDraftClaim<T>(
+    entry: ConversationEntry,
+    explicitConversationId: string | undefined,
+    post: (conversationId?: string) => Promise<T>
+  ): Promise<T> {
+    const known = explicitConversationId ?? entry.conversationId;
+    if (known) {
+      return post(known);
+    }
+
+    const pending = this.#pendingDraftClaims.get(entry.agentId);
+    if (pending) {
+      return pending.then((claimedId) => post(claimedId ?? entry.conversationId));
+    }
+
+    let resolveClaim!: (conversationId: string | undefined) => void;
+    const claimGate = new Promise<string | undefined>((resolve) => {
+      resolveClaim = resolve;
+    });
+    this.#pendingDraftClaims.set(entry.agentId, claimGate);
+
+    return post(undefined).finally(() => {
+      resolveClaim(entry.conversationId);
+      this.#pendingDraftClaims.delete(entry.agentId);
+    });
   }
 }

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -1,17 +1,19 @@
 import {
   type AgentConversationState,
-  type AgentMessage,
+  type AgentEventEnvelope,
   appendUserMessage,
+  applyEnvelopes,
   createInitialAgentConversationState,
 } from '@novu/agent-event-protocol';
 
 /**
- * One conversation's local state: messages plus the ids used to find it.
- * This is in-memory UI cache, not a sync copy of the server timeline.
+ * Stable local identity for one conversation.
+ * The object reference never changes; timeline fields are overwritten in place.
+ * This is an in-memory UI cache, not a synchronized copy of the server timeline.
  */
 export type ConversationEntry = AgentConversationState & {
   agentId: string;
-  /** Public `conv_*` id once the server returns it (or when resuming). */
+  /** Public `conv_*` id once assigned (uncontrolled send) or when resuming. */
   conversationId?: string;
 };
 
@@ -23,15 +25,13 @@ function createOptimisticMessageId(): string {
   return `opt_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function setMessageStatus(
-  state: AgentConversationState,
-  messageId: string,
-  status: AgentMessage['status']
-): AgentConversationState {
-  return {
-    ...state,
-    messages: state.messages.map((message) => (message.id === messageId ? { ...message, status } : message)),
-  };
+function applyState(entry: ConversationEntry, next: AgentConversationState): void {
+  entry.messages = next.messages;
+  entry.isRunning = next.isRunning;
+  entry.status = next.status;
+  entry.lastSequence = next.lastSequence;
+  entry.error = next.error;
+  entry.activeAssistantMessageId = next.activeAssistantMessageId;
 }
 
 /**
@@ -40,17 +40,18 @@ function setMessageStatus(
  * Owns the message list the UI paints. `AgentChat` mutates this store around
  * HTTP calls; the hook listens via `onUpdate` → `agent_chat.messages.updated`.
  *
- * Dual index — same entry, two lookup keys:
- * - `#byAgentId` — first send / uncontrolled chat (`useAgentChat({ agentId })`)
- * - `#byConversationId` — after the server returns `conv_*`, or when resuming
+ * Dual index — same stable holder, two lookup keys:
+ * - `#byAgentId` — uncontrolled draft for that agent (omit conversationId on send)
+ * - `#byConversationId` — alias added once the public `conv_*` id is known
  *
- * We never delete and recreate an entry to "move" keys. After adopt, the same
- * object is reachable by agentId and by conversationId.
+ * Holders are never swapped. `conversationId` is an alias on the existing object.
+ * Resume/`loadConversation` indexes by conversationId only and does not claim the
+ * agent draft key (so uncontrolled sends stay on the draft, not a resumed chat).
  */
 export class AgentChatStore {
-  /** Uncontrolled chats and adopted chats keyed by agent. */
+  /** Uncontrolled draft (and sticky resume) keyed by agent. */
   #byAgentId = new Map<string, ConversationEntry>();
-  /** Same entry objects, keyed by public conversation id once known. */
+  /** Same holders keyed by public conversation id once known. */
   #byConversationId = new Map<string, ConversationEntry>();
   /** Fired after every mutation so AgentChat can emit to React. */
   #onUpdate: (entry: ConversationEntry) => void;
@@ -67,7 +68,7 @@ export class AgentChatStore {
 
   /**
    * Look up an existing conversation.
-   * Prefer conversationId when present; otherwise fall back to agentId.
+   * Prefer conversationId when present; otherwise the agent draft.
    */
   get(agentId: string, conversationId?: string): ConversationEntry | undefined {
     if (conversationId) {
@@ -76,20 +77,17 @@ export class AgentChatStore {
         return byId;
       }
 
-      // First send may have adopted conversationId on the agent-keyed entry
-      // before #byConversationId was populated for a concurrent reader.
-      const byAgent = this.#byAgentId.get(agentId);
-      if (byAgent?.conversationId === conversationId) {
-        return byAgent;
-      }
-
       return undefined;
     }
 
     return this.#byAgentId.get(agentId);
   }
 
-  /** Return the entry if it exists; otherwise create an empty one. */
+  /**
+   * Return the entry if it exists; otherwise create an empty holder.
+   * With `conversationId`: conversation index only (resume / controlled).
+   * Without: agent draft slot (uncontrolled send / sticky resume).
+   */
   getOrCreate(agentId: string, conversationId?: string): ConversationEntry {
     const existing = this.get(agentId, conversationId);
     if (existing) {
@@ -116,122 +114,75 @@ export class AgentChatStore {
    * Returns the optimistic message id so the caller can mark it sent/failed.
    */
   appendSending(entry: ConversationEntry, text: string): string {
-    const current = this.#latest(entry);
     const messageId = createOptimisticMessageId();
-    const next: ConversationEntry = {
-      ...current,
-      ...appendUserMessage(current, {
+    applyState(
+      entry,
+      appendUserMessage(entry, {
         id: messageId,
         createdAt: new Date().toISOString(),
         status: 'sending',
         parts: [{ type: 'text', text, state: 'done' }],
-      }),
-    };
-
-    this.#replace(current, next);
-    this.#onUpdate(next);
+      })
+    );
+    this.#onUpdate(entry);
 
     return messageId;
   }
 
   /**
-   * Mark an optimistic message `sent` and attach the server conversation id.
-   * When `serverMessageId` is present, swap the optimistic id so history/live join.
-   * Indexes the entry under conversationId so remount/resume can find it.
+   * Mark an optimistic message `sent`, swap in the server message id, and adopt
+   * conversationId as an alias on this same holder (sticky uncontrolled resume).
    */
   markSent(
     entry: ConversationEntry,
-    optimisticMessageId: string,
-    conversationId: string,
-    serverMessageId?: string
+    args: { optimisticMessageId: string; serverMessageId: string; conversationId: string }
   ): ConversationEntry {
-    const current = this.#latest(entry);
-    const messages = current.messages.map((message) => {
-      if (message.id !== optimisticMessageId) {
-        return message;
-      }
+    entry.messages = entry.messages.map((message) =>
+      message.id === args.optimisticMessageId
+        ? { ...message, id: args.serverMessageId, status: 'sent' as const }
+        : message
+    );
 
-      return {
-        ...message,
-        id: serverMessageId ?? message.id,
-        status: 'sent' as const,
-      };
-    });
-    const next: ConversationEntry = {
-      ...current,
-      messages,
-      conversationId,
-    };
+    if (!entry.conversationId) {
+      entry.conversationId = args.conversationId;
+      this.#byConversationId.set(args.conversationId, entry);
+    }
 
-    this.#replace(current, next);
-    this.#onUpdate(next);
+    this.#onUpdate(entry);
 
-    return next;
+    return entry;
   }
 
   /** Mark an optimistic message `failed`. No auto-retry (no idempotency key). */
   markFailed(entry: ConversationEntry, messageId: string): ConversationEntry {
-    const current = this.#latest(entry);
-    const next: ConversationEntry = {
-      ...current,
-      ...setMessageStatus(current, messageId, 'failed'),
-    };
+    entry.messages = entry.messages.map((message) =>
+      message.id === messageId ? { ...message, status: 'failed' as const } : message
+    );
+    this.#onUpdate(entry);
 
-    this.#replace(current, next);
-    this.#onUpdate(next);
-
-    return next;
+    return entry;
   }
 
   /**
-   * Replace local timeline with a folded history page (open/resume).
-   * Keeps agentId; adopts conversationId into both indexes.
+   * Fold a history page of envelopes into this holder (open/resume).
+   * Server ids win; local-only messages (in-flight or not yet on the page) stay.
    */
-  replaceFromHistory(
-    entry: ConversationEntry,
-    history: AgentConversationState,
-    conversationId: string
-  ): ConversationEntry {
-    const current = this.#latest(entry);
-    const next: ConversationEntry = {
-      ...history,
-      agentId: current.agentId,
-      conversationId,
-    };
+  absorbHistoryPage(entry: ConversationEntry, envelopes: AgentEventEnvelope[]): ConversationEntry {
+    const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
+    const serverIds = new Set(folded.messages.map((message) => message.id));
+    const localOnly = entry.messages.filter((message) => !serverIds.has(message.id));
 
-    this.#replace(current, next);
-    this.#onUpdate(next);
+    applyState(entry, {
+      ...folded,
+      messages: [...folded.messages, ...localOnly],
+    });
 
-    return next;
-  }
-
-  /**
-   * Re-read the live entry from the maps.
-   * Callers may hold a stale object reference while another send mutates the store.
-   */
-  #latest(entry: ConversationEntry): ConversationEntry {
     if (entry.conversationId) {
-      return this.#byConversationId.get(entry.conversationId) ?? this.#byAgentId.get(entry.agentId) ?? entry;
+      this.#byConversationId.set(entry.conversationId, entry);
     }
 
-    return this.#byAgentId.get(entry.agentId) ?? entry;
-  }
+    this.#onUpdate(entry);
 
-  /**
-   * Swap `prev` for `next` in both indexes.
-   * Keeps agentId and conversationId pointing at the same updated entry.
-   */
-  #replace(prev: ConversationEntry, next: ConversationEntry): void {
-    if (this.#byAgentId.get(prev.agentId) === prev) {
-      this.#byAgentId.set(next.agentId, next);
-    }
-
-    if (prev.conversationId && this.#byConversationId.get(prev.conversationId) === prev) {
-      this.#byConversationId.delete(prev.conversationId);
-    }
-
-    if (next.conversationId) {
-      this.#byConversationId.set(next.conversationId, next);
-    }
+    return entry;
   }
 }

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -7,27 +7,30 @@ import {
 } from '@novu/agent-event-protocol';
 
 /**
- * Stable local identity for one conversation.
+ * Stable local identity for one conversation holder.
  * The object reference never changes; timeline fields are overwritten in place.
  * This is an in-memory UI cache, not a synchronized copy of the server timeline.
  */
 export type ConversationEntry = AgentConversationState & {
   agentId: string;
-  /** Public `conv_*` id once the draft is claimed, or when resuming. */
+  /** Public `conv_*` id once created on the server, or when resuming. */
   conversationId?: string;
   /**
-   * Immutable subscription key for emits.
-   * Draft holders stay `agent:<agentId>` after claim; resumed holders are `conv:<id>`.
+   * Immutable subscription / map key for this holder's whole life.
+   * Create sessions use `local_*`; resume sessions use the `conv_*` id.
    */
   key: string;
+  /** Serializes overlapping creates on this holder until a `conv_*` exists. */
+  pendingCreate?: Promise<void>;
 };
 
-export function draftKey(agentId: string): string {
-  return `agent:${agentId}`;
-}
+/** Client-minted holder key for a create session (before `conv_*` exists). */
+export function createLocalConversationKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `local_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+  }
 
-export function resumeKey(conversationId: string): string {
-  return `conv:${conversationId}`;
+  return `local_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function createOptimisticMessageId(): string {
@@ -53,24 +56,12 @@ function applyState(entry: ConversationEntry, next: AgentConversationState): voi
  * Owns the message list the UI paints. `AgentChat` mutates this store around
  * HTTP calls; the hook listens via `onUpdate` → `agent_chat.messages.updated`.
  *
- * Dual index — same stable holder, two lookup keys:
- * - `#byAgentId` — agent draft (omit conversationId on send / sticky resume)
- * - `#byConversationId` — alias added once the public `conv_*` id is known
- *
- * Holders are never swapped. `conversationId` is an alias on the existing object.
- * Resume/`loadConversation` indexes by conversationId only and does not claim the
- * agent draft key (so draft sends stay on the draft, not a resumed chat).
+ * One map keyed by an immutable holder `key` (NV-8445: state keyed by conversation
+ * identity — `local_*` until create returns `conv_*`, then the same key stays).
+ * Omit `conversationId` on send always creates; callers pass the returned id next.
  */
 export class AgentChatStore {
-  /** Agent draft (and sticky resume after claim) keyed by agent. */
-  #byAgentId = new Map<string, ConversationEntry>();
-  /** Same holders keyed by public conversation id once known. */
-  #byConversationId = new Map<string, ConversationEntry>();
-  /**
-   * In-flight draft claim per agent (server mint of `conv_*`).
-   * Waiters reuse the claimed id; concurrent posts after claim are not gated.
-   */
-  #pendingDraftClaims = new Map<string, Promise<string | undefined>>();
+  #byKey = new Map<string, ConversationEntry>();
   /** Fired after every mutation so AgentChat can emit to React. */
   #onUpdate: (entry: ConversationEntry) => void;
 
@@ -80,51 +71,42 @@ export class AgentChatStore {
 
   /** Drop all conversations (wired into `Novu.clearCache` / changeSubscriber). */
   clear(): void {
-    this.#byAgentId.clear();
-    this.#byConversationId.clear();
-    this.#pendingDraftClaims.clear();
+    this.#byKey.clear();
   }
 
-  /**
-   * Look up an existing conversation.
-   * Prefer conversationId when present; otherwise the agent draft.
-   */
-  get(agentId: string, conversationId?: string): ConversationEntry | undefined {
-    if (conversationId) {
-      const byId = this.#byConversationId.get(conversationId);
-      if (byId?.agentId === agentId) {
-        return byId;
-      }
+  get(key: string): ConversationEntry | undefined {
+    return this.#byKey.get(key);
+  }
 
-      return undefined;
+  /** Find a holder that already has this public conversation id (same-session append). */
+  getByConversationId(agentId: string, conversationId: string): ConversationEntry | undefined {
+    for (const entry of this.#byKey.values()) {
+      if (entry.agentId === agentId && entry.conversationId === conversationId) {
+        return entry;
+      }
     }
 
-    return this.#byAgentId.get(agentId);
+    return undefined;
   }
 
   /**
-   * Return the entry if it exists; otherwise create an empty holder.
-   * With `conversationId`: conversation index only (resume).
-   * Without: agent draft slot (first send claims; later sends sticky-resume).
+   * Return the entry for `key` if it exists; otherwise create an empty holder.
+   * Does not reuse another holder that merely shares `conversationId` — resume
+   * (`key === conversationId`) stays separate from an in-flight `local_*` create.
    */
-  getOrCreate(agentId: string, conversationId?: string): ConversationEntry {
-    const existing = this.get(agentId, conversationId);
+  getOrCreate(args: { agentId: string; key: string; conversationId?: string }): ConversationEntry {
+    const existing = this.#byKey.get(args.key);
     if (existing) {
       return existing;
     }
 
     const entry: ConversationEntry = {
       ...createInitialAgentConversationState(),
-      agentId,
-      conversationId,
-      key: conversationId ? resumeKey(conversationId) : draftKey(agentId),
+      agentId: args.agentId,
+      conversationId: args.conversationId,
+      key: args.key,
     };
-
-    if (conversationId) {
-      this.#byConversationId.set(conversationId, entry);
-    } else {
-      this.#byAgentId.set(agentId, entry);
-    }
+    this.#byKey.set(args.key, entry);
 
     return entry;
   }
@@ -150,9 +132,8 @@ export class AgentChatStore {
   }
 
   /**
-   * Mark an optimistic message `sent`, swap in the server message id, and adopt
-   * conversationId as an alias on this same holder (sticky draft resume).
-   * Does not change `entry.key` — draft listeners keep matching after claim.
+   * Mark an optimistic message `sent`, swap in the server message id, and record
+   * the public conversation id on this holder. Does not change `entry.key`.
    */
   markSent(
     entry: ConversationEntry,
@@ -166,7 +147,6 @@ export class AgentChatStore {
 
     if (!entry.conversationId) {
       entry.conversationId = args.conversationId;
-      this.#byConversationId.set(args.conversationId, entry);
     }
 
     this.#onUpdate(entry);
@@ -195,12 +175,9 @@ export class AgentChatStore {
 
     applyState(entry, {
       ...folded,
+      // Local-only (e.g. failed / in-flight) stay after the server page; cheap ordering approx.
       messages: [...folded.messages, ...localOnly],
     });
-
-    if (entry.conversationId) {
-      this.#byConversationId.set(entry.conversationId, entry);
-    }
 
     this.#onUpdate(entry);
 
@@ -209,10 +186,12 @@ export class AgentChatStore {
 
   /**
    * Run an HTTP post for this entry.
-   * Unclaimed drafts: only one create in flight; waiters reuse the claimed `conv_*`.
-   * After claim (or resume / explicit id): posts run immediately with no gating.
+   * Unclaimed creates: one in flight at a time on this holder; waiters re-check
+   * `entry.conversationId` so a successful create is reused and a failed create
+   * still serializes the next attempt (no fan-out double mint).
+   * After claim (or explicit id): posts run immediately with no gating.
    */
-  withDraftClaim<T>(
+  withCreateClaim<T>(
     entry: ConversationEntry,
     explicitConversationId: string | undefined,
     post: (conversationId?: string) => Promise<T>
@@ -222,20 +201,21 @@ export class AgentChatStore {
       return post(known);
     }
 
-    const pending = this.#pendingDraftClaims.get(entry.agentId);
-    if (pending) {
-      return pending.then((claimedId) => post(claimedId ?? entry.conversationId));
-    }
+    const run = async (): Promise<T> => {
+      if (entry.conversationId) {
+        return post(entry.conversationId);
+      }
 
-    let resolveClaim!: (conversationId: string | undefined) => void;
-    const claimGate = new Promise<string | undefined>((resolve) => {
-      resolveClaim = resolve;
-    });
-    this.#pendingDraftClaims.set(entry.agentId, claimGate);
+      return post(undefined);
+    };
 
-    return post(undefined).finally(() => {
-      resolveClaim(entry.conversationId);
-      this.#pendingDraftClaims.delete(entry.agentId);
-    });
+    const previous = entry.pendingCreate ?? Promise.resolve();
+    const current = previous.then(run, run);
+    entry.pendingCreate = current.then(
+      () => undefined,
+      () => undefined
+    );
+
+    return current;
   }
 }

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -8,19 +8,19 @@ import {
 
 /**
  * Stable local identity for one conversation holder.
- * The object reference never changes; timeline fields are overwritten in place.
- * This is an in-memory UI cache, not a synchronized copy of the server timeline.
+ * The object reference does not change. Timeline fields are overwritten in place.
+ * This store is an in-memory UI cache. It is not a synchronized server timeline.
  */
 export type ConversationEntry = AgentConversationState & {
   agentId: string;
-  /** Public `conv_*` id once created on the server, or when resuming. */
+  /** Public conversation id after create, or when the session resumes. */
   conversationId?: string;
   /**
-   * Immutable subscription / map key for this holder's whole life.
-   * Create sessions use `local_*`; resume sessions use the `conv_*` id.
+   * Map key for this holder. The key does not change for the life of the holder.
+   * Create sessions use `local_*`. Resume sessions use the `conv_*` id.
    */
   key: string;
-  /** Serializes overlapping creates on this holder until a `conv_*` exists. */
+  /** One create at a time on this holder until a conversation id exists. */
   pendingCreate?: Promise<void>;
 };
 
@@ -39,7 +39,6 @@ function mintClientId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}`;
 }
 
-/** Client-minted holder key for a create session (before `conv_*` exists). */
 export function createLocalConversationKey(): string {
   return mintClientId('local');
 }
@@ -59,24 +58,17 @@ function applyState(entry: ConversationEntry, next: AgentConversationState): voi
 
 /**
  * In-memory store for agent-chat conversations.
- *
- * Owns the message list the UI paints. `AgentChat` mutates this store around
- * HTTP calls; the hook listens via `onUpdate` → `agent_chat.messages.updated`.
- *
- * One map keyed by an immutable holder `key` (NV-8445: state keyed by conversation
- * identity — `local_*` until create returns `conv_*`, then the same key stays).
- * Omit `conversationId` on send always creates; callers pass the returned id next.
+ * `AgentChat` updates this store around HTTP calls. The hook listens on `onUpdate`.
+ * The map key is the immutable holder `key`.
  */
 export class AgentChatStore {
   #byKey = new Map<string, ConversationEntry>();
-  /** Fired after every mutation so AgentChat can emit to React. */
   #onUpdate: (entry: ConversationEntry) => void;
 
   constructor(onUpdate: (entry: ConversationEntry) => void) {
     this.#onUpdate = onUpdate;
   }
 
-  /** Drop all conversations (wired into `Novu.clearCache` / changeSubscriber). */
   clear(): void {
     this.#byKey.clear();
   }
@@ -85,7 +77,7 @@ export class AgentChatStore {
     return this.#byKey.get(key);
   }
 
-  /** Find a holder that already has this public conversation id (same-session append). */
+  /** Find a holder that already claimed this conversation id. */
   getByConversationId(agentId: string, conversationId: string): ConversationEntry | undefined {
     for (const entry of this.#byKey.values()) {
       if (entry.agentId === agentId && entry.conversationId === conversationId) {
@@ -97,9 +89,9 @@ export class AgentChatStore {
   }
 
   /**
-   * Return the entry for `key` if it exists; otherwise create an empty holder.
-   * Does not reuse another holder that merely shares `conversationId` — resume
-   * (`key === conversationId`) stays separate from an in-flight `local_*` create.
+   * Return the entry for `key`, or create an empty holder.
+   * This method does not reuse a holder that only shares `conversationId`.
+   * Resume (`key === conversationId`) stays separate from an in-flight `local_*` create.
    */
   getOrCreate(args: { agentId: string; key: string; conversationId?: string }): ConversationEntry {
     const existing = this.#byKey.get(args.key);
@@ -118,10 +110,7 @@ export class AgentChatStore {
     return entry;
   }
 
-  /**
-   * Append a local user bubble with status `sending` before the HTTP call.
-   * Returns the optimistic message id so the caller can mark it sent/failed.
-   */
+  /** Append a user message with status `sending`. Returns the optimistic message id. */
   appendSending(entry: ConversationEntry, text: string): string {
     const messageId = createOptimisticMessageId();
     applyState(
@@ -139,8 +128,8 @@ export class AgentChatStore {
   }
 
   /**
-   * Mark an optimistic message `sent`, swap in the server message id, and record
-   * the public conversation id on this holder. Does not change `entry.key`.
+   * Mark an optimistic message as `sent` and set the server message id.
+   * Also records the public conversation id. Does not change `entry.key`.
    */
   markSent(
     entry: ConversationEntry,
@@ -161,7 +150,6 @@ export class AgentChatStore {
     return entry;
   }
 
-  /** Mark an optimistic message `failed`. No auto-retry (no idempotency key). */
   markFailed(entry: ConversationEntry, messageId: string): ConversationEntry {
     entry.messages = entry.messages.map((message) =>
       message.id === messageId ? { ...message, status: 'failed' as const } : message
@@ -172,8 +160,8 @@ export class AgentChatStore {
   }
 
   /**
-   * Fold a history page of envelopes into this holder (open/resume).
-   * Server ids win; local-only messages (in-flight or not yet on the page) stay.
+   * Merge a history page into this holder.
+   * Server message ids win. Local-only messages stay on the holder.
    */
   absorbHistoryPage(entry: ConversationEntry, envelopes: AgentEventEnvelope[]): ConversationEntry {
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
@@ -182,7 +170,6 @@ export class AgentChatStore {
 
     applyState(entry, {
       ...folded,
-      // Local-only (e.g. failed / in-flight) stay after the server page; cheap ordering approx.
       messages: [...folded.messages, ...localOnly],
     });
 
@@ -193,10 +180,11 @@ export class AgentChatStore {
 
   /**
    * Run an HTTP post for this entry.
-   * Unclaimed creates: one in flight at a time on this holder; waiters re-check
-   * `entry.conversationId` so a successful create is reused and a failed create
-   * still serializes the next attempt (no fan-out double mint).
-   * After claim (or explicit id): posts run immediately with no gating.
+   * If the holder has no conversation id, only one create runs at a time.
+   * Waiters read `entry.conversationId` again after the prior create finishes.
+   * If a create succeeds, later waiters reuse that id.
+   * If a create fails, the next attempt still waits in line.
+   * If the conversation id is already known, the post runs with no gate.
    */
   withCreateClaim<T>(
     entry: ConversationEntry,

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -24,21 +24,28 @@ export type ConversationEntry = AgentConversationState & {
   pendingCreate?: Promise<void>;
 };
 
-/** Client-minted holder key for a create session (before `conv_*` exists). */
-export function createLocalConversationKey(): string {
+function mintClientId(prefix: string): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return `local_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+    return `${prefix}_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
   }
 
-  return `local_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(6);
+    crypto.getRandomValues(bytes);
+
+    return `${prefix}_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+  }
+
+  return `${prefix}_${Date.now().toString(36)}`;
+}
+
+/** Client-minted holder key for a create session (before `conv_*` exists). */
+export function createLocalConversationKey(): string {
+  return mintClientId('local');
 }
 
 function createOptimisticMessageId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return `opt_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
-  }
-
-  return `opt_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  return mintClientId('opt');
 }
 
 function applyState(entry: ConversationEntry, next: AgentConversationState): void {

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -1,0 +1,198 @@
+import {
+  type AgentConversationState,
+  type AgentMessage,
+  appendUserMessage,
+  createInitialAgentConversationState,
+} from '@novu/agent-event-protocol';
+
+/**
+ * One conversation's local state: messages plus the ids used to find it.
+ * This is in-memory UI cache, not a sync copy of the server timeline.
+ */
+export type ConversationEntry = AgentConversationState & {
+  agentId: string;
+  /** Public `conv_*` id once the server returns it (or when resuming). */
+  conversationId?: string;
+};
+
+function createOptimisticMessageId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `opt_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+  }
+
+  return `opt_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function setMessageStatus(
+  state: AgentConversationState,
+  messageId: string,
+  status: AgentMessage['status']
+): AgentConversationState {
+  return {
+    ...state,
+    messages: state.messages.map((message) => (message.id === messageId ? { ...message, status } : message)),
+  };
+}
+
+/**
+ * In-memory store for agent-chat conversations.
+ *
+ * Owns the message list the UI paints. `AgentChat` mutates this store around
+ * HTTP calls; the hook listens via `onUpdate` → `agent_chat.messages.updated`.
+ *
+ * Dual index — same entry, two lookup keys:
+ * - `#byAgentId` — first send / uncontrolled chat (`useAgentChat({ agentId })`)
+ * - `#byConversationId` — after the server returns `conv_*`, or when resuming
+ *
+ * We never delete and recreate an entry to "move" keys. After adopt, the same
+ * object is reachable by agentId and by conversationId.
+ */
+export class AgentChatStore {
+  /** Uncontrolled chats and adopted chats keyed by agent. */
+  #byAgentId = new Map<string, ConversationEntry>();
+  /** Same entry objects, keyed by public conversation id once known. */
+  #byConversationId = new Map<string, ConversationEntry>();
+  /** Fired after every mutation so AgentChat can emit to React. */
+  #onUpdate: (entry: ConversationEntry) => void;
+
+  constructor(onUpdate: (entry: ConversationEntry) => void) {
+    this.#onUpdate = onUpdate;
+  }
+
+  /** Drop all conversations (wired into `Novu.clearCache` / changeSubscriber). */
+  clear(): void {
+    this.#byAgentId.clear();
+    this.#byConversationId.clear();
+  }
+
+  /**
+   * Look up an existing conversation.
+   * Prefer conversationId when present; otherwise fall back to agentId.
+   */
+  get(agentId: string, conversationId?: string): ConversationEntry | undefined {
+    if (conversationId) {
+      const byId = this.#byConversationId.get(conversationId);
+      if (byId?.agentId === agentId) {
+        return byId;
+      }
+
+      // First send may have adopted conversationId on the agent-keyed entry
+      // before #byConversationId was populated for a concurrent reader.
+      const byAgent = this.#byAgentId.get(agentId);
+      if (byAgent?.conversationId === conversationId) {
+        return byAgent;
+      }
+
+      return undefined;
+    }
+
+    return this.#byAgentId.get(agentId);
+  }
+
+  /** Return the entry if it exists; otherwise create an empty one. */
+  getOrCreate(agentId: string, conversationId?: string): ConversationEntry {
+    const existing = this.get(agentId, conversationId);
+    if (existing) {
+      return existing;
+    }
+
+    const entry: ConversationEntry = {
+      ...createInitialAgentConversationState(),
+      agentId,
+      conversationId,
+    };
+
+    if (conversationId) {
+      this.#byConversationId.set(conversationId, entry);
+    } else {
+      this.#byAgentId.set(agentId, entry);
+    }
+
+    return entry;
+  }
+
+  /**
+   * Append a local user bubble with status `sending` before the HTTP call.
+   * Returns the optimistic message id so the caller can mark it sent/failed.
+   */
+  appendSending(entry: ConversationEntry, text: string): string {
+    const current = this.#latest(entry);
+    const messageId = createOptimisticMessageId();
+    const next: ConversationEntry = {
+      ...current,
+      ...appendUserMessage(current, {
+        id: messageId,
+        createdAt: new Date().toISOString(),
+        status: 'sending',
+        parts: [{ type: 'text', text, state: 'done' }],
+      }),
+    };
+
+    this.#replace(current, next);
+    this.#onUpdate(next);
+
+    return messageId;
+  }
+
+  /**
+   * Mark an optimistic message `sent` and attach the server conversation id.
+   * Indexes the entry under conversationId so remount/resume can find it.
+   */
+  markSent(entry: ConversationEntry, messageId: string, conversationId: string): ConversationEntry {
+    const current = this.#latest(entry);
+    const next: ConversationEntry = {
+      ...current,
+      ...setMessageStatus(current, messageId, 'sent'),
+      conversationId,
+    };
+
+    this.#replace(current, next);
+    this.#onUpdate(next);
+
+    return next;
+  }
+
+  /** Mark an optimistic message `failed`. No auto-retry (no idempotency key). */
+  markFailed(entry: ConversationEntry, messageId: string): ConversationEntry {
+    const current = this.#latest(entry);
+    const next: ConversationEntry = {
+      ...current,
+      ...setMessageStatus(current, messageId, 'failed'),
+    };
+
+    this.#replace(current, next);
+    this.#onUpdate(next);
+
+    return next;
+  }
+
+  /**
+   * Re-read the live entry from the maps.
+   * Callers may hold a stale object reference while another send mutates the store.
+   */
+  #latest(entry: ConversationEntry): ConversationEntry {
+    if (entry.conversationId) {
+      return this.#byConversationId.get(entry.conversationId) ?? this.#byAgentId.get(entry.agentId) ?? entry;
+    }
+
+    return this.#byAgentId.get(entry.agentId) ?? entry;
+  }
+
+  /**
+   * Swap `prev` for `next` in both indexes.
+   * Keeps agentId and conversationId pointing at the same updated entry.
+   */
+  #replace(prev: ConversationEntry, next: ConversationEntry): void {
+    if (this.#byAgentId.get(prev.agentId) === prev) {
+      this.#byAgentId.set(next.agentId, next);
+    }
+
+    if (prev.conversationId && this.#byConversationId.get(prev.conversationId) === prev) {
+      this.#byConversationId.delete(prev.conversationId);
+    }
+
+    if (next.conversationId) {
+      this.#byConversationId.set(next.conversationId, next);
+    }
+  }
+}

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -136,13 +136,30 @@ export class AgentChatStore {
 
   /**
    * Mark an optimistic message `sent` and attach the server conversation id.
+   * When `serverMessageId` is present, swap the optimistic id so history/live join.
    * Indexes the entry under conversationId so remount/resume can find it.
    */
-  markSent(entry: ConversationEntry, messageId: string, conversationId: string): ConversationEntry {
+  markSent(
+    entry: ConversationEntry,
+    optimisticMessageId: string,
+    conversationId: string,
+    serverMessageId?: string
+  ): ConversationEntry {
     const current = this.#latest(entry);
+    const messages = current.messages.map((message) => {
+      if (message.id !== optimisticMessageId) {
+        return message;
+      }
+
+      return {
+        ...message,
+        id: serverMessageId ?? message.id,
+        status: 'sent' as const,
+      };
+    });
     const next: ConversationEntry = {
       ...current,
-      ...setMessageStatus(current, messageId, 'sent'),
+      messages,
       conversationId,
     };
 
@@ -158,6 +175,28 @@ export class AgentChatStore {
     const next: ConversationEntry = {
       ...current,
       ...setMessageStatus(current, messageId, 'failed'),
+    };
+
+    this.#replace(current, next);
+    this.#onUpdate(next);
+
+    return next;
+  }
+
+  /**
+   * Replace local timeline with a folded history page (open/resume).
+   * Keeps agentId; adopts conversationId into both indexes.
+   */
+  replaceFromHistory(
+    entry: ConversationEntry,
+    history: AgentConversationState,
+    conversationId: string
+  ): ConversationEntry {
+    const current = this.#latest(entry);
+    const next: ConversationEntry = {
+      ...history,
+      agentId: current.agentId,
+      conversationId,
     };
 
     this.#replace(current, next);

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -61,9 +61,8 @@ describe('AgentChat', () => {
     expect(snapshot?.messages[0]?.status).toBe('failed');
   });
 
-  it('keeps both messages sent when two sends race before conversationId exists', async () => {
+  it('serializes uncontrolled sends until conversationId is assigned', async () => {
     let resolveFirst!: (value: { identifier: string; messageId: string }) => void;
-    let resolveSecond!: (value: { identifier: string; messageId: string }) => void;
     sendMessage
       .mockImplementationOnce(
         () =>
@@ -71,24 +70,45 @@ describe('AgentChat', () => {
             resolveFirst = resolve;
           })
       )
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveSecond = resolve;
-          })
-      );
+      .mockImplementationOnce(async (args) => {
+        expect(args.conversationId).toBe('conv_abcdefghijkl');
+
+        return { identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' };
+      });
 
     const first = agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
     const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
 
+    // Both bubbles paint immediately; only the HTTP create is serialized.
+    expect(agentChat.getConversation({ agentId: 'agent_1' })?.messages).toHaveLength(2);
+    expect(agentChat.getConversation({ agentId: 'agent_1' })?.messages.map((m) => m.status)).toEqual([
+      'sending',
+      'sending',
+    ]);
+
+    // Chain runs on a microtask — first POST starts, second stays queued.
+    await Promise.resolve();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenNthCalledWith(1, {
+      agentId: 'agent_1',
+      text: 'one',
+      conversationId: undefined,
+    });
+
     resolveFirst({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' });
-    resolveSecond({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
 
     await expect(first).resolves.toEqual({
       data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' },
     });
     await expect(second).resolves.toEqual({
       data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      agentId: 'agent_1',
+      text: 'two',
+      conversationId: 'conv_abcdefghijkl',
     });
 
     const byAgent = agentChat.getConversation({ agentId: 'agent_1' });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1,3 +1,4 @@
+import { AGENT_EVENT_PROTOCOL_VERSION } from '@novu/agent-event-protocol';
 import { AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
@@ -6,12 +7,14 @@ describe('AgentChat', () => {
   const inboxServiceInstance = { isSessionInitialized: true } as any;
   let emitter: NovuEventEmitter;
   let sendMessage: jest.Mock;
+  let getEvents: jest.Mock;
   let agentChat: AgentChat;
 
   beforeEach(() => {
     emitter = new NovuEventEmitter();
     sendMessage = jest.fn();
-    const agentChatService = { sendMessage } as unknown as AgentChatService;
+    getEvents = jest.fn();
+    const agentChatService = { sendMessage, getEvents } as unknown as AgentChatService;
     agentChat = new AgentChat({
       inboxServiceInstance,
       eventEmitterInstance: emitter,
@@ -19,18 +22,21 @@ describe('AgentChat', () => {
     });
   });
 
-  it('appends an optimistic user message then marks it sent', async () => {
-    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl' });
-    const updates: Array<{ messages: Array<{ status: string; role: string }> }> = [];
+  it('appends an optimistic user message then marks it sent with server messageId', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
+    const updates: Array<{ messages: Array<{ id: string; status: string; role: string }> }> = [];
     emitter.on('agent_chat.messages.updated', ({ data }) => {
-      updates.push({ messages: data.messages.map((m) => ({ status: m.status, role: m.role })) });
+      updates.push({ messages: data.messages.map((m) => ({ id: m.id, status: m.status, role: m.role })) });
     });
 
     const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
 
-    expect(result).toEqual({ data: { conversationId: 'conv_abcdefghijkl' } });
-    expect(updates[0]?.messages).toEqual([{ status: 'sending', role: 'user' }]);
-    expect(updates[1]?.messages).toEqual([{ status: 'sent', role: 'user' }]);
+    expect(result).toEqual({
+      data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' },
+    });
+    expect(updates[0]?.messages[0]?.status).toBe('sending');
+    expect(updates[0]?.messages[0]?.id).toMatch(/^opt_/);
+    expect(updates[1]?.messages).toEqual([{ id: 'msg_abcdefghijkl', status: 'sent', role: 'user' }]);
 
     const snapshot = agentChat.getConversation({
       agentId: 'agent_1',
@@ -38,6 +44,7 @@ describe('AgentChat', () => {
     });
     expect(snapshot?.messages).toHaveLength(1);
     expect(snapshot?.messages[0]).toMatchObject({
+      id: 'msg_abcdefghijkl',
       role: 'user',
       status: 'sent',
       parts: [{ type: 'text', text: 'hello', state: 'done' }],
@@ -55,8 +62,8 @@ describe('AgentChat', () => {
   });
 
   it('keeps both messages sent when two sends race before conversationId exists', async () => {
-    let resolveFirst!: (value: { identifier: string }) => void;
-    let resolveSecond!: (value: { identifier: string }) => void;
+    let resolveFirst!: (value: { identifier: string; messageId: string }) => void;
+    let resolveSecond!: (value: { identifier: string; messageId: string }) => void;
     sendMessage
       .mockImplementationOnce(
         () =>
@@ -74,11 +81,15 @@ describe('AgentChat', () => {
     const first = agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
     const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
 
-    resolveFirst({ identifier: 'conv_abcdefghijkl' });
-    resolveSecond({ identifier: 'conv_abcdefghijkl' });
+    resolveFirst({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' });
+    resolveSecond({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
 
-    await expect(first).resolves.toEqual({ data: { conversationId: 'conv_abcdefghijkl' } });
-    await expect(second).resolves.toEqual({ data: { conversationId: 'conv_abcdefghijkl' } });
+    await expect(first).resolves.toEqual({
+      data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' },
+    });
+    await expect(second).resolves.toEqual({
+      data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' },
+    });
 
     const byAgent = agentChat.getConversation({ agentId: 'agent_1' });
     const byId = agentChat.getConversation({
@@ -88,6 +99,7 @@ describe('AgentChat', () => {
 
     expect(byAgent?.messages).toHaveLength(2);
     expect(byAgent?.messages.map((m) => m.status)).toEqual(['sent', 'sent']);
+    expect(byAgent?.messages.map((m) => m.id)).toEqual(['msg_aaaaaaaaaaaa', 'msg_bbbbbbbbbbbb']);
     expect(byAgent?.messages.map((m) => m.parts[0])).toEqual([
       { type: 'text', text: 'one', state: 'done' },
       { type: 'text', text: 'two', state: 'done' },
@@ -97,7 +109,7 @@ describe('AgentChat', () => {
   });
 
   it('returns retained messages for agentId after adopt without conversationId prop', async () => {
-    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl' });
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
     await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
 
@@ -111,7 +123,7 @@ describe('AgentChat', () => {
   });
 
   it('clearCache drops retained conversation state', async () => {
-    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl' });
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
     await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
     agentChat.clearCache();
@@ -123,5 +135,112 @@ describe('AgentChat', () => {
         conversationId: 'conv_abcdefghijkl',
       })
     ).toBeUndefined();
+  });
+
+  it('loadConversation folds history into the store including user turns', async () => {
+    getEvents.mockResolvedValue({
+      events: [
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 1,
+          timestamp: '2026-08-06T12:00:00.000Z',
+          event: {
+            type: 'message',
+            role: 'user',
+            messageId: 'msg_user0000001',
+            content: { markdown: 'prior question' },
+          },
+        },
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't2',
+          sequence: 2,
+          timestamp: '2026-08-06T12:00:01.000Z',
+          event: {
+            type: 'message',
+            role: 'assistant',
+            messageId: 'msg_asst0000001',
+            content: { markdown: 'prior answer' },
+          },
+        },
+      ],
+      hasMore: false,
+      next: null,
+      previous: null,
+    });
+
+    const result = await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.hasMore).toBe(false);
+    expect(result.data?.messages).toHaveLength(2);
+    expect(result.data?.messages[0]).toMatchObject({
+      id: 'msg_user0000001',
+      role: 'user',
+      parts: [{ type: 'text', text: 'prior question', state: 'done' }],
+    });
+    expect(result.data?.messages[1]).toMatchObject({
+      id: 'msg_asst0000001',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'prior answer', state: 'done' }],
+    });
+
+    const snapshot = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    expect(snapshot?.messages).toEqual(result.data?.messages);
+  });
+
+  it('loadConversation replaces optimistic local state with server history', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_local000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'stale local' });
+
+    getEvents.mockResolvedValue({
+      events: [
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 1,
+          timestamp: '2026-08-06T12:00:00.000Z',
+          event: {
+            type: 'message',
+            role: 'user',
+            messageId: 'msg_server00001',
+            content: { markdown: 'from server' },
+          },
+        },
+      ],
+      hasMore: true,
+      next: null,
+      previous: 'act_older',
+    });
+
+    const result = await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.hasMore).toBe(true);
+    expect(result.data?.messages).toHaveLength(1);
+    expect(result.data?.messages[0]).toMatchObject({
+      id: 'msg_server00001',
+      parts: [{ type: 'text', text: 'from server', state: 'done' }],
+    });
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1,0 +1,127 @@
+import { AgentChatService } from '../api';
+import { NovuEventEmitter } from '../event-emitter';
+import { AgentChat } from './agent-chat';
+
+describe('AgentChat', () => {
+  const inboxServiceInstance = { isSessionInitialized: true } as any;
+  let emitter: NovuEventEmitter;
+  let sendMessage: jest.Mock;
+  let agentChat: AgentChat;
+
+  beforeEach(() => {
+    emitter = new NovuEventEmitter();
+    sendMessage = jest.fn();
+    const agentChatService = { sendMessage } as unknown as AgentChatService;
+    agentChat = new AgentChat({
+      inboxServiceInstance,
+      eventEmitterInstance: emitter,
+      agentChatService,
+    });
+  });
+
+  it('appends an optimistic user message then marks it sent', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl' });
+    const updates: Array<{ messages: Array<{ status: string; role: string }> }> = [];
+    emitter.on('agent_chat.messages.updated', ({ data }) => {
+      updates.push({ messages: data.messages.map((m) => ({ status: m.status, role: m.role })) });
+    });
+
+    const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+
+    expect(result).toEqual({ data: { conversationId: 'conv_abcdefghijkl' } });
+    expect(updates[0]?.messages).toEqual([{ status: 'sending', role: 'user' }]);
+    expect(updates[1]?.messages).toEqual([{ status: 'sent', role: 'user' }]);
+
+    const snapshot = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    expect(snapshot?.messages).toHaveLength(1);
+    expect(snapshot?.messages[0]).toMatchObject({
+      role: 'user',
+      status: 'sent',
+      parts: [{ type: 'text', text: 'hello', state: 'done' }],
+    });
+  });
+
+  it('marks the optimistic message failed when the request errors', async () => {
+    sendMessage.mockRejectedValue(new Error('network'));
+
+    const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+
+    expect(result.error).toBeDefined();
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1' });
+    expect(snapshot?.messages[0]?.status).toBe('failed');
+  });
+
+  it('keeps both messages sent when two sends race before conversationId exists', async () => {
+    let resolveFirst!: (value: { identifier: string }) => void;
+    let resolveSecond!: (value: { identifier: string }) => void;
+    sendMessage
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          })
+      );
+
+    const first = agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
+    const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
+
+    resolveFirst({ identifier: 'conv_abcdefghijkl' });
+    resolveSecond({ identifier: 'conv_abcdefghijkl' });
+
+    await expect(first).resolves.toEqual({ data: { conversationId: 'conv_abcdefghijkl' } });
+    await expect(second).resolves.toEqual({ data: { conversationId: 'conv_abcdefghijkl' } });
+
+    const byAgent = agentChat.getConversation({ agentId: 'agent_1' });
+    const byId = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(byAgent?.messages).toHaveLength(2);
+    expect(byAgent?.messages.map((m) => m.status)).toEqual(['sent', 'sent']);
+    expect(byAgent?.messages.map((m) => m.parts[0])).toEqual([
+      { type: 'text', text: 'one', state: 'done' },
+      { type: 'text', text: 'two', state: 'done' },
+    ]);
+    expect(byId?.messages).toEqual(byAgent?.messages);
+    expect(byAgent?.conversationId).toBe('conv_abcdefghijkl');
+  });
+
+  it('returns retained messages for agentId after adopt without conversationId prop', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1' });
+    expect(snapshot?.conversationId).toBe('conv_abcdefghijkl');
+    expect(snapshot?.messages).toHaveLength(1);
+    expect(snapshot?.messages[0]).toMatchObject({
+      status: 'sent',
+      parts: [{ type: 'text', text: 'hello', state: 'done' }],
+    });
+  });
+
+  it('clearCache drops retained conversation state', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+    agentChat.clearCache();
+
+    expect(agentChat.getConversation({ agentId: 'agent_1' })).toBeUndefined();
+    expect(
+      agentChat.getConversation({
+        agentId: 'agent_1',
+        conversationId: 'conv_abcdefghijkl',
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -108,7 +108,7 @@ describe('AgentChat', () => {
     expect(byAgent?.conversationId).toBe('conv_abcdefghijkl');
   });
 
-  it('returns retained messages for agentId after adopt without conversationId prop', async () => {
+  it('returns retained messages for agentId after the conversation id is assigned', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
     await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
@@ -173,9 +173,7 @@ describe('AgentChat', () => {
           },
         },
       ],
-      hasMore: false,
-      next: null,
-      previous: null,
+      olderCursor: null,
     });
 
     const result = await agentChat.loadConversation({
@@ -183,7 +181,6 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    expect(result.data?.hasMore).toBe(false);
     expect(result.data?.messages).toHaveLength(2);
     expect(result.data?.messages[0]).toMatchObject({
       id: 'msg_user0000001',
@@ -203,9 +200,9 @@ describe('AgentChat', () => {
     expect(snapshot?.messages).toEqual(result.data?.messages);
   });
 
-  it('loadConversation replaces optimistic local state with server history', async () => {
+  it('loadConversation merges history with local-only messages by messageId', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_local000001' });
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'stale local' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'ack locally' });
 
     getEvents.mockResolvedValue({
       events: [
@@ -226,9 +223,7 @@ describe('AgentChat', () => {
           },
         },
       ],
-      hasMore: true,
-      next: null,
-      previous: 'act_older',
+      olderCursor: 'act_older',
     });
 
     const result = await agentChat.loadConversation({
@@ -236,11 +231,118 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    expect(result.data?.hasMore).toBe(true);
-    expect(result.data?.messages).toHaveLength(1);
-    expect(result.data?.messages[0]).toMatchObject({
-      id: 'msg_server00001',
-      parts: [{ type: 'text', text: 'from server', state: 'done' }],
+    expect(result.data?.messages).toHaveLength(2);
+    expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_server00001', 'msg_local000001']);
+    expect(result.data?.messages[1]).toMatchObject({
+      id: 'msg_local000001',
+      parts: [{ type: 'text', text: 'ack locally', state: 'done' }],
     });
+  });
+
+  it('loadConversation dedupes when history already contains the ack’d messageId', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_shared00001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'same turn' });
+
+    getEvents.mockResolvedValue({
+      events: [
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 1,
+          timestamp: '2026-08-06T12:00:00.000Z',
+          event: {
+            type: 'message',
+            role: 'user',
+            messageId: 'msg_shared00001',
+            content: { markdown: 'same turn' },
+          },
+        },
+      ],
+      olderCursor: null,
+    });
+
+    const result = await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.messages).toHaveLength(1);
+    expect(result.data?.messages[0]?.id).toBe('msg_shared00001');
+  });
+
+  it('loadConversation does not claim the agent draft — uncontrolled send starts a new chat', async () => {
+    getEvents.mockResolvedValue({
+      events: [
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_bbbbbbbbbbbb',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 1,
+          timestamp: '2026-08-06T12:00:00.000Z',
+          event: {
+            type: 'message',
+            role: 'user',
+            messageId: 'msg_hist0000001',
+            content: { markdown: 'old thread' },
+          },
+        },
+      ],
+      olderCursor: null,
+    });
+
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_bbbbbbbbbbbb',
+    });
+
+    sendMessage.mockResolvedValue({ identifier: 'conv_aaaaaaaaaaaa', messageId: 'msg_new00000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'fresh draft' });
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      agentId: 'agent_1',
+      text: 'fresh draft',
+      conversationId: undefined,
+    });
+
+    const draft = agentChat.getConversation({ agentId: 'agent_1' });
+    const resumed = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_bbbbbbbbbbbb',
+    });
+
+    expect(draft?.conversationId).toBe('conv_aaaaaaaaaaaa');
+    expect(draft?.messages).toHaveLength(1);
+    expect(draft?.messages[0]).toMatchObject({
+      id: 'msg_new00000001',
+      parts: [{ type: 'text', text: 'fresh draft', state: 'done' }],
+    });
+    expect(resumed?.messages).toHaveLength(1);
+    expect(resumed?.messages[0]?.id).toBe('msg_hist0000001');
+  });
+
+  it('sticky-resumes the agent draft on a second uncontrolled send', async () => {
+    sendMessage
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' })
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
+
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      agentId: 'agent_1',
+      text: 'two',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    const draft = agentChat.getConversation({ agentId: 'agent_1' });
+    expect(draft?.messages).toHaveLength(2);
+    expect(draft?.conversationId).toBe('conv_abcdefghijkl');
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -2,6 +2,7 @@ import { AGENT_EVENT_PROTOCOL_VERSION } from '@novu/agent-event-protocol';
 import { AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
+import { draftKey, resumeKey } from './agent-chat-store';
 
 describe('AgentChat', () => {
   const inboxServiceInstance = { isSessionInitialized: true } as any;
@@ -24,9 +25,17 @@ describe('AgentChat', () => {
 
   it('appends an optimistic user message then marks it sent with server messageId', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
-    const updates: Array<{ messages: Array<{ id: string; status: string; role: string }> }> = [];
+    const updates: Array<{
+      key: string;
+      conversationId?: string;
+      messages: Array<{ id: string; status: string; role: string }>;
+    }> = [];
     emitter.on('agent_chat.messages.updated', ({ data }) => {
-      updates.push({ messages: data.messages.map((m) => ({ id: m.id, status: m.status, role: m.role })) });
+      updates.push({
+        key: data.key,
+        conversationId: data.conversationId,
+        messages: data.messages.map((m) => ({ id: m.id, status: m.status, role: m.role })),
+      });
     });
 
     const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
@@ -34,8 +43,12 @@ describe('AgentChat', () => {
     expect(result).toEqual({
       data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' },
     });
+    expect(updates[0]?.key).toBe(draftKey('agent_1'));
+    expect(updates[0]?.conversationId).toBeUndefined();
     expect(updates[0]?.messages[0]?.status).toBe('sending');
     expect(updates[0]?.messages[0]?.id).toMatch(/^opt_/);
+    expect(updates[1]?.key).toBe(draftKey('agent_1'));
+    expect(updates[1]?.conversationId).toBe('conv_abcdefghijkl');
     expect(updates[1]?.messages).toEqual([{ id: 'msg_abcdefghijkl', status: 'sent', role: 'user' }]);
 
     const snapshot = agentChat.getConversation({
@@ -43,12 +56,31 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
     expect(snapshot?.messages).toHaveLength(1);
+    expect(snapshot?.key).toBe(draftKey('agent_1'));
     expect(snapshot?.messages[0]).toMatchObject({
       id: 'msg_abcdefghijkl',
       role: 'user',
       status: 'sent',
       parts: [{ type: 'text', text: 'hello', state: 'done' }],
     });
+  });
+
+  it('keeps draft emit key stable so a draft listener sees sending → sent', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
+    const draftStatuses: string[] = [];
+    const key = draftKey('agent_1');
+
+    emitter.on('agent_chat.messages.updated', ({ data }) => {
+      if (data.key !== key) {
+        return;
+      }
+
+      draftStatuses.push(data.messages[0]?.status ?? '');
+    });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+
+    expect(draftStatuses).toEqual(['sending', 'sent']);
   });
 
   it('marks the optimistic message failed when the request errors', async () => {
@@ -61,7 +93,7 @@ describe('AgentChat', () => {
     expect(snapshot?.messages[0]?.status).toBe('failed');
   });
 
-  it('serializes uncontrolled sends until conversationId is assigned', async () => {
+  it('serializes unclaimed draft creates until conversationId is claimed', async () => {
     let resolveFirst!: (value: { identifier: string; messageId: string }) => void;
     sendMessage
       .mockImplementationOnce(
@@ -86,7 +118,6 @@ describe('AgentChat', () => {
       'sending',
     ]);
 
-    // Chain runs on a microtask — first POST starts, second stays queued.
     await Promise.resolve();
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenNthCalledWith(1, {
@@ -128,13 +159,86 @@ describe('AgentChat', () => {
     expect(byAgent?.conversationId).toBe('conv_abcdefghijkl');
   });
 
-  it('returns retained messages for agentId after the conversation id is assigned', async () => {
+  it('does not serialize sticky-resume draft sends after the claim', async () => {
+    let resolveFirst!: (value: { identifier: string; messageId: string }) => void;
+    let resolveSecond!: (value: { identifier: string; messageId: string }) => void;
+    let resolveThird!: (value: { identifier: string; messageId: string }) => void;
+
+    sendMessage
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveThird = resolve;
+          })
+      );
+
+    const first = agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
+    await Promise.resolve();
+    resolveFirst({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' });
+    await first;
+
+    const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
+    const third = agentChat.sendMessage({ agentId: 'agent_1', text: 'three' });
+    await Promise.resolve();
+
+    // Both sticky-resume POSTs are in flight (no claim gate after conv_* is known).
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      agentId: 'agent_1',
+      text: 'two',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(3, {
+      agentId: 'agent_1',
+      text: 'three',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    resolveSecond({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
+    resolveThird({ identifier: 'conv_abcdefghijkl', messageId: 'msg_cccccccccccc' });
+    await expect(second).resolves.toMatchObject({ data: { messageId: 'msg_bbbbbbbbbbbb' } });
+    await expect(third).resolves.toMatchObject({ data: { messageId: 'msg_cccccccccccc' } });
+  });
+
+  it('releases draft claim waiters when the create fails so the next send can mint', async () => {
+    sendMessage
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' });
+
+    const failed = await agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
+    expect(failed.error).toBeDefined();
+
+    const retry = await agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
+    expect(retry).toEqual({
+      data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' },
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      agentId: 'agent_1',
+      text: 'two',
+      conversationId: undefined,
+    });
+  });
+
+  it('returns retained messages for agentId after the conversation id is claimed', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
     await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
 
     const snapshot = agentChat.getConversation({ agentId: 'agent_1' });
     expect(snapshot?.conversationId).toBe('conv_abcdefghijkl');
+    expect(snapshot?.key).toBe(draftKey('agent_1'));
     expect(snapshot?.messages).toHaveLength(1);
     expect(snapshot?.messages[0]).toMatchObject({
       status: 'sent',
@@ -217,6 +321,7 @@ describe('AgentChat', () => {
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
+    expect(snapshot?.key).toBe(resumeKey('conv_abcdefghijkl'));
     expect(snapshot?.messages).toEqual(result.data?.messages);
   });
 
@@ -294,7 +399,7 @@ describe('AgentChat', () => {
     expect(result.data?.messages[0]?.id).toBe('msg_shared00001');
   });
 
-  it('loadConversation does not claim the agent draft — uncontrolled send starts a new chat', async () => {
+  it('loadConversation does not claim the agent draft — draft send starts a new chat', async () => {
     getEvents.mockResolvedValue({
       events: [
         {
@@ -338,16 +443,18 @@ describe('AgentChat', () => {
     });
 
     expect(draft?.conversationId).toBe('conv_aaaaaaaaaaaa');
+    expect(draft?.key).toBe(draftKey('agent_1'));
     expect(draft?.messages).toHaveLength(1);
     expect(draft?.messages[0]).toMatchObject({
       id: 'msg_new00000001',
       parts: [{ type: 'text', text: 'fresh draft', state: 'done' }],
     });
+    expect(resumed?.key).toBe(resumeKey('conv_bbbbbbbbbbbb'));
     expect(resumed?.messages).toHaveLength(1);
     expect(resumed?.messages[0]?.id).toBe('msg_hist0000001');
   });
 
-  it('sticky-resumes the agent draft on a second uncontrolled send', async () => {
+  it('sticky-resumes the agent draft on a second draft send', async () => {
     sendMessage
       .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' })
       .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -265,6 +265,38 @@ describe('AgentChat', () => {
     expect(snapshot?.key).toBe('local_session1');
   });
 
+  it('rejects a stale key that points at a different claimed conversation', async () => {
+    sendMessage
+      .mockResolvedValueOnce({ identifier: 'conv_aaaaaaaaaaaa', messageId: 'msg_aaaaaaaaaaaa' })
+      .mockResolvedValueOnce({ identifier: 'conv_bbbbbbbbbbbb', messageId: 'msg_bbbbbbbbbbbb' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'one', key: 'local_stale' });
+
+    await agentChat.sendMessage({
+      agentId: 'agent_1',
+      text: 'two',
+      key: 'local_stale',
+      conversationId: 'conv_bbbbbbbbbbbb',
+    });
+
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      agentId: 'agent_1',
+      text: 'two',
+      conversationId: 'conv_bbbbbbbbbbbb',
+    });
+
+    const previous = agentChat.getConversation({ agentId: 'agent_1', key: 'local_stale' });
+    expect(previous?.messages).toHaveLength(1);
+    expect(previous?.conversationId).toBe('conv_aaaaaaaaaaaa');
+
+    const next = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_bbbbbbbbbbbb',
+    });
+    expect(next?.messages).toHaveLength(1);
+    expect(next?.key).toBe('conv_bbbbbbbbbbbb');
+  });
+
   it('resume-by-id after create receives sending → sent on the resume key', async () => {
     sendMessage
       .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' })

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -2,7 +2,6 @@ import { AGENT_EVENT_PROTOCOL_VERSION } from '@novu/agent-event-protocol';
 import { AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
-import { draftKey, resumeKey } from './agent-chat-store';
 
 describe('AgentChat', () => {
   const inboxServiceInstance = { isSessionInitialized: true } as any;
@@ -38,16 +37,16 @@ describe('AgentChat', () => {
       });
     });
 
-    const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+    const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
 
     expect(result).toEqual({
       data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' },
     });
-    expect(updates[0]?.key).toBe(draftKey('agent_1'));
+    expect(updates[0]?.key).toBe('local_session1');
     expect(updates[0]?.conversationId).toBeUndefined();
     expect(updates[0]?.messages[0]?.status).toBe('sending');
     expect(updates[0]?.messages[0]?.id).toMatch(/^opt_/);
-    expect(updates[1]?.key).toBe(draftKey('agent_1'));
+    expect(updates[1]?.key).toBe('local_session1');
     expect(updates[1]?.conversationId).toBe('conv_abcdefghijkl');
     expect(updates[1]?.messages).toEqual([{ id: 'msg_abcdefghijkl', status: 'sent', role: 'user' }]);
 
@@ -55,8 +54,7 @@ describe('AgentChat', () => {
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(snapshot?.messages).toHaveLength(1);
-    expect(snapshot?.key).toBe(draftKey('agent_1'));
+    expect(snapshot?.key).toBe('local_session1');
     expect(snapshot?.messages[0]).toMatchObject({
       id: 'msg_abcdefghijkl',
       role: 'user',
@@ -65,35 +63,34 @@ describe('AgentChat', () => {
     });
   });
 
-  it('keeps draft emit key stable so a draft listener sees sending → sent', async () => {
+  it('keeps the session key stable so a create listener sees sending → sent', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
-    const draftStatuses: string[] = [];
-    const key = draftKey('agent_1');
+    const statuses: string[] = [];
 
     emitter.on('agent_chat.messages.updated', ({ data }) => {
-      if (data.key !== key) {
+      if (data.key !== 'local_session1') {
         return;
       }
 
-      draftStatuses.push(data.messages[0]?.status ?? '');
+      statuses.push(data.messages[0]?.status ?? '');
     });
 
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
 
-    expect(draftStatuses).toEqual(['sending', 'sent']);
+    expect(statuses).toEqual(['sending', 'sent']);
   });
 
   it('marks the optimistic message failed when the request errors', async () => {
     sendMessage.mockRejectedValue(new Error('network'));
 
-    const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+    const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
 
     expect(result.error).toBeDefined();
-    const snapshot = agentChat.getConversation({ agentId: 'agent_1' });
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
     expect(snapshot?.messages[0]?.status).toBe('failed');
   });
 
-  it('serializes unclaimed draft creates until conversationId is claimed', async () => {
+  it('serializes overlapping creates on the same session key until conversationId is claimed', async () => {
     let resolveFirst!: (value: { identifier: string; messageId: string }) => void;
     sendMessage
       .mockImplementationOnce(
@@ -108,15 +105,10 @@ describe('AgentChat', () => {
         return { identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' };
       });
 
-    const first = agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
-    const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
+    const first = agentChat.sendMessage({ agentId: 'agent_1', text: 'one', key: 'local_session1' });
+    const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two', key: 'local_session1' });
 
-    // Both bubbles paint immediately; only the HTTP create is serialized.
-    expect(agentChat.getConversation({ agentId: 'agent_1' })?.messages).toHaveLength(2);
-    expect(agentChat.getConversation({ agentId: 'agent_1' })?.messages.map((m) => m.status)).toEqual([
-      'sending',
-      'sending',
-    ]);
+    expect(agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' })?.messages).toHaveLength(2);
 
     await Promise.resolve();
     expect(sendMessage).toHaveBeenCalledTimes(1);
@@ -135,42 +127,42 @@ describe('AgentChat', () => {
       data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' },
     });
 
-    expect(sendMessage).toHaveBeenCalledTimes(2);
     expect(sendMessage).toHaveBeenNthCalledWith(2, {
       agentId: 'agent_1',
       text: 'two',
       conversationId: 'conv_abcdefghijkl',
     });
-
-    const byAgent = agentChat.getConversation({ agentId: 'agent_1' });
-    const byId = agentChat.getConversation({
-      agentId: 'agent_1',
-      conversationId: 'conv_abcdefghijkl',
-    });
-
-    expect(byAgent?.messages).toHaveLength(2);
-    expect(byAgent?.messages.map((m) => m.status)).toEqual(['sent', 'sent']);
-    expect(byAgent?.messages.map((m) => m.id)).toEqual(['msg_aaaaaaaaaaaa', 'msg_bbbbbbbbbbbb']);
-    expect(byAgent?.messages.map((m) => m.parts[0])).toEqual([
-      { type: 'text', text: 'one', state: 'done' },
-      { type: 'text', text: 'two', state: 'done' },
-    ]);
-    expect(byId?.messages).toEqual(byAgent?.messages);
-    expect(byAgent?.conversationId).toBe('conv_abcdefghijkl');
   });
 
-  it('does not serialize sticky-resume draft sends after the claim', async () => {
-    let resolveFirst!: (value: { identifier: string; messageId: string }) => void;
+  it('omitting conversationId on two different session keys creates two conversations', async () => {
+    sendMessage
+      .mockResolvedValueOnce({ identifier: 'conv_aaaaaaaaaaaa', messageId: 'msg_aaaaaaaaaaaa' })
+      .mockResolvedValueOnce({ identifier: 'conv_bbbbbbbbbbbb', messageId: 'msg_bbbbbbbbbbbb' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'one', key: 'local_a' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'two', key: 'local_b' });
+
+    expect(sendMessage).toHaveBeenNthCalledWith(1, {
+      agentId: 'agent_1',
+      text: 'one',
+      conversationId: undefined,
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      agentId: 'agent_1',
+      text: 'two',
+      conversationId: undefined,
+    });
+
+    expect(agentChat.getConversation({ agentId: 'agent_1', key: 'local_a' })?.conversationId).toBe('conv_aaaaaaaaaaaa');
+    expect(agentChat.getConversation({ agentId: 'agent_1', key: 'local_b' })?.conversationId).toBe('conv_bbbbbbbbbbbb');
+  });
+
+  it('does not serialize appends after the conversation id is known', async () => {
     let resolveSecond!: (value: { identifier: string; messageId: string }) => void;
     let resolveThird!: (value: { identifier: string; messageId: string }) => void;
 
     sendMessage
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveFirst = resolve;
-          })
-      )
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' })
       .mockImplementationOnce(
         () =>
           new Promise((resolve) => {
@@ -184,27 +176,23 @@ describe('AgentChat', () => {
           })
       );
 
-    const first = agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
-    await Promise.resolve();
-    resolveFirst({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' });
-    await first;
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'one', key: 'local_session1' });
 
-    const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
-    const third = agentChat.sendMessage({ agentId: 'agent_1', text: 'three' });
-    await Promise.resolve();
-
-    // Both sticky-resume POSTs are in flight (no claim gate after conv_* is known).
-    expect(sendMessage).toHaveBeenCalledTimes(3);
-    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+    const second = agentChat.sendMessage({
       agentId: 'agent_1',
       text: 'two',
+      key: 'local_session1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(sendMessage).toHaveBeenNthCalledWith(3, {
+    const third = agentChat.sendMessage({
       agentId: 'agent_1',
       text: 'three',
+      key: 'local_session1',
       conversationId: 'conv_abcdefghijkl',
     });
+    await Promise.resolve();
+
+    expect(sendMessage).toHaveBeenCalledTimes(3);
 
     resolveSecond({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
     resolveThird({ identifier: 'conv_abcdefghijkl', messageId: 'msg_cccccccccccc' });
@@ -212,47 +200,111 @@ describe('AgentChat', () => {
     await expect(third).resolves.toMatchObject({ data: { messageId: 'msg_cccccccccccc' } });
   });
 
-  it('releases draft claim waiters when the create fails so the next send can mint', async () => {
+  it('serializes create retries after a failed create so waiters do not double-mint', async () => {
+    let resolveSecond!: (value: { identifier: string; messageId: string }) => void;
+    let resolveThird!: (value: { identifier: string; messageId: string }) => void;
+
     sendMessage
       .mockRejectedValueOnce(new Error('network'))
-      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' });
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveThird = resolve;
+          })
+      );
 
-    const failed = await agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
-    expect(failed.error).toBeDefined();
+    const failed = agentChat.sendMessage({ agentId: 'agent_1', text: 'one', key: 'local_session1' });
+    const second = agentChat.sendMessage({ agentId: 'agent_1', text: 'two', key: 'local_session1' });
+    const third = agentChat.sendMessage({ agentId: 'agent_1', text: 'three', key: 'local_session1' });
 
-    const retry = await agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
-    expect(retry).toEqual({
-      data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' },
+    await expect(failed).resolves.toMatchObject({ error: expect.anything() });
+
+    await Promise.resolve();
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+
+    resolveSecond({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
+    await expect(second).resolves.toEqual({
+      data: { conversationId: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' },
     });
-    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+
+    await Promise.resolve();
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(sendMessage).toHaveBeenNthCalledWith(3, {
       agentId: 'agent_1',
-      text: 'two',
-      conversationId: undefined,
+      text: 'three',
+      conversationId: 'conv_abcdefghijkl',
     });
+
+    resolveThird({ identifier: 'conv_abcdefghijkl', messageId: 'msg_cccccccccccc' });
+    await expect(third).resolves.toMatchObject({ data: { messageId: 'msg_cccccccccccc' } });
   });
 
-  it('returns retained messages for agentId after the conversation id is claimed', async () => {
-    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
+  it('appends by conversationId alone after create (JS caller without local key)', async () => {
+    sendMessage
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' })
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
 
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
-
-    const snapshot = agentChat.getConversation({ agentId: 'agent_1' });
-    expect(snapshot?.conversationId).toBe('conv_abcdefghijkl');
-    expect(snapshot?.key).toBe(draftKey('agent_1'));
-    expect(snapshot?.messages).toHaveLength(1);
-    expect(snapshot?.messages[0]).toMatchObject({
-      status: 'sent',
-      parts: [{ type: 'text', text: 'hello', state: 'done' }],
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'one', key: 'local_session1' });
+    await agentChat.sendMessage({
+      agentId: 'agent_1',
+      text: 'two',
+      conversationId: 'conv_abcdefghijkl',
     });
+
+    const snapshot = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    expect(snapshot?.messages).toHaveLength(2);
+    expect(snapshot?.key).toBe('local_session1');
+  });
+
+  it('resume-by-id after create receives sending → sent on the resume key', async () => {
+    sendMessage
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' })
+      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'one', key: 'local_session1' });
+
+    const resumeStatuses: string[] = [];
+    emitter.on('agent_chat.messages.updated', ({ data }) => {
+      if (data.key !== 'conv_abcdefghijkl') {
+        return;
+      }
+
+      resumeStatuses.push(data.messages.map((m) => m.status).join(','));
+    });
+
+    getEvents.mockResolvedValue({ events: [], olderCursor: null });
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    await agentChat.sendMessage({
+      agentId: 'agent_1',
+      text: 'two',
+      key: 'conv_abcdefghijkl',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(resumeStatuses.some((s) => s.includes('sending'))).toBe(true);
+    expect(resumeStatuses.some((s) => s.includes('sent'))).toBe(true);
   });
 
   it('clearCache drops retained conversation state', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
 
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
     agentChat.clearCache();
 
-    expect(agentChat.getConversation({ agentId: 'agent_1' })).toBeUndefined();
+    expect(agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' })).toBeUndefined();
     expect(
       agentChat.getConversation({
         agentId: 'agent_1',
@@ -311,23 +363,23 @@ describe('AgentChat', () => {
       role: 'user',
       parts: [{ type: 'text', text: 'prior question', state: 'done' }],
     });
-    expect(result.data?.messages[1]).toMatchObject({
-      id: 'msg_asst0000001',
-      role: 'assistant',
-      parts: [{ type: 'text', text: 'prior answer', state: 'done' }],
-    });
 
     const snapshot = agentChat.getConversation({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(snapshot?.key).toBe(resumeKey('conv_abcdefghijkl'));
+    expect(snapshot?.key).toBe('conv_abcdefghijkl');
     expect(snapshot?.messages).toEqual(result.data?.messages);
   });
 
   it('loadConversation merges history with local-only messages by messageId', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_local000001' });
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'ack locally' });
+    await agentChat.sendMessage({
+      agentId: 'agent_1',
+      text: 'ack locally',
+      key: 'conv_abcdefghijkl',
+      conversationId: 'conv_abcdefghijkl',
+    });
 
     getEvents.mockResolvedValue({
       events: [
@@ -356,17 +408,17 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    expect(result.data?.messages).toHaveLength(2);
     expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_server00001', 'msg_local000001']);
-    expect(result.data?.messages[1]).toMatchObject({
-      id: 'msg_local000001',
-      parts: [{ type: 'text', text: 'ack locally', state: 'done' }],
-    });
   });
 
   it('loadConversation dedupes when history already contains the ack’d messageId', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_shared00001' });
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'same turn' });
+    await agentChat.sendMessage({
+      agentId: 'agent_1',
+      text: 'same turn',
+      key: 'conv_abcdefghijkl',
+      conversationId: 'conv_abcdefghijkl',
+    });
 
     getEvents.mockResolvedValue({
       events: [
@@ -399,7 +451,7 @@ describe('AgentChat', () => {
     expect(result.data?.messages[0]?.id).toBe('msg_shared00001');
   });
 
-  it('loadConversation does not claim the agent draft — draft send starts a new chat', async () => {
+  it('loadConversation uses a resume holder separate from an in-flight create session', async () => {
     getEvents.mockResolvedValue({
       events: [
         {
@@ -428,48 +480,26 @@ describe('AgentChat', () => {
     });
 
     sendMessage.mockResolvedValue({ identifier: 'conv_aaaaaaaaaaaa', messageId: 'msg_new00000001' });
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'fresh draft' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'fresh chat', key: 'local_new' });
 
     expect(sendMessage).toHaveBeenCalledWith({
       agentId: 'agent_1',
-      text: 'fresh draft',
+      text: 'fresh chat',
       conversationId: undefined,
     });
 
-    const draft = agentChat.getConversation({ agentId: 'agent_1' });
+    const created = agentChat.getConversation({ agentId: 'agent_1', key: 'local_new' });
     const resumed = agentChat.getConversation({
       agentId: 'agent_1',
       conversationId: 'conv_bbbbbbbbbbbb',
     });
 
-    expect(draft?.conversationId).toBe('conv_aaaaaaaaaaaa');
-    expect(draft?.key).toBe(draftKey('agent_1'));
-    expect(draft?.messages).toHaveLength(1);
-    expect(draft?.messages[0]).toMatchObject({
+    expect(created?.conversationId).toBe('conv_aaaaaaaaaaaa');
+    expect(created?.messages[0]).toMatchObject({
       id: 'msg_new00000001',
-      parts: [{ type: 'text', text: 'fresh draft', state: 'done' }],
+      parts: [{ type: 'text', text: 'fresh chat', state: 'done' }],
     });
-    expect(resumed?.key).toBe(resumeKey('conv_bbbbbbbbbbbb'));
-    expect(resumed?.messages).toHaveLength(1);
+    expect(resumed?.key).toBe('conv_bbbbbbbbbbbb');
     expect(resumed?.messages[0]?.id).toBe('msg_hist0000001');
-  });
-
-  it('sticky-resumes the agent draft on a second draft send', async () => {
-    sendMessage
-      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_aaaaaaaaaaaa' })
-      .mockResolvedValueOnce({ identifier: 'conv_abcdefghijkl', messageId: 'msg_bbbbbbbbbbbb' });
-
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'one' });
-    await agentChat.sendMessage({ agentId: 'agent_1', text: 'two' });
-
-    expect(sendMessage).toHaveBeenNthCalledWith(2, {
-      agentId: 'agent_1',
-      text: 'two',
-      conversationId: 'conv_abcdefghijkl',
-    });
-
-    const draft = agentChat.getConversation({ agentId: 'agent_1' });
-    expect(draft?.messages).toHaveLength(2);
-    expect(draft?.conversationId).toBe('conv_abcdefghijkl');
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,4 +1,4 @@
-import { InboxService } from '../api';
+import { AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
@@ -6,26 +6,30 @@ import { NovuError } from '../utils/errors';
 import type { SendMessageArgs, SendMessageResult } from './types';
 
 export class AgentChat extends BaseModule {
+  #agentChatService: AgentChatService;
+
   constructor({
     inboxServiceInstance,
     eventEmitterInstance,
+    agentChatService,
   }: {
     inboxServiceInstance: InboxService;
     eventEmitterInstance: NovuEventEmitter;
+    agentChatService: AgentChatService;
   }) {
     super({ inboxServiceInstance, eventEmitterInstance });
+    this.#agentChatService = agentChatService;
   }
 
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
     return this.callWithSession(async () => {
-      void args;
+      try {
+        const data = await this.#agentChatService.sendMessage(args);
 
-      return {
-        error: new NovuError(
-          'AgentChat.sendMessage is not wired yet — WebChatService comes next',
-          new Error('Not implemented')
-        ),
-      };
+        return { data: { conversationId: data.identifier } };
+      } catch (error) {
+        return { error: new NovuError('Failed to send agent chat message', error) };
+      }
     });
   }
 }

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -10,6 +10,12 @@ import type { LoadConversationArgs, LoadConversationResult, SendMessageArgs, Sen
 export class AgentChat extends BaseModule {
   #agentChatService: AgentChatService;
   #store: AgentChatStore;
+  /**
+   * Per-agent chain for uncontrolled sends.
+   * The first create must finish (and adopt `conv_*`) before the next POST omits
+   * `conversationIdentifier` — otherwise the server mints two conversations.
+   */
+  #uncontrolledSendChain = new Map<string, Promise<unknown>>();
 
   constructor({
     inboxServiceInstance,
@@ -35,6 +41,7 @@ export class AgentChat extends BaseModule {
 
   clearCache(): void {
     this.#store.clear();
+    this.#uncontrolledSendChain.clear();
   }
 
   getConversation({
@@ -86,31 +93,54 @@ export class AgentChat extends BaseModule {
       // Controlled: explicit conversationId. Uncontrolled: agent draft (sticky resume).
       const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
       const optimisticId = this.#store.appendSending(entry, args.text);
-      const conversationId = args.conversationId ?? entry.conversationId;
 
-      try {
-        const data = await this.#agentChatService.sendMessage({
-          ...args,
-          conversationId,
-        });
+      const post = async (): Result<SendMessageResult> => {
+        // Re-read after any prior uncontrolled create so sticky resume picks up conv_*.
+        const live = this.#store.get(args.agentId, args.conversationId) ?? entry;
+        const conversationId = args.conversationId ?? live.conversationId;
 
-        this.#store.markSent(entry, {
-          optimisticMessageId: optimisticId,
-          serverMessageId: data.messageId,
-          conversationId: data.identifier,
-        });
+        try {
+          const data = await this.#agentChatService.sendMessage({
+            ...args,
+            conversationId,
+          });
 
-        return {
-          data: {
+          this.#store.markSent(entry, {
+            optimisticMessageId: optimisticId,
+            serverMessageId: data.messageId,
             conversationId: data.identifier,
-            messageId: data.messageId,
-          },
-        };
-      } catch (error) {
-        this.#store.markFailed(entry, optimisticId);
+          });
 
-        return { error: new NovuError('Failed to send agent chat message', error) };
+          return {
+            data: {
+              conversationId: data.identifier,
+              messageId: data.messageId,
+            },
+          };
+        } catch (error) {
+          this.#store.markFailed(entry, optimisticId);
+
+          return { error: new NovuError('Failed to send agent chat message', error) };
+        }
+      };
+
+      // Paint optimistically immediately; only serialize the HTTP create so two
+      // overlapping uncontrolled first-sends cannot mint two server conversations.
+      if (!args.conversationId) {
+        const previous = this.#uncontrolledSendChain.get(args.agentId) ?? Promise.resolve();
+        const current = previous.then(post, post);
+        this.#uncontrolledSendChain.set(
+          args.agentId,
+          current.then(
+            () => undefined,
+            () => undefined
+          )
+        );
+
+        return current;
       }
+
+      return post();
     });
   }
 }

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,12 +1,15 @@
+import type { AgentMessage } from '@novu/agent-event-protocol';
 import { AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
+import { AgentChatStore } from './agent-chat-store';
 import type { SendMessageArgs, SendMessageResult } from './types';
 
 export class AgentChat extends BaseModule {
   #agentChatService: AgentChatService;
+  #store: AgentChatStore;
 
   constructor({
     inboxServiceInstance,
@@ -19,15 +22,57 @@ export class AgentChat extends BaseModule {
   }) {
     super({ inboxServiceInstance, eventEmitterInstance });
     this.#agentChatService = agentChatService;
+    this.#store = new AgentChatStore((entry) => {
+      this._emitter.emit('agent_chat.messages.updated', {
+        data: {
+          agentId: entry.agentId,
+          conversationId: entry.conversationId,
+          messages: entry.messages,
+        },
+      });
+    });
+  }
+
+  clearCache(): void {
+    this.#store.clear();
+  }
+
+  getConversation({
+    agentId,
+    conversationId,
+  }: {
+    agentId: string;
+    conversationId?: string;
+  }): { conversationId?: string; messages: AgentMessage[] } | undefined {
+    const entry = this.#store.get(agentId, conversationId);
+    if (!entry) {
+      return undefined;
+    }
+
+    return {
+      conversationId: entry.conversationId,
+      messages: entry.messages,
+    };
   }
 
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
     return this.callWithSession(async () => {
+      const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
+      const optimisticId = this.#store.appendSending(entry, args.text);
+
       try {
-        const data = await this.#agentChatService.sendMessage(args);
+        const live = this.#store.get(args.agentId, args.conversationId) ?? this.#store.get(args.agentId);
+        const data = await this.#agentChatService.sendMessage({
+          ...args,
+          conversationId: args.conversationId ?? live?.conversationId,
+        });
+
+        this.#store.markSent(entry, optimisticId, data.identifier);
 
         return { data: { conversationId: data.identifier } };
       } catch (error) {
+        this.#store.markFailed(entry, optimisticId);
+
         return { error: new NovuError('Failed to send agent chat message', error) };
       }
     });

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -4,7 +4,7 @@ import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
-import { AgentChatStore } from './agent-chat-store';
+import { AgentChatStore, createLocalConversationKey } from './agent-chat-store';
 import type { LoadConversationArgs, LoadConversationResult, SendMessageArgs, SendMessageResult } from './types';
 
 export class AgentChat extends BaseModule {
@@ -41,12 +41,19 @@ export class AgentChat extends BaseModule {
   getConversation({
     agentId,
     conversationId,
+    key,
   }: {
     agentId: string;
     conversationId?: string;
-  }): { conversationId?: string; messages: AgentMessage[]; key?: string } | undefined {
-    const entry = this.#store.get(agentId, conversationId);
-    if (!entry) {
+    key?: string;
+  }): { conversationId?: string; messages: AgentMessage[]; key: string } | undefined {
+    const entry = key
+      ? this.#store.get(key)
+      : conversationId
+        ? (this.#store.get(conversationId) ?? this.#store.getByConversationId(agentId, conversationId))
+        : undefined;
+
+    if (!entry || entry.agentId !== agentId) {
       return undefined;
     }
 
@@ -59,7 +66,7 @@ export class AgentChat extends BaseModule {
 
   /**
    * Fetch the newest history page and merge it into the local timeline.
-   * Indexes by conversationId only — does not claim the agent draft.
+   * Holder key is the public conversation id (resume).
    */
   async loadConversation(args: LoadConversationArgs): Result<LoadConversationResult> {
     return this.callWithSession(async () => {
@@ -68,7 +75,11 @@ export class AgentChat extends BaseModule {
           conversationId: args.conversationId,
         });
 
-        const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
+        const entry = this.#store.getOrCreate({
+          agentId: args.agentId,
+          key: args.conversationId,
+          conversationId: args.conversationId,
+        });
         const next = this.#store.absorbHistoryPage(entry, page.events);
 
         return {
@@ -85,14 +96,24 @@ export class AgentChat extends BaseModule {
 
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
     return this.callWithSession(async () => {
-      // Explicit conversationId → resume. Omit → agent draft (claim on first send).
-      const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
+      const key = args.key ?? args.conversationId ?? createLocalConversationKey();
+      // Prefer the session key; if the caller only has conversationId (plain JS
+      // after create), reuse the holder that already claimed that id.
+      const entry =
+        this.#store.get(key) ??
+        (args.conversationId ? this.#store.getByConversationId(args.agentId, args.conversationId) : undefined) ??
+        this.#store.getOrCreate({
+          agentId: args.agentId,
+          key,
+          conversationId: args.conversationId,
+        });
       const optimisticId = this.#store.appendSending(entry, args.text);
 
-      return this.#store.withDraftClaim(entry, args.conversationId, async (conversationId) => {
+      return this.#store.withCreateClaim(entry, args.conversationId, async (conversationId) => {
         try {
           const data = await this.#agentChatService.sendMessage({
-            ...args,
+            agentId: args.agentId,
+            text: args.text,
             conversationId,
           });
 

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -65,8 +65,8 @@ export class AgentChat extends BaseModule {
   }
 
   /**
-   * Fetch the newest history page and merge it into the local timeline.
-   * Holder key is the public conversation id (resume).
+   * Load the newest history page into the local holder.
+   * The holder key is the public conversation id.
    */
   async loadConversation(args: LoadConversationArgs): Result<LoadConversationResult> {
     return this.callWithSession(async () => {
@@ -130,8 +130,8 @@ export class AgentChat extends BaseModule {
   }
 
   /**
-   * Resolve the holder for a send. Rejects a key that belongs to another agent
-   * or a different claimed conversation (stale session key after prop change).
+   * Find the holder for a send.
+   * Reject a key when the holder belongs to another agent or another claimed conversation.
    */
   #resolveSendEntry(args: SendMessageArgs, key: string): ConversationEntry {
     const byKey = this.#store.get(key);
@@ -150,7 +150,7 @@ export class AgentChat extends BaseModule {
       );
     }
 
-    // Stale key must not call getOrCreate(key) — that would return the wrong holder.
+    // If the key is stale, do not call getOrCreate with that key. That returns the wrong holder.
     const createKey = byKey ? createLocalConversationKey() : key;
 
     return this.#store.getOrCreate({

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,11 +1,12 @@
 import type { AgentMessage } from '@novu/agent-event-protocol';
+import { applyEnvelopes, createInitialAgentConversationState } from '@novu/agent-event-protocol';
 import { AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
 import { AgentChatStore } from './agent-chat-store';
-import type { SendMessageArgs, SendMessageResult } from './types';
+import type { LoadConversationArgs, LoadConversationResult, SendMessageArgs, SendMessageResult } from './types';
 
 export class AgentChat extends BaseModule {
   #agentChatService: AgentChatService;
@@ -55,6 +56,33 @@ export class AgentChat extends BaseModule {
     };
   }
 
+  /**
+   * Fetch the newest history page and replace the local timeline.
+   * Used on open/resume when the parent passes `conversationId`.
+   */
+  async loadConversation(args: LoadConversationArgs): Result<LoadConversationResult> {
+    return this.callWithSession(async () => {
+      try {
+        const page = await this.#agentChatService.getEvents({
+          conversationId: args.conversationId,
+        });
+        const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
+        const folded = applyEnvelopes(createInitialAgentConversationState(), page.events);
+        const next = this.#store.replaceFromHistory(entry, folded, args.conversationId);
+
+        return {
+          data: {
+            conversationId: args.conversationId,
+            messages: next.messages,
+            hasMore: page.hasMore,
+          },
+        };
+      } catch (error) {
+        return { error: new NovuError('Failed to load agent chat conversation', error) };
+      }
+    });
+  }
+
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
     return this.callWithSession(async () => {
       const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
@@ -67,9 +95,14 @@ export class AgentChat extends BaseModule {
           conversationId: args.conversationId ?? live?.conversationId,
         });
 
-        this.#store.markSent(entry, optimisticId, data.identifier);
+        this.#store.markSent(entry, optimisticId, data.identifier, data.messageId);
 
-        return { data: { conversationId: data.identifier } };
+        return {
+          data: {
+            conversationId: data.identifier,
+            messageId: data.messageId,
+          },
+        };
       } catch (error) {
         this.#store.markFailed(entry, optimisticId);
 

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,5 +1,4 @@
 import type { AgentMessage } from '@novu/agent-event-protocol';
-import { applyEnvelopes, createInitialAgentConversationState } from '@novu/agent-event-protocol';
 import { AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
@@ -57,8 +56,8 @@ export class AgentChat extends BaseModule {
   }
 
   /**
-   * Fetch the newest history page and replace the local timeline.
-   * Used on open/resume when the parent passes `conversationId`.
+   * Fetch the newest history page and merge it into the local timeline.
+   * Indexes by conversationId only — does not claim the uncontrolled agent draft.
    */
   async loadConversation(args: LoadConversationArgs): Result<LoadConversationResult> {
     return this.callWithSession(async () => {
@@ -66,15 +65,14 @@ export class AgentChat extends BaseModule {
         const page = await this.#agentChatService.getEvents({
           conversationId: args.conversationId,
         });
+
         const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
-        const folded = applyEnvelopes(createInitialAgentConversationState(), page.events);
-        const next = this.#store.replaceFromHistory(entry, folded, args.conversationId);
+        const next = this.#store.absorbHistoryPage(entry, page.events);
 
         return {
           data: {
             conversationId: args.conversationId,
             messages: next.messages,
-            hasMore: page.hasMore,
           },
         };
       } catch (error) {
@@ -85,17 +83,22 @@ export class AgentChat extends BaseModule {
 
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
     return this.callWithSession(async () => {
+      // Controlled: explicit conversationId. Uncontrolled: agent draft (sticky resume).
       const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
       const optimisticId = this.#store.appendSending(entry, args.text);
+      const conversationId = args.conversationId ?? entry.conversationId;
 
       try {
-        const live = this.#store.get(args.agentId, args.conversationId) ?? this.#store.get(args.agentId);
         const data = await this.#agentChatService.sendMessage({
           ...args,
-          conversationId: args.conversationId ?? live?.conversationId,
+          conversationId,
         });
 
-        this.#store.markSent(entry, optimisticId, data.identifier, data.messageId);
+        this.#store.markSent(entry, {
+          optimisticMessageId: optimisticId,
+          serverMessageId: data.messageId,
+          conversationId: data.identifier,
+        });
 
         return {
           data: {

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -4,7 +4,7 @@ import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
-import { AgentChatStore, createLocalConversationKey } from './agent-chat-store';
+import { AgentChatStore, type ConversationEntry, createLocalConversationKey } from './agent-chat-store';
 import type { LoadConversationArgs, LoadConversationResult, SendMessageArgs, SendMessageResult } from './types';
 
 export class AgentChat extends BaseModule {
@@ -97,16 +97,7 @@ export class AgentChat extends BaseModule {
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
     return this.callWithSession(async () => {
       const key = args.key ?? args.conversationId ?? createLocalConversationKey();
-      // Prefer the session key; if the caller only has conversationId (plain JS
-      // after create), reuse the holder that already claimed that id.
-      const entry =
-        this.#store.get(key) ??
-        (args.conversationId ? this.#store.getByConversationId(args.agentId, args.conversationId) : undefined) ??
-        this.#store.getOrCreate({
-          agentId: args.agentId,
-          key,
-          conversationId: args.conversationId,
-        });
+      const entry = this.#resolveSendEntry(args, key);
       const optimisticId = this.#store.appendSending(entry, args.text);
 
       return this.#store.withCreateClaim(entry, args.conversationId, async (conversationId) => {
@@ -136,5 +127,51 @@ export class AgentChat extends BaseModule {
         }
       });
     });
+  }
+
+  /**
+   * Resolve the holder for a send. Rejects a key that belongs to another agent
+   * or a different claimed conversation (stale session key after prop change).
+   */
+  #resolveSendEntry(args: SendMessageArgs, key: string): ConversationEntry {
+    const byKey = this.#store.get(key);
+    if (byKey && this.#isUsableSendEntry(byKey, args)) {
+      return byKey;
+    }
+
+    if (args.conversationId) {
+      return (
+        this.#store.getByConversationId(args.agentId, args.conversationId) ??
+        this.#store.getOrCreate({
+          agentId: args.agentId,
+          key: args.conversationId,
+          conversationId: args.conversationId,
+        })
+      );
+    }
+
+    // Stale key must not call getOrCreate(key) — that would return the wrong holder.
+    const createKey = byKey ? createLocalConversationKey() : key;
+
+    return this.#store.getOrCreate({
+      agentId: args.agentId,
+      key: createKey,
+    });
+  }
+
+  #isUsableSendEntry(entry: ConversationEntry, args: SendMessageArgs): boolean {
+    if (entry.agentId !== args.agentId) {
+      return false;
+    }
+
+    if (
+      args.conversationId !== undefined &&
+      entry.conversationId !== undefined &&
+      entry.conversationId !== args.conversationId
+    ) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -10,12 +10,6 @@ import type { LoadConversationArgs, LoadConversationResult, SendMessageArgs, Sen
 export class AgentChat extends BaseModule {
   #agentChatService: AgentChatService;
   #store: AgentChatStore;
-  /**
-   * Per-agent chain for uncontrolled sends.
-   * The first create must finish (and adopt `conv_*`) before the next POST omits
-   * `conversationIdentifier` — otherwise the server mints two conversations.
-   */
-  #uncontrolledSendChain = new Map<string, Promise<unknown>>();
 
   constructor({
     inboxServiceInstance,
@@ -33,6 +27,7 @@ export class AgentChat extends BaseModule {
         data: {
           agentId: entry.agentId,
           conversationId: entry.conversationId,
+          key: entry.key,
           messages: entry.messages,
         },
       });
@@ -41,7 +36,6 @@ export class AgentChat extends BaseModule {
 
   clearCache(): void {
     this.#store.clear();
-    this.#uncontrolledSendChain.clear();
   }
 
   getConversation({
@@ -50,7 +44,7 @@ export class AgentChat extends BaseModule {
   }: {
     agentId: string;
     conversationId?: string;
-  }): { conversationId?: string; messages: AgentMessage[] } | undefined {
+  }): { conversationId?: string; messages: AgentMessage[]; key?: string } | undefined {
     const entry = this.#store.get(agentId, conversationId);
     if (!entry) {
       return undefined;
@@ -59,12 +53,13 @@ export class AgentChat extends BaseModule {
     return {
       conversationId: entry.conversationId,
       messages: entry.messages,
+      key: entry.key,
     };
   }
 
   /**
    * Fetch the newest history page and merge it into the local timeline.
-   * Indexes by conversationId only — does not claim the uncontrolled agent draft.
+   * Indexes by conversationId only — does not claim the agent draft.
    */
   async loadConversation(args: LoadConversationArgs): Result<LoadConversationResult> {
     return this.callWithSession(async () => {
@@ -90,15 +85,11 @@ export class AgentChat extends BaseModule {
 
   async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
     return this.callWithSession(async () => {
-      // Controlled: explicit conversationId. Uncontrolled: agent draft (sticky resume).
+      // Explicit conversationId → resume. Omit → agent draft (claim on first send).
       const entry = this.#store.getOrCreate(args.agentId, args.conversationId);
       const optimisticId = this.#store.appendSending(entry, args.text);
 
-      const post = async (): Result<SendMessageResult> => {
-        // Re-read after any prior uncontrolled create so sticky resume picks up conv_*.
-        const live = this.#store.get(args.agentId, args.conversationId) ?? entry;
-        const conversationId = args.conversationId ?? live.conversationId;
-
+      return this.#store.withDraftClaim(entry, args.conversationId, async (conversationId) => {
         try {
           const data = await this.#agentChatService.sendMessage({
             ...args,
@@ -122,25 +113,7 @@ export class AgentChat extends BaseModule {
 
           return { error: new NovuError('Failed to send agent chat message', error) };
         }
-      };
-
-      // Paint optimistically immediately; only serialize the HTTP create so two
-      // overlapping uncontrolled first-sends cannot mint two server conversations.
-      if (!args.conversationId) {
-        const previous = this.#uncontrolledSendChain.get(args.agentId) ?? Promise.resolve();
-        const current = previous.then(post, post);
-        this.#uncontrolledSendChain.set(
-          args.agentId,
-          current.then(
-            () => undefined,
-            () => undefined
-          )
-        );
-
-        return current;
-      }
-
-      return post();
+      });
     });
   }
 }

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,0 +1,31 @@
+import { InboxService } from '../api';
+import { BaseModule } from '../base-module';
+import { NovuEventEmitter } from '../event-emitter';
+import type { Result } from '../types';
+import { NovuError } from '../utils/errors';
+import type { SendMessageArgs, SendMessageResult } from './types';
+
+export class AgentChat extends BaseModule {
+  constructor({
+    inboxServiceInstance,
+    eventEmitterInstance,
+  }: {
+    inboxServiceInstance: InboxService;
+    eventEmitterInstance: NovuEventEmitter;
+  }) {
+    super({ inboxServiceInstance, eventEmitterInstance });
+  }
+
+  async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
+    return this.callWithSession(async () => {
+      void args;
+
+      return {
+        error: new NovuError(
+          'AgentChat.sendMessage is not wired yet — WebChatService comes next',
+          new Error('Not implemented')
+        ),
+      };
+    });
+  }
+}

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,0 +1,2 @@
+export { AgentChat } from './agent-chat';
+export type { SendMessageArgs, SendMessageResult } from './types';

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,2 +1,2 @@
 export { AgentChat } from './agent-chat';
-export type { SendMessageArgs, SendMessageResult } from './types';
+export type { AgentChatMessagesUpdated, AgentMessage, SendMessageArgs, SendMessageResult } from './types';

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,2 +1,9 @@
 export { AgentChat } from './agent-chat';
-export type { AgentChatMessagesUpdated, AgentMessage, SendMessageArgs, SendMessageResult } from './types';
+export type {
+  AgentChatMessagesUpdated,
+  AgentMessage,
+  LoadConversationArgs,
+  LoadConversationResult,
+  SendMessageArgs,
+  SendMessageResult,
+} from './types';

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -11,6 +11,18 @@ export type SendMessageArgs = {
 
 export type SendMessageResult = {
   conversationId: string;
+  messageId: string;
+};
+
+export type LoadConversationArgs = {
+  agentId: string;
+  conversationId: string;
+};
+
+export type LoadConversationResult = {
+  conversationId: string;
+  messages: AgentMessage[];
+  hasMore: boolean;
 };
 
 export type AgentChatMessagesUpdated = {

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -7,8 +7,7 @@ export type SendMessageArgs = {
   text: string;
   /**
    * Resume this conversation.
-   * Omit to use the agent draft: a new chat on first send, or sticky resume of
-   * the draft started by a prior uncontrolled send for this agent.
+   * Omit to use the agent draft: first send claims a `conv_*`, later sends sticky-resume it.
    * Loading another conversation via `loadConversation` does not change the draft.
    */
   conversationId?: string;
@@ -32,5 +31,10 @@ export type LoadConversationResult = {
 export type AgentChatMessagesUpdated = {
   agentId: string;
   conversationId?: string;
+  /**
+   * Immutable subscription key for this holder.
+   * Draft emits stay `agent:<agentId>` after claim; resume emits are `conv:<id>`.
+   */
+  key: string;
   messages: AgentMessage[];
 };

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -6,11 +6,16 @@ export type SendMessageArgs = {
   agentId: string;
   text: string;
   /**
-   * Resume this conversation.
-   * Omit to use the agent draft: first send claims a `conv_*`, later sends sticky-resume it.
-   * Loading another conversation via `loadConversation` does not change the draft.
+   * Existing conversation to append to.
+   * Omit to create a new conversation (no implicit reuse of a prior chat).
+   * After create, pass the returned `conversationId` on later sends.
    */
   conversationId?: string;
+  /**
+   * Immutable holder key for the local store / emit subscription.
+   * Defaults to `conversationId` when resuming, or a minted `local_*` key on create.
+   */
+  key?: string;
 };
 
 export type SendMessageResult = {
@@ -31,10 +36,7 @@ export type LoadConversationResult = {
 export type AgentChatMessagesUpdated = {
   agentId: string;
   conversationId?: string;
-  /**
-   * Immutable subscription key for this holder.
-   * Draft emits stay `agent:<agentId>` after claim; resume emits are `conv:<id>`.
-   */
+  /** Immutable holder key — stable for the life of the local conversation entry. */
   key: string;
   messages: AgentMessage[];
 };

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -1,0 +1,10 @@
+export type SendMessageArgs = {
+  agentId: string;
+  text: string;
+  /** Resume an existing conversation. Omit to start a new one. */
+  conversationId?: string;
+};
+
+export type SendMessageResult = {
+  conversationId: string;
+};

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -7,13 +7,13 @@ export type SendMessageArgs = {
   text: string;
   /**
    * Existing conversation to append to.
-   * Omit to create a new conversation (no implicit reuse of a prior chat).
+   * Omit this field to create a new conversation. The client does not reuse a prior chat.
    * After create, pass the returned `conversationId` on later sends.
    */
   conversationId?: string;
   /**
-   * Immutable holder key for the local store / emit subscription.
-   * Defaults to `conversationId` when resuming, or a minted `local_*` key on create.
+   * Immutable holder key for the local store and emit subscription.
+   * Defaults to `conversationId` on resume, or a minted `local_*` key on create.
    */
   key?: string;
 };
@@ -36,7 +36,7 @@ export type LoadConversationResult = {
 export type AgentChatMessagesUpdated = {
   agentId: string;
   conversationId?: string;
-  /** Immutable holder key — stable for the life of the local conversation entry. */
+  /** Immutable holder key. Stable for the life of the local conversation entry. */
   key: string;
   messages: AgentMessage[];
 };

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -5,7 +5,12 @@ export type { AgentMessage };
 export type SendMessageArgs = {
   agentId: string;
   text: string;
-  /** Resume an existing conversation. Omit to start a new one. */
+  /**
+   * Resume this conversation.
+   * Omit to use the agent draft: a new chat on first send, or sticky resume of
+   * the draft started by a prior uncontrolled send for this agent.
+   * Loading another conversation via `loadConversation` does not change the draft.
+   */
   conversationId?: string;
 };
 
@@ -22,7 +27,6 @@ export type LoadConversationArgs = {
 export type LoadConversationResult = {
   conversationId: string;
   messages: AgentMessage[];
-  hasMore: boolean;
 };
 
 export type AgentChatMessagesUpdated = {

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -1,3 +1,7 @@
+import type { AgentMessage } from '@novu/agent-event-protocol';
+
+export type { AgentMessage };
+
 export type SendMessageArgs = {
   agentId: string;
   text: string;
@@ -7,4 +11,10 @@ export type SendMessageArgs = {
 
 export type SendMessageResult = {
   conversationId: string;
+};
+
+export type AgentChatMessagesUpdated = {
+  agentId: string;
+  conversationId?: string;
+  messages: AgentMessage[];
 };

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -1,0 +1,57 @@
+import { AgentChatService } from './agent-chat-service';
+import { HttpClient } from './http-client';
+
+describe('AgentChatService', () => {
+  it('POSTs a new conversation message', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { identifier: 'conv_abcdefghijkl' } }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const httpClient = new HttpClient({ apiUrl: 'https://test.novu.co' });
+    httpClient.setAuthorizationToken('test-token');
+    const service = new AgentChatService({ httpClient });
+
+    const result = await service.sendMessage({ agentId: 'agent_1', text: 'hello' });
+
+    expect(result).toEqual({ identifier: 'conv_abcdefghijkl' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://test.novu.co/v1/web-chat/conversations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ agentId: 'agent_1', text: 'hello' }),
+      })
+    );
+  });
+
+  it('includes conversationIdentifier when resuming', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { identifier: 'conv_abcdefghijkl' } }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const httpClient = new HttpClient({ apiUrl: 'https://test.novu.co' });
+    const service = new AgentChatService({ httpClient });
+
+    await service.sendMessage({
+      agentId: 'agent_1',
+      text: 'again',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://test.novu.co/v1/web-chat/conversations',
+      expect.objectContaining({
+        body: JSON.stringify({
+          agentId: 'agent_1',
+          text: 'again',
+          conversationIdentifier: 'conv_abcdefghijkl',
+        }),
+      })
+    );
+  });
+});

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -6,7 +6,7 @@ describe('AgentChatService', () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
       status: 201,
-      json: async () => ({ data: { identifier: 'conv_abcdefghijkl' } }),
+      json: async () => ({ data: { identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' } }),
     } as Response);
     global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -16,7 +16,7 @@ describe('AgentChatService', () => {
 
     const result = await service.sendMessage({ agentId: 'agent_1', text: 'hello' });
 
-    expect(result).toEqual({ identifier: 'conv_abcdefghijkl' });
+    expect(result).toEqual({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
     expect(fetchMock).toHaveBeenCalledWith(
       'https://test.novu.co/v1/web-chat/conversations',
       expect.objectContaining({
@@ -30,7 +30,7 @@ describe('AgentChatService', () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
       status: 201,
-      json: async () => ({ data: { identifier: 'conv_abcdefghijkl' } }),
+      json: async () => ({ data: { identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' } }),
     } as Response);
     global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -52,6 +52,37 @@ describe('AgentChatService', () => {
           conversationIdentifier: 'conv_abcdefghijkl',
         }),
       })
+    );
+  });
+
+  it('GETs conversation events', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          events: [],
+          hasMore: false,
+          next: null,
+          previous: null,
+        },
+      }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const httpClient = new HttpClient({ apiUrl: 'https://test.novu.co' });
+    const service = new AgentChatService({ httpClient });
+
+    const result = await service.getEvents({
+      conversationId: 'conv_abcdefghijkl',
+      limit: 50,
+      before: 'act_cursor',
+    });
+
+    expect(result).toEqual({ events: [], hasMore: false, next: null, previous: null });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://test.novu.co/v1/web-chat/conversations/conv_abcdefghijkl/events?before=act_cursor&limit=50',
+      expect.objectContaining({ method: 'GET' })
     );
   });
 });

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -62,9 +62,7 @@ describe('AgentChatService', () => {
       json: async () => ({
         data: {
           events: [],
-          hasMore: false,
-          next: null,
-          previous: null,
+          olderCursor: null,
         },
       }),
     } as Response);
@@ -75,13 +73,11 @@ describe('AgentChatService', () => {
 
     const result = await service.getEvents({
       conversationId: 'conv_abcdefghijkl',
-      limit: 50,
-      before: 'act_cursor',
     });
 
-    expect(result).toEqual({ events: [], hasMore: false, next: null, previous: null });
+    expect(result).toEqual({ events: [], olderCursor: null });
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://test.novu.co/v1/web-chat/conversations/conv_abcdefghijkl/events?before=act_cursor&limit=50',
+      'https://test.novu.co/v1/web-chat/conversations/conv_abcdefghijkl/events',
       expect.objectContaining({ method: 'GET' })
     );
   });

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -1,0 +1,31 @@
+import { HttpClient } from './http-client';
+
+// TODO(NV-8553): rename path to `/agent-chat/conversations` when platform rename lands
+const AGENT_CHAT_CONVERSATIONS_ROUTE = '/web-chat/conversations';
+
+export type AgentChatSendMessageArgs = {
+  agentId: string;
+  text: string;
+  /** Resume an existing conversation (`conv_*`). */
+  conversationId?: string;
+};
+
+export type AgentChatSendMessageResponse = {
+  identifier: string;
+};
+
+export class AgentChatService {
+  #httpClient: HttpClient;
+
+  constructor({ httpClient }: { httpClient: HttpClient }) {
+    this.#httpClient = httpClient;
+  }
+
+  async sendMessage(args: AgentChatSendMessageArgs): Promise<AgentChatSendMessageResponse> {
+    return this.#httpClient.post(AGENT_CHAT_CONVERSATIONS_ROUTE, {
+      agentId: args.agentId,
+      text: args.text,
+      ...(args.conversationId ? { conversationIdentifier: args.conversationId } : {}),
+    });
+  }
+}

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -7,7 +7,7 @@ const AGENT_CHAT_CONVERSATIONS_ROUTE = '/web-chat/conversations';
 export type AgentChatSendMessageArgs = {
   agentId: string;
   text: string;
-  /** Resume an existing conversation (`conv_*`). */
+  /** The `conv_*` id of an existing conversation to resume. */
   conversationId?: string;
 };
 
@@ -18,17 +18,12 @@ export type AgentChatSendMessageResponse = {
 
 export type AgentChatGetEventsArgs = {
   conversationId: string;
-  after?: string;
-  before?: string;
-  afterSequence?: number;
-  limit?: number;
 };
 
 export type AgentChatGetEventsResponse = {
   events: AgentEventEnvelope[];
-  hasMore: boolean;
-  next: string | null;
-  previous: string | null;
+  /** Cursor toward older history (wire field; unused until loadOlder). */
+  olderCursor: string | null;
 };
 
 export class AgentChatService {
@@ -47,23 +42,6 @@ export class AgentChatService {
   }
 
   async getEvents(args: AgentChatGetEventsArgs): Promise<AgentChatGetEventsResponse> {
-    const searchParams = new URLSearchParams();
-    if (args.after) {
-      searchParams.set('after', args.after);
-    }
-    if (args.before) {
-      searchParams.set('before', args.before);
-    }
-    if (args.afterSequence !== undefined) {
-      searchParams.set('afterSequence', String(args.afterSequence));
-    }
-    if (args.limit !== undefined) {
-      searchParams.set('limit', String(args.limit));
-    }
-
-    return this.#httpClient.get(
-      `${AGENT_CHAT_CONVERSATIONS_ROUTE}/${encodeURIComponent(args.conversationId)}/events`,
-      searchParams
-    );
+    return this.#httpClient.get(`${AGENT_CHAT_CONVERSATIONS_ROUTE}/${encodeURIComponent(args.conversationId)}/events`);
   }
 }

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -1,3 +1,4 @@
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import { HttpClient } from './http-client';
 
 // TODO(NV-8553): rename path to `/agent-chat/conversations` when platform rename lands
@@ -12,6 +13,22 @@ export type AgentChatSendMessageArgs = {
 
 export type AgentChatSendMessageResponse = {
   identifier: string;
+  messageId: string;
+};
+
+export type AgentChatGetEventsArgs = {
+  conversationId: string;
+  after?: string;
+  before?: string;
+  afterSequence?: number;
+  limit?: number;
+};
+
+export type AgentChatGetEventsResponse = {
+  events: AgentEventEnvelope[];
+  hasMore: boolean;
+  next: string | null;
+  previous: string | null;
 };
 
 export class AgentChatService {
@@ -27,5 +44,26 @@ export class AgentChatService {
       text: args.text,
       ...(args.conversationId ? { conversationIdentifier: args.conversationId } : {}),
     });
+  }
+
+  async getEvents(args: AgentChatGetEventsArgs): Promise<AgentChatGetEventsResponse> {
+    const searchParams = new URLSearchParams();
+    if (args.after) {
+      searchParams.set('after', args.after);
+    }
+    if (args.before) {
+      searchParams.set('before', args.before);
+    }
+    if (args.afterSequence !== undefined) {
+      searchParams.set('afterSequence', String(args.afterSequence));
+    }
+    if (args.limit !== undefined) {
+      searchParams.set('limit', String(args.limit));
+    }
+
+    return this.#httpClient.get(
+      `${AGENT_CHAT_CONVERSATIONS_ROUTE}/${encodeURIComponent(args.conversationId)}/events`,
+      searchParams
+    );
   }
 }

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -7,7 +7,7 @@ const AGENT_CHAT_CONVERSATIONS_ROUTE = '/web-chat/conversations';
 export type AgentChatSendMessageArgs = {
   agentId: string;
   text: string;
-  /** The `conv_*` id of an existing conversation to resume. */
+  /** Existing conversation id. Omit this field to create a new conversation. */
   conversationId?: string;
 };
 
@@ -22,7 +22,7 @@ export type AgentChatGetEventsArgs = {
 
 export type AgentChatGetEventsResponse = {
   events: AgentEventEnvelope[];
-  /** Cursor toward older history (wire field; unused until loadOlder). */
+  /** Cursor for older history. */
   olderCursor: string | null;
 };
 

--- a/packages/js/src/api/inbox-service.ts
+++ b/packages/js/src/api/inbox-service.ts
@@ -34,7 +34,9 @@ import type {
 import { SeverityLevelEnum } from '../types';
 import { HttpClient, HttpClientOptions } from './http-client';
 
-export type InboxServiceOptions = HttpClientOptions;
+export type InboxServiceOptions = HttpClientOptions & {
+  httpClient?: HttpClient;
+};
 
 const INBOX_ROUTE = '/inbox';
 const INBOX_NOTIFICATIONS_ROUTE = `${INBOX_ROUTE}/notifications`;
@@ -128,7 +130,8 @@ export class InboxService {
   #httpClient: HttpClient;
 
   constructor(options: InboxServiceOptions = {}) {
-    this.#httpClient = new HttpClient(options);
+    const { httpClient, ...httpClientOptions } = options;
+    this.#httpClient = httpClient ?? new HttpClient(httpClientOptions);
   }
 
   async initializeSession({

--- a/packages/js/src/api/index.ts
+++ b/packages/js/src/api/index.ts
@@ -1,2 +1,3 @@
+export * from './agent-chat-service';
 export * from './http-client';
 export * from './inbox-service';

--- a/packages/js/src/event-emitter/types.ts
+++ b/packages/js/src/event-emitter/types.ts
@@ -1,3 +1,4 @@
+import type { AgentChatMessagesUpdated } from '../agent-chat/types';
 import type {
   ChannelConnectionResponse,
   ChannelEndpointResponse,
@@ -182,6 +183,10 @@ type SocketEvents = {
   [key in NotificationUnreadEvent]: { result: { total: number; severity: Record<string, number> } };
 };
 
+type AgentChatEvents = {
+  'agent_chat.messages.updated': { data: AgentChatMessagesUpdated };
+};
+
 /**
  * Events that are emitted by Novu Event Emitter.
  *
@@ -225,6 +230,7 @@ export type Events = SessionInitializeEvents &
   ChannelEndpointLinkEvents &
   SocketConnectEvents &
   SocketEvents &
+  AgentChatEvents &
   NotificationReadEvents &
   NotificationUnreadEvents &
   NotificationSeenEvents &

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,5 +1,11 @@
 export type * from 'json-logic-js';
-export type { AgentMessage, SendMessageArgs, SendMessageResult } from './agent-chat';
+export type {
+  AgentMessage,
+  LoadConversationArgs,
+  LoadConversationResult,
+  SendMessageArgs,
+  SendMessageResult,
+} from './agent-chat';
 export type {
   ChannelConnectionResponse,
   ChannelEndpointResponse,

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,5 +1,5 @@
 export type * from 'json-logic-js';
-export type { SendMessageArgs, SendMessageResult } from './agent-chat';
+export type { AgentMessage, SendMessageArgs, SendMessageResult } from './agent-chat';
 export type {
   ChannelConnectionResponse,
   ChannelEndpointResponse,

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,4 +1,5 @@
 export type * from 'json-logic-js';
+export type { SendMessageArgs, SendMessageResult } from './agent-chat';
 export type {
   ChannelConnectionResponse,
   ChannelEndpointResponse,

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -147,6 +147,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
     this.preferences.cache.clearAll();
     this.preferences.scheduleCache.clearAll();
     this.subscriptions.cache.clearAll();
+    this.agentChat.clearCache();
   }
 
   /**

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -1,5 +1,5 @@
 import { AgentChat } from './agent-chat';
-import { InboxService } from './api';
+import { AgentChatService, HttpClient, InboxService } from './api';
 import { ChannelConnections } from './channel-connections';
 import { ChannelEndpoints } from './channel-endpoints';
 import type { EventHandler, EventNames, Events } from './event-emitter';
@@ -16,7 +16,9 @@ import type { BaseSocketInterface } from './ws/base-socket';
 export class Novu implements Pick<NovuEventEmitter, 'on'> {
   #emitter: NovuEventEmitter;
   #session: Session;
+  #httpClient: HttpClient;
   #inboxService: InboxService;
+  #agentChatService: AgentChatService;
   #options: NovuOptions;
 
   public readonly notifications: Notifications;
@@ -60,8 +62,14 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
 
   constructor(options: NovuOptions) {
     this.#options = options;
-    this.#inboxService = new InboxService({
+    this.#httpClient = new HttpClient({
       apiUrl: options.apiUrl || options.backendUrl,
+    });
+    this.#inboxService = new InboxService({
+      httpClient: this.#httpClient,
+    });
+    this.#agentChatService = new AgentChatService({
+      httpClient: this.#httpClient,
     });
     this.#emitter = new NovuEventEmitter();
     const subscriber = buildSubscriber({ subscriberId: options.subscriberId, subscriber: options.subscriber });
@@ -108,6 +116,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
     this.agentChat = new AgentChat({
       inboxServiceInstance: this.#inboxService,
       eventEmitterInstance: this.#emitter,
+      agentChatService: this.#agentChatService,
     });
     this.socket = createSocket({
       socketUrl: options.socketUrl,

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -1,3 +1,4 @@
+import { AgentChat } from './agent-chat';
 import { InboxService } from './api';
 import { ChannelConnections } from './channel-connections';
 import { ChannelEndpoints } from './channel-endpoints';
@@ -23,6 +24,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
   public readonly subscriptions: Subscriptions;
   public readonly channelConnections: ChannelConnections;
   public readonly channelEndpoints: ChannelEndpoints;
+  public readonly agentChat: AgentChat;
   public readonly socket: BaseSocketInterface;
 
   public on: <Key extends EventNames>(eventName: Key, listener: EventHandler<Events[Key]>) => () => void;
@@ -100,6 +102,10 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
       eventEmitterInstance: this.#emitter,
     });
     this.channelEndpoints = new ChannelEndpoints({
+      inboxServiceInstance: this.#inboxService,
+      eventEmitterInstance: this.#emitter,
+    });
+    this.agentChat = new AgentChat({
       inboxServiceInstance: this.#inboxService,
       eventEmitterInstance: this.#emitter,
     });

--- a/packages/js/tsup.config.ts
+++ b/packages/js/tsup.config.ts
@@ -57,7 +57,10 @@ const baseConfig: Options = {
 const baseModuleConfig: Options = {
   ...baseConfig,
   treeshake: true,
-  dts: true,
+  dts: {
+    resolve: ['@novu/agent-event-protocol'],
+  },
+  noExternal: ['@novu/agent-event-protocol'],
   entry: {
     index: './src/index.ts',
     'ui/index': './src/ui/index.ts',
@@ -94,6 +97,7 @@ export default defineConfig((config: Options) => {
     format: ['iife'],
     minify: true,
     dts: false,
+    noExternal: ['@novu/agent-event-protocol'],
     outExtension: () => {
       return {
         js: '.min.js',

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export type * from '@novu/js';
 export { PreferenceLevel, SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/js';
 export { NovuProvider, useNovu } from './NovuProvider';
+export * from './useAgentChat';
 export * from './useChannelConnection';
 export * from './useChannelConnections';
 export * from './useChannelEndpoint';

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,0 +1,63 @@
+import type { NovuError, SendMessageResult } from '@novu/js';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNovu } from './NovuProvider';
+
+export type UseAgentChatProps = {
+  /** Which agent to talk to. Required for uncontrolled (new) conversations. */
+  agentId: string;
+  /** Resume an existing conversation. Omit to start a new one on first send. */
+  conversationId?: string;
+  onError?: (error: NovuError) => void;
+};
+
+export type UseAgentChatResult = {
+  conversationId?: string;
+  error?: NovuError;
+  sendMessage: (text: string) => Promise<{
+    data?: SendMessageResult;
+    error?: NovuError;
+  }>;
+};
+
+export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
+  const { agentId, conversationId: conversationIdProp } = props;
+  const propsRef = useRef(props);
+  propsRef.current = props;
+
+  const novu = useNovu();
+  const [conversationId, setConversationId] = useState<string | undefined>(conversationIdProp);
+  const [error, setError] = useState<NovuError>();
+
+  useEffect(() => {
+    setConversationId(conversationIdProp);
+  }, [conversationIdProp]);
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      const { onError } = propsRef.current;
+      setError(undefined);
+
+      const response = await novu.agentChat.sendMessage({
+        agentId,
+        text,
+        conversationId,
+      });
+
+      if (response.error) {
+        setError(response.error);
+        onError?.(response.error);
+      } else if (response.data) {
+        setConversationId(response.data.conversationId);
+      }
+
+      return response;
+    },
+    [novu, agentId, conversationId]
+  );
+
+  return {
+    sendMessage,
+    conversationId,
+    error,
+  };
+};

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,5 +1,6 @@
-import type { NovuError, SendMessageResult } from '@novu/js';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AgentMessage, NovuError, SendMessageResult } from '@novu/js';
+import { useCallback, useEffect, useState } from 'react';
+import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
 
 export type UseAgentChatProps = {
@@ -11,6 +12,7 @@ export type UseAgentChatProps = {
 };
 
 export type UseAgentChatResult = {
+  messages: AgentMessage[];
   conversationId?: string;
   error?: NovuError;
   sendMessage: (text: string) => Promise<{
@@ -21,41 +23,76 @@ export type UseAgentChatResult = {
 
 export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const { agentId, conversationId: conversationIdProp } = props;
-  const propsRef = useRef(props);
-  propsRef.current = props;
-
+  const propsRef = useDataRef(props);
   const novu = useNovu();
-  const [conversationId, setConversationId] = useState<string | undefined>(conversationIdProp);
+
+  const [adoptedConversationId, setAdoptedConversationId] = useState<string>();
+  const conversationId = conversationIdProp ?? adoptedConversationId;
+  const conversationIdRef = useDataRef(conversationId);
+
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [error, setError] = useState<NovuError>();
 
   useEffect(() => {
-    setConversationId(conversationIdProp);
+    if (conversationIdProp) {
+      setAdoptedConversationId(undefined);
+    }
   }, [conversationIdProp]);
+
+  useEffect(() => {
+    const snapshot = novu.agentChat.getConversation({ agentId, conversationId: conversationIdProp });
+    if (snapshot) {
+      setMessages(snapshot.messages);
+      if (snapshot.conversationId && !conversationIdProp) {
+        setAdoptedConversationId(snapshot.conversationId);
+      }
+    } else {
+      setMessages([]);
+    }
+
+    const cleanup = novu.on('agent_chat.messages.updated', ({ data }) => {
+      if (data.agentId !== agentId) {
+        return;
+      }
+
+      const currentConversationId = conversationIdRef.current;
+      if (currentConversationId && data.conversationId && data.conversationId !== currentConversationId) {
+        return;
+      }
+
+      setMessages(data.messages);
+      if (data.conversationId && !propsRef.current.conversationId) {
+        setAdoptedConversationId(data.conversationId);
+      }
+    });
+
+    return cleanup;
+  }, [novu, agentId, conversationIdProp, conversationIdRef, propsRef]);
 
   const sendMessage = useCallback(
     async (text: string) => {
-      const { onError } = propsRef.current;
       setError(undefined);
 
       const response = await novu.agentChat.sendMessage({
         agentId,
         text,
-        conversationId,
+        conversationId: conversationIdRef.current,
       });
 
       if (response.error) {
         setError(response.error);
-        onError?.(response.error);
-      } else if (response.data) {
-        setConversationId(response.data.conversationId);
+        propsRef.current.onError?.(response.error);
+      } else if (response.data && !propsRef.current.conversationId) {
+        setAdoptedConversationId(response.data.conversationId);
       }
 
       return response;
     },
-    [novu, agentId, conversationId]
+    [novu, agentId, conversationIdRef, propsRef]
   );
 
   return {
+    messages,
     sendMessage,
     conversationId,
     error,

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -99,8 +99,11 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         return;
       }
 
+      // Exact identity: draft (no id) only accepts draft updates; a controlled /
+      // assigned conversation only accepts that conversationId. Prevents same-agent
+      // hooks from painting each other's timelines.
       const currentConversationId = conversationIdRef.current;
-      if (currentConversationId && data.conversationId && data.conversationId !== currentConversationId) {
+      if ((data.conversationId ?? undefined) !== (currentConversationId ?? undefined)) {
         return;
       }
 

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -7,9 +7,9 @@ export type UseAgentChatProps = {
   /** The agent that receives the messages. */
   agentId: string;
   /**
-   * Resume this conversation (loads history on mount) — controlled mode.
-   * Omit for the agent draft (uncontrolled): first send claims a chat; later sends sticky-resume it.
-   * Loading another conversation elsewhere does not steal that draft.
+   * Resume this conversation (loads history on mount).
+   * Omit to start a new chat: the first send creates a conversation; later sends
+   * pass the returned id. Remount or clear this prop to start another new chat.
    */
   conversationId?: string;
   onSuccess?: (data: LoadConversationResult) => void;
@@ -31,14 +31,27 @@ export type UseAgentChatResult = {
   }>;
 };
 
-function subscriptionKey(agentId: string, conversationIdProp?: string): string {
-  return conversationIdProp ? `conv:${conversationIdProp}` : `agent:${agentId}`;
+function createSessionKey(conversationId?: string): string {
+  if (conversationId) {
+    return conversationId;
+  }
+
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `local_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+  }
+
+  return `local_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 }
 
 export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const { agentId, conversationId: conversationIdProp } = props;
   const propsRef = useDataRef(props);
   const novu = useNovu();
+
+  const [sessionKey, setSessionKey] = useState(() => createSessionKey(conversationIdProp));
+  const sessionKeyRef = useDataRef(sessionKey);
+  const prevAgentIdRef = useRef(agentId);
+  const prevConversationIdPropRef = useRef(conversationIdProp);
 
   const [assignedConversationId, setAssignedConversationId] = useState<string>();
   const conversationId = conversationIdProp ?? assignedConversationId;
@@ -51,12 +64,35 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const fetchGenerationRef = useRef(0);
 
   useEffect(() => {
+    const agentChanged = prevAgentIdRef.current !== agentId;
+    const prevConversationIdProp = prevConversationIdPropRef.current;
+    prevAgentIdRef.current = agentId;
+    prevConversationIdPropRef.current = conversationIdProp;
+
+    if (agentChanged) {
+      setAssignedConversationId(undefined);
+      setSessionKey(createSessionKey(conversationIdProp));
+      setMessages([]);
+      setError(undefined);
+      setIsLoading(Boolean(conversationIdProp));
+
+      return;
+    }
+
     if (conversationIdProp) {
       setAssignedConversationId(undefined);
-    } else {
-      setIsLoading(false);
+      setSessionKey(conversationIdProp);
+
+      return;
     }
-  }, [conversationIdProp]);
+
+    setIsLoading(false);
+    if (prevConversationIdProp !== undefined) {
+      setAssignedConversationId(undefined);
+      setSessionKey(createSessionKey());
+      setMessages([]);
+    }
+  }, [agentId, conversationIdProp]);
 
   const fetchConversation = useCallback(
     async (targetConversationId: string) => {
@@ -78,6 +114,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         setError(response.error);
         propsRef.current.onError?.(response.error);
       } else if (response.data) {
+        setMessages(response.data.messages);
         propsRef.current.onSuccess?.(response.data);
       }
 
@@ -88,21 +125,22 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   );
 
   useEffect(() => {
-    const snapshot = novu.agentChat.getConversation({ agentId, conversationId: conversationIdProp });
+    const snapshot = novu.agentChat.getConversation({
+      agentId,
+      key: sessionKey,
+      conversationId: conversationIdProp,
+    });
     if (snapshot) {
       setMessages(snapshot.messages);
       if (snapshot.conversationId && !conversationIdProp) {
         setAssignedConversationId(snapshot.conversationId);
       }
-    } else {
+    } else if (!conversationIdProp) {
       setMessages([]);
     }
 
-    const key = subscriptionKey(agentId, conversationIdProp);
     const cleanup = novu.on('agent_chat.messages.updated', ({ data }) => {
-      // Stable holder key from @novu/js — draft stays `agent:…` after claim, so
-      // the first sending→sent transition is not dropped.
-      if (data.key !== key) {
+      if (data.key !== sessionKeyRef.current) {
         return;
       }
 
@@ -117,7 +155,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     }
 
     return cleanup;
-  }, [novu, agentId, conversationIdProp, conversationIdRef, propsRef, fetchConversation]);
+  }, [novu, agentId, conversationIdProp, sessionKey, sessionKeyRef, conversationIdRef, propsRef, fetchConversation]);
 
   const refetch = useCallback(async () => {
     const id = conversationIdRef.current;
@@ -135,6 +173,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       const response = await novu.agentChat.sendMessage({
         agentId,
         text,
+        key: sessionKeyRef.current,
         conversationId: conversationIdRef.current,
       });
 
@@ -147,7 +186,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
       return response;
     },
-    [novu, agentId, conversationIdRef, propsRef]
+    [novu, agentId, sessionKeyRef, conversationIdRef, propsRef]
   );
 
   return {

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -4,12 +4,11 @@ import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
 
 export type UseAgentChatProps = {
-  /** The agent that receives the messages. */
   agentId: string;
   /**
-   * Resume this conversation (loads history on mount).
-   * Omit to start a new chat: the first send creates a conversation; later sends
-   * pass the returned id. Remount or clear this prop to start another new chat.
+   * Resume this conversation. The hook loads history on mount.
+   * Omit this prop to start a new chat. The first send creates a conversation.
+   * Later sends pass the returned id. Remount or clear this prop to start another chat.
    */
   conversationId?: string;
   onSuccess?: (data: LoadConversationResult) => void;
@@ -20,9 +19,8 @@ export type UseAgentChatResult = {
   messages: AgentMessage[];
   conversationId?: string;
   error?: NovuError;
-  /** True until the first history fetch completes. Always false when no `conversationId` prop is given. */
+  /** True until the first history fetch completes. False when there is no `conversationId` prop. */
   isLoading: boolean;
-  /** True while a history fetch is in progress. */
   isFetching: boolean;
   refetch: () => Promise<void>;
   sendMessage: (text: string) => Promise<{
@@ -51,8 +49,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const propsRef = useDataRef(props);
   const novu = useNovu();
 
-  // Controlled resume uses the prop as key synchronously (no effect lag).
-  // Uncontrolled create sessions keep a local_* key until remount / prop clear / agent change.
+  // Resume: the prop is the key on the same render (no effect lag).
+  // Create: keep a `local_*` key until remount, prop clear, or agent change.
   const [localSessionKey, setLocalSessionKey] = useState(createLocalSessionKey);
   const sessionKey = conversationIdProp ?? localSessionKey;
   const sessionKeyRef = useDataRef(sessionKey);

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,12 +1,16 @@
 import type { AgentMessage, LoadConversationResult, NovuError, SendMessageResult } from '@novu/js';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
 
 export type UseAgentChatProps = {
-  /** Which agent to talk to. Required for uncontrolled (new) conversations. */
+  /** The agent that receives the messages. */
   agentId: string;
-  /** Resume an existing conversation. Omit to start a new one on first send. */
+  /**
+   * Resume this conversation (loads history on mount).
+   * Omit for the agent draft: first send starts a chat; later sends sticky-resume it.
+   * Loading another conversation elsewhere does not steal that draft.
+   */
   conversationId?: string;
   onSuccess?: (data: LoadConversationResult) => void;
   onError?: (error: NovuError) => void;
@@ -16,9 +20,9 @@ export type UseAgentChatResult = {
   messages: AgentMessage[];
   conversationId?: string;
   error?: NovuError;
-  /** True until the first history fetch finishes (only when `conversationId` prop is set). */
+  /** True until the first history fetch completes. Always false when no `conversationId` prop is given. */
   isLoading: boolean;
-  /** True while any history fetch is in flight. */
+  /** True while a history fetch is in progress. */
   isFetching: boolean;
   refetch: () => Promise<void>;
   sendMessage: (text: string) => Promise<{
@@ -32,50 +36,49 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const propsRef = useDataRef(props);
   const novu = useNovu();
 
-  const [adoptedConversationId, setAdoptedConversationId] = useState<string>();
-  const conversationId = conversationIdProp ?? adoptedConversationId;
+  const [assignedConversationId, setAssignedConversationId] = useState<string>();
+  const conversationId = conversationIdProp ?? assignedConversationId;
   const conversationIdRef = useDataRef(conversationId);
 
   const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [error, setError] = useState<NovuError>();
   const [isLoading, setIsLoading] = useState(Boolean(conversationIdProp));
   const [isFetching, setIsFetching] = useState(false);
+  const fetchGenerationRef = useRef(0);
 
   useEffect(() => {
     if (conversationIdProp) {
-      setAdoptedConversationId(undefined);
+      setAssignedConversationId(undefined);
+    } else {
+      setIsLoading(false);
     }
   }, [conversationIdProp]);
 
   const fetchConversation = useCallback(
-    async (targetConversationId: string, options?: { refetch?: boolean }) => {
-      if (options?.refetch) {
-        setError(undefined);
-        setIsLoading(true);
-      }
-
+    async (targetConversationId: string) => {
+      const generation = ++fetchGenerationRef.current;
+      setError(undefined);
+      setIsLoading(true);
       setIsFetching(true);
 
-      try {
-        const response = await novu.agentChat.loadConversation({
-          agentId,
-          conversationId: targetConversationId,
-        });
+      const response = await novu.agentChat.loadConversation({
+        agentId,
+        conversationId: targetConversationId,
+      });
 
-        if (response.error) {
-          setError(response.error);
-          propsRef.current.onError?.(response.error);
-        } else if (response.data) {
-          propsRef.current.onSuccess?.(response.data);
-        }
-      } catch (err) {
-        const novuError = err as NovuError;
-        setError(novuError);
-        propsRef.current.onError?.(novuError);
-      } finally {
-        setIsLoading(false);
-        setIsFetching(false);
+      if (generation !== fetchGenerationRef.current) {
+        return;
       }
+
+      if (response.error) {
+        setError(response.error);
+        propsRef.current.onError?.(response.error);
+      } else if (response.data) {
+        propsRef.current.onSuccess?.(response.data);
+      }
+
+      setIsLoading(false);
+      setIsFetching(false);
     },
     [novu, agentId, propsRef]
   );
@@ -85,7 +88,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     if (snapshot) {
       setMessages(snapshot.messages);
       if (snapshot.conversationId && !conversationIdProp) {
-        setAdoptedConversationId(snapshot.conversationId);
+        setAssignedConversationId(snapshot.conversationId);
       }
     } else {
       setMessages([]);
@@ -103,14 +106,12 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
       setMessages(data.messages);
       if (data.conversationId && !propsRef.current.conversationId) {
-        setAdoptedConversationId(data.conversationId);
+        setAssignedConversationId(data.conversationId);
       }
     });
 
     if (conversationIdProp) {
-      void fetchConversation(conversationIdProp, { refetch: true });
-    } else {
-      setIsLoading(false);
+      void fetchConversation(conversationIdProp);
     }
 
     return cleanup;
@@ -122,7 +123,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       return;
     }
 
-    await fetchConversation(id, { refetch: true });
+    await fetchConversation(id);
   }, [conversationIdRef, fetchConversation]);
 
   const sendMessage = useCallback(
@@ -139,7 +140,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         setError(response.error);
         propsRef.current.onError?.(response.error);
       } else if (response.data && !propsRef.current.conversationId) {
-        setAdoptedConversationId(response.data.conversationId);
+        setAssignedConversationId(response.data.conversationId);
       }
 
       return response;

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -7,8 +7,8 @@ export type UseAgentChatProps = {
   /** The agent that receives the messages. */
   agentId: string;
   /**
-   * Resume this conversation (loads history on mount).
-   * Omit for the agent draft: first send starts a chat; later sends sticky-resume it.
+   * Resume this conversation (loads history on mount) — controlled mode.
+   * Omit for the agent draft (uncontrolled): first send claims a chat; later sends sticky-resume it.
    * Loading another conversation elsewhere does not steal that draft.
    */
   conversationId?: string;
@@ -30,6 +30,10 @@ export type UseAgentChatResult = {
     error?: NovuError;
   }>;
 };
+
+function subscriptionKey(agentId: string, conversationIdProp?: string): string {
+  return conversationIdProp ? `conv:${conversationIdProp}` : `agent:${agentId}`;
+}
 
 export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const { agentId, conversationId: conversationIdProp } = props;
@@ -94,16 +98,11 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setMessages([]);
     }
 
+    const key = subscriptionKey(agentId, conversationIdProp);
     const cleanup = novu.on('agent_chat.messages.updated', ({ data }) => {
-      if (data.agentId !== agentId) {
-        return;
-      }
-
-      // Exact identity: draft (no id) only accepts draft updates; a controlled /
-      // assigned conversation only accepts that conversationId. Prevents same-agent
-      // hooks from painting each other's timelines.
-      const currentConversationId = conversationIdRef.current;
-      if ((data.conversationId ?? undefined) !== (currentConversationId ?? undefined)) {
+      // Stable holder key from @novu/js — draft stays `agent:…` after claim, so
+      // the first sending→sent transition is not dropped.
+      if (data.key !== key) {
         return;
       }
 

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -31,16 +31,19 @@ export type UseAgentChatResult = {
   }>;
 };
 
-function createSessionKey(conversationId?: string): string {
-  if (conversationId) {
-    return conversationId;
-  }
-
+function createLocalSessionKey(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return `local_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
   }
 
-  return `local_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(6);
+    crypto.getRandomValues(bytes);
+
+    return `local_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+  }
+
+  return `local_${Date.now().toString(36)}`;
 }
 
 export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
@@ -48,7 +51,10 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const propsRef = useDataRef(props);
   const novu = useNovu();
 
-  const [sessionKey, setSessionKey] = useState(() => createSessionKey(conversationIdProp));
+  // Controlled resume uses the prop as key synchronously (no effect lag).
+  // Uncontrolled create sessions keep a local_* key until remount / prop clear / agent change.
+  const [localSessionKey, setLocalSessionKey] = useState(createLocalSessionKey);
+  const sessionKey = conversationIdProp ?? localSessionKey;
   const sessionKeyRef = useDataRef(sessionKey);
   const prevAgentIdRef = useRef(agentId);
   const prevConversationIdPropRef = useRef(conversationIdProp);
@@ -71,7 +77,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
     if (agentChanged) {
       setAssignedConversationId(undefined);
-      setSessionKey(createSessionKey(conversationIdProp));
+      setLocalSessionKey(createLocalSessionKey());
       setMessages([]);
       setError(undefined);
       setIsLoading(Boolean(conversationIdProp));
@@ -81,7 +87,6 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
     if (conversationIdProp) {
       setAssignedConversationId(undefined);
-      setSessionKey(conversationIdProp);
 
       return;
     }
@@ -89,7 +94,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     setIsLoading(false);
     if (prevConversationIdProp !== undefined) {
       setAssignedConversationId(undefined);
-      setSessionKey(createSessionKey());
+      setLocalSessionKey(createLocalSessionKey());
       setMessages([]);
     }
   }, [agentId, conversationIdProp]);

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, NovuError, SendMessageResult } from '@novu/js';
+import type { AgentMessage, LoadConversationResult, NovuError, SendMessageResult } from '@novu/js';
 import { useCallback, useEffect, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
@@ -8,6 +8,7 @@ export type UseAgentChatProps = {
   agentId: string;
   /** Resume an existing conversation. Omit to start a new one on first send. */
   conversationId?: string;
+  onSuccess?: (data: LoadConversationResult) => void;
   onError?: (error: NovuError) => void;
 };
 
@@ -15,6 +16,11 @@ export type UseAgentChatResult = {
   messages: AgentMessage[];
   conversationId?: string;
   error?: NovuError;
+  /** True until the first history fetch finishes (only when `conversationId` prop is set). */
+  isLoading: boolean;
+  /** True while any history fetch is in flight. */
+  isFetching: boolean;
+  refetch: () => Promise<void>;
   sendMessage: (text: string) => Promise<{
     data?: SendMessageResult;
     error?: NovuError;
@@ -32,12 +38,47 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
   const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [error, setError] = useState<NovuError>();
+  const [isLoading, setIsLoading] = useState(Boolean(conversationIdProp));
+  const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
     if (conversationIdProp) {
       setAdoptedConversationId(undefined);
     }
   }, [conversationIdProp]);
+
+  const fetchConversation = useCallback(
+    async (targetConversationId: string, options?: { refetch?: boolean }) => {
+      if (options?.refetch) {
+        setError(undefined);
+        setIsLoading(true);
+      }
+
+      setIsFetching(true);
+
+      try {
+        const response = await novu.agentChat.loadConversation({
+          agentId,
+          conversationId: targetConversationId,
+        });
+
+        if (response.error) {
+          setError(response.error);
+          propsRef.current.onError?.(response.error);
+        } else if (response.data) {
+          propsRef.current.onSuccess?.(response.data);
+        }
+      } catch (err) {
+        const novuError = err as NovuError;
+        setError(novuError);
+        propsRef.current.onError?.(novuError);
+      } finally {
+        setIsLoading(false);
+        setIsFetching(false);
+      }
+    },
+    [novu, agentId, propsRef]
+  );
 
   useEffect(() => {
     const snapshot = novu.agentChat.getConversation({ agentId, conversationId: conversationIdProp });
@@ -66,8 +107,23 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       }
     });
 
+    if (conversationIdProp) {
+      void fetchConversation(conversationIdProp, { refetch: true });
+    } else {
+      setIsLoading(false);
+    }
+
     return cleanup;
-  }, [novu, agentId, conversationIdProp, conversationIdRef, propsRef]);
+  }, [novu, agentId, conversationIdProp, conversationIdRef, propsRef, fetchConversation]);
+
+  const refetch = useCallback(async () => {
+    const id = conversationIdRef.current;
+    if (!id) {
+      return;
+    }
+
+    await fetchConversation(id, { refetch: true });
+  }, [conversationIdRef, fetchConversation]);
 
   const sendMessage = useCallback(
     async (text: string) => {
@@ -96,5 +152,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     sendMessage,
     conversationId,
     error,
+    isLoading,
+    isFetching,
+    refetch,
   };
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -65,6 +65,8 @@ export {
   TelegramConnectButton,
 } from './components';
 export type {
+  UseAgentChatProps,
+  UseAgentChatResult,
   UseChannelConnectionProps,
   UseChannelConnectionResult,
   UseChannelConnectionsProps,
@@ -85,6 +87,7 @@ export type {
   UseTelegramSubscriberLinkResult,
 } from './hooks';
 export {
+  useAgentChat,
   useChannelConnection,
   useChannelConnections,
   useChannelEndpoint,

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -1,6 +1,8 @@
 import type { InboxProps } from '../components/Inbox';
 import { ShadowRootDetector } from '../components/ShadowRootDetector';
 import type {
+  UseAgentChatProps,
+  UseAgentChatResult,
   UseCreateSubscriptionProps,
   UseCreateSubscriptionResult,
   UseNotificationsProps,
@@ -73,6 +75,16 @@ export function TelegramConnectButton() {
 
 export function useNovu() {
   return null;
+}
+
+export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
+  return {
+    messages: [],
+    isLoading: false,
+    isFetching: false,
+    refetch: () => Promise.resolve(),
+    sendMessage: () => Promise.resolve({ data: undefined, error: undefined }),
+  };
 }
 
 export function useCounts(_: UseCountsProps): UseCountsResult {
@@ -191,6 +203,8 @@ export type {
 export type { BellProps, InboxContentProps, InboxProps, NotificationProps, NovuProviderProps } from '../components';
 
 export type {
+  UseAgentChatProps,
+  UseAgentChatResult,
   UseCountsProps,
   UseCountsResult,
   UseNotificationsProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,13 +467,13 @@ importers:
         version: 8.1.6
       '@sentry/nestjs':
         specifier: ^10.63.0
-        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@sentry/node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@sentry/profiling-node':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))
       '@slack/types':
         specifier: 2.20.1
         version: 2.20.1
@@ -593,7 +593,7 @@ importers:
         version: 3.3.8
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1449,7 +1449,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1642,7 +1642,7 @@ importers:
         version: 11.5.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -1833,7 +1833,7 @@ importers:
         version: 4.18.1
       nest-raven:
         specifier: 10.1.0
-        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0)
       newrelic:
         specifier: 13.19.2
         version: 13.19.2
@@ -3697,6 +3697,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
+      '@novu/agent-event-protocol':
+        specifier: workspace:*
+        version: link:../agent-event-protocol
       '@types/jest':
         specifier: ^29.2.3
         version: 29.5.2
@@ -31719,33 +31722,33 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))':
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7)
 
-  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/sso@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(12c00ccae77465cd3d8531352eae4aee))(better-call@1.3.7(zod@4.3.5))':
@@ -31774,9 +31777,9 @@ snapshots:
       tldts: 6.1.86
       zod: 4.3.6
 
-  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -36054,7 +36057,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.39.0
-    optional: true
 
   '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -36556,15 +36558,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.214.0
-      import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -36700,9 +36693,8 @@ snapshots:
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.39.0
-    optional: true
 
   '@opentelemetry/sdk-logs@0.201.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -36801,8 +36793,8 @@ snapshots:
   '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
@@ -39998,20 +39990,6 @@ snapshots:
     dependencies:
       '@sentry/core': 10.63.0
 
-  '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
-    dependencies:
-      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.27)(@nestjs/websockets@11.1.27)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.63.0
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
-
   '@sentry/nestjs@10.63.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -40037,19 +40015,6 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-
-  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.63.0
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      import-in-the-middle: 3.0.1
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
 
   '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
@@ -40087,23 +40052,6 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.63.0
-      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.63.0
-      import-in-the-middle: 3.0.1
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
-
   '@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -40129,14 +40077,6 @@ snapshots:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
 
-  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.0)
-      '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.63.0
-
   '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -40144,16 +40084,6 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
-
-  '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))':
-    dependencies:
-      '@sentry/core': 10.63.0
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-      '@sentry/node-cpu-profiler': 2.4.2
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - supports-color
 
   '@sentry/profiling-node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -45470,13 +45400,13 @@ snapshots:
 
   better-auth@1.6.23(12c00ccae77465cd3d8531352eae4aee):
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1052.0)(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7))
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.1.1
@@ -53376,25 +53306,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
-    dependencies:
-      '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
-      rxjs: 7.8.2
-    optionalDependencies:
-      '@nestjs/graphql': 12.0.9(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(ts-morph@24.0.0)
-    transitivePeerDependencies:
-      - '@apollo/subgraph'
-      - '@nestjs/core'
-      - bufferutil
-      - class-transformer
-      - class-validator
-      - graphql
-      - reflect-metadata
-      - ts-morph
-      - utf-8-validate
-
-  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+  nest-raven@10.1.0(@nestjs/common@11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.27)(@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)))(class-transformer@0.5.1)(class-validator@0.15.1)(graphql@16.9.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(ts-morph@24.0.0):
     dependencies:
       '@nestjs/common': 11.1.27(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@sentry/node': 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1))


### PR DESCRIPTION
## Summary
- Add headless `useAgentChat` in `@novu/react` backed by `novu.agentChat` in `@novu/js`, with optimistic send, conversation adoption, and history load via `GET .../events`.
- Server polish for open/resume: required `message.role`, POST returns `{ identifier, messageId }`, newest history page by default, DB-filtered event activity listing, and list-conversations aligned to shared cursor pagination helpers.
- Keep `@novu/js` store seams small: stable conversation holders, `absorbHistoryPage` fold/merge, agent-draft sticky resume that `loadConversation` does not steal; defer `afterSequence` / client `olderCursor` until socket gap-fill / `fetchMore`.

## Test plan
- [ ] Unit: `packages/js` agent-chat + agent-chat-service tests; `packages/agent-event-protocol` apply-envelope specs
- [ ] Unit: `packages/chat-adapter-web` adapter POST returns `messageId`
- [ ] E2E: `apps/api` web-chat conversation + agent-events-ingest (role-less / user-role rejected; newest page + `before` pagination)
- [ ] Manual: mount `useAgentChat({ agentId })`, send twice (sticky resume), remount paints local cache
- [ ] Manual: mount `useAgentChat({ agentId, conversationId })`, history paints with user + assistant turns, uncontrolled draft remains separate

Linear: https://linear.app/novu/issue/NV-8445/headless-useagentchat-novujs-novureact

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds headless agent chat support across the JavaScript and React SDKs and aligns web-chat creation, history, and event contracts across the API.
- Adds optimistic sends, stable conversation holders, history folding, and React hook subscriptions.
- Adds web-chat resume and newest-first history pagination with durable user and assistant message events.
- Returns server message identifiers consistently through the web adapter and API.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because changing agents can route a send into an untracked holder, dropping visible updates and potentially splitting subsequent messages across conversations.

The stale-key fix handles controlled conversation changes, but an agent change still resets the local key only after render; a send in that interval causes the SDK to mint a hidden replacement holder that the hook does not subscribe to.

**Files Needing Attention:** packages/react/src/hooks/useAgentChat.ts and packages/js/src/agent-chat/agent-chat.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/agent-chat/agent-chat.ts | Adds optimistic send and holder resolution, but stale keys during an agent transition can be replaced with an untracked holder key. |
| packages/js/src/agent-chat/agent-chat-store.ts | Adds stable in-memory holders, serialized first-conversation creation, optimistic status transitions, and history merging. |
| packages/react/src/hooks/useAgentChat.ts | Adds the headless React hook and key-scoped subscriptions; agent key reset timing still permits dropped updates. |
| apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts | Changes durable history loading to newest-page retrieval with backward cursor pagination. |
| libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts | Adds database-filtered activity retrieval supporting ordered web-chat event history. |
| packages/agent-event-protocol/src/apply-envelope.ts | Extends message folding to distinguish user and assistant roles for reconstructed chat history. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Hook as useAgentChat
    participant SDK as AgentChat
    participant Store as AgentChatStore
    participant API as Web Chat API
    Hook->>SDK: sendMessage(agentId, key, conversationId)
    SDK->>Store: resolve holder + append optimistic message
    Store-->>Hook: messages.updated(holder key)
    SDK->>API: POST message
    API-->>SDK: identifier + messageId
    SDK->>Store: claim conversation + mark sent
    Store-->>Hook: messages.updated(holder key)
    Hook->>SDK: loadConversation(identifier)
    SDK->>API: GET newest events page
    API-->>SDK: events + olderCursor
    SDK->>Store: absorb history page
    Store-->>Hook: merged messages
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fjs%2Fsrc%2Fagent-chat%2Fagent-chat.ts%3A153-159%0A**Replacement%20holder%20drops%20updates**%0A%0AWhen%20an%20uncontrolled%20hook%20changes%20%60agentId%60%20and%20sends%20before%20the%20effect%20resets%20its%20local%20session%20key%2C%20this%20branch%20replaces%20the%20previous%20agent's%20holder%20with%20a%20newly%20keyed%20holder%20that%20is%20not%20communicated%20to%20the%20hook.%20The%20hook%20remains%20subscribed%20to%20the%20old%20key%2C%20so%20it%20drops%20the%20optimistic%20and%20sent%20updates%2C%20and%20additional%20sends%20during%20the%20transition%20can%20create%20separate%20server%20conversations.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/js/src/agent-chat/agent-chat.ts:153-159
**Replacement holder drops updates**

When an uncontrolled hook changes `agentId` and sends before the effect resets its local session key, this branch replaces the previous agent's holder with a newly keyed holder that is not communicated to the hook. The hook remains subscribed to the old key, so it drops the optimistic and sent updates, and additional sends during the transition can create separate server conversations.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["docs(js,react): trim agent-chat comments..."](https://github.com/novuhq/novu/commit/c0b5de412a0333ab319d74986fd19e7c988567cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51116918)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)
- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)

<!-- /greptile_comment -->