### PR TITLE
chore(worker): fix socket-worker local wrangler env fixes NV-8561

### DIFF
--- a/enterprise/workers/socket/.dev.vars.example
+++ b/enterprise/workers/socket/.dev.vars.example
@@ -1,0 +1,8 @@
+# Copy to .dev.vars (gitignored), then fill from your local API env:
+#   cp .dev.vars.example .dev.vars
+#
+# JWT_SECRET       = apps/api/src/.env → JWT_SECRET
+# INTERNAL_API_KEY = apps/api/src/.env → INTERNAL_SERVICES_API_KEY
+
+JWT_SECRET=
+INTERNAL_API_KEY=

--- a/enterprise/workers/socket/README.md
+++ b/enterprise/workers/socket/README.md
@@ -1,0 +1,38 @@
+# @novu/socket-worker
+
+Cloudflare Worker + Durable Object for Novu Cloud WebSockets (PartySocket).
+
+## Local development
+
+This package is standalone (not in the pnpm workspace). From this directory:
+
+```bash
+npm install
+cp .dev.vars.example .dev.vars
+# Fill JWT_SECRET and INTERNAL_API_KEY from apps/api/src/.env
+# (INTERNAL_API_KEY must match INTERNAL_SERVICES_API_KEY)
+npm run dev
+```
+
+`npm run dev` runs `wrangler dev --env local` (usually `http://127.0.0.1:8787`).
+
+Local `thalamus-observer` uses **8788** so both workers can run at once; keep socket on 8787.
+
+`.dev.vars` is gitignored. The `local` wrangler env sets `API_URL` to `http://127.0.0.1:3000`.
+
+### Wire API / worker / playground
+
+In `apps/api/src/.env` and `apps/worker/src/.env`:
+
+```env
+SOCKET_WORKER_URL=http://127.0.0.1:8787
+```
+
+Keep `NOVU_ENTERPRISE=true` and the same `INTERNAL_SERVICES_API_KEY` as `.dev.vars` `INTERNAL_API_KEY`. Locally, Cloudflare sockets are the realtime path.
+
+Playground (`playground/agent-chat`):
+
+```env
+NEXT_PUBLIC_NOVU_SOCKET_URL=http://127.0.0.1:8787
+NEXT_PUBLIC_NOVU_SOCKET_TYPE=cloud
+```

--- a/enterprise/workers/socket/package.json
+++ b/enterprise/workers/socket/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",
-    "dev": "wrangler dev",
-    "start": "wrangler dev",
+    "dev": "wrangler dev --env local",
+    "start": "wrangler dev --env local",
     "cf-typegen": "wrangler types",
     "deploy:staging": "wrangler deploy --env staging",
     "deploy:production-us": "wrangler deploy --env production-us",

--- a/enterprise/workers/socket/wrangler.jsonc
+++ b/enterprise/workers/socket/wrangler.jsonc
@@ -29,8 +29,8 @@
         ]
       },
       "vars": {
-        "NODE_ENV": "staging",
-        "API_URL": "https://fa3f-46-117-110-24.ngrok-free.app",
+        "NODE_ENV": "development",
+        "API_URL": "http://127.0.0.1:3000",
         "REGION": "global"
       }
     },


### PR DESCRIPTION
## Summary
- Point the socket worker `local` wrangler env at `http://127.0.0.1:3000` with `NODE_ENV=development` (removes a stale ngrok URL).
- Run `dev`/`start` with `--env local`.
- Add README + `.dev.vars.example` for local Cloud socket development alongside the API (port 8787).

Companion: #12273 (thalamus-observer on 8788).

## Test plan
- [ ] From `enterprise/workers/socket`: `cp .dev.vars.example .dev.vars`, fill secrets from `apps/api/src/.env`, run `npm install && npm run dev`
- [ ] Confirm worker listens on `http://127.0.0.1:8787`
- [ ] With API `SOCKET_WORKER_URL=http://127.0.0.1:8787`, verify a local inbox/agent-chat socket connects

Linear: https://linear.app/novu/issue/NV-8561

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the standalone socket worker's local Wrangler environment and documents running it alongside the API. The secret-file instructions do not match the newly environment-qualified Wrangler command.
- Runs `dev` and `start` with the `local` Wrangler environment.
- Replaces the stale ngrok API endpoint with `127.0.0.1:3000` and sets development mode.
- Adds local setup documentation and a secret-variable template.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the local Wrangler command and documented secret filename agree, because the advertised development flow cannot authenticate sockets or internal sends.

Selecting the `local` Wrangler environment while creating only `.dev.vars` leaves both required authentication secrets unavailable on the changed development path.

**Files Needing Attention:** enterprise/workers/socket/package.json, enterprise/workers/socket/README.md, enterprise/workers/socket/.dev.vars.example

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| enterprise/workers/socket/package.json | The environment-qualified development scripts conflict with the documented `.dev.vars` secret filename, leaving required secrets unloaded. |
| enterprise/workers/socket/README.md | The local setup is clear, but it instructs developers to create the wrong Wrangler secret file for `--env local`. |
| enterprise/workers/socket/.dev.vars.example | The template contains the required secret names, but its documented destination does not match environment-specific loading. |
| enterprise/workers/socket/wrangler.jsonc | The local environment now consistently targets the development API on port 3000 and retains its Durable Object binding. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aenterprise%2Fworkers%2Fsocket%2Fpackage.json%3A7-8%0A**Local%20secrets%20are%20not%20loaded**%0A%0AWhen%20a%20developer%20follows%20the%20README%20and%20runs%20%60npm%20run%20dev%60%20or%20%60npm%20start%60%2C%20%60--env%20local%60%20makes%20Wrangler%20use%20the%20environment-specific%20secret%20file%20while%20the%20instructions%20create%20%60.dev.vars%60.%20This%20leaves%20%60JWT_SECRET%60%20and%20%60INTERNAL_API_KEY%60%20unavailable%2C%20causing%20WebSocket%20authentication%20to%20return%20401%20and%20authenticated%20%60%2Fsend%60%20requests%20to%20return%20a%20500%20configuration%20error.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12272&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
enterprise/workers/socket/package.json:7-8
**Local secrets are not loaded**

When a developer follows the README and runs `npm run dev` or `npm start`, `--env local` makes Wrangler use the environment-specific secret file while the instructions create `.dev.vars`. This leaves `JWT_SECRET` and `INTERNAL_API_KEY` unavailable, causing WebSocket authentication to return 401 and authenticated `/send` requests to return a 500 configuration error.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): fix socket-worker local w..."](https://github.com/novuhq/novu/commit/ad5f564903d1f5f54ca511f7b1cab98c1e6dd345) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51153465)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Enterprise module (`enterprise/`)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/enterprise-module.md)

<!-- /greptile_comment -->