### PR TITLE
chore(worker): run thalamus-observer locally on 8788 fixes NV-8562

### DIFF
--- a/enterprise/workers/thalamus-observer/README.md
+++ b/enterprise/workers/thalamus-observer/README.md
@@ -19,6 +19,14 @@ npm install
 npm run dev
 ```
 
+`npm run dev` listens on **`http://127.0.0.1:8788`** (local wrangler env `dev.port`, not the Wrangler default 8787). That leaves **8787** free for `@novu/socket-worker`.
+
+Point the API at it:
+
+```env
+THALAMUS_CF_URL=http://127.0.0.1:8788
+```
+
 Optional `.dev.vars` for local secrets (never commit):
 
 ```bash

--- a/enterprise/workers/thalamus-observer/package.json
+++ b/enterprise/workers/thalamus-observer/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "wrangler dev --env local",
-    "start": "wrangler dev --env local",
+    "dev": "wrangler dev --env local --port 8788",
+    "start": "wrangler dev --env local --port 8788",
     "deploy": "wrangler deploy",
     "deploy:local": "wrangler deploy --env local",
     "deploy:staging": "wrangler deploy --env staging",

--- a/enterprise/workers/thalamus-observer/wrangler.jsonc
+++ b/enterprise/workers/thalamus-observer/wrangler.jsonc
@@ -22,6 +22,10 @@
     "local": {
       "name": "thalamus-observer-local",
       "workers_dev": true,
+      // Keep local thalamus off 8787 so @novu/socket-worker can own that port.
+      "dev": {
+        "port": 8788
+      },
       "durable_objects": {
         "bindings": [
           {


### PR DESCRIPTION
## Summary
- Bind thalamus-observer local wrangler env to port **8788** so `@novu/socket-worker` can keep **8787**.
- Document `THALAMUS_CF_URL=http://127.0.0.1:8788` in the README.

Companion: #12272 (socket-worker local env + README).

## Test plan
- [ ] From `enterprise/workers/thalamus-observer`: `npm run dev` listens on `http://127.0.0.1:8788`
- [ ] Start socket worker on 8787 at the same time without a port conflict
- [ ] With `THALAMUS_CF_URL=http://127.0.0.1:8788` in the API env, confirm thalamus traffic reaches the local worker

Linear: https://linear.app/novu/issue/NV-8562

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves local thalamus-observer development from Wrangler’s default port 8787 to 8788, leaving 8787 available for the socket worker.
- Configures both `dev` and `start` scripts to use port 8788.
- Adds the matching local-environment port to `wrangler.jsonc`.
- Documents the API’s local `THALAMUS_CF_URL` setting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the scripts, Wrangler configuration, and documentation consistently using port 8788.

The local development commands and environment configuration resolve to the same supported Wrangler port, while staging and production deployment paths remain unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| enterprise/workers/thalamus-observer/README.md | Documents the new local endpoint and the API environment variable needed to reach it. |
| enterprise/workers/thalamus-observer/package.json | Explicitly runs the local Wrangler development server on port 8788. |
| enterprise/workers/thalamus-observer/wrangler.jsonc | Sets the local Wrangler environment’s development port to 8788 without affecting deployed environments. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): run thalamus-observer loc..."](https://github.com/novuhq/novu/commit/5b09ea9f2120c6ff331e81dd615bbda57e13ed02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51153474)</sub>

<!-- /greptile_comment -->