### PR TITLE
chore(release): bump version to 3.19.0 across all packages

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/api-service",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@novu/dashboard",
   "private": true,
-  "version": "3.18.5",
+  "version": "3.19.0",
   "type": "module",
   "portless": {
     "name": "dashboard.novu"

--- a/apps/inbound-mail/package.json
+++ b/apps/inbound-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/inbound-mail",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/worker",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/ws",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "description": "",
   "author": "",
   "private": true,

--- a/libs/application-generic/package.json
+++ b/libs/application-generic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/application-generic",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Generic backend code used inside of Novu's different services",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/libs/internal-sdk/.speakeasy/gen.yaml
+++ b/libs/internal-sdk/.speakeasy/gen.yaml
@@ -49,7 +49,7 @@ postman:
   outputModelSuffix: output
   packageName: novu/api
 typescript:
-  version: 3.18.2
+  version: 3.19.0
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/libs/internal-sdk/jsr.json
+++ b/libs/internal-sdk/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@novu/api",
-  "version": "3.18.2",
+  "version": "3.19.0",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/libs/internal-sdk/package.json
+++ b/libs/internal-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/api",
-  "version": "3.18.2",
+  "version": "3.19.0",
   "author": "Novu",
   "main": "./index.js",
   "sideEffects": false,

--- a/libs/internal-sdk/src/lib/config.ts
+++ b/libs/internal-sdk/src/lib/config.ts
@@ -65,8 +65,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 
 export const SDK_METADATA = {
   language: "typescript",
-  openapiDocVersion: "3.18.0",
-  sdkVersion: "3.18.2",
+  openapiDocVersion: "3.19.0",
+  sdkVersion: "3.19.0",
   genVersion: "2.918.1",
-  userAgent: "speakeasy-sdk/typescript 3.18.2 2.918.1 3.18.0 @novu/api",
+  userAgent: "speakeasy-sdk/typescript 3.19.0 2.918.1 3.19.0 @novu/api",
 } as const;


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns service, shared-library, and generated internal SDK release metadata on version 3.19.0.
- Bumps five service applications, the dashboard, and `application-generic`.
- Synchronizes the internal SDK’s npm, JSR, Speakeasy, OpenAPI, and user-agent version metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the changed release metadata is internally consistent and no reachable failure was identified.

The service version changes are metadata-only, workspace dependencies continue resolving through local links, and all generated internal SDK version fields move together to 3.19.0.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/package.json | Bumps the API service version to 3.19.0, which also supplies the OpenAPI document and self-hosted release versions. |
| libs/internal-sdk/.speakeasy/gen.yaml | Updates the generated TypeScript SDK version input to 3.19.0. |
| libs/internal-sdk/package.json | Aligns the npm package version with the generated SDK release. |
| libs/internal-sdk/jsr.json | Aligns the JSR package version with the npm and generator metadata. |
| libs/internal-sdk/src/lib/config.ts | Consistently updates generated SDK, OpenAPI, and request user-agent metadata to 3.19.0. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to 3.19.0 a..."](https://github.com/novuhq/novu/commit/f35710b2a65fd72d859406097a4b64b609f8f548) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51166815)</sub>

<!-- /greptile_comment -->