### PR TITLE
refactor(dal): migrate AiChatRepository to BaseRepositoryV2

### DIFF
--- a/libs/dal/src/repositories/ai-chat/ai-chat.repository.ts
+++ b/libs/dal/src/repositories/ai-chat/ai-chat.repository.ts
@@ -1,11 +1,11 @@
 import { AiResourceTypeEnum } from '@novu/shared';
 import type { ClientSession } from 'mongoose';
 import type { EnforceEnvOrOrgIds } from '../../types';
-import { BaseRepository } from '../base-repository';
+import { BaseRepositoryV2 } from '../base-repository-v2';
 import { AiChatDBModel, AiChatEntity, AiChatSnapshotRef } from './ai-chat.entity';
 import { AiChat } from './ai-chat.schema';
 
-export class AiChatRepository extends BaseRepository<AiChatDBModel, AiChatEntity, EnforceEnvOrOrgIds> {
+export class AiChatRepository extends BaseRepositoryV2<AiChatDBModel, AiChatEntity, EnforceEnvOrOrgIds> {
   constructor() {
     super(AiChat, AiChatEntity);
   }
@@ -25,7 +25,7 @@ export class AiChatRepository extends BaseRepository<AiChatDBModel, AiChatEntity
         resourceType,
         resourceId,
       },
-      undefined,
+      '*',
       { sort: { updatedAt: -1 }, limit: 1 }
     );
 


### PR DESCRIPTION
## What type of PR is this?
- [x] Refactor / Technical Debt

## Description
Migrated `AiChatRepository` from the legacy `BaseRepository` class to `BaseRepositoryV2`.

### Changes Made:
- Updated `AiChatRepository` inheritance and imports to use `BaseRepositoryV2`.
- Updated the projection argument in `findLatestByResource` from `undefined` to explicit `'*'` to align with `BaseRepositoryV2` query overloads.

## How Has This Been Tested?
- Successfully compiled `@novu/shared` (`pnpm --filter @novu/shared build`).
- Successfully built `@novu/dal` (`pnpm --filter @novu/dal build`) with zero TypeScript compilation errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates `AiChatRepository` to `BaseRepositoryV2` and supplies the required all-fields projection for its latest-chat query.
- Replaces the deprecated base repository inheritance.
- Preserves tenant enforcement and existing query sorting.
- Uses `'*'` to retain full-entity reads under the V2 projection contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The updated repository preserves tenant-scoped query behavior, full-field selection, sort order, write semantics, and session handling under BaseRepositoryV2.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/dal/src/repositories/ai-chat/ai-chat.repository.ts | The repository migration conforms to the V2 projection API, with no reachable compatibility defect identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refractor(dal): migrate AiChatRepository..."](https://github.com/novuhq/novu/commit/6ca8d9e941d42c14235c00f579f9f9806e9f7f21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51468556)</sub>

**Context used:**

- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)

<!-- /greptile_comment -->