### PR TITLE
feat(shared): expose SES configurationSetName in Integration Store form fixes NV-8558

### DIFF
--- a/libs/application-generic/src/dtos/credentials.dto.ts
+++ b/libs/application-generic/src/dtos/credentials.dto.ts
@@ -158,6 +158,11 @@ export class CredentialsDto implements ICredentials {
   @ApiPropertyOptional()
   @IsString()
   @IsOptional()
+  configurationSetName?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
   apiKeyRequestHeader?: string;
 
   @ApiPropertyOptional()

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -56,6 +56,7 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       redirectUrl: Schema.Types.String,
       hmac: Schema.Types.Boolean,
       ipPoolName: Schema.Types.String,
+      configurationSetName: Schema.Types.String,
       apiKeyRequestHeader: Schema.Types.String,
       secretKeyRequestHeader: Schema.Types.String,
       idPath: Schema.Types.String,

--- a/packages/providers/src/lib/email/ses/ses.provider.spec.ts
+++ b/packages/providers/src/lib/email/ses/ses.provider.spec.ts
@@ -1,7 +1,14 @@
 import { SESv2Client } from '@aws-sdk/client-sesv2';
 import { EmailEventStatusEnum } from '@novu/stateless';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { SESEmailProvider } from './ses.provider';
+
+// Restore spies between tests so each `vi.spyOn(SESv2Client.prototype, 'send')` starts with a
+// fresh call history. Without this, repeated spyOn calls share one accumulating mock and
+// `spy.mock.calls[0]` leaks the first test's invocation into every later test.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // Stub sns-validator so URL/structure tests don't perform real HTTPS cert downloads.
 // Tests assert the URL was either rejected before reaching the validator (Invalid AWS
@@ -187,6 +194,32 @@ test('should trigger ses library correctly with _passthrough', async () => {
   expect(spy).toHaveBeenCalled();
   expect(emailContent.includes('Subject: test subject _passthrough')).toBe(true);
   expect(response.id).toEqual('<mock-message-id@email.amazonses.com>');
+});
+
+test('should apply ConfigurationSetName when configurationSetName is set', async () => {
+  const mockResponse = { MessageId: 'mock-message-id' };
+  const spy = vi.spyOn(SESv2Client.prototype, 'send').mockImplementation(async () => {
+    return mockResponse as any;
+  });
+
+  const provider = new SESEmailProvider({ ...mockConfig, configurationSetName: 'my-config-set' });
+  await provider.sendMessage(mockNovuMessage);
+
+  expect(spy).toHaveBeenCalled();
+  expect(spy.mock.calls[0][0].input['ConfigurationSetName']).toEqual('my-config-set');
+});
+
+test('should not set ConfigurationSetName when configurationSetName is absent', async () => {
+  const mockResponse = { MessageId: 'mock-message-id' };
+  const spy = vi.spyOn(SESv2Client.prototype, 'send').mockImplementation(async () => {
+    return mockResponse as any;
+  });
+
+  const provider = new SESEmailProvider(mockConfig);
+  await provider.sendMessage(mockNovuMessage);
+
+  expect(spy).toHaveBeenCalled();
+  expect(spy.mock.calls[0][0].input['ConfigurationSetName']).toBeUndefined();
 });
 
 describe('getMessageId', () => {

--- a/packages/shared/src/consts/providers/configurations/provider-configuration.ts
+++ b/packages/shared/src/consts/providers/configurations/provider-configuration.ts
@@ -106,12 +106,6 @@ const sesConfigurations: ConfigConfiguration[] = [
       },
     ],
   },
-  {
-    key: 'configurationSetName',
-    displayName: 'Configuration Set Name',
-    type: 'string',
-    required: false,
-  },
 ];
 
 export const pushConfigurations: ConfigConfiguration[] = [

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -324,6 +324,13 @@ export const sesConfig: IConfigCredential[] = [
     type: 'string',
     required: true,
   },
+  {
+    key: CredentialsKeyEnum.ConfigurationSetName,
+    displayName: 'Configuration Set Name',
+    description: 'The name of the SES Configuration Set to apply to sent emails',
+    type: 'string',
+    required: false,
+  },
   ...mailConfigBase,
 ];
 

--- a/packages/shared/src/entities/integration/credential.interface.ts
+++ b/packages/shared/src/entities/integration/credential.interface.ts
@@ -26,6 +26,8 @@ export interface ICredentials {
   redirectUrl?: string;
   hmac?: boolean;
   ipPoolName?: string;
+  /** Amazon SES: name of the Configuration Set applied to sent emails. */
+  configurationSetName?: string;
   apiKeyRequestHeader?: string;
   secretKeyRequestHeader?: string;
   idPath?: string;

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -28,6 +28,7 @@ export enum CredentialsKeyEnum {
   RedirectUrl = 'redirectUrl',
   Hmac = 'hmac',
   IpPoolName = 'ipPoolName',
+  ConfigurationSetName = 'configurationSetName',
   ApiKeyRequestHeader = 'apiKeyRequestHeader',
   SecretKeyRequestHeader = 'secretKeyRequestHeader',
   IdPath = 'idPath',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What & why

The Amazon SES email provider already reads `this.config.configurationSetName` and applies it to sends (`ses: { ConfigurationSetName }`), but there was no discoverable way to set it from the dashboard. The value could only be set by passing an `X-SES-CONFIGURATION-SET` header per message, editing the credentials document directly, or via a **buried** field nested inside the SES *Email Activity Tracking* configuration group (gated behind the `inboundWebhookEnabled` switch).

This PR surfaces **Configuration Set Name** as a first-class, always-visible optional field in the SES credentials form. The dashboard renders it automatically from the schema.

### Changes

- **`packages/shared`**
  - Add `ConfigurationSetName = 'configurationSetName'` to `CredentialsKeyEnum`.
  - Add an optional `Configuration Set Name` entry to `sesConfig` (the SES credentials schema wired into the Integration Store form via `channels/email.ts`).
  - Add `configurationSetName?: string` to `ICredentials`.
  - Remove the duplicate `configurationSetName` entry from the buried `sesConfigurations` (Activity Tracking) group so there is a single input rather than two conflicting ones. `IConfigurations.configurationSetName` is retained for backward-compatible reads of previously-saved values (the send-path merges `{ ...credentials, ...configurations }`).
- **`libs/application-generic`** — add `configurationSetName` to `CredentialsDto` so the API accepts and persists it (not added to `secureCredentials`; it is not a secret).
- **`libs/dal`** — add `configurationSetName` to the integration `credentials` sub-schema so Mongoose persists it.
- **`packages/providers`** — add unit tests asserting the provider applies `ConfigurationSetName` to the SES command when set (and omits it otherwise), and fix a pre-existing spy-isolation bug in the SES spec (`vi.spyOn` re-attached to an already-spied `send`, so `spy.mock.calls[0]` leaked the first test's call into later tests). Restoring mocks between tests repairs 3 previously-failing tests.

### Testing

- `packages/providers` SES spec: **22/22 passing** (was 17/20 before the isolation fix; the 3 broken tests now pass alongside the 2 new coverage tests).
- Type-checks: `@novu/shared`, `@novu/providers`, `@novu/application-generic`, and `@novu/dal` all build cleanly.
- No live UI walkthrough: Docker cannot start in this sandbox (iptables NAT permission denied), so the full app stack / dashboard could not be brought up. The field is schema-driven and rendered automatically from `sesConfig`, verified via the provider registry wiring (`sesConfig` → `channels/email.ts` → dashboard).

### Distribution safety

Purely additive schema/credential change; no gating needed. Community, Cloud, and self-hosted all render the same form from the shared schema.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8558](https://linear.app/novu/issue/NV-8558/ses-provider-reads-configurationsetname-but-the-integration-store-ui)

<div><a href="https://cursor.com/agents/bc-12371bda-3981-4a76-9c98-f6039afa40f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12371bda-3981-4a76-9c98-f6039afa40f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exposes Amazon SES Configuration Set Name as an optional first-class credential and carries it through API validation, persistence, and shared typing. It also adds provider coverage and isolates SES test spies, but legacy values are not mapped into the new field.

- Adds `configurationSetName` to the SES credential schema, DTO, interface, enum, and Mongoose integration schema.
- Removes the duplicate field from the SES activity-tracking configuration group.
- Adds SES command tests for present and absent configuration-set names.
- Restores spies after each SES provider test.

<h3>Confidence Score: 4/5</h3>

The legacy SES configuration-set compatibility issue should be fixed before merging because existing integrations cannot reliably view or update their effective value through the new field.

Existing values remain in configurations while the replacement input reads credentials, and the provider merge allows the hidden legacy value to override a newly saved credential value.

**Files Needing Attention:** packages/shared/src/consts/providers/configurations/provider-configuration.ts and packages/shared/src/consts/providers/credentials/provider-credentials.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/consts/providers/configurations/provider-configuration.ts | Removes the legacy SES configuration input without mapping existing persisted values to the replacement credential field. |
| packages/shared/src/consts/providers/credentials/provider-credentials.ts | Adds the optional first-class SES Configuration Set Name credential input. |
| libs/application-generic/src/dtos/credentials.dto.ts | Allows the API credential DTO to accept the optional string value. |
| libs/dal/src/repositories/integration/integration.schema.ts | Adds Mongoose persistence for configurationSetName under integration credentials. |
| packages/providers/src/lib/email/ses/ses.provider.spec.ts | Adds configuration-set payload coverage and correctly restores per-test spies. |
| packages/shared/src/entities/integration/credential.interface.ts | Extends the shared credentials interface with the optional SES field. |
| packages/shared/src/types/providers.ts | Adds the credential key enum member used by the schema-driven form. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Legacy["Existing integration\nconfigurations.configurationSetName"] --> FormConfig["Dashboard configurations state\nfield no longer rendered"]
  StoredCredentials["integration.credentials"] --> FormCredentials["New credentials input"]
  FormCredentials --> SavedCredentials["credentials.configurationSetName"]
  FormConfig --> SavedConfigurations["legacy configurations.configurationSetName"]
  SavedCredentials --> Merge["Provider config merge"]
  SavedConfigurations -->|higher precedence| Merge
  Merge --> SES["SES ConfigurationSetName"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fshared%2Fsrc%2Fconsts%2Fproviders%2Fconfigurations%2Fprovider-configuration.ts%3A109%0A**Legacy%20configuration%20overrides%20new%20field**%0A%0AIf%20an%20existing%20SES%20integration%20stores%20%60configurationSetName%60%20under%20%60configurations%60%2C%20removing%20this%20field%20from%20the%20configuration%20schema%20leaves%20the%20new%20credentials%20input%20blank%20while%20the%20provider%20merge%20still%20gives%20the%20hidden%20legacy%20value%20precedence.%20Entering%20a%20replacement%20through%20the%20new%20field%20therefore%20does%20not%20change%20the%20effective%20SES%20configuration%20set%2C%20and%20saving%20the%20form%20can%20remove%20the%20legacy%20value.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12285&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/shared/src/consts/providers/configurations/provider-configuration.ts:109
**Legacy configuration overrides new field**

If an existing SES integration stores `configurationSetName` under `configurations`, removing this field from the configuration schema leaves the new credentials input blank while the provider merge still gives the hidden legacy value precedence. Entering a replacement through the new field therefore does not change the effective SES configuration set, and saving the form can remove the legacy value.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(providers): cover SES configuration..."](https://github.com/novuhq/novu/commit/d6ea0bbb3c693377cb63e5cdb91689d4730c4946) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51577456)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)
- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)
- Knowledge Base — [Providers package](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/providers-package.md)
</details>

<!-- /greptile_comment -->