### PR TITLE
chore(docker): update service images to version 3.19.0 in docker-compose.yml

### DIFF
--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       start_period: 20s
 
   api:
-    image: "ghcr.io/novuhq/novu/api:3.18.0"
+    image: "ghcr.io/novuhq/novu/api:3.19.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -109,7 +109,7 @@ services:
       start_period: 40s
 
   worker:
-    image: "ghcr.io/novuhq/novu/worker:3.18.0"
+    image: "ghcr.io/novuhq/novu/worker:3.19.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -162,7 +162,7 @@ services:
       start_period: 20s
 
   ws:
-    image: "ghcr.io/novuhq/novu/ws:3.18.0"
+    image: "ghcr.io/novuhq/novu/ws:3.19.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -203,7 +203,7 @@ services:
       start_period: 40s
 
   dashboard:
-    image: "ghcr.io/novuhq/novu/dashboard:3.18.0"
+    image: "ghcr.io/novuhq/novu/dashboard:3.19.0"
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
…

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the community Docker Compose stack from Novu 3.18.0 to 3.19.0.
- Advances the API, worker, WebSocket, and dashboard container image tags together.
- Leaves service configuration, dependencies, and health checks unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the coordinated image-version update introduces no identified blocking or non-blocking defect.

The four related services remain version-aligned, and the repository’s release configuration supports publishing each service under the selected version.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/community/docker-compose.yml | Consistently updates all four first-party service image tags to version 3.19.0 with no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docker): update service images to ..."](https://github.com/novuhq/novu/commit/444edccc0af543e57378bd0f1a9cd729057b10e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51738191)</sub>

<!-- /greptile_comment -->