### PR TITLE
feat(js,react,api): wire agent-chat live WS, status, fetchMore, approvals fixes NV-8445

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -92,6 +92,7 @@ import { WebChatEnabledGuard } from './shared/web-chat-enabled.guard';
 import { USE_CASES } from './usecases';
 import { WebChatController } from './web-chat/web-chat.controller';
 import { WebChatEventFactory } from './web-chat/web-chat-event.factory';
+import { WebChatLiveActivityPublisher } from './web-chat/web-chat-live-activity.publisher';
 import { WebChatPlatformDeliveryService } from './web-chat/web-chat-platform-delivery.service';
 import { WebChatPublicationService } from './web-chat/web-chat-publication.service';
 import { WebChatResumeAuthorizationService } from './web-chat/web-chat-resume-authorization.service';
@@ -176,6 +177,7 @@ import { WebChatSessionVerifier } from './web-chat/web-chat-session.verifier';
     WebChatResumeAuthorizationService,
     WebChatEventFactory,
     WebChatPlatformDeliveryService,
+    WebChatLiveActivityPublisher,
     OutboundDeliveryInfo,
     McpNovuAppCredentialsService,
     DemoClaudeQuotaPolicy,

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
@@ -72,12 +72,14 @@ describe('AgentConversationService', () => {
     conversationRepository: ConversationRepository,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     activityRepository: any = makeActivityRepository(),
-    eventSequenceService = makeEventSequenceService()
+    eventSequenceService = makeEventSequenceService(),
+    webChatLiveActivityPublisher = { emit: sinon.stub().resolves(undefined) }
   ) {
     return new AgentConversationService(
       conversationRepository,
       activityRepository as any,
       eventSequenceService,
+      webChatLiveActivityPublisher as any,
       makeLogger() as any
     );
   }
@@ -132,6 +134,7 @@ describe('AgentConversationService', () => {
         conversationRepository,
         activityRepository as any,
         makeEventSequenceService(),
+        { emit: sinon.stub().resolves(undefined) } as any,
         logger as any
       );
 
@@ -224,6 +227,7 @@ describe('AgentConversationService', () => {
       conversationRepository,
       {} as any,
       makeEventSequenceService(),
+      { emit: sinon.stub().resolves(undefined) } as any,
       makeLogger() as any
     );
 
@@ -256,6 +260,7 @@ describe('AgentConversationService', () => {
       conversationRepository,
       {} as any,
       makeEventSequenceService(),
+      { emit: sinon.stub().resolves(undefined) } as any,
       makeLogger() as any
     );
 
@@ -284,6 +289,7 @@ describe('AgentConversationService', () => {
       conversationRepository,
       {} as any,
       makeEventSequenceService(),
+      { emit: sinon.stub().resolves(undefined) } as any,
       makeLogger() as any
     );
 

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -14,6 +14,9 @@ import {
   isDuplicateKeyError,
 } from '@novu/dal';
 import type { TriggerRecipientsPayload } from '@novu/shared';
+import { usesProtocolEventApprovals } from '../../shared/enums/agent-platform.enum';
+import { mintApprovalActionIds } from '../../shared/tool-approval/mint-approval-action-ids';
+import { WebChatLiveActivityPublisher } from '../../web-chat/web-chat-live-activity.publisher';
 import { ConversationEventSequenceService } from './conversation-event-sequence.service';
 
 export const INBOUND_ATTACHMENT_ONLY_PREVIEW = '[Attachment]';
@@ -129,6 +132,9 @@ export interface PersistToolApprovalRequestParams extends ConversationActivityCo
   input?: Record<string, unknown>;
   /** Human-readable preview for the display timeline. */
   preview?: string;
+  /** When omitted, self-hosted `tool-approval:*` ids are minted. */
+  approveActionId?: string;
+  denyActionId?: string;
 }
 
 export type MetadataOp =
@@ -177,6 +183,7 @@ export class AgentConversationService {
     private readonly conversationRepository: ConversationRepository,
     private readonly activityRepository: ConversationActivityRepository,
     private readonly eventSequenceService: ConversationEventSequenceService,
+    private readonly webChatLiveActivityPublisher: WebChatLiveActivityPublisher,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -530,8 +537,12 @@ export class AgentConversationService {
       params.environmentId,
       params.organizationId
     );
+    const actionIds =
+      params.approveActionId && params.denyActionId
+        ? { approveActionId: params.approveActionId, denyActionId: params.denyActionId }
+        : mintApprovalActionIds({ approvalId: params.approvalId });
 
-    return this.activityRepository.createToolActivity({
+    const activity = await this.activityRepository.createToolActivity({
       identifier: `act_${shortId(12)}`,
       conversationId: params.conversationId,
       platform: params.channel.platform,
@@ -546,11 +557,17 @@ export class AgentConversationService {
         toolCallId: params.toolCallId,
         toolName: params.toolName,
         input: params.input,
+        approveActionId: actionIds.approveActionId,
+        denyActionId: actionIds.denyActionId,
       },
       sequence,
       environmentId: params.environmentId,
       organizationId: params.organizationId,
     });
+
+    await this.emitProtocolEventActivity(params, activity);
+
+    return activity;
   }
 
   /** Links a delivered approval card message to its ledger row (for platform edits). */
@@ -709,7 +726,7 @@ export class AgentConversationService {
    * message list from history via `toModelMessages`, so the decision must live in
    * the transcript — not only in the ephemeral approval card.
    */
-  async persistToolApprovalDecision(params: PersistToolApprovalDecisionParams): Promise<void> {
+  async persistToolApprovalDecision(params: PersistToolApprovalDecisionParams): Promise<ConversationActivityEntity> {
     const toolName = params.toolName ?? 'tool call';
     const sequence = await this.resolveEventSequence(
       params.conversationId,
@@ -717,7 +734,7 @@ export class AgentConversationService {
       params.organizationId
     );
 
-    await this.activityRepository.createToolActivity({
+    const activity = await this.activityRepository.createToolActivity({
       identifier: `act_${shortId(12)}`,
       conversationId: params.conversationId,
       platform: params.channel.platform,
@@ -732,6 +749,10 @@ export class AgentConversationService {
       environmentId: params.environmentId,
       organizationId: params.organizationId,
     });
+
+    await this.emitProtocolEventActivity(params, activity);
+
+    return activity;
   }
 
   async persistToolResult(params: PersistToolResultParams): Promise<void> {
@@ -741,7 +762,7 @@ export class AgentConversationService {
       params.organizationId
     );
 
-    await this.activityRepository.createToolActivity({
+    const activity = await this.activityRepository.createToolActivity({
       identifier: `act_${shortId(12)}`,
       conversationId: params.conversationId,
       platform: params.channel.platform,
@@ -755,6 +776,31 @@ export class AgentConversationService {
       sequence,
       environmentId: params.environmentId,
       organizationId: params.organizationId,
+    });
+
+    await this.emitProtocolEventActivity(params, activity);
+  }
+
+  private async emitProtocolEventActivity(
+    params: ConversationActivityContext,
+    activity: ConversationActivityEntity
+  ): Promise<void> {
+    if (!usesProtocolEventApprovals(params.channel.platform)) {
+      return;
+    }
+
+    const conversation = await this.getConversation(params.conversationId, params.environmentId, params.organizationId);
+    if (!conversation) {
+      return;
+    }
+
+    await this.webChatLiveActivityPublisher.emit({
+      agentId: conversation._agentId,
+      agentIdentifier: params.agentIdentifier,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+      conversation,
+      activity,
     });
   }
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -84,6 +84,7 @@ describe('AgentInboundHandler', () => {
       setFirstPlatformMessageId: sinon.stub().resolves(undefined),
       findByPlatformThread: sinon.stub().resolves(conversation),
       getHistory: sinon.stub().resolves(overrides.history ?? []),
+      persistToolApprovalDecision: sinon.stub().resolves({ _id: 'decision-1' }),
       findSourceActivity: sinon
         .stub()
         .callsFake(

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -1154,14 +1154,6 @@ export class AgentInboundHandler implements OnModuleInit {
       return;
     }
 
-    const actorType =
-      participantType === ConversationParticipantTypeEnum.SUBSCRIBER
-        ? ConversationActivitySenderTypeEnum.SUBSCRIBER
-        : ConversationActivitySenderTypeEnum.PLATFORM_USER;
-    await this.recordApprovalVerdict(conversation, config, action, actorType, participantId);
-
-    // Everything else (incl. mcp-approval:* for managed) routes through the runtime,
-    // which owns its own action semantics.
     const [subscriber, agent] = await Promise.all([
       subscriberId
         ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
@@ -1173,6 +1165,14 @@ export class AgentInboundHandler implements OnModuleInit {
       ]),
     ]);
 
+    const actorType =
+      participantType === ConversationParticipantTypeEnum.SUBSCRIBER
+        ? ConversationActivitySenderTypeEnum.SUBSCRIBER
+        : ConversationActivitySenderTypeEnum.PLATFORM_USER;
+    await this.recordApprovalVerdict(conversation, config, action, actorType, participantId);
+
+    // Everything else (incl. mcp-approval:* for managed) routes through the runtime,
+    // which owns its own action semantics.
     const context = await this.connectionContextResolver.resolve(config, rawEvent, userId);
 
     const runtime = this.runtimeResolver.resolve(agent);

--- a/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -20,7 +20,11 @@ import type {
 } from '../../../shared/dtos/agent-reply-payload.dto';
 import { isValidMetadataSignalKey } from '../../../shared/dtos/agent-reply-payload.dto';
 import { AgentEventEnum } from '../../../shared/enums/agent-event.enum';
-import { AgentPlatformEnum, usesReplyBasedApprovals } from '../../../shared/enums/agent-platform.enum';
+import {
+  AgentPlatformEnum,
+  usesProtocolEventApprovals,
+  usesReplyBasedApprovals,
+} from '../../../shared/enums/agent-platform.enum';
 import { adaptApprovalContentForReplyBasedPlatform } from '../../../shared/tool-approval/reply-based-approval';
 import {
   buildSelfHostedApprovalCard,
@@ -159,6 +163,13 @@ export class HandleAgentReply {
 
     let replyInfo: SentMessageInfo | undefined;
     if (command.reply) {
+      const skipProtocolPortableApprovalCard =
+        usesProtocolEventApprovals(channel.platform) &&
+        !!command.toolApprovalRequest &&
+        !!command.reply.toolApprovalCard &&
+        command.reply.markdown === undefined &&
+        command.reply.card === undefined;
+
       // System-generated replies (e.g. runtime error notices) are always
       // delivered but never count an active conversation, and they bypass the
       // free-tier gate so an error message is never swallowed by a 402.
@@ -174,7 +185,9 @@ export class HandleAgentReply {
         });
       }
 
-      replyInfo = await this.deliverMessage(command, conversation, channel, command.reply, agentName);
+      if (!skipProtocolPortableApprovalCard) {
+        replyInfo = await this.deliverMessage(command, conversation, channel, command.reply, agentName);
+      }
 
       if (toolApprovalActivityId && replyInfo) {
         await this.linkToolApprovalRequestCard(command, conversation, toolApprovalActivityId, replyInfo.messageId);
@@ -565,6 +578,8 @@ export class HandleAgentReply {
         toolCallId: request.toolCallId,
         toolName: request.name,
         input: request.input,
+        approveActionId: request.approveActionId,
+        denyActionId: request.denyActionId,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
       });

--- a/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
@@ -120,9 +120,8 @@ export class ManagedRuntime implements AgentRuntime {
    * have no bridge onAction to forward to, and link buttons are handled in ingress).
    */
   private async handleAction(turn: ConversationTurn): Promise<void> {
-    const toolApproval = parseToolApprovalActionId(turn.action?.id);
-
-    if (!toolApproval) {
+    const parsed = parseToolApprovalActionId(turn.action?.id);
+    if (!parsed) {
       return;
     }
 
@@ -137,7 +136,7 @@ export class ManagedRuntime implements AgentRuntime {
         agentId: turn.agentId,
         subscriberId: turn.subscriber?.subscriberId ?? undefined,
         platform: turn.config.platform,
-        parsed: toolApproval,
+        parsed,
         sourceMessageId: turn.action?.sourceMessageId,
         platformThreadId: turn.platformThreadId,
         actionValue: turn.action?.value,

--- a/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-approval/handle-pending-tool-approvals.usecase.ts
@@ -8,8 +8,9 @@ import { HandleAgentReplyCommand } from '../../conversation-runtime/reply/handle
 import { HandleAgentReply } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
 import { HandlePlanProgressCommand } from '../../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.command';
 import { HandlePlanProgress } from '../../conversation-runtime/reply/handle-plan-progress/handle-plan-progress.usecase';
-import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { AgentPlatformEnum, usesProtocolEventApprovals } from '../../shared/enums/agent-platform.enum';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
+import { managedApprovalGrammar, mintApprovalActionIds } from '../../shared/tool-approval/mint-approval-action-ids';
 import { ManagedAgentService } from '../managed-agent.service';
 import { ManagedAgentProviderFactory } from '../managed-agent-provider-factory.service';
 import { HandleNovuResolveCommand } from '../novu-resolve/handle-novu-resolve.command';
@@ -404,9 +405,16 @@ export class HandlePendingToolApprovals {
     command: HandlePendingToolApprovalsCommand,
     tool: PendingToolApproval
   ): Promise<void> {
-    const delivery = buildManagedApprovalCard({
-      platform: command.platform,
-      tool,
+    const skipPortableCard = usesProtocolEventApprovals(command.platform);
+    const delivery = skipPortableCard
+      ? null
+      : buildManagedApprovalCard({
+          platform: command.platform,
+          tool,
+        });
+    const actionIds = mintApprovalActionIds({
+      approvalId: tool.toolUseId,
+      grammar: managedApprovalGrammar(tool.mcpServerName),
     });
 
     try {
@@ -418,21 +426,27 @@ export class HandlePendingToolApprovals {
           conversationId: command.conversationId,
           agentIdentifier: command.agentIdentifier,
           integrationIdentifier: command.integrationIdentifier,
-          reply: delivery.content,
-          slackNative: delivery.slackNative,
+          ...(delivery ? { reply: delivery.content, slackNative: delivery.slackNative } : {}),
           toolApprovalRequest: {
             approvalId: tool.toolUseId,
             toolCallId: tool.toolUseId,
             name: tool.toolName,
             input: tool.input,
+            approveActionId: actionIds.approveActionId,
+            denyActionId: actionIds.denyActionId,
           },
         })
       );
     } catch (err) {
-      this.logger.error(err, `Failed to deliver tool-approval card for session ${command.sessionId}`);
+      this.logger.error(
+        err,
+        skipPortableCard
+          ? `Failed to ledger tool-approval request for session ${command.sessionId}`
+          : `Failed to deliver tool-approval card for session ${command.sessionId}`
+      );
       captureAgentException(err, {
         component: 'handle-pending-tool-approvals',
-        operation: 'deliver-tool-approval-card',
+        operation: skipPortableCard ? 'ledger-tool-approval-request' : 'deliver-tool-approval-card',
         sessionId: command.sessionId,
       });
 

--- a/apps/api/src/app/agents/shared/agent-event-sink.service.ts
+++ b/apps/api/src/app/agents/shared/agent-event-sink.service.ts
@@ -24,7 +24,7 @@ import {
   toReplyContent,
   toThalamusUsage,
 } from './agent-event-mappers';
-import { AgentPlatformEnum } from './enums/agent-platform.enum';
+import { AgentPlatformEnum, usesProtocolEventApprovals } from './enums/agent-platform.enum';
 import { captureAgentException } from './errors/capture-agent-sentry';
 import { McpConnectionErrorHandler } from './mcp-connection-error.handler';
 
@@ -220,7 +220,10 @@ export class AgentEventSink {
     };
 
     try {
-      const shouldDeliverCard = autoDeliverCard && !context.suppressReply;
+      const shouldDeliverCard =
+        autoDeliverCard &&
+        !context.suppressReply &&
+        !(context.platform && usesProtocolEventApprovals(context.platform));
 
       await this.handleAgentReply.execute(
         HandleAgentReplyCommand.create({

--- a/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-reply-payload.dto.ts
@@ -384,6 +384,22 @@ export class ToolApprovalRequestPayloadDto {
   @IsOptional()
   @IsObject()
   input?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description: 'Server-minted approve action id. When omitted, self-hosted tool-approval:* is minted at persist.',
+    example: 'tool-approval:approve:apr_01HZX',
+  })
+  @IsOptional()
+  @IsString()
+  approveActionId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Server-minted deny action id. When omitted, self-hosted tool-approval:* is minted at persist.',
+    example: 'tool-approval:deny:apr_01HZX',
+  })
+  @IsOptional()
+  @IsString()
+  denyActionId?: string;
 }
 
 @ApiExtraModels(MarkdownReplyContentDto, CardReplyContentDto, ToolApprovalCardReplyContentDto, FileRefDto)

--- a/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/shared/enums/agent-platform.enum.ts
@@ -69,3 +69,8 @@ export function requiresShortConnectUrl(platform: string): boolean {
 export function usesReplyBasedApprovals(platform: string): boolean {
   return !resolvePlatformEgressCapabilities(platform).interactiveButtons;
 }
+
+/** Platforms that surface tool approvals via agent-event protocol instead of portable cards. */
+export function usesProtocolEventApprovals(platform: string): boolean {
+  return platform === AgentPlatformEnum.WEB_CHAT;
+}

--- a/apps/api/src/app/agents/shared/tool-approval/mint-approval-action-ids.ts
+++ b/apps/api/src/app/agents/shared/tool-approval/mint-approval-action-ids.ts
@@ -1,0 +1,45 @@
+import { buildApprovalActionId } from '@novu/framework/internal';
+import {
+  buildToolApprovalActionId,
+  DIRECT_TOOL_APPROVAL_ACTION_PREFIX,
+  MCP_TOOL_APPROVAL_ACTION_PREFIX,
+  type ToolApprovalActionPrefix,
+} from './action-id';
+
+export type ApprovalActionIdGrammar = { kind: 'self-hosted' } | { kind: 'managed'; prefix: ToolApprovalActionPrefix };
+
+export type MintedApprovalActionIds = {
+  approveActionId: string;
+  denyActionId: string;
+};
+
+/**
+ * Mint the same action-id grammar Slack/Teams cards already put on buttons.
+ * Self-hosted: `tool-approval:{approve|deny}:{approvalId}`
+ * Managed: `mcp-approval|direct-approval:{approve|deny}:{toolUseId}` (approvalId === toolUseId).
+ */
+export function mintApprovalActionIds(params: {
+  approvalId: string;
+  grammar?: ApprovalActionIdGrammar;
+}): MintedApprovalActionIds {
+  const grammar = params.grammar ?? { kind: 'self-hosted' };
+
+  if (grammar.kind === 'managed') {
+    return {
+      approveActionId: buildToolApprovalActionId(grammar.prefix, 'approve', params.approvalId),
+      denyActionId: buildToolApprovalActionId(grammar.prefix, 'deny', params.approvalId),
+    };
+  }
+
+  return {
+    approveActionId: buildApprovalActionId('approve', params.approvalId),
+    denyActionId: buildApprovalActionId('deny', params.approvalId),
+  };
+}
+
+export function managedApprovalGrammar(mcpServerName: string | undefined): ApprovalActionIdGrammar {
+  return {
+    kind: 'managed',
+    prefix: mcpServerName !== undefined ? MCP_TOOL_APPROVAL_ACTION_PREFIX : DIRECT_TOOL_APPROVAL_ACTION_PREFIX,
+  };
+}

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -11,6 +11,7 @@ import {
   ConversationActivityTypeEnum,
   type ConversationEventActivityFilter,
 } from '@novu/dal';
+import { mintApprovalActionIds } from '../shared/tool-approval/mint-approval-action-ids';
 
 /**
  * Which durable activities the web-chat history surface exposes as events.
@@ -65,12 +66,19 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
         return null;
       }
 
+      const actionIds =
+        toolData.approveActionId && toolData.denyActionId
+          ? { approveActionId: toolData.approveActionId, denyActionId: toolData.denyActionId }
+          : mintApprovalActionIds({ approvalId: toolData.approvalId });
+
       return {
         type: 'tool-approval-request',
         approvalId: toolData.approvalId,
         toolUseId: toolData.toolCallId,
         toolName: toolData.toolName,
         input: toolData.input,
+        approveActionId: actionIds.approveActionId,
+        denyActionId: actionIds.denyActionId,
       };
     }
 
@@ -160,6 +168,22 @@ function toMappableActivity(
   }
 
   return { activity, event, sequence: activity.sequence };
+}
+
+/**
+ * Build a live WS envelope from a freshly persisted activity row.
+ * Returns null when the activity type is not mappable or lacks a sequence.
+ */
+export function buildLiveEnvelopeFromActivity(
+  activity: ConversationActivityEntity,
+  context: EventMapContext
+): AgentEventEnvelope | null {
+  const mappable = toMappableActivity(activity);
+  if (!mappable) {
+    return null;
+  }
+
+  return buildEnvelope(mappable.activity, mappable.event, mappable.sequence, context);
 }
 
 /**

--- a/apps/api/src/app/agents/web-chat/web-chat-live-activity.publisher.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-live-activity.publisher.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
+import { PinoLogger, WebSocketsQueueService } from '@novu/application-generic';
+import {
+  ConversationActivityEntity,
+  ConversationEntity,
+  ConversationParticipantTypeEnum,
+  SubscriberRepository,
+} from '@novu/dal';
+import { WebSocketEventEnum } from '@novu/shared';
+import { buildLiveEnvelopeFromActivity } from './activity-to-events';
+
+export type WebChatLiveActivityEmitParams = {
+  agentId: string;
+  agentIdentifier: string;
+  environmentId: string;
+  organizationId: string;
+  conversation: ConversationEntity;
+  activity: ConversationActivityEntity;
+};
+
+/**
+ * Emits durable web-chat activities on live WS from the persist seam only.
+ * Keeps TOOL_APPROVAL_REQUEST/DECISION/RESULT ordering aligned with history.
+ */
+@Injectable()
+export class WebChatLiveActivityPublisher {
+  constructor(
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly webSocketsQueueService: WebSocketsQueueService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async emit(params: WebChatLiveActivityEmitParams): Promise<void> {
+    const envelope = buildLiveEnvelopeFromActivity(params.activity, {
+      conversationId: params.conversation._id,
+      conversationIdentifier: params.conversation.identifier,
+      agentIdentifier: params.agentIdentifier,
+    });
+    if (!envelope) {
+      return;
+    }
+
+    await this.emitBestEffort(params, envelope);
+  }
+
+  private async emitBestEffort(params: WebChatLiveActivityEmitParams, envelope: AgentEventEnvelope): Promise<void> {
+    try {
+      const subscriberExternalId = params.conversation.participants.find(
+        (participant) => participant.type === ConversationParticipantTypeEnum.SUBSCRIBER
+      )?.id;
+
+      if (!subscriberExternalId) {
+        this.logger.warn(
+          { conversationId: params.conversation._id, agentId: params.agentId },
+          'web chat live emit skipped: no subscriber participant'
+        );
+
+        return;
+      }
+
+      const subscriber = await this.subscriberRepository.findBySubscriberId(params.environmentId, subscriberExternalId);
+
+      if (!subscriber) {
+        this.logger.warn(
+          { subscriberExternalId, environmentId: params.environmentId },
+          'web chat live emit skipped: subscriber entity not found'
+        );
+
+        return;
+      }
+
+      await this.webSocketsQueueService.add({
+        name: 'sendMessage',
+        data: {
+          event: WebSocketEventEnum.AGENT_EVENT,
+          userId: subscriber._id,
+          _environmentId: params.environmentId,
+          _organizationId: params.organizationId,
+          subscriberId: subscriber.subscriberId,
+          payload: envelope as unknown as Record<string, unknown>,
+          contextKeys: [],
+        },
+        groupId: params.organizationId,
+      });
+    } catch (err) {
+      this.logger.warn(
+        { err, conversationId: params.conversation._id, sequence: envelope.sequence },
+        'web chat live WS enqueue failed'
+      );
+    }
+  }
+}

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.entity.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.entity.ts
@@ -49,6 +49,10 @@ export interface ConversationActivityToolData {
   approved?: boolean;
   /** Executed tool output, or the `execution-denied` marker (result). */
   output?: unknown;
+  /** Server-minted action id for approve (request). Echoed by headless / card UIs. */
+  approveActionId?: string;
+  /** Server-minted action id for deny (request). Echoed by headless / card UIs. */
+  denyActionId?: string;
 }
 
 export class ConversationActivityEntity {

--- a/packages/agent-event-protocol/src/agent-event.types.ts
+++ b/packages/agent-event-protocol/src/agent-event.types.ts
@@ -18,6 +18,12 @@ export interface AgentApprovalRequest {
   toolName: string;
   input?: Record<string, unknown>;
   source?: AgentToolSource;
+  /**
+   * Server-minted platform action ids for headless / card UIs to echo back.
+   * Clients must not invent these — grammars differ across runtimes.
+   */
+  approveActionId?: string;
+  denyActionId?: string;
 }
 
 export type AgentSignal =

--- a/packages/agent-event-protocol/src/agent-message.types.ts
+++ b/packages/agent-event-protocol/src/agent-message.types.ts
@@ -41,6 +41,10 @@ export type AgentApprovalPart = {
   input?: Record<string, unknown>;
   source?: AgentToolSource;
   state: AgentApprovalPartState;
+  /** Server-minted; echo via respondToApproval. Do not invent client-side. */
+  approveActionId?: string;
+  /** Server-minted; echo via respondToApproval. Do not invent client-side. */
+  denyActionId?: string;
 };
 
 export type AgentSourcePart = {

--- a/packages/agent-event-protocol/src/apply-envelope.ts
+++ b/packages/agent-event-protocol/src/apply-envelope.ts
@@ -131,6 +131,8 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
             toolName: event.toolName,
             input: event.input,
             source: event.source,
+            approveActionId: event.approveActionId,
+            denyActionId: event.denyActionId,
             state: 'pending',
           },
         ],

--- a/packages/chat-adapter-web/src/adapter.spec.ts
+++ b/packages/chat-adapter-web/src/adapter.spec.ts
@@ -218,20 +218,20 @@ describe('NovuWebChatAdapterImpl', () => {
     });
   });
 
-  it('returns 400 when actionId is missing conversationIdentifier or sourceMessageId', async () => {
+  it('returns 400 when actionId is missing conversationIdentifier or non-approval sourceMessageId', async () => {
     const { adapter, processAction } = await createAdapter(createConfig({ authorizeResume: async () => true }));
 
     const missingConv = await adapter.handleWebhook(
       jsonRequest({
         agentId: 'a',
-        actionId: 'tool-approval:approve:tc1',
+        actionId: 'some-button-id',
         sourceMessageId: 'act_card0000001',
       })
     );
     const missingSource = await adapter.handleWebhook(
       jsonRequest({
         agentId: 'a',
-        actionId: 'tool-approval:approve:tc1',
+        actionId: 'some-button-id',
         conversationIdentifier: 'conv_abcdefghijkl',
       })
     );
@@ -239,6 +239,28 @@ describe('NovuWebChatAdapterImpl', () => {
     expect(missingConv.status).toBe(400);
     expect(missingSource.status).toBe(400);
     expect(processAction).not.toHaveBeenCalled();
+  });
+
+  it('dispatches approval actionId without sourceMessageId', async () => {
+    const { adapter, processAction } = await createAdapter(createConfig({ authorizeResume: async () => true }));
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({
+        agentId: 'a',
+        actionId: 'tool-approval:approve:tc1',
+        conversationIdentifier: 'conv_abcdefghijkl',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.identifier).toBe('conv_abcdefghijkl');
+    expect(processAction).toHaveBeenCalledOnce();
+    expect(processAction.mock.calls[0]?.[0]).toMatchObject({
+      actionId: 'tool-approval:approve:tc1',
+      messageId: '',
+      threadId: 'web_chat:conv_abcdefghijkl',
+    });
   });
 
   it('postMessage delegates to deliverMessage without inventing mongo semantics', async () => {

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -20,6 +20,7 @@ import type {
 import {
   ADAPTER_NAME,
   conversationIdFromThreadId,
+  isApprovalActionId,
   isValidConversationId,
   mintActivityId,
   mintConversationId,
@@ -41,7 +42,7 @@ const JSON_HEADERS = { 'content-type': 'application/json' } as const;
 
 type IngressKind =
   | { type: 'message'; text: string }
-  | { type: 'action'; actionId: string; sourceMessageId: string; value?: string };
+  | { type: 'action'; actionId: string; sourceMessageId?: string; value?: string };
 
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
@@ -173,18 +174,23 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
       return { type: 'message', text };
     }
 
-    if (hasAction) {
-      const sourceMessageId = typeof body.sourceMessageId === 'string' ? body.sourceMessageId.trim() : '';
-      if (!sourceMessageId) {
-        return jsonResponse({ message: 'sourceMessageId is required with actionId' }, 400);
-      }
-
-      const value = typeof body.value === 'string' ? body.value : undefined;
-
-      return { type: 'action', actionId, sourceMessageId, value };
+    if (!hasAction) {
+      return jsonResponse({ message: 'text or actionId is required' }, 400);
     }
 
-    return jsonResponse({ message: 'text or actionId is required' }, 400);
+    const sourceMessageId = typeof body.sourceMessageId === 'string' ? body.sourceMessageId.trim() : '';
+    if (!isApprovalActionId(actionId) && !sourceMessageId) {
+      return jsonResponse({ message: 'sourceMessageId is required with actionId' }, 400);
+    }
+
+    const value = typeof body.value === 'string' ? body.value : undefined;
+
+    return {
+      type: 'action',
+      actionId,
+      ...(sourceMessageId ? { sourceMessageId } : {}),
+      value,
+    };
   }
 
   private async handleMessageIngress(
@@ -243,7 +249,8 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
         adapter: this,
         actionId: kind.actionId,
         value: kind.value,
-        messageId: kind.sourceMessageId,
+        // Chat ActionEvent requires messageId; headless approvals have no card carrier.
+        messageId: kind.sourceMessageId ?? '',
         threadId,
         user,
         raw: body,
@@ -270,7 +277,7 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
 
     if (!resumeId) {
       if (opts.requireExisting) {
-        return jsonResponse({ message: 'conversationIdentifier is required with actionId' }, 400);
+        return jsonResponse({ message: 'conversationIdentifier is required for actions' }, 400);
       }
 
       return mintConversationId();

--- a/packages/chat-adapter-web/src/index.ts
+++ b/packages/chat-adapter-web/src/index.ts
@@ -19,6 +19,7 @@ export {
   CONVERSATION_ID_PATTERN,
   conversationIdFromThreadId,
   extractCardPlainText,
+  isApprovalActionId,
   isValidConversationId,
   isValidMessageId,
   MESSAGE_ID_PATTERN,

--- a/packages/chat-adapter-web/src/types.ts
+++ b/packages/chat-adapter-web/src/types.ts
@@ -76,7 +76,10 @@ export type WebChatRequestBody = {
   text?: string;
   /** Interactive / approval button id (e.g. `tool-approval:approve:…`). XOR with `text`. */
   actionId?: string;
-  /** Platform message id of the clicked card/button; required with `actionId`. */
+  /**
+   * Platform message id of the clicked card/button.
+   * Required with non-approval `actionId`; optional for approval action ids (headless).
+   */
   sourceMessageId?: string;
   /** Optional button/select value alongside `actionId`. */
   value?: string;

--- a/packages/chat-adapter-web/src/utils.ts
+++ b/packages/chat-adapter-web/src/utils.ts
@@ -45,6 +45,15 @@ export function conversationIdFromThreadId(threadId: string): string {
   return threadId;
 }
 
+/** Approval action ids may omit sourceMessageId (headless / no card carrier). */
+export function isApprovalActionId(actionId: string): boolean {
+  return (
+    actionId.startsWith('tool-approval:') ||
+    actionId.startsWith('mcp-approval:') ||
+    actionId.startsWith('direct-approval:')
+  );
+}
+
 /** Flatten card title + text/link children for live/history markdown parity. */
 export function extractCardPlainText(card: CardElement): string {
   const title = typeof card.title === 'string' ? card.title.trim() : '';

--- a/packages/js/scripts/size-limit.mjs
+++ b/packages/js/scripts/size-limit.mjs
@@ -15,12 +15,13 @@ const modules = [
   {
     name: 'UMD minified',
     filePath: umdPath,
-    limitInBytes: 216_000,
+    // Raised for headless agentChat on Novu (NV-8445). Split to ./agent-chat later if needed.
+    limitInBytes: 224_000,
   },
   {
     name: 'UMD gzip',
     filePath: umdGzipPath,
-    limitInBytes: 60_000,
+    limitInBytes: 62_000,
   },
 ];
 

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -21,6 +21,11 @@ export type ConversationEntry = AgentConversationState & {
    * Create sessions use `local_*`. Resume sessions use the `conv_*` id.
    */
   key: string;
+  /**
+   * Cursor toward older history (`before` on the next page). Null when unknown,
+   * exhausted, or on a create-only holder before any history load.
+   */
+  olderCursor: string | null;
   /** One create at a time on this holder until a conversation id exists. */
   pendingCreate?: Promise<void>;
 };
@@ -129,6 +134,7 @@ export class AgentChatStore {
       agentId: args.agentId,
       conversationId: args.conversationId,
       key: args.key,
+      olderCursor: null,
     };
     this.#byKey.set(args.key, entry);
 
@@ -188,7 +194,11 @@ export class AgentChatStore {
    * Merge a history page into this holder.
    * Server message ids win. Local-only messages stay on the holder.
    */
-  absorbHistoryPage(entry: ConversationEntry, envelopes: AgentEventEnvelope[]): ConversationEntry {
+  absorbHistoryPage(
+    entry: ConversationEntry,
+    envelopes: AgentEventEnvelope[],
+    olderCursor: string | null
+  ): ConversationEntry {
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const serverIds = new Set(folded.messages.map((message) => message.id));
     const localOnly = entry.messages.filter((message) => !serverIds.has(message.id));
@@ -197,6 +207,28 @@ export class AgentChatStore {
       ...folded,
       messages: [...folded.messages, ...localOnly],
     });
+    entry.olderCursor = olderCursor;
+
+    this.#onUpdate(entry);
+
+    return entry;
+  }
+
+  /**
+   * Fold an older history page into this holder without resetting live timeline fields.
+   * Preserves `lastSequence` so the live sequence gate stays valid after pagination.
+   */
+  prependOlderPage(
+    entry: ConversationEntry,
+    envelopes: AgentEventEnvelope[],
+    olderCursor: string | null
+  ): ConversationEntry {
+    const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
+    const existingIds = new Set(entry.messages.map((message) => message.id));
+    const olderMessages = folded.messages.filter((message) => !existingIds.has(message.id));
+
+    entry.messages = [...olderMessages, ...entry.messages];
+    entry.olderCursor = olderCursor;
 
     this.#onUpdate(entry);
 

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -101,6 +101,18 @@ export class AgentChatStore {
     return matches;
   }
 
+  /** Holders that already have a public conversation id (eligible for reconnect catch-up). */
+  listClaimed(): Array<ConversationEntry & { conversationId: string }> {
+    const claimed: Array<ConversationEntry & { conversationId: string }> = [];
+    for (const entry of this.#byKey.values()) {
+      if (entry.conversationId) {
+        claimed.push(entry as ConversationEntry & { conversationId: string });
+      }
+    }
+
+    return claimed;
+  }
+
   /**
    * Return the entry for `key`, or create an empty holder.
    * This method does not reuse a holder that only shares `conversationId`.
@@ -191,8 +203,15 @@ export class AgentChatStore {
     return entry;
   }
 
-  /** Fold one live envelope onto this holder and notify listeners. */
+  /**
+   * Apply one live envelope onto this holder and notify listeners.
+   * Drops envelopes at or behind `lastSequence` so catch-up HTTP + buffered WS overlap is safe.
+   */
   applyLiveEnvelope(entry: ConversationEntry, envelope: AgentEventEnvelope): ConversationEntry {
+    if (envelope.sequence <= entry.lastSequence) {
+      return entry;
+    }
+
     applyState(entry, applyEnvelope(entry, envelope));
     this.#onUpdate(entry);
 

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -2,6 +2,7 @@ import {
   type AgentConversationState,
   type AgentEventEnvelope,
   appendUserMessage,
+  applyEnvelope,
   applyEnvelopes,
   createInitialAgentConversationState,
 } from '@novu/agent-event-protocol';
@@ -86,6 +87,18 @@ export class AgentChatStore {
     }
 
     return undefined;
+  }
+
+  /** All holders that already claimed this conversation id (create + resume can both exist). */
+  findByConversationId(agentId: string, conversationId: string): ConversationEntry[] {
+    const matches: ConversationEntry[] = [];
+    for (const entry of this.#byKey.values()) {
+      if (entry.agentId === agentId && entry.conversationId === conversationId) {
+        matches.push(entry);
+      }
+    }
+
+    return matches;
   }
 
   /**
@@ -173,6 +186,14 @@ export class AgentChatStore {
       messages: [...folded.messages, ...localOnly],
     });
 
+    this.#onUpdate(entry);
+
+    return entry;
+  }
+
+  /** Fold one live envelope onto this holder and notify listeners. */
+  applyLiveEnvelope(entry: ConversationEntry, envelope: AgentEventEnvelope): ConversationEntry {
+    applyState(entry, applyEnvelope(entry, envelope));
     this.#onUpdate(entry);
 
     return entry;

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1,4 +1,4 @@
-import { AGENT_EVENT_PROTOCOL_VERSION } from '@novu/agent-event-protocol';
+import { AGENT_EVENT_PROTOCOL_VERSION, derivePendingApprovals } from '@novu/agent-event-protocol';
 import { AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
@@ -7,6 +7,7 @@ describe('AgentChat', () => {
   const inboxServiceInstance = { isSessionInitialized: true } as any;
   let emitter: NovuEventEmitter;
   let sendMessage: jest.Mock;
+  let respondToApproval: jest.Mock;
   let getEvents: jest.Mock;
   let connect: jest.Mock;
   let agentChat: AgentChat;
@@ -14,9 +15,10 @@ describe('AgentChat', () => {
   beforeEach(() => {
     emitter = new NovuEventEmitter();
     sendMessage = jest.fn();
+    respondToApproval = jest.fn();
     getEvents = jest.fn();
     connect = jest.fn().mockResolvedValue({ data: undefined });
-    const agentChatService = { sendMessage, getEvents } as unknown as AgentChatService;
+    const agentChatService = { sendMessage, respondToApproval, getEvents } as unknown as AgentChatService;
     agentChat = new AgentChat({
       inboxServiceInstance,
       eventEmitterInstance: emitter,
@@ -1088,5 +1090,219 @@ describe('AgentChat', () => {
       'msg_live0000002',
     ]);
     expect(snapshot?.hasMore).toBe(false);
+  });
+
+  function approvalHistoryPage(approvalId: string) {
+    return {
+      events: [
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 1,
+          timestamp: '2026-08-07T12:00:00.000Z',
+          event: { type: 'run-start' as const },
+        },
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 2,
+          timestamp: '2026-08-07T12:00:01.000Z',
+          event: { type: 'message-start' as const, messageId: 'msg_asst0000001' },
+        },
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 3,
+          timestamp: '2026-08-07T12:00:02.000Z',
+          event: {
+            type: 'tool-approval-request' as const,
+            approvalId,
+            toolUseId: 'tu_0000001',
+            toolName: 'deleteOrder',
+            input: { orderId: '123' },
+            approveActionId: `tool-approval:approve:${approvalId}`,
+            denyActionId: `tool-approval:deny:${approvalId}`,
+          },
+        },
+        {
+          version: AGENT_EVENT_PROTOCOL_VERSION,
+          conversationId: 'internal',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          agentId: 'agent_1',
+          runId: 'history',
+          turnId: 't1',
+          sequence: 4,
+          timestamp: '2026-08-07T12:00:03.000Z',
+          event: { type: 'run-finish' as const, outcome: 'paused' as const },
+        },
+      ],
+      olderCursor: null,
+    };
+  }
+
+  it('loadConversation exposes messages that derive pending approvals after fold', async () => {
+    getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
+
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    const snapshot = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(derivePendingApprovals(snapshot?.messages ?? [])).toEqual([
+      {
+        type: 'approval',
+        approvalId: 'approval_000001',
+        toolUseId: 'tu_0000001',
+        toolName: 'deleteOrder',
+        input: { orderId: '123' },
+        state: 'pending',
+        approveActionId: 'tool-approval:approve:approval_000001',
+        denyActionId: 'tool-approval:deny:approval_000001',
+      },
+    ]);
+  });
+
+  it('respondToApproval POSTs echoed actionId and does not flip pending state optimistically', async () => {
+    getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
+    respondToApproval.mockResolvedValue({
+      identifier: 'conv_abcdefghijkl',
+    });
+
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    const result = await agentChat.respondToApproval({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      approvalId: 'approval_000001',
+      decision: 'approved',
+    });
+
+    expect(result).toEqual({
+      data: { conversationId: 'conv_abcdefghijkl' },
+    });
+    expect(respondToApproval).toHaveBeenCalledWith({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      actionId: 'tool-approval:approve:approval_000001',
+    });
+
+    const snapshot = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    expect(derivePendingApprovals(snapshot?.messages ?? [])[0]?.state).toBe('pending');
+  });
+
+  it('respondToApproval resolves pending state only after tool-approval-response envelope', async () => {
+    getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
+    respondToApproval.mockResolvedValue({
+      identifier: 'conv_abcdefghijkl',
+    });
+
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    await agentChat.respondToApproval({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      approvalId: 'approval_000001',
+      decision: 'approved',
+    });
+
+    emitter.emit('agent_chat.agent_event', {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 't1',
+        sequence: 5,
+        timestamp: '2026-08-07T12:00:04.000Z',
+        event: {
+          type: 'tool-approval-response',
+          approvalId: 'approval_000001',
+          decision: 'approved',
+        },
+      },
+    });
+
+    const snapshot = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    expect(derivePendingApprovals(snapshot?.messages ?? [])).toEqual([]);
+    expect(snapshot?.messages[0]?.parts.find((part) => part.type === 'approval')).toMatchObject({
+      approvalId: 'approval_000001',
+      state: 'approved',
+    });
+  });
+
+  it('respondToApproval returns error without POST when pending approval is missing', async () => {
+    getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
+
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    const result = await agentChat.respondToApproval({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      approvalId: 'approval_missing',
+      decision: 'denied',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(respondToApproval).not.toHaveBeenCalled();
+  });
+
+  it('respondToApproval returns error without POST when pending approval lacks action id', async () => {
+    const page = approvalHistoryPage('approval_000001');
+    const requestEvent = page.events[2]?.event as {
+      type: 'tool-approval-request';
+      approveActionId?: string;
+      denyActionId?: string;
+    };
+    delete requestEvent.approveActionId;
+    delete requestEvent.denyActionId;
+    getEvents.mockResolvedValue(page);
+
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    const result = await agentChat.respondToApproval({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      approvalId: 'approval_000001',
+      decision: 'denied',
+    });
+
+    expect(result.error).toBeDefined();
+    expect(respondToApproval).not.toHaveBeenCalled();
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -8,17 +8,20 @@ describe('AgentChat', () => {
   let emitter: NovuEventEmitter;
   let sendMessage: jest.Mock;
   let getEvents: jest.Mock;
+  let connect: jest.Mock;
   let agentChat: AgentChat;
 
   beforeEach(() => {
     emitter = new NovuEventEmitter();
     sendMessage = jest.fn();
     getEvents = jest.fn();
+    connect = jest.fn().mockResolvedValue({ data: undefined });
     const agentChatService = { sendMessage, getEvents } as unknown as AgentChatService;
     agentChat = new AgentChat({
       inboxServiceInstance,
       eventEmitterInstance: emitter,
       agentChatService,
+      socket: { connect },
     });
   });
 
@@ -627,5 +630,19 @@ describe('AgentChat', () => {
 
     const snapshot = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
     expect(snapshot?.messages).toHaveLength(1);
+  });
+
+  it('connects the socket on the first subscribe and refcounts later calls', () => {
+    agentChat.subscribe();
+    agentChat.subscribe();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    agentChat.unsubscribe();
+    agentChat.unsubscribe();
+    agentChat.unsubscribe();
+
+    agentChat.subscribe();
+    expect(connect).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -955,6 +955,52 @@ describe('AgentChat', () => {
     await waitForMessageIds(['msg_user0000001', 'msg_asst_first001', 'msg_asst_second01']);
   });
 
+  it('reconnect catch-up preserves previously fetched older pages and olderCursor', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 3, messageId: 'msg_new0000001', role: 'user', markdown: 'recent' }], 'act_page0001')
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_old0000001', role: 'user', markdown: 'older' }], 'act_older0001')
+    );
+    await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    agentChat.subscribe();
+    getEvents.mockClear();
+    getEvents.mockResolvedValueOnce(
+      historyPage(
+        [
+          { sequence: 3, messageId: 'msg_new0000001', role: 'user', markdown: 'recent' },
+          { sequence: 4, messageId: 'msg_asst_missed1', role: 'assistant', markdown: 'missed while offline' },
+        ],
+        'act_page0001'
+      )
+    );
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await waitForGetEventsCalls(1);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const conversation = agentChat.getConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    expect(conversation?.messages.map((message) => message.id)).toEqual([
+      'msg_old0000001',
+      'msg_new0000001',
+      'msg_asst_missed1',
+    ]);
+    expect(conversation?.hasMore).toBe(true);
+  });
+
   it('does not catch up when nothing is subscribed', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
     await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -534,4 +534,98 @@ describe('AgentChat', () => {
     expect(resumed?.key).toBe('conv_bbbbbbbbbbbb');
     expect(resumed?.messages[0]?.id).toBe('msg_hist0000001');
   });
+
+  it('folds a live agent_chat.agent_event into the matching conversation holder', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    const updates: string[][] = [];
+    emitter.on('agent_chat.messages.updated', ({ data }) => {
+      if (data.key === 'local_session1') {
+        updates.push(data.messages.map((message) => message.id));
+      }
+    });
+
+    emitter.emit('agent_chat.agent_event', {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 'turn_1',
+        sequence: 1,
+        timestamp: '2026-08-07T12:00:00.000Z',
+        event: {
+          type: 'message',
+          role: 'assistant',
+          messageId: 'msg_asst0000001',
+          content: { markdown: 'live reply' },
+        },
+      },
+    });
+
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
+    expect(snapshot?.messages).toHaveLength(2);
+    expect(snapshot?.messages[1]).toMatchObject({
+      id: 'msg_asst0000001',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'live reply', state: 'done' }],
+    });
+    expect(updates.at(-1)).toEqual(['msg_user0000001', 'msg_asst0000001']);
+  });
+
+  it('ignores live envelopes for conversations that are not open', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    emitter.emit('agent_chat.agent_event', {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_otherother1',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 'turn_1',
+        sequence: 1,
+        timestamp: '2026-08-07T12:00:00.000Z',
+        event: {
+          type: 'message',
+          role: 'assistant',
+          messageId: 'msg_asst0000001',
+          content: { markdown: 'other chat' },
+        },
+      },
+    });
+
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
+    expect(snapshot?.messages).toHaveLength(1);
+    expect(snapshot?.messages[0]?.id).toBe('msg_user0000001');
+  });
+
+  it('ignores live envelopes without conversationIdentifier', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    emitter.emit('agent_chat.agent_event', {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 'turn_1',
+        sequence: 1,
+        timestamp: '2026-08-07T12:00:00.000Z',
+        event: {
+          type: 'message',
+          role: 'assistant',
+          messageId: 'msg_asst0000001',
+          content: { markdown: 'no public id' },
+        },
+      },
+    });
+
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
+    expect(snapshot?.messages).toHaveLength(1);
+  });
 });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -999,6 +999,77 @@ describe('AgentChat', () => {
       'msg_asst_missed1',
     ]);
     expect(conversation?.hasMore).toBe(true);
+    // Newest catch-up page already overlaps known sequence — do not walk olderCursor.
+    expect(getEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconnect catch-up pages older events when the offline gap exceeds one page', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_user0000001', role: 'user', markdown: 'hello' }], null)
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+    agentChat.subscribe();
+    getEvents.mockClear();
+
+    getEvents.mockImplementation((args: { conversationId: string; before?: string }) => {
+      if (!args.before) {
+        return Promise.resolve(
+          historyPage(
+            [
+              { sequence: 4, messageId: 'msg_asst_page2a', role: 'assistant', markdown: 'newest page a' },
+              { sequence: 5, messageId: 'msg_asst_page2b', role: 'assistant', markdown: 'newest page b' },
+            ],
+            'act_mid0001'
+          )
+        );
+      }
+
+      expect(args.before).toBe('act_mid0001');
+
+      return Promise.resolve(
+        historyPage(
+          [
+            { sequence: 2, messageId: 'msg_asst_page1a', role: 'assistant', markdown: 'older missed a' },
+            { sequence: 3, messageId: 'msg_asst_page1b', role: 'assistant', markdown: 'older missed b' },
+          ],
+          null
+        )
+      );
+    });
+
+    const expectedIds = ['msg_user0000001', 'msg_asst_page1a', 'msg_asst_page1b', 'msg_asst_page2a', 'msg_asst_page2b'];
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await waitForGetEventsCalls(2);
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`timed out waiting for ${expectedIds.join(',')}`)), 1000);
+      const unsubscribe = emitter.on('agent_chat.messages.updated', ({ data }) => {
+        if (data.messages.map((message) => message.id).join() === expectedIds.join()) {
+          clearTimeout(timeout);
+          unsubscribe();
+          resolve();
+        }
+      });
+
+      const current = agentChat.getConversation({
+        agentId: 'agent_1',
+        conversationId: 'conv_abcdefghijkl',
+      });
+      if (current?.messages.map((message) => message.id).join() === expectedIds.join()) {
+        clearTimeout(timeout);
+        unsubscribe();
+        resolve();
+      }
+    });
+
+    expect(getEvents).toHaveBeenNthCalledWith(1, { conversationId: 'conv_abcdefghijkl' });
+    expect(getEvents).toHaveBeenNthCalledWith(2, {
+      conversationId: 'conv_abcdefghijkl',
+      before: 'act_mid0001',
+    });
   });
 
   it('does not catch up when nothing is subscribed', async () => {

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -538,6 +538,66 @@ describe('AgentChat', () => {
     expect(resumed?.messages[0]?.id).toBe('msg_hist0000001');
   });
 
+  it('tracks isRunning and status on messages.updated and getConversation after live run lifecycle', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    const updates: Array<{ isRunning: boolean; status: string }> = [];
+    emitter.on('agent_chat.messages.updated', ({ data }) => {
+      if (data.key === 'local_session1') {
+        updates.push({ isRunning: data.isRunning, status: data.status });
+      }
+    });
+
+    emitter.emit('agent_chat.agent_event', {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 'turn_1',
+        sequence: 1,
+        timestamp: '2026-08-07T12:00:00.000Z',
+        event: { type: 'run-start' },
+      },
+    });
+
+    emitter.emit('agent_chat.agent_event', {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 'turn_1',
+        sequence: 2,
+        timestamp: '2026-08-07T12:00:01.000Z',
+        event: { type: 'run-finish', outcome: 'completed' },
+      },
+    });
+
+    emitter.emit('agent_chat.agent_event', {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 'turn_1',
+        sequence: 3,
+        timestamp: '2026-08-07T12:00:02.000Z',
+        event: { type: 'resolve' },
+      },
+    });
+
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
+    expect(snapshot?.isRunning).toBe(false);
+    expect(snapshot?.status).toBe('resolved');
+    expect(updates.some((update) => update.isRunning === true && update.status === 'active')).toBe(true);
+    expect(updates.at(-1)).toEqual({ isRunning: false, status: 'resolved' });
+  });
+
   it('folds a live agent_chat.agent_event into the matching conversation holder', async () => {
     sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
     await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -712,7 +712,8 @@ describe('AgentChat', () => {
       messageId: string;
       role: 'user' | 'assistant';
       markdown: string;
-    }>
+    }>,
+    olderCursor: string | null = null
   ) {
     return {
       events: events.map((event) => ({
@@ -731,7 +732,7 @@ describe('AgentChat', () => {
           content: { markdown: event.markdown },
         },
       })),
-      olderCursor: null,
+      olderCursor,
     };
   }
 
@@ -972,5 +973,120 @@ describe('AgentChat', () => {
     await Promise.resolve();
 
     expect(getEvents).not.toHaveBeenCalled();
+  });
+
+  it('loadConversation sets hasMore from olderCursor', async () => {
+    getEvents.mockResolvedValue(
+      historyPage([{ sequence: 3, messageId: 'msg_new0000001', role: 'user', markdown: 'recent' }], 'act_older0001')
+    );
+
+    const result = await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(result.data?.hasMore).toBe(true);
+    expect(agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })?.hasMore).toBe(true);
+  });
+
+  it('fetchMore prepends older messages and advances the cursor', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 3, messageId: 'msg_new0000001', role: 'user', markdown: 'recent' }], 'act_page0001')
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_old0000001', role: 'user', markdown: 'older' }], 'act_older0001')
+    );
+
+    const result = await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(getEvents).toHaveBeenLastCalledWith({
+      conversationId: 'conv_abcdefghijkl',
+      before: 'act_page0001',
+    });
+    expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_old0000001', 'msg_new0000001']);
+    expect(result.data?.hasMore).toBe(true);
+    expect(agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' })?.hasMore).toBe(true);
+  });
+
+  it('fetchMore no-ops when olderCursor is null and does not call getEvents', async () => {
+    getEvents.mockResolvedValue(
+      historyPage([{ sequence: 1, messageId: 'msg_only0000001', role: 'user', markdown: 'only page' }], null)
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    getEvents.mockClear();
+
+    const result = await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    expect(getEvents).not.toHaveBeenCalled();
+    expect(result.data?.hasMore).toBe(false);
+    expect(result.data?.messages.map((message) => message.id)).toEqual(['msg_only0000001']);
+  });
+
+  it('fetchMore does not lower lastSequence so live envelopes still apply', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage(
+        [
+          { sequence: 3, messageId: 'msg_new0000001', role: 'user', markdown: 'recent user' },
+          { sequence: 4, messageId: 'msg_new0000002', role: 'assistant', markdown: 'recent assistant' },
+        ],
+        'act_page0001'
+      )
+    );
+    await agentChat.loadConversation({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({
+        sequence: 5,
+        messageId: 'msg_live0000001',
+        markdown: 'live after load',
+      })
+    );
+
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 1, messageId: 'msg_old0000001', role: 'user', markdown: 'older user' }], null)
+    );
+
+    await agentChat.fetchMore({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+    });
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({
+        sequence: 6,
+        messageId: 'msg_live0000002',
+        markdown: 'live after fetchMore',
+      })
+    );
+
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+    expect(snapshot?.messages.map((message) => message.id)).toEqual([
+      'msg_old0000001',
+      'msg_new0000001',
+      'msg_new0000002',
+      'msg_live0000001',
+      'msg_live0000002',
+    ]);
+    expect(snapshot?.hasMore).toBe(false);
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -645,4 +645,272 @@ describe('AgentChat', () => {
     agentChat.subscribe();
     expect(connect).toHaveBeenCalledTimes(2);
   });
+
+  function historyPage(
+    events: Array<{
+      sequence: number;
+      messageId: string;
+      role: 'user' | 'assistant';
+      markdown: string;
+    }>
+  ) {
+    return {
+      events: events.map((event) => ({
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'history',
+        turnId: 't1',
+        sequence: event.sequence,
+        timestamp: '2026-08-07T12:00:00.000Z',
+        event: {
+          type: 'message' as const,
+          role: event.role,
+          messageId: event.messageId,
+          content: { markdown: event.markdown },
+        },
+      })),
+      olderCursor: null,
+    };
+  }
+
+  function liveAssistantEnvelope(args: { sequence: number; messageId: string; markdown: string }) {
+    return {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 't1',
+        sequence: args.sequence,
+        timestamp: '2026-08-07T12:00:03.000Z',
+        event: {
+          type: 'message' as const,
+          role: 'assistant' as const,
+          messageId: args.messageId,
+          content: { markdown: args.markdown },
+        },
+      },
+    };
+  }
+
+  async function waitForMessageIds(expected: string[]): Promise<void> {
+    const current = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
+    if (current && current.messages.map((message) => message.id).join() === expected.join()) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`timed out waiting for ${expected.join(',')}`)), 1000);
+      const unsubscribe = emitter.on('agent_chat.messages.updated', ({ data }) => {
+        if (data.key !== 'local_session1') {
+          return;
+        }
+
+        if (data.messages.map((message) => message.id).join() === expected.join()) {
+          clearTimeout(timeout);
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+  }
+
+  async function waitForGetEventsCalls(count: number): Promise<void> {
+    if (getEvents.mock.calls.length >= count) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`timed out waiting for getEvents × ${count}`)), 1000);
+      const timer = setInterval(() => {
+        if (getEvents.mock.calls.length >= count) {
+          clearTimeout(timeout);
+          clearInterval(timer);
+          resolve();
+        }
+      }, 0);
+    });
+  }
+
+  async function openClaimedConversation(): Promise<void> {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+    agentChat.subscribe();
+  }
+
+  it('on reconnect catch-up pulls newest events into open conversations', async () => {
+    await openClaimedConversation();
+
+    getEvents.mockResolvedValue(
+      historyPage([
+        { sequence: 1, messageId: 'msg_user0000001', role: 'user', markdown: 'hello' },
+        { sequence: 2, messageId: 'msg_asst_missed1', role: 'assistant', markdown: 'missed while offline' },
+      ])
+    );
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await waitForMessageIds(['msg_user0000001', 'msg_asst_missed1']);
+
+    expect(getEvents).toHaveBeenCalledWith({ conversationId: 'conv_abcdefghijkl' });
+  });
+
+  it('buffers live envelopes during catch-up and applies them after', async () => {
+    await openClaimedConversation();
+
+    let resolveEvents!: (value: ReturnType<typeof historyPage>) => void;
+    getEvents.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveEvents = resolve;
+        })
+    );
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await waitForGetEventsCalls(1);
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({
+        sequence: 3,
+        messageId: 'msg_asst_live001',
+        markdown: 'arrived during catch-up',
+      })
+    );
+
+    expect(agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' })?.messages).toHaveLength(1);
+
+    resolveEvents(
+      historyPage([
+        { sequence: 1, messageId: 'msg_user0000001', role: 'user', markdown: 'hello' },
+        { sequence: 2, messageId: 'msg_asst_http001', role: 'assistant', markdown: 'from http catch-up' },
+      ])
+    );
+
+    await waitForMessageIds(['msg_user0000001', 'msg_asst_http001', 'msg_asst_live001']);
+  });
+
+  it('does not duplicate envelopes already present in the catch-up page', async () => {
+    await openClaimedConversation();
+
+    let resolveEvents!: (value: ReturnType<typeof historyPage>) => void;
+    getEvents.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveEvents = resolve;
+        })
+    );
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await waitForGetEventsCalls(1);
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({
+        sequence: 2,
+        messageId: 'msg_asst_overlap1',
+        markdown: 'same as http page',
+      })
+    );
+
+    resolveEvents(
+      historyPage([
+        { sequence: 1, messageId: 'msg_user0000001', role: 'user', markdown: 'hello' },
+        { sequence: 2, messageId: 'msg_asst_overlap1', role: 'assistant', markdown: 'same as http page' },
+      ])
+    );
+
+    await waitForMessageIds(['msg_user0000001', 'msg_asst_overlap1']);
+
+    const assistant = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' })?.messages[1];
+    expect(assistant?.parts).toEqual([{ type: 'text', text: 'same as http page', state: 'done' }]);
+  });
+
+  it('flushes buffered live envelopes when catch-up HTTP fails', async () => {
+    await openClaimedConversation();
+
+    let rejectEvents!: (error: Error) => void;
+    getEvents.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectEvents = reject;
+        })
+    );
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await waitForGetEventsCalls(1);
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({
+        sequence: 2,
+        messageId: 'msg_asst_flush001',
+        markdown: 'kept after http failure',
+      })
+    );
+
+    rejectEvents(new Error('getEvents failed'));
+    await waitForMessageIds(['msg_user0000001', 'msg_asst_flush001']);
+  });
+
+  it('runs a second catch-up when reconnect arrives during an in-flight catch-up', async () => {
+    await openClaimedConversation();
+
+    const resolvers: Array<(value: ReturnType<typeof historyPage>) => void> = [];
+    getEvents.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await waitForGetEventsCalls(1);
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+
+    resolvers[0]!(
+      historyPage([
+        { sequence: 1, messageId: 'msg_user0000001', role: 'user', markdown: 'hello' },
+        { sequence: 2, messageId: 'msg_asst_first001', role: 'assistant', markdown: 'first catch-up' },
+      ])
+    );
+
+    await waitForMessageIds(['msg_user0000001', 'msg_asst_first001']);
+    await waitForGetEventsCalls(2);
+
+    resolvers[1]!(
+      historyPage([
+        { sequence: 1, messageId: 'msg_user0000001', role: 'user', markdown: 'hello' },
+        { sequence: 2, messageId: 'msg_asst_first001', role: 'assistant', markdown: 'first catch-up' },
+        { sequence: 3, messageId: 'msg_asst_second01', role: 'assistant', markdown: 'second catch-up' },
+      ])
+    );
+
+    await waitForMessageIds(['msg_user0000001', 'msg_asst_first001', 'msg_asst_second01']);
+  });
+
+  it('does not catch up when nothing is subscribed', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000001' });
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    emitter.emit('socket.connect.resolved', { args: { socketUrl: 'http://127.0.0.1:8787' } });
+    await Promise.resolve();
+
+    expect(getEvents).not.toHaveBeenCalled();
+  });
+
+  it('does not catch up when socket connect resolves with an error', async () => {
+    await openClaimedConversation();
+
+    emitter.emit('socket.connect.resolved', {
+      args: { socketUrl: 'http://127.0.0.1:8787' },
+      error: new Error('connect failed'),
+    });
+    await Promise.resolve();
+
+    expect(getEvents).not.toHaveBeenCalled();
+  });
 });

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from '@novu/agent-event-protocol';
+import type { AgentEventEnvelope, AgentMessage } from '@novu/agent-event-protocol';
 import { AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
@@ -31,6 +31,9 @@ export class AgentChat extends BaseModule {
           messages: entry.messages,
         },
       });
+    });
+    this._emitter.on('agent_chat.agent_event', ({ result }) => {
+      this.#handleAgentEvent(result);
     });
   }
 
@@ -173,5 +176,21 @@ export class AgentChat extends BaseModule {
     }
 
     return true;
+  }
+
+  /**
+   * Live WS path: fold envelopes into open holders only.
+   * Unknown conversations are dropped — mount/resume creates the holder.
+   */
+  #handleAgentEvent(envelope: AgentEventEnvelope): void {
+    const conversationId = envelope.conversationIdentifier;
+    if (!conversationId) {
+      return;
+    }
+
+    const entries = this.#store.findByConversationId(envelope.agentId, conversationId);
+    for (const entry of entries) {
+      this.#store.applyLiveEnvelope(entry, envelope);
+    }
   }
 }

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -412,18 +412,46 @@ export class AgentChat extends BaseModule {
 
   async #catchUpConversation(conversationId: string, holders: ConversationEntry[]): Promise<void> {
     try {
-      const page = await this.#agentChatService.getEvents({ conversationId });
-      // Fold only missed live envelopes. Do not rebuild from the newest history page —
-      // that would reorder/drop already-loaded older pages and reset `olderCursor`.
-      const envelopes = [...page.events].sort((left, right) => left.sequence - right.sequence);
+      const activeHolders = holders
+        .map((holder) => this.#store.get(holder.key))
+        .filter((entry): entry is ConversationEntry => entry != null && entry.conversationId === conversationId);
 
-      for (const holder of holders) {
+      if (activeHolders.length === 0) {
+        return;
+      }
+
+      // Page toward older events until we reach already-known sequence territory.
+      // One newest page is not enough when the offline gap exceeds the server page size.
+      const knownThrough = Math.min(...activeHolders.map((entry) => entry.lastSequence));
+      const missed: AgentEventEnvelope[] = [];
+      let before: string | undefined;
+
+      for (let pageIndex = 0; pageIndex < 20; pageIndex += 1) {
+        const page = await this.#agentChatService.getEvents({
+          conversationId,
+          ...(before ? { before } : {}),
+        });
+        const envelopes = [...page.events].sort((left, right) => left.sequence - right.sequence);
+        missed.push(...envelopes);
+
+        const oldestInPage = envelopes[0]?.sequence;
+        if (page.olderCursor == null || oldestInPage == null || oldestInPage <= knownThrough) {
+          break;
+        }
+
+        before = page.olderCursor;
+      }
+
+      // Apply oldest→newest so message order stays chronological across pages.
+      missed.sort((left, right) => left.sequence - right.sequence);
+
+      for (const holder of activeHolders) {
         const entry = this.#store.get(holder.key);
         if (!entry || entry.conversationId !== conversationId) {
           continue;
         }
 
-        for (const envelope of envelopes) {
+        for (const envelope of missed) {
           this.#store.applyLiveEnvelope(entry, envelope);
         }
       }

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -41,6 +41,8 @@ export class AgentChat extends BaseModule {
           conversationId: entry.conversationId,
           key: entry.key,
           messages: entry.messages,
+          isRunning: entry.isRunning,
+          status: entry.status,
         },
       });
     });
@@ -80,15 +82,15 @@ export class AgentChat extends BaseModule {
     this.#catchUpBuffer = null;
   }
 
-  getConversation({
-    agentId,
-    conversationId,
-    key,
-  }: {
-    agentId: string;
-    conversationId?: string;
-    key?: string;
-  }): { conversationId?: string; messages: AgentMessage[]; key: string } | undefined {
+  getConversation({ agentId, conversationId, key }: { agentId: string; conversationId?: string; key?: string }):
+    | {
+        conversationId?: string;
+        messages: AgentMessage[];
+        key: string;
+        isRunning: boolean;
+        status: ConversationEntry['status'];
+      }
+    | undefined {
     const entry = key
       ? this.#store.get(key)
       : conversationId
@@ -103,6 +105,8 @@ export class AgentChat extends BaseModule {
       conversationId: entry.conversationId,
       messages: entry.messages,
       key: entry.key,
+      isRunning: entry.isRunning,
+      status: entry.status,
     };
   }
 

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -4,24 +4,30 @@ import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
+import type { BaseSocketInterface } from '../ws/base-socket';
 import { AgentChatStore, type ConversationEntry, createLocalConversationKey } from './agent-chat-store';
 import type { LoadConversationArgs, LoadConversationResult, SendMessageArgs, SendMessageResult } from './types';
 
 export class AgentChat extends BaseModule {
   #agentChatService: AgentChatService;
   #store: AgentChatStore;
+  #socket: Pick<BaseSocketInterface, 'connect'>;
+  #liveSubscriberCount = 0;
 
   constructor({
     inboxServiceInstance,
     eventEmitterInstance,
     agentChatService,
+    socket,
   }: {
     inboxServiceInstance: InboxService;
     eventEmitterInstance: NovuEventEmitter;
     agentChatService: AgentChatService;
+    socket: Pick<BaseSocketInterface, 'connect'>;
   }) {
     super({ inboxServiceInstance, eventEmitterInstance });
     this.#agentChatService = agentChatService;
+    this.#socket = socket;
     this.#store = new AgentChatStore((entry) => {
       this._emitter.emit('agent_chat.messages.updated', {
         data: {
@@ -35,6 +41,25 @@ export class AgentChat extends BaseModule {
     this._emitter.on('agent_chat.agent_event', ({ result }) => {
       this.#handleAgentEvent(result);
     });
+  }
+
+  /**
+   * Keep the socket connected while at least one consumer wants live events.
+   * Call from hook mount / vanilla open. Pair with `unsubscribe`.
+   */
+  subscribe(): void {
+    this.#liveSubscriberCount += 1;
+    if (this.#liveSubscriberCount === 1) {
+      void this.#socket.connect();
+    }
+  }
+
+  unsubscribe(): void {
+    if (this.#liveSubscriberCount === 0) {
+      return;
+    }
+
+    this.#liveSubscriberCount -= 1;
   }
 
   clearCache(): void {

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -6,7 +6,14 @@ import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
 import type { BaseSocketInterface } from '../ws/base-socket';
 import { AgentChatStore, type ConversationEntry, createLocalConversationKey } from './agent-chat-store';
-import type { LoadConversationArgs, LoadConversationResult, SendMessageArgs, SendMessageResult } from './types';
+import type {
+  FetchMoreArgs,
+  FetchMoreResult,
+  LoadConversationArgs,
+  LoadConversationResult,
+  SendMessageArgs,
+  SendMessageResult,
+} from './types';
 
 export class AgentChat extends BaseModule {
   #agentChatService: AgentChatService;
@@ -43,6 +50,7 @@ export class AgentChat extends BaseModule {
           messages: entry.messages,
           isRunning: entry.isRunning,
           status: entry.status,
+          hasMore: entry.olderCursor != null,
         },
       });
     });
@@ -89,6 +97,7 @@ export class AgentChat extends BaseModule {
         key: string;
         isRunning: boolean;
         status: ConversationEntry['status'];
+        hasMore: boolean;
       }
     | undefined {
     const entry = key
@@ -107,6 +116,7 @@ export class AgentChat extends BaseModule {
       key: entry.key,
       isRunning: entry.isRunning,
       status: entry.status,
+      hasMore: entry.olderCursor != null,
     };
   }
 
@@ -126,16 +136,57 @@ export class AgentChat extends BaseModule {
           key: args.conversationId,
           conversationId: args.conversationId,
         });
-        const next = this.#store.absorbHistoryPage(entry, page.events);
+        const next = this.#store.absorbHistoryPage(entry, page.events, page.olderCursor);
 
         return {
           data: {
             conversationId: args.conversationId,
             messages: next.messages,
+            hasMore: next.olderCursor != null,
           },
         };
       } catch (error) {
         return { error: new NovuError('Failed to load agent chat conversation', error) };
+      }
+    });
+  }
+
+  async fetchMore(args: FetchMoreArgs): Result<FetchMoreResult> {
+    return this.callWithSession(async () => {
+      const entry = this.#resolveFetchEntry(args);
+      if (!entry?.conversationId) {
+        return {
+          data: {
+            messages: entry?.messages ?? [],
+            hasMore: entry != null && entry.olderCursor != null,
+          },
+        };
+      }
+
+      if (entry.olderCursor == null) {
+        return {
+          data: {
+            messages: entry.messages,
+            hasMore: false,
+          },
+        };
+      }
+
+      try {
+        const page = await this.#agentChatService.getEvents({
+          conversationId: entry.conversationId,
+          before: entry.olderCursor,
+        });
+        const next = this.#store.prependOlderPage(entry, page.events, page.olderCursor);
+
+        return {
+          data: {
+            messages: next.messages,
+            hasMore: next.olderCursor != null,
+          },
+        };
+      } catch (error) {
+        return { error: new NovuError('Failed to load older agent chat messages', error) };
       }
     });
   }
@@ -173,6 +224,21 @@ export class AgentChat extends BaseModule {
         }
       });
     });
+  }
+
+  #resolveFetchEntry(args: FetchMoreArgs): ConversationEntry | undefined {
+    if (args.key) {
+      const byKey = this.#store.get(args.key);
+      if (byKey && byKey.agentId === args.agentId) {
+        return byKey;
+      }
+    }
+
+    if (args.conversationId) {
+      return this.#store.get(args.conversationId) ?? this.#store.getByConversationId(args.agentId, args.conversationId);
+    }
+
+    return undefined;
   }
 
   /**
@@ -306,7 +372,7 @@ export class AgentChat extends BaseModule {
           continue;
         }
 
-        this.#store.absorbHistoryPage(entry, page.events);
+        this.#store.absorbHistoryPage(entry, page.events, page.olderCursor);
       }
     } catch {
       // Best-effort catch-up; buffered live envelopes still flush in the outer finally.

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,4 +1,5 @@
 import type { AgentEventEnvelope, AgentMessage } from '@novu/agent-event-protocol';
+import { derivePendingApprovals } from '@novu/agent-event-protocol';
 import { AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
@@ -11,6 +12,8 @@ import type {
   FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
+  RespondToApprovalArgs,
+  RespondToApprovalResult,
   SendMessageArgs,
   SendMessageResult,
 } from './types';
@@ -118,6 +121,51 @@ export class AgentChat extends BaseModule {
       status: entry.status,
       hasMore: entry.olderCursor != null,
     };
+  }
+
+  async respondToApproval(args: RespondToApprovalArgs): Result<RespondToApprovalResult> {
+    return this.callWithSession(async () => {
+      const entry = this.#resolveFetchEntry(args);
+      if (!entry?.conversationId) {
+        return {
+          error: new NovuError(
+            'Cannot respond to approval without a conversation id',
+            new Error('missing conversation id')
+          ),
+        };
+      }
+
+      const pending = derivePendingApprovals(entry.messages).find((part) => part.approvalId === args.approvalId);
+      if (!pending) {
+        return { error: new NovuError('Pending approval not found', new Error('pending approval not found')) };
+      }
+
+      const actionId = args.decision === 'approved' ? pending.approveActionId : pending.denyActionId;
+      if (!actionId) {
+        return {
+          error: new NovuError(
+            'Pending approval is missing action id',
+            new Error('pending approval missing action id')
+          ),
+        };
+      }
+
+      try {
+        const data = await this.#agentChatService.respondToApproval({
+          agentId: args.agentId,
+          conversationId: entry.conversationId,
+          actionId,
+        });
+
+        return {
+          data: {
+            conversationId: data.identifier,
+          },
+        };
+      } catch (error) {
+        return { error: new NovuError('Failed to respond to approval', error) };
+      }
+    });
   }
 
   /**

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -13,6 +13,12 @@ export class AgentChat extends BaseModule {
   #store: AgentChatStore;
   #socket: Pick<BaseSocketInterface, 'connect'>;
   #liveSubscriberCount = 0;
+  /**
+   * Non-null while a reconnect catch-up is in flight: live envelopes are buffered here
+   * and applied after the HTTP page is absorbed. Serialized via `#catchUpChain`.
+   */
+  #catchUpBuffer: AgentEventEnvelope[] | null = null;
+  #catchUpChain: Promise<void> = Promise.resolve();
 
   constructor({
     inboxServiceInstance,
@@ -41,6 +47,13 @@ export class AgentChat extends BaseModule {
     this._emitter.on('agent_chat.agent_event', ({ result }) => {
       this.#handleAgentEvent(result);
     });
+    this._emitter.on('socket.connect.resolved', ({ error }) => {
+      if (error) {
+        return;
+      }
+
+      this.#requestCatchUp();
+    });
   }
 
   /**
@@ -64,6 +77,7 @@ export class AgentChat extends BaseModule {
 
   clearCache(): void {
     this.#store.clear();
+    this.#catchUpBuffer = null;
   }
 
   getConversation({
@@ -204,10 +218,25 @@ export class AgentChat extends BaseModule {
   }
 
   /**
-   * Live WS path: fold envelopes into open holders only.
-   * Unknown conversations are dropped — mount/resume creates the holder.
+   * Live WS path: apply envelopes into open conversations only.
+   * Unknown conversations are dropped — mount/resume creates the entry.
+   * During reconnect catch-up, all live envelopes are buffered until HTTP finishes.
    */
   #handleAgentEvent(envelope: AgentEventEnvelope): void {
+    if (!envelope.conversationIdentifier) {
+      return;
+    }
+
+    if (this.#catchUpBuffer) {
+      this.#catchUpBuffer.push(envelope);
+
+      return;
+    }
+
+    this.#applyLiveEnvelope(envelope);
+  }
+
+  #applyLiveEnvelope(envelope: AgentEventEnvelope): void {
     const conversationId = envelope.conversationIdentifier;
     if (!conversationId) {
       return;
@@ -216,6 +245,67 @@ export class AgentChat extends BaseModule {
     const entries = this.#store.findByConversationId(envelope.agentId, conversationId);
     for (const entry of entries) {
       this.#store.applyLiveEnvelope(entry, envelope);
+    }
+  }
+
+  #requestCatchUp(): void {
+    if (this.#liveSubscriberCount === 0) {
+      return;
+    }
+
+    // Keep the chain alive after a rejected run so later reconnects still catch up.
+    this.#catchUpChain = this.#catchUpChain.catch(() => undefined).then(() => this.#catchUpOpenConversations());
+  }
+
+  async #catchUpOpenConversations(): Promise<void> {
+    if (this.#liveSubscriberCount === 0 || !this._inboxService.isSessionInitialized) {
+      return;
+    }
+
+    const claimed = this.#store.listClaimed();
+    if (claimed.length === 0) {
+      return;
+    }
+
+    const byConversationId = new Map<string, ConversationEntry[]>();
+    for (const entry of claimed) {
+      const holders = byConversationId.get(entry.conversationId) ?? [];
+      holders.push(entry);
+      byConversationId.set(entry.conversationId, holders);
+    }
+
+    this.#catchUpBuffer = [];
+
+    try {
+      await Promise.all(
+        [...byConversationId.entries()].map(([conversationId, holders]) =>
+          this.#catchUpConversation(conversationId, holders)
+        )
+      );
+    } finally {
+      const buffered = this.#catchUpBuffer ?? [];
+      this.#catchUpBuffer = null;
+
+      for (const envelope of buffered) {
+        this.#applyLiveEnvelope(envelope);
+      }
+    }
+  }
+
+  async #catchUpConversation(conversationId: string, holders: ConversationEntry[]): Promise<void> {
+    try {
+      const page = await this.#agentChatService.getEvents({ conversationId });
+
+      for (const holder of holders) {
+        const entry = this.#store.get(holder.key);
+        if (!entry || entry.conversationId !== conversationId) {
+          continue;
+        }
+
+        this.#store.absorbHistoryPage(entry, page.events);
+      }
+    } catch {
+      // Best-effort catch-up; buffered live envelopes still flush in the outer finally.
     }
   }
 }

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -413,6 +413,9 @@ export class AgentChat extends BaseModule {
   async #catchUpConversation(conversationId: string, holders: ConversationEntry[]): Promise<void> {
     try {
       const page = await this.#agentChatService.getEvents({ conversationId });
+      // Fold only missed live envelopes. Do not rebuild from the newest history page —
+      // that would reorder/drop already-loaded older pages and reset `olderCursor`.
+      const envelopes = [...page.events].sort((left, right) => left.sequence - right.sequence);
 
       for (const holder of holders) {
         const entry = this.#store.get(holder.key);
@@ -420,7 +423,9 @@ export class AgentChat extends BaseModule {
           continue;
         }
 
-        this.#store.absorbHistoryPage(entry, page.events, page.olderCursor);
+        for (const envelope of envelopes) {
+          this.#store.applyLiveEnvelope(entry, envelope);
+        }
       }
     } catch {
       // Best-effort catch-up; buffered live envelopes still flush in the outer finally.

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,6 +1,7 @@
 export { AgentChat } from './agent-chat';
 export type {
   AgentChatMessagesUpdated,
+  AgentConversationStatus,
   AgentMessage,
   LoadConversationArgs,
   LoadConversationResult,

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,5 +1,6 @@
 export { AgentChat } from './agent-chat';
 export type {
+  AgentApprovalPart,
   AgentChatMessagesUpdated,
   AgentConversationStatus,
   AgentMessage,
@@ -7,6 +8,8 @@ export type {
   FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
+  RespondToApprovalArgs,
+  RespondToApprovalResult,
   SendMessageArgs,
   SendMessageResult,
 } from './types';

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -3,6 +3,8 @@ export type {
   AgentChatMessagesUpdated,
   AgentConversationStatus,
   AgentMessage,
+  FetchMoreArgs,
+  FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
   SendMessageArgs,

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -31,6 +31,18 @@ export type LoadConversationArgs = {
 export type LoadConversationResult = {
   conversationId: string;
   messages: AgentMessage[];
+  hasMore: boolean;
+};
+
+export type FetchMoreArgs = {
+  agentId: string;
+  conversationId?: string;
+  key?: string;
+};
+
+export type FetchMoreResult = {
+  messages: AgentMessage[];
+  hasMore: boolean;
 };
 
 export type AgentChatMessagesUpdated = {
@@ -41,4 +53,5 @@ export type AgentChatMessagesUpdated = {
   messages: AgentMessage[];
   isRunning: boolean;
   status: AgentConversationStatus;
+  hasMore: boolean;
 };

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -1,6 +1,6 @@
-import type { AgentConversationStatus, AgentMessage } from '@novu/agent-event-protocol';
+import type { AgentApprovalPart, AgentConversationStatus, AgentMessage } from '@novu/agent-event-protocol';
 
-export type { AgentConversationStatus, AgentMessage };
+export type { AgentApprovalPart, AgentConversationStatus, AgentMessage };
 
 export type SendMessageArgs = {
   agentId: string;
@@ -43,6 +43,18 @@ export type FetchMoreArgs = {
 export type FetchMoreResult = {
   messages: AgentMessage[];
   hasMore: boolean;
+};
+
+export type RespondToApprovalArgs = {
+  agentId: string;
+  approvalId: string;
+  decision: 'approved' | 'denied';
+  conversationId?: string;
+  key?: string;
+};
+
+export type RespondToApprovalResult = {
+  conversationId: string;
 };
 
 export type AgentChatMessagesUpdated = {

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -1,6 +1,6 @@
-import type { AgentMessage } from '@novu/agent-event-protocol';
+import type { AgentConversationStatus, AgentMessage } from '@novu/agent-event-protocol';
 
-export type { AgentMessage };
+export type { AgentConversationStatus, AgentMessage };
 
 export type SendMessageArgs = {
   agentId: string;
@@ -39,4 +39,6 @@ export type AgentChatMessagesUpdated = {
   /** Immutable holder key. Stable for the life of the local conversation entry. */
   key: string;
   messages: AgentMessage[];
+  isRunning: boolean;
+  status: AgentConversationStatus;
 };

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -81,4 +81,33 @@ describe('AgentChatService', () => {
       expect.objectContaining({ method: 'GET' })
     );
   });
+
+  it('GETs older conversation events with before cursor', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          events: [],
+          olderCursor: 'act_older0001',
+        },
+      }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const httpClient = new HttpClient({ apiUrl: 'https://test.novu.co' });
+    const service = new AgentChatService({ httpClient });
+
+    const result = await service.getEvents({
+      conversationId: 'conv_abcdefghijkl',
+      before: 'act_page0001',
+      limit: 50,
+    });
+
+    expect(result).toEqual({ events: [], olderCursor: 'act_older0001' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://test.novu.co/v1/web-chat/conversations/conv_abcdefghijkl/events?before=act_page0001&limit=50',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
 });

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -82,6 +82,38 @@ describe('AgentChatService', () => {
     );
   });
 
+  it('POSTs approval decision by echoing actionId', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { identifier: 'conv_abcdefghijkl' } }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const httpClient = new HttpClient({ apiUrl: 'https://test.novu.co' });
+    httpClient.setAuthorizationToken('test-token');
+    const service = new AgentChatService({ httpClient });
+
+    const result = await service.respondToApproval({
+      agentId: 'agent_1',
+      conversationId: 'conv_abcdefghijkl',
+      actionId: 'tool-approval:approve:approval_000001',
+    });
+
+    expect(result).toEqual({ identifier: 'conv_abcdefghijkl' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://test.novu.co/v1/web-chat/conversations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          agentId: 'agent_1',
+          conversationIdentifier: 'conv_abcdefghijkl',
+          actionId: 'tool-approval:approve:approval_000001',
+        }),
+      })
+    );
+  });
+
   it('GETs older conversation events with before cursor', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -18,6 +18,9 @@ export type AgentChatSendMessageResponse = {
 
 export type AgentChatGetEventsArgs = {
   conversationId: string;
+  /** Activity `_id` cursor that loads older history. Omit to get the newest page. */
+  before?: string;
+  limit?: number;
 };
 
 export type AgentChatGetEventsResponse = {
@@ -42,6 +45,19 @@ export class AgentChatService {
   }
 
   async getEvents(args: AgentChatGetEventsArgs): Promise<AgentChatGetEventsResponse> {
-    return this.#httpClient.get(`${AGENT_CHAT_CONVERSATIONS_ROUTE}/${encodeURIComponent(args.conversationId)}/events`);
+    const params = new URLSearchParams();
+    if (args.before) {
+      params.set('before', args.before);
+    }
+    if (args.limit != null) {
+      params.set('limit', String(args.limit));
+    }
+
+    const query = params.toString();
+    const suffix = query ? `?${query}` : '';
+
+    return this.#httpClient.get(
+      `${AGENT_CHAT_CONVERSATIONS_ROUTE}/${encodeURIComponent(args.conversationId)}/events${suffix}`
+    );
   }
 }

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -29,6 +29,17 @@ export type AgentChatGetEventsResponse = {
   olderCursor: string | null;
 };
 
+export type AgentChatRespondToApprovalArgs = {
+  agentId: string;
+  conversationId: string;
+  /** Server-minted approve/deny action id echoed from the pending approval part. */
+  actionId: string;
+};
+
+export type AgentChatRespondToApprovalResponse = {
+  identifier: string;
+};
+
 export class AgentChatService {
   #httpClient: HttpClient;
 
@@ -41,6 +52,14 @@ export class AgentChatService {
       agentId: args.agentId,
       text: args.text,
       ...(args.conversationId ? { conversationIdentifier: args.conversationId } : {}),
+    });
+  }
+
+  async respondToApproval(args: AgentChatRespondToApprovalArgs): Promise<AgentChatRespondToApprovalResponse> {
+    return this.#httpClient.post(AGENT_CHAT_CONVERSATIONS_ROUTE, {
+      agentId: args.agentId,
+      conversationIdentifier: args.conversationId,
+      actionId: args.actionId,
     });
   }
 

--- a/packages/js/src/event-emitter/types.ts
+++ b/packages/js/src/event-emitter/types.ts
@@ -1,3 +1,4 @@
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import type { AgentChatMessagesUpdated } from '../agent-chat/types';
 import type {
   ChannelConnectionResponse,
@@ -175,12 +176,15 @@ type SocketConnectEvents = BaseEvents<'socket.connect', { socketUrl: string }, u
 export type NotificationReceivedEvent = `notifications.${WebSocketEvent.RECEIVED}`;
 export type NotificationUnseenEvent = `notifications.${WebSocketEvent.UNSEEN}`;
 export type NotificationUnreadEvent = `notifications.${WebSocketEvent.UNREAD}`;
+export type AgentChatAgentEvent = 'agent_chat.agent_event';
 type SocketEvents = {
   [key in NotificationReceivedEvent]: { result: Notification };
 } & {
   [key in NotificationUnseenEvent]: { result: number };
 } & {
   [key in NotificationUnreadEvent]: { result: { total: number; severity: Record<string, number> } };
+} & {
+  [key in AgentChatAgentEvent]: { result: AgentEventEnvelope };
 };
 
 type AgentChatEvents = {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -2,6 +2,8 @@ export type * from 'json-logic-js';
 export type {
   AgentConversationStatus,
   AgentMessage,
+  FetchMoreArgs,
+  FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
   SendMessageArgs,

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,11 +1,15 @@
+export { derivePendingApprovals } from '@novu/agent-event-protocol';
 export type * from 'json-logic-js';
 export type {
+  AgentApprovalPart,
   AgentConversationStatus,
   AgentMessage,
   FetchMoreArgs,
   FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
+  RespondToApprovalArgs,
+  RespondToApprovalResult,
   SendMessageArgs,
   SendMessageResult,
 } from './agent-chat';

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,5 +1,6 @@
 export type * from 'json-logic-js';
 export type {
+  AgentConversationStatus,
   AgentMessage,
   LoadConversationArgs,
   LoadConversationResult,

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -113,16 +113,17 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
       inboxServiceInstance: this.#inboxService,
       eventEmitterInstance: this.#emitter,
     });
-    this.agentChat = new AgentChat({
-      inboxServiceInstance: this.#inboxService,
-      eventEmitterInstance: this.#emitter,
-      agentChatService: this.#agentChatService,
-    });
     this.socket = createSocket({
       socketUrl: options.socketUrl,
       socketOptions: options.socketOptions,
       eventEmitterInstance: this.#emitter,
       inboxServiceInstance: this.#inboxService,
+    });
+    this.agentChat = new AgentChat({
+      inboxServiceInstance: this.#inboxService,
+      eventEmitterInstance: this.#emitter,
+      agentChatService: this.#agentChatService,
+      socket: this.socket,
     });
 
     this.on = (eventName, listener) => {

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -55,6 +55,7 @@ export enum WebSocketEvent {
   RECEIVED = 'notification_received',
   UNREAD = 'unread_count_changed',
   UNSEEN = 'unseen_count_changed',
+  AGENT_EVENT = 'agent_event',
 }
 
 export enum SocketType {

--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -1,8 +1,10 @@
 import 'event-target-polyfill';
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import { WebSocket } from 'partysocket';
 import { InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import {
+  AgentChatAgentEvent,
   NotificationReceivedEvent,
   NotificationUnreadEvent,
   NotificationUnseenEvent,
@@ -32,6 +34,7 @@ const HIBERNATION_PING_PAYLOAD = 'ping';
 const NOTIFICATION_RECEIVED: NotificationReceivedEvent = 'notifications.notification_received';
 const UNSEEN_COUNT_CHANGED: NotificationUnseenEvent = 'notifications.unseen_count_changed';
 const UNREAD_COUNT_CHANGED: NotificationUnreadEvent = 'notifications.unread_count_changed';
+const AGENT_CHAT_AGENT_EVENT: AgentChatAgentEvent = 'agent_chat.agent_event';
 
 const mapToNotification = ({
   _id,
@@ -185,6 +188,19 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
     }
   };
 
+  #agentEvent = (event: MessageEvent) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data.event === WebSocketEvent.AGENT_EVENT) {
+        this.#emitter.emit(AGENT_CHAT_AGENT_EVENT, {
+          result: data.data as AgentEventEnvelope,
+        });
+      }
+    } catch (error) {
+      // Failed to parse agent event
+    }
+  };
+
   #handleMessage = (event: MessageEvent) => {
     if (event.data === HIBERNATION_PING_PAYLOAD || event.data === 'pong') {
       return;
@@ -202,6 +218,9 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
           break;
         case WebSocketEvent.UNREAD:
           this.#unreadCountChanged(event);
+          break;
+        case WebSocketEvent.AGENT_EVENT:
+          this.#agentEvent(event);
           break;
         default:
         // Unknown WebSocket event type
@@ -296,7 +315,10 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
 
   isSocketEvent(eventName: string): eventName is SocketEventNames {
     return (
-      eventName === NOTIFICATION_RECEIVED || eventName === UNSEEN_COUNT_CHANGED || eventName === UNREAD_COUNT_CHANGED
+      eventName === NOTIFICATION_RECEIVED ||
+      eventName === UNSEEN_COUNT_CHANGED ||
+      eventName === UNREAD_COUNT_CHANGED ||
+      eventName === AGENT_CHAT_AGENT_EVENT
     );
   }
 

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -1,7 +1,9 @@
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import io, { Socket as SocketIO } from 'socket.io-client';
 import { InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import {
+  AgentChatAgentEvent,
   NotificationReceivedEvent,
   NotificationUnreadEvent,
   NotificationUnseenEvent,
@@ -27,6 +29,7 @@ const PRODUCTION_SOCKET_URL = 'https://ws.novu.co';
 const NOTIFICATION_RECEIVED: NotificationReceivedEvent = 'notifications.notification_received';
 const UNSEEN_COUNT_CHANGED: NotificationUnseenEvent = 'notifications.unseen_count_changed';
 const UNREAD_COUNT_CHANGED: NotificationUnreadEvent = 'notifications.unread_count_changed';
+const AGENT_CHAT_AGENT_EVENT: AgentChatAgentEvent = 'agent_chat.agent_event';
 
 const mapToNotification = ({
   _id,
@@ -157,6 +160,12 @@ export class Socket extends BaseModule implements BaseSocketInterface {
     });
   };
 
+  #agentEvent = (envelope: AgentEventEnvelope) => {
+    this.#emitter.emit(AGENT_CHAT_AGENT_EVENT, {
+      result: envelope,
+    });
+  };
+
   async #initializeSocket(): Promise<void> {
     if (this.#socketIo) {
       return;
@@ -185,6 +194,7 @@ export class Socket extends BaseModule implements BaseSocketInterface {
     this.#socketIo?.on(WebSocketEvent.RECEIVED, this.#notificationReceived);
     this.#socketIo?.on(WebSocketEvent.UNSEEN, this.#unseenCountChanged);
     this.#socketIo?.on(WebSocketEvent.UNREAD, this.#unreadCountChanged);
+    this.#socketIo?.on(WebSocketEvent.AGENT_EVENT, this.#agentEvent);
   }
 
   async #handleConnectSocket(): Result<void> {
@@ -210,7 +220,10 @@ export class Socket extends BaseModule implements BaseSocketInterface {
 
   isSocketEvent(eventName: string): eventName is SocketEventNames {
     return (
-      eventName === NOTIFICATION_RECEIVED || eventName === UNSEEN_COUNT_CHANGED || eventName === UNREAD_COUNT_CHANGED
+      eventName === NOTIFICATION_RECEIVED ||
+      eventName === UNSEEN_COUNT_CHANGED ||
+      eventName === UNREAD_COUNT_CHANGED ||
+      eventName === AGENT_CHAT_AGENT_EVENT
     );
   }
 

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -128,6 +128,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   );
 
   useEffect(() => {
+    novu.agentChat.subscribe();
+
     const snapshot = novu.agentChat.getConversation({
       agentId,
       key: sessionKey,
@@ -157,7 +159,10 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       void fetchConversation(conversationIdProp);
     }
 
-    return cleanup;
+    return () => {
+      cleanup();
+      novu.agentChat.unsubscribe();
+    };
   }, [novu, agentId, conversationIdProp, sessionKey, sessionKeyRef, conversationIdRef, propsRef, fetchConversation]);
 
   const refetch = useCallback(async () => {

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,11 +1,14 @@
 import type {
+  AgentApprovalPart,
   AgentConversationStatus,
   AgentMessage,
   LoadConversationResult,
   NovuError,
+  RespondToApprovalResult,
   SendMessageResult,
 } from '@novu/js';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { derivePendingApprovals } from '@novu/js';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
 
@@ -23,6 +26,7 @@ export type UseAgentChatProps = {
 
 export type UseAgentChatResult = {
   messages: AgentMessage[];
+  pendingApprovals: AgentApprovalPart[];
   conversationId?: string;
   error?: NovuError;
   /** True until the first history fetch completes. False when there is no `conversationId` prop. */
@@ -39,6 +43,10 @@ export type UseAgentChatResult = {
   }>;
   sendMessage: (text: string) => Promise<{
     data?: SendMessageResult;
+    error?: NovuError;
+  }>;
+  respondToApproval: (args: { approvalId: string; decision: 'approved' | 'denied' }) => Promise<{
+    data?: RespondToApprovalResult;
     error?: NovuError;
   }>;
 };
@@ -83,6 +91,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const [isLoading, setIsLoading] = useState(Boolean(conversationIdProp));
   const [isFetching, setIsFetching] = useState(false);
   const fetchGenerationRef = useRef(0);
+
+  const pendingApprovals = useMemo(() => derivePendingApprovals(messages), [messages]);
 
   useEffect(() => {
     const agentChanged = prevAgentIdRef.current !== agentId;
@@ -248,9 +258,33 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     [novu, agentId, sessionKeyRef, conversationIdRef, propsRef]
   );
 
+  const respondToApproval = useCallback(
+    async (args: { approvalId: string; decision: 'approved' | 'denied' }) => {
+      setError(undefined);
+
+      const response = await novu.agentChat.respondToApproval({
+        agentId,
+        key: sessionKeyRef.current,
+        conversationId: conversationIdRef.current,
+        approvalId: args.approvalId,
+        decision: args.decision,
+      });
+
+      if (response.error) {
+        setError(response.error);
+        propsRef.current.onError?.(response.error);
+      }
+
+      return response;
+    },
+    [novu, agentId, sessionKeyRef, conversationIdRef, propsRef]
+  );
+
   return {
     messages,
+    pendingApprovals,
     sendMessage,
+    respondToApproval,
     conversationId,
     error,
     isLoading,

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,4 +1,10 @@
-import type { AgentMessage, LoadConversationResult, NovuError, SendMessageResult } from '@novu/js';
+import type {
+  AgentConversationStatus,
+  AgentMessage,
+  LoadConversationResult,
+  NovuError,
+  SendMessageResult,
+} from '@novu/js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
@@ -22,6 +28,8 @@ export type UseAgentChatResult = {
   /** True until the first history fetch completes. False when there is no `conversationId` prop. */
   isLoading: boolean;
   isFetching: boolean;
+  isRunning: boolean;
+  status: AgentConversationStatus;
   refetch: () => Promise<void>;
   sendMessage: (text: string) => Promise<{
     data?: SendMessageResult;
@@ -62,6 +70,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const conversationIdRef = useDataRef(conversationId);
 
   const [messages, setMessages] = useState<AgentMessage[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [status, setStatus] = useState<AgentConversationStatus>('active');
   const [error, setError] = useState<NovuError>();
   const [isLoading, setIsLoading] = useState(Boolean(conversationIdProp));
   const [isFetching, setIsFetching] = useState(false);
@@ -77,6 +87,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setAssignedConversationId(undefined);
       setLocalSessionKey(createLocalSessionKey());
       setMessages([]);
+      setIsRunning(false);
+      setStatus('active');
       setError(undefined);
       setIsLoading(Boolean(conversationIdProp));
 
@@ -94,6 +106,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setAssignedConversationId(undefined);
       setLocalSessionKey(createLocalSessionKey());
       setMessages([]);
+      setIsRunning(false);
+      setStatus('active');
     }
   }, [agentId, conversationIdProp]);
 
@@ -137,11 +151,15 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     });
     if (snapshot) {
       setMessages(snapshot.messages);
+      setIsRunning(snapshot.isRunning);
+      setStatus(snapshot.status);
       if (snapshot.conversationId && !conversationIdProp) {
         setAssignedConversationId(snapshot.conversationId);
       }
     } else if (!conversationIdProp) {
       setMessages([]);
+      setIsRunning(false);
+      setStatus('active');
     }
 
     const cleanup = novu.on('agent_chat.messages.updated', ({ data }) => {
@@ -150,6 +168,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       }
 
       setMessages(data.messages);
+      setIsRunning(data.isRunning);
+      setStatus(data.status);
       if (data.conversationId && !propsRef.current.conversationId) {
         setAssignedConversationId(data.conversationId);
       }
@@ -204,6 +224,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     error,
     isLoading,
     isFetching,
+    isRunning,
+    status,
     refetch,
   };
 };

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -30,7 +30,13 @@ export type UseAgentChatResult = {
   isFetching: boolean;
   isRunning: boolean;
   status: AgentConversationStatus;
+  /** True when older history pages are available via `fetchMore`. */
+  hasMore: boolean;
   refetch: () => Promise<void>;
+  fetchMore: () => Promise<{
+    data?: { messages: AgentMessage[]; hasMore: boolean };
+    error?: NovuError;
+  }>;
   sendMessage: (text: string) => Promise<{
     data?: SendMessageResult;
     error?: NovuError;
@@ -72,6 +78,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [status, setStatus] = useState<AgentConversationStatus>('active');
+  const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<NovuError>();
   const [isLoading, setIsLoading] = useState(Boolean(conversationIdProp));
   const [isFetching, setIsFetching] = useState(false);
@@ -89,6 +96,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setMessages([]);
       setIsRunning(false);
       setStatus('active');
+      setHasMore(false);
       setError(undefined);
       setIsLoading(Boolean(conversationIdProp));
 
@@ -108,6 +116,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setMessages([]);
       setIsRunning(false);
       setStatus('active');
+      setHasMore(false);
     }
   }, [agentId, conversationIdProp]);
 
@@ -132,6 +141,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         propsRef.current.onError?.(response.error);
       } else if (response.data) {
         setMessages(response.data.messages);
+        setHasMore(response.data.hasMore);
         propsRef.current.onSuccess?.(response.data);
       }
 
@@ -153,6 +163,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setMessages(snapshot.messages);
       setIsRunning(snapshot.isRunning);
       setStatus(snapshot.status);
+      setHasMore(snapshot.hasMore);
       if (snapshot.conversationId && !conversationIdProp) {
         setAssignedConversationId(snapshot.conversationId);
       }
@@ -160,6 +171,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setMessages([]);
       setIsRunning(false);
       setStatus('active');
+      setHasMore(false);
     }
 
     const cleanup = novu.on('agent_chat.messages.updated', ({ data }) => {
@@ -170,6 +182,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       setMessages(data.messages);
       setIsRunning(data.isRunning);
       setStatus(data.status);
+      setHasMore(data.hasMore);
       if (data.conversationId && !propsRef.current.conversationId) {
         setAssignedConversationId(data.conversationId);
       }
@@ -193,6 +206,24 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
     await fetchConversation(id);
   }, [conversationIdRef, fetchConversation]);
+
+  const fetchMore = useCallback(async () => {
+    const response = await novu.agentChat.fetchMore({
+      agentId,
+      key: sessionKeyRef.current,
+      conversationId: conversationIdRef.current,
+    });
+
+    if (response.error) {
+      setError(response.error);
+      propsRef.current.onError?.(response.error);
+    } else if (response.data) {
+      setMessages(response.data.messages);
+      setHasMore(response.data.hasMore);
+    }
+
+    return response;
+  }, [novu, agentId, sessionKeyRef, conversationIdRef, propsRef]);
 
   const sendMessage = useCallback(
     async (text: string) => {
@@ -226,6 +257,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     isFetching,
     isRunning,
     status,
+    hasMore,
     refetch,
+    fetchMore,
   };
 };

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -82,7 +82,11 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
     messages: [],
     isLoading: false,
     isFetching: false,
+    isRunning: false,
+    status: 'active',
+    hasMore: false,
     refetch: () => Promise.resolve(),
+    fetchMore: () => Promise.resolve({ data: undefined, error: undefined }),
     sendMessage: () => Promise.resolve({ data: undefined, error: undefined }),
   };
 }

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -80,6 +80,7 @@ export function useNovu() {
 export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
   return {
     messages: [],
+    pendingApprovals: [],
     isLoading: false,
     isFetching: false,
     isRunning: false,
@@ -88,6 +89,7 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
     refetch: () => Promise.resolve(),
     fetchMore: () => Promise.resolve({ data: undefined, error: undefined }),
     sendMessage: () => Promise.resolve({ data: undefined, error: undefined }),
+    respondToApproval: () => Promise.resolve({ data: undefined, error: undefined }),
   };
 }
 


### PR DESCRIPTION
## Summary
- Wire `AGENT_EVENT` through party-socket and socket.io, fold live envelopes into open conversations, and refcount socket subscribe from `useAgentChat` mount.
- Add reconnect gap-fill (buffer → `getEvents` → flush with `sequence > lastSequence`), plus hook `isRunning` / `status` and `fetchMore` / `hasMore`.
- Wire tool approvals end-to-end: server-minted `approveActionId` / `denyActionId`, `pendingApprovals`, and `respondToApproval` echoing `actionId` (live fan-out via `WebChatLiveActivityPublisher`).

## Out of scope (follow-ups)
- Hook callbacks: `onMessage` / `onApprovalRequested` / `onEvent`
- Dedicated `@novu/js` `./agent-chat` entry (keep UMD small)

## Test plan
- [ ] Mount `useAgentChat` with `conversationId` → history loads; live agent replies appear without refetch
- [ ] Two mounts on the same conversation share one subscription; unmount both → socket can disconnect
- [ ] Kill/reconnect socket mid-run → missed durable events appear; no duplicate bubbles
- [ ] Long conversation → `hasMore` true; `fetchMore` prepends older messages
- [ ] Tool that needs approval → `pendingApprovals` populated; approve/deny clears via echoed action ids (second tab / live path)
- [ ] Failed send/load surfaces `error` / `onError` without throwing

Linear: https://linear.app/novu/issue/NV-8445/headless-useagentchat-novujs-novureact

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds live agent-chat WebSocket events, reconnect gap-fill, pagination and status APIs, and end-to-end tool approval actions. The reconnect fix now traverses multiple pages, but its fixed 20-page ceiling can still leave sufficiently large offline gaps incomplete.

- Publishes durable web-chat activities over subscriber WebSockets.
- Adds client-side live-event folding, reconnect buffering, history pagination, and React hook lifecycle management.
- Persists server-minted approval action IDs and exposes approval response APIs.

<h3>Confidence Score: 4/5</h3>

The reconnect pagination ceiling must be fixed before merging because sufficiently large offline gaps still leave durable conversation events missing.

Reconnect catch-up follows older cursors across multiple pages but stops after 20 requests regardless of whether it has reached the holder's known sequence, leaving events beyond the first 1,000 absent when the API uses its default page size.

**Files Needing Attention:** packages/js/src/agent-chat/agent-chat.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/agent-chat/agent-chat.ts | Adds live event handling and reconnect pagination, but the 20-page cap can leave large offline gaps incomplete. |
| packages/js/src/agent-chat/agent-chat-store.ts | Adds pagination cursors and sequence-gated live envelope application while preserving previously loaded history. |
| apps/api/src/app/agents/web-chat/web-chat-live-activity.publisher.ts | Converts persisted web-chat activities into protocol envelopes and enqueues best-effort subscriber WebSocket delivery. |
| apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts | Persists approval action IDs and publishes web-chat approval activities after durable storage. |
| packages/react/src/hooks/useAgentChat.ts | Exposes agent-chat status, pagination, approvals, and refcounted live subscription lifecycle through React. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Hook as useAgentChat
  participant SDK as AgentChat
  participant API as Events API
  participant WS as WebSocket
  Hook->>SDK: subscribe()
  SDK->>WS: connect()
  WS-->>SDK: reconnect
  loop Up to 20 pages
    SDK->>API: getEvents(before)
    API-->>SDK: events + olderCursor
  end
  Note over SDK,API: A remaining cursor after page 20 is not followed
  WS-->>SDK: buffered live envelopes
  SDK->>SDK: apply catch-up then flush buffer
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fjs%2Fsrc%2Fagent-chat%2Fagent-chat.ts%3A429%0A**Reconnect%20catch-up%20stops%20early**%0A%0AWhen%20an%20open%20conversation%20reconnects%20after%20accumulating%20more%20than%201%2C000%20durable%20events%2C%20the%20fixed%2020-page%20loop%20exits%20while%20%60olderCursor%60%20still%20points%20to%20missed%20events%20and%20before%20%60knownThrough%60%20is%20reached%2C%20causing%20older%20messages%2C%20approvals%2C%20and%20tool%20results%20to%20remain%20absent%20from%20client%20state.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/js/src/agent-chat/agent-chat.ts:429
**Reconnect catch-up stops early**

When an open conversation reconnects after accumulating more than 1,000 durable events, the fixed 20-page loop exits while `olderCursor` still points to missed events and before `knownThrough` is reached, causing older messages, approvals, and tool results to remain absent from client state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(js): page agent-chat reconnect catch..."](https://github.com/novuhq/novu/commit/76904070e082a5e48a40a6e5eb1eea9e9c185236) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51752651)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->