### PR TITLE
feat(js,react): add agent-chat hook callbacks via a store change descriptor fixes NV-8445

### DIFF
--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -1,11 +1,14 @@
 import {
   type AgentConversationState,
   type AgentEventEnvelope,
+  type AgentMessage,
   appendUserMessage,
   applyEnvelope,
   applyEnvelopes,
   createInitialAgentConversationState,
+  derivePendingApprovals,
 } from '@novu/agent-event-protocol';
+import type { AgentChatChange, AgentChatChangeSource } from './types';
 
 /**
  * Stable local identity for one conversation holder.
@@ -26,6 +29,11 @@ export type ConversationEntry = AgentConversationState & {
    * exhausted, or on a create-only holder before any history load.
    */
   olderCursor: string | null;
+  /**
+   * Approvals already reported as new. Add-only: an approvalId is never raised twice,
+   * so a resolved approval must not fall out and be reported again.
+   */
+  reportedApprovalIds: Set<string>;
   /** One create at a time on this holder until a conversation id exists. */
   pendingCreate?: Promise<void>;
 };
@@ -53,6 +61,12 @@ function createOptimisticMessageId(): string {
   return mintClientId('opt');
 }
 
+function messagesAddedSince(previous: AgentMessage[], next: AgentMessage[]): AgentMessage[] {
+  const known = new Set(previous.map((message) => message.id));
+
+  return next.filter((message) => !known.has(message.id));
+}
+
 function applyState(entry: ConversationEntry, next: AgentConversationState): void {
   entry.messages = next.messages;
   entry.isRunning = next.isRunning;
@@ -69,10 +83,37 @@ function applyState(entry: ConversationEntry, next: AgentConversationState): voi
  */
 export class AgentChatStore {
   #byKey = new Map<string, ConversationEntry>();
-  #onUpdate: (entry: ConversationEntry) => void;
+  #onUpdate: (entry: ConversationEntry, change: AgentChatChange) => void;
 
-  constructor(onUpdate: (entry: ConversationEntry) => void) {
+  constructor(onUpdate: (entry: ConversationEntry, change: AgentChatChange) => void) {
     this.#onUpdate = onUpdate;
+  }
+
+  /**
+   * Notify listeners with the folded snapshot and what the fold added.
+   * Only this store can tell the three sources apart, so it reports them instead of
+   * leaving each consumer to guess from the snapshot alone.
+   */
+  #publish(entry: ConversationEntry, source: AgentChatChangeSource, addedMessages: AgentMessage[]): void {
+    const newApprovals = derivePendingApprovals(entry.messages).filter(
+      (approval) => !entry.reportedApprovalIds.has(approval.approvalId)
+    );
+    for (const approval of newApprovals) {
+      entry.reportedApprovalIds.add(approval.approvalId);
+    }
+
+    this.#onUpdate(entry, { ...source, addedMessages, newApprovals });
+  }
+
+  /**
+   * Mark a backfilled page's approvals as already reported.
+   * An older page can carry a request whose response is on a page already folded, which
+   * leaves it looking pending. Paging backwards is never new activity.
+   */
+  #suppressApprovals(entry: ConversationEntry, messages: AgentMessage[]): void {
+    for (const approval of derivePendingApprovals(messages)) {
+      entry.reportedApprovalIds.add(approval.approvalId);
+    }
   }
 
   clear(): void {
@@ -135,13 +176,18 @@ export class AgentChatStore {
       conversationId: args.conversationId,
       key: args.key,
       olderCursor: null,
+      reportedApprovalIds: new Set(),
     };
     this.#byKey.set(args.key, entry);
 
     return entry;
   }
 
-  /** Append a user message with status `sending`. Returns the optimistic message id. */
+  /**
+   * Append a user message with status `sending`. Returns the optimistic message id.
+   * The optimistic message is not reported as added: `markSent` reports it once under
+   * the server id, and `markFailed` never reports it.
+   */
   appendSending(entry: ConversationEntry, text: string): string {
     const messageId = createOptimisticMessageId();
     applyState(
@@ -153,7 +199,7 @@ export class AgentChatStore {
         parts: [{ type: 'text', text, state: 'done' }],
       })
     );
-    this.#onUpdate(entry);
+    this.#publish(entry, { kind: 'local' }, []);
 
     return messageId;
   }
@@ -166,6 +212,7 @@ export class AgentChatStore {
     entry: ConversationEntry,
     args: { optimisticMessageId: string; serverMessageId: string; conversationId: string }
   ): ConversationEntry {
+    const previous = entry.messages;
     entry.messages = entry.messages.map((message) =>
       message.id === args.optimisticMessageId
         ? { ...message, id: args.serverMessageId, status: 'sent' as const }
@@ -176,7 +223,7 @@ export class AgentChatStore {
       entry.conversationId = args.conversationId;
     }
 
-    this.#onUpdate(entry);
+    this.#publish(entry, { kind: 'local' }, messagesAddedSince(previous, entry.messages));
 
     return entry;
   }
@@ -185,7 +232,7 @@ export class AgentChatStore {
     entry.messages = entry.messages.map((message) =>
       message.id === messageId ? { ...message, status: 'failed' as const } : message
     );
-    this.#onUpdate(entry);
+    this.#publish(entry, { kind: 'local' }, []);
 
     return entry;
   }
@@ -199,9 +246,10 @@ export class AgentChatStore {
     envelopes: AgentEventEnvelope[],
     olderCursor: string | null
   ): ConversationEntry {
+    const previous = entry.messages;
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const serverIds = new Set(folded.messages.map((message) => message.id));
-    const localOnly = entry.messages.filter((message) => !serverIds.has(message.id));
+    const localOnly = previous.filter((message) => !serverIds.has(message.id));
 
     applyState(entry, {
       ...folded,
@@ -209,7 +257,7 @@ export class AgentChatStore {
     });
     entry.olderCursor = olderCursor;
 
-    this.#onUpdate(entry);
+    this.#publish(entry, { kind: 'history' }, messagesAddedSince(previous, entry.messages));
 
     return entry;
   }
@@ -229,8 +277,9 @@ export class AgentChatStore {
 
     entry.messages = [...olderMessages, ...entry.messages];
     entry.olderCursor = olderCursor;
+    this.#suppressApprovals(entry, olderMessages);
 
-    this.#onUpdate(entry);
+    this.#publish(entry, { kind: 'history' }, olderMessages);
 
     return entry;
   }
@@ -244,8 +293,9 @@ export class AgentChatStore {
       return entry;
     }
 
+    const previous = entry.messages;
     applyState(entry, applyEnvelope(entry, envelope));
-    this.#onUpdate(entry);
+    this.#publish(entry, { kind: 'live', envelope }, messagesAddedSince(previous, entry.messages));
 
     return entry;
   }

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -2,6 +2,7 @@ import { AGENT_EVENT_PROTOCOL_VERSION, derivePendingApprovals } from '@novu/agen
 import { AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
+import type { AgentChatChange } from './types';
 
 describe('AgentChat', () => {
   const inboxServiceInstance = { isSessionInitialized: true } as any;
@@ -759,6 +760,29 @@ describe('AgentChat', () => {
     };
   }
 
+  function liveEnvelope(args: { sequence: number; event: Record<string, unknown> }) {
+    return {
+      result: {
+        version: AGENT_EVENT_PROTOCOL_VERSION,
+        conversationId: 'internal',
+        conversationIdentifier: 'conv_abcdefghijkl',
+        agentId: 'agent_1',
+        runId: 'run_1',
+        turnId: 't1',
+        sequence: args.sequence,
+        timestamp: '2026-08-07T12:00:03.000Z',
+        event: args.event,
+      },
+    } as any;
+  }
+
+  function liveUserEnvelope(args: { sequence: number; messageId: string }) {
+    return liveEnvelope({
+      sequence: args.sequence,
+      event: { type: 'message', role: 'user', messageId: args.messageId, content: { markdown: 'second' } },
+    });
+  }
+
   async function waitForMessageIds(expected: string[]): Promise<void> {
     const current = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
     if (current && current.messages.map((message) => message.id).join() === expected.join()) {
@@ -1421,5 +1445,185 @@ describe('AgentChat', () => {
 
     expect(result.error).toBeDefined();
     expect(respondToApproval).not.toHaveBeenCalled();
+  });
+
+  function recordChanges(key: string) {
+    const changes: AgentChatChange[] = [];
+    emitter.on('agent_chat.messages.updated', ({ data }) => {
+      if (data.key === key) {
+        changes.push(data.change);
+      }
+    });
+
+    return changes;
+  }
+
+  it('reports a live fold as new activity while a history page is in flight', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 3, messageId: 'msg_new0000001', role: 'user', markdown: 'recent' }], 'act_page0001')
+    );
+    await agentChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+
+    let resolveOlderPage!: (value: ReturnType<typeof historyPage>) => void;
+    getEvents.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOlderPage = resolve;
+        })
+    );
+
+    const changes = recordChanges('conv_abcdefghijkl');
+    const older = agentChat.fetchMore({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({ sequence: 4, messageId: 'msg_live0000001', markdown: 'live during fetchMore' })
+    );
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.kind).toBe('live');
+    expect(changes[0]?.addedMessages.map((message) => message.id)).toEqual(['msg_live0000001']);
+
+    resolveOlderPage(
+      historyPage([{ sequence: 1, messageId: 'msg_old0000001', role: 'user', markdown: 'older' }], null)
+    );
+    await older;
+
+    expect(changes[1]?.kind).toBe('history');
+    expect(changes[1]?.addedMessages.map((message) => message.id)).toEqual(['msg_old0000001']);
+  });
+
+  it('carries the envelope that caused a live fold', async () => {
+    await openClaimedConversation();
+    const changes = recordChanges('local_session1');
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({ sequence: 2, messageId: 'msg_asst0000001', markdown: 'live reply' })
+    );
+
+    const change = changes[0];
+    expect(change?.kind === 'live' && change.envelope.sequence).toBe(2);
+  });
+
+  it('does not report an envelope the sequence gate drops', async () => {
+    await openClaimedConversation();
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({ sequence: 2, messageId: 'msg_asst0000001', markdown: 'live reply' })
+    );
+
+    const changes = recordChanges('local_session1');
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveAssistantEnvelope({ sequence: 2, messageId: 'msg_asst0000001', markdown: 'duplicate' })
+    );
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it('reports a sent message once under the server id and never the optimistic id', async () => {
+    sendMessage.mockResolvedValue({ identifier: 'conv_abcdefghijkl', messageId: 'msg_abcdefghijkl' });
+    const changes = recordChanges('local_session1');
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    expect(changes.map((change) => change.kind)).toEqual(['local', 'local']);
+    expect(changes.map((change) => change.addedMessages.map((message) => message.id))).toEqual([
+      [],
+      ['msg_abcdefghijkl'],
+    ]);
+  });
+
+  it('does not report a sent message twice when the live echo folds before the ack', async () => {
+    await openClaimedConversation();
+
+    let resolveSend!: (value: { identifier: string; messageId: string }) => void;
+    sendMessage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = resolve;
+        })
+    );
+
+    const changes = recordChanges('local_session1');
+    const sent = agentChat.sendMessage({ agentId: 'agent_1', text: 'second', key: 'local_session1' });
+
+    emitter.emit('agent_chat.agent_event', liveUserEnvelope({ sequence: 2, messageId: 'msg_user0000002' }));
+    resolveSend({ identifier: 'conv_abcdefghijkl', messageId: 'msg_user0000002' });
+    await sent;
+
+    const reported = changes.flatMap((change) => change.addedMessages.map((message) => message.id));
+    expect(reported.filter((id) => id === 'msg_user0000002')).toHaveLength(1);
+  });
+
+  it('reports no added message when a send fails', async () => {
+    sendMessage.mockRejectedValue(new Error('network'));
+    const changes = recordChanges('local_session1');
+
+    await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    expect(changes.map((change) => change.kind)).toEqual(['local', 'local']);
+    expect(changes.map((change) => change.addedMessages)).toEqual([[], []]);
+  });
+
+  it('reports a pending approval from history once across reloads', async () => {
+    getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
+    const changes = recordChanges('conv_abcdefghijkl');
+
+    await agentChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+    await agentChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+
+    expect(changes[0]?.newApprovals.map((approval) => approval.approvalId)).toEqual(['approval_000001']);
+    expect(changes[1]?.newApprovals).toEqual([]);
+  });
+
+  it('reports a live approval on the fold that raises it, adding no message', async () => {
+    await openClaimedConversation();
+    const changes = recordChanges('local_session1');
+
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveEnvelope({ sequence: 2, event: { type: 'message-start', messageId: 'msg_asst0000001' } })
+    );
+    emitter.emit(
+      'agent_chat.agent_event',
+      liveEnvelope({
+        sequence: 3,
+        event: {
+          type: 'tool-approval-request',
+          approvalId: 'approval_000001',
+          toolUseId: 'tu_0000001',
+          toolName: 'deleteOrder',
+          input: { orderId: '123' },
+          approveActionId: 'tool-approval:approve:approval_000001',
+          denyActionId: 'tool-approval:deny:approval_000001',
+        },
+      })
+    );
+
+    expect(changes[0]?.newApprovals).toEqual([]);
+    expect(changes[1]?.kind).toBe('live');
+    expect(changes[1]?.addedMessages).toEqual([]);
+    expect(changes[1]?.newApprovals.map((approval) => approval.approvalId)).toEqual(['approval_000001']);
+  });
+
+  it('stays silent for an approval discovered by paging backwards', async () => {
+    getEvents.mockResolvedValueOnce(
+      historyPage([{ sequence: 9, messageId: 'msg_new0000001', role: 'user', markdown: 'recent' }], 'act_page0001')
+    );
+    await agentChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+
+    getEvents.mockResolvedValueOnce(approvalHistoryPage('approval_000001'));
+    const changes = recordChanges('conv_abcdefghijkl');
+    await agentChat.fetchMore({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+
+    const snapshot = agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
+    expect(derivePendingApprovals(snapshot?.messages ?? []).map((approval) => approval.approvalId)).toEqual([
+      'approval_000001',
+    ]);
+    expect(changes[0]?.kind).toBe('history');
+    expect(changes[0]?.newApprovals).toEqual([]);
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -44,7 +44,7 @@ export class AgentChat extends BaseModule {
     super({ inboxServiceInstance, eventEmitterInstance });
     this.#agentChatService = agentChatService;
     this.#socket = socket;
-    this.#store = new AgentChatStore((entry) => {
+    this.#store = new AgentChatStore((entry, change) => {
       this._emitter.emit('agent_chat.messages.updated', {
         data: {
           agentId: entry.agentId,
@@ -54,6 +54,7 @@ export class AgentChat extends BaseModule {
           isRunning: entry.isRunning,
           status: entry.status,
           hasMore: entry.olderCursor != null,
+          change,
         },
       });
     });

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,8 +1,10 @@
 export { AgentChat } from './agent-chat';
 export type {
   AgentApprovalPart,
+  AgentChatChange,
   AgentChatMessagesUpdated,
   AgentConversationStatus,
+  AgentEventEnvelope,
   AgentMessage,
   FetchMoreArgs,
   FetchMoreResult,

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -1,6 +1,11 @@
-import type { AgentApprovalPart, AgentConversationStatus, AgentMessage } from '@novu/agent-event-protocol';
+import type {
+  AgentApprovalPart,
+  AgentConversationStatus,
+  AgentEventEnvelope,
+  AgentMessage,
+} from '@novu/agent-event-protocol';
 
-export type { AgentApprovalPart, AgentConversationStatus, AgentMessage };
+export type { AgentApprovalPart, AgentConversationStatus, AgentEventEnvelope, AgentMessage };
 
 export type SendMessageArgs = {
   agentId: string;
@@ -57,6 +62,23 @@ export type RespondToApprovalResult = {
   conversationId: string;
 };
 
+/** What caused a fold. A live fold carries the envelope that caused it. Internal to the store seam. */
+export type AgentChatChangeSource =
+  | { kind: 'live'; envelope: AgentEventEnvelope }
+  | { kind: 'history' }
+  | { kind: 'local' };
+
+/**
+ * What one fold added to a holder, next to the folded snapshot.
+ * A `history` fold replays stored events, so it is catch-up and not new activity.
+ */
+export type AgentChatChange = AgentChatChangeSource & {
+  /** Messages this fold added. A fold that only changes existing messages adds none. */
+  addedMessages: AgentMessage[];
+  /** Approvals that became pending in this fold. One approval is reported one time. */
+  newApprovals: AgentApprovalPart[];
+};
+
 export type AgentChatMessagesUpdated = {
   agentId: string;
   conversationId?: string;
@@ -66,4 +88,5 @@ export type AgentChatMessagesUpdated = {
   isRunning: boolean;
   status: AgentConversationStatus;
   hasMore: boolean;
+  change: AgentChatChange;
 };

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -2,7 +2,9 @@ export { derivePendingApprovals } from '@novu/agent-event-protocol';
 export type * from 'json-logic-js';
 export type {
   AgentApprovalPart,
+  AgentChatChange,
   AgentConversationStatus,
+  AgentEventEnvelope,
   AgentMessage,
   FetchMoreArgs,
   FetchMoreResult,

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,6 +1,7 @@
 import type {
   AgentApprovalPart,
   AgentConversationStatus,
+  AgentEventEnvelope,
   AgentMessage,
   LoadConversationResult,
   NovuError,
@@ -22,6 +23,27 @@ export type UseAgentChatProps = {
   conversationId?: string;
   onSuccess?: (data: LoadConversationResult) => void;
   onError?: (error: NovuError) => void;
+  /**
+   * Fires once per message, when the message id first appears on the conversation.
+   * History pages are silent: only new activity fires.
+   * An agent message can still be empty at this point, because the first envelope of a
+   * turn creates the message before any text is folded into it.
+   * A send that never reaches the server does not fire: the message flips to `failed` instead.
+   */
+  onMessage?: (message: AgentMessage) => void;
+  /**
+   * Fires once per approval request, including approvals still pending on mount, so a
+   * resumed conversation reports what it is blocked on. Paging backwards is silent.
+   * The run waits until `respondToApproval` answers.
+   */
+  onApprovalRequested?: (approval: AgentApprovalPart) => void;
+  /**
+   * Raw envelopes for this conversation, before the derived callbacks for the same fold.
+   * A duplicate envelope that the store drops does not fire. Neither does an envelope that
+   * arrives before a newly created conversation claims its id.
+   * The store folds the envelope before this callback runs, so `messages` here is one render old.
+   */
+  onEvent?: (envelope: AgentEventEnvelope) => void;
 };
 
 export type UseAgentChatResult = {
@@ -177,6 +199,12 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       if (snapshot.conversationId && !conversationIdProp) {
         setAssignedConversationId(snapshot.conversationId);
       }
+
+      // The store reports each approval once per holder, and a holder outlives a mount.
+      // Replay from the snapshot so a remount still learns what the run is blocked on.
+      for (const approval of derivePendingApprovals(snapshot.messages)) {
+        propsRef.current.onApprovalRequested?.(approval);
+      }
     } else if (!conversationIdProp) {
       setMessages([]);
       setIsRunning(false);
@@ -196,6 +224,21 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       if (data.conversationId && !propsRef.current.conversationId) {
         setAssignedConversationId(data.conversationId);
       }
+
+      const { change } = data;
+      if (change.kind === 'live') {
+        propsRef.current.onEvent?.(change.envelope);
+      }
+
+      if (change.kind !== 'history') {
+        for (const message of change.addedMessages) {
+          propsRef.current.onMessage?.(message);
+        }
+      }
+
+      for (const approval of change.newApprovals) {
+        propsRef.current.onApprovalRequested?.(approval);
+      }
     });
 
     if (conversationIdProp) {
@@ -206,7 +249,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
       cleanup();
       novu.agentChat.unsubscribe();
     };
-  }, [novu, agentId, conversationIdProp, sessionKey, sessionKeyRef, conversationIdRef, propsRef, fetchConversation]);
+  }, [novu, agentId, conversationIdProp, sessionKey, sessionKeyRef, propsRef, fetchConversation]);
 
   const refetch = useCallback(async () => {
     const id = conversationIdRef.current;


### PR DESCRIPTION
## Summary

Adds the three hook callbacks listed as out-of-scope follow-ups in #12292: `onMessage`, `onApprovalRequested` and `onEvent` on `useAgentChat`.

The interesting part is where the logic lives. `AgentChatStore` emits the **whole** message array after every fold, so a consumer cannot tell new activity from a history page. The first attempt diffed snapshots inside the hook with a seen-id set, suppressed while a history fetch was in flight. That loses live activity permanently: ids are recorded before the suppression check, so a message that arrives during `fetchMore` is marked seen and never reported. Confirmed in a browser repro.

The store already knows which of its six mutators ran and throws that away. It now publishes it instead:

```ts
export type AgentChatChange = AgentChatChangeSource & {
  addedMessages: AgentMessage[];
  newApprovals: AgentApprovalPart[];
};
```

`kind` is `live` (carrying the envelope that caused the fold), `history`, or `local`. The hook reads it on the listener it already had — no seen set, no refcount, no second listener.

## Why this shape

- **`addedMessages` is diffed by the store**, which also owns the `opt_*` → `msg_*` rewrite, so an optimistic send is reported once under the server id and a failed send is never reported.
- **`newApprovals` cannot be derived** from `addedMessages`: an approval attaches as a part on an assistant message that already exists, so the fold that raises one usually adds zero messages.
- **`onEvent` rides the same emit**, matched by holder key. Previously it filtered on a conversation id held in React state, which lags the store by one commit and dropped the first turn of every new conversation. It now also fires *before* the derived callbacks for the same fold.
- Approvals are reported at most once per holder (add-only set). Paging backwards is silent, because an older page can carry a request whose response is already folded and would look pending. A hook mount replays still-pending approvals from its snapshot, so resuming a blocked conversation reports what it is waiting on.

## Flow

```mermaid
flowchart LR
    A["history page"] --> E["emit snapshot<br/>+ change descriptor"]
    B["live envelope"] --> E
    C["local send / ack"] --> E
    E --> H["hook reads change.kind<br/>no diff, no timing"]
```

## Breaking changes

None. `agent_chat.messages.updated` gains a `change` field; `AgentChatChange` is a new export from `@novu/js`. UMD budget still passes.

## Out of scope

- Dedicated `@novu/js` `./agent-chat` entry point (still a follow-up from #12292)
- `refetch` creating a second holder for one conversation (pre-existing)
- Token streaming semantics for `onMessage` (NV-8444)

## Test plan

- [x] 47 unit tests pass in `packages/js/src/agent-chat`, 6 new for the descriptor
- [x] Both new regression tests mutation-checked: reverting each fix fails that test and only that test
- [x] `@novu/js` + `@novu/react` build clean, `attw` green, UMD size limit passing
- [x] Browser: send during an in-flight history fetch → `onMessage` fires for both the user message and the live agent reply (previously silent)
- [x] Browser: cold resume of a 4-message conversation → all render, zero `onMessage` (history silent)
- [x] Browser: `onEvent` fires before `onMessage` for the same envelope
- [ ] Approval replay on remount and backfill suppression — unit-tested only; the local agent emits no `tool-approval-request` envelopes

Linear: https://linear.app/novu/issue/NV-8445/headless-useagentchat-novujs-novureact

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds change descriptors to agent-chat store updates and exposes `onMessage`, `onApprovalRequested`, and `onEvent` callbacks through `useAgentChat`.

- Distinguishes live, history, and local folds while reporting newly added messages and approvals.
- Reconciles optimistic messages under server IDs and suppresses callbacks for failed sends and historical backfill.
- Replays pending approvals when a hook mounts and exports the new public descriptor and envelope types.
- Adds regression coverage for concurrent history/live activity, duplicate sequence handling, optimistic acknowledgement ordering, and approval reporting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The store retains conversation-aware routing and sequence gating while its new descriptors correctly distinguish historical, local, and live activity, reconcile optimistic IDs, and deduplicate approval notifications.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/agent-chat/agent-chat-store.ts | Adds source-aware change publication, message-ID reconciliation, and per-holder approval reporting and backfill suppression. |
| packages/js/src/agent-chat/agent-chat.ts | Propagates each store change descriptor through the existing agent-chat update event. |
| packages/js/src/agent-chat/types.ts | Defines the public discriminated change descriptor and extends message-update payloads with it. |
| packages/react/src/hooks/useAgentChat.ts | Adds callback props, pending-approval replay, and ordered callback dispatch from store change descriptors. |
| packages/js/src/agent-chat/agent-chat.test.ts | Covers live/history concurrency, sequence suppression, optimistic reconciliation, failure behavior, and approval reporting semantics. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  History["History page"] --> Store["AgentChatStore fold"]
  Live["Live envelope"] --> Store
  Local["Local send / acknowledgement"] --> Store
  Store --> Change["Snapshot + AgentChatChange"]
  Change --> Hook["useAgentChat listener"]
  Hook --> Event["onEvent"]
  Hook --> Message["onMessage"]
  Hook --> Approval["onApprovalRequested"]
```

<sub>Reviews (1): Last reviewed commit: ["feat(js,react): add agent-chat hook call..."](https://github.com/novuhq/novu/commit/a011c7c00ca3880141f51f237b0c6c302ecc8365) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51778544)</sub>

**Context used:**

- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->