### PR TITLE
fix(api-service, worker): increase body parser limits and encode attachments as base64 for bridge events fixes NV-8571

### DIFF
--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -116,8 +116,12 @@ export async function bootstrap(
   app.useGlobalInterceptors(new ResponseInterceptor());
   app.useGlobalInterceptors(getErrorInterceptor());
 
-  app.use(extendedBodySizeRoutes, bodyParser.json({ limit: '26mb' }));
-  app.use(extendedBodySizeRoutes, bodyParser.urlencoded({ limit: '26mb', extended: true }));
+  /*
+   * ~20 MB raw attachments become ~26.7 MB base64 JSON. Keep headroom above that so
+   * trigger + internal bridge requests with large attachments are not rejected at 26 MB.
+   */
+  app.use(extendedBodySizeRoutes, bodyParser.json({ limit: '30mb' }));
+  app.use(extendedBodySizeRoutes, bodyParser.urlencoded({ limit: '30mb', extended: true }));
 
   app.use('/v1/agents', bodyParser.json({ limit: '8mb', verify: agentRawBodyBuffer }));
 

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.spec.ts
@@ -178,6 +178,58 @@ describe('ExecuteBridgeJob - redundant workflow lookup', () => {
     expect(bridgeRequest.event.actor).to.deep.equal(actor);
   });
 
+  it('encodes rehydrated attachment Buffers as base64 for the bridge event', async () => {
+    const { usecase, executeBridgeRequest } = buildUsecase();
+    const fileBytes = Buffer.from('pdf-bytes');
+    const attachment = {
+      name: 'invoice.pdf',
+      mime: 'application/pdf',
+      file: fileBytes,
+      storagePath: 'org/env/id/invoice.pdf',
+    };
+
+    const command = {
+      environmentId: 'env_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+      identifier: 'wf-identifier',
+      jobId: 'job_1',
+      job: {
+        _id: 'job_1',
+        _templateId: 'tpl_1',
+        _parentId: undefined,
+        _environmentId: 'env_1',
+        _organizationId: 'org_1',
+        step: { stepId: 'step_1', uuid: 'step_1' },
+      },
+      variables: {
+        subscriber: { subscriberId: 'recipient-01' },
+        payload: { attachments: [attachment] },
+        env: { name: 'Development', type: 'dev' },
+      },
+      workflow: {
+        _id: 'tpl_1',
+        type: ResourceTypeEnum.BRIDGE,
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+        triggers: [{ identifier: 'wf-identifier' }],
+      },
+    } as never;
+
+    await usecase.execute(command);
+
+    const bridgeRequest = executeBridgeRequest.execute.firstCall.args[0];
+    expect(bridgeRequest.event.payload.attachments).to.deep.equal([
+      {
+        name: 'invoice.pdf',
+        mime: 'application/pdf',
+        file: fileBytes.toString('base64'),
+        storagePath: 'org/env/id/invoice.pdf',
+      },
+    ]);
+    // Original in-memory attachment used for channel delivery must stay a Buffer.
+    expect(Buffer.isBuffer(attachment.file)).to.equal(true);
+  });
+
   it('stitches STEP_PROVIDER_CONTROLS docs into controls.providerOverrides for the bridge event', async () => {
     const { usecase, executeBridgeRequest, controlValuesRepository } = buildUsecase();
 

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -207,7 +207,32 @@ export class ExecuteBridgeJob {
     // Remove internal params
     const { __source, ...payload } = originalPayload;
 
-    return payload;
+    if (!Array.isArray(payload.attachments) || payload.attachments.length === 0) {
+      return payload;
+    }
+
+    /*
+     * Rehydrated attachment files are Node Buffers. JSON.stringify turns those into
+     * `{"type":"Buffer","data":[...]}` (~3.4x the raw size), which overflows the API
+     * bridge body limit for files larger than ~5–7 MB. Encode as base64 for the bridge
+     * wire format (same shape clients send on trigger) without mutating the original
+     * payload used later for channel delivery.
+     */
+    return {
+      ...payload,
+      attachments: payload.attachments.map((attachment) => {
+        const file = attachment?.file;
+
+        if (!Buffer.isBuffer(file) && !(file instanceof Uint8Array)) {
+          return attachment;
+        }
+
+        return {
+          ...attachment,
+          file: Buffer.from(file).toString('base64'),
+        };
+      }),
+    };
   }
 
   public async buildStepsMap(job: JobEntity, environmentId: string): Promise<Record<string, Record<string, unknown>>> {

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -41,6 +41,7 @@ import {
   ControlValuesLevelEnum,
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
+  IAttachmentOptions,
   ITriggerPayload,
   JobStatusEnum,
   ResourceOriginEnum,
@@ -217,21 +218,33 @@ export class ExecuteBridgeJob {
      * bridge body limit for files larger than ~5–7 MB. Encode as base64 for the bridge
      * wire format (same shape clients send on trigger) without mutating the original
      * payload used later for channel delivery.
+     *
+     * Cast: IAttachmentOptions.file is typed as Buffer, but the bridge JSON body must
+     * carry a base64 string. Runtime consumers of this normalized payload expect that.
      */
-    return {
-      ...payload,
-      attachments: payload.attachments.map((attachment) => {
-        const file = attachment?.file;
+    const attachments = payload.attachments.map((attachment) => {
+      const file: unknown = attachment?.file;
 
-        if (!Buffer.isBuffer(file) && !(file instanceof Uint8Array)) {
-          return attachment;
-        }
+      if (Buffer.isBuffer(file)) {
+        return {
+          ...attachment,
+          file: file.toString('base64'),
+        };
+      }
 
+      if (file instanceof Uint8Array) {
         return {
           ...attachment,
           file: Buffer.from(file).toString('base64'),
         };
-      }),
+      }
+
+      return attachment;
+    }) as IAttachmentOptions[];
+
+    return {
+      ...payload,
+      attachments,
     };
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises selected API body-parser limits and normalizes rehydrated attachment bytes to base64 before sending bridge events.
- Increases extended-route JSON and URL-encoded request limits from 26 MB to 30 MB.
- Converts Buffer and Uint8Array attachment data to base64 without mutating the payload retained for channel delivery.
- Adds focused coverage for bridge attachment encoding and immutability.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/bootstrap.ts | Raises the extended-route body-parser limits to accommodate larger base64-encoded request payloads. |
| apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts | Copies attachment metadata and converts binary file values to base64 for bridge-event serialization. |
| apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.spec.ts | Verifies base64 bridge encoding while ensuring the original attachment remains a Buffer. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(worker): normalize attachment file e..."](https://github.com/novuhq/novu/commit/a69116ae4ae1e5ed6c227eb4633e3f3432c9d9ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51791192)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [API App (apps/api)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-app.md)
- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)
- Knowledge Base — [Notification Trigger Flow](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/notification-trigger-flow.md)
</details>

<!-- /greptile_comment -->