### PR TITLE
docs(docs): remove outdated 7MB attachment limit FAQ for code steps fixes NV-8571

### DIFF
--- a/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/code-steps.mdx
@@ -240,14 +240,6 @@ npm install --save-dev @novu/framework
   The CLI publishes to non production environments only. Publishing directly to Production is blocked. To promote changes to Production, use the **Publish changes** button in the Novu dashboard.
 </Note>
 
-## Frequently Asked Questions
-
-Frequently asked questions related to code steps: 
-
-### What is the attachment limit for email type code step
-
-If email step is created using custom code, then maximum attachment size limit is 7MB. Checkout the [ending email attachments](/platform/integrations/email#sending-attachments) documentation to learn on how to send the email attachments while triggering the workflow.
-
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the outdated FAQ entry in the Code Steps documentation that stated a 7MB attachment limit for email code steps. The code step resolver now supports the same **20MB** attachment limit as all other email steps, so this separate mention was incorrect and confusing for customers.

## Changes

- Removed the "What is the attachment limit for email type code step" FAQ entry from `docs/platform/workflow/add-and-configure-steps/code-steps.mdx`
- The empty "Frequently Asked Questions" heading was also removed since it had no remaining entries

## Context

A customer reported that ~10-11MB CSV attachments were failing with `PayloadTooLarge`. The underlying fix (shipped to staging) unified the code step resolver to the same 20MB limit documented on the [Payload Limits](/api-reference/payload-limits) and [Email](/platform/integrations/email#sending-attachments) pages. This PR cleans up the docs to match.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1786339816834749?thread_ts=1786339816.834749&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-11a8227d-125a-5be4-8ac9-90bd8046a4b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11a8227d-125a-5be4-8ac9-90bd8046a4b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes an outdated attachment-limit FAQ from the Code Steps documentation now that code-based email steps share the standard 20 MB limit.

- Removes the obsolete 7 MB attachment-limit guidance.
- Removes the now-empty Frequently Asked Questions section.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only removes obsolete documentation and leaves no empty section behind.

The deleted FAQ contradicted the updated attachment limit, and its removal does not break the surrounding MDX structure or documentation flow.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/workflow/add-and-configure-steps/code-steps.mdx | Cleanly removes outdated attachment-limit guidance and its empty parent section without affecting surrounding documentation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove outdated 7MB attachment lim..."](https://github.com/novuhq/novu/commit/85e223c2eedf4a2e6ce0ecdc5727861103740f59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51812336)</sub>

<!-- /greptile_comment -->