### PR TITLE
refactor(js): move conversation projection into @novu/js fixes NV-8572

### DIFF
--- a/packages/agent-event-protocol/package.json
+++ b/packages/agent-event-protocol/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "build": "tsup",
     "lint": "biome lint .",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/agent-event-protocol/src/agent-event.types.ts
+++ b/packages/agent-event-protocol/src/agent-event.types.ts
@@ -1,5 +1,10 @@
-import type { AgentMessageRole } from './agent-message.types';
-import type { AgentFileRef, AgentMessageContent, AgentToolResultContent, AgentToolSource } from './wire-content.types';
+import type {
+  AgentFileRef,
+  AgentMessageContent,
+  AgentMessageRole,
+  AgentToolResultContent,
+  AgentToolSource,
+} from './wire-content.types';
 
 export const AGENT_EVENT_PROTOCOL_VERSION = 1 as const;
 

--- a/packages/agent-event-protocol/src/index.ts
+++ b/packages/agent-event-protocol/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Wire-only AgentEvent contract: envelope shapes, event union, and runtime guards.
+ * Server paths validate, store, and forward envelopes — they do not fold timelines.
+ * Client-side projection (`applyEnvelope` → `AgentMessage[]`) lives in `@novu/js` agent-chat.
+ */
 export type {
   AgentApprovalRequest,
   AgentEvent,
@@ -9,24 +14,9 @@ export type {
 } from './agent-event.types';
 export { AGENT_EVENT_PROTOCOL_VERSION, isAgentEventEnvelope, isDeltaEvent } from './agent-event.types';
 export type {
-  AgentApprovalPart,
-  AgentApprovalPartState,
-  AgentCardPart,
-  AgentConversationError,
-  AgentConversationState,
-  AgentConversationStatus,
-  AgentFilePart,
-  AgentMessage,
-  AgentMessagePart,
+  AgentFileRef,
+  AgentMessageContent,
   AgentMessageRole,
-  AgentMessageStatus,
-  AgentSourcePart,
-  AgentTextPart,
-  AgentTextPartState,
-  AgentThinkingPart,
-  AgentToolPart,
-  AgentToolPartState,
-} from './agent-message.types';
-export { createInitialAgentConversationState, derivePendingApprovals } from './agent-message.types';
-export { appendUserMessage, applyEnvelope, applyEnvelopes } from './apply-envelope';
-export type { AgentFileRef, AgentMessageContent, AgentToolResultContent, AgentToolSource } from './wire-content.types';
+  AgentToolResultContent,
+  AgentToolSource,
+} from './wire-content.types';

--- a/packages/agent-event-protocol/src/wire-content.types.ts
+++ b/packages/agent-event-protocol/src/wire-content.types.ts
@@ -1,3 +1,5 @@
+export type AgentMessageRole = 'user' | 'assistant';
+
 export type AgentToolSource = { type: 'builtin' } | { type: 'custom' } | { type: 'mcp'; serverName: string };
 
 export type AgentToolResultContent =

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -1,13 +1,11 @@
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import {
   type AgentConversationState,
-  type AgentEventEnvelope,
   type AgentMessage,
-  appendUserMessage,
-  applyEnvelope,
-  applyEnvelopes,
   createInitialAgentConversationState,
   derivePendingApprovals,
-} from '@novu/agent-event-protocol';
+} from './agent-message.types';
+import { appendUserMessage, applyEnvelope, applyEnvelopes } from './apply-envelope';
 import type { AgentChatChange, AgentChatChangeSource } from './types';
 
 /**

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1,7 +1,8 @@
-import { AGENT_EVENT_PROTOCOL_VERSION, derivePendingApprovals } from '@novu/agent-event-protocol';
+import { AGENT_EVENT_PROTOCOL_VERSION } from '@novu/agent-event-protocol';
 import { AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
+import { derivePendingApprovals } from './agent-message.types';
 import type { AgentChatChange } from './types';
 
 describe('AgentChat', () => {

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,5 +1,4 @@
-import type { AgentEventEnvelope, AgentMessage } from '@novu/agent-event-protocol';
-import { derivePendingApprovals } from '@novu/agent-event-protocol';
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import { AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
@@ -7,6 +6,7 @@ import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
 import type { BaseSocketInterface } from '../ws/base-socket';
 import { AgentChatStore, type ConversationEntry, createLocalConversationKey } from './agent-chat-store';
+import { type AgentMessage, derivePendingApprovals } from './agent-message.types';
 import type {
   FetchMoreArgs,
   FetchMoreResult,

--- a/packages/js/src/agent-chat/agent-message.types.ts
+++ b/packages/js/src/agent-chat/agent-message.types.ts
@@ -1,6 +1,6 @@
-import type { AgentToolResultContent, AgentToolSource } from './wire-content.types';
+import type { AgentMessageRole, AgentToolResultContent, AgentToolSource } from '@novu/agent-event-protocol';
 
-export type AgentMessageRole = 'user' | 'assistant';
+export type { AgentMessageRole };
 
 export type AgentMessageStatus = 'sending' | 'sent' | 'failed';
 

--- a/packages/js/src/agent-chat/apply-envelope.test.ts
+++ b/packages/js/src/agent-chat/apply-envelope.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it } from 'vitest';
-import { AGENT_EVENT_PROTOCOL_VERSION, type AgentEvent, type AgentEventEnvelope } from './agent-event.types';
+import { AGENT_EVENT_PROTOCOL_VERSION, type AgentEvent, type AgentEventEnvelope } from '@novu/agent-event-protocol';
 import { type AgentMessage, createInitialAgentConversationState } from './agent-message.types';
 import { appendUserMessage, applyEnvelope, applyEnvelopes } from './apply-envelope';
 

--- a/packages/js/src/agent-chat/apply-envelope.ts
+++ b/packages/js/src/agent-chat/apply-envelope.ts
@@ -1,4 +1,8 @@
-import type { AgentEventEnvelope } from './agent-event.types';
+/**
+ * Folds `AgentEventEnvelope` streams into a parts-based `AgentMessage[]` timeline.
+ * Runs on clients only (live WS + durable history); the server append-only stores envelopes.
+ */
+import type { AgentEventEnvelope, AgentFileRef, AgentMessageContent } from '@novu/agent-event-protocol';
 import type {
   AgentConversationState,
   AgentMessage,
@@ -9,7 +13,6 @@ import type {
   AgentToolPart,
 } from './agent-message.types';
 import { createInitialAgentConversationState } from './agent-message.types';
-import type { AgentFileRef, AgentMessageContent } from './wire-content.types';
 
 export function applyEnvelopes(
   initialState: AgentConversationState = createInitialAgentConversationState(),

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,4 +1,5 @@
 export { AgentChat } from './agent-chat';
+export { derivePendingApprovals } from './agent-message.types';
 export type {
   AgentApprovalPart,
   AgentChatChange,

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -1,9 +1,5 @@
-import type {
-  AgentApprovalPart,
-  AgentConversationStatus,
-  AgentEventEnvelope,
-  AgentMessage,
-} from '@novu/agent-event-protocol';
+import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
+import type { AgentApprovalPart, AgentConversationStatus, AgentMessage } from './agent-message.types';
 
 export type { AgentApprovalPart, AgentConversationStatus, AgentEventEnvelope, AgentMessage };
 

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,4 +1,3 @@
-export { derivePendingApprovals } from '@novu/agent-event-protocol';
 export type * from 'json-logic-js';
 export type {
   AgentApprovalPart,
@@ -15,6 +14,7 @@ export type {
   SendMessageArgs,
   SendMessageResult,
 } from './agent-chat';
+export { derivePendingApprovals } from './agent-chat';
 export type {
   ChannelConnectionResponse,
   ChannelEndpointResponse,


### PR DESCRIPTION
## Summary
- Keep `@novu/agent-event-protocol` wire-only (envelopes, events, guards, content types)
- Move client-only projection (`applyEnvelope`, `AgentMessage[]`, `derivePendingApprovals`) into `@novu/js` under `src/agent-chat/`
- API/framework unchanged — wire imports only; no new workspace package

## Test plan
- [x] `pnpm --filter @novu/js test --testPathPattern=apply-envelope` (8/8)
- [x] `pnpm --filter @novu/js test --testPathPattern=agent-chat` (60/60)
- [x] `pnpm --filter @novu/js build` (attw + UMD size limits pass)
- [x] NV-8435 architecture amendment recorded on parent spec

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR keeps the agent-event protocol package focused on wire contracts and moves client-side conversation projection into `@novu/js`.
- Relocates message projection types, reducers, and tests into `packages/js/src/agent-chat`.
- Updates internal imports and preserves the public `@novu/js` agent-chat exports.
- Leaves API and framework consumers on the wire-only protocol surface.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the outstanding manifest-lockfile mismatch can still make frozen pnpm installs fail.

The `packages/agent-event-protocol` manifest declares `tsup` as `^8.0.2`, while its lockfile importer records `^8.3.5`, so frozen dependency installation can abort before builds or tests run.

**Files Needing Attention:** packages/agent-event-protocol/package.json and pnpm-lock.yaml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/agent-event-protocol/src/index.ts | Narrows the package exports to wire-level event contracts, guards, and content types. |
| packages/js/src/agent-chat/apply-envelope.ts | Relocates the client-side envelope projection reducer into the JavaScript SDK without substantive reducer changes. |
| packages/js/src/agent-chat/agent-message.types.ts | Relocates projected conversation and message types while sourcing wire-level types from the protocol package. |
| packages/js/src/agent-chat/index.ts | Exposes the relocated approval projection helper through the agent-chat public entry point. |
| packages/js/src/index.ts | Preserves the top-level `derivePendingApprovals` export through the new local agent-chat module. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API["API / Framework"] -->|"wire envelopes"| Protocol["@novu/agent-event-protocol"]
  Protocol -->|"AgentEventEnvelope"| JS["@novu/js agent-chat"]
  JS -->|"applyEnvelope"| Timeline["AgentMessage[] timeline"]
  Timeline --> Consumers["Headless client consumers"]
```

<sub>Reviews (4): Last reviewed commit: ["merge(next): resolve conflicts keeping w..."](https://github.com/novuhq/novu/commit/8296b7f85cdc4a768197b59fda8a2e29da220051) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51835893)</sub>

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->