### PR TITLE
chore(dashboard,maily-core): rich chat editor predictable image preview fixes NV-8535

### DIFF
--- a/apps/dashboard/src/components/maily/maily-config.tsx
+++ b/apps/dashboard/src/components/maily/maily-config.tsx
@@ -340,12 +340,14 @@ export const useCreateExtensions = ({
     isAllowedVariable: IsAllowedVariable
   ) => (props: NodeViewProps) => JSX.Element;
   translationValueInput: TranslationValueInputComponent;
-  /** Chat-specific image defaults (left align, no resize, preview-sized). Email keeps kit defaults. */
+  /** Chat-specific image defaults (left align, no resize, Slack-like bounds). Email keeps kit defaults. */
   imageExtensionOptions?: {
     resizable?: boolean;
     defaultAlignment?: 'left' | 'center' | 'right';
     maxWidth?: number;
     maxHeight?: number;
+    /** Chat-only: preview-matching max-bounds fit. Leave unset for email. */
+    fitToMaxBounds?: boolean;
   };
 }) => {
   /**

--- a/apps/dashboard/src/components/maily/maily.tsx
+++ b/apps/dashboard/src/components/maily/maily.tsx
@@ -56,6 +56,8 @@ type MailyProps = HTMLAttributes<HTMLDivElement> & {
     defaultAlignment?: 'left' | 'center' | 'right';
     maxWidth?: number;
     maxHeight?: number;
+    /** Chat-only: preview-matching max-bounds fit. Leave unset for email. */
+    fitToMaxBounds?: boolean;
   };
 };
 

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-body-maily.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-body-maily.tsx
@@ -18,6 +18,7 @@ import { FormField } from '@/components/primitives/form/form';
 import { CompletionRange } from '@/components/primitives/variable-editor';
 import { useCreateVariable } from '@/components/variable/hooks/use-create-variable';
 import { ControlInput } from '@/components/workflow-editor/control-input';
+import { CHAT_IMAGE_BOUNDS } from '@/components/workflow-editor/steps/chat/preview/chat-image-sizing';
 import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { useWorkflowSchema } from '@/components/workflow-editor/workflow-schema-provider';
 import { useCreateTranslationKey } from '@/hooks/use-create-translation-key';
@@ -42,11 +43,13 @@ const CHAT_MENU_CONFIG = {
   },
 } as const;
 
+/** Slack-measured bounds — must match preview `MessageImage` / `fitChatImage`. Chat-only. */
 const CHAT_IMAGE_EXTENSION_OPTIONS = {
   resizable: false,
   defaultAlignment: 'left' as const,
-  // Match chat preview `MessageImage` (`max-h-60` → 240px) so editor size matches preview.
-  maxHeight: 240,
+  fitToMaxBounds: true,
+  maxWidth: CHAT_IMAGE_BOUNDS.maxWidth,
+  maxHeight: CHAT_IMAGE_BOUNDS.maxHeight,
 };
 
 const CHAT_ADDITIONAL_EXTENSIONS = [CardActionsExtension, CardButtonExtension];

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/card-renderer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/card-renderer.tsx
@@ -96,7 +96,12 @@ function MessageImage({ src, alt }: { src: string; alt: string }) {
       className="pointer-events-none my-2 max-w-full object-contain object-left"
       style={
         dimensions
-          ? { width: dimensions.width, height: dimensions.height }
+          ? {
+              width: dimensions.width,
+              maxWidth: '100%',
+              height: 'auto',
+              aspectRatio: `${dimensions.width} / ${dimensions.height}`,
+            }
           : { maxWidth: '100%', maxHeight: CHAT_IMAGE_BOUNDS.maxHeight, visibility: 'hidden' }
       }
       onLoad={(event) => {

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/card-renderer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/card-renderer.tsx
@@ -6,8 +6,10 @@ import type {
   CardElementLinkElement,
   CardElementTextElement,
 } from '@novu/shared';
+import { useState } from 'react';
 
 import { cn } from '@/utils/ui';
+import { CHAT_IMAGE_BOUNDS, fitChatImage } from './chat-image-sizing';
 import { renderInlineMarkdown } from './inline-markdown';
 
 /**
@@ -70,6 +72,20 @@ function MessageText({ element }: { element: CardElementTextElement }) {
 }
 
 function MessageImage({ src, alt }: { src: string; alt: string }) {
+  const [dimensions, setDimensions] = useState<{ width: number; height: number } | null>(null);
+  const [hasError, setHasError] = useState(false);
+  const [loadedSrc, setLoadedSrc] = useState(src);
+
+  if (loadedSrc !== src) {
+    setLoadedSrc(src);
+    setDimensions(null);
+    setHasError(false);
+  }
+
+  if (hasError) {
+    return null;
+  }
+
   return (
     <img
       src={src}
@@ -77,7 +93,17 @@ function MessageImage({ src, alt }: { src: string; alt: string }) {
       loading="lazy"
       decoding="async"
       draggable={false}
-      className="pointer-events-none my-2 max-h-60 w-full max-w-full object-contain object-left"
+      className="pointer-events-none my-2 max-w-full object-contain object-left"
+      style={
+        dimensions
+          ? { width: dimensions.width, height: dimensions.height }
+          : { maxWidth: '100%', maxHeight: CHAT_IMAGE_BOUNDS.maxHeight, visibility: 'hidden' }
+      }
+      onLoad={(event) => {
+        const target = event.currentTarget;
+        setDimensions(fitChatImage(target.naturalWidth, target.naturalHeight));
+      }}
+      onError={() => setHasError(true)}
     />
   );
 }

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/preview/chat-image-sizing.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/preview/chat-image-sizing.ts
@@ -1,0 +1,26 @@
+/**
+ * Slack-measured image display bounds for Rich Chat editor + preview parity.
+ * Images fit within max bounds while preserving aspect ratio and never
+ * upscaling beyond natural size. Small images (e.g. 16×16) render at native size.
+ */
+export const CHAT_IMAGE_BOUNDS = {
+  maxWidth: 600,
+  maxHeight: 400,
+} as const;
+
+/**
+ * Fit natural image dimensions into the chat max bounds, preserving aspect ratio
+ * and never upscaling beyond the source size.
+ */
+export function fitChatImage(naturalWidth: number, naturalHeight: number): { width: number; height: number } {
+  if (naturalWidth <= 0 || naturalHeight <= 0) {
+    return { width: 0, height: 0 };
+  }
+
+  const scale = Math.min(1, CHAT_IMAGE_BOUNDS.maxWidth / naturalWidth, CHAT_IMAGE_BOUNDS.maxHeight / naturalHeight);
+
+  return {
+    width: Math.round(naturalWidth * scale),
+    height: Math.round(naturalHeight * scale),
+  };
+}

--- a/libs/maily-core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/libs/maily-core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -118,6 +118,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
               }
             }}
             tooltip="Source URL"
+            placeholder="Image URL"
             icon={ImageDown}
             editor={editor}
             isVariable={state.isSrcVariable}

--- a/libs/maily-core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
+++ b/libs/maily-core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
@@ -56,6 +56,7 @@ export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
                 .run();
             }}
             tooltip="Source URL"
+            placeholder="Image URL"
             icon={ImageDownIcon}
             editor={editor}
             isVariable={state.isSrcVariable}

--- a/libs/maily-core/src/editor/nodes/image/image-view.tsx
+++ b/libs/maily-core/src/editor/nodes/image/image-view.tsx
@@ -168,6 +168,11 @@ export function ImageView(props: NodeViewProps) {
 
   const imageOptions = getNodeOptions<ImageExtensionOptions>(editor, 'image');
   const { alignment = imageOptions?.defaultAlignment ?? 'center', width, height, src, borderRadius } = node.attrs || {};
+  const fitToMaxBounds = imageOptions?.fitToMaxBounds === true;
+  const fittedWidth = width && width !== 'auto' ? Number(width) : null;
+  const fittedHeight = height && height !== 'auto' ? Number(height) : null;
+  const hasFittedSize =
+    fittedWidth != null && !Number.isNaN(fittedWidth) && fittedHeight != null && !Number.isNaN(fittedHeight);
 
   const {
     externalLink,
@@ -345,11 +350,20 @@ export function ImageView(props: NodeViewProps) {
       className={cn('mly-image-drop-zone', isDraggingOver && 'mly-drag-over')}
       style={{
         ...(hasImageSrc && status === 'loaded'
-          ? {
-              width: width ? `${width}px` : undefined,
-              height: height ? `${height}px` : undefined,
-              ...resizingStyle,
-            }
+          ? fitToMaxBounds
+            ? {
+                // Keep aspect ratio when `maxWidth: 100%` shrinks below the fitted width
+                // (fixed height + object-fit:fill would otherwise stretch the image).
+                width: hasFittedSize ? `${fittedWidth}px` : undefined,
+                maxWidth: '100%',
+                height: 'auto',
+                aspectRatio: hasFittedSize ? `${fittedWidth} / ${fittedHeight}` : undefined,
+              }
+            : {
+                width: width ? `${width}px` : undefined,
+                height: height ? `${height}px` : undefined,
+                ...resizingStyle,
+              }
           : {}),
         overflow: 'hidden',
         position: 'relative',
@@ -402,16 +416,28 @@ export function ImageView(props: NodeViewProps) {
           <img
             {...attrs}
             ref={imgRef}
-            style={{
-              ...resizingStyle,
-              cursor: 'default',
-              objectFit: 'fill',
-              marginBottom: 0,
-              borderRadius,
-              width: resizingStyle?.width ? `${resizingStyle.width}px` : width ? `${width}px` : 'auto',
-              height: resizingStyle?.height ? `${resizingStyle.height}px` : height ? `${height}px` : 'auto',
-              maxWidth: '100%',
-            }}
+            style={
+              fitToMaxBounds
+                ? {
+                    cursor: 'default',
+                    objectFit: 'contain',
+                    marginBottom: 0,
+                    borderRadius,
+                    width: '100%',
+                    height: 'auto',
+                    maxWidth: '100%',
+                  }
+                : {
+                    ...resizingStyle,
+                    cursor: 'default',
+                    objectFit: 'fill',
+                    marginBottom: 0,
+                    borderRadius,
+                    width: resizingStyle?.width ? `${resizingStyle.width}px` : width ? `${width}px` : 'auto',
+                    height: resizingStyle?.height ? `${resizingStyle.height}px` : height ? `${height}px` : 'auto',
+                    maxWidth: '100%',
+                  }
+            }
             draggable={editor.isEditable}
             className={cn(isPlaceholderImage && 'mly-animate-pulse mly-opacity-40')}
           />

--- a/libs/maily-core/src/editor/nodes/image/image-view.tsx
+++ b/libs/maily-core/src/editor/nodes/image/image-view.tsx
@@ -18,14 +18,35 @@ function fitImageWithinBounds({
   containerWidth,
   maxWidth,
   maxHeight,
+  fitToMaxBounds,
 }: {
   naturalWidth: number;
   naturalHeight: number;
   containerWidth: number;
   maxWidth?: number;
   maxHeight?: number;
+  /** Chat-only: preview-matching scale; email leaves this false. */
+  fitToMaxBounds?: boolean;
 }) {
   const aspectRatio = getAspectRatio(naturalWidth, naturalHeight);
+
+  // Rich chat: same scale math as the preview — ignore editor container width so stored
+  // size matches preview. CSS `maxWidth: 100%` handles narrow panels.
+  if (fitToMaxBounds) {
+    const scale = Math.min(
+      1,
+      (maxWidth ?? Number.POSITIVE_INFINITY) / naturalWidth,
+      (maxHeight ?? Number.POSITIVE_INFINITY) / naturalHeight
+    );
+
+    return {
+      width: Math.round(naturalWidth * scale),
+      height: Math.round(naturalHeight * scale),
+      aspectRatio,
+    };
+  }
+
+  // Email / default: fit within the editor container (and optional max caps), never upscale.
   let width = Math.min(containerWidth, naturalWidth, maxWidth ?? Number.POSITIVE_INFINITY);
   let height = Math.min(getNewHeight(width, aspectRatio), naturalHeight);
 
@@ -40,7 +61,7 @@ function fitImageWithinBounds({
 export type ImageStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
 export function ImageView(props: NodeViewProps) {
-  const { node, selected, editor } = props;
+  const { node, selected, editor, updateAttributes } = props;
 
   const [status, setStatus] = useState<ImageStatus>('idle');
   const [isPlaceholderImage, setIsPlaceholderImage] = useState(false);
@@ -210,15 +231,15 @@ export function ImageView(props: NodeViewProps) {
       const { naturalWidth, naturalHeight } = img;
       const wrapper = wrapperRef?.current;
       const imageOptions = getNodeOptions<ImageExtensionOptions>(editor, 'image');
+      const fitToMaxBounds = imageOptions?.fitToMaxBounds === true;
       const numericWidth = width === 'auto' ? null : Number(width);
       const numericHeight = height === 'auto' ? null : Number(height);
       const exceedsMaxWidth =
         imageOptions?.maxWidth != null && numericWidth != null && numericWidth > imageOptions.maxWidth;
       const exceedsMaxHeight =
         imageOptions?.maxHeight != null && numericHeight != null && numericHeight > imageOptions.maxHeight;
-      const shouldFitSize = width === 'auto' || exceedsMaxWidth || exceedsMaxHeight;
 
-      if (!wrapper || !naturalWidth || !shouldFitSize) {
+      if (!wrapper || !naturalWidth) {
         return;
       }
 
@@ -232,16 +253,28 @@ export function ImageView(props: NodeViewProps) {
         containerWidth: wrapper.offsetWidth,
         maxWidth: imageOptions?.maxWidth,
         maxHeight: imageOptions?.maxHeight,
+        fitToMaxBounds,
       });
 
-      editor
-        .chain()
-        .updateImageAttributes({
-          width: nextWidth,
-          height: nextHeight,
-          aspectRatio,
-        })
-        .run();
+      // Chat (`fitToMaxBounds`): re-sync when attrs drift from preview math. Email: auto / overflow only.
+      const sizeMismatch =
+        fitToMaxBounds &&
+        numericWidth != null &&
+        numericHeight != null &&
+        (Math.round(numericWidth) !== nextWidth || Math.round(numericHeight) !== nextHeight);
+      const shouldFitSize = width === 'auto' || exceedsMaxWidth || exceedsMaxHeight || sizeMismatch;
+
+      if (!shouldFitSize) {
+        return;
+      }
+
+      // Use NodeView `updateAttributes` — `editor.chain().updateImageAttributes` only
+      // touches the current selection, so unloaded/saved images would keep stale sizes.
+      updateAttributes({
+        width: nextWidth,
+        height: nextHeight,
+        aspectRatio,
+      });
     };
     img.onerror = () => {
       setStatus('error');
@@ -377,6 +410,7 @@ export function ImageView(props: NodeViewProps) {
               borderRadius,
               width: resizingStyle?.width ? `${resizingStyle.width}px` : width ? `${width}px` : 'auto',
               height: resizingStyle?.height ? `${resizingStyle.height}px` : height ? `${height}px` : 'auto',
+              maxWidth: '100%',
             }}
             draggable={editor.isEditable}
             className={cn(isPlaceholderImage && 'mly-animate-pulse mly-opacity-40')}

--- a/libs/maily-core/src/editor/nodes/image/image.ts
+++ b/libs/maily-core/src/editor/nodes/image/image.ts
@@ -29,8 +29,14 @@ export type ImageExtensionOptions = {
   defaultAlignment?: 'left' | 'center' | 'right';
   /** Cap applied when auto-sizing a newly loaded image. */
   maxWidth?: number;
-  /** Cap applied when auto-sizing a newly loaded image (e.g. chat preview `max-h-60`). */
+  /** Cap applied when auto-sizing a newly loaded image (e.g. chat Slack-like bounds). */
   maxHeight?: number;
+  /**
+   * When true (rich chat only), size images with maxWidth/maxHeight scale math that matches
+   * the chat preview — ignores editor container width and re-syncs stale attrs. Email keeps
+   * the default container-based fit (leave unset / false).
+   */
+  fitToMaxBounds?: boolean;
 };
 
 declare module '@tiptap/core' {
@@ -49,6 +55,7 @@ export const ImageExtension = TiptapImage.extend<ImageExtensionOptions>({
       defaultAlignment: 'center',
       maxWidth: undefined,
       maxHeight: undefined,
+      fitToMaxBounds: false,
     };
   },
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard: Rich Chat Editor predictable image node preview.

### Screenshots

https://github.com/user-attachments/assets/e30bdd1a-39d0-453e-af7e-8dc7d1af9c7f

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns rich-chat image sizing between the editor and preview while preserving natural aspect ratios and avoiding upscaling.
- Adds shared Slack-like maximum image bounds and preview fitting logic.
- Introduces chat-only fitted sizing and attribute synchronization in the Maily image node.
- Updates image URL field placeholders and preview loading/error behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/maily-core/src/editor/nodes/image/image-view.tsx | The responsive fix now constrains the fitted wrapper proportionally and renders the image with contain sizing, resolving the previously reported distortion. |
| apps/dashboard/src/components/workflow-editor/steps/chat/preview/card-renderer.tsx | The preview measures natural image dimensions and applies bounded, aspect-ratio-preserving dimensions. |
| apps/dashboard/src/components/workflow-editor/steps/chat/preview/chat-image-sizing.ts | The new sizing helper consistently preserves aspect ratio, enforces chat bounds, and avoids upscaling. |
| apps/dashboard/src/components/workflow-editor/steps/chat/chat-body-maily.tsx | Chat editor configuration now enables the same maximum-bound fitting behavior used by the preview. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(dashboard,maily-core): suggestions..."](https://github.com/novuhq/novu/commit/1c9c51c34e3254cbcc1876bd676539c20f8aa76e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51899591)</sub>

<!-- /greptile_comment -->