### PR TITLE
fix(docs): remove public beta notice from Slack and HTTP step documentation

### DIFF
--- a/docs/platform/integrations/chat/slack.mdx
+++ b/docs/platform/integrations/chat/slack.mdx
@@ -4,10 +4,6 @@ sidebarTitle: 'Slack'
 description: "Connect Slack to Novu to send workflow chat notifications through OAuth, deliver messages to channels or DMs, and format content with Block Kit."
 ---
 
-<Note>
-  This feature is currently in public beta, please contact us at support@novu.co to enable it for your organization.
-</Note>
-
 The Slack chat integration lets your application send notifications directly to your subscribers' Slack workspaces using their own Slack accounts and workspace permissions. With this integration, Novu can deliver messages to Slack channels, direct messages (DMs) to Slack users, and incoming webhooks. For incoming webhooks, Novu can use Slack's native channel picker during OAuth.
 
 Novu handles the full lifecycle of Slack connections and message delivery. You define where notifications should be delivered, and Novu automatically routes each message to the correct Slack workspace, channel, or user.

--- a/docs/platform/workflow/add-and-configure-steps/configure-action-steps/http-step.mdx
+++ b/docs/platform/workflow/add-and-configure-steps/configure-action-steps/http-step.mdx
@@ -7,10 +7,6 @@ The HTTP step is an Action step that allows workflows to call external APIs duri
 
 This guide explains how to add and configure an HTTP step for your specific needs.
 
-<Note>
-  This feature is currently in public beta, please contact us at support@novu.co to enable it for your organization.
-</Note>
-
 ## Adding an HTTP step
 
 You can add an HTTP step anywhere within a workflow. When workflow execution reaches this step, the workflow will perform the configured request and the response can be used by steps that follow.


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes outdated public-beta and support-enablement notices from the Slack integration and HTTP step documentation.
- Leaves the remaining setup and usage instructions unchanged.
- Normalizes the trailing newline in the HTTP step document.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

The changes remove two beta notices without altering product code, configuration instructions, examples, links, or documented runtime behavior, and no blocking or non-blocking defect remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/platform/integrations/chat/slack.mdx | Removes the Slack public-beta notice; no actionable documentation defect was identified. |
| docs/platform/workflow/add-and-configure-steps/configure-action-steps/http-step.mdx | Removes the HTTP-step public-beta notice and adds a final newline; no actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): remove public beta notice fro..."](https://github.com/novuhq/novu/commit/66d83f15d266aaae41d47eb165e013f8ada5fad7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52094527)</sub>

<!-- /greptile_comment -->