### PR TITLE
fix(api,dal): scope agent web-chat to inbox context keys fixes NV-8551

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
@@ -240,6 +240,109 @@ describe('AgentConversationService', () => {
     expect(create.firstCall.args[0].title).to.equal(DEFAULT_CONVERSATION_TITLE);
   });
 
+  it('stamps sorted contextKeys on create when provided', async () => {
+    const create = sinon.stub().resolves({
+      _id: 'new-conv',
+      participants: [],
+      channels: [],
+      status: ConversationStatusEnum.ACTIVE,
+    });
+
+    const conversationRepository = {
+      findByPlatformThread: sinon.stub().resolves(null),
+      create,
+      updateStatus: sinon.stub(),
+      updateParticipants: sinon.stub(),
+    } as unknown as ConversationRepository;
+
+    const service = new AgentConversationService(
+      conversationRepository,
+      {} as any,
+      makeEventSequenceService(),
+      { emit: sinon.stub().resolves(undefined) } as any,
+      makeLogger() as any
+    );
+
+    await service.createOrGetConversation({
+      ...baseCreateParams(),
+      platform: 'web_chat',
+      contextKeys: ['tenant:acme', 'app:billing'],
+    });
+
+    expect(create.calledOnce).to.equal(true);
+    expect(create.firstCall.args[0].contextKeys).to.deep.equal(['app:billing', 'tenant:acme']);
+  });
+
+  it('rejects reuse when session contextKeys do not match stored conversation', async () => {
+    const existing = {
+      _id: 'existing-conv',
+      status: ConversationStatusEnum.ACTIVE,
+      participants: [{ type: ConversationParticipantTypeEnum.SUBSCRIBER, id: 'sub-1' }],
+      channels: [],
+      contextKeys: ['tenant:acme'],
+    };
+
+    const findOne = sinon.stub().resolves(null);
+    const conversationRepository = {
+      findByPlatformThread: sinon.stub().resolves(existing),
+      findOne,
+      buildContextExactMatchQuery: sinon.stub().returns({ contextKeys: { $all: ['tenant:globex'], $size: 1 } }),
+      updateStatus: sinon.stub(),
+      updateParticipants: sinon.stub(),
+    } as unknown as ConversationRepository;
+
+    const service = new AgentConversationService(
+      conversationRepository,
+      {} as any,
+      makeEventSequenceService(),
+      { emit: sinon.stub().resolves(undefined) } as any,
+      makeLogger() as any
+    );
+
+    let threw = false;
+    try {
+      await service.createOrGetConversation({
+        ...baseCreateParams(),
+        platform: 'web_chat',
+        contextKeys: ['tenant:globex'],
+      });
+    } catch (err) {
+      threw = true;
+      expect((err as Error).message).to.equal('Conversation context mismatch');
+    }
+    expect(threw).to.equal(true);
+    expect(findOne.calledOnce).to.equal(true);
+  });
+
+  it('omits contextKeys on create when not provided', async () => {
+    const create = sinon.stub().resolves({
+      _id: 'new-conv',
+      participants: [],
+      channels: [],
+      status: ConversationStatusEnum.ACTIVE,
+    });
+
+    const conversationRepository = {
+      findByPlatformThread: sinon.stub().resolves(null),
+      create,
+      updateStatus: sinon.stub(),
+      updateParticipants: sinon.stub(),
+    } as unknown as ConversationRepository;
+
+    const service = new AgentConversationService(
+      conversationRepository,
+      {} as any,
+      makeEventSequenceService(),
+      { emit: sinon.stub().resolves(undefined) } as any,
+      makeLogger() as any
+    );
+
+    await service.createOrGetConversation(baseCreateParams());
+
+    expect(create.calledOnce).to.equal(true);
+    expect(create.firstCall.args[0]).to.not.have.property('contextKeys');
+  });
+
   it('scopes createOrGetConversation lookup by agent id and integration id', async () => {
     const findByPlatformThread = sinon.stub().resolves(null);
     const create = sinon.stub().resolves({

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
@@ -273,6 +273,42 @@ describe('AgentConversationService', () => {
     expect(create.firstCall.args[0].contextKeys).to.deep.equal(['app:billing', 'tenant:acme']);
   });
 
+  it('rejects reuse when stored conversation has contextKeys but caller omits them', async () => {
+    const existing = {
+      _id: 'existing-conv',
+      status: ConversationStatusEnum.ACTIVE,
+      participants: [{ type: ConversationParticipantTypeEnum.SUBSCRIBER, id: 'sub-1' }],
+      channels: [],
+      contextKeys: ['tenant:acme'],
+    };
+
+    const conversationRepository = {
+      findByPlatformThread: sinon.stub().resolves(existing),
+      updateStatus: sinon.stub(),
+      updateParticipants: sinon.stub(),
+    } as unknown as ConversationRepository;
+
+    const service = new AgentConversationService(
+      conversationRepository,
+      {} as any,
+      makeEventSequenceService(),
+      { emit: sinon.stub().resolves(undefined) } as any,
+      makeLogger() as any
+    );
+
+    let threw = false;
+    try {
+      await service.createOrGetConversation({
+        ...baseCreateParams(),
+        platform: 'web_chat',
+      });
+    } catch (err) {
+      threw = true;
+      expect((err as Error).message).to.equal('Conversation context mismatch');
+    }
+    expect(threw).to.equal(true);
+  });
+
   it('rejects reuse when session contextKeys do not match stored conversation', async () => {
     const existing = {
       _id: 'existing-conv',

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -78,6 +78,7 @@ export interface CreateOrGetConversationParams {
   identifier?: string;
   /** Originating Notification id when opening from a workflow-seeded platform thread (create only). */
   notificationId?: string;
+  contextKeys?: string[];
 }
 
 export interface PersistInboundMessageParams {
@@ -217,6 +218,21 @@ export class AgentConversationService {
       platformThreadId
     );
     if (existing) {
+      if (params.contextKeys !== undefined) {
+        const contextMatch = await this.conversationRepository.findOne(
+          {
+            _id: existing._id,
+            _environmentId: environmentId,
+            _organizationId: organizationId,
+            $and: [this.conversationRepository.buildContextExactMatchQuery(params.contextKeys)],
+          },
+          '_id'
+        );
+        if (!contextMatch) {
+          throw new BadRequestException('Conversation context mismatch');
+        }
+      }
+
       if (existing.status === ConversationStatusEnum.RESOLVED) {
         await this.conversationRepository.updateStatus(
           environmentId,
@@ -254,6 +270,7 @@ export class AgentConversationService {
       title: getConversationTitle(params.firstMessageText),
       metadata: {},
       isDirectMessage: params.isDirectMessage,
+      ...(params.contextKeys !== undefined ? { contextKeys: [...params.contextKeys].sort() } : {}),
       _environmentId: environmentId,
       _organizationId: organizationId,
       lastActivityAt: new Date().toISOString(),

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -226,11 +226,13 @@ export class AgentConversationService {
             _organizationId: organizationId,
             $and: [this.conversationRepository.buildContextExactMatchQuery(params.contextKeys)],
           },
-          '_id'
+          ['_id']
         );
         if (!contextMatch) {
           throw new BadRequestException('Conversation context mismatch');
         }
+      } else if (existing.contextKeys?.length) {
+        throw new BadRequestException('Conversation context mismatch');
       }
 
       if (existing.status === ConversationStatusEnum.RESOLVED) {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException, type OnModuleInit } from '@nestjs/common';
 import { AnalyticsService, PinoLogger } from '@novu/application-generic';
+import type { WebChatRawMessage } from '@novu/chat-adapter-web';
 import {
   AgentIntegrationRepository,
   AgentRepository,
@@ -43,10 +44,7 @@ import { type AutoProvisionPlatform, shouldAutoProvisionInbound } from '../../sh
 import { extractWorkspaceId } from '../../shared/util/workspace-id';
 import { InboundAckService } from '../ack/inbound-ack.service';
 import { AgentAttachmentStorage, type StoredAttachment } from '../conversation/agent-attachment-storage.service';
-import {
-  AgentConversationService,
-  getInboundActivityPreview,
-} from '../conversation/agent-conversation.service';
+import { AgentConversationService, getInboundActivityPreview } from '../conversation/agent-conversation.service';
 import {
   AgentSubscriberResolver,
   BotAuthorSkippedError,
@@ -498,6 +496,10 @@ export class AgentInboundHandler implements OnModuleInit {
       workspaceId: extractWorkspaceId(config.platform, message.raw) ?? undefined,
       identifier: this.webChatConversationIdentifier(config.platform, platformThreadId),
       notificationId: workflowOriginMessage?._notificationId,
+      contextKeys:
+        config.platform === AgentPlatformEnum.WEB_CHAT
+          ? ((message.raw as WebChatRawMessage | undefined)?.contextKeys ?? [])
+          : undefined,
     });
 
     if (workflowOriginMessage) {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -1354,6 +1354,10 @@ export class AgentInboundHandler implements OnModuleInit {
       isDirectMessage: thread.isDM,
       workspaceId: extractWorkspaceId(config.platform, rawEvent) ?? undefined,
       notificationId: workflowOriginMessage?._notificationId,
+      contextKeys:
+        config.platform === AgentPlatformEnum.WEB_CHAT
+          ? ((rawEvent as WebChatRawMessage | undefined)?.contextKeys ?? [])
+          : undefined,
     });
 
     if (workflowOriginMessage) {

--- a/apps/api/src/app/agents/e2e/web-chat-conversation-context.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation-context.e2e.ts
@@ -1,0 +1,283 @@
+import { AGENT_EVENT_PROTOCOL_VERSION, type AgentEventEnvelope } from '@novu/agent-event-protocol';
+import { WebSocketsQueueService } from '@novu/application-generic';
+import { ChatProviderIdEnum, type ContextPayload, WebSocketEventEnum } from '@novu/shared';
+import { testServer } from '@novu/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
+import { AgentTestContext, conversationRepository, setupAgentTestContext } from './helpers/agent-test-setup';
+
+const POLL_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 50;
+
+async function pollFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = POLL_TIMEOUT_MS): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await fn();
+      if (result) return result;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  throw new Error(
+    `pollFor timed out after ${timeoutMs}ms${lastError ? `; last error: ${(lastError as Error).message}` : ''}`
+  );
+}
+
+describe('Web Chat - context-scoped conversations #novu-v2', () => {
+  let ctx: AgentTestContext;
+  let subscriberToken: string;
+
+  before(() => {
+    process.env.IS_AGENT_EVENT_PROTOCOL_ENABLED = 'true';
+    process.env.IS_AGENT_WEB_CHAT_ENABLED = 'true';
+  });
+
+  after(() => {
+    delete process.env.IS_AGENT_EVENT_PROTOCOL_ENABLED;
+    delete process.env.IS_AGENT_WEB_CHAT_ENABLED;
+  });
+
+  beforeEach(async () => {
+    ctx = await setupAgentTestContext();
+
+    const bridgeExecutor = testServer.getService(BridgeExecutorService);
+    sinon.stub(bridgeExecutor, 'execute').resolves();
+
+    const inboxSession = await ctx.session.testAgent.post('/v1/inbox/session').send({
+      applicationIdentifier: ctx.session.environment.identifier,
+      subscriberId: ctx.session.subscriberId,
+    });
+    expect(inboxSession.status).to.equal(201);
+    subscriberToken = inboxSession.body.data.token;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function linkWebChat(agentIdentifier = ctx.agentIdentifier) {
+    const res = await ctx.session.testAgent.post(`/v1/agents/${agentIdentifier}/integrations`).send({
+      providerId: ChatProviderIdEnum.NovuWebChat,
+    });
+    expect(res.status).to.equal(201);
+
+    return res.body.data;
+  }
+
+  function createConversation(
+    body: { agentId: string; text: string; conversationIdentifier?: string },
+    token = subscriberToken
+  ) {
+    return ctx.session.testAgent.post('/v1/web-chat/conversations').set('Authorization', `Bearer ${token}`).send(body);
+  }
+
+  function listConversations(token = subscriberToken) {
+    return ctx.session.testAgent.get('/v1/web-chat/conversations').set('Authorization', `Bearer ${token}`);
+  }
+
+  function getConversation(conversationIdentifier: string, token = subscriberToken) {
+    return ctx.session.testAgent
+      .get(`/v1/web-chat/conversations/${conversationIdentifier}`)
+      .set('Authorization', `Bearer ${token}`);
+  }
+
+  function getEvents(conversationIdentifier: string, token = subscriberToken) {
+    return ctx.session.testAgent
+      .get(`/v1/web-chat/conversations/${conversationIdentifier}/events`)
+      .set('Authorization', `Bearer ${token}`);
+  }
+
+  async function waitForConversation(identifier: string) {
+    return pollFor(() =>
+      conversationRepository.findOne(
+        {
+          identifier,
+          _environmentId: ctx.session.environment._id,
+        },
+        '*'
+      )
+    );
+  }
+
+  async function createSubscriberTokenWithContext(context: ContextPayload) {
+    const inboxSession = await ctx.session.testAgent.post('/v1/inbox/session').send({
+      applicationIdentifier: ctx.session.environment.identifier,
+      subscriberId: ctx.session.subscriberId,
+      context,
+    });
+    expect(inboxSession.status).to.equal(201);
+
+    return {
+      token: inboxSession.body.data.token as string,
+      contextKeys: inboxSession.body.data.contextKeys as string[],
+    };
+  }
+
+  function messageEnvelope(conversationId: string, messageId: string): AgentEventEnvelope {
+    return {
+      version: AGENT_EVENT_PROTOCOL_VERSION,
+      conversationId,
+      agentId: ctx.agentIdentifier,
+      runId: 'run-e2e',
+      turnId: 'turn-e2e',
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      event: {
+        type: 'message',
+        role: 'assistant',
+        messageId,
+        content: { markdown: `Agent reply ${messageId}` },
+      },
+    };
+  }
+
+  it('should stamp session contextKeys on create and emit AGENT_EVENT with the same keys', async () => {
+    await linkWebChat();
+    const { token, contextKeys } = await createSubscriberTokenWithContext({ tenant: 'acme-corp' });
+    expect(contextKeys).to.deep.equal(['tenant:acme-corp']);
+
+    const wsQueue = testServer.getService(WebSocketsQueueService);
+    const addStub = sinon.stub(wsQueue, 'add');
+
+    const createRes = await createConversation(
+      {
+        agentId: ctx.agentIdentifier,
+        text: 'Context-scoped thread',
+      },
+      token
+    );
+    expect(createRes.status).to.equal(201);
+    const conversation = await waitForConversation(createRes.body.data.identifier);
+    expect(conversation.contextKeys).to.deep.equal(['tenant:acme-corp']);
+
+    const messageId = `msg-context-${Date.now()}`;
+    const ingestRes = await ctx.session.testAgent.post('/v1/agents/events/ingest').send({
+      events: [messageEnvelope(conversation._id, messageId)],
+    });
+    expect(ingestRes.status).to.equal(200);
+
+    const liveJob = await pollFor(() => {
+      const jobs = addStub
+        .getCalls()
+        .map((call) => call.args[0])
+        .filter(
+          (job) =>
+            job?.data?.event === WebSocketEventEnum.AGENT_EVENT &&
+            (job.data.payload as AgentEventEnvelope)?.event?.type === 'message'
+        );
+
+      return jobs[0] ?? null;
+    });
+
+    expect(liveJob.data.contextKeys).to.deep.equal(['tenant:acme-corp']);
+  });
+
+  it('should isolate list/get/events by inbox session context', async () => {
+    await linkWebChat();
+    const acme = await createSubscriberTokenWithContext({ tenant: 'acme-corp' });
+    const globex = await createSubscriberTokenWithContext({ tenant: 'globex' });
+
+    const createRes = await createConversation(
+      {
+        agentId: ctx.agentIdentifier,
+        text: 'Acme-only chat',
+      },
+      acme.token
+    );
+    expect(createRes.status).to.equal(201);
+    const identifier = createRes.body.data.identifier as string;
+    await waitForConversation(identifier);
+
+    const acmeList = await listConversations(acme.token);
+    expect(acmeList.status).to.equal(200);
+    expect(acmeList.body.data.some((item: { identifier: string }) => item.identifier === identifier)).to.equal(true);
+
+    const globexList = await listConversations(globex.token);
+    expect(globexList.status).to.equal(200);
+    expect(globexList.body.data.some((item: { identifier: string }) => item.identifier === identifier)).to.equal(false);
+
+    const defaultList = await listConversations(subscriberToken);
+    expect(defaultList.status).to.equal(200);
+    expect(defaultList.body.data.some((item: { identifier: string }) => item.identifier === identifier)).to.equal(
+      false
+    );
+
+    expect((await getConversation(identifier, acme.token)).status).to.equal(200);
+    expect((await getEvents(identifier, acme.token)).status).to.equal(200);
+    expect((await getConversation(identifier, globex.token)).status).to.equal(404);
+    expect((await getEvents(identifier, globex.token)).status).to.equal(404);
+    expect((await getConversation(identifier, subscriberToken)).status).to.equal(404);
+  });
+
+  it('should deny resume when session context does not match conversation', async () => {
+    await linkWebChat();
+    const acme = await createSubscriberTokenWithContext({ tenant: 'acme-corp' });
+    const globex = await createSubscriberTokenWithContext({ tenant: 'globex' });
+
+    const createRes = await createConversation(
+      {
+        agentId: ctx.agentIdentifier,
+        text: 'Acme-only thread',
+      },
+      acme.token
+    );
+    expect(createRes.status).to.equal(201);
+    const identifier = createRes.body.data.identifier as string;
+
+    const resumeRes = await createConversation(
+      {
+        agentId: ctx.agentIdentifier,
+        text: 'Cross-context resume attempt',
+        conversationIdentifier: identifier,
+      },
+      globex.token
+    );
+    expect(resumeRes.status).to.equal(404);
+  });
+
+  it('should keep no-context sessions working for live emit and REST', async () => {
+    await linkWebChat();
+    const wsQueue = testServer.getService(WebSocketsQueueService);
+    const addStub = sinon.stub(wsQueue, 'add');
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Default context thread',
+    });
+    expect(createRes.status).to.equal(201);
+    const conversation = await waitForConversation(createRes.body.data.identifier);
+    expect(conversation.contextKeys ?? []).to.deep.equal([]);
+
+    const messageId = `msg-default-context-${Date.now()}`;
+    await ctx.session.testAgent.post('/v1/agents/events/ingest').send({
+      events: [messageEnvelope(conversation._id, messageId)],
+    });
+
+    const liveJob = await pollFor(() => {
+      const jobs = addStub
+        .getCalls()
+        .map((call) => call.args[0])
+        .filter(
+          (job) =>
+            job?.data?.event === WebSocketEventEnum.AGENT_EVENT &&
+            (job.data.payload as AgentEventEnvelope)?.event?.type === 'message'
+        );
+
+      return jobs[0] ?? null;
+    });
+    expect(liveJob.data.contextKeys).to.deep.equal([]);
+
+    const listRes = await listConversations(subscriberToken);
+    expect(listRes.status).to.equal(200);
+    expect(
+      listRes.body.data.some((item: { identifier: string }) => item.identifier === createRes.body.data.identifier)
+    ).to.equal(true);
+    expect((await getConversation(createRes.body.data.identifier, subscriberToken)).status).to.equal(200);
+  });
+});

--- a/apps/api/src/app/agents/web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/get-web-chat-conversation/get-web-chat-conversation.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { AgentRepository, ConversationParticipantTypeEnum, ConversationRepository } from '@novu/dal';
 import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
 import type { WebChatConversationMetadataDto } from '../../dtos/web-chat-conversation.dto';
+import { withWebChatContextFilter } from '../../web-chat-context-query.util';
 import { GetWebChatConversationCommand } from './get-web-chat-conversation.command';
 
 @Injectable()
@@ -13,11 +14,15 @@ export class GetWebChatConversation {
 
   async execute(command: GetWebChatConversationCommand): Promise<WebChatConversationMetadataDto> {
     const conversation = await this.conversationRepository.findOne(
-      {
-        identifier: command.conversationIdentifier,
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-      },
+      withWebChatContextFilter(
+        this.conversationRepository,
+        {
+          identifier: command.conversationIdentifier,
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+        },
+        command.contextKeys
+      ),
       '*'
     );
 

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversation-events/list-web-chat-conversation-events.usecase.ts
@@ -12,6 +12,7 @@ import {
   mapNewestFirstEventActivities,
   WEB_CHAT_EVENT_ACTIVITY_FILTER,
 } from '../../activity-to-events';
+import { withWebChatContextFilter } from '../../web-chat-context-query.util';
 import { ListWebChatConversationEventsCommand } from './list-web-chat-conversation-events.command';
 
 interface EventPageResult {
@@ -30,11 +31,15 @@ export class ListWebChatConversationEvents {
 
   async execute(command: ListWebChatConversationEventsCommand): Promise<EventPageResult> {
     const conversation = await this.conversationRepository.findOne(
-      {
-        identifier: command.conversationIdentifier,
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-      },
+      withWebChatContextFilter(
+        this.conversationRepository,
+        {
+          identifier: command.conversationIdentifier,
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+        },
+        command.contextKeys
+      ),
       '*'
     );
 

--- a/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts
+++ b/apps/api/src/app/agents/web-chat/usecases/list-web-chat-conversations/list-web-chat-conversations.usecase.ts
@@ -25,6 +25,7 @@ export class ListWebChatConversations {
       organizationId: command.organizationId,
       subscriberId: command.subscriberId,
       provider: [AgentPlatformEnum.WEB_CHAT],
+      contextKeys: command.contextKeys ?? [],
       after: command.after,
       before: command.before,
       limit: command.limit,

--- a/apps/api/src/app/agents/web-chat/web-chat-context-query.util.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-context-query.util.ts
@@ -1,0 +1,12 @@
+import type { ConversationRepository } from '@novu/dal';
+
+export function withWebChatContextFilter<T extends Record<string, unknown>>(
+  repository: ConversationRepository,
+  query: T,
+  contextKeys?: string[]
+): T & { $and: Record<string, unknown>[] } {
+  return {
+    ...query,
+    $and: [repository.buildContextExactMatchQuery(contextKeys ?? [])],
+  };
+}

--- a/apps/api/src/app/agents/web-chat/web-chat-live-activity.publisher.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-live-activity.publisher.ts
@@ -81,7 +81,7 @@ export class WebChatLiveActivityPublisher {
           _organizationId: params.organizationId,
           subscriberId: subscriber.subscriberId,
           payload: envelope as unknown as Record<string, unknown>,
-          contextKeys: [],
+          contextKeys: params.conversation.contextKeys ?? [],
         },
         groupId: params.organizationId,
       });

--- a/apps/api/src/app/agents/web-chat/web-chat-platform-delivery.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-platform-delivery.service.ts
@@ -271,7 +271,7 @@ export class WebChatPlatformDeliveryService {
           _organizationId: context.config.organizationId,
           subscriberId: subscriber.subscriberId,
           payload: envelope as unknown as Record<string, unknown>,
-          contextKeys: [],
+          contextKeys: conversation.contextKeys ?? [],
         },
         groupId: context.config.organizationId,
       });

--- a/apps/api/src/app/agents/web-chat/web-chat-resume-authorization.service.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-resume-authorization.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import type { WebChatSession } from '@novu/chat-adapter-web';
 import { ConversationParticipantTypeEnum, ConversationRepository } from '@novu/dal';
 import { AgentPlatformEnum } from '../shared/enums/agent-platform.enum';
+import { withWebChatContextFilter } from './web-chat-context-query.util';
 
 @Injectable()
 export class WebChatResumeAuthorizationService {
@@ -12,11 +13,15 @@ export class WebChatResumeAuthorizationService {
    */
   async canResume(params: { conversationId: string; session: WebChatSession; agentId: string }): Promise<boolean> {
     const conversation = await this.conversationRepository.findOne(
-      {
-        identifier: params.conversationId,
-        _environmentId: params.session.environmentId,
-        _organizationId: params.session.organizationId,
-      },
+      withWebChatContextFilter(
+        this.conversationRepository,
+        {
+          identifier: params.conversationId,
+          _environmentId: params.session.environmentId,
+          _organizationId: params.session.organizationId,
+        },
+        params.session.contextKeys
+      ),
       '*'
     );
 

--- a/apps/api/src/app/agents/web-chat/web-chat-session.verifier.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat-session.verifier.ts
@@ -39,6 +39,7 @@ export class WebChatSessionVerifier {
         subscriberId: subscriber.subscriberId,
         environmentId: subscriber._environmentId,
         organizationId: subscriber._organizationId,
+        contextKeys: Array.isArray(payload.contextKeys) ? payload.contextKeys : [],
       };
     } catch {
       return null;

--- a/apps/api/src/app/agents/web-chat/web-chat.controller.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat.controller.ts
@@ -107,6 +107,7 @@ export class WebChatController {
         environmentId: subscriberSession.environmentId,
         organizationId: subscriberSession.organizationId,
         subscriberId: subscriberSession.subscriberId,
+        contextKeys: subscriberSession.contextKeys ?? [],
         after: query.after,
         before: query.before,
         limit: query.limit ?? 50,
@@ -128,6 +129,7 @@ export class WebChatController {
         environmentId: subscriberSession.environmentId,
         organizationId: subscriberSession.organizationId,
         subscriberId: subscriberSession.subscriberId,
+        contextKeys: subscriberSession.contextKeys ?? [],
         conversationIdentifier: identifier,
       })
     );
@@ -145,6 +147,7 @@ export class WebChatController {
         environmentId: subscriberSession.environmentId,
         organizationId: subscriberSession.organizationId,
         subscriberId: subscriberSession.subscriberId,
+        contextKeys: subscriberSession.contextKeys ?? [],
         conversationIdentifier: identifier,
         before: query.before,
         limit: query.limit ?? 50,

--- a/libs/dal/src/repositories/conversation/conversation.entity.ts
+++ b/libs/dal/src/repositories/conversation/conversation.entity.ts
@@ -151,6 +151,8 @@ export class ConversationEntity {
    */
   eventSequence?: number;
 
+  contextKeys?: string[];
+
   _environmentId: EnvironmentId;
 
   _organizationId: OrganizationId;

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -570,6 +570,7 @@ export class ConversationRepository extends BaseRepositoryV2<
     identifier,
     provider,
     createdAfter,
+    contextKeys,
   }: {
     organizationId: string;
     environmentId: string;
@@ -585,6 +586,7 @@ export class ConversationRepository extends BaseRepositoryV2<
     identifier?: string;
     provider?: string[];
     createdAfter?: string;
+    contextKeys?: string[];
   }): Promise<{
     data: ConversationEntity[];
     next: string | null;
@@ -647,6 +649,11 @@ export class ConversationRepository extends BaseRepositoryV2<
 
     if (createdAfter) {
       query.createdAt = { $gte: new Date(createdAfter) };
+    }
+
+    if (contextKeys !== undefined) {
+      const contextQuery = this.buildContextExactMatchQuery(contextKeys);
+      query.$and = [...(query.$and ?? []), contextQuery];
     }
 
     return this.findWithCursorBasedPagination({

--- a/libs/dal/src/repositories/conversation/conversation.schema.ts
+++ b/libs/dal/src/repositories/conversation/conversation.schema.ts
@@ -138,6 +138,10 @@ const conversationSchema = new Schema<ConversationDBModel>(
       type: Schema.Types.Number,
       default: 0,
     },
+    contextKeys: {
+      type: [Schema.Types.String],
+      default: undefined,
+    },
     lastActivityAt: {
       type: Schema.Types.String,
     },
@@ -158,6 +162,8 @@ const conversationSchema = new Schema<ConversationDBModel>(
 conversationSchema.index({ _environmentId: 1, identifier: 1 }, { unique: true });
 conversationSchema.index({ _environmentId: 1, 'channels.platformThreadId': 1 });
 conversationSchema.index({ _environmentId: 1, 'participants.id': 1, status: 1 });
+// Multikey alone — do not compound with participants (Mongo forbids parallel arrays).
+conversationSchema.index({ _environmentId: 1, contextKeys: 1 });
 conversationSchema.index({ _environmentId: 1, _agentId: 1, _id: 1 });
 conversationSchema.index({ _environmentId: 1, _agentId: 1, createdAt: 1 });
 conversationSchema.index({ _environmentId: 1, _agentId: 1, lastActivityAt: 1 });

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -254,7 +254,7 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
         messageId: kind.sourceMessageId ?? '',
         threadId,
         user,
-        raw: body,
+        raw: { ...body, contextKeys: session.contextKeys ?? [] },
       },
       options
     );

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -213,6 +213,7 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
       text: kind.text,
       subscriberId: session.subscriberId,
       createdAt: new Date().toISOString(),
+      contextKeys: session.contextKeys ?? [],
     });
 
     this.chat!.processMessage(this, threadId, message, options);

--- a/packages/chat-adapter-web/src/types.ts
+++ b/packages/chat-adapter-web/src/types.ts
@@ -2,6 +2,7 @@ export type WebChatSession = {
   subscriberId: string;
   environmentId: string;
   organizationId: string;
+  contextKeys?: string[];
 };
 
 export type WebChatDeliverMessageParams = {
@@ -68,6 +69,7 @@ export type WebChatRawMessage = {
   text: string;
   subscriberId: string;
   createdAt: string;
+  contextKeys?: string[];
 };
 
 export type WebChatRequestBody = {


### PR DESCRIPTION
## Summary

- Store inbox `contextKeys` on agent conversations at web-chat create time and emit `agent_event` WebSocket frames with matching keys so context-scoped subscribers receive live updates (fixes silent WS drop from empty `contextKeys`).
- Filter web-chat list/get/events/resume REST paths with the same `buildContextExactMatchQuery` semantics as Inbox; reject conversation reuse when session context does not match stored keys.
- Add DAL support (`contextKeys` field + env index) and e2e coverage for context isolation and resume authorization.

## Test plan

- [x] `agent-conversation.service.spec.ts` — stamp, omit, and mismatch tests
- [x] `web-chat-conversation-context.e2e.ts` — stamp+emit, list/get/events isolation, resume deny cross-context, no-context compat
- [ ] Manual: inbox session with non-empty `context`, start web-chat, confirm `agent_event` arrives without reload

Fixes [NV-8551](https://linear.app/novu/issue/NV-8551/bug-agent-events-never-reach-context-scoped-subscribers-contextkeys)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR scopes agent web-chat conversations and realtime events to the Inbox session context, preventing context-scoped WebSocket updates from being silently dropped.
- Persists normalized `contextKeys` when web-chat conversations are created and validates them when conversations are reused.
- Applies exact context matching to conversation list, get, event-history, and resume paths.
- Publishes live agent events with the conversation’s stored context keys.
- Adds the conversation schema field and supporting environment/context index.
- Adds unit and end-to-end coverage for context isolation and no-context compatibility.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts | Persists sorted context keys for new conversations and rejects reuse when the session context does not exactly match. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts | Propagates web-chat session context keys from normalized inbound messages and actions into conversation creation. |
| apps/api/src/app/agents/web-chat/web-chat-context-query.util.ts | Centralizes exact context filtering for web-chat conversation reads and resume authorization. |
| libs/dal/src/repositories/conversation/conversation.repository.ts | Adds optional exact context filtering to paginated conversation queries. |
| libs/dal/src/repositories/conversation/conversation.schema.ts | Persists context keys and adds an environment-scoped multikey index without combining parallel arrays. |
| packages/chat-adapter-web/src/adapter.ts | Attaches verified session context keys to inbound web-chat message and action payloads. |
| apps/api/src/app/agents/e2e/web-chat-conversation-context.e2e.ts | Covers context stamping, realtime publication, REST isolation, resume authorization, and empty-context compatibility. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client as Web-chat client
  participant API as Web-chat API
  participant Adapter as Web-chat adapter
  participant Runtime as Agent runtime
  participant DB as Conversation DAL
  participant WS as WebSocket queue

  Client->>API: Create or resume with Inbox token
  API->>Adapter: Verified session with contextKeys
  Adapter->>Runtime: Inbound message plus contextKeys
  Runtime->>DB: Create or find conversation
  DB-->>Runtime: Conversation scoped by exact context match
  Runtime->>WS: Publish agent_event with stored contextKeys
  WS-->>Client: Deliver to matching context subscriber
```

<sub>Reviews (2): Last reviewed commit: ["fix(api): harden web-chat context isolat..."](https://github.com/novuhq/novu/commit/e2e474b35964db2da0c0483ac3f9ca10dfbd5182) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52145484)</sub>

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)

<!-- /greptile_comment -->