### PR TITLE
fix(api-service,js): sync 402 on web chat accept when plan limits block fixes NV-8575

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
+++ b/apps/api/src/app/agents/conversation-runtime/egress/outbound.gateway.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, forwardRef, Inject, Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import { ConversationChannel } from '@novu/dal';
 import type { SentMessageInfo } from '@novu/framework/internal';
@@ -95,6 +95,7 @@ export interface ThreadReplyPersistContext {
 @Injectable()
 export class OutboundGateway {
   constructor(
+    @Inject(forwardRef(() => ChatInstanceRegistry))
     private readonly registry: ChatInstanceRegistry,
     private readonly conversation: AgentConversationService,
     private readonly agentConfigResolver: AgentConfigResolver,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -2,7 +2,7 @@ import type { SlackAdapter } from '@chat-adapter/slack';
 import type { TeamsAdapter } from '@chat-adapter/teams';
 import type { TelegramAdapter } from '@chat-adapter/telegram';
 import type { WhatsAppAdapter } from '@chat-adapter/whatsapp';
-import { BadRequestException, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 import type { NovuWebChatAdapter } from '@novu/chat-adapter-web';
 import type { Adapter, Chat, Message, ReactionEvent, SlashCommandEvent, Thread } from 'chat';
@@ -123,6 +123,7 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     private readonly webChatSessionVerifier: WebChatSessionVerifier,
     private readonly webChatPlatformDelivery: WebChatPlatformDeliveryService,
     private readonly webChatResumeAuthorization: WebChatResumeAuthorizationService,
+    @Inject(forwardRef(() => PlanLimitGateService))
     private readonly planLimitGate: PlanLimitGateService
   ) {
     this.logger.setContext(this.constructor.name);

--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -14,7 +14,10 @@ import { AgentEmailSender, resolveAgentEmailSenderName } from '../../email/agent
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentException, captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { esmImport } from '../../shared/util/esm-import';
-import { WebChatPlatformDeliveryService } from '../../web-chat/web-chat-platform-delivery.service';
+import {
+  type WebChatPlatformDeliveryContext,
+  WebChatPlatformDeliveryService,
+} from '../../web-chat/web-chat-platform-delivery.service';
 import { WebChatResumeAuthorizationService } from '../../web-chat/web-chat-resume-authorization.service';
 import { WebChatSessionVerifier } from '../../web-chat/web-chat-session.verifier';
 import { AgentActionTokenService } from '../action-token/agent-action-token.service';
@@ -201,9 +204,14 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     config: ResolvedAgentConfig,
     adapterFingerprint: string
   ): Promise<ChatWithAdapters> {
-    const chat = await this.createChatInstance(instanceKey, agentId, platform, config);
+    const cached: CachedChat = {
+      chat: null as unknown as ChatWithAdapters,
+      config,
+      adapterFingerprint,
+    };
+    const chat = await this.createChatInstance(instanceKey, agentId, platform, cached);
     await chat.initialize();
-    const cached: CachedChat = { chat, config, adapterFingerprint };
+    cached.chat = chat;
     this.registerEventHandlers(agentId, cached);
     this.instances.set(instanceKey, cached);
 
@@ -240,14 +248,14 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     instanceKey: string,
     agentId: string,
     platform: AgentPlatformEnum,
-    config: ResolvedAgentConfig
+    cached: CachedChat
   ): Promise<ChatWithAdapters> {
     const [{ Chat: ChatCtor }, { createIoRedisState }] = await Promise.all([
       esmImport('chat'),
       esmImport('@chat-adapter/state-ioredis'),
     ]);
 
-    const adapters = await this.buildAdapters(agentId, platform, config);
+    const adapters = await this.buildAdapters(agentId, platform, cached);
     const client = this.cacheService.client;
     if (!client) {
       throw new Error('Cache in-memory provider client is not available for Conversational SDK state adapter');
@@ -307,8 +315,9 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
   private async buildAdapters(
     agentId: string,
     platform: AgentPlatformEnum,
-    config: ResolvedAgentConfig
+    cached: CachedChat
   ): Promise<Record<string, unknown>> {
+    const config = cached.config;
     const { credentials, connectionAccessToken } = config;
 
     switch (platform) {
@@ -480,7 +489,12 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
       }
       case AgentPlatformEnum.WEB_CHAT: {
         const { createWebChatAdapter } = await esmImport('@novu/chat-adapter-web');
-        const deliveryContext = { agentId, config };
+        const deliveryContext: WebChatPlatformDeliveryContext = {
+          agentId,
+          get config() {
+            return cached.config;
+          },
+        };
 
         return {
           web_chat: createWebChatAdapter({
@@ -488,8 +502,8 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
             verifySession: (request) => this.webChatSessionVerifier.verifySession(request),
             authorizeResume: ({ conversationId, session }) =>
               this.webChatResumeAuthorization.canResume({ conversationId, session, agentId }),
-            checkAcceptLimits: ({ isNewThread }) =>
-              this.planLimitGate.checkWebChatAcceptLimits(agentId, config, isNewThread),
+            checkAcceptLimits: ({ isNewThread, conversationId }) =>
+              this.planLimitGate.checkWebChatAcceptLimits(agentId, cached.config, { isNewThread, conversationId }),
             deliverMessage: this.webChatPlatformDelivery.createDeliverMessage(deliveryContext),
             editMessage: this.webChatPlatformDelivery.createEditMessage(deliveryContext),
             deleteMessage: this.webChatPlatformDelivery.createDeleteMessage(deliveryContext),

--- a/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts
@@ -19,6 +19,7 @@ import { WebChatResumeAuthorizationService } from '../../web-chat/web-chat-resum
 import { WebChatSessionVerifier } from '../../web-chat/web-chat-session.verifier';
 import { AgentActionTokenService } from '../action-token/agent-action-token.service';
 import type { InboundReactionEvent } from './inbound-turn.handler';
+import { PlanLimitGateService } from './plan-limit-gate.service';
 
 /**
  * The adapters this registry knows how to build, keyed by `AgentPlatformEnum`
@@ -118,7 +119,8 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
     private readonly agentEmailSender: AgentEmailSender,
     private readonly webChatSessionVerifier: WebChatSessionVerifier,
     private readonly webChatPlatformDelivery: WebChatPlatformDeliveryService,
-    private readonly webChatResumeAuthorization: WebChatResumeAuthorizationService
+    private readonly webChatResumeAuthorization: WebChatResumeAuthorizationService,
+    private readonly planLimitGate: PlanLimitGateService
   ) {
     this.logger.setContext(this.constructor.name);
     this.instances = new LRUCache<string, CachedChat>({
@@ -486,6 +488,8 @@ export class ChatInstanceRegistry implements OnModuleDestroy {
             verifySession: (request) => this.webChatSessionVerifier.verifySession(request),
             authorizeResume: ({ conversationId, session }) =>
               this.webChatResumeAuthorization.canResume({ conversationId, session, agentId }),
+            checkAcceptLimits: ({ isNewThread }) =>
+              this.planLimitGate.checkWebChatAcceptLimits(agentId, config, isNewThread),
             deliverMessage: this.webChatPlatformDelivery.createDeliverMessage(deliveryContext),
             editMessage: this.webChatPlatformDelivery.createEditMessage(deliveryContext),
             deleteMessage: this.webChatPlatformDelivery.createDeleteMessage(deliveryContext),

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { AgentEntitlementsService, PinoLogger } from '@novu/application-generic';
 import { ConversationEntity } from '@novu/dal';
 import type { AgentAction } from '@novu/framework';
@@ -87,6 +87,7 @@ export class PlanLimitGateService {
   constructor(
     private readonly logger: PinoLogger,
     private readonly agentEntitlements: AgentEntitlementsService,
+    @Inject(forwardRef(() => OutboundGateway))
     private readonly outboundGateway: OutboundGateway,
     private readonly conversationActivation: ConversationActivationService,
     private readonly conversationService: AgentConversationService

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -4,6 +4,7 @@ import { ConversationEntity } from '@novu/dal';
 import type { AgentAction } from '@novu/framework';
 import type { CardElement, Thread } from 'chat';
 import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { captureAgentWarning } from '../../shared/errors/capture-agent-sentry';
 import { buildAttributedNovuUrl } from '../../shared/util/novu-attribution-url';
 import { AgentConversationService } from '../conversation/agent-conversation.service';
@@ -94,11 +95,6 @@ export class PlanLimitGateService {
   }
 
   /**
-   * Returns `true` when inbound processing must stop because the agent or its
-   * channel is over the plan limit. Posts the upgrade card unless the trigger
-   * is a link-button action (see class docs).
-   */
-  /**
    * Sync gate for web chat accept (`POST /web-chat/conversations`) before minting
    * `conv_*`. Returns block payload for HTTP 402; `null` when the turn may proceed.
    * Keyless orgs skip; entitlement errors fail open (same as runtime gate).
@@ -113,37 +109,12 @@ export class PlanLimitGateService {
     }
 
     try {
-      const { agentWithinLimit, channelWithinLimit } = await this.agentEntitlements.checkRuntimeLimits(
-        config.organizationId,
-        config.environmentId,
-        agentId,
-        config.providerId
-      );
+      const block = await this.resolvePlanLimitBlock(agentId, config, {
+        includeConversationLimit: isNewThread,
+        isDirectMessage: true,
+      });
 
-      if (!agentWithinLimit) {
-        return { reason: 'agents', message: PLAN_LIMIT_BLOCK_MESSAGES.agents };
-      }
-
-      if (!channelWithinLimit) {
-        return { reason: 'channels', message: PLAN_LIMIT_BLOCK_MESSAGES.channels };
-      }
-
-      if (isNewThread) {
-        const { blocked } = await this.conversationActivation.shouldBlockFreeTier({
-          conversation: undefined,
-          platform: config.platform,
-          organizationId: config.organizationId,
-          environmentId: config.environmentId,
-          agentId,
-          isDirectMessage: true,
-        });
-
-        if (blocked) {
-          return { reason: 'conversations', message: PLAN_LIMIT_BLOCK_MESSAGES.conversations };
-        }
-      }
-
-      return null;
+      return block ? { reason: block, message: PLAN_LIMIT_BLOCK_MESSAGES[block] } : null;
     } catch (err) {
       this.logger.warn(err, `[agent:${agentId}] Web chat accept limit check failed, failing open`);
 
@@ -151,6 +122,11 @@ export class PlanLimitGateService {
     }
   }
 
+  /**
+   * Returns `true` when inbound processing must stop because the agent or its
+   * channel is over the plan limit. Posts the upgrade card unless the trigger
+   * is a link-button action (see class docs).
+   */
   async maybeBlock(
     agentId: string,
     config: ResolvedAgentConfig,
@@ -161,25 +137,13 @@ export class PlanLimitGateService {
       return false;
     }
 
-    const { agentWithinLimit, channelWithinLimit } = await this.agentEntitlements.checkRuntimeLimits(
-      config.organizationId,
-      config.environmentId,
-      agentId,
-      config.providerId
-    );
-
-    let reason: PlanLimitBlockReason | null = null;
-    if (!agentWithinLimit) {
-      reason = 'agents';
-    } else if (!channelWithinLimit) {
-      reason = 'channels';
-    }
+    const reason = await this.resolveAgentChannelBlockReason(agentId, config);
 
     if (!reason) {
       return false;
     }
 
-    if (!isLinkButtonActionId(action?.id)) {
+    if (this.shouldPostUpgradeCard(config) && !isLinkButtonActionId(action?.id)) {
       await this.postUpgradeRequiredReply(agentId, config, thread, reason);
     }
 
@@ -208,12 +172,8 @@ export class PlanLimitGateService {
       return false;
     }
 
-    const { blocked } = await this.conversationActivation.shouldBlockFreeTier({
+    const blocked = await this.isConversationBlocked(agentId, config, {
       conversation,
-      platform: config.platform,
-      organizationId: config.organizationId,
-      environmentId: config.environmentId,
-      agentId,
       isDirectMessage: thread.isDM,
     });
 
@@ -221,9 +181,78 @@ export class PlanLimitGateService {
       return false;
     }
 
-    await this.postUpgradeRequiredReply(agentId, config, thread, 'conversations', conversation);
+    if (this.shouldPostUpgradeCard(config)) {
+      await this.postUpgradeRequiredReply(agentId, config, thread, 'conversations', conversation);
+    }
 
     return true;
+  }
+
+  /** Web chat returns HTTP 402 on accept; skip in-thread upgrade cards at runtime. */
+  private shouldPostUpgradeCard(config: ResolvedAgentConfig): boolean {
+    return config.platform !== AgentPlatformEnum.WEB_CHAT;
+  }
+
+  private async resolveAgentChannelBlockReason(
+    agentId: string,
+    config: ResolvedAgentConfig
+  ): Promise<Extract<PlanLimitBlockReason, 'agents' | 'channels'> | null> {
+    const { agentWithinLimit, channelWithinLimit } = await this.agentEntitlements.checkRuntimeLimits(
+      config.organizationId,
+      config.environmentId,
+      agentId,
+      config.providerId
+    );
+
+    if (!agentWithinLimit) {
+      return 'agents';
+    }
+
+    if (!channelWithinLimit) {
+      return 'channels';
+    }
+
+    return null;
+  }
+
+  private async isConversationBlocked(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    params: { conversation?: ConversationEntity; isDirectMessage: boolean }
+  ): Promise<boolean> {
+    const { blocked } = await this.conversationActivation.shouldBlockFreeTier({
+      conversation: params.conversation,
+      platform: config.platform,
+      organizationId: config.organizationId,
+      environmentId: config.environmentId,
+      agentId,
+      isDirectMessage: params.isDirectMessage,
+    });
+
+    return blocked;
+  }
+
+  private async resolvePlanLimitBlock(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    params: { includeConversationLimit: boolean; isDirectMessage: boolean; conversation?: ConversationEntity }
+  ): Promise<PlanLimitBlockReason | null> {
+    const agentChannelReason = await this.resolveAgentChannelBlockReason(agentId, config);
+
+    if (agentChannelReason) {
+      return agentChannelReason;
+    }
+
+    if (!params.includeConversationLimit) {
+      return null;
+    }
+
+    const blocked = await this.isConversationBlocked(agentId, config, {
+      conversation: params.conversation,
+      isDirectMessage: params.isDirectMessage,
+    });
+
+    return blocked ? 'conversations' : null;
   }
 
   /** Fail-soft: failing to post the card must not crash the inbound webhook. */

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -22,7 +22,7 @@ export function isLinkButtonActionId(id: string | undefined): boolean {
 /** Which plan entitlement caused an over-limit agent/channel/conversation to be soft-blocked at runtime. */
 export type PlanLimitBlockReason = 'agents' | 'channels' | 'conversations';
 
-const PLAN_LIMIT_BLOCK_MESSAGES: Record<PlanLimitBlockReason, string> = {
+export const PLAN_LIMIT_BLOCK_MESSAGES: Record<PlanLimitBlockReason, string> = {
   agents:
     "This agent isn't active on your current Novu plan — you've reached the number of agents included in your plan. Please upgrade your plan to activate it.",
   channels:
@@ -98,6 +98,59 @@ export class PlanLimitGateService {
    * channel is over the plan limit. Posts the upgrade card unless the trigger
    * is a link-button action (see class docs).
    */
+  /**
+   * Sync gate for web chat accept (`POST /web-chat/conversations`) before minting
+   * `conv_*`. Returns block payload for HTTP 402; `null` when the turn may proceed.
+   * Keyless orgs skip; entitlement errors fail open (same as runtime gate).
+   */
+  async checkWebChatAcceptLimits(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    isNewThread: boolean
+  ): Promise<{ reason: PlanLimitBlockReason; message: string } | null> {
+    if (config.isKeyless) {
+      return null;
+    }
+
+    try {
+      const { agentWithinLimit, channelWithinLimit } = await this.agentEntitlements.checkRuntimeLimits(
+        config.organizationId,
+        config.environmentId,
+        agentId,
+        config.providerId
+      );
+
+      if (!agentWithinLimit) {
+        return { reason: 'agents', message: PLAN_LIMIT_BLOCK_MESSAGES.agents };
+      }
+
+      if (!channelWithinLimit) {
+        return { reason: 'channels', message: PLAN_LIMIT_BLOCK_MESSAGES.channels };
+      }
+
+      if (isNewThread) {
+        const { blocked } = await this.conversationActivation.shouldBlockFreeTier({
+          conversation: undefined,
+          platform: config.platform,
+          organizationId: config.organizationId,
+          environmentId: config.environmentId,
+          agentId,
+          isDirectMessage: true,
+        });
+
+        if (blocked) {
+          return { reason: 'conversations', message: PLAN_LIMIT_BLOCK_MESSAGES.conversations };
+        }
+      }
+
+      return null;
+    } catch (err) {
+      this.logger.warn(err, `[agent:${agentId}] Web chat accept limit check failed, failing open`);
+
+      return null;
+    }
+  }
+
   async maybeBlock(
     agentId: string,
     config: ResolvedAgentConfig,

--- a/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts
@@ -102,16 +102,27 @@ export class PlanLimitGateService {
   async checkWebChatAcceptLimits(
     agentId: string,
     config: ResolvedAgentConfig,
-    isNewThread: boolean
+    params: { isNewThread: boolean; conversationId?: string }
   ): Promise<{ reason: PlanLimitBlockReason; message: string } | null> {
     if (config.isKeyless) {
       return null;
     }
 
     try {
+      let conversation: ConversationEntity | undefined;
+      if (params.conversationId) {
+        conversation =
+          (await this.conversationService.findByPublicIdentifier(
+            config.environmentId,
+            config.organizationId,
+            params.conversationId
+          )) ?? undefined;
+      }
+
       const block = await this.resolvePlanLimitBlock(agentId, config, {
-        includeConversationLimit: isNewThread,
+        includeConversationLimit: params.isNewThread || Boolean(params.conversationId),
         isDirectMessage: true,
+        conversation,
       });
 
       return block ? { reason: block, message: PLAN_LIMIT_BLOCK_MESSAGES[block] } : null;

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -11,6 +11,7 @@ import { ChatProviderIdEnum, WebSocketEventEnum } from '@novu/shared';
 import { testServer } from '@novu/testing';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { ConversationActivationService } from '../conversation-runtime/conversation/conversation-activation.service';
 import { BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
 import {
   AgentTestContext,
@@ -1001,6 +1002,52 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     expect(bridgeStub.called).to.equal(false);
     const activations = await activationRepository.count({ _organizationId: ctx.session.organization._id });
     expect(activations).to.equal(0);
+  });
+
+  it('should return 402 on accept when channel is over plan limit without minting conv_*', async () => {
+    await linkWebChat();
+    const bridgeExecutor = testServer.getService(BridgeExecutorService);
+    const bridgeStub = bridgeExecutor.execute as sinon.SinonStub;
+
+    sinon.stub(testServer.getService(AgentEntitlementsService), 'checkRuntimeLimits').resolves({
+      agentWithinLimit: true,
+      channelWithinLimit: false,
+    });
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Blocked by channel limit',
+    });
+
+    expect(createRes.status).to.equal(402);
+    expect(createRes.body.reason).to.equal('channels');
+    expect(createRes.body.message).to.be.a('string').and.not.empty;
+    expect(bridgeStub.called).to.equal(false);
+  });
+
+  it('should return 402 on accept when free-tier conversation cap is reached on a new thread', async () => {
+    await linkWebChat();
+    const bridgeExecutor = testServer.getService(BridgeExecutorService);
+    const bridgeStub = bridgeExecutor.execute as sinon.SinonStub;
+
+    sinon.stub(testServer.getService(AgentEntitlementsService), 'checkRuntimeLimits').resolves({
+      agentWithinLimit: true,
+      channelWithinLimit: true,
+    });
+    sinon.stub(testServer.getService(ConversationActivationService), 'shouldBlockFreeTier').resolves({
+      blocked: true,
+      limit: 100,
+    });
+
+    const createRes = await createConversation({
+      agentId: ctx.agentIdentifier,
+      text: 'Blocked by conversation limit',
+    });
+
+    expect(createRes.status).to.equal(402);
+    expect(createRes.body.reason).to.equal('conversations');
+    expect(createRes.body.message).to.be.a('string').and.not.empty;
+    expect(bridgeStub.called).to.equal(false);
   });
 
   it('should initialize sequence allocation above legacy unsequenced history', async () => {

--- a/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
+++ b/apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts
@@ -11,7 +11,6 @@ import { ChatProviderIdEnum, WebSocketEventEnum } from '@novu/shared';
 import { testServer } from '@novu/testing';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { PlanLimitGateService } from '../conversation-runtime/ingress/plan-limit-gate.service';
 import { BridgeExecutorService } from '../conversation-runtime/runtime/bridge-executor.service';
 import {
   AgentTestContext,
@@ -980,11 +979,10 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
     ).to.equal(true);
   });
 
-  it('should soft-block plan-limit turns mid-inbound without activating the agent', async () => {
+  it('should return 402 on accept when agent is over plan limit without minting conv_*', async () => {
     await linkWebChat();
     const bridgeExecutor = testServer.getService(BridgeExecutorService);
     const bridgeStub = bridgeExecutor.execute as sinon.SinonStub;
-    const maybeBlockSpy = sinon.spy(testServer.getService(PlanLimitGateService), 'maybeBlock');
 
     sinon.stub(testServer.getService(AgentEntitlementsService), 'checkRuntimeLimits').resolves({
       agentWithinLimit: false,
@@ -995,12 +993,11 @@ describe('Web Chat - /web-chat/conversations #novu-v2', () => {
       agentId: ctx.agentIdentifier,
       text: 'Blocked by plan limit',
     });
-    // Same spine as other channels: accept returns 201; PlanLimitGate soft-blocks
-    // inside inbound-turn (upgrade card may be ephemeral for brand-new web threads).
-    expect(createRes.status).to.equal(201);
-    expect(createRes.body.data.identifier).to.match(/^conv_/);
 
-    await pollFor(async () => (maybeBlockSpy.called && (await maybeBlockSpy.returnValues[0]) ? true : null));
+    expect(createRes.status).to.equal(402);
+    expect(createRes.body.reason).to.equal('agents');
+    expect(createRes.body.message).to.be.a('string').and.not.empty;
+    expect(createRes.body.data).to.equal(undefined);
     expect(bridgeStub.called).to.equal(false);
     const activations = await activationRepository.count({ _organizationId: ctx.session.organization._id });
     expect(activations).to.equal(0);

--- a/apps/api/src/app/agents/web-chat/web-chat.controller.ts
+++ b/apps/api/src/app/agents/web-chat/web-chat.controller.ts
@@ -55,8 +55,9 @@ export class WebChatController {
   ) {}
 
   /**
-   * Adapter webhook ingress (same spine as other channels). Plan limits are
-   * enforced mid-turn by `PlanLimitGateService` in inbound-turn. Optional body
+   * Adapter webhook ingress (same spine as other channels). Plan limits on web
+   * chat accept are enforced synchronously (HTTP 402) before minting `conv_*`;
+   * other channels soft-block mid-turn via `PlanLimitGateService`. Optional body
    * `conversationIdentifier` / `id` resumes via ACL.
    */
   @Post('/conversations')

--- a/packages/chat-adapter-web/src/adapter.spec.ts
+++ b/packages/chat-adapter-web/src/adapter.spec.ts
@@ -125,7 +125,11 @@ describe('NovuWebChatAdapterImpl', () => {
     expect(response.status).toBe(402);
     expect(body).toEqual({ reason: 'agents', message: 'Upgrade your plan' });
     expect(processMessage).not.toHaveBeenCalled();
-    expect(checkAcceptLimits).toHaveBeenCalledWith({ session: SESSION, isNewThread: true });
+    expect(checkAcceptLimits).toHaveBeenCalledWith({
+      session: SESSION,
+      isNewThread: true,
+      conversationId: undefined,
+    });
   });
 
   it('returns 402 on resume when checkAcceptLimits blocks agent/channel limits', async () => {
@@ -143,7 +147,29 @@ describe('NovuWebChatAdapterImpl', () => {
 
     expect(response.status).toBe(402);
     expect(processMessage).not.toHaveBeenCalled();
-    expect(checkAcceptLimits).toHaveBeenCalledWith({ session: SESSION, isNewThread: false });
+    expect(checkAcceptLimits).toHaveBeenCalledWith({
+      session: SESSION,
+      isNewThread: false,
+      conversationId: 'conv_abcdefghijkl',
+    });
+  });
+
+  it('returns 404 before 402 when resume is unauthorized even if limits would block', async () => {
+    const checkAcceptLimits = vi.fn(async () => ({
+      reason: 'agents' as const,
+      message: 'Upgrade your plan',
+    }));
+    const { adapter, processMessage } = await createAdapter(
+      createConfig({ checkAcceptLimits, authorizeResume: async () => false })
+    );
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({ agentId: 'a', text: 'nope', conversationIdentifier: 'conv_abcdefghijkl' })
+    );
+
+    expect(response.status).toBe(404);
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(checkAcceptLimits).not.toHaveBeenCalled();
   });
 
   it('dispatches processMessage then returns 201', async () => {

--- a/packages/chat-adapter-web/src/adapter.spec.ts
+++ b/packages/chat-adapter-web/src/adapter.spec.ts
@@ -112,6 +112,40 @@ describe('NovuWebChatAdapterImpl', () => {
     expect(processAction).not.toHaveBeenCalled();
   });
 
+  it('returns 402 when checkAcceptLimits blocks a new thread', async () => {
+    const checkAcceptLimits = vi.fn(async () => ({
+      reason: 'agents' as const,
+      message: 'Upgrade your plan',
+    }));
+    const { adapter, processMessage } = await createAdapter(createConfig({ checkAcceptLimits }));
+
+    const response = await adapter.handleWebhook(jsonRequest({ agentId: 'agent_1', text: 'Hello' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(402);
+    expect(body).toEqual({ reason: 'agents', message: 'Upgrade your plan' });
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(checkAcceptLimits).toHaveBeenCalledWith({ session: SESSION, isNewThread: true });
+  });
+
+  it('returns 402 on resume when checkAcceptLimits blocks agent/channel limits', async () => {
+    const checkAcceptLimits = vi.fn(async () => ({
+      reason: 'channels' as const,
+      message: 'Channel limit reached',
+    }));
+    const { adapter, processMessage } = await createAdapter(
+      createConfig({ checkAcceptLimits, authorizeResume: async () => true })
+    );
+
+    const response = await adapter.handleWebhook(
+      jsonRequest({ agentId: 'a', text: 'follow up', conversationIdentifier: 'conv_abcdefghijkl' })
+    );
+
+    expect(response.status).toBe(402);
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(checkAcceptLimits).toHaveBeenCalledWith({ session: SESSION, isNewThread: false });
+  });
+
   it('dispatches processMessage then returns 201', async () => {
     const { adapter, processMessage } = await createAdapter();
 

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -199,15 +199,33 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
     body: WebChatRequestBody,
     options?: WebhookOptions
   ): Promise<Response> {
-    const isNewThread = this.resolveResumeConversationId(body) === null;
-    const blocked = await this.checkAcceptLimits(session, isNewThread);
-    if (blocked) {
-      return blocked;
+    const resumeId = this.resolveResumeConversationId(body);
+    if (resumeId === 'invalid') {
+      return jsonResponse({ message: 'Invalid conversation id' }, 400);
     }
 
-    const conversationId = await this.resolveConversationId(body, session, { requireExisting: false });
-    if (conversationId instanceof Response) {
-      return conversationId;
+    let conversationId: string;
+    if (resumeId) {
+      const allowed = this.config.authorizeResume
+        ? await this.config.authorizeResume({ conversationId: resumeId, session })
+        : false;
+      if (!allowed) {
+        return jsonResponse({ message: 'Conversation not found' }, 404);
+      }
+
+      const blocked = await this.checkAcceptLimits(session, false, resumeId);
+      if (blocked) {
+        return blocked;
+      }
+
+      conversationId = resumeId;
+    } else {
+      const blocked = await this.checkAcceptLimits(session, true);
+      if (blocked) {
+        return blocked;
+      }
+
+      conversationId = mintConversationId();
     }
 
     // Always mint message ids. Client `messageId` idempotency would ack a ghost
@@ -237,14 +255,14 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
     body: WebChatRequestBody,
     options?: WebhookOptions
   ): Promise<Response> {
-    const blocked = await this.checkAcceptLimits(session, false);
-    if (blocked) {
-      return blocked;
-    }
-
     const conversationId = await this.resolveConversationId(body, session, { requireExisting: true });
     if (conversationId instanceof Response) {
       return conversationId;
+    }
+
+    const blocked = await this.checkAcceptLimits(session, false, conversationId);
+    if (blocked) {
+      return blocked;
     }
 
     const threadId = this.encodeThreadId({ conversationId });
@@ -274,12 +292,16 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
   }
 
   /** Sync plan-limit gate before minting or dispatching. */
-  private async checkAcceptLimits(session: WebChatSession, isNewThread: boolean): Promise<Response | null> {
+  private async checkAcceptLimits(
+    session: WebChatSession,
+    isNewThread: boolean,
+    conversationId?: string
+  ): Promise<Response | null> {
     if (!this.config.checkAcceptLimits) {
       return null;
     }
 
-    const block = await this.config.checkAcceptLimits({ session, isNewThread });
+    const block = await this.config.checkAcceptLimits({ session, isNewThread, conversationId });
     if (!block) {
       return null;
     }

--- a/packages/chat-adapter-web/src/adapter.ts
+++ b/packages/chat-adapter-web/src/adapter.ts
@@ -199,6 +199,12 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
     body: WebChatRequestBody,
     options?: WebhookOptions
   ): Promise<Response> {
+    const isNewThread = this.resolveResumeConversationId(body) === null;
+    const blocked = await this.checkAcceptLimits(session, isNewThread);
+    if (blocked) {
+      return blocked;
+    }
+
     const conversationId = await this.resolveConversationId(body, session, { requireExisting: false });
     if (conversationId instanceof Response) {
       return conversationId;
@@ -231,6 +237,11 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
     body: WebChatRequestBody,
     options?: WebhookOptions
   ): Promise<Response> {
+    const blocked = await this.checkAcceptLimits(session, false);
+    if (blocked) {
+      return blocked;
+    }
+
     const conversationId = await this.resolveConversationId(body, session, { requireExisting: true });
     if (conversationId instanceof Response) {
       return conversationId;
@@ -260,6 +271,20 @@ export class NovuWebChatAdapterImpl implements Adapter<WebChatThreadId, WebChatR
     );
 
     return jsonResponse({ data: { identifier: conversationId } }, 200);
+  }
+
+  /** Sync plan-limit gate before minting or dispatching. */
+  private async checkAcceptLimits(session: WebChatSession, isNewThread: boolean): Promise<Response | null> {
+    if (!this.config.checkAcceptLimits) {
+      return null;
+    }
+
+    const block = await this.config.checkAcceptLimits({ session, isNewThread });
+    if (!block) {
+      return null;
+    }
+
+    return jsonResponse({ reason: block.reason, message: block.message }, 402);
   }
 
   /**

--- a/packages/chat-adapter-web/src/index.ts
+++ b/packages/chat-adapter-web/src/index.ts
@@ -2,8 +2,11 @@ import { NovuWebChatAdapterImpl } from './adapter.js';
 import type { WebChatAdapterConfig } from './types.js';
 
 export type {
+  WebChatAcceptLimitBlock,
+  WebChatAcceptLimitBlockReason,
   WebChatAdapterConfig,
   WebChatAuthorizeResumeParams,
+  WebChatCheckAcceptLimitsParams,
   WebChatDeleteMessageParams,
   WebChatDeliverMessageParams,
   WebChatDeliverMessageResult,

--- a/packages/chat-adapter-web/src/types.ts
+++ b/packages/chat-adapter-web/src/types.ts
@@ -55,6 +55,8 @@ export type WebChatCheckAcceptLimitsParams = {
   session: WebChatSession;
   /** `true` when the client did not supply a resume conversation id. */
   isNewThread: boolean;
+  /** Authorized resume id; omitted for brand-new threads. */
+  conversationId?: string;
 };
 
 export type WebChatAdapterConfig = {

--- a/packages/chat-adapter-web/src/types.ts
+++ b/packages/chat-adapter-web/src/types.ts
@@ -44,6 +44,19 @@ export type WebChatAuthorizeResumeParams = {
   session: WebChatSession;
 };
 
+export type WebChatAcceptLimitBlockReason = 'agents' | 'channels' | 'conversations';
+
+export type WebChatAcceptLimitBlock = {
+  reason: WebChatAcceptLimitBlockReason;
+  message: string;
+};
+
+export type WebChatCheckAcceptLimitsParams = {
+  session: WebChatSession;
+  /** `true` when the client did not supply a resume conversation id. */
+  isNewThread: boolean;
+};
+
 export type WebChatAdapterConfig = {
   userName?: string;
   verifySession: (request: Request) => Promise<WebChatSession | null>;
@@ -52,6 +65,11 @@ export type WebChatAdapterConfig = {
    * thread may be resumed (participant + web_chat + agent). Denied → adapter 404.
    */
   authorizeResume?: (params: WebChatAuthorizeResumeParams) => Promise<boolean>;
+  /**
+   * Sync plan-limit gate before minting a conversation id or dispatching the turn.
+   * When blocked, the adapter returns HTTP 402 with `{ reason, message }`.
+   */
+  checkAcceptLimits?: (params: WebChatCheckAcceptLimitsParams) => Promise<WebChatAcceptLimitBlock | null>;
   deliverMessage: (params: WebChatDeliverMessageParams) => Promise<WebChatDeliverMessageResult>;
   editMessage: (params: WebChatEditMessageParams) => Promise<WebChatDeliverMessageResult>;
   deleteMessage: (params: WebChatDeleteMessageParams) => Promise<void>;

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -1,5 +1,5 @@
 import { AGENT_EVENT_PROTOCOL_VERSION } from '@novu/agent-event-protocol';
-import { AgentChatService } from '../api';
+import { AgentChatPlanLimitError, AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
 import { derivePendingApprovals } from './agent-message.types';
@@ -95,6 +95,18 @@ describe('AgentChat', () => {
     expect(result.error).toBeDefined();
     const snapshot = agentChat.getConversation({ agentId: 'agent_1', key: 'local_session1' });
     expect(snapshot?.messages[0]?.status).toBe('failed');
+  });
+
+  it('returns AgentChatPlanLimitError when accept is blocked by plan limits', async () => {
+    sendMessage.mockRejectedValue(new AgentChatPlanLimitError('agents', 'Upgrade your plan to activate this agent.'));
+
+    const result = await agentChat.sendMessage({ agentId: 'agent_1', text: 'hello', key: 'local_session1' });
+
+    expect(result.error).toBeInstanceOf(AgentChatPlanLimitError);
+    expect(result.error).toMatchObject({
+      reason: 'agents',
+      message: 'Upgrade your plan to activate this agent.',
+    });
   });
 
   it('serializes overlapping creates on the same session key until conversationId is claimed', async () => {

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -1,5 +1,5 @@
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
-import { AgentChatService, InboxService } from '../api';
+import { AgentChatPlanLimitError, AgentChatService, InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { NovuEventEmitter } from '../event-emitter';
 import type { Result } from '../types';
@@ -127,8 +127,10 @@ export class AgentChat extends BaseModule {
     };
   }
 
-  async respondToApproval(args: RespondToApprovalArgs): Result<RespondToApprovalResult> {
-    return this.callWithSession(async () => {
+  async respondToApproval(
+    args: RespondToApprovalArgs
+  ): Result<RespondToApprovalResult, NovuError | AgentChatPlanLimitError> {
+    return this.callWithSession<RespondToApprovalResult, NovuError | AgentChatPlanLimitError>(async () => {
       const entry = this.#resolveFetchEntry(args);
       if (!entry?.conversationId) {
         return {
@@ -168,6 +170,10 @@ export class AgentChat extends BaseModule {
           },
         };
       } catch (error) {
+        if (error instanceof AgentChatPlanLimitError) {
+          return { error };
+        }
+
         return { error: new NovuError('Failed to respond to approval', error) };
       }
     });
@@ -244,8 +250,8 @@ export class AgentChat extends BaseModule {
     });
   }
 
-  async sendMessage(args: SendMessageArgs): Result<SendMessageResult> {
-    return this.callWithSession(async () => {
+  async sendMessage(args: SendMessageArgs): Result<SendMessageResult, NovuError | AgentChatPlanLimitError> {
+    return this.callWithSession<SendMessageResult, NovuError | AgentChatPlanLimitError>(async () => {
       const key = args.key ?? args.conversationId ?? createLocalConversationKey();
       const entry = this.#resolveSendEntry(args, key);
       const optimisticId = this.#store.appendSending(entry, args.text);
@@ -273,6 +279,10 @@ export class AgentChat extends BaseModule {
           };
         } catch (error) {
           this.#store.markFailed(entry, optimisticId);
+
+          if (error instanceof AgentChatPlanLimitError) {
+            return { error };
+          }
 
           return { error: new NovuError('Failed to send agent chat message', error) };
         }

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -2,6 +2,29 @@ import { AgentChatService } from './agent-chat-service';
 import { HttpClient } from './http-client';
 
 describe('AgentChatService', () => {
+  it('throws AgentChatPlanLimitError on 402 accept response', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 402,
+      json: async () => ({
+        reason: 'agents',
+        message: 'Upgrade your plan to activate this agent.',
+      }),
+    } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const httpClient = new HttpClient({ apiUrl: 'https://test.novu.co' });
+    httpClient.setAuthorizationToken('test-token');
+    const service = new AgentChatService({ httpClient });
+
+    await expect(service.sendMessage({ agentId: 'agent_1', text: 'hello' })).rejects.toMatchObject({
+      name: 'AgentChatPlanLimitError',
+      reason: 'agents',
+      message: 'Upgrade your plan to activate this agent.',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('POSTs a new conversation message', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -5,6 +5,18 @@ import { HttpClient } from './http-client';
 // TODO(NV-8553): rename path to `/agent-chat/conversations` when platform rename lands
 const AGENT_CHAT_CONVERSATIONS_ROUTE = '/web-chat/conversations';
 
+export type AgentChatPlanLimitReason = 'agents' | 'channels' | 'conversations';
+
+export class AgentChatPlanLimitError extends Error {
+  readonly reason: AgentChatPlanLimitReason;
+
+  constructor(reason: AgentChatPlanLimitReason, message: string) {
+    super(message);
+    this.name = 'AgentChatPlanLimitError';
+    this.reason = reason;
+  }
+}
+
 export type AgentChatSendMessageArgs = AgentHashFields & {
   agentId: string;
   text: string;
@@ -49,7 +61,7 @@ export class AgentChatService {
   }
 
   async sendMessage(args: AgentChatSendMessageArgs): Promise<AgentChatSendMessageResponse> {
-    return this.#httpClient.post(AGENT_CHAT_CONVERSATIONS_ROUTE, {
+    return this.#postAccept({
       agentId: args.agentId,
       text: args.text,
       ...(args.conversationId ? { conversationIdentifier: args.conversationId } : {}),
@@ -58,12 +70,42 @@ export class AgentChatService {
   }
 
   async respondToApproval(args: AgentChatRespondToApprovalArgs): Promise<AgentChatRespondToApprovalResponse> {
-    return this.#httpClient.post(AGENT_CHAT_CONVERSATIONS_ROUTE, {
+    return this.#postAccept({
       agentId: args.agentId,
       conversationIdentifier: args.conversationId,
       actionId: args.actionId,
       ...(args.agentHash ? { agentHash: args.agentHash } : {}),
     });
+  }
+
+  async #postAccept<T extends AgentChatSendMessageResponse | AgentChatRespondToApprovalResponse>(
+    body: Record<string, string>
+  ): Promise<T> {
+    try {
+      return await this.#httpClient.post<T>(AGENT_CHAT_CONVERSATIONS_ROUTE, body);
+    } catch (err) {
+      throw this.#maybeRethrowPlanLimitError(err);
+    }
+  }
+
+  #maybeRethrowPlanLimitError(err: unknown): Error {
+    if (!(err instanceof Error)) {
+      return new Error(String(err));
+    }
+
+    const status = (err as Error & { status?: number }).status;
+    const body = (err as Error & { body?: { reason?: string; message?: string } }).body;
+    if (
+      status === 402 &&
+      body &&
+      typeof body.reason === 'string' &&
+      typeof body.message === 'string' &&
+      (body.reason === 'agents' || body.reason === 'channels' || body.reason === 'conversations')
+    ) {
+      return new AgentChatPlanLimitError(body.reason, body.message);
+    }
+
+    return err;
   }
 
   async getEvents(args: AgentChatGetEventsArgs): Promise<AgentChatGetEventsResponse> {

--- a/packages/js/src/api/http-client.ts
+++ b/packages/js/src/api/http-client.ts
@@ -115,9 +115,12 @@ export class HttpClient {
 
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(
+      const error = new Error(
         `${this.headers['Novu-Client-Version']} error. Status: ${response.status}, Message: ${errorData.message}`
-      );
+      ) as Error & { status?: number; body?: unknown };
+      error.status = response.status;
+      error.body = errorData;
+      throw error;
     }
     if (response.status === 204) {
       return undefined as unknown as T;

--- a/packages/js/src/base-module.ts
+++ b/packages/js/src/base-module.ts
@@ -46,7 +46,7 @@ export class BaseModule {
 
   protected onSessionError(_: unknown): void {}
 
-  async callWithSession<T>(fn: () => Result<T>): Result<T> {
+  async callWithSession<T, E = NovuError>(fn: () => Result<T, E>): Result<T, E> {
     if (this._inboxService.isSessionInitialized) {
       return fn();
     }
@@ -54,7 +54,7 @@ export class BaseModule {
     if (this.#sessionError) {
       return Promise.resolve({
         error: new NovuError('Failed to initialize session, please contact the support', this.#sessionError),
-      });
+      }) as Result<T, E>;
     }
 
     return new Promise((resolve, reject) => {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -17,6 +17,8 @@ export type {
   SendMessageResult,
 } from './agent-chat';
 export { derivePendingApprovals } from './agent-chat';
+export type { AgentChatPlanLimitReason } from './api/agent-chat-service';
+export { AgentChatPlanLimitError } from './api/agent-chat-service';
 export type {
   ChannelConnectionResponse,
   ChannelEndpointResponse,

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,5 +1,6 @@
 import type {
   AgentApprovalPart,
+  AgentChatPlanLimitError,
   AgentConversationStatus,
   AgentConversationTyping,
   AgentEventEnvelope,
@@ -24,7 +25,7 @@ export type UseAgentChatProps = AgentHashFields & {
    */
   conversationId?: string;
   onSuccess?: (data: LoadConversationResult) => void;
-  onError?: (error: NovuError) => void;
+  onError?: (error: NovuError | AgentChatPlanLimitError) => void;
   /**
    * Fires once per message, when the message id first appears on the conversation.
    * History pages are silent: only new activity fires.
@@ -52,7 +53,7 @@ export type UseAgentChatResult = {
   messages: AgentMessage[];
   pendingApprovals: AgentApprovalPart[];
   conversationId?: string;
-  error?: NovuError;
+  error?: NovuError | AgentChatPlanLimitError;
   /** True until the first history fetch completes. False when there is no `conversationId` prop. */
   isLoading: boolean;
   isFetching: boolean;
@@ -68,11 +69,11 @@ export type UseAgentChatResult = {
   }>;
   sendMessage: (text: string) => Promise<{
     data?: SendMessageResult;
-    error?: NovuError;
+    error?: NovuError | AgentChatPlanLimitError;
   }>;
   respondToApproval: (args: { approvalId: string; decision: 'approved' | 'denied' }) => Promise<{
     data?: RespondToApprovalResult;
-    error?: NovuError;
+    error?: NovuError | AgentChatPlanLimitError;
   }>;
 };
 
@@ -146,7 +147,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const [typing, setTyping] = useState<AgentConversationTyping>();
   const [status, setStatus] = useState<AgentConversationStatus>('active');
   const [hasMore, setHasMore] = useState(false);
-  const [error, setError] = useState<NovuError>();
+  const [error, setError] = useState<NovuError | AgentChatPlanLimitError>();
   const [isLoading, setIsLoading] = useState(Boolean(conversationIdProp));
   const [isFetching, setIsFetching] = useState(false);
   const fetchGenerationRef = useRef(0);


### PR DESCRIPTION
## Summary

- Web chat `POST /web-chat/conversations` returns **HTTP 402** with `{ reason, message }` **before** minting `conv_*` when agent, channel, or (new-thread) conversation plan limits block the accept.
- Host apps own upgrade UI via `AgentChatPlanLimitError` (`@novu/js`); Slack/Telegram keep in-thread upgrade cards unchanged.
- Shared limit resolution lives in `PlanLimitGateService`; web chat skips runtime upgrade-card posts (402 is the contract).

## Test plan

- [x] `@novu/chat-adapter-web` vitest (22/22)
- [x] `@novu/js` agent-chat-service + AgentChat plan-limit tests
- [x] API e2e: agent / channel / conversation 402 on new thread (`web-chat-conversation.e2e.ts`)
- [ ] Full API e2e suite in CI

## Related

- Linear: [NV-8575](https://linear.app/novu/issue/NV-8575) (implements [NV-8464](https://linear.app/novu/issue/NV-8464) Option A)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves web-chat plan-limit enforcement into the synchronous conversation-accept path and exposes typed plan-limit errors through the JavaScript and React SDKs.
- Authorizes supplied conversation IDs before checking plan limits.
- Returns HTTP 402 before minting new conversation identifiers when agent, channel, or conversation limits block acceptance.
- Adds `AgentChatPlanLimitError` propagation to `@novu/js` and `useAgentChat`.
- Retains runtime upgrade cards for external chat platforms while suppressing them for web chat.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because transient synchronous limit-check failures can still produce successful web-chat accepts whose turns are silently discarded by the runtime gate.

The resume-authorization ordering issue is fixed, but the previously reported fail-open path remains: the synchronous gate returns success after a lookup failure, while a later runtime limit decision can stop processing without an HTTP error, Bridge invocation, upgrade card, or client event.

**Files Needing Attention:** apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts, packages/chat-adapter-web/src/adapter.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/chat-adapter-web/src/adapter.ts | Reorders resume authorization ahead of limit checks and adds synchronous HTTP 402 handling before conversation ID minting or dispatch. |
| apps/api/src/app/agents/conversation-runtime/ingress/plan-limit-gate.service.ts | Centralizes agent, channel, and conversation limit resolution for synchronous web-chat acceptance and existing runtime gating. |
| apps/api/src/app/agents/conversation-runtime/ingress/chat-instance.registry.ts | Injects the plan-limit gate into the cached web-chat adapter configuration and adds circular-dependency forwarding. |
| packages/js/src/api/agent-chat-service.ts | Converts structured HTTP 402 responses into the exported `AgentChatPlanLimitError`. |
| packages/js/src/api/http-client.ts | Attaches HTTP status and parsed response bodies to request errors so service-specific handling can inspect them. |
| packages/js/src/agent-chat/agent-chat.ts | Preserves typed plan-limit errors through message and approval result objects. |
| packages/react/src/hooks/useAgentChat.ts | Extends the hook’s public error types to include plan-limit failures. |
| apps/api/src/app/agents/e2e/web-chat-conversation.e2e.ts | Adds coverage for synchronous agent, channel, and new-conversation limit responses. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Host as Host application
  participant SDK as @novu/js
  participant Adapter as Web-chat adapter
  participant Auth as Resume authorization
  participant Gate as PlanLimitGateService
  participant Runtime as Agent runtime

  Host->>SDK: sendMessage / respondToApproval
  SDK->>Adapter: POST /web-chat/conversations
  alt Resume request
    Adapter->>Auth: authorize conversation
    alt Unauthorized
      Auth-->>Adapter: denied
      Adapter-->>SDK: 404
    else Authorized
      Auth-->>Adapter: allowed
      Adapter->>Gate: check accept limits
    end
  else New conversation
    Adapter->>Gate: check accept limits
  end
  alt Plan limit reached
    Gate-->>Adapter: reason and message
    Adapter-->>SDK: 402
    SDK-->>Host: AgentChatPlanLimitError
  else Allowed
    Gate-->>Adapter: allowed
    Adapter->>Runtime: dispatch turn
    Adapter-->>SDK: 201 / 200
  end
```

<sub>Reviews (3): Last reviewed commit: ["fix(NV-8575): break PlanLimitGate circul..."](https://github.com/novuhq/novu/commit/7bd7b5289d022cc88e60189fb45cb5ee3505e4d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52175985)</sub>

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->