### PR TITLE
feat(dashboard,application-generic): chat step editors - text and block fixes NV-8579

### DIFF
--- a/apps/dashboard/src/components/chat-editor-select.tsx
+++ b/apps/dashboard/src/components/chat-editor-select.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { RiCodeSSlashFill, RiDashboardLine } from 'react-icons/ri';
+import { ConfirmationModal } from '@/components/confirmation-modal';
+import { isEmptyMailyJson } from '@/components/maily/maily-utils';
+import { FormField } from '@/components/primitives/form/form';
+import { Tabs, TabsList, TabsTrigger } from '@/components/primitives/tabs';
+import {
+  type ChatEditorType,
+  deriveChatEditorType,
+} from '@/components/workflow-editor/steps/chat/derive-chat-editor-type';
+
+const EDITOR_TYPE_LABEL: Record<ChatEditorType, string> = {
+  block: 'Block editor',
+  text: 'Text editor',
+};
+
+export const ChatEditorSelect = ({
+  isLoading,
+  saveForm,
+  disabled,
+}: {
+  isLoading: boolean;
+  saveForm?: (options: { editorType: ChatEditorType; forceSubmit?: boolean; onSuccess?: () => void }) => Promise<void>;
+  disabled?: boolean;
+}) => {
+  const { control, setValue } = useFormContext();
+  const [pendingEditorType, setPendingEditorType] = useState<ChatEditorType | null>(null);
+  const body = useWatch({ name: 'body', control });
+
+  return (
+    <FormField
+      control={control}
+      name="editorType"
+      render={({ field }) => {
+        const displayValue = deriveChatEditorType(body, field.value, true);
+
+        return (
+          <>
+            <Tabs
+              defaultValue="editor"
+              value={displayValue}
+              onValueChange={(value) => {
+                if (value !== 'block' && value !== 'text') {
+                  return;
+                }
+
+                if (value === displayValue) {
+                  return;
+                }
+
+                if (!body || body === '' || isEmptyMailyJson(body)) {
+                  field.onChange(value);
+                  if (isEmptyMailyJson(body)) {
+                    setValue('body', '', { shouldDirty: true });
+                  }
+
+                  return;
+                }
+
+                setPendingEditorType(value);
+              }}
+              className="flex h-full flex-1 flex-col"
+            >
+              <TabsList className="w-min">
+                <TabsTrigger value="block" className="gap-1.5" size="xs" disabled={disabled}>
+                  <RiDashboardLine className="size-3.5" />
+                  <span>Block editor</span>
+                </TabsTrigger>
+                <TabsTrigger value="text" className="gap-1.5" size="xs" disabled={disabled}>
+                  <RiCodeSSlashFill className="size-3.5" />
+                  <span>Text editor</span>
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <ConfirmationModal
+              open={pendingEditorType !== null}
+              onOpenChange={(open) => {
+                if (!open) {
+                  setPendingEditorType(null);
+                }
+              }}
+              onConfirm={() => {
+                if (!pendingEditorType) {
+                  return;
+                }
+
+                const nextEditorType = pendingEditorType;
+                field.onChange(nextEditorType);
+                setValue('body', '', { shouldDirty: true });
+                saveForm?.({ editorType: nextEditorType, onSuccess: () => setPendingEditorType(null) });
+              }}
+              title="Are you sure?"
+              description={`Switching to the ${pendingEditorType ? EDITOR_TYPE_LABEL[pendingEditorType] : 'editor'} will erase your current content. You'll start from an empty template. Sure you want to continue?`}
+              confirmButtonText="Proceed"
+              isLoading={isLoading}
+            />
+          </>
+        );
+      }}
+    />
+  );
+};

--- a/apps/dashboard/src/components/maily/maily-utils.spec.ts
+++ b/apps/dashboard/src/components/maily/maily-utils.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { plainTextToMailyJson } from './maily-utils';
+
+const variableNode = (id: string) => ({
+  type: 'variable',
+  attrs: {
+    id,
+    label: null,
+    fallback: null,
+    required: false,
+    aliasFor: null,
+  },
+});
+
+describe('plainTextToMailyJson', () => {
+  it('converts legacy liquid variables into maily variable nodes', () => {
+    const result = JSON.parse(plainTextToMailyJson('hello from the old chat! {{payload.foo}}'));
+
+    expect(result).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'hello from the old chat! ' }, variableNode('payload.foo')],
+        },
+      ],
+    });
+  });
+
+  it('preserves filters on the variable id', () => {
+    const result = JSON.parse(
+      plainTextToMailyJson(
+        "Hi {{ subscriber.firstName }}, order {{payload.id | upcase}} status {{payload.status | default: 'pending' | upcase}} {{payload.foo | truncate: 10}}"
+      )
+    );
+
+    expect(result.content[0].content).toEqual([
+      { type: 'text', text: 'Hi ' },
+      variableNode('subscriber.firstName'),
+      { type: 'text', text: ', order ' },
+      variableNode('payload.id | upcase'),
+      { type: 'text', text: ' status ' },
+      variableNode("payload.status | default: 'pending' | upcase"),
+      { type: 'text', text: ' ' },
+      variableNode('payload.foo | truncate: 10'),
+    ]);
+  });
+
+  it('leaves translation variables as text for the translation decorator', () => {
+    const result = JSON.parse(plainTextToMailyJson('Say {{t.greeting}} please'));
+
+    expect(result.content[0].content).toEqual([{ type: 'text', text: 'Say {{t.greeting}} please' }]);
+  });
+
+  it('converts regular variables while keeping translation markers as text', () => {
+    const result = JSON.parse(plainTextToMailyJson('{{t.hello}} {{payload.name | capitalize}} and {{ T.farewell }}'));
+
+    expect(result.content[0].content).toEqual([
+      { type: 'text', text: '{{t.hello}} ' },
+      variableNode('payload.name | capitalize'),
+      { type: 'text', text: ' and {{ T.farewell }}' },
+    ]);
+  });
+
+  it('keeps plain text lines without variables unchanged', () => {
+    const result = JSON.parse(plainTextToMailyJson('just text\n\nsecond line'));
+
+    expect(result.content).toEqual([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'just text' }],
+      },
+      { type: 'paragraph', content: [] },
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'second line' }],
+      },
+    ]);
+  });
+
+  it('handles variables that occupy the whole line', () => {
+    const result = JSON.parse(plainTextToMailyJson('{{payload.only}}'));
+
+    expect(result.content[0].content).toEqual([variableNode('payload.only')]);
+  });
+});

--- a/apps/dashboard/src/components/maily/maily-utils.ts
+++ b/apps/dashboard/src/components/maily/maily-utils.ts
@@ -1,3 +1,6 @@
+import { TRANSLATION_KEY_SINGLE_REGEX } from '@novu/shared';
+import { parseVariable, VARIABLE_REGEX_STRING } from '@/utils/liquid';
+
 export const isEmptyMailyJson = (value: unknown): boolean => {
   if (typeof value !== 'string') return false;
 
@@ -18,10 +21,92 @@ export const isEmptyMailyJson = (value: unknown): boolean => {
   }
 };
 
+type MailyInlineNode =
+  | { type: 'text'; text: string }
+  | {
+      type: 'variable';
+      attrs: {
+        id: string;
+        label: null;
+        fallback: null;
+        required: false;
+        aliasFor: null;
+      };
+    };
+
+function createVariableNode(id: string): MailyInlineNode {
+  return {
+    type: 'variable',
+    attrs: {
+      id,
+      label: null,
+      fallback: null,
+      required: false,
+      aliasFor: null,
+    },
+  };
+}
+
+function isTranslationVariable(expression: string): boolean {
+  // Keep {{t.key}} as text so InlineDecoratorExtension can render translation pills.
+  return TRANSLATION_KEY_SINGLE_REGEX.test(expression);
+}
+
+/**
+ * Splits a plain-text line into TipTap inline nodes, turning Liquid
+ * `{{ variable }}` expressions (including filters) into variable nodes so they
+ * render as pills. Translation markers (`{{t.key}}`) stay as text for the
+ * translation decorator.
+ */
+function lineToInlineContent(line: string): MailyInlineNode[] {
+  if (line.length === 0) return [];
+
+  const content: MailyInlineNode[] = [];
+  const regex = new RegExp(VARIABLE_REGEX_STRING, 'g');
+  let lastIndex = 0;
+
+  for (const match of line.matchAll(regex)) {
+    const matchedExpression = match[0];
+    const matchIndex = match.index ?? 0;
+
+    // Leave translation keys in the text stream for the decorator plugin.
+    if (isTranslationVariable(matchedExpression)) {
+      continue;
+    }
+
+    const parsed = parseVariable(matchedExpression);
+    // Preserve filters (`| default: 'x'`, `| upcase`, etc.) on the variable id.
+    const variableId = parsed?.fullLiquidExpression;
+
+    if (!variableId) {
+      continue;
+    }
+
+    if (matchIndex > lastIndex) {
+      content.push({ type: 'text', text: line.slice(lastIndex, matchIndex) });
+    }
+
+    content.push(createVariableNode(variableId));
+    lastIndex = matchIndex + matchedExpression.length;
+  }
+
+  if (lastIndex < line.length) {
+    content.push({ type: 'text', text: line.slice(lastIndex) });
+  }
+
+  // No convertible variables matched — keep the original line as a single text node.
+  if (content.length === 0) {
+    return [{ type: 'text', text: line }];
+  }
+
+  return content;
+}
+
 /**
  * Wraps a legacy plain-string body into a minimal Maily/TipTap document so it
  * can be opened in the block editor as text blocks. Each line becomes its own
- * paragraph; empty lines are preserved as empty paragraphs.
+ * paragraph; empty lines are preserved as empty paragraphs. Liquid variables
+ * are converted to variable nodes so they appear as pills in the editor.
  */
 export const plainTextToMailyJson = (value: string): string => {
   const content = value
@@ -29,7 +114,7 @@ export const plainTextToMailyJson = (value: string): string => {
     .split('\n')
     .map((line) => ({
       type: 'paragraph',
-      content: line.length > 0 ? [{ type: 'text', text: line }] : [],
+      content: lineToInlineContent(line),
     }));
 
   return JSON.stringify({ type: 'doc', content });

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-body-maily.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-body-maily.tsx
@@ -7,7 +7,7 @@ import { useFormContext } from 'react-hook-form';
 import { EditorOverlays } from '@/components/editor-overlays';
 import { createChatEditorBlocks } from '@/components/maily/chat-blocks';
 import { Maily } from '@/components/maily/maily';
-import { isMailyJson, plainTextToMailyJson, wrapLegacyCardButtons } from '@/components/maily/maily-utils';
+import { isMailyJson, wrapLegacyCardButtons } from '@/components/maily/maily-utils';
 import { VariableFrom } from '@/components/maily/types';
 import {
   MailyVariablesListView,
@@ -271,14 +271,15 @@ export const ChatBodyMaily = () => {
       name="body"
       render={({ field }) => {
         const rawBody: string = field.value ?? '';
-        // Back-compat: Maily JSON loads as-is; a legacy plain string opens as
-        // text blocks; an empty body starts a fresh block editor.
+        // Only load Maily JSON in the block editor. Legacy plain/Liquid bodies
+        // are routed to the text editor via deriveChatEditorType — never
+        // silently convert them here.
         const getEditorValue = () => {
           if (isMailyJson(rawBody)) {
             return wrapLegacyCardButtons(rawBody);
           }
 
-          return rawBody.length > 0 ? plainTextToMailyJson(rawBody) : '';
+          return '';
         };
 
         return (

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-body.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-body.tsx
@@ -1,8 +1,10 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { TabsSection } from '@/components/workflow-editor/steps/tabs-section';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { BaseBody } from '../base/base-body';
 import { ChatBodyMaily } from './chat-body-maily';
+import { deriveChatEditorType } from './derive-chat-editor-type';
 
 const LegacyChatBody = () => (
   <TabsSection className="p-0 pb-3">
@@ -12,11 +14,25 @@ const LegacyChatBody = () => (
   </TabsSection>
 );
 
+const RichChatBody = () => {
+  const { control } = useFormContext();
+  const body = useWatch({ name: 'body', control });
+  const editorType = useWatch({ name: 'editorType', control });
+  const resolvedEditorType = deriveChatEditorType(body, editorType, true);
+
+  if (resolvedEditorType === 'text') {
+    return <BaseBody />;
+  }
+
+  return <ChatBodyMaily />;
+};
+
 /**
- * Chat step body editor. Behind `IS_CHAT_BLOCK_EDITOR_ENABLED` the step is
- * authored with the restricted Maily block editor, which handles back-compat internally
- * (Maily JSON loads as-is; a legacy plain string opens as text blocks). Without the flag
- * the legacy plain-text editor is used. The same flag gates rich-chat delivery server-side.
+ * Chat step body editor. Behind `IS_CHAT_BLOCK_EDITOR_ENABLED` the step can
+ * switch between the Maily block editor and a plain-text editor.
+ * Legacy raw/Liquid bodies open in Text; new empty steps default to Block.
+ * The Block/Text toggle is rendered by chat-editor inside the TabsSection
+ * (top-right). Without the flag the legacy plain-text editor is used unchanged.
  */
 export const ChatBody = () => {
   const isBlockEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CHAT_BLOCK_EDITOR_ENABLED);
@@ -25,9 +41,5 @@ export const ChatBody = () => {
     return <LegacyChatBody />;
   }
 
-  return (
-    <div className="flex h-full min-h-0 flex-1 flex-col">
-      <ChatBodyMaily />
-    </div>
-  );
+  return <RichChatBody />;
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor.tsx
@@ -4,6 +4,7 @@ import {
   type ContentOverrideProviderId,
   EnvironmentTypeEnum,
   FeatureFlagsKeysEnum,
+  UiComponentEnum,
   type UiSchema,
 } from '@novu/shared';
 import { type ReactNode, useCallback } from 'react';
@@ -14,14 +15,29 @@ import {
 } from '@/components/workflow-editor/steps/shared/provider-overrides/content-override-panel';
 import { SlackBlockKitBuilderHint } from '@/components/workflow-editor/steps/shared/provider-overrides/slack-block-kit-builder-hint';
 import { useProviderOverrideOptions } from '@/components/workflow-editor/steps/shared/provider-overrides/use-provider-override-options';
+import { TabsSection } from '@/components/workflow-editor/steps/tabs-section';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { StepEditorUnavailable } from '../step-editor-unavailable';
 
 type ChatEditorProps = { uiSchema: UiSchema };
 
+function ChatEditorSelectAction({ editorTypeComponent }: { editorTypeComponent?: UiComponentEnum }) {
+  return (
+    <div className="flex items-center">
+      {getComponentByType({ component: editorTypeComponent ?? UiComponentEnum.CHAT_EDITOR_SELECT })}
+    </div>
+  );
+}
+
 /** Split out so the flag-off editor never subscribes to the `providerOverrides` form field. */
-function ChatOverrideEditor({ defaultContent }: { defaultContent: ReactNode }) {
+function ChatOverrideEditor({
+  defaultContent,
+  defaultContentActions,
+}: {
+  defaultContent: ReactNode;
+  defaultContentActions?: ReactNode;
+}) {
   const { providerOptions, providerOverrides } = useProviderOverrideOptions(ChannelTypeEnum.CHAT);
 
   const getEditorExtras = useCallback((providerId: ContentOverrideProviderId): ProviderOverrideEditorExtras => {
@@ -40,6 +56,7 @@ function ChatOverrideEditor({ defaultContent }: { defaultContent: ReactNode }) {
       providerOptions={providerOptions}
       providerOverrides={providerOverrides}
       defaultContent={defaultContent}
+      defaultContentActions={defaultContentActions}
       showEscapeHatchBadge
       getEditorExtras={getEditorExtras}
     />
@@ -49,17 +66,34 @@ function ChatOverrideEditor({ defaultContent }: { defaultContent: ReactNode }) {
 export const ChatEditor = (props: ChatEditorProps) => {
   const { currentEnvironment } = useEnvironment();
   const { uiSchema } = props;
-  const { body } = uiSchema?.properties ?? {};
+  const { body, editorType } = uiSchema?.properties ?? {};
   const areProviderOverridesEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CHAT_PROVIDER_OVERRIDES_ENABLED);
+  const isBlockEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CHAT_BLOCK_EDITOR_ENABLED);
 
   if (currentEnvironment?.type !== EnvironmentTypeEnum.DEV) {
     return <StepEditorUnavailable />;
   }
 
   const defaultContent = body ? getComponentByType({ component: body.component }) : null;
+  const defaultContentActions = isBlockEditorEnabled ? (
+    <ChatEditorSelectAction editorTypeComponent={editorType?.component} />
+  ) : undefined;
 
   if (areProviderOverridesEnabled) {
-    return <ChatOverrideEditor defaultContent={defaultContent} />;
+    return <ChatOverrideEditor defaultContent={defaultContent} defaultContentActions={defaultContentActions} />;
+  }
+
+  if (defaultContentActions) {
+    return (
+      <TabsSection className="flex min-h-0 flex-1 flex-col p-3">
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
+          <div className="flex shrink-0 items-center justify-end">{defaultContentActions}</div>
+          <div className="rounded-12 bg-bg-weak flex min-h-0 flex-1 flex-col gap-2 border border-neutral-100 p-2">
+            {defaultContent}
+          </div>
+        </div>
+      </TabsSection>
+    );
   }
 
   return <div className="flex h-full flex-col">{defaultContent}</div>;

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.spec.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { deriveChatEditorType } from './derive-chat-editor-type';
+
+const mailyBody = JSON.stringify({
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+});
+
+describe('deriveChatEditorType', () => {
+  it('prefers an explicit editorType', () => {
+    expect(deriveChatEditorType('{% if true %}x{% endif %}', 'block', true)).toBe('block');
+    expect(deriveChatEditorType(mailyBody, 'text', true)).toBe('text');
+  });
+
+  it('routes Maily JSON to block when editorType is unset', () => {
+    expect(deriveChatEditorType(mailyBody, undefined, true)).toBe('block');
+  });
+
+  it('routes non-empty plain/Liquid bodies to text when editorType is unset', () => {
+    expect(deriveChatEditorType('{% if true %}x{% endif %}', undefined, true)).toBe('text');
+    expect(deriveChatEditorType('hello {{payload.foo}}', undefined, true)).toBe('text');
+  });
+
+  it('defaults empty bodies to block when the flag is on', () => {
+    expect(deriveChatEditorType('', undefined, true)).toBe('block');
+    expect(deriveChatEditorType(undefined, undefined, true)).toBe('block');
+  });
+
+  it('defaults empty bodies to text when the flag is off', () => {
+    expect(deriveChatEditorType('', undefined, false)).toBe('text');
+  });
+});

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.ts
@@ -1,0 +1,30 @@
+import { isMailyJson } from '@/components/maily/maily-utils';
+
+export type ChatEditorType = 'block' | 'text';
+
+/**
+ * Resolve which chat editor to show.
+ * - Explicit `editorType` always wins.
+ * - Maily JSON bodies open in the block editor.
+ * - Non-empty plain/Liquid bodies open in the text editor (legacy-safe).
+ * - Empty bodies default to `block` when the block editor flag is on, otherwise `text`.
+ */
+export function deriveChatEditorType(
+  body: unknown,
+  editorType: unknown,
+  isBlockEditorEnabled: boolean
+): ChatEditorType {
+  if (editorType === 'block' || editorType === 'text') {
+    return editorType;
+  }
+
+  if (typeof body === 'string' && isMailyJson(body)) {
+    return 'block';
+  }
+
+  if (typeof body === 'string' && body.length > 0) {
+    return 'text';
+  }
+
+  return isBlockEditorEnabled ? 'block' : 'text';
+}

--- a/apps/dashboard/src/components/workflow-editor/steps/component-utils.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/component-utils.tsx
@@ -1,4 +1,5 @@
 import { EnvironmentTypeEnum, UiComponentEnum } from '@novu/shared';
+import { ChatEditorSelect } from '@/components/chat-editor-select';
 import { EmailEditorSelect } from '@/components/email-editor-select';
 import { DelayWindow } from '@/components/workflow-editor/steps/delay/delay-window';
 import { DigestDelayTabs } from '@/components/workflow-editor/steps/digest-delay-tabs/digest-delay-tabs';
@@ -42,6 +43,20 @@ const EmailEditorSelectInternal = () => {
   );
 };
 
+const ChatEditorSelectInternal = () => {
+  const { isUpdatePatchPending } = useWorkflow();
+  const { saveForm } = useSaveForm();
+  const { currentEnvironment } = useEnvironment();
+
+  return (
+    <ChatEditorSelect
+      isLoading={isUpdatePatchPending}
+      saveForm={saveForm}
+      disabled={currentEnvironment?.type !== EnvironmentTypeEnum.DEV}
+    />
+  );
+};
+
 export const getComponentByType = ({ component }: { component?: UiComponentEnum }) => {
   switch (component) {
     case UiComponentEnum.IN_APP_AVATAR: {
@@ -73,6 +88,10 @@ export const getComponentByType = ({ component }: { component?: UiComponentEnum 
 
     case UiComponentEnum.EMAIL_EDITOR_SELECT: {
       return <EmailEditorSelectInternal />;
+    }
+
+    case UiComponentEnum.CHAT_EDITOR_SELECT: {
+      return <ChatEditorSelectInternal />;
     }
 
     case UiComponentEnum.EMAIL_BODY:

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-override-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/provider-overrides/content-override-panel.tsx
@@ -34,6 +34,11 @@ type ContentOverridePanelProps = {
   providerOptions: ProviderOverrideOption[];
   providerOverrides: ProviderOverrides | undefined;
   defaultContent: ReactNode;
+  /**
+   * Rendered at the top-right inside the TabsSection when showing default content
+   * (e.g. Block/Text editor toggle). Hidden while a provider override is selected.
+   */
+  defaultContentActions?: ReactNode;
   showEscapeHatchBadge?: boolean;
   getEditorExtras?: (providerId: ContentOverrideProviderId) => ProviderOverrideEditorExtras;
 };
@@ -43,6 +48,7 @@ export function ContentOverridePanel({
   providerOptions,
   providerOverrides,
   defaultContent,
+  defaultContentActions,
   showEscapeHatchBadge,
   getEditorExtras,
 }: ContentOverridePanelProps) {
@@ -251,8 +257,13 @@ export function ContentOverridePanel({
           />
         ) : (
           defaultContent && (
-            <div className="rounded-12 bg-bg-weak flex min-h-0 flex-1 flex-col gap-2 border border-neutral-100 p-2">
-              {defaultContent}
+            <div className="flex min-h-0 flex-1 flex-col gap-2">
+              {defaultContentActions && (
+                <div className="flex shrink-0 items-center justify-end">{defaultContentActions}</div>
+              )}
+              <div className="rounded-12 bg-bg-weak flex min-h-0 flex-1 flex-col gap-2 border border-neutral-100 p-2">
+                {defaultContent}
+              </div>
             </div>
           )
         )}

--- a/libs/application-generic/src/schemas/control/chat-control.schema.ts
+++ b/libs/application-generic/src/schemas/control/chat-control.schema.ts
@@ -8,6 +8,10 @@ export const chatControlZodSchema = z
   .object({
     skip: skipZodSchema,
     body: z.string(),
+    // Optional with no static default so flag-off orgs never persist editorType.
+    // When IS_CHAT_BLOCK_EDITOR_ENABLED is on, the dashboard derives 'block' for
+    // empty/new steps and 'text' for legacy raw bodies.
+    editorType: z.enum(['block', 'text']).optional(),
   })
   .strict();
 
@@ -19,6 +23,9 @@ export const chatUiSchema: UiSchema = {
   properties: {
     body: {
       component: UiComponentEnum.CHAT_BODY,
+    },
+    editorType: {
+      component: UiComponentEnum.CHAT_EDITOR_SELECT,
     },
     skip: skipStepUiSchema.properties.skip,
   },

--- a/libs/application-generic/src/utils/sanitize-control-values.spec.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.spec.ts
@@ -24,4 +24,16 @@ describe('dashboardSanitizeControlValues', () => {
 
     expect(sanitized).not.toHaveProperty('providerOverrides');
   });
+
+  it('keeps chat editorType when present', () => {
+    const sanitized = dashboardSanitizeControlValues(logger, { body: 'hello', editorType: 'text' }, StepTypeEnum.CHAT);
+
+    expect(sanitized).toEqual({ body: 'hello', editorType: 'text' });
+  });
+
+  it('omits chat editorType when absent', () => {
+    const sanitized = dashboardSanitizeControlValues(logger, { body: 'hello' }, StepTypeEnum.CHAT);
+
+    expect(sanitized).not.toHaveProperty('editorType');
+  });
 });

--- a/libs/application-generic/src/utils/sanitize-control-values.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.ts
@@ -142,6 +142,7 @@ function sanitizeChat(controlValues: WithProviderOverrides<ChatControlType>) {
   const mappedValues: ChatControlType = {
     body: sanitizeEmptyInput(controlValues.body),
     skip: controlValues.skip,
+    editorType: controlValues.editorType,
   };
 
   return keepProviderOverrides(filterNullishValues(mappedValues) as Record<string, unknown>, controlValues);

--- a/packages/shared/src/dto/workflows/step.dto.ts
+++ b/packages/shared/src/dto/workflows/step.dto.ts
@@ -71,6 +71,7 @@ export enum UiSchemaGroupEnum {
 
 export enum UiComponentEnum {
   EMAIL_EDITOR_SELECT = 'EMAIL_EDITOR_SELECT',
+  CHAT_EDITOR_SELECT = 'CHAT_EDITOR_SELECT',
   LAYOUT_SELECT = 'LAYOUT_SELECT',
   /** @deprecated use EMAIL_BODY instead  */
   BLOCK_EDITOR = 'BLOCK_EDITOR',


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard: chat step editors - text and block.

### Screenshots

https://github.com/user-attachments/assets/197f5487-752f-456f-9d90-a755fef286a8

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds selectable text and block editors for chat workflow steps, persists the selected editor type, and routes legacy plain-text bodies to the text editor.
- Adds the chat editor selector and integrates it with provider-override and default-content layouts.
- Adds editor-type derivation and plain-text-to-Maily variable conversion utilities.
- Extends chat control schemas and sanitization to retain the optional editor type.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until schema-valid block-mode controls can no longer hide and overwrite an existing plain-text chat body.

The schema accepts block mode independently of body format, while the dashboard honors that mode and initializes the block editor with empty content for a non-Maily body.

**Files Needing Attention:** libs/application-generic/src/schemas/control/chat-control.schema.ts, apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.ts, apps/dashboard/src/components/workflow-editor/steps/chat/chat-body-maily.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/chat-editor-select.tsx | Adds the destructive block/text editor toggle, confirmation flow, and body reset behavior. |
| apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.ts | Resolves the editor from explicit state or body format, but explicit block mode permits incompatible plain-text bodies to reach the block editor. |
| apps/dashboard/src/components/workflow-editor/steps/chat/chat-body-maily.tsx | Stops converting legacy text and intentionally loads non-Maily bodies as empty, exposing data hiding when paired with explicit block mode. |
| libs/application-generic/src/schemas/control/chat-control.schema.ts | Adds the optional editor type without enforcing compatibility between block mode and the serialized body format. |
| apps/dashboard/src/components/maily/maily-utils.ts | Adds covered conversion of plain-text Liquid variables into Maily inline variable nodes. |
| libs/application-generic/src/utils/sanitize-control-values.ts | Retains the optional chat editor type while continuing to filter nullish values. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Values["Chat control values"] --> Resolve["deriveChatEditorType"]
  Resolve -->|text| Text["Plain-text editor"]
  Resolve -->|block| Block["Maily block editor"]
  Block --> Check{"Body is Maily JSON?"}
  Check -->|yes| Load["Load existing document"]
  Check -->|no| Empty["Load empty editor"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Fapplication-generic%2Fsrc%2Fschemas%2Fcontrol%2Fchat-control.schema.ts%3A14%0A**Block%20mode%20hides%20plain-text%20bodies**%0A%0AWhen%20a%20workflow%20update%20or%20import%20supplies%20%60editorType%3A%20'block'%60%20with%20a%20plain-text%20or%20Liquid%20body%2C%20the%20schema%20accepts%20the%20combination%2C%20the%20dashboard%20honors%20block%20mode%2C%20and%20%60ChatBodyMaily%60%20loads%20an%20empty%20value%2C%20causing%20the%20existing%20message%20to%20appear%20blank%20and%20allowing%20new%20content%20to%20overwrite%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/application-generic/src/schemas/control/chat-control.schema.ts:14
**Block mode hides plain-text bodies**

When a workflow update or import supplies `editorType: 'block'` with a plain-text or Liquid body, the schema accepts the combination, the dashboard honors block mode, and `ChatBodyMaily` loads an empty value, causing the existing message to appear blank and allowing new content to overwrite it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard,application-generic): cha..."](https://github.com/novuhq/novu/commit/cd2742da0fe13b5a44442e7695c148ba6d9b4507) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52237670)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)

<!-- /greptile_comment -->