### PR TITLE
fix(worker): route inbound email CC and BCC recipients fixes NV-8542

### DIFF
--- a/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
+++ b/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
@@ -299,6 +299,10 @@ describe('Should handle the new arrived mail', () => {
       userDomain || USER_MAIL_DOMAIN
     }`;
 
+    // Routing follows the SMTP envelope, which for a reply is the same
+    // tokenized address the mail was delivered to.
+    mail.envelopeTo = [{ address: mail.to[0].address, args: false }];
+
     return mail;
   }
 });

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
@@ -114,6 +114,59 @@ describe('InboundEmailParse terminal-trace policy', () => {
     sinon.assert.calledOnce(logInboundEmailRequest.execute);
   });
 
+  it('checks subsequent recipients when an earlier Novu domain has no matching route', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'customer@example.com', name: '' }];
+    command.envelopeTo = [
+      { address: 'unmatched@verified-domain.com', args: false },
+      { address: 'support@verified-domain.com', args: false },
+    ];
+    domainRouteStrategy.execute.onFirstCall().resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 422,
+      message: 'No matching inbound route',
+    });
+    domainRouteStrategy.execute.onSecondCall().resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledTwice(domainRouteStrategy.execute);
+    expect(domainRouteStrategy.execute.getCall(1).args[1]).to.equal('support@verified-domain.com');
+    sinon.assert.calledOnce(logInboundEmailRequest.execute);
+    expect(logInboundEmailRequest.execute.getCall(0).args[0].outcome.status).to.equal(200);
+  });
+
+  it('prefers the message header for reply-to routing and retains the envelope as fallback', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'parse+header-txn-nv-e=env@mail.domain.com', name: '' }];
+    command.envelopeTo = [{ address: 'parse+envelope-txn-nv-e=env@local-demo.com', args: false }];
+    replyToStrategy.execute.resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'header-txn',
+      strategy: 'reply-to',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledOnceWithExactly(
+      replyToStrategy.execute,
+      command,
+      'parse+header-txn-nv-e=env@mail.domain.com'
+    );
+    sinon.assert.notCalled(domainRouteStrategy.execute);
+  });
+
   it('traces 422 InboundParseProcessingError once and does not rethrow', async () => {
     domainRouteStrategy.execute.rejects(
       new InboundParseProcessingError('Domain is not verified', {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
@@ -159,11 +159,7 @@ describe('InboundEmailParse terminal-trace policy', () => {
 
     await usecase.execute(command);
 
-    sinon.assert.calledOnceWithExactly(
-      replyToStrategy.execute,
-      command,
-      'parse+header-txn-nv-e=env@mail.domain.com'
-    );
+    sinon.assert.calledOnceWithExactly(replyToStrategy.execute, command, 'parse+header-txn-nv-e=env@mail.domain.com');
     sinon.assert.notCalled(domainRouteStrategy.execute);
   });
 

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
@@ -68,11 +68,7 @@ describe('InboundEmailParse terminal-trace policy', () => {
 
     await usecase.execute(command);
 
-    sinon.assert.calledOnceWithExactly(
-      domainRouteStrategy.execute,
-      command,
-      'support@verified-domain.com'
-    );
+    sinon.assert.calledOnceWithExactly(domainRouteStrategy.execute, command, 'support@verified-domain.com');
     sinon.assert.calledOnce(logInboundEmailRequest.execute);
   });
 

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
@@ -53,6 +53,71 @@ describe('InboundEmailParse terminal-trace policy', () => {
     sandbox.restore();
   });
 
+  it('routes an email using the CC recipient from the SMTP envelope', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'customer@example.com', name: '' }];
+    command.cc = [{ address: 'support@verified-domain.com', name: '' }];
+    command.envelopeTo = [{ address: 'support@verified-domain.com', args: false }];
+    domainRouteStrategy.execute.resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledOnceWithExactly(
+      domainRouteStrategy.execute,
+      command,
+      'support@verified-domain.com'
+    );
+    sinon.assert.calledOnce(logInboundEmailRequest.execute);
+  });
+
+  it('routes an email using a BCC recipient that is only present in the SMTP envelope', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'customer@example.com', name: '' }];
+    command.cc = [];
+    command.envelopeTo = [{ address: 'agent@verified-domain.com', args: false }];
+    domainRouteStrategy.execute.resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'agent',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledOnceWithExactly(domainRouteStrategy.execute, command, 'agent@verified-domain.com');
+    sinon.assert.calledOnce(logInboundEmailRequest.execute);
+  });
+
+  it('checks subsequent envelope recipients when an earlier recipient has no Novu domain', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'customer@example.com', name: '' }];
+    command.envelopeTo = [
+      { address: 'customer@example.com', args: false },
+      { address: 'support@verified-domain.com', args: false },
+    ];
+    domainRouteStrategy.execute.onFirstCall().rejects(new BadRequestException('No domain found'));
+    domainRouteStrategy.execute.onSecondCall().resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledTwice(domainRouteStrategy.execute);
+    expect(domainRouteStrategy.execute.getCall(1).args[1]).to.equal('support@verified-domain.com');
+    sinon.assert.calledOnce(logInboundEmailRequest.execute);
+  });
+
   it('traces 422 InboundParseProcessingError once and does not rethrow', async () => {
     domainRouteStrategy.execute.rejects(
       new InboundParseProcessingError('Domain is not verified', {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts
@@ -6,6 +6,7 @@ import { InboundEmailParseCommand } from './inbound-email-parse.command';
 import { InboundEmailParse } from './inbound-email-parse.usecase';
 import {
   INBOUND_DELIVERY_FAILURE_CUSTOMER_MESSAGE,
+  INBOUND_UNMATCHED_ROUTE_MESSAGE,
   InboundParseDroppedError,
   InboundParseProcessingError,
 } from './inbound-parse-outcome';
@@ -127,7 +128,7 @@ describe('InboundEmailParse terminal-trace policy', () => {
       transactionId: 'txn_1',
       strategy: 'domain-route',
       status: 422,
-      message: 'No matching inbound route',
+      message: INBOUND_UNMATCHED_ROUTE_MESSAGE,
     });
     domainRouteStrategy.execute.onSecondCall().resolves({
       organizationId: 'org_1',
@@ -145,22 +146,121 @@ describe('InboundEmailParse terminal-trace policy', () => {
     expect(logInboundEmailRequest.execute.getCall(0).args[0].outcome.status).to.equal(200);
   });
 
-  it('prefers the message header for reply-to routing and retains the envelope as fallback', async () => {
+  it('routes a reply using the envelope recipient', async () => {
     const command = buildCommand();
-    command.to = [{ address: 'parse+header-txn-nv-e=env@mail.domain.com', name: '' }];
-    command.envelopeTo = [{ address: 'parse+envelope-txn-nv-e=env@local-demo.com', args: false }];
+    command.to = [{ address: 'parse+txn-nv-e=env@mail.domain.com', name: '' }];
+    command.envelopeTo = [{ address: 'parse+txn-nv-e=env@mail.domain.com', args: false }];
     replyToStrategy.execute.resolves({
       organizationId: 'org_1',
       environmentId: 'env_1',
-      transactionId: 'header-txn',
+      transactionId: 'txn',
       strategy: 'reply-to',
       status: 200,
     });
 
     await usecase.execute(command);
 
-    sinon.assert.calledOnceWithExactly(replyToStrategy.execute, command, 'parse+header-txn-nv-e=env@mail.domain.com');
+    sinon.assert.calledOnceWithExactly(replyToStrategy.execute, command, 'parse+txn-nv-e=env@mail.domain.com');
     sinon.assert.notCalled(domainRouteStrategy.execute);
+  });
+
+  it('never routes to a To/CC header address while the message has envelope recipients', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'anything@attacker-domain.com', name: '' }];
+    command.cc = [{ address: 'support@victim-domain.com', name: '' }];
+    command.envelopeTo = [{ address: 'anything@attacker-domain.com', args: false }];
+    domainRouteStrategy.execute.resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 422,
+      message: INBOUND_UNMATCHED_ROUTE_MESSAGE,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledOnceWithExactly(domainRouteStrategy.execute, command, 'anything@attacker-domain.com');
+    const attemptedAddresses = domainRouteStrategy.execute.getCalls().map((call) => call.args[1]);
+    expect(attemptedAddresses).to.not.include('support@victim-domain.com');
+  });
+
+  it('never hands a header-only reply token to the reply-to strategy', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'support@verified-domain.com', name: '' }];
+    command.cc = [{ address: 'parse+victim-txn-nv-e=victim-env@mail.domain.com', name: '' }];
+    command.envelopeTo = [{ address: 'support@verified-domain.com', args: false }];
+    domainRouteStrategy.execute.resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.notCalled(replyToStrategy.execute);
+    sinon.assert.calledOnceWithExactly(domainRouteStrategy.execute, command, 'support@verified-domain.com');
+  });
+
+  it('falls back to To/CC headers only when the payload carries no envelope recipients', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'customer@example.com', name: '' }];
+    command.cc = [{ address: 'support@verified-domain.com', name: '' }];
+    command.envelopeTo = [];
+    domainRouteStrategy.execute.onFirstCall().rejects(new BadRequestException('No domain found'));
+    domainRouteStrategy.execute.onSecondCall().resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledTwice(domainRouteStrategy.execute);
+    expect(domainRouteStrategy.execute.getCall(1).args[1]).to.equal('support@verified-domain.com');
+  });
+
+  it('still delivers a routable recipient when another recipient carries an unusable reply token', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'support@verified-domain.com', name: '' }];
+    command.envelopeTo = [
+      { address: 'invalid-nv-e=@attacker-domain.com', args: false },
+      { address: 'support@verified-domain.com', args: false },
+    ];
+    replyToStrategy.execute.rejects(new BadRequestException('Missing metadata segment in address'));
+    domainRouteStrategy.execute.resolves({
+      organizationId: 'org_1',
+      environmentId: 'env_1',
+      transactionId: 'txn_1',
+      strategy: 'domain-route',
+      status: 200,
+    });
+
+    await usecase.execute(command);
+
+    sinon.assert.calledOnceWithExactly(domainRouteStrategy.execute, command, 'support@verified-domain.com');
+    sinon.assert.calledOnce(logInboundEmailRequest.execute);
+    expect(logInboundEmailRequest.execute.getCall(0).args[0].outcome.status).to.equal(200);
+    sinon.assert.notCalled(logInboundEmailRequest.logUnresolvedFailure);
+  });
+
+  it('surfaces the reply-to failure when no other recipient is routable', async () => {
+    const command = buildCommand();
+    command.to = [{ address: 'parse+-nv-e=env@mail.domain.com', name: '' }];
+    command.envelopeTo = [{ address: 'parse+-nv-e=env@mail.domain.com', args: false }];
+    replyToStrategy.execute.rejects(new BadRequestException('Missing transactionId on address'));
+
+    await usecase.execute(command);
+
+    sinon.assert.notCalled(domainRouteStrategy.execute);
+    sinon.assert.calledOnce(logInboundEmailRequest.logUnresolvedFailure);
+    const logArg = logInboundEmailRequest.logUnresolvedFailure.getCall(0).args[0];
+    expect(logArg.message).to.contain('Missing transactionId on address');
+    expect(logArg.severity).to.equal('warning');
   });
 
   it('traces 422 InboundParseProcessingError once and does not rethrow', async () => {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import { InboundEmailParseCommand } from './inbound-email-parse.command';
 import {
+  INBOUND_UNMATCHED_ROUTE_MESSAGE,
   InboundParseDroppedError,
   InboundParseOutcome,
   InboundParseProcessingError,
@@ -10,6 +11,19 @@ import {
 import { LogInboundEmailRequest } from './log-inbound-email-request.usecase';
 import { DomainRouteStrategy } from './strategies/domain-route.strategy';
 import { ReplyToStrategy } from './strategies/reply-to.strategy';
+
+/**
+ * Result of walking the recipient list through `DomainRouteStrategy`.
+ *
+ * `resolved` carries the first recipient that produced a verdict for its
+ * tenant, `unmatched` means a verified Novu domain was found but no route
+ * covered the address, and `unroutable` means no recipient belonged to Novu
+ * at all.
+ */
+type DomainRouteAttempt =
+  | { kind: 'resolved'; outcome: InboundParseOutcome | undefined }
+  | { kind: 'unmatched'; outcome: InboundParseOutcome }
+  | { kind: 'unroutable'; error?: BadRequestException };
 
 /**
  * Worker entry point for inbound email parsing.
@@ -51,16 +65,15 @@ export class InboundEmailParse {
   }
 
   async execute(command: InboundEmailParseCommand): Promise<void> {
-    const domainRouteAddresses = getRecipientAddresses(command, ['envelopeTo', 'to', 'cc']);
-    const replyToAddresses = getRecipientAddresses(command, ['to', 'cc', 'envelopeTo']);
+    const recipients = getRoutingRecipients(command);
 
-    this.logger.info({ recipientAddresses: domainRouteAddresses }, 'Received new email to parse');
+    this.logger.info(
+      { recipientCount: recipients.length, envelopeRecipientCount: command.envelopeTo?.length ?? 0 },
+      'Received new email to parse'
+    );
 
     try {
-      const replyToAddress = replyToAddresses.find((address) => this.isReplyToAddress(address));
-      const outcome = replyToAddress
-        ? await this.replyToStrategy.execute(command, replyToAddress)
-        : await this.executeDomainRoute(command, domainRouteAddresses);
+      const outcome = await this.route(command, recipients);
 
       if (outcome) {
         await this.logInboundEmailRequest.execute({ command, outcome });
@@ -119,23 +132,81 @@ export class InboundEmailParse {
     }
   }
 
+  private async route(
+    command: InboundEmailParseCommand,
+    recipients: string[]
+  ): Promise<InboundParseOutcome | undefined> {
+    const replyToAddress = recipients.find(isReplyToAddress);
+
+    if (!replyToAddress) {
+      return this.executeDomainRoute(command, recipients);
+    }
+
+    try {
+      return await this.replyToStrategy.execute(command, replyToAddress);
+    } catch (error) {
+      if (!isNonRetriableFailure(error)) {
+        throw error;
+      }
+
+      /*
+       * The reply-to marker is only a substring of the local part, so any
+       * recipient can carry it without being a usable reply token. Retry the
+       * remaining recipients as domain routes instead of dropping the message,
+       * so one unusable address cannot suppress delivery for a legitimate
+       * route on the same email. The original failure is surfaced when nothing
+       * else is deliverable, keeping the reply-to diagnostics intact.
+       */
+      const fallback = await this.attemptDomainRoutes(
+        command,
+        recipients.filter((address) => address !== replyToAddress)
+      );
+
+      if (fallback.kind === 'resolved' && fallback.outcome && isDelivered(fallback.outcome)) {
+        return fallback.outcome;
+      }
+
+      throw error;
+    }
+  }
+
   private async executeDomainRoute(
     command: InboundEmailParseCommand,
-    recipientAddresses: string[]
+    recipients: string[]
   ): Promise<InboundParseOutcome | undefined> {
+    const attempt = await this.attemptDomainRoutes(command, recipients);
+
+    if (attempt.kind === 'unroutable') {
+      throw attempt.error ?? new BadRequestException('Inbound email has no recipient address');
+    }
+
+    return attempt.outcome;
+  }
+
+  /**
+   * Walk the recipients in order and stop on the first one that resolves to a
+   * tenant verdict. Recipients that belong to no Novu domain
+   * (`BadRequestException`) or to a domain without a covering route are
+   * skipped, so an address in Cc or Bcc still routes when the primary
+   * recipient is someone else.
+   */
+  private async attemptDomainRoutes(
+    command: InboundEmailParseCommand,
+    recipients: string[]
+  ): Promise<DomainRouteAttempt> {
+    let unmatched: InboundParseOutcome | undefined;
     let lastBadRequest: BadRequestException | undefined;
-    let unmatchedRouteOutcome: InboundParseOutcome | undefined;
 
-    for (const recipientAddress of recipientAddresses) {
+    for (const recipient of recipients) {
       try {
-        const outcome = await this.domainRouteStrategy.execute(command, recipientAddress);
+        const outcome = await this.domainRouteStrategy.execute(command, recipient);
 
-        if (outcome?.status === 422 && outcome.message === 'No matching inbound route') {
-          unmatchedRouteOutcome = outcome;
+        if (outcome && isUnmatchedRoute(outcome)) {
+          unmatched = outcome;
           continue;
         }
 
-        return outcome;
+        return { kind: 'resolved', outcome };
       } catch (error) {
         if (!(error instanceof BadRequestException)) {
           throw error;
@@ -145,31 +216,45 @@ export class InboundEmailParse {
       }
     }
 
-    if (unmatchedRouteOutcome) {
-      return unmatchedRouteOutcome;
+    if (unmatched) {
+      return { kind: 'unmatched', outcome: unmatched };
     }
 
-    throw lastBadRequest ?? new BadRequestException('Inbound email has no recipient address');
-  }
-
-  private isReplyToAddress(address: string): boolean {
-    return address.includes('-nv-e=');
+    return { kind: 'unroutable', error: lastBadRequest };
   }
 }
 
-type RecipientField = 'envelopeTo' | 'to' | 'cc';
+/**
+ * Recipients that routing decisions are allowed to use.
+ *
+ * Only SMTP envelope recipients (`RCPT TO`) are trusted: they record where the
+ * message was actually delivered, and they cover Cc and Bcc recipients — Bcc
+ * is deliberately absent from the message headers. The `To`/`Cc` headers are
+ * written by the sender and may name any address, including another tenant's
+ * inbound address, so they are consulted only for payloads that carry no
+ * envelope recipients at all (queue payloads predating envelope capture).
+ */
+function getRoutingRecipients(command: InboundEmailParseCommand): string[] {
+  const envelopeRecipients = collectAddresses(command.envelopeTo);
 
-function getRecipientAddresses(command: InboundEmailParseCommand, fieldOrder: RecipientField[]): string[] {
-  const recipients = fieldOrder.flatMap((field) => command[field] ?? []) as unknown[];
-  const addresses = recipients
-    .map(getRecipientAddress)
+  if (envelopeRecipients.length > 0) {
+    return envelopeRecipients;
+  }
+
+  return collectAddresses([...(command.to ?? []), ...(command.cc ?? [])]);
+}
+
+function collectAddresses(recipients: unknown[] | undefined): string[] {
+  const addresses = (recipients ?? [])
+    .map(toRecipientAddress)
     .filter((address): address is string => Boolean(address))
-    .map((address) => address.toLowerCase());
+    .map((address) => address.trim().toLowerCase())
+    .filter((address) => address.length > 0);
 
   return [...new Set(addresses)];
 }
 
-function getRecipientAddress(recipient: unknown): string | undefined {
+function toRecipientAddress(recipient: unknown): string | undefined {
   if (typeof recipient === 'string') {
     return recipient;
   }
@@ -181,6 +266,30 @@ function getRecipientAddress(recipient: unknown): string | undefined {
   const address = recipient.address;
 
   return typeof address === 'string' ? address : undefined;
+}
+
+function isReplyToAddress(address: string): boolean {
+  return address.includes('-nv-e=');
+}
+
+function isUnmatchedRoute(outcome: InboundParseOutcome): boolean {
+  return outcome.status === 422 && outcome.message === INBOUND_UNMATCHED_ROUTE_MESSAGE;
+}
+
+function isDelivered(outcome: InboundParseOutcome): boolean {
+  return outcome.status >= 200 && outcome.status < 300;
+}
+
+function isNonRetriableFailure(error: unknown): boolean {
+  if (error instanceof BadRequestException) {
+    return true;
+  }
+
+  return (
+    error instanceof InboundParseProcessingError &&
+    Boolean(error.outcome) &&
+    !isRetriableInboundFailureStatus(error.outcome?.status ?? 0)
+  );
 }
 
 function extractMessage(error: unknown): string {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
@@ -3,6 +3,7 @@ import { PinoLogger } from '@novu/application-generic';
 import { InboundEmailParseCommand } from './inbound-email-parse.command';
 import {
   InboundParseDroppedError,
+  InboundParseOutcome,
   InboundParseProcessingError,
   isRetriableInboundFailureStatus,
 } from './inbound-parse-outcome';
@@ -50,14 +51,15 @@ export class InboundEmailParse {
   }
 
   async execute(command: InboundEmailParseCommand): Promise<void> {
-    const toAddress = command.to[0].address;
+    const recipientAddresses = getRecipientAddresses(command);
 
-    this.logger.info({ toAddress }, 'Received new email to parse');
+    this.logger.info({ recipientAddresses }, 'Received new email to parse');
 
     try {
-      const outcome = this.isReplyToAddress(toAddress)
-        ? await this.replyToStrategy.execute(command)
-        : await this.domainRouteStrategy.execute(command);
+      const replyToAddress = recipientAddresses.find((address) => this.isReplyToAddress(address));
+      const outcome = replyToAddress
+        ? await this.replyToStrategy.execute(command, replyToAddress)
+        : await this.executeDomainRoute(command, recipientAddresses);
 
       if (outcome) {
         await this.logInboundEmailRequest.execute({ command, outcome });
@@ -116,9 +118,54 @@ export class InboundEmailParse {
     }
   }
 
+  private async executeDomainRoute(
+    command: InboundEmailParseCommand,
+    recipientAddresses: string[]
+  ): Promise<InboundParseOutcome | undefined> {
+    let lastBadRequest: BadRequestException | undefined;
+
+    for (const recipientAddress of recipientAddresses) {
+      try {
+        return await this.domainRouteStrategy.execute(command, recipientAddress);
+      } catch (error) {
+        if (!(error instanceof BadRequestException)) {
+          throw error;
+        }
+
+        lastBadRequest = error;
+      }
+    }
+
+    throw lastBadRequest ?? new BadRequestException('Inbound email has no recipient address');
+  }
+
   private isReplyToAddress(address: string): boolean {
     return address.includes('-nv-e=');
   }
+}
+
+function getRecipientAddresses(command: InboundEmailParseCommand): string[] {
+  const recipients: unknown[] = [...(command.envelopeTo ?? []), ...(command.to ?? []), ...(command.cc ?? [])];
+  const addresses = recipients
+    .map(getRecipientAddress)
+    .filter((address): address is string => Boolean(address))
+    .map((address) => address.toLowerCase());
+
+  return [...new Set(addresses)];
+}
+
+function getRecipientAddress(recipient: unknown): string | undefined {
+  if (typeof recipient === 'string') {
+    return recipient;
+  }
+
+  if (!recipient || typeof recipient !== 'object' || !('address' in recipient)) {
+    return undefined;
+  }
+
+  const address = recipient.address;
+
+  return typeof address === 'string' ? address : undefined;
 }
 
 function extractMessage(error: unknown): string {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts
@@ -51,15 +51,16 @@ export class InboundEmailParse {
   }
 
   async execute(command: InboundEmailParseCommand): Promise<void> {
-    const recipientAddresses = getRecipientAddresses(command);
+    const domainRouteAddresses = getRecipientAddresses(command, ['envelopeTo', 'to', 'cc']);
+    const replyToAddresses = getRecipientAddresses(command, ['to', 'cc', 'envelopeTo']);
 
-    this.logger.info({ recipientAddresses }, 'Received new email to parse');
+    this.logger.info({ recipientAddresses: domainRouteAddresses }, 'Received new email to parse');
 
     try {
-      const replyToAddress = recipientAddresses.find((address) => this.isReplyToAddress(address));
+      const replyToAddress = replyToAddresses.find((address) => this.isReplyToAddress(address));
       const outcome = replyToAddress
         ? await this.replyToStrategy.execute(command, replyToAddress)
-        : await this.executeDomainRoute(command, recipientAddresses);
+        : await this.executeDomainRoute(command, domainRouteAddresses);
 
       if (outcome) {
         await this.logInboundEmailRequest.execute({ command, outcome });
@@ -123,10 +124,18 @@ export class InboundEmailParse {
     recipientAddresses: string[]
   ): Promise<InboundParseOutcome | undefined> {
     let lastBadRequest: BadRequestException | undefined;
+    let unmatchedRouteOutcome: InboundParseOutcome | undefined;
 
     for (const recipientAddress of recipientAddresses) {
       try {
-        return await this.domainRouteStrategy.execute(command, recipientAddress);
+        const outcome = await this.domainRouteStrategy.execute(command, recipientAddress);
+
+        if (outcome?.status === 422 && outcome.message === 'No matching inbound route') {
+          unmatchedRouteOutcome = outcome;
+          continue;
+        }
+
+        return outcome;
       } catch (error) {
         if (!(error instanceof BadRequestException)) {
           throw error;
@@ -134,6 +143,10 @@ export class InboundEmailParse {
 
         lastBadRequest = error;
       }
+    }
+
+    if (unmatchedRouteOutcome) {
+      return unmatchedRouteOutcome;
     }
 
     throw lastBadRequest ?? new BadRequestException('Inbound email has no recipient address');
@@ -144,8 +157,10 @@ export class InboundEmailParse {
   }
 }
 
-function getRecipientAddresses(command: InboundEmailParseCommand): string[] {
-  const recipients: unknown[] = [...(command.envelopeTo ?? []), ...(command.to ?? []), ...(command.cc ?? [])];
+type RecipientField = 'envelopeTo' | 'to' | 'cc';
+
+function getRecipientAddresses(command: InboundEmailParseCommand, fieldOrder: RecipientField[]): string[] {
+  const recipients = fieldOrder.flatMap((field) => command[field] ?? []) as unknown[];
   const addresses = recipients
     .map(getRecipientAddress)
     .filter((address): address is string => Boolean(address))

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-parse-outcome.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-parse-outcome.ts
@@ -75,6 +75,14 @@ export function inboundTransactionIdFromMessageId(messageId: string | undefined)
 /** Customer-visible message for downstream/system delivery failures (5xx). */
 export const INBOUND_DELIVERY_FAILURE_CUSTOMER_MESSAGE = 'Inbound delivery failed due to a temporary internal error';
 
+/**
+ * Emitted when a recipient resolves to a verified domain that has no route for
+ * the address. Callers walking several recipients use it to tell "this address
+ * is not routable" apart from a tenant-level failure, so the message is shared
+ * rather than duplicated as a literal.
+ */
+export const INBOUND_UNMATCHED_ROUTE_MESSAGE = 'No matching inbound route';
+
 /** 5xx outcomes are retriable — terminal traces are written once retries exhaust. */
 export function isRetriableInboundFailureStatus(status: number): boolean {
   return status >= 500;

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.spec.ts
@@ -120,6 +120,23 @@ describe('DomainRouteStrategy', () => {
     expect(agentCall.args[0].mail.spf).to.equal('pass');
   });
 
+  it('should match the domain using the selected envelope recipient', async () => {
+    const routes = makeRoutes([{ address: 'support', type: DomainRouteTypeEnum.AGENT, destination: 'agent-001' }]);
+    const command = makeCommand('customer');
+    command.to = [{ address: 'customer@other.com', name: '' }];
+    command.cc = [{ address: `support@${DOMAIN_NAME}`, name: '' }];
+    domainRepository.findByName.resolves(makeVerifiedDomain() as any);
+    domainRouteRepository.findByDomainAndAddresses.resolves(routes as any);
+
+    await strategy.execute(command, `support@${DOMAIN_NAME}`);
+
+    sinon.assert.calledOnceWithExactly(domainRepository.findByName as any, DOMAIN_NAME);
+    const agentCall = inboundDomainRouteDelivery.deliverToAgent.getCall(0);
+    expect(agentCall.args[0].toAddress).to.equal(`support@${DOMAIN_NAME}`);
+    expect(agentCall.args[0].mail.to).to.deep.equal(command.to);
+    expect(agentCall.args[0].mail.cc).to.deep.equal(command.cc);
+  });
+
   it('should strip a +nv reply token and prefer exact then stripped custom-domain routes', async () => {
     const originId = '65f1a2b3c4d5e6f7a8b9c0d1';
     const tokenized = buildAgentReplyToAddress('support@example.com', originId);

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
@@ -17,6 +17,7 @@ import { DomainRouteTypeEnum, DomainStatusEnum, splitAgentReplyLocalPart } from 
 import { InboundEmailParseCommand } from '../inbound-email-parse.command';
 import {
   getDeliveryFailureDiagnostics,
+  INBOUND_UNMATCHED_ROUTE_MESSAGE,
   InboundParseDroppedError,
   InboundParseOutcome,
   InboundParseProcessingError,
@@ -117,7 +118,7 @@ export class DomainRouteStrategy {
     if (!route) {
       this.logger.info({ toAddress, domain: domain.name }, 'No route matched the inbound email');
 
-      return { ...baseResolved, strategy: 'domain-route', status: 422, message: 'No matching inbound route' };
+      return { ...baseResolved, strategy: 'domain-route', status: 422, message: INBOUND_UNMATCHED_ROUTE_MESSAGE };
     }
 
     const mail = this.commandToMail(command);

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
@@ -46,8 +46,11 @@ export class DomainRouteStrategy {
     this.logger.setContext(this.constructor.name);
   }
 
-  async execute(command: InboundEmailParseCommand): Promise<InboundParseOutcome | undefined> {
-    const toAddress = command.to[0].address;
+  async execute(
+    command: InboundEmailParseCommand,
+    recipientAddress = command.to[0].address
+  ): Promise<InboundParseOutcome | undefined> {
+    const toAddress = recipientAddress;
 
     this.logger.info({ toAddress }, 'Processing domain-route email');
 

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
@@ -42,7 +42,10 @@ export class ReplyToStrategy {
     private attachmentRehydrator: AttachmentRehydrator
   ) {}
 
-  async execute(command: InboundEmailParseCommand, recipientAddress = command.to[0].address): Promise<InboundParseOutcome> {
+  async execute(
+    command: InboundEmailParseCommand,
+    recipientAddress = command.to[0].address
+  ): Promise<InboundParseOutcome> {
     const { domain, transactionId, environmentId } = this.splitTo(recipientAddress);
 
     Logger.log({ domain, transactionId, environmentId }, 'Processing reply-to email', LOG_CONTEXT);

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
@@ -42,8 +42,8 @@ export class ReplyToStrategy {
     private attachmentRehydrator: AttachmentRehydrator
   ) {}
 
-  async execute(command: InboundEmailParseCommand): Promise<InboundParseOutcome> {
-    const { domain, transactionId, environmentId } = this.splitTo(command.to[0].address);
+  async execute(command: InboundEmailParseCommand, recipientAddress = command.to[0].address): Promise<InboundParseOutcome> {
+    const { domain, transactionId, environmentId } = this.splitTo(recipientAddress);
 
     Logger.log({ domain, transactionId, environmentId }, 'Processing reply-to email', LOG_CONTEXT);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Inbound routing now decides on SMTP envelope recipients (`RCPT TO`) instead of the first `To` header address. The envelope records where the message was actually delivered and already contains CC and BCC recipients, so a Novu address routes even when someone else is the primary recipient.

Message headers stay out of routing decisions. `To`/`Cc` are written by the sender and can name any address, including another tenant's inbound address, so they are consulted only for queue payloads that carry no envelope recipients at all. Delivered webhook payloads still carry the original `To`/`Cc` values unchanged.

A recipient carrying the `-nv-e=` reply marker no longer decides the fate of the whole message. When reply-to handling fails non-retriably, the remaining recipients are tried as domain routes; the original reply-to failure is surfaced only when nothing else is deliverable, which keeps existing reply-to diagnostics intact.

```mermaid
flowchart LR
  A[SMTP envelope recipients] --> B{Reply marker present?}
  B -->|Yes| C[Reply-to handling]
  C -->|Non-retriable failure| D[Try remaining recipients]
  B -->|No| D
  D --> E{Route resolved?}
  E -->|No| D
  E -->|Yes| F[Webhook or agent delivery]
  G[To/CC headers] -.->|only when envelope is empty| D
```

Linear: [NV-8542](https://linear.app/novu/issue/NV-8542/novu-inbound-email-ignores-ccbcc-addresses)

### Screenshots

Not applicable; worker-only change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

Not applicable.

### Special notes for your reviewer

BCC is resolvable only from the SMTP envelope, since it is deliberately absent from message headers.

Review findings addressed, each with a test that fails on the previous revision:
- Header-based cross-tenant routing (Hacktron HIGH) and header-steered reply-to (Cursor MEDIUM): routing no longer reads `To`/`Cc` when envelope recipients exist.
- Malformed reply marker dropping legitimate mail (Greptile P1, Hacktron HIGH): reply-to failures fall back to the remaining recipients.
- Recipient PII in logs (Cursor MEDIUM): the entry log now records recipient counts instead of addresses.

The reply-to fixture in `inbound-email-parse.spec.ts` now sets `envelopeTo` to the address under test, matching how a reply actually arrives.

Known limitation, unchanged by this PR: when one message carries routable recipients for two different tenants, delivery goes to the first match rather than fanning out. Fan-out would need the request-log pipeline to support multiple terminal traces per request.

Validation: 44 tests pass (14 use-case, 24 domain-route, 6 reply-to integration); worker build reports zero TypeScript issues; Biome reports no errors on changed files.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-8542](https://linear.app/novu/issue/NV-8542/novu-inbound-email-ignores-ccbcc-addresses)

<div><a href="https://cursor.com/agents/bc-28d9d111-1660-41b1-b373-50675b811c8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28d9d111-1660-41b1-b373-50675b811c8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR routes inbound mail using ordered SMTP-envelope recipients, retaining header recipients only as a legacy fallback. It also attempts domain routing after an unusable reply marker, but the fallback does not evaluate later reply-token recipients correctly.

- Passes the selected envelope address into reply and domain routing strategies.
- Iterates domain-route candidates until a matching route is found.
- Preserves original To and CC fields in delivered payloads.
- Adds routing and terminal-trace coverage for CC, BCC, and malformed reply markers.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because an earlier malformed reply marker can still prevent a later valid reply recipient from being attached to its intended transaction.

The fallback fixes suppression of ordinary domain-route recipients, but it sends all remaining recipients only through DomainRouteStrategy; consequently, a later valid reply token never reaches the strategy that parses its transaction and environment metadata.

**Files Needing Attention:** apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts | Adds envelope-first recipient iteration and malformed-token fallback, but only the first reply-token candidate can reach ReplyToStrategy. |
| apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts | Accepts an explicitly selected recipient while preserving the original message headers in delivered payloads. |
| apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts | Accepts an explicitly selected reply recipient and parses its transaction and environment metadata. |
| apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.spec.ts | Adds broad multi-recipient coverage but omits the malformed-first, valid-reply-token-second case. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Ordered envelope recipients] --> B[Find first address containing reply marker]
  B --> C[ReplyToStrategy]
  C -->|Success| D[Deliver reply]
  C -->|Non-retriable parse failure| E[Remove failed address]
  E --> F[DomainRouteStrategy for every remaining address]
  F --> G[Valid later reply token is not parsed as a reply]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Finbound-email-parse%2Finbound-email-parse.usecase.ts%3A139%0A**Later%20reply%20token%20bypasses%20parsing**%0A%0AWhen%20an%20SMTP%20envelope%20contains%20a%20malformed%20%60-nv-e%3D%60%20address%20before%20a%20valid%20reply-token%20address%2C%20%60find%60%20selects%20the%20malformed%20recipient%20and%20the%20fallback%20sends%20the%20valid%20recipient%20only%20through%20%60DomainRouteStrategy%60.%20Its%20embedded%20environment%20and%20transaction%20metadata%20are%20therefore%20never%20parsed%2C%20causing%20the%20valid%20reply%20to%20be%20dropped%20or%20delivered%20without%20being%20attached%20to%20the%20intended%20transaction.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/worker/src/app/workflow/usecases/inbound-email-parse/inbound-email-parse.usecase.ts:139
**Later reply token bypasses parsing**

When an SMTP envelope contains a malformed `-nv-e=` address before a valid reply-token address, `find` selects the malformed recipient and the fallback sends the valid recipient only through `DomainRouteStrategy`. Its embedded environment and transaction metadata are therefore never parsed, causing the valid reply to be dropped or delivered without being attached to the intended transaction.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(worker): route inbound email only on..."](https://github.com/novuhq/novu/commit/d433a9f55e07064530312a39f42c60031d0274f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52505866)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Worker App: Job Processing and Workflow Execution](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/worker-app.md)

<!-- /greptile_comment -->