### PR TITLE
feat(api-service): context-scoped bridge URL override for agent connect fixes NV-8582

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-connection-context.resolver.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-connection-context.resolver.spec.ts
@@ -1,0 +1,172 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ResolvedAgentConfig } from '../../channels/agent-config-resolver.service';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { InboundConnectionContextResolver } from './inbound-connection-context.resolver';
+
+interface FakeContext {
+  type: string;
+  id: string;
+  key: string;
+  data: Record<string, unknown>;
+  bridgeUrl?: string;
+}
+
+function makeLogger() {
+  return {
+    warn: sinon.stub(),
+    error: sinon.stub(),
+    debug: sinon.stub(),
+    info: sinon.stub(),
+    setContext: sinon.stub(),
+  };
+}
+
+function makeConfig(platform: AgentPlatformEnum): ResolvedAgentConfig {
+  return {
+    platform,
+    environmentId: 'env-1',
+    organizationId: 'org-1',
+    integrationIdentifier: 'integration-1',
+  } as unknown as ResolvedAgentConfig;
+}
+
+function makeContext(type: string, id: string, bridgeUrl?: string, data: Record<string, unknown> = {}): FakeContext {
+  return { type, id, key: `${type}:${id}`, data, bridgeUrl };
+}
+
+/**
+ * `findByKeys` is called once per scope with the keys stored on that scope's connection/endpoint,
+ * so route each call to the matching contexts by key.
+ */
+function makeContextRepository(contexts: FakeContext[]) {
+  const byKey = new Map(contexts.map((context) => [context.key, context]));
+
+  return {
+    findByKeys: sinon.stub().callsFake(async (_env: string, _org: string, keys: string[]) =>
+      keys.map((key) => byKey.get(key)).filter((context): context is FakeContext => !!context)
+    ),
+  };
+}
+
+describe('InboundConnectionContextResolver', () => {
+  describe('endpoint scope (Telegram)', () => {
+    function build(endpointContextKeys: string[], contexts: FakeContext[]) {
+      const channelConnectionRepository = { findOne: sinon.stub().resolves(null) };
+      const channelEndpointRepository = {
+        findByPlatformIdentity: sinon.stub().resolves({ contextKeys: endpointContextKeys }),
+      };
+      const contextRepository = makeContextRepository(contexts);
+      const logger = makeLogger();
+
+      const resolver = new InboundConnectionContextResolver(
+        channelConnectionRepository as any,
+        channelEndpointRepository as any,
+        contextRepository as any,
+        logger as any
+      );
+
+      return { resolver, logger };
+    }
+
+    it('returns the bridge URL override from a resolved context', async () => {
+      const { resolver } = build(['tenant:acme'], [makeContext('tenant', 'acme', 'https://acme.example.com/api/novu')]);
+
+      const result = await resolver.resolve(makeConfig(AgentPlatformEnum.TELEGRAM), {}, 'chat-1');
+
+      expect(result.context).to.deep.equal({ tenant: 'acme' });
+      expect(result.bridgeUrl).to.equal('https://acme.example.com/api/novu');
+    });
+
+    it('leaves the override undefined when no resolved context sets one', async () => {
+      const { resolver } = build(['tenant:acme'], [makeContext('tenant', 'acme')]);
+
+      const result = await resolver.resolve(makeConfig(AgentPlatformEnum.TELEGRAM), {}, 'chat-1');
+
+      expect(result.context).to.deep.equal({ tenant: 'acme' });
+      expect(result.bridgeUrl).to.equal(undefined);
+    });
+
+    it('picks the first override by sorted key and warns when contexts disagree', async () => {
+      const { resolver, logger } = build(
+        ['tenant:acme', 'app:billing'],
+        [
+          makeContext('tenant', 'acme', 'https://acme.example.com/api/novu'),
+          makeContext('app', 'billing', 'https://billing.example.com/api/novu'),
+        ]
+      );
+
+      const result = await resolver.resolve(makeConfig(AgentPlatformEnum.TELEGRAM), {}, 'chat-1');
+
+      // Sorted by key, `app:billing` < `tenant:acme`, so the app override wins.
+      expect(result.bridgeUrl).to.equal('https://billing.example.com/api/novu');
+      expect(logger.warn.calledOnce, 'warns on conflicting overrides').to.equal(true);
+    });
+
+    it('does not warn when multiple contexts share the same override', async () => {
+      const { resolver, logger } = build(
+        ['tenant:acme', 'app:billing'],
+        [
+          makeContext('tenant', 'acme', 'https://shared.example.com/api/novu'),
+          makeContext('app', 'billing', 'https://shared.example.com/api/novu'),
+        ]
+      );
+
+      const result = await resolver.resolve(makeConfig(AgentPlatformEnum.TELEGRAM), {}, 'chat-1');
+
+      expect(result.bridgeUrl).to.equal('https://shared.example.com/api/novu');
+      expect(logger.warn.called).to.equal(false);
+    });
+  });
+
+  describe('workspace scope (Slack)', () => {
+    it('lets the per-user endpoint override win over the workspace override', async () => {
+      const channelConnectionRepository = {
+        findOne: sinon.stub().resolves({ identifier: 'conn-1', contextKeys: ['tenant:workspace'] }),
+      };
+      const channelEndpointRepository = {
+        findByPlatformIdentity: sinon.stub().resolves({ contextKeys: ['tenant:user'] }),
+      };
+      const contextRepository = makeContextRepository([
+        makeContext('tenant', 'workspace', 'https://workspace.example.com/api/novu'),
+        makeContext('tenant', 'user', 'https://user.example.com/api/novu'),
+      ]);
+      const logger = makeLogger();
+
+      const resolver = new InboundConnectionContextResolver(
+        channelConnectionRepository as any,
+        channelEndpointRepository as any,
+        contextRepository as any,
+        logger as any
+      );
+
+      const result = await resolver.resolve(makeConfig(AgentPlatformEnum.SLACK), { team_id: 'W1' }, 'U1');
+
+      expect(result.bridgeUrl).to.equal('https://user.example.com/api/novu');
+    });
+
+    it('falls back to the workspace override when the endpoint has none', async () => {
+      const channelConnectionRepository = {
+        findOne: sinon.stub().resolves({ identifier: 'conn-1', contextKeys: ['tenant:workspace'] }),
+      };
+      const channelEndpointRepository = {
+        findByPlatformIdentity: sinon.stub().resolves(null),
+      };
+      const contextRepository = makeContextRepository([
+        makeContext('tenant', 'workspace', 'https://workspace.example.com/api/novu'),
+      ]);
+      const logger = makeLogger();
+
+      const resolver = new InboundConnectionContextResolver(
+        channelConnectionRepository as any,
+        channelEndpointRepository as any,
+        contextRepository as any,
+        logger as any
+      );
+
+      const result = await resolver.resolve(makeConfig(AgentPlatformEnum.SLACK), { team_id: 'W1' }, 'U1');
+
+      expect(result.bridgeUrl).to.equal('https://workspace.example.com/api/novu');
+    });
+  });
+});

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-connection-context.resolver.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-connection-context.resolver.ts
@@ -22,6 +22,18 @@ function toContextValue(context: ContextEntity): AgentContextValue {
 }
 
 /**
+ * The connect-time context resolved for an inbound turn, plus an optional per-context bridge URL
+ * override. When `bridgeUrl` is set, the bridge executor routes this turn's bridge call there
+ * instead of the agent's default bridge URL.
+ */
+export interface ResolvedInboundContext {
+  context: AgentContextPayload | null;
+  bridgeUrl?: string;
+}
+
+const EMPTY_RESOLVED_CONTEXT: ResolvedInboundContext = { context: null };
+
+/**
  * Resolves the connect-time context bound to an inbound chat so a Novu-hosted multi-tenant agent
  * (e.g. NovuCopilot) can learn which customer tenant a turn belongs to. Two scopes are supported,
  * matching where the connect flow persisted the context:
@@ -64,7 +76,7 @@ export class InboundConnectionContextResolver {
     config: ResolvedAgentConfig,
     rawEvent: unknown,
     platformUserId?: string | null
-  ): Promise<AgentContextPayload | null> {
+  ): Promise<ResolvedInboundContext> {
     const extractWorkspaceId = WORKSPACE_ID_EXTRACTORS[config.platform];
 
     if (extractWorkspaceId) {
@@ -87,25 +99,30 @@ export class InboundConnectionContextResolver {
     config: ResolvedAgentConfig,
     workspaceId: string | null,
     platformUserId: string | null
-  ): Promise<AgentContextPayload | null> {
+  ): Promise<ResolvedInboundContext> {
     // Resolve the workspace connection first so the per-user endpoint lookup can be scoped to it.
     const connection = await this.findWorkspaceConnection(config, workspaceId);
 
-    const [workspaceContext, endpointContext] = await Promise.all([
+    const [workspaceResult, endpointResult] = await Promise.all([
       this.buildWorkspaceContext(config, connection, workspaceId),
       // Scope the per-user endpoint to the resolved workspace connection. Without it, a platform
       // user (e.g. a Slack `userId`) linked in another customer org — which shares Novu's hosted
       // env/integration — could match here and override the current workspace's tenant.
       platformUserId && connection
         ? this.resolveByEndpoint(config, platformUserId, connection.identifier)
-        : Promise.resolve(null),
+        : Promise.resolve(EMPTY_RESOLVED_CONTEXT),
     ]);
 
-    if (!workspaceContext && !endpointContext) {
-      return null;
+    if (!workspaceResult.context && !endpointResult.context) {
+      return EMPTY_RESOLVED_CONTEXT;
     }
 
-    return { ...(workspaceContext ?? {}), ...(endpointContext ?? {}) };
+    return {
+      context: { ...(workspaceResult.context ?? {}), ...(endpointResult.context ?? {}) },
+      // The verified per-user endpoint context takes precedence over the workspace hint, so its
+      // bridge URL override wins on conflict; the workspace override is the fallback.
+      bridgeUrl: endpointResult.bridgeUrl ?? workspaceResult.bridgeUrl,
+    };
   }
 
   private async findWorkspaceConnection(
@@ -134,9 +151,9 @@ export class InboundConnectionContextResolver {
     config: ResolvedAgentConfig,
     connection: ChannelConnectionEntity | null,
     workspaceId: string | null
-  ): Promise<AgentContextPayload | null> {
+  ): Promise<ResolvedInboundContext> {
     if (!connection) {
-      return null;
+      return EMPTY_RESOLVED_CONTEXT;
     }
 
     try {
@@ -144,7 +161,7 @@ export class InboundConnectionContextResolver {
     } catch (err) {
       this.logResolveFailure(err, config, { scope: 'workspace', workspaceId });
 
-      return null;
+      return EMPTY_RESOLVED_CONTEXT;
     }
   }
 
@@ -157,11 +174,11 @@ export class InboundConnectionContextResolver {
     config: ResolvedAgentConfig,
     platformUserId: string | null,
     connectionIdentifier?: string
-  ): Promise<AgentContextPayload | null> {
+  ): Promise<ResolvedInboundContext> {
     const endpointConfig = PLATFORM_ENDPOINT_CONFIG[config.platform];
 
     if (!endpointConfig || !platformUserId) {
-      return null;
+      return EMPTY_RESOLVED_CONTEXT;
     }
 
     try {
@@ -179,31 +196,73 @@ export class InboundConnectionContextResolver {
     } catch (err) {
       this.logResolveFailure(err, config, { scope: 'endpoint', platformUserId });
 
-      return null;
+      return EMPTY_RESOLVED_CONTEXT;
     }
   }
 
   private async buildContextFromKeys(
     config: ResolvedAgentConfig,
     contextKeys: string[] | undefined
-  ): Promise<AgentContextPayload | null> {
+  ): Promise<ResolvedInboundContext> {
     if (!contextKeys?.length) {
-      return null;
+      return EMPTY_RESOLVED_CONTEXT;
     }
 
     const contexts = await this.contextRepository.findByKeys(config.environmentId, config.organizationId, contextKeys);
 
     if (!contexts.length) {
-      return null;
+      return EMPTY_RESOLVED_CONTEXT;
     }
+
+    // Deterministic order so bridge URL selection and conflict logging are stable across turns.
+    const sorted = [...contexts].sort((a, b) => a.key.localeCompare(b.key));
 
     const payload: AgentContextPayload = {};
 
-    for (const context of contexts) {
+    for (const context of sorted) {
       payload[context.type] = toContextValue(context);
     }
 
-    return payload;
+    return {
+      context: payload,
+      bridgeUrl: this.selectBridgeUrlOverride(config, sorted),
+    };
+  }
+
+  /**
+   * Any resolved context may carry a `bridgeUrl` override. When several within the same scope set
+   * one, pick the first by sorted key (stable) and warn on divergent values so misconfiguration is
+   * diagnosable.
+   */
+  private selectBridgeUrlOverride(config: ResolvedAgentConfig, sortedContexts: ContextEntity[]): string | undefined {
+    const withBridgeUrl = sortedContexts.filter((context) => !!context.bridgeUrl);
+
+    if (!withBridgeUrl.length) {
+      return undefined;
+    }
+
+    const selected = withBridgeUrl[0];
+    const distinct = new Set(withBridgeUrl.map((context) => context.bridgeUrl));
+
+    if (distinct.size > 1) {
+      this.logger.warn(
+        {
+          platform: config.platform,
+          integrationIdentifier: config.integrationIdentifier,
+          selectedContextKey: selected.key,
+          conflictingContextKeys: withBridgeUrl.map((context) => context.key),
+        },
+        'Multiple resolved contexts define different bridge URLs; using the first by sorted key'
+      );
+      captureAgentWarning(new Error('Conflicting context bridge URL overrides'), {
+        component: 'inbound-connection-context-resolver',
+        operation: 'select-bridge-url-override',
+        platform: config.platform,
+        integrationIdentifier: config.integrationIdentifier,
+      });
+    }
+
+    return selected.bridgeUrl;
   }
 
   private logResolveFailure(err: unknown, config: ResolvedAgentConfig, extra: Record<string, unknown>): void {

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.ts
@@ -558,7 +558,11 @@ export class AgentInboundHandler implements OnModuleInit {
       };
     }
 
-    const context = await this.connectionContextResolver.resolve(config, message.raw, message.author?.userId);
+    const { context, bridgeUrl: bridgeUrlOverride } = await this.connectionContextResolver.resolve(
+      config,
+      message.raw,
+      message.author?.userId
+    );
 
     const runtime = this.runtimeResolver.resolve(agent);
     const turn: ConversationTurn = {
@@ -568,6 +572,7 @@ export class AgentInboundHandler implements OnModuleInit {
       conversation,
       subscriber,
       context,
+      bridgeUrlOverride,
       subscriberResolution: resolution,
       message,
       event,
@@ -1272,7 +1277,11 @@ export class AgentInboundHandler implements OnModuleInit {
         : undefined,
     };
 
-    const context = await this.connectionContextResolver.resolve(config, event.raw, platformUserId);
+    const { context, bridgeUrl: bridgeUrlOverride } = await this.connectionContextResolver.resolve(
+      config,
+      event.raw,
+      platformUserId
+    );
     const runtime = this.runtimeResolver.resolve(agent);
     const turn: ConversationTurn = {
       agentId,
@@ -1281,6 +1290,7 @@ export class AgentInboundHandler implements OnModuleInit {
       conversation,
       subscriber,
       context,
+      bridgeUrlOverride,
       subscriberResolution: reactionResolution,
       message: null,
       event: AgentEventEnum.ON_REACTION,
@@ -1400,7 +1410,11 @@ export class AgentInboundHandler implements OnModuleInit {
 
     // Everything else (incl. mcp-approval:* for managed) routes through the runtime,
     // which owns its own action semantics.
-    const context = await this.connectionContextResolver.resolve(config, rawEvent, userId);
+    const { context, bridgeUrl: bridgeUrlOverride } = await this.connectionContextResolver.resolve(
+      config,
+      rawEvent,
+      userId
+    );
 
     const runtime = this.runtimeResolver.resolve(agent);
     const turn: ConversationTurn = {
@@ -1410,6 +1424,7 @@ export class AgentInboundHandler implements OnModuleInit {
       conversation,
       subscriber,
       context,
+      bridgeUrlOverride,
       subscriberResolution: actionResolution,
       message: null,
       event: AgentEventEnum.ON_ACTION,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.spec.ts
@@ -98,6 +98,71 @@ describe('BridgeExecutorService', () => {
     };
   }
 
+  describe('resolveBridgeUrl', () => {
+    function resolve(
+      config: Record<string, unknown>,
+      bridgeUrlOverride?: string
+    ): { url: string | null; logger: ReturnType<typeof makeLogger> } {
+      const { service, logger } = makeService();
+      const url = (service as any).resolveBridgeUrl(config, 'agent-1', AgentEventEnum.ON_MESSAGE, bridgeUrlOverride);
+
+      return { url, logger };
+    }
+
+    it('uses the agent default bridge URL when no override or dev bridge is set', () => {
+      const { url } = resolve({ bridgeUrl: 'https://agent-default.example.com/api/novu' });
+
+      expect(url).to.be.a('string');
+      const parsed = new URL(url as string);
+      expect(parsed.origin + parsed.pathname).to.equal('https://agent-default.example.com/api/novu');
+      expect(parsed.searchParams.get('action')).to.equal('agent-event');
+      expect(parsed.searchParams.get('agentId')).to.equal('agent-1');
+    });
+
+    it('prefers the per-context override over the agent default', () => {
+      const { url, logger } = resolve(
+        { bridgeUrl: 'https://agent-default.example.com/api/novu' },
+        'https://tenant-acme.example.com/api/novu'
+      );
+
+      expect(new URL(url as string).host).to.equal('tenant-acme.example.com');
+      expect(logger.info.calledOnce, 'logs when an override is applied').to.equal(true);
+    });
+
+    it('prefers the active dev bridge over the context override', () => {
+      const { url } = resolve(
+        {
+          bridgeUrl: 'https://agent-default.example.com/api/novu',
+          devBridgeActive: true,
+          devBridgeUrl: 'https://dev.example.com/api/novu',
+        },
+        'https://tenant-acme.example.com/api/novu'
+      );
+
+      expect(new URL(url as string).host).to.equal('dev.example.com');
+    });
+
+    it('falls back to the context override when a dev bridge URL exists but is inactive', () => {
+      const { url } = resolve(
+        {
+          bridgeUrl: 'https://agent-default.example.com/api/novu',
+          devBridgeActive: false,
+          devBridgeUrl: 'https://dev.example.com/api/novu',
+        },
+        'https://tenant-acme.example.com/api/novu'
+      );
+
+      expect(new URL(url as string).host).to.equal('tenant-acme.example.com');
+    });
+
+    it('returns null when neither an override nor an agent bridge URL is configured', () => {
+      const { url, logger } = resolve({});
+
+      expect(url).to.equal(null);
+      expect(logger.warn.calledOnce).to.equal(true);
+    });
+  });
+
   describe('buildPayload', () => {
     it('should include eventsUrl when the agent event protocol flag is enabled', async () => {
       const { service, featureFlagsService } = makeService({ isEventProtocolEnabled: true });

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts
@@ -145,6 +145,12 @@ export interface AgentExecutionParams {
   platformContext: AgentPlatformContext;
   /** Trusted connect-time context resolved from the inbound channel connection; forwarded as `ctx.context`. */
   context?: AgentContextPayload | null;
+  /**
+   * Per-context bridge URL override resolved from the connect-time context. Takes precedence over the
+   * agent's default `bridgeUrl` (but not the active dev bridge). Re-validated by the SSRF guard on
+   * every send attempt.
+   */
+  bridgeUrlOverride?: string;
   action?: AgentAction;
   reaction?: BridgeReaction;
   storedAttachments?: StoredAttachment[];
@@ -177,7 +183,7 @@ export class BridgeExecutorService {
     try {
       const { config, event } = params;
 
-      const bridgeUrl = this.resolveBridgeUrl(config, agentIdentifier, event);
+      const bridgeUrl = this.resolveBridgeUrl(config, agentIdentifier, event, params.bridgeUrlOverride);
       if (!bridgeUrl) {
         throw new NoBridgeUrlError(agentIdentifier);
       }
@@ -295,11 +301,32 @@ export class BridgeExecutorService {
     });
   }
 
-  private resolveBridgeUrl(config: ResolvedAgentConfig, agentIdentifier: string, event: AgentEventEnum): string | null {
+  /** Host only (no path/query) so override routing can be diagnosed without logging a full URL. */
+  private safeHost(rawUrl: string): string {
+    try {
+      return new URL(rawUrl).host;
+    } catch {
+      return 'invalid-url';
+    }
+  }
+
+  private resolveBridgeUrl(
+    config: ResolvedAgentConfig,
+    agentIdentifier: string,
+    event: AgentEventEnum,
+    bridgeUrlOverride?: string
+  ): string | null {
     let baseUrl: string | undefined;
 
+    // Precedence: active dev bridge (local development) > per-context override > agent default.
     if (config.devBridgeActive && config.devBridgeUrl) {
       baseUrl = config.devBridgeUrl;
+    } else if (bridgeUrlOverride) {
+      baseUrl = bridgeUrlOverride;
+      this.logger.info(
+        { agentIdentifier, bridgeHost: this.safeHost(bridgeUrlOverride) },
+        `[agent:${agentIdentifier}] Routing bridge call to per-context bridge URL override`
+      );
     } else if (config.bridgeUrl) {
       baseUrl = config.bridgeUrl;
     }

--- a/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/bridge.runtime.ts
@@ -65,6 +65,7 @@ export class BridgeRuntime implements AgentRuntime {
       conversation: turn.conversation,
       subscriber: turn.subscriber,
       context: turn.context ?? null,
+      bridgeUrlOverride: turn.bridgeUrlOverride,
       message: turn.message,
       platformContext: buildAgentPlatformContext({
         platformThreadId: turn.platformThreadId,

--- a/apps/api/src/app/agents/conversation-runtime/runtime/conversation-turn.ts
+++ b/apps/api/src/app/agents/conversation-runtime/runtime/conversation-turn.ts
@@ -15,6 +15,11 @@ export interface ConversationTurn {
   subscriber: SubscriberEntity | null;
   context?: AgentContextPayload | null;
   /**
+   * Optional per-context bridge URL override resolved from the connect-time context. When set, the
+   * bridge executor routes this turn here instead of the agent's default bridge URL.
+   */
+  bridgeUrlOverride?: string;
+  /**
    * How `subscriber` was (or wasn't) resolved. Lets the unresolved-subscriber
    * gate distinguish a genuine unknown sender from a resolution failure and
    * log/reply accordingly.

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -1,6 +1,8 @@
 import {
   AgentRepository,
+  ChannelConnectionRepository,
   ChannelEndpointRepository,
+  ContextRepository,
   ConversationActivitySenderTypeEnum,
   ConversationParticipantTypeEnum,
   ConversationStatusEnum,
@@ -392,6 +394,63 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
 
       expect(bridgeCalls.length).to.equal(1);
       expect(bridgeCalls[0].subscriber, 'custom-code open must Pass null, not auto-provision').to.equal(null);
+    });
+  });
+
+  describe('Context bridge URL override', () => {
+    const channelConnectionRepository = new ChannelConnectionRepository();
+    const contextRepository = new ContextRepository();
+
+    async function setWorkspaceContextKeys(contextKeys: string[]) {
+      await channelConnectionRepository.update(
+        {
+          _environmentId: ctx.session.environment._id,
+          _organizationId: ctx.session.organization._id,
+          integrationIdentifier: ctx.integrationIdentifier,
+          'workspace.id': 'W_TEAM',
+        },
+        { $set: { contextKeys } }
+      );
+    }
+
+    async function createContext(type: string, id: string, bridgeUrl?: string) {
+      await contextRepository.create({
+        _environmentId: ctx.session.environment._id,
+        _organizationId: ctx.session.organization._id,
+        type,
+        id,
+        key: `${type}:${id}`,
+        data: {},
+        ...(bridgeUrl ? { bridgeUrl } : {}),
+      });
+    }
+
+    it('routes the bridge call to a resolved context bridgeUrl override', async () => {
+      const overrideUrl = 'https://tenant-acme.example.com/api/novu';
+      await createContext('tenant', 'wh-override-acme', overrideUrl);
+      await setWorkspaceContextKeys(['tenant:wh-override-acme']);
+
+      const threadId = `T_CTX_OVERRIDE_${Date.now()}`;
+      const msg = { ...mockMessage({ userId: 'U_CTX', text: 'route me' }), raw: { team_id: 'W_TEAM' } };
+
+      await invokeInbound(threadId, msg as any);
+
+      expect(bridgeCalls.length).to.equal(1);
+      expect(bridgeCalls[0].bridgeUrlOverride).to.equal(overrideUrl);
+      expect(bridgeCalls[0].context).to.have.property('tenant');
+    });
+
+    it('leaves bridgeUrlOverride undefined when the resolved context has no bridgeUrl', async () => {
+      await createContext('tenant', 'wh-plain-acme');
+      await setWorkspaceContextKeys(['tenant:wh-plain-acme']);
+
+      const threadId = `T_CTX_PLAIN_${Date.now()}`;
+      const msg = { ...mockMessage({ userId: 'U_CTX2', text: 'no override' }), raw: { team_id: 'W_TEAM' } };
+
+      await invokeInbound(threadId, msg as any);
+
+      expect(bridgeCalls.length).to.equal(1);
+      expect(bridgeCalls[0].bridgeUrlOverride).to.equal(undefined);
     });
   });
 

--- a/apps/api/src/app/agents/e2e/helpers/bridge-executor-test-stub.ts
+++ b/apps/api/src/app/agents/e2e/helpers/bridge-executor-test-stub.ts
@@ -37,7 +37,8 @@ interface BridgeExecutorInternals {
   resolveBridgeUrl: (
     config: AgentExecutionParams['config'],
     agentIdentifier: string,
-    event: AgentExecutionParams['event']
+    event: AgentExecutionParams['event'],
+    bridgeUrlOverride?: string
   ) => string | null;
   buildPayload: (params: AgentExecutionParams) => Promise<AgentBridgeRequest>;
   getDecryptedSecretKey: GetDecryptedSecretKey;
@@ -60,7 +61,12 @@ export function stubBridgeExecutorWithRealHttp(bridgeExecutor: BridgeExecutorSer
     calls.push(params);
 
     const agentIdentifier = params.config.agentIdentifier;
-    const bridgeUrl = internals.resolveBridgeUrl(params.config, agentIdentifier, params.event);
+    const bridgeUrl = internals.resolveBridgeUrl(
+      params.config,
+      agentIdentifier,
+      params.event,
+      params.bridgeUrlOverride
+    );
 
     if (!bridgeUrl) {
       throw new NoBridgeUrlError(agentIdentifier);

--- a/apps/api/src/app/contexts/contexts.controller.ts
+++ b/apps/api/src/app/contexts/contexts.controller.ts
@@ -72,6 +72,7 @@ export class ContextsController {
         type: body.type,
         id: body.id,
         data: body.data,
+        bridgeUrl: body.bridgeUrl,
       })
     );
 
@@ -104,6 +105,7 @@ export class ContextsController {
         type,
         id,
         data: body.data,
+        bridgeUrl: body.bridgeUrl,
       })
     );
 

--- a/apps/api/src/app/contexts/dtos/create-context-request.dto.ts
+++ b/apps/api/src/app/contexts/dtos/create-context-request.dto.ts
@@ -1,7 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsValidContextData } from '@novu/application-generic';
 import { CONTEXT_IDENTIFIER_REGEX, ContextData, ContextId, ContextType } from '@novu/shared';
-import { IsDefined, IsOptional, IsString, Matches, MaxLength, MinLength } from 'class-validator';
+import { IsDefined, IsOptional, IsString, IsUrl, Matches, MaxLength, MinLength } from 'class-validator';
 
 export class CreateContextRequestDto {
   @ApiProperty({
@@ -47,4 +47,15 @@ export class CreateContextRequestDto {
   @IsOptional()
   @IsValidContextData()
   data?: ContextData;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional bridge URL override for agent connect. When an inbound agent turn resolves this context, ' +
+      'its bridge call is routed here instead of the agent default bridge URL. Must be a publicly reachable URL.',
+    example: 'https://tenant-acme.example.com/api/novu',
+    type: String,
+  })
+  @IsOptional()
+  @IsUrl({ require_tld: false })
+  bridgeUrl?: string;
 }

--- a/apps/api/src/app/contexts/dtos/dto.mapper.ts
+++ b/apps/api/src/app/contexts/dtos/dto.mapper.ts
@@ -8,5 +8,6 @@ export function mapContextEntityToDto(context: ContextEntity): GetContextRespons
     type: context.type,
     id: context.id,
     data: context.data,
+    bridgeUrl: context.bridgeUrl,
   };
 }

--- a/apps/api/src/app/contexts/dtos/get-context-response.dto.ts
+++ b/apps/api/src/app/contexts/dtos/get-context-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ContextData, ContextType } from '@novu/shared';
 
 export class GetContextResponseDto {
@@ -19,6 +19,12 @@ export class GetContextResponseDto {
     additionalProperties: true,
   })
   data: ContextData;
+
+  @ApiPropertyOptional({
+    description: 'Bridge URL override for agent connect, if configured on this context',
+    type: String,
+  })
+  bridgeUrl?: string;
 
   @ApiProperty({
     description: 'Creation timestamp',

--- a/apps/api/src/app/contexts/dtos/update-context-request.dto.ts
+++ b/apps/api/src/app/contexts/dtos/update-context-request.dto.ts
@@ -1,7 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsValidContextData } from '@novu/application-generic';
 import { ContextData } from '@novu/shared';
-import { IsDefined } from 'class-validator';
+import { IsDefined, IsOptional, IsUrl } from 'class-validator';
 
 export class UpdateContextRequestDto {
   @ApiProperty({
@@ -14,4 +14,17 @@ export class UpdateContextRequestDto {
   @IsDefined()
   @IsValidContextData()
   data: ContextData;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional bridge URL override for agent connect. When an inbound agent turn resolves this context, ' +
+      'its bridge call is routed here instead of the agent default bridge URL. Must be a publicly reachable URL. ' +
+      'Pass null to clear an existing override.',
+    example: 'https://tenant-acme.example.com/api/novu',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsUrl({ require_tld: false })
+  bridgeUrl?: string | null;
 }

--- a/apps/api/src/app/contexts/e2e/context-bridge-url.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/context-bridge-url.e2e.ts
@@ -20,7 +20,7 @@ describe('Context bridgeUrl override - /contexts #novu-v2', () => {
   });
 
   it('persists and returns bridgeUrl on create', async () => {
-    const bridgeUrl = 'https://tenant-acme.example.com/api/novu';
+    const bridgeUrl = 'https://example.com/api/novu';
 
     const res = await session.testAgent.post('/v2/contexts').send({
       type: 'tenant',
@@ -51,7 +51,7 @@ describe('Context bridgeUrl override - /contexts #novu-v2', () => {
       data: { region: 'us-east-1' },
     });
 
-    const bridgeUrl = 'https://tenant-acme.example.com/api/novu';
+    const bridgeUrl = 'https://example.com/api/novu';
     const res = await session.testAgent.patch('/v2/contexts/tenant/bridge-update-acme').send({
       data: { region: 'us-west-2' },
       bridgeUrl,
@@ -71,7 +71,7 @@ describe('Context bridgeUrl override - /contexts #novu-v2', () => {
   });
 
   it('preserves an existing bridgeUrl when update omits it', async () => {
-    const bridgeUrl = 'https://tenant-acme.example.com/api/novu';
+    const bridgeUrl = 'https://example.com/api/novu';
     await contextRepository.create({
       _organizationId: session.organization._id,
       _environmentId: session.environment._id,
@@ -98,7 +98,7 @@ describe('Context bridgeUrl override - /contexts #novu-v2', () => {
       id: 'bridge-clear-acme',
       key: 'tenant:bridge-clear-acme',
       data: {},
-      bridgeUrl: 'https://tenant-acme.example.com/api/novu',
+      bridgeUrl: 'https://example.com/api/novu',
     });
 
     const res = await session.testAgent.patch('/v2/contexts/tenant/bridge-clear-acme').send({
@@ -122,7 +122,7 @@ describe('Context bridgeUrl override - /contexts #novu-v2', () => {
     const res = await session.testAgent.post('/v2/contexts').send({
       type: 'tenant',
       id: 'bridge-ssrf-loopback',
-      bridgeUrl: 'http://127.0.0.1:3000/api/novu',
+      bridgeUrl: 'http://localhost:4000/api/novu',
     });
 
     expect(res.status).to.equal(400);

--- a/apps/api/src/app/contexts/e2e/context-bridge-url.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/context-bridge-url.e2e.ts
@@ -1,0 +1,158 @@
+import { ContextRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+/**
+ * `bridgeUrl` is a trusted, SSRF-guarded routing field. These tests hit the raw v2 REST surface
+ * (not the generated SDK) so they don't depend on regenerating `@novu/api` for the new field.
+ */
+describe('Context bridgeUrl override - /contexts #novu-v2', () => {
+  let session: UserSession;
+  const contextRepository = new ContextRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  afterEach(async () => {
+    await contextRepository.delete({ _environmentId: session.environment._id });
+  });
+
+  it('persists and returns bridgeUrl on create', async () => {
+    const bridgeUrl = 'https://tenant-acme.example.com/api/novu';
+
+    const res = await session.testAgent.post('/v2/contexts').send({
+      type: 'tenant',
+      id: 'bridge-create-acme',
+      data: { region: 'us-east-1' },
+      bridgeUrl,
+    });
+
+    expect(res.status, JSON.stringify(res.body)).to.equal(201);
+    expect(res.body.data.bridgeUrl).to.equal(bridgeUrl);
+
+    const stored = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'bridge-create-acme',
+    });
+    expect(stored?.bridgeUrl).to.equal(bridgeUrl);
+  });
+
+  it('sets bridgeUrl on update independently of data', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'bridge-update-acme',
+      key: 'tenant:bridge-update-acme',
+      data: { region: 'us-east-1' },
+    });
+
+    const bridgeUrl = 'https://tenant-acme.example.com/api/novu';
+    const res = await session.testAgent.patch('/v2/contexts/tenant/bridge-update-acme').send({
+      data: { region: 'us-west-2' },
+      bridgeUrl,
+    });
+
+    expect(res.status, JSON.stringify(res.body)).to.equal(200);
+    expect(res.body.data.bridgeUrl).to.equal(bridgeUrl);
+    expect(res.body.data.data).to.deep.equal({ region: 'us-west-2' });
+
+    const stored = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'bridge-update-acme',
+    });
+    expect(stored?.bridgeUrl).to.equal(bridgeUrl);
+  });
+
+  it('preserves an existing bridgeUrl when update omits it', async () => {
+    const bridgeUrl = 'https://tenant-acme.example.com/api/novu';
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'bridge-preserve-acme',
+      key: 'tenant:bridge-preserve-acme',
+      data: {},
+      bridgeUrl,
+    });
+
+    const res = await session.testAgent.patch('/v2/contexts/tenant/bridge-preserve-acme').send({
+      data: { region: 'eu-central-1' },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).to.equal(200);
+    expect(res.body.data.bridgeUrl).to.equal(bridgeUrl);
+  });
+
+  it('clears bridgeUrl when update passes null', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'bridge-clear-acme',
+      key: 'tenant:bridge-clear-acme',
+      data: {},
+      bridgeUrl: 'https://tenant-acme.example.com/api/novu',
+    });
+
+    const res = await session.testAgent.patch('/v2/contexts/tenant/bridge-clear-acme').send({
+      data: {},
+      bridgeUrl: null,
+    });
+
+    expect(res.status, JSON.stringify(res.body)).to.equal(200);
+    expect(res.body.data.bridgeUrl).to.equal(undefined);
+
+    const stored = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'bridge-clear-acme',
+    });
+    expect(stored?.bridgeUrl, 'bridgeUrl unset in storage').to.equal(undefined);
+  });
+
+  it('rejects a loopback bridgeUrl on create (SSRF)', async () => {
+    const res = await session.testAgent.post('/v2/contexts').send({
+      type: 'tenant',
+      id: 'bridge-ssrf-loopback',
+      bridgeUrl: 'http://127.0.0.1:3000/api/novu',
+    });
+
+    expect(res.status).to.equal(400);
+    expect(JSON.stringify(res.body)).to.contain('bridgeUrl');
+
+    const stored = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'bridge-ssrf-loopback',
+    });
+    expect(stored, 'context not created when SSRF-blocked').to.not.exist;
+  });
+
+  it('rejects a metadata-service bridgeUrl on update (SSRF)', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'bridge-ssrf-metadata',
+      key: 'tenant:bridge-ssrf-metadata',
+      data: {},
+    });
+
+    const res = await session.testAgent.patch('/v2/contexts/tenant/bridge-ssrf-metadata').send({
+      data: {},
+      bridgeUrl: 'http://169.254.169.254/latest/meta-data/',
+    });
+
+    expect(res.status).to.equal(400);
+    expect(JSON.stringify(res.body)).to.contain('bridgeUrl');
+  });
+});

--- a/apps/api/src/app/contexts/usecases/assert-safe-context-bridge-url.ts
+++ b/apps/api/src/app/contexts/usecases/assert-safe-context-bridge-url.ts
@@ -1,0 +1,25 @@
+import { BadRequestException } from '@nestjs/common';
+import { assertSafeOutboundUrl, resolvePublicAddresses, SsrfBlockedError } from '@novu/application-generic';
+
+/**
+ * A context `bridgeUrl` is `fetch()`ed from inside the API process on every inbound agent turn whose
+ * resolved connect-time context includes it, carrying a Novu HMAC and a sensitive payload (subscriber
+ * PII + conversation history). Without an SSRF guard an authenticated WORKFLOW_WRITE caller could
+ * repoint routing at internal hosts (loopback, RFC1918, link-local 169.254.169.254, cloud metadata).
+ * Mirrors the agent bridge URL guard in UpdateAgent.
+ */
+export async function assertSafeContextBridgeUrl(url: string | undefined | null): Promise<void> {
+  if (!url) {
+    return;
+  }
+
+  try {
+    const parsed = assertSafeOutboundUrl(url);
+    await resolvePublicAddresses(parsed.hostname);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      throw new BadRequestException(`bridgeUrl: ${err.message}`);
+    }
+    throw err;
+  }
+}

--- a/apps/api/src/app/contexts/usecases/create-context/create-context.command.ts
+++ b/apps/api/src/app/contexts/usecases/create-context/create-context.command.ts
@@ -1,6 +1,6 @@
 import { EnvironmentWithUserCommand, IsValidContextData } from '@novu/application-generic';
 import { ContextData, ContextId, ContextType } from '@novu/shared';
-import { IsDefined, IsOptional, IsString } from 'class-validator';
+import { IsDefined, IsOptional, IsString, IsUrl } from 'class-validator';
 
 export class CreateContextCommand extends EnvironmentWithUserCommand {
   @IsDefined()
@@ -14,4 +14,8 @@ export class CreateContextCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsValidContextData()
   data?: ContextData;
+
+  @IsOptional()
+  @IsUrl({ require_tld: false })
+  bridgeUrl?: string;
 }

--- a/apps/api/src/app/contexts/usecases/create-context/create-context.usecase.ts
+++ b/apps/api/src/app/contexts/usecases/create-context/create-context.usecase.ts
@@ -1,6 +1,7 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { ContextEntity, ContextRepository, isDuplicateKeyError } from '@novu/dal';
 import { createContextKey } from '@novu/shared';
+import { assertSafeContextBridgeUrl } from '../assert-safe-context-bridge-url';
 import { CreateContextCommand } from './create-context.command';
 
 @Injectable()
@@ -8,6 +9,8 @@ export class CreateContext {
   constructor(private contextRepository: ContextRepository) {}
 
   async execute(command: CreateContextCommand): Promise<ContextEntity> {
+    await assertSafeContextBridgeUrl(command.bridgeUrl);
+
     const existingContext = await this.contextRepository.findOne({
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
@@ -27,6 +30,7 @@ export class CreateContext {
         id: command.id,
         key: createContextKey(command.type, command.id),
         data: command.data || {},
+        ...(command.bridgeUrl ? { bridgeUrl: command.bridgeUrl } : {}),
       });
     } catch (error) {
       if (isDuplicateKeyError(error)) {

--- a/apps/api/src/app/contexts/usecases/update-context/update-context.command.ts
+++ b/apps/api/src/app/contexts/usecases/update-context/update-context.command.ts
@@ -1,6 +1,6 @@
 import { EnvironmentWithUserCommand, IsValidContextData } from '@novu/application-generic';
 import { ContextData, ContextId, ContextType } from '@novu/shared';
-import { IsDefined, IsString } from 'class-validator';
+import { IsDefined, IsOptional, IsString, IsUrl, ValidateIf } from 'class-validator';
 
 export class UpdateContextCommand extends EnvironmentWithUserCommand {
   @IsDefined()
@@ -14,4 +14,10 @@ export class UpdateContextCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   @IsValidContextData()
   data: ContextData;
+
+  // `null` explicitly clears the override; `undefined` leaves it untouched.
+  @IsOptional()
+  @ValidateIf((_, value) => value !== null)
+  @IsUrl({ require_tld: false })
+  bridgeUrl?: string | null;
 }

--- a/apps/api/src/app/contexts/usecases/update-context/update-context.usecase.ts
+++ b/apps/api/src/app/contexts/usecases/update-context/update-context.usecase.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { ContextEntity, ContextRepository } from '@novu/dal';
+import { assertSafeContextBridgeUrl } from '../assert-safe-context-bridge-url';
 import { UpdateContextCommand } from './update-context.command';
 
 @Injectable()
@@ -7,6 +8,8 @@ export class UpdateContext {
   constructor(private contextRepository: ContextRepository) {}
 
   async execute(command: UpdateContextCommand): Promise<ContextEntity> {
+    await assertSafeContextBridgeUrl(command.bridgeUrl);
+
     const query = {
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
@@ -21,12 +24,20 @@ export class UpdateContext {
       throw new NotFoundException(`Context with type '${command.type}' and id '${command.id}' not found`);
     }
 
-    // Update only the data field
-    const updatedContext = await this.contextRepository.findOneAndUpdate(
-      query,
-      { $set: { data: command.data } },
-      { new: true }
-    );
+    // `data` is always replaced; `bridgeUrl` is managed independently — set when a URL is provided,
+    // unset when explicitly `null`, and left untouched when omitted.
+    const update: {
+      $set: { data: typeof command.data; bridgeUrl?: string };
+      $unset?: { bridgeUrl: '' };
+    } = { $set: { data: command.data } };
+
+    if (command.bridgeUrl === null) {
+      update.$unset = { bridgeUrl: '' };
+    } else if (command.bridgeUrl !== undefined) {
+      update.$set.bridgeUrl = command.bridgeUrl;
+    }
+
+    const updatedContext = await this.contextRepository.findOneAndUpdate(query, update, { new: true });
 
     // biome-ignore lint/style/noNonNullAssertion: we know it exists since we found it
     return updatedContext!;

--- a/apps/api/src/app/inbox/e2e/session.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/session.e2e.ts
@@ -1235,6 +1235,43 @@ describe('Session - /inbox/session (POST) #novu-v2', async () => {
     expect(contextKeys).to.include('projectId:project-456');
   });
 
+  it('does not let a session context payload set a root bridgeUrl override', async () => {
+    // Security regression: agent bridge routing reads the Context root `bridgeUrl`, which is writable
+    // only via the trusted /v2/contexts API. A subscriber-facing session payload only carries
+    // `{ id, data }`, so a `data.bridgeUrl` must never surface as a routable root override.
+    await setIntegrationConfig({
+      _environmentId: session.environment._id,
+      _organizationId: session.environment._organizationId,
+      hmac: false,
+    });
+
+    const context: ContextPayload = {
+      tenant: { id: 'attacker', data: { bridgeUrl: 'https://attacker.example.com/api/novu' } },
+    };
+
+    const { body, status } = await initializeSession({
+      applicationIdentifier: session.environment.identifier,
+      subscriberId: mockSubscriberId,
+      context,
+    });
+
+    expect(status).to.equal(201);
+    expect(body.data.contextKeys).to.deep.equal(['tenant:attacker']);
+
+    const stored = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'attacker',
+    });
+
+    expect(stored, 'context created from session payload').to.exist;
+    expect(stored?.bridgeUrl, 'root bridgeUrl must not be settable via a session context payload').to.equal(undefined);
+    expect((stored?.data as Record<string, unknown>)?.bridgeUrl, 'the value stays inert inside data').to.equal(
+      'https://attacker.example.com/api/novu'
+    );
+  });
+
   it('should reuse existing contexts on subsequent sessions', async () => {
     await setIntegrationConfig({
       _environmentId: session.environment._id,

--- a/libs/dal/src/repositories/context/context.entity.ts
+++ b/libs/dal/src/repositories/context/context.entity.ts
@@ -12,6 +12,8 @@ export class ContextEntity implements Context {
   type: ContextType;
   data: ContextData;
 
+  bridgeUrl?: string;
+
   key: string;
 
   createdAt: string;

--- a/libs/dal/src/repositories/context/context.schema.ts
+++ b/libs/dal/src/repositories/context/context.schema.ts
@@ -31,6 +31,10 @@ const contextSchema = new Schema<ContextDBModel>(
       required: false,
       default: {},
     },
+    bridgeUrl: {
+      type: Schema.Types.String,
+      required: false,
+    },
   },
   { ...schemaOptions, minimize: false }
 );

--- a/packages/shared/src/types/context.ts
+++ b/packages/shared/src/types/context.ts
@@ -10,6 +10,13 @@ export type Context = {
   type: ContextType;
   data: ContextData;
 
+  /**
+   * Optional bridge URL override. When set, an inbound agent turn whose resolved connect-time context
+   * includes this context routes its bridge call here instead of the agent's default bridge URL.
+   * Only writable through the trusted `/v2/contexts` API (never via subscriber-facing context payloads).
+   */
+  bridgeUrl?: string;
+
   key: string;
 
   createdAt: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds an optional root-level `bridgeUrl` on the **Context** entity. When an inbound agent turn resolves a connect-time context that carries a `bridgeUrl`, the bridge executor routes that turn to the override instead of the agent's default bridge URL. This lets a single hosted agent route each tenant to its own bridge endpoint.

## Why root field, not `data.bridgeUrl`

It is routing/security config: it needs URL + SSRF validation, must update independently of `data`, and must never be mixed into the customer `data` that is forwarded to the bridge as `ctx.context`.

The decisive reason is the trust boundary. Subscriber-facing flows (inbox session, Slack/Teams/Telegram connect buttons, trigger `context` payloads) create Context documents from browser-supplied payloads, but those only ever carry `{ id, data }`. A root `bridgeUrl` is therefore **impossible to set** from any subscriber path — it is writable only via the `WORKFLOW_WRITE` `/v2/contexts` API. With a reserved `data.bridgeUrl` and HMAC disabled, a browser could auto-create a context with an attacker-controlled URL and exfiltrate the signed bridge payload (subscriber PII + history).

## How it routes

```mermaid
flowchart LR
  inbound[Inbound webhook] --> resolver[ContextResolver.resolve]
  resolver -->|"context payload + bridgeUrl override"| turn[ConversationTurn]
  turn --> exec[BridgeExecutor.execute]
  exec --> pick{resolveBridgeUrl}
  pick -->|devBridge active| dev[devBridgeUrl]
  pick -->|else context override| ctx[context.bridgeUrl]
  pick -->|else| def[agent.bridgeUrl]
```

- Any resolved context can carry the override. When several within a scope set one, the first by sorted `key` wins and a conflict warning is logged. Endpoint-scope context wins over workspace-scope (mirrors the existing payload-merge precedence).
- Precedence: active dev bridge > context override > agent default.

## Changes

- `packages/shared`, `libs/dal`: `bridgeUrl` on `Context` type, entity, and schema.
- `apps/api` contexts CRUD: `bridgeUrl` on create/update DTOs + commands + use cases (with SSRF guard `assertSafeOutboundUrl` + `resolvePublicAddresses`), exposed on the response, wired through the controller; OpenAPI regenerated.
- `apps/api` agent runtime: `InboundConnectionContextResolver` now returns `{ context, bridgeUrl }`; threaded through `ConversationTurn` → `BridgeRuntime` → `BridgeExecutorService.resolveBridgeUrl`. The existing per-attempt SSRF guard re-validates the chosen URL on every send.

## Security

- Override writable only through the trusted `/v2/contexts` API. Never settable via subscriber sessions / connect buttons / trigger payloads (they only carry `{ id, data }`).
- SSRF guard on write; execute-time SSRF guard already re-runs on every bridge send.
- Info log emitted (agent + bridge host) whenever an override is applied.

## Distribution

Community-safe and additive. No new env/flags. Managed runtime (no bridge) is unaffected.

## Testing

- Context e2e: persist + return `bridgeUrl`; SSRF rejection on create and update.
- Resolver spec: single override, endpoint-over-workspace precedence, conflict warning, none set.
- Bridge-executor spec: precedence dev > context > agent.
- Agent inbound e2e: context `bridgeUrl` routes the POST to the override; absent → agent default.
- Inbox session security regression: a session `context` payload with `data.bridgeUrl` produces no routable override.

## Note

The internal SDK (`libs/internal-sdk`) was not regenerated in this environment because the `speakeasy` CLI is unavailable; the OpenAPI spec is regenerated and correct, so SDK regeneration is a mechanical follow-up in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da89bc94-8d7b-4750-a1da-13b59fd75c1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da89bc94-8d7b-4750-a1da-13b59fd75c1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a trusted, context-scoped Bridge URL override for inbound agent turns, with management-API validation and execution-time SSRF protection.
- Extends the Context API and persistence model with an optional `bridgeUrl`.
- Resolves deterministic endpoint- and workspace-scoped overrides and propagates them through the conversation runtime.
- Applies active development Bridge, context override, and agent default precedence.
- Adds API, resolver, executor, inbound-flow, and subscriber-boundary regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-connection-context.resolver.ts | Resolves context payloads and deterministic Bridge URL overrides with endpoint-over-workspace precedence and conflict diagnostics. |
| apps/api/src/app/agents/conversation-runtime/runtime/bridge-executor.service.ts | Selects the development, context, or default Bridge URL and sends it through the existing guarded outbound request path. |
| apps/api/src/app/contexts/usecases/assert-safe-context-bridge-url.ts | Adds write-time URL and public-address validation for context-scoped Bridge destinations. |
| apps/api/src/app/contexts/usecases/update-context/update-context.usecase.ts | Updates context data while independently preserving, setting, or unsetting the Bridge URL field. |
| libs/dal/src/repositories/context/context.schema.ts | Adds optional persistence for the context-level Bridge URL override. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Inbound["Inbound platform event"] --> Resolver["Connection context resolver"]
  Resolver --> Turn["Conversation turn"]
  Turn --> Runtime["Bridge runtime"]
  Runtime --> Choice{"Select Bridge URL"}
  Choice -->|Active development Bridge| Dev["Development Bridge URL"]
  Choice -->|Context override| Context["Context bridgeUrl"]
  Choice -->|Otherwise| Default["Agent default URL"]
  Dev --> Guard["Execution-time SSRF validation"]
  Context --> Guard
  Default --> Guard
  Guard --> Bridge["Customer Bridge"]
```

<sub>Reviews (2): Last reviewed commit: ["test(api-service): use resolvable/loopba..."](https://github.com/novuhq/novu/commit/1f34fa8f0e85264e0bfe47ea987d343eca7da289) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52515135)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [API App (apps/api)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-app.md)
- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)
- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
</details>

<!-- /greptile_comment -->