### PR TITLE
fix(providers,api-service): always validate outbound webhook destinations fixes NV-8583

### DIFF
--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.spec.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.spec.ts
@@ -1,6 +1,8 @@
+import * as dns from 'node:dns';
 import { BadRequestException } from '@nestjs/common';
 import { EmailProviderIdEnum, PushProviderIdEnum, SmsProviderIdEnum, ToolProviderIdEnum } from '@novu/shared';
 import { expect } from 'chai';
+import { restore, stub } from 'sinon';
 import { validateOutboundIntegrationCredentials } from './validate-outbound-integration-credentials';
 
 async function expectRejection(promise: Promise<void>, messagePart: string): Promise<void> {
@@ -14,6 +16,18 @@ async function expectRejection(promise: Promise<void>, messagePart: string): Pro
 }
 
 describe('validateOutboundIntegrationCredentials', () => {
+  beforeEach(() => {
+    stub(dns.promises, 'lookup').callsFake(((hostname: string) => {
+      const address = hostname === 'private.example.test' ? '10.0.0.5' : '93.184.216.34';
+
+      return Promise.resolve([{ address, family: 4 }]);
+    }) as never);
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
   it('should reject an email webhook URL pointing at the cloud metadata endpoint', async () => {
     await expectRejection(
       validateOutboundIntegrationCredentials(EmailProviderIdEnum.EmailWebhook, {
@@ -60,6 +74,23 @@ describe('validateOutboundIntegrationCredentials', () => {
         authenticateByToken: true,
       }),
       'Auth URL is not allowed'
+    );
+  });
+
+  it('should ignore a generic SMS auth URL when token authentication is disabled', async () => {
+    await validateOutboundIntegrationCredentials(SmsProviderIdEnum.GenericSms, {
+      baseUrl: 'https://sms.example.com/send',
+      domain: 'http://192.168.1.10/auth',
+      authenticateByToken: false,
+    });
+  });
+
+  it('should reject a hostname that resolves to a private network', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(EmailProviderIdEnum.EmailWebhook, {
+        webhookUrl: 'https://private.example.test/novu',
+      }),
+      'Webhook URL is not allowed'
     );
   });
 

--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.spec.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.spec.ts
@@ -1,0 +1,108 @@
+import { BadRequestException } from '@nestjs/common';
+import { EmailProviderIdEnum, PushProviderIdEnum, SmsProviderIdEnum, ToolProviderIdEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { validateOutboundIntegrationCredentials } from './validate-outbound-integration-credentials';
+
+async function expectRejection(promise: Promise<void>, messagePart: string): Promise<void> {
+  try {
+    await promise;
+    throw new Error(`Expected validation to reject with "${messagePart}"`);
+  } catch (error) {
+    expect(error).to.be.instanceOf(BadRequestException);
+    expect((error as BadRequestException).message).to.contain(messagePart);
+  }
+}
+
+describe('validateOutboundIntegrationCredentials', () => {
+  it('should reject an email webhook URL pointing at the cloud metadata endpoint', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(EmailProviderIdEnum.EmailWebhook, {
+        webhookUrl: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/novu',
+      }),
+      'Webhook URL is not allowed'
+    );
+  });
+
+  it('should reject an email webhook URL pointing at loopback', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(EmailProviderIdEnum.EmailWebhook, {
+        webhookUrl: 'http://127.0.0.1:6379/',
+      }),
+      'Webhook URL is not allowed'
+    );
+  });
+
+  it('should reject a non-http scheme', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(EmailProviderIdEnum.EmailWebhook, {
+        webhookUrl: 'file:///etc/passwd',
+      }),
+      'Webhook URL is not a valid http(s) URL.'
+    );
+  });
+
+  it('should reject a generic SMS base URL pointing at a private network', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(SmsProviderIdEnum.GenericSms, {
+        baseUrl: 'http://10.0.0.5/send',
+        apiKeyRequestHeader: 'apiKey',
+        apiKey: 'key',
+      }),
+      'Base URL is not allowed'
+    );
+  });
+
+  it('should reject a generic SMS auth URL pointing at a private network', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(SmsProviderIdEnum.GenericSms, {
+        baseUrl: 'https://sms.example.com/send',
+        domain: 'http://192.168.1.10/auth',
+        authenticateByToken: true,
+      }),
+      'Auth URL is not allowed'
+    );
+  });
+
+  it('should reject a push webhook URL pointing at loopback', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(PushProviderIdEnum.PushWebhook, {
+        webhookUrl: 'http://localhost:8080/hook',
+      }),
+      'Webhook URL is not allowed'
+    );
+  });
+
+  it('should reject a tool webhook URL pointing at loopback', async () => {
+    await expectRejection(
+      validateOutboundIntegrationCredentials(ToolProviderIdEnum.Webhook, {
+        webhookUrl: 'http://127.0.0.1:8080/hook',
+      }),
+      'Webhook URL is not allowed'
+    );
+  });
+
+  it('should accept public destinations', async () => {
+    await validateOutboundIntegrationCredentials(EmailProviderIdEnum.EmailWebhook, {
+      webhookUrl: 'https://hooks.example.com/novu',
+    });
+
+    await validateOutboundIntegrationCredentials(SmsProviderIdEnum.GenericSms, {
+      baseUrl: 'https://sms.example.com/send',
+      domain: 'https://sms.example.com/auth',
+      authenticateByToken: true,
+    });
+  });
+
+  it('should skip URL validation for providers without an operator-supplied destination', async () => {
+    await validateOutboundIntegrationCredentials(EmailProviderIdEnum.SendGrid, {
+      apiKey: 'key',
+      from: 'sender@example.com',
+    });
+  });
+
+  it('should skip validation when the destination is not set', async () => {
+    await validateOutboundIntegrationCredentials(ToolProviderIdEnum.Webhook, {
+      webhookUrl: '',
+    });
+  });
+});

--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
@@ -16,7 +16,7 @@ const { assertSafeSmtpOutboundTargetSync } =
   require('@novu/shared/utils/validate-smtp-outbound-target') as ValidateSmtpOutboundTargetModule;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { assertSafeOutboundUrl, normalizeOutboundHttpUrl, SsrfBlockedError } =
+const { assertSafeOutboundUrl, normalizeOutboundHttpUrl, resolvePublicAddresses, SsrfBlockedError } =
   require('@novu/shared/utils/ssrf-url-validation') as SsrfUrlValidationModule;
 
 /**
@@ -25,7 +25,7 @@ const { assertSafeOutboundUrl, normalizeOutboundHttpUrl, SsrfBlockedError } =
  * mirrors the send-time guard in the providers; internal targets that are legitimately
  * required must be allow-listed via NOVU_SAFE_OUTBOUND_ALLOW.
  */
-function assertSafeCredentialUrl(rawUrl: string | undefined, fieldLabel: string): void {
+async function assertSafeCredentialUrl(rawUrl: string | undefined, fieldLabel: string): Promise<void> {
   if (!rawUrl?.trim()) {
     return;
   }
@@ -37,7 +37,8 @@ function assertSafeCredentialUrl(rawUrl: string | undefined, fieldLabel: string)
   }
 
   try {
-    assertSafeOutboundUrl(url);
+    const parsedUrl = assertSafeOutboundUrl(url);
+    await resolvePublicAddresses(parsedUrl.hostname);
   } catch (error) {
     if (error instanceof SsrfBlockedError) {
       throw new Error(`${fieldLabel} is not allowed: ${error.message}`);
@@ -73,12 +74,15 @@ export async function validateOutboundIntegrationCredentials(
       providerId === PushProviderIdEnum.PushWebhook ||
       providerId === ToolProviderIdEnum.Webhook
     ) {
-      assertSafeCredentialUrl(credentials.webhookUrl, 'Webhook URL');
+      await assertSafeCredentialUrl(credentials.webhookUrl, 'Webhook URL');
     }
 
     if (providerId === SmsProviderIdEnum.GenericSms) {
-      assertSafeCredentialUrl(credentials.baseUrl, 'Base URL');
-      assertSafeCredentialUrl(credentials.domain, 'Auth URL');
+      await assertSafeCredentialUrl(credentials.baseUrl, 'Base URL');
+
+      if (credentials.authenticateByToken) {
+        await assertSafeCredentialUrl(credentials.domain, 'Auth URL');
+      }
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
+++ b/apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts
@@ -1,11 +1,51 @@
 import { BadRequestException } from '@nestjs/common';
-import { assertAllowedSinchSmsRegion, EmailProviderIdEnum, ICredentials, SmsProviderIdEnum } from '@novu/shared';
+import {
+  assertAllowedSinchSmsRegion,
+  EmailProviderIdEnum,
+  ICredentials,
+  PushProviderIdEnum,
+  SmsProviderIdEnum,
+  ToolProviderIdEnum,
+} from '@novu/shared';
 
 type ValidateSmtpOutboundTargetModule = typeof import('@novu/shared/dist/cjs/utils/validate-smtp-outbound-target');
+type SsrfUrlValidationModule = typeof import('@novu/shared/dist/cjs/utils/ssrf-url-validation');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { assertSafeSmtpOutboundTargetSync } =
   require('@novu/shared/utils/validate-smtp-outbound-target') as ValidateSmtpOutboundTargetModule;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { assertSafeOutboundUrl, normalizeOutboundHttpUrl, SsrfBlockedError } =
+  require('@novu/shared/utils/ssrf-url-validation') as SsrfUrlValidationModule;
+
+/**
+ * Rejects operator-supplied destinations that point at internal infrastructure, so a
+ * blocked target fails at save time with a clear error instead of at send time. This
+ * mirrors the send-time guard in the providers; internal targets that are legitimately
+ * required must be allow-listed via NOVU_SAFE_OUTBOUND_ALLOW.
+ */
+function assertSafeCredentialUrl(rawUrl: string | undefined, fieldLabel: string): void {
+  if (!rawUrl?.trim()) {
+    return;
+  }
+
+  const url = normalizeOutboundHttpUrl(rawUrl);
+
+  if (!url) {
+    throw new Error(`${fieldLabel} is not a valid http(s) URL.`);
+  }
+
+  try {
+    assertSafeOutboundUrl(url);
+  } catch (error) {
+    if (error instanceof SsrfBlockedError) {
+      throw new Error(`${fieldLabel} is not allowed: ${error.message}`);
+    }
+
+    throw error;
+  }
+}
 
 export async function validateOutboundIntegrationCredentials(
   providerId: string,
@@ -26,6 +66,19 @@ export async function validateOutboundIntegrationCredentials(
 
     if (providerId === SmsProviderIdEnum.Sinch) {
       assertAllowedSinchSmsRegion(credentials.region);
+    }
+
+    if (
+      providerId === EmailProviderIdEnum.EmailWebhook ||
+      providerId === PushProviderIdEnum.PushWebhook ||
+      providerId === ToolProviderIdEnum.Webhook
+    ) {
+      assertSafeCredentialUrl(credentials.webhookUrl, 'Webhook URL');
+    }
+
+    if (providerId === SmsProviderIdEnum.GenericSms) {
+      assertSafeCredentialUrl(credentials.baseUrl, 'Base URL');
+      assertSafeCredentialUrl(credentials.domain, 'Auth URL');
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/docs/community/self-hosting-novu/deploy-with-docker.mdx
+++ b/docs/community/self-hosting-novu/deploy-with-docker.mdx
@@ -610,6 +610,16 @@ The Dashboard container is served separately on its configured port (default **4
     Link-local and cloud metadata addresses (`169.254.0.0/16`, `fe80::/10`, `metadata.google.internal`) cannot be allow-listed.
   </Accordion>
 
+  <Accordion title="Why is my provider webhook URL rejected?">
+    The same outbound SSRF protection applies to operator-configured provider destinations, not just bridge URLs. This covers the Email Webhook, Generic SMS, Chat Webhook, Push Webhook, and Tool Webhook integrations.
+
+    A private, loopback, link-local, or metadata destination is rejected when you save the integration, and again before each send. To point one of these integrations at an internal service, add its host or CIDR to `NOVU_SAFE_OUTBOUND_ALLOW` on both the API and Worker services:
+
+    ```bash
+    NOVU_SAFE_OUTBOUND_ALLOW=sms-gateway.internal,10.0.0.0/8
+    ```
+  </Accordion>
+
   <Accordion title="When is Local Tunnel Required?">
     If the application and Novu deployment reside on different networks, you can still interact with your self-hosted Novu instance using the Novu CLI. The CLI allows you to specify the Dashboard URL and Bridge Endpoint Origin to enable communication across networks via the Novu Cloud Local Tunnel.
 

--- a/docs/community/self-hosting-novu/deploy-with-docker.mdx
+++ b/docs/community/self-hosting-novu/deploy-with-docker.mdx
@@ -611,9 +611,9 @@ The Dashboard container is served separately on its configured port (default **4
   </Accordion>
 
   <Accordion title="Why is my provider webhook URL rejected?">
-    The same outbound SSRF protection applies to operator-configured provider destinations, not just bridge URLs. This covers the Email Webhook, Generic SMS, Chat Webhook, Push Webhook, and Tool Webhook integrations.
+    The same outbound SSRF protection applies to provider destinations, not just bridge URLs. This covers the Email Webhook, Generic SMS, Chat Webhook, Push Webhook, and Tool Webhook integrations.
 
-    A private, loopback, link-local, or metadata destination is rejected when you save the integration, and again before each send. To point one of these integrations at an internal service, add its host or CIDR to `NOVU_SAFE_OUTBOUND_ALLOW` on both the API and Worker services:
+    Private, loopback, link-local, or metadata destinations configured on Email Webhook, Generic SMS, Push Webhook, and Tool Webhook integrations are rejected when you save the integration and checked again before each send. Chat Webhook destinations come from subscriber channel credentials, so they are checked during delivery. To point one of these integrations at an internal service, add its host or CIDR to `NOVU_SAFE_OUTBOUND_ALLOW` on both the API and Worker services:
 
     ```bash
     NOVU_SAFE_OUTBOUND_ALLOW=sms-gateway.internal,10.0.0.0/8

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
@@ -48,10 +48,8 @@ afterEach(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-describe('with SSRF protection (enterprise cloud)', () => {
+describe('with an allow-listed target', () => {
   beforeAll(() => {
-    process.env.NOVU_ENTERPRISE = 'true';
-    process.env.IS_SELF_HOSTED = 'false';
     process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
     const realLookup = dns.promises.lookup.bind(dns.promises);
     vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
@@ -68,8 +66,6 @@ describe('with SSRF protection (enterprise cloud)', () => {
   afterAll(() => {
     vi.restoreAllMocks();
     restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
-    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
-    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
   test('should trigger email-webhook-provider library correctly', async () => {
@@ -177,18 +173,20 @@ describe('with SSRF protection (enterprise cloud)', () => {
   });
 });
 
-describe('without SSRF protection (self-hosted)', () => {
+describe('on self-hosted builds', () => {
   beforeAll(() => {
-    process.env.NOVU_ENTERPRISE = 'true';
+    delete process.env.NOVU_ENTERPRISE;
     process.env.IS_SELF_HOSTED = 'true';
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
   });
 
   afterAll(() => {
     restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
     restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
+    restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
   });
 
-  test('should allow requests to private IPs via axios', async () => {
+  test('should block loopback targets', async () => {
     const provider = new EmailWebhookProvider({
       webhookUrl: directServerUrl,
       hmacSecretKey: 'super-secret-key',
@@ -196,15 +194,61 @@ describe('without SSRF protection (self-hosted)', () => {
       retryCount: 1,
     });
 
-    await provider.sendMessage({
-      to: ['johndoe@example.com'],
-      from: 'janedoe@example.com',
-      subject: 'test',
-      html: '<h1>test</h1>',
-      text: 'test',
+    await expect(
+      provider.sendMessage({
+        to: ['johndoe@example.com'],
+        from: 'janedoe@example.com',
+        subject: 'test',
+        html: '<h1>test</h1>',
+        text: 'test',
+      })
+    ).rejects.toThrow(/Email webhook URL blocked/);
+
+    expect(lastRequest).toBeNull();
+  });
+
+  test('should block the cloud metadata endpoint', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/novu',
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
     });
 
-    expect(lastRequest).not.toBeNull();
-    expect(lastRequest?.method).toBe('POST');
+    await expect(
+      provider.sendMessage({
+        to: ['johndoe@example.com'],
+        from: 'janedoe@example.com',
+        subject: 'test',
+        html: '<h1>test</h1>',
+        text: 'test',
+      })
+    ).rejects.toThrow(/Email webhook URL blocked/);
+  });
+
+  test('should allow targets added to the outbound allow list', async () => {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+
+    try {
+      const provider = new EmailWebhookProvider({
+        webhookUrl: directServerUrl,
+        hmacSecretKey: 'super-secret-key',
+        retryDelay: 1,
+        retryCount: 1,
+      });
+
+      await provider.sendMessage({
+        to: ['johndoe@example.com'],
+        from: 'janedoe@example.com',
+        subject: 'test',
+        html: '<h1>test</h1>',
+        text: 'test',
+      });
+
+      expect(lastRequest).not.toBeNull();
+      expect(lastRequest?.method).toBe('POST');
+    } finally {
+      delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+    }
   });
 });

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { setTimeout } from 'node:timers/promises';
-import { EmailProviderIdEnum, isOutboundSsrfProtectionEnabled } from '@novu/shared';
+import { EmailProviderIdEnum } from '@novu/shared';
 import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
 import {
   assertSafeOutboundUrl,
@@ -15,7 +15,6 @@ import {
   IEmailProvider,
   ISendMessageSuccessResponse,
 } from '@novu/stateless';
-import axios from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -72,11 +71,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
       'X-Novu-Signature': hmacValue,
     };
 
-    if (isOutboundSsrfProtectionEnabled()) {
-      await this.sendWithSsrfProtection(bodyData, requestHeaders);
-    } else {
-      await this.sendWithAxios(bodyData, requestHeaders);
-    }
+    await this.sendWebhook(bodyData, requestHeaders);
 
     return {
       id: options.id,
@@ -84,34 +79,17 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     };
   }
 
-  private async sendWithAxios(bodyData: string, requestHeaders: Record<string, string>): Promise<void> {
-    let sent = false;
-
-    for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
-      try {
-        await axios.create().post(this.config.webhookUrl, bodyData, {
-          headers: requestHeaders,
-        });
-        sent = true;
-      } catch {
-        await setTimeout(this.config.retryDelay);
-      }
-    }
-
-    if (!sent) {
-      throw new Error('webhook send failed !');
-    }
-  }
-
-  private async sendWithSsrfProtection(bodyData: string, requestHeaders: Record<string, string>): Promise<void> {
+  private async sendWebhook(bodyData: string, requestHeaders: Record<string, string>): Promise<void> {
     const webhookUrl = normalizeOutboundHttpUrl(this.config.webhookUrl);
 
     if (!webhookUrl) {
       throw new EmailWebhookUrlBlockedError('Email webhook URL blocked: Invalid URL format.');
     }
 
-    // Structure-only check (scheme, credentials, blocked hostnames). Literal private IPs
-    // are rejected at connect time inside safeOutboundJsonRequest.
+    // Validate the destination on every deployment mode, matching the other webhook
+    // providers. The connect-time DNS guard and redirect re-validation happen inside
+    // safeOutboundJsonRequest. Internal targets must be allow-listed via
+    // NOVU_SAFE_OUTBOUND_ALLOW.
     try {
       assertSafeOutboundUrl(webhookUrl);
     } catch (err) {

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
@@ -58,10 +58,8 @@ afterEach(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-describe('with SSRF protection (enterprise cloud)', () => {
+describe('with an allow-listed target', () => {
   beforeAll(() => {
-    process.env.NOVU_ENTERPRISE = 'true';
-    process.env.IS_SELF_HOSTED = 'false';
     process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
     const realLookup = dns.promises.lookup.bind(dns.promises);
     vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
@@ -78,8 +76,6 @@ describe('with SSRF protection (enterprise cloud)', () => {
   afterAll(() => {
     vi.restoreAllMocks();
     restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
-    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
-    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
   test('should trigger generic-sms library correctly', async () => {
@@ -173,18 +169,20 @@ describe('with SSRF protection (enterprise cloud)', () => {
   });
 });
 
-describe('without SSRF protection (self-hosted)', () => {
+describe('on self-hosted builds', () => {
   beforeAll(() => {
-    process.env.NOVU_ENTERPRISE = 'true';
+    delete process.env.NOVU_ENTERPRISE;
     process.env.IS_SELF_HOSTED = 'true';
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
   });
 
   afterAll(() => {
     restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
     restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
+    restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
   });
 
-  test('should allow requests to private IPs via axios', async () => {
+  test('should block loopback targets', async () => {
     const provider = new GenericSmsProvider({
       baseUrl: directServerUrl,
       apiKeyRequestHeader: 'apiKey',
@@ -194,12 +192,57 @@ describe('without SSRF protection (self-hosted)', () => {
       datePath: 'message.date',
     });
 
-    const result = await provider.sendMessage({
-      to: '+1234567890',
-      content: 'SMS Content form Generic SMS Provider',
+    await expect(
+      provider.sendMessage({
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
+      })
+    ).rejects.toThrow(/Generic SMS URL blocked/);
+
+    expect(lastRequest).toBeNull();
+  });
+
+  test('should block the cloud metadata endpoint used as the auth URL', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: 'https://sms.example.com/send',
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+      authenticateByToken: true,
+      authenticationTokenKey: 'token',
+      domain: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/novu',
     });
 
-    expect(lastRequest).not.toBeNull();
-    expect(result.id).toBeDefined();
+    await expect(
+      provider.sendMessage({
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
+      })
+    ).rejects.toThrow(/Generic SMS auth URL blocked/);
+  });
+
+  test('should allow targets added to the outbound allow list', async () => {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+
+    try {
+      const provider = new GenericSmsProvider({
+        baseUrl: directServerUrl,
+        apiKeyRequestHeader: 'apiKey',
+        apiKey: '123456',
+        from: 'sender-id',
+        idPath: 'message.id',
+        datePath: 'message.date',
+      });
+
+      const result = await provider.sendMessage({
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
+      });
+
+      expect(lastRequest).not.toBeNull();
+      expect(result.id).toBeDefined();
+    } finally {
+      delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+    }
   });
 });

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -1,4 +1,4 @@
-import { isOutboundSsrfProtectionEnabled, SmsProviderIdEnum } from '@novu/shared';
+import { SmsProviderIdEnum } from '@novu/shared';
 import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
 import {
   assertSafeOutboundUrl,
@@ -7,7 +7,6 @@ import {
 } from '@novu/shared/utils/ssrf-url-validation';
 import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
 
-import axios, { AxiosInstance } from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -15,7 +14,6 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
   id = SmsProviderIdEnum.GenericSms;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
   protected casing = CasingEnum.CAMEL_CASE;
-  axiosInstance?: AxiosInstance;
   headers: Record<string, string>;
 
   constructor(
@@ -41,69 +39,11 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     if (this.config?.secretKeyRequestHeader && this.config?.secretKey) {
       this.headers[this.config?.secretKeyRequestHeader] = config.secretKey;
     }
-
-    if (!this.config?.authenticateByToken) {
-      this.axiosInstance = axios.create({
-        baseURL: config.baseUrl,
-        headers: this.headers,
-      });
-    }
   }
 
   async sendMessage(
     options: ISmsOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
-  ): Promise<ISendMessageSuccessResponse> {
-    if (isOutboundSsrfProtectionEnabled()) {
-      return this.sendMessageWithSsrfProtection(options, bridgeProviderData);
-    }
-
-    return this.sendMessageWithAxios(options, bridgeProviderData);
-  }
-
-  private async sendMessageWithAxios(
-    options: ISmsOptions,
-    bridgeProviderData: WithPassthrough<Record<string, unknown>>
-  ): Promise<ISendMessageSuccessResponse> {
-    const data = this.transform(bridgeProviderData, {
-      ...options,
-      sender: options.from || this.config.from,
-    });
-
-    if (this.config?.authenticateByToken) {
-      const tokenAxiosInstance = await axios.request({
-        method: 'POST',
-        baseURL: this.config.domain,
-        headers: this.headers,
-      });
-
-      const token = tokenAxiosInstance.data.data[this.config.authenticationTokenKey!];
-
-      this.axiosInstance = axios.create({
-        baseURL: this.config.baseUrl,
-        headers: {
-          [this.config.authenticationTokenKey!]: token,
-          ...data.headers,
-        },
-      });
-    }
-
-    const response = await this.axiosInstance!.request({
-      method: 'POST',
-      data: data.body,
-    });
-
-    const responseData = response.data as Record<string, unknown>;
-
-    return {
-      id: this.getResponseValue(this.config.idPath || 'id', responseData) ?? '',
-      date: this.getResponseValue(this.config.datePath || 'date', responseData) || new Date().toISOString(),
-    };
-  }
-
-  private async sendMessageWithSsrfProtection(
-    options: ISmsOptions,
-    bridgeProviderData: WithPassthrough<Record<string, unknown>>
   ): Promise<ISendMessageSuccessResponse> {
     const data = this.transform(bridgeProviderData, {
       ...options,

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -68,14 +68,15 @@ export const isClerkEnabled = () => isEEAuthEnabled() && getEEAuthProvider() ===
 export const isBetterAuthEnabled = () => isEEAuthEnabled() && getEEAuthProvider() === 'better-auth';
 
 /**
- * Outbound SSRF DNS-pinning for non-bridge paths (HTTP request steps, provider
- * webhooks, etc.) applies on Novu Cloud Enterprise builds.
+ * Outbound SSRF DNS-pinning for HTTP request steps applies on Novu Cloud
+ * Enterprise builds.
  *
- * Bridge user-supplied URLs always enforce DNS pinning regardless of
- * deployment mode — see ExecuteFrameworkRequest. Self-hosted operators who
- * need private/internal bridge targets must allow-list them via
- * NOVU_SAFE_OUTBOUND_ALLOW (link-local / cloud-metadata ranges are never
- * allow-listed).
+ * Bridge user-supplied URLs and provider webhook targets (email webhook,
+ * generic SMS, chat/push/tool webhooks) always enforce the outbound URL policy
+ * regardless of deployment mode — see ExecuteFrameworkRequest and the webhook
+ * providers. Self-hosted operators who need private/internal targets must
+ * allow-list them via NOVU_SAFE_OUTBOUND_ALLOW (link-local / cloud-metadata
+ * ranges are never allow-listed).
  */
 export const isOutboundSsrfProtectionEnabled = (): boolean => {
   const isEnterprise = getEnvVariable('NOVU_ENTERPRISE') === 'true' || getEnvVariable('CI_EE_TEST') === 'true';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

`EmailWebhookProvider.sendMessage()` and `GenericSmsProvider.sendMessage()` branched on `isOutboundSsrfProtectionEnabled()` and fell back to a raw `axios` call with **no** URL validation when the flag was false. That flag requires `NOVU_ENTERPRISE=true` **and** `IS_SELF_HOSTED` unset, so on the default OSS / self-hosted build the SSRF guard added in NV-7918 was dead code: anyone with `INTEGRATION_WRITE` could point an Email Webhook or Generic SMS integration at `http://169.254.169.254/...` or an internal host and have the worker issue the request from its trusted network position.

Every sibling provider (`chat-webhook`, `push-webhook`, `tool-webhook`, `grafana`, Infobip, Pusher Beams) already calls `assertSafeOutboundUrl()` unconditionally, and the bridge path removed the same gate in NV-7560 with the note that gating it "left self-hosted deployments with only the incomplete sync hostname denylist". These two providers were the last ones still gated.

Changes:

- **`packages/providers`** — remove the flag branch and the unvalidated `axios` fallback from both providers, so the outbound URL policy and the DNS-pinned client always apply. Generic SMS also drops the now-unused `axiosInstance` field.
- **`apps/api`** — `validateOutboundIntegrationCredentials` previously only covered `CustomSMTP` host/port and the `Sinch` region, so a blocked destination was validated neither at save time nor at send time. It now validates and resolves `webhookUrl` for the email/push/tool webhook providers and `baseUrl` plus the auth URL (when token authentication is enabled) for generic SMS, returning a `400` with a clear message instead of failing silently at send time.
- **`docs`** — document that provider webhook destinations follow the same policy as bridge URLs, clarify that Chat Webhook destinations are validated during delivery, and show how to allow-list internal targets with `NOVU_SAFE_OUTBOUND_ALLOW`.

Self-hosted operators who legitimately need an internal destination use the existing `NOVU_SAFE_OUTBOUND_ALLOW` escape hatch, unchanged from the bridge path. Link-local and cloud metadata ranges remain non-allow-listable.

```mermaid
flowchart LR
  A["sendMessage()"] --> B{"before: isOutboundSsrfProtectionEnabled()?"}
  B -- "true (Cloud EE)" --> C["assertSafeOutboundUrl + DNS-pinned client"]
  B -- "false (OSS / self-hosted)" --> D["axios.post(webhookUrl) — no validation"]
  A2["sendMessage() (after)"] --> C2["assertSafeOutboundUrl + DNS-pinned client"]
  C2 --> E["allow-listed internal targets via NOVU_SAFE_OUTBOUND_ALLOW"]
```

### Screenshots

Saving an Email Webhook integration pointed at the cloud metadata endpoint is now rejected, and a valid public URL still saves. Recorded against this environment, which runs with `NOVU_ENTERPRISE=true` and `IS_SELF_HOSTED=true` — precisely the configuration where the guard used to be skipped.

<a href="https://cursor.com/agents/bc-e58fa346-5831-41d2-8d57-1e7ac31ef6d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_blocks_metadata_webhook_url_then_accepts_valid_url.mp4"><img src="https://cursor.com/artifacts/c/art-c73a3f17-81b7-4852-8384-08f2a9525b96" alt="dashboard_blocks_metadata_webhook_url_then_accepts_valid_url.mp4" /></a>

![Dashboard error toast reading Webhook URL is not allowed: Requests to private or reserved IP addresses are not allowed (resolved: 169.254.169.254)](https://cursor.com/artifacts/c/art-a6dc8a81-159f-49fd-afbd-37dd0f86bcb5)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

**Behaviour change for self-hosted operators.** An existing self-hosted deployment whose Email Webhook or Generic SMS integration points at a private address will start failing, both when saving credentials and when sending, until the host or CIDR is added to `NOVU_SAFE_OUTBOUND_ALLOW` on the API and Worker. That is the same trade-off already accepted for bridge URLs in NV-7560, and it is now documented in the self-hosting FAQ.

**Tests.** Both provider specs previously asserted the opposite behaviour (`should allow requests to private IPs via axios`); those cases are replaced with blocked-target assertions plus an allow-list case that proves the escape hatch still works. The `apps/api` unit spec covers literal and DNS-resolved blocked destinations and verifies that an unused Generic SMS auth URL does not block saves.

The 22 failing tests in `packages/providers` (sns, sendgrid, ses, apns, mailjet, nodemailer, pushpad, azure-sms, plivo) are pre-existing on `next` — verified by re-running them on a clean tree.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e58fa346-5831-41d2-8d57-1e7ac31ef6d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e58fa346-5831-41d2-8d57-1e7ac31ef6d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes outbound destination validation unconditional for Email Webhook and Generic SMS providers and adds API-side validation before integrations are saved. It also updates self-hosting guidance for allow-listed internal destinations.
- Removes the deployment-mode SSRF validation bypass from Email Webhook and Generic SMS delivery.
- Resolves and validates webhook and Generic SMS destinations during integration saves.
- Documents save-time versus delivery-time checks and `NOVU_SAFE_OUTBOUND_ALLOW`.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until token-enabled Generic SMS integrations reject a missing authentication URL when credentials are saved.

Token-enabled Generic SMS credentials can pass API validation without a domain, then fail every delivery when the provider attempts to validate and use that required URL.

**Files Needing Attention:** apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts | Adds save-time DNS-aware destination validation, but token-enabled Generic SMS credentials can still save without the required authentication URL. |
| apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.spec.ts | Covers blocked, public, and inactive Generic SMS authentication destinations but omits the active-without-domain case. |
| packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts | Removes the raw Axios fallback and always sends through the SSRF-safe outbound request path. |
| packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts | Removes the unvalidated Axios path and consistently validates both authentication and message destinations during delivery. |
| docs/community/self-hosting-novu/deploy-with-docker.mdx | Accurately documents provider validation timing and API/Worker allow-list configuration. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Save["Create or update integration"] --> Validate["API destination validation"]
  Validate --> Persist["Persist credentials"]
  Persist --> Worker["Worker sends notification"]
  Worker --> Provider["Email Webhook or Generic SMS provider"]
  Provider --> Guard["Resolve, validate, and pin destination"]
  Guard --> External["Allowed external service"]
  Guard --> Reject["Reject blocked destination"]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fapi%2Fsrc%2Fapp%2Fintegrations%2Futils%2Fvalidate-outbound-integration-credentials.ts%3A83-85%0A**Missing%20authentication%20URL%20saves**%0A%0AWhen%20%60authenticateByToken%60%20is%20enabled%20but%20%60domain%60%20is%20empty%20or%20omitted%2C%20%60assertSafeCredentialUrl%60%20returns%20without%20validation%2C%20so%20the%20integration%20saves%20successfully%20but%20every%20delivery%20fails%20when%20the%20provider%20rejects%20the%20missing%20authentication%20URL.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28credentials.authenticateByToken%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28!credentials.domain%3F.trim%28%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20throw%20new%20Error%28'Auth%20URL%20is%20required%20when%20token%20authentication%20is%20enabled.'%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20await%20assertSafeCredentialUrl%28credentials.domain%2C%20'Auth%20URL'%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12320&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/app/integrations/utils/validate-outbound-integration-credentials.ts:83-85
**Missing authentication URL saves**

When `authenticateByToken` is enabled but `domain` is empty or omitted, `assertSafeCredentialUrl` returns without validation, so the integration saves successfully but every delivery fails when the provider rejects the missing authentication URL.

```suggestion
      if (credentials.authenticateByToken) {
        if (!credentials.domain?.trim()) {
          throw new Error('Auth URL is required when token authentication is enabled.');
        }

        await assertSafeCredentialUrl(credentials.domain, 'Auth URL');
      }
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): align credential valid..."](https://github.com/novuhq/novu/commit/d7df9f7cd2b4a64b5ab679e3c13bd8d302f5d6a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52530205)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Providers package](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/providers-package.md)

<!-- /greptile_comment -->