### PR TITLE
feat(api-service,js): emit MCP connection events for agent chat fixes NV-8578

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.spec.ts
@@ -149,6 +149,77 @@ describe('AgentConversationService', () => {
     });
   });
 
+  describe('MCP connection activities', () => {
+    it('persists request and result activities and publishes both to web chat', async () => {
+      const activityRepository = makeActivityRepository();
+      activityRepository.createAgentActivity.callsFake(async (params: Record<string, unknown>) => ({
+        _id: `activity-${activityRepository.createAgentActivity.callCount}`,
+        ...params,
+      }));
+      const conversationRepository = {
+        touchActivity: sinon.stub().resolves(undefined),
+      } as unknown as ConversationRepository;
+      const publisher = { emitPersistedClientEvent: sinon.stub().resolves(undefined) };
+      const service = makeService(
+        conversationRepository,
+        activityRepository,
+        makeEventSequenceService(sinon.stub().onFirstCall().resolves(10).onSecondCall().resolves(11)),
+        publisher
+      );
+      const context = {
+        ...basePersistParams(),
+        channel: {
+          platform: 'web_chat',
+          _integrationId: 'integration-a',
+          platformThreadId: 'thread-1',
+        },
+      };
+
+      await service.persistMcpConnectionRequest({
+        ...context,
+        actionId: 'tool-use-1',
+        mcpId: 'stripe',
+        displayName: 'Stripe',
+        authorizeUrl: 'https://example.com/authorize',
+      });
+      await service.persistMcpConnectionResult({
+        ...context,
+        actionId: 'tool-use-1',
+        mcpId: 'stripe',
+        status: 'connected',
+      });
+
+      expect(activityRepository.createAgentActivity.firstCall.args[0]).to.deep.include({
+        identifier: 'mcp-connection:tool-use-1:request',
+        type: ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST,
+        sequence: 10,
+        richContent: {
+          mcpConnection: {
+            actionId: 'tool-use-1',
+            mcpId: 'stripe',
+            displayName: 'Stripe',
+            authorizeUrl: 'https://example.com/authorize',
+            authorizeUrlWithAutoApprove: undefined,
+          },
+        },
+      });
+      expect(activityRepository.createAgentActivity.secondCall.args[0]).to.deep.include({
+        identifier: 'mcp-connection:tool-use-1:result',
+        type: ConversationActivityTypeEnum.MCP_CONNECTION_RESULT,
+        sequence: 11,
+        richContent: {
+          mcpConnection: {
+            actionId: 'tool-use-1',
+            mcpId: 'stripe',
+            status: 'connected',
+            message: undefined,
+          },
+        },
+      });
+      expect(publisher.emitPersistedClientEvent.callCount).to.equal(2);
+    });
+  });
+
   describe('event sequencing', () => {
     it('allocates a sequence for durable tool activities on any channel', async () => {
       const conversationRepository = {} as unknown as ConversationRepository;

--- a/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts
@@ -186,6 +186,21 @@ export interface PersistToolResultParams extends ConversationActivityContext {
   preview?: string;
 }
 
+export interface PersistMcpConnectionRequestParams extends ConversationActivityContext {
+  actionId: string;
+  mcpId: string;
+  displayName: string;
+  authorizeUrl: string;
+  authorizeUrlWithAutoApprove?: string;
+}
+
+export interface PersistMcpConnectionResultParams extends ConversationActivityContext {
+  actionId: string;
+  mcpId: string;
+  status: 'connected' | 'failed';
+  message?: string;
+}
+
 @Injectable()
 export class AgentConversationService {
   constructor(
@@ -625,7 +640,9 @@ export class AgentConversationService {
   }
 
   private async persistAgentActivity(
-    params: PersistAgentActivityParams & { toolData?: ConversationActivityToolData },
+    params: PersistAgentActivityParams & {
+      toolData?: ConversationActivityToolData;
+    },
     type: ConversationActivityTypeEnum,
     touch: 'activity' | 'preview'
   ): Promise<ConversationActivityEntity> {
@@ -819,6 +836,69 @@ export class AgentConversationService {
       agentIdentifier: params.agentIdentifier,
       activity,
     });
+  }
+
+  async persistMcpConnectionRequest(params: PersistMcpConnectionRequestParams): Promise<ConversationActivityEntity> {
+    const activity = await this.persistAgentActivity(
+      {
+        ...params,
+        identifier: `mcp-connection:${params.actionId}:request`,
+        content: `Connect ${params.displayName}`,
+        richContent: {
+          mcpConnection: {
+            actionId: params.actionId,
+            mcpId: params.mcpId,
+            displayName: params.displayName,
+            authorizeUrl: params.authorizeUrl,
+            authorizeUrlWithAutoApprove: params.authorizeUrlWithAutoApprove,
+          },
+        },
+      },
+      ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST,
+      'activity'
+    );
+
+    await this.webChatLiveActivityPublisher.emitPersistedClientEvent({
+      channel: params.channel,
+      conversationId: params.conversationId,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+      agentIdentifier: params.agentIdentifier,
+      activity,
+    });
+
+    return activity;
+  }
+
+  async persistMcpConnectionResult(params: PersistMcpConnectionResultParams): Promise<ConversationActivityEntity> {
+    const activity = await this.persistAgentActivity(
+      {
+        ...params,
+        identifier: `mcp-connection:${params.actionId}:result`,
+        content: params.status === 'connected' ? 'Connection completed' : (params.message ?? 'Connection failed'),
+        richContent: {
+          mcpConnection: {
+            actionId: params.actionId,
+            mcpId: params.mcpId,
+            status: params.status,
+            message: params.message,
+          },
+        },
+      },
+      ConversationActivityTypeEnum.MCP_CONNECTION_RESULT,
+      'activity'
+    );
+
+    await this.webChatLiveActivityPublisher.emitPersistedClientEvent({
+      channel: params.channel,
+      conversationId: params.conversationId,
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+      agentIdentifier: params.agentIdentifier,
+      activity,
+    });
+
+    return activity;
   }
 
   /**

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.spec.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.spec.ts
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
+import { HandleNovuToolsCommand, NovuToolsActionEnum } from './handle-novu-tools.command';
+import { HandleNovuTools } from './handle-novu-tools.usecase';
+
+describe('HandleNovuTools', () => {
+  it('persists a protocol connection request instead of delivering a card for web chat', async () => {
+    const channel = {
+      platform: AgentPlatformEnum.WEB_CHAT,
+      _integrationId: 'integration-id',
+      platformThreadId: 'web_chat:conversation-id',
+    };
+    const generateMcpOAuthUrl = {
+      executeForSetupCard: sinon.stub().resolves({
+        authorizeUrl: 'https://example.com/authorize',
+        authorizeUrlWithAutoApprove: 'https://example.com/authorize?autoApprove=true',
+      }),
+    };
+    const agentConversationService = {
+      getConversation: sinon.stub().resolves({ _id: 'conversation-id' }),
+      getPrimaryChannel: sinon.stub().returns(channel),
+      persistMcpConnectionRequest: sinon.stub().resolves({ _id: 'activity-id' }),
+    };
+    const handleAgentReply = { execute: sinon.stub().resolves(undefined) };
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    const usecase = new HandleNovuTools(
+      {} as never,
+      {} as never,
+      {} as never,
+      generateMcpOAuthUrl as never,
+      {} as never,
+      agentConversationService as never,
+      handleAgentReply as never,
+      {} as never,
+      logger as never
+    );
+
+    await usecase.execute(
+      HandleNovuToolsCommand.create({
+        userId: 'organization-id',
+        environmentId: 'environment-id',
+        organizationId: 'organization-id',
+        toolUseId: 'tool-use-id',
+        action: NovuToolsActionEnum.RequestConnect,
+        mcpId: 'example-mcp',
+        conversationId: 'conversation-id',
+        agentId: 'agent-id',
+        agentIdentifier: 'agent-identifier',
+        integrationIdentifier: 'integration-identifier',
+        subscriberId: 'subscriber-id',
+        sessionId: 'session-id',
+        platform: AgentPlatformEnum.WEB_CHAT,
+        platformThreadId: 'web_chat:conversation-id',
+      })
+    );
+
+    expect(
+      agentConversationService.persistMcpConnectionRequest.calledOnceWithExactly({
+        conversationId: 'conversation-id',
+        environmentId: 'environment-id',
+        organizationId: 'organization-id',
+        agentIdentifier: 'agent-identifier',
+        channel,
+        actionId: 'tool-use-id',
+        mcpId: 'example-mcp',
+        displayName: 'example-mcp',
+        authorizeUrl: 'https://example.com/authorize',
+        authorizeUrlWithAutoApprove: 'https://example.com/authorize?autoApprove=true',
+      })
+    ).to.equal(true);
+    expect(handleAgentReply.execute.called).to.equal(false);
+  });
+});

--- a/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.ts
+++ b/apps/api/src/app/agents/managed-runtime/tool-connect/handle-novu-tools.usecase.ts
@@ -2,11 +2,13 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import { AgentMcpServerRepository, McpConnectionRepository, SubscriberRepository } from '@novu/dal';
 import { MCP_SERVERS, McpConnectionStatusEnum } from '@novu/shared';
+import { AgentConversationService } from '../../conversation-runtime/conversation/agent-conversation.service';
 import { HandleAgentReplyCommand } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../../conversation-runtime/reply/handle-agent-reply/handle-agent-reply.usecase';
 import { McpConnectRedirectService } from '../../mcp/connections/mcp-connect-redirect.service';
 import { GenerateMcpOAuthUrlCommand } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.command';
 import { GenerateMcpOAuthUrl } from '../../mcp/oauth/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
+import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';
 import { ManagedAgentService } from '../managed-agent.service';
 import { buildConnectCardDelivery } from './connect-card.builder';
 import { HandleNovuToolsCommand, NovuToolsActionEnum } from './handle-novu-tools.command';
@@ -20,6 +22,7 @@ export class HandleNovuTools {
     private readonly mcpConnectionRepository: McpConnectionRepository,
     private readonly generateMcpOAuthUrl: GenerateMcpOAuthUrl,
     private readonly mcpConnectRedirect: McpConnectRedirectService,
+    private readonly agentConversationService: AgentConversationService,
     private readonly handleAgentReply: HandleAgentReply,
     @Inject(forwardRef(() => ManagedAgentService))
     private readonly managedAgentService: ManagedAgentService,
@@ -112,6 +115,32 @@ export class HandleNovuTools {
 
     const mcp = MCP_SERVERS.find((s) => s.id === command.mcpId);
     const mcpName = mcp?.name ?? command.mcpId;
+
+    if (command.platform === AgentPlatformEnum.WEB_CHAT) {
+      const conversation = await this.agentConversationService.getConversation(
+        command.conversationId,
+        command.environmentId,
+        command.organizationId
+      );
+      if (!conversation) {
+        throw new Error(`Conversation ${command.conversationId} not found`);
+      }
+
+      await this.agentConversationService.persistMcpConnectionRequest({
+        conversationId: command.conversationId,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        agentIdentifier: command.agentIdentifier,
+        channel: this.agentConversationService.getPrimaryChannel(conversation),
+        actionId: command.toolUseId,
+        mcpId: command.mcpId,
+        displayName: mcpName,
+        authorizeUrl: oauthUrls.authorizeUrl,
+        authorizeUrlWithAutoApprove: oauthUrls.authorizeUrlWithAutoApprove,
+      });
+
+      return;
+    }
 
     const delivery = await buildConnectCardDelivery(
       {

--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.spec.ts
@@ -1,8 +1,12 @@
-import type { McpConnectionOAuthClient } from '@novu/dal';
+import type { McpConnectionEntity, McpConnectionOAuthClient } from '@novu/dal';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
+import { AgentPlatformEnum } from '../../../shared/enums/agent-platform.enum';
+import type { McpOAuthState } from '../generate-mcp-oauth-url/mcp-oauth-state';
 import {
   buildTokenExchangeAuth,
+  McpOAuthCallback,
   mapUpstreamCallbackErrorCode,
   parseUpstreamErrorToken,
 } from './mcp-oauth-callback.usecase';
@@ -140,5 +144,112 @@ describe('buildTokenExchangeAuth', () => {
     expect(headers.Authorization).to.equal(undefined);
     expect(params.get('client_id')).to.equal('client-id');
     expect(params.get('client_secret')).to.equal(null);
+  });
+});
+
+describe('McpOAuthCallback managed chat resume', () => {
+  it('resumes the parked web-chat tool call when publishing the connected result fails', async () => {
+    const channel = {
+      platform: AgentPlatformEnum.WEB_CHAT,
+      _integrationId: 'integration-id',
+      platformThreadId: 'web_chat:conversation-id',
+    };
+    const subscriberRepository = {
+      findOne: sinon.stub().resolves({ subscriberId: 'subscriber-external-id' }),
+    };
+    const managedAgentService = {
+      sendToolResult: sinon.stub().resolves(undefined),
+    };
+    const agentConversationService = {
+      getConversation: sinon.stub().resolves({ _id: 'conversation-id' }),
+      getPrimaryChannel: sinon.stub().returns(channel),
+      persistMcpConnectionResult: sinon.stub().rejects(new Error('publisher unavailable')),
+    };
+    const outboundGateway = {
+      startTypingInConversation: sinon.stub().resolves(undefined),
+    };
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    const callback = new McpOAuthCallback(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      subscriberRepository as never,
+      {} as never,
+      {} as never,
+      managedAgentService as never,
+      agentConversationService as never,
+      outboundGateway as never,
+      {} as never,
+      {} as never,
+      logger as never
+    );
+    const resumeSessionAfterConnect = (
+      callback as unknown as {
+        resumeSessionAfterConnect(stateData: McpOAuthState, connection: McpConnectionEntity): Promise<void>;
+      }
+    ).resumeSessionAfterConnect.bind(callback);
+    const stateData = {
+      environmentId: 'environment-id',
+      organizationId: 'organization-id',
+      agentId: 'agent-id',
+      agentMcpServerId: 'agent-mcp-server-id',
+      subscriberId: 'subscriber-mongo-id',
+      mcpId: 'example-mcp',
+      scope: 'subscriber',
+      timestamp: Date.now(),
+      conversationId: 'conversation-id',
+      agentIdentifier: 'agent-identifier',
+      integrationIdentifier: 'integration-identifier',
+      toolUseId: 'tool-use-id',
+      platform: AgentPlatformEnum.WEB_CHAT,
+      platformThreadId: 'web_chat:conversation-id',
+    } as McpOAuthState;
+
+    await resumeSessionAfterConnect(stateData, {} as McpConnectionEntity);
+
+    expect(
+      agentConversationService.persistMcpConnectionResult.calledOnceWithExactly({
+        conversationId: 'conversation-id',
+        environmentId: 'environment-id',
+        organizationId: 'organization-id',
+        agentIdentifier: 'agent-identifier',
+        channel,
+        actionId: 'tool-use-id',
+        mcpId: 'example-mcp',
+        status: 'connected',
+      })
+    ).to.equal(true);
+    expect(
+      managedAgentService.sendToolResult.calledOnceWithExactly({
+        conversationId: 'conversation-id',
+        environmentId: 'environment-id',
+        organizationId: 'organization-id',
+        agentIdentifier: 'agent-identifier',
+        integrationIdentifier: 'integration-identifier',
+        subscriberId: 'subscriber-external-id',
+        toolUseId: 'tool-use-id',
+        content: 'OK',
+        followUpMessage:
+          "example-mcp is now connected and ready. Resume the user's original request. Use the available tools directly. Do not output any preamble or mention the connection — go straight to action.",
+        platform: AgentPlatformEnum.WEB_CHAT,
+        platformThreadId: 'web_chat:conversation-id',
+        suppressReply: true,
+      })
+    ).to.equal(true);
+    expect(
+      agentConversationService.persistMcpConnectionResult.calledBefore(managedAgentService.sendToolResult)
+    ).to.equal(true);
+    expect(
+      logger.warn.calledOnceWithExactly(
+        sinon.match.instanceOf(Error),
+        'Failed to record MCP connection result; continuing session resume'
+      )
+    ).to.equal(true);
   });
 });

--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
@@ -55,6 +55,7 @@ import { McpOAuthCallbackCommand, type McpOAuthCallbackResult } from './mcp-oaut
 import { type DcrTokenExchangeOutcome, resolveDcrTokenExchangeOutcome } from './token-exchange-outcome';
 
 const MAX_ERROR_MESSAGE_LEN = 256;
+const MCP_CONNECTION_FAILED_MESSAGE = 'Connection failed. Try again.';
 
 class AlreadyConnectedBailout extends Error {
   readonly status = 'connected' as const;
@@ -863,23 +864,27 @@ export class McpOAuthCallback {
     );
 
     if (stateData.platform === AgentPlatformEnum.WEB_CHAT && stateData.toolUseId && stateData.conversationId) {
-      const conversation = await this.agentConversationService.getConversation(
-        stateData.conversationId,
-        stateData.environmentId,
-        stateData.organizationId
-      );
-      if (conversation) {
-        await this.agentConversationService.persistMcpConnectionResult({
-          conversationId: stateData.conversationId,
-          environmentId: stateData.environmentId,
-          organizationId: stateData.organizationId,
-          agentIdentifier: stateData.agentIdentifier ?? '',
-          channel: this.agentConversationService.getPrimaryChannel(conversation),
-          actionId: stateData.toolUseId,
-          mcpId: stateData.mcpId,
-          status: 'failed',
-          message: error,
-        });
+      try {
+        const conversation = await this.agentConversationService.getConversation(
+          stateData.conversationId,
+          stateData.environmentId,
+          stateData.organizationId
+        );
+        if (conversation) {
+          await this.agentConversationService.persistMcpConnectionResult({
+            conversationId: stateData.conversationId,
+            environmentId: stateData.environmentId,
+            organizationId: stateData.organizationId,
+            agentIdentifier: stateData.agentIdentifier ?? '',
+            channel: this.agentConversationService.getPrimaryChannel(conversation),
+            actionId: stateData.toolUseId,
+            mcpId: stateData.mcpId,
+            status: 'failed',
+            message: MCP_CONNECTION_FAILED_MESSAGE,
+          });
+        }
+      } catch (err) {
+        this.logger.warn(err, 'Failed to record MCP connection failure');
       }
     }
   }

--- a/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
+++ b/apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
@@ -31,6 +31,7 @@ import {
   resolvePersistedMcpTokenEndpointAuthMethod,
 } from '@novu/shared';
 import { areHexDigestsEqual } from '../../../../shared/helpers/timing-safe-equal';
+import { AgentConversationService } from '../../../conversation-runtime/conversation/agent-conversation.service';
 import { OutboundGateway } from '../../../conversation-runtime/egress/outbound.gateway';
 import { ManagedAgentService } from '../../../managed-runtime/managed-agent.service';
 import { trackAgentMcpOAuthCompleted, trackAgentMcpOAuthFailed } from '../../../shared/analytics/agent-analytics';
@@ -104,6 +105,7 @@ export class McpOAuthCallback {
     private readonly discoveryService: McpOAuthDiscoveryService,
     private readonly mcpConnectionVaultService: McpConnectionVaultService,
     private readonly managedAgentService: ManagedAgentService,
+    private readonly agentConversationService: AgentConversationService,
     private readonly outboundGateway: OutboundGateway,
     private readonly getNovuAppCredentials: McpNovuAppCredentialsService,
     private readonly analyticsService: AnalyticsService,
@@ -567,7 +569,31 @@ export class McpOAuthCallback {
       return;
     }
 
-    this.deleteConnectCard(stateData, connection);
+    if (stateData.platform === AgentPlatformEnum.WEB_CHAT && stateData.toolUseId && stateData.conversationId) {
+      try {
+        const conversation = await this.agentConversationService.getConversation(
+          stateData.conversationId,
+          stateData.environmentId,
+          stateData.organizationId
+        );
+        if (conversation) {
+          await this.agentConversationService.persistMcpConnectionResult({
+            conversationId: stateData.conversationId,
+            environmentId: stateData.environmentId,
+            organizationId: stateData.organizationId,
+            agentIdentifier: stateData.agentIdentifier ?? '',
+            channel: this.agentConversationService.getPrimaryChannel(conversation),
+            actionId: stateData.toolUseId,
+            mcpId: stateData.mcpId,
+            status: 'connected',
+          });
+        }
+      } catch (err) {
+        this.logger.warn(err, 'Failed to record MCP connection result; continuing session resume');
+      }
+    } else {
+      this.deleteConnectCard(stateData, connection);
+    }
     this.showTypingIndicator(stateData);
 
     await this.managedAgentService.sendToolResult({
@@ -835,6 +861,27 @@ export class McpOAuthCallback {
         $unset: { oauthState: 1 },
       }
     );
+
+    if (stateData.platform === AgentPlatformEnum.WEB_CHAT && stateData.toolUseId && stateData.conversationId) {
+      const conversation = await this.agentConversationService.getConversation(
+        stateData.conversationId,
+        stateData.environmentId,
+        stateData.organizationId
+      );
+      if (conversation) {
+        await this.agentConversationService.persistMcpConnectionResult({
+          conversationId: stateData.conversationId,
+          environmentId: stateData.environmentId,
+          organizationId: stateData.organizationId,
+          agentIdentifier: stateData.agentIdentifier ?? '',
+          channel: this.agentConversationService.getPrimaryChannel(conversation),
+          actionId: stateData.toolUseId,
+          mcpId: stateData.mcpId,
+          status: 'failed',
+          message: error,
+        });
+      }
+    }
   }
 
   private async handleTokenExchangeErrorOutcome(args: {

--- a/apps/api/src/app/agents/shared/agent-event-sink.service.ts
+++ b/apps/api/src/app/agents/shared/agent-event-sink.service.ts
@@ -203,6 +203,8 @@ export class AgentEventSink {
       case 'source':
       case 'custom':
       case 'tool-approval-response':
+      case 'mcp-connection-request':
+      case 'mcp-connection-result':
       case 'message-start':
       case 'message-end':
         this.logger.debug({ eventType: event.type, runId: envelope.runId }, 'Agent event no-op');

--- a/apps/api/src/app/agents/web-chat/activity-to-events.spec.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.spec.ts
@@ -65,4 +65,55 @@ describe('activity-to-events run lifecycle', () => {
     ]);
     expect(envelopes.every((envelope) => envelope.runId === 'run-1')).to.equal(true);
   });
+
+  it('maps MCP connection activities to protocol events', () => {
+    const envelopes = mapNewestFirstEventActivities(
+      [
+        activity({
+          type: ConversationActivityTypeEnum.MCP_CONNECTION_RESULT,
+          identifier: 'mcp-connection:connect-1:result',
+          sequence: 2,
+          richContent: {
+            mcpConnection: {
+              actionId: 'connect-1',
+              mcpId: 'stripe',
+              status: 'connected',
+            },
+          },
+        }),
+        activity({
+          type: ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST,
+          identifier: 'mcp-connection:connect-1:request',
+          sequence: 1,
+          richContent: {
+            mcpConnection: {
+              actionId: 'connect-1',
+              mcpId: 'stripe',
+              displayName: 'Stripe',
+              authorizeUrl: 'https://example.com/authorize',
+            },
+          },
+        }),
+      ],
+      context
+    );
+
+    expect(envelopes.map((envelope) => envelope.event)).to.deep.equal([
+      {
+        type: 'mcp-connection-request',
+        actionId: 'connect-1',
+        mcpId: 'stripe',
+        displayName: 'Stripe',
+        authorizeUrl: 'https://example.com/authorize',
+        authorizeUrlWithAutoApprove: undefined,
+      },
+      {
+        type: 'mcp-connection-result',
+        actionId: 'connect-1',
+        mcpId: 'stripe',
+        status: 'connected',
+        message: undefined,
+      },
+    ]);
+  });
 });

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -16,6 +16,16 @@ import {
 } from '../conversation-runtime/conversation/run-lifecycle-activity';
 import { mintApprovalActionIds } from '../shared/tool-approval/mint-approval-action-ids';
 
+type McpConnectionActivityData = {
+  actionId?: string;
+  mcpId?: string;
+  displayName?: string;
+  authorizeUrl?: string;
+  authorizeUrlWithAutoApprove?: string;
+  status?: 'connected' | 'failed';
+  message?: string;
+};
+
 function filesFromRichContent(richContent?: Record<string, unknown>) {
   const files = richContent?.files;
   if (!Array.isArray(files) || files.length === 0) {
@@ -93,6 +103,37 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
         type: 'tool-use-result',
         toolUseId: toolData.toolCallId,
         content: [{ type: 'text', text: String(toolData.output ?? activity.content) }],
+      };
+    }
+
+    case ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST: {
+      const data = activity.richContent?.mcpConnection as McpConnectionActivityData | undefined;
+      if (!data?.actionId || !data.mcpId || !data.displayName || !data.authorizeUrl) {
+        return null;
+      }
+
+      return {
+        type: 'mcp-connection-request',
+        actionId: data.actionId,
+        mcpId: data.mcpId,
+        displayName: data.displayName,
+        authorizeUrl: data.authorizeUrl,
+        authorizeUrlWithAutoApprove: data.authorizeUrlWithAutoApprove,
+      };
+    }
+
+    case ConversationActivityTypeEnum.MCP_CONNECTION_RESULT: {
+      const data = activity.richContent?.mcpConnection as McpConnectionActivityData | undefined;
+      if (!data?.actionId || !data.mcpId || !data.status) {
+        return null;
+      }
+
+      return {
+        type: 'mcp-connection-result',
+        actionId: data.actionId,
+        mcpId: data.mcpId,
+        status: data.status,
+        message: data.message,
       };
     }
 

--- a/libs/dal/src/repositories/conversation-activity/activity-views.spec.ts
+++ b/libs/dal/src/repositories/conversation-activity/activity-views.spec.ts
@@ -31,6 +31,8 @@ describe('activity-views', () => {
       'signal.other',
       'tool_approval_request',
       'tool_approval_decision',
+      'mcp_connection_request',
+      'mcp_connection_result',
     ]);
   });
 

--- a/libs/dal/src/repositories/conversation-activity/activity-views.ts
+++ b/libs/dal/src/repositories/conversation-activity/activity-views.ts
@@ -30,6 +30,8 @@ export const ACTIVITY_KINDS = [
   'tool_approval_request',
   'tool_approval_decision',
   'tool_result',
+  'mcp_connection_request',
+  'mcp_connection_result',
   'run_start',
   'run_finish',
   'run_error',
@@ -55,6 +57,8 @@ export const ACTIVITY_VIEW_MEMBERSHIP: Record<ActivityKind, readonly ActivityVie
   tool_approval_request: ['agent_handoff', 'client_events', 'operator_timeline', 'approval_activities'],
   tool_approval_decision: ['agent_handoff', 'client_events', 'operator_timeline', 'approval_activities'],
   tool_result: ['agent_handoff', 'client_events', 'approval_activities'],
+  mcp_connection_request: ['client_events', 'operator_timeline'],
+  mcp_connection_result: ['client_events', 'operator_timeline'],
   run_start: ['client_events'],
   run_finish: ['client_events'],
   run_error: ['client_events'],
@@ -121,6 +125,12 @@ function matchForKind(kind: ActivityKind): FilterQuery<ConversationActivityDBMod
 
     case 'tool_result':
       return { type: ConversationActivityTypeEnum.TOOL_RESULT };
+
+    case 'mcp_connection_request':
+      return { type: ConversationActivityTypeEnum.MCP_CONNECTION_REQUEST };
+
+    case 'mcp_connection_result':
+      return { type: ConversationActivityTypeEnum.MCP_CONNECTION_RESULT };
 
     case 'run_start':
       return { type: ConversationActivityTypeEnum.RUN_START };

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.entity.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.entity.ts
@@ -20,6 +20,10 @@ export enum ConversationActivityTypeEnum {
   TOOL_APPROVAL_DECISION = 'tool_approval_decision',
   /** Outcome of an executed (or denied) tool call. Carries `{ toolCallId, toolName, output }` in `toolData`. */
   TOOL_RESULT = 'tool_result',
+  /** An MCP OAuth connection is required before the agent can continue. */
+  MCP_CONNECTION_REQUEST = 'mcp_connection_request',
+  /** Outcome of a previously requested MCP OAuth connection. */
+  MCP_CONNECTION_RESULT = 'mcp_connection_result',
   /** Agent run began. Client fold sets `isRunning`; excluded from model/bridge history. */
   RUN_START = 'run_start',
   /** Agent run ended (`richContent.lifecycle` holds outcome). Excluded from model/bridge history. */

--- a/packages/agent-event-protocol/src/agent-event.types.ts
+++ b/packages/agent-event-protocol/src/agent-event.types.ts
@@ -96,6 +96,21 @@ export type AgentEvent =
       reason?: string;
       automatic?: boolean;
     }
+  | {
+      type: 'mcp-connection-request';
+      actionId: string;
+      mcpId: string;
+      displayName: string;
+      authorizeUrl: string;
+      authorizeUrlWithAutoApprove?: string;
+    }
+  | {
+      type: 'mcp-connection-result';
+      actionId: string;
+      mcpId: string;
+      status: 'connected' | 'failed';
+      message?: string;
+    }
   // Conversation ops
   | { type: 'resolve'; summary?: string }
   | { type: 'signal'; signal: AgentSignal }

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -3,7 +3,7 @@ import {
   type AgentConversationState,
   type AgentMessage,
   createInitialAgentConversationState,
-  derivePendingApprovals,
+  derivePendingActions,
 } from './agent-message.types';
 import { appendUserMessage, applyEnvelope, applyEnvelopes } from './apply-envelope';
 import type { AgentChatChange, AgentChatChangeSource } from './types';
@@ -28,10 +28,10 @@ export type ConversationEntry = AgentConversationState & {
    */
   olderCursor: string | null;
   /**
-   * Approvals already reported as new. Add-only: an approvalId is never raised twice,
-   * so a resolved approval must not fall out and be reported again.
+   * Actions already reported as new. Add-only: an action id is never raised twice,
+   * so a resolved action must not fall out and be reported again.
    */
-  reportedApprovalIds: Set<string>;
+  reportedActionIds: Set<string>;
   /** One create at a time on this holder until a conversation id exists. */
   pendingCreate?: Promise<void>;
 };
@@ -96,24 +96,22 @@ export class AgentChatStore {
    * leaving each consumer to guess from the snapshot alone.
    */
   #publish(entry: ConversationEntry, source: AgentChatChangeSource, addedMessages: AgentMessage[]): void {
-    const newApprovals = derivePendingApprovals(entry.messages).filter(
-      (approval) => !entry.reportedApprovalIds.has(approval.approvalId)
-    );
-    for (const approval of newApprovals) {
-      entry.reportedApprovalIds.add(approval.approvalId);
+    const newActions = derivePendingActions(entry.messages).filter((action) => !entry.reportedActionIds.has(action.id));
+    for (const action of newActions) {
+      entry.reportedActionIds.add(action.id);
     }
 
-    this.#onUpdate(entry, { ...source, addedMessages, newApprovals });
+    this.#onUpdate(entry, { ...source, addedMessages, newActions });
   }
 
   /**
-   * Mark a backfilled page's approvals as already reported.
+   * Mark a backfilled page's actions as already reported.
    * An older page can carry a request whose response is on a page already folded, which
    * leaves it looking pending. Paging backwards is never new activity.
    */
-  #suppressApprovals(entry: ConversationEntry, messages: AgentMessage[]): void {
-    for (const approval of derivePendingApprovals(messages)) {
-      entry.reportedApprovalIds.add(approval.approvalId);
+  #suppressActions(entry: ConversationEntry, messages: AgentMessage[]): void {
+    for (const action of derivePendingActions(messages)) {
+      entry.reportedActionIds.add(action.id);
     }
   }
 
@@ -177,7 +175,7 @@ export class AgentChatStore {
       conversationId: args.conversationId,
       key: args.key,
       olderCursor: null,
-      reportedApprovalIds: new Set(),
+      reportedActionIds: new Set(),
     };
     this.#byKey.set(args.key, entry);
 
@@ -278,7 +276,7 @@ export class AgentChatStore {
 
     entry.messages = [...olderMessages, ...entry.messages];
     entry.olderCursor = olderCursor;
-    this.#suppressApprovals(entry, olderMessages);
+    this.#suppressActions(entry, olderMessages);
 
     this.#publish(entry, { kind: 'history' }, olderMessages);
 

--- a/packages/js/src/agent-chat/agent-chat-store.ts
+++ b/packages/js/src/agent-chat/agent-chat-store.ts
@@ -8,6 +8,11 @@ import {
 import { appendUserMessage, applyEnvelope, applyEnvelopes } from './apply-envelope';
 import type { AgentChatChange, AgentChatChangeSource } from './types';
 
+type McpConnectionResult = {
+  status: 'connected' | 'failed';
+  message?: string;
+};
+
 /**
  * Stable local identity for one conversation holder.
  * The object reference does not change. Timeline fields are overwritten in place.
@@ -32,6 +37,8 @@ export type ConversationEntry = AgentConversationState & {
    * so a resolved action must not fall out and be reported again.
    */
   reportedActionIds: Set<string>;
+  /** Terminal MCP results retained while history pages load independently. */
+  mcpConnectionResults: Map<string, McpConnectionResult>;
   /** One create at a time on this holder until a conversation id exists. */
   pendingCreate?: Promise<void>;
 };
@@ -115,6 +122,36 @@ export class AgentChatStore {
     }
   }
 
+  #recordMcpConnectionResults(entry: ConversationEntry, envelopes: AgentEventEnvelope[]): void {
+    for (const { event } of envelopes) {
+      if (event.type === 'mcp-connection-result') {
+        entry.mcpConnectionResults.set(event.actionId, {
+          status: event.status,
+          message: event.message,
+        });
+      }
+    }
+  }
+
+  #applyMcpConnectionResults(entry: ConversationEntry, messages: AgentMessage[]): AgentMessage[] {
+    if (entry.mcpConnectionResults.size === 0) {
+      return messages;
+    }
+
+    return messages.map((message) => ({
+      ...message,
+      parts: message.parts.map((part) => {
+        if (part.type !== 'mcp-connection') {
+          return part;
+        }
+
+        const result = entry.mcpConnectionResults.get(part.actionId);
+
+        return result ? { ...part, state: result.status, message: result.message } : part;
+      }),
+    }));
+  }
+
   clear(): void {
     this.#byKey.clear();
   }
@@ -176,6 +213,7 @@ export class AgentChatStore {
       key: args.key,
       olderCursor: null,
       reportedActionIds: new Set(),
+      mcpConnectionResults: new Map(),
     };
     this.#byKey.set(args.key, entry);
 
@@ -246,13 +284,14 @@ export class AgentChatStore {
     olderCursor: string | null
   ): ConversationEntry {
     const previous = entry.messages;
+    this.#recordMcpConnectionResults(entry, envelopes);
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const serverIds = new Set(folded.messages.map((message) => message.id));
     const localOnly = previous.filter((message) => !serverIds.has(message.id));
 
     applyState(entry, {
       ...folded,
-      messages: [...folded.messages, ...localOnly],
+      messages: this.#applyMcpConnectionResults(entry, [...folded.messages, ...localOnly]),
     });
     entry.olderCursor = olderCursor;
 
@@ -270,9 +309,13 @@ export class AgentChatStore {
     envelopes: AgentEventEnvelope[],
     olderCursor: string | null
   ): ConversationEntry {
+    this.#recordMcpConnectionResults(entry, envelopes);
     const folded = applyEnvelopes(createInitialAgentConversationState(), envelopes);
     const existingIds = new Set(entry.messages.map((message) => message.id));
-    const olderMessages = folded.messages.filter((message) => !existingIds.has(message.id));
+    const olderMessages = this.#applyMcpConnectionResults(
+      entry,
+      folded.messages.filter((message) => !existingIds.has(message.id))
+    );
 
     entry.messages = [...olderMessages, ...entry.messages];
     entry.olderCursor = olderCursor;
@@ -293,7 +336,12 @@ export class AgentChatStore {
     }
 
     const previous = entry.messages;
-    applyState(entry, applyEnvelope(entry, envelope));
+    this.#recordMcpConnectionResults(entry, [envelope]);
+    const next = applyEnvelope(entry, envelope);
+    applyState(entry, {
+      ...next,
+      messages: this.#applyMcpConnectionResults(entry, next.messages),
+    });
     this.#publish(entry, { kind: 'live', envelope }, messagesAddedSince(previous, entry.messages));
 
     return entry;

--- a/packages/js/src/agent-chat/agent-chat.test.ts
+++ b/packages/js/src/agent-chat/agent-chat.test.ts
@@ -2,14 +2,14 @@ import { AGENT_EVENT_PROTOCOL_VERSION } from '@novu/agent-event-protocol';
 import { AgentChatPlanLimitError, AgentChatService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { AgentChat } from './agent-chat';
-import { derivePendingApprovals } from './agent-message.types';
+import { derivePendingActions } from './agent-message.types';
 import type { AgentChatChange } from './types';
 
 describe('AgentChat', () => {
   const inboxServiceInstance = { isSessionInitialized: true } as any;
   let emitter: NovuEventEmitter;
   let sendMessage: jest.Mock;
-  let respondToApproval: jest.Mock;
+  let respondToAction: jest.Mock;
   let getEvents: jest.Mock;
   let connect: jest.Mock;
   let agentChat: AgentChat;
@@ -17,10 +17,10 @@ describe('AgentChat', () => {
   beforeEach(() => {
     emitter = new NovuEventEmitter();
     sendMessage = jest.fn();
-    respondToApproval = jest.fn();
+    respondToAction = jest.fn();
     getEvents = jest.fn();
     connect = jest.fn().mockResolvedValue({ data: undefined });
-    const agentChatService = { sendMessage, respondToApproval, getEvents } as unknown as AgentChatService;
+    const agentChatService = { sendMessage, respondToAction, getEvents } as unknown as AgentChatService;
     agentChat = new AgentChat({
       inboxServiceInstance,
       eventEmitterInstance: emitter,
@@ -1364,23 +1364,23 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    expect(derivePendingApprovals(snapshot?.messages ?? [])).toEqual([
+    expect(derivePendingActions(snapshot?.messages ?? [])).toEqual([
       {
-        type: 'approval',
+        type: 'tool-approval',
+        id: 'approval_000001',
         approvalId: 'approval_000001',
         toolUseId: 'tu_0000001',
         toolName: 'deleteOrder',
         input: { orderId: '123' },
-        state: 'pending',
         approveActionId: 'tool-approval:approve:approval_000001',
         denyActionId: 'tool-approval:deny:approval_000001',
       },
     ]);
   });
 
-  it('respondToApproval POSTs echoed actionId and does not flip pending state optimistically', async () => {
+  it('respondToAction POSTs echoed actionId and does not flip pending state optimistically', async () => {
     getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
-    respondToApproval.mockResolvedValue({
+    respondToAction.mockResolvedValue({
       identifier: 'conv_abcdefghijkl',
     });
 
@@ -1389,17 +1389,17 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    const result = await agentChat.respondToApproval({
+    const result = await agentChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      approvalId: 'approval_000001',
+      actionId: 'approval_000001',
       decision: 'approved',
     });
 
     expect(result).toEqual({
       data: { conversationId: 'conv_abcdefghijkl' },
     });
-    expect(respondToApproval).toHaveBeenCalledWith({
+    expect(respondToAction).toHaveBeenCalledWith({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
       actionId: 'tool-approval:approve:approval_000001',
@@ -1409,12 +1409,12 @@ describe('AgentChat', () => {
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(derivePendingApprovals(snapshot?.messages ?? [])[0]?.state).toBe('pending');
+    expect(derivePendingActions(snapshot?.messages ?? [])[0]?.type).toBe('tool-approval');
   });
 
-  it('respondToApproval resolves pending state only after tool-approval-response envelope', async () => {
+  it('respondToAction resolves pending state only after tool-approval-response envelope', async () => {
     getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
-    respondToApproval.mockResolvedValue({
+    respondToAction.mockResolvedValue({
       identifier: 'conv_abcdefghijkl',
     });
 
@@ -1423,10 +1423,10 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    await agentChat.respondToApproval({
+    await agentChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      approvalId: 'approval_000001',
+      actionId: 'approval_000001',
       decision: 'approved',
     });
 
@@ -1452,14 +1452,14 @@ describe('AgentChat', () => {
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
     });
-    expect(derivePendingApprovals(snapshot?.messages ?? [])).toEqual([]);
+    expect(derivePendingActions(snapshot?.messages ?? [])).toEqual([]);
     expect(snapshot?.messages[0]?.parts.find((part) => part.type === 'approval')).toMatchObject({
       approvalId: 'approval_000001',
       state: 'approved',
     });
   });
 
-  it('respondToApproval returns error without POST when pending approval is missing', async () => {
+  it('respondToAction returns error without POST when pending approval is missing', async () => {
     getEvents.mockResolvedValue(approvalHistoryPage('approval_000001'));
 
     await agentChat.loadConversation({
@@ -1467,18 +1467,18 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    const result = await agentChat.respondToApproval({
+    const result = await agentChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      approvalId: 'approval_missing',
+      actionId: 'approval_missing',
       decision: 'denied',
     });
 
     expect(result.error).toBeDefined();
-    expect(respondToApproval).not.toHaveBeenCalled();
+    expect(respondToAction).not.toHaveBeenCalled();
   });
 
-  it('respondToApproval returns error without POST when pending approval lacks action id', async () => {
+  it('respondToAction returns error without POST when pending approval lacks action id', async () => {
     const page = approvalHistoryPage('approval_000001');
     const requestEvent = page.events[2]?.event as {
       type: 'tool-approval-request';
@@ -1494,15 +1494,15 @@ describe('AgentChat', () => {
       conversationId: 'conv_abcdefghijkl',
     });
 
-    const result = await agentChat.respondToApproval({
+    const result = await agentChat.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
-      approvalId: 'approval_000001',
+      actionId: 'approval_000001',
       decision: 'denied',
     });
 
     expect(result.error).toBeDefined();
-    expect(respondToApproval).not.toHaveBeenCalled();
+    expect(respondToAction).not.toHaveBeenCalled();
   });
 
   function recordChanges(key: string) {
@@ -1633,8 +1633,8 @@ describe('AgentChat', () => {
     await agentChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
     await agentChat.loadConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
 
-    expect(changes[0]?.newApprovals.map((approval) => approval.approvalId)).toEqual(['approval_000001']);
-    expect(changes[1]?.newApprovals).toEqual([]);
+    expect(changes[0]?.newActions.map((action) => action.id)).toEqual(['approval_000001']);
+    expect(changes[1]?.newActions).toEqual([]);
   });
 
   it('reports a live approval on the fold that raises it, adding no message', async () => {
@@ -1661,10 +1661,10 @@ describe('AgentChat', () => {
       })
     );
 
-    expect(changes[0]?.newApprovals).toEqual([]);
+    expect(changes[0]?.newActions).toEqual([]);
     expect(changes[1]?.kind).toBe('live');
     expect(changes[1]?.addedMessages).toEqual([]);
-    expect(changes[1]?.newApprovals.map((approval) => approval.approvalId)).toEqual(['approval_000001']);
+    expect(changes[1]?.newActions.map((action) => action.id)).toEqual(['approval_000001']);
   });
 
   it('stays silent for an approval discovered by paging backwards', async () => {
@@ -1678,10 +1678,8 @@ describe('AgentChat', () => {
     await agentChat.fetchMore({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
 
     const snapshot = agentChat.getConversation({ agentId: 'agent_1', conversationId: 'conv_abcdefghijkl' });
-    expect(derivePendingApprovals(snapshot?.messages ?? []).map((approval) => approval.approvalId)).toEqual([
-      'approval_000001',
-    ]);
+    expect(derivePendingActions(snapshot?.messages ?? []).map((action) => action.id)).toEqual(['approval_000001']);
     expect(changes[0]?.kind).toBe('history');
-    expect(changes[0]?.newApprovals).toEqual([]);
+    expect(changes[0]?.newActions).toEqual([]);
   });
 });

--- a/packages/js/src/agent-chat/agent-chat.ts
+++ b/packages/js/src/agent-chat/agent-chat.ts
@@ -6,14 +6,14 @@ import type { Result } from '../types';
 import { NovuError } from '../utils/errors';
 import type { BaseSocketInterface } from '../ws/base-socket';
 import { AgentChatStore, type ConversationEntry, createLocalConversationKey } from './agent-chat-store';
-import { type AgentMessage, derivePendingApprovals } from './agent-message.types';
+import { type AgentMessage, derivePendingActions } from './agent-message.types';
 import type {
   FetchMoreArgs,
   FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
-  RespondToApprovalArgs,
-  RespondToApprovalResult,
+  RespondToActionArgs,
+  RespondToActionResult,
   SendMessageArgs,
   SendMessageResult,
 } from './types';
@@ -127,23 +127,21 @@ export class AgentChat extends BaseModule {
     };
   }
 
-  async respondToApproval(
-    args: RespondToApprovalArgs
-  ): Result<RespondToApprovalResult, NovuError | AgentChatPlanLimitError> {
-    return this.callWithSession<RespondToApprovalResult, NovuError | AgentChatPlanLimitError>(async () => {
+  async respondToAction(args: RespondToActionArgs): Result<RespondToActionResult, NovuError | AgentChatPlanLimitError> {
+    return this.callWithSession<RespondToActionResult, NovuError | AgentChatPlanLimitError>(async () => {
       const entry = this.#resolveFetchEntry(args);
       if (!entry?.conversationId) {
         return {
           error: new NovuError(
-            'Cannot respond to approval without a conversation id',
+            'Cannot respond to action without a conversation id',
             new Error('missing conversation id')
           ),
         };
       }
 
-      const pending = derivePendingApprovals(entry.messages).find((part) => part.approvalId === args.approvalId);
-      if (!pending) {
-        return { error: new NovuError('Pending approval not found', new Error('pending approval not found')) };
+      const pending = derivePendingActions(entry.messages).find((action) => action.id === args.actionId);
+      if (!pending || pending.type !== 'tool-approval') {
+        return { error: new NovuError('Pending action not found', new Error('pending action not found')) };
       }
 
       const actionId = args.decision === 'approved' ? pending.approveActionId : pending.denyActionId;
@@ -157,7 +155,7 @@ export class AgentChat extends BaseModule {
       }
 
       try {
-        const data = await this.#agentChatService.respondToApproval({
+        const data = await this.#agentChatService.respondToAction({
           agentId: args.agentId,
           conversationId: entry.conversationId,
           actionId,
@@ -174,7 +172,7 @@ export class AgentChat extends BaseModule {
           return { error };
         }
 
-        return { error: new NovuError('Failed to respond to approval', error) };
+        return { error: new NovuError('Failed to respond to action', error) };
       }
     });
   }

--- a/packages/js/src/agent-chat/agent-message.types.ts
+++ b/packages/js/src/agent-chat/agent-message.types.ts
@@ -9,6 +9,7 @@ export type AgentTextPartState = 'streaming' | 'done';
 export type AgentToolPartState = 'input-streaming' | 'input-available' | 'output-available' | 'output-error';
 
 export type AgentApprovalPartState = 'pending' | 'approved' | 'denied';
+export type AgentMcpConnectionPartState = 'pending' | 'connected' | 'failed';
 
 export type AgentTextPart = {
   type: 'text';
@@ -41,11 +42,33 @@ export type AgentApprovalPart = {
   input?: Record<string, unknown>;
   source?: AgentToolSource;
   state: AgentApprovalPartState;
-  /** Server-minted; echo via respondToApproval. Do not invent client-side. */
+  /** Server-minted; echo via respondToAction. Do not invent client-side. */
   approveActionId?: string;
-  /** Server-minted; echo via respondToApproval. Do not invent client-side. */
+  /** Server-minted; echo via respondToAction. Do not invent client-side. */
   denyActionId?: string;
 };
+
+export type AgentMcpConnectionPart = {
+  type: 'mcp-connection';
+  actionId: string;
+  mcpId: string;
+  displayName: string;
+  authorizeUrl: string;
+  authorizeUrlWithAutoApprove?: string;
+  state: AgentMcpConnectionPartState;
+  message?: string;
+};
+
+export type AgentToolApprovalAction = Omit<AgentApprovalPart, 'type' | 'state'> & {
+  type: 'tool-approval';
+  id: string;
+};
+
+export type AgentMcpConnectionAction = Omit<AgentMcpConnectionPart, 'state' | 'message'> & {
+  id: string;
+};
+
+export type AgentPendingAction = AgentToolApprovalAction | AgentMcpConnectionAction;
 
 export type AgentSourcePart = {
   type: 'source';
@@ -72,6 +95,7 @@ export type AgentMessagePart =
   | AgentThinkingPart
   | AgentToolPart
   | AgentApprovalPart
+  | AgentMcpConnectionPart
   | AgentSourcePart
   | AgentFilePart
   | AgentCardPart;
@@ -120,13 +144,25 @@ export function createInitialAgentConversationState(): AgentConversationState {
   };
 }
 
-export function derivePendingApprovals(messages: AgentMessage[]): AgentApprovalPart[] {
-  const pending: AgentApprovalPart[] = [];
+export function derivePendingActions(messages: AgentMessage[]): AgentPendingAction[] {
+  const pending: AgentPendingAction[] = [];
 
   for (const message of messages) {
     for (const part of message.parts) {
       if (part.type === 'approval' && part.state === 'pending') {
-        pending.push(part);
+        const { state: _state, ...action } = part;
+        pending.push({
+          ...action,
+          type: 'tool-approval',
+          id: part.approvalId,
+        });
+      }
+      if (part.type === 'mcp-connection' && part.state === 'pending') {
+        const { state: _state, message: _message, ...action } = part;
+        pending.push({
+          ...action,
+          id: part.actionId,
+        });
       }
     }
   }

--- a/packages/js/src/agent-chat/apply-envelope.test.ts
+++ b/packages/js/src/agent-chat/apply-envelope.test.ts
@@ -205,6 +205,34 @@ describe('applyEnvelope', () => {
     expect(approval).toMatchObject({ type: 'approval', approvalId: 'a1', state: 'approved' });
   });
 
+  it('folds MCP connection requests and results into one action part', () => {
+    const state = applyEnvelopes(createInitialAgentConversationState(), [
+      envelope(1, { type: 'message-start', messageId: 'm1' }),
+      envelope(2, {
+        type: 'mcp-connection-request',
+        actionId: 'connect-1',
+        mcpId: 'stripe',
+        displayName: 'Stripe',
+        authorizeUrl: 'https://example.com/authorize',
+      }),
+      envelope(3, {
+        type: 'mcp-connection-result',
+        actionId: 'connect-1',
+        mcpId: 'stripe',
+        status: 'connected',
+      }),
+    ]);
+
+    expect(state.messages[0]?.parts).toContainEqual({
+      type: 'mcp-connection',
+      actionId: 'connect-1',
+      mcpId: 'stripe',
+      displayName: 'Stripe',
+      authorizeUrl: 'https://example.com/authorize',
+      state: 'connected',
+    });
+  });
+
   it('folds durable user messages when role is user', () => {
     const state = applyEnvelopes(createInitialAgentConversationState(), [
       envelope(1, {

--- a/packages/js/src/agent-chat/apply-envelope.ts
+++ b/packages/js/src/agent-chat/apply-envelope.ts
@@ -155,6 +155,28 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
     case 'tool-approval-response':
       return applyApprovalResponse(state, event.approvalId, event.decision);
 
+    case 'mcp-connection-request':
+      return clearTyping(
+        withActiveAssistantMessage(state, envelope, (message) => ({
+          ...message,
+          parts: [
+            ...message.parts,
+            {
+              type: 'mcp-connection',
+              actionId: event.actionId,
+              mcpId: event.mcpId,
+              displayName: event.displayName,
+              authorizeUrl: event.authorizeUrl,
+              authorizeUrlWithAutoApprove: event.authorizeUrlWithAutoApprove,
+              state: 'pending',
+            },
+          ],
+        }))
+      );
+
+    case 'mcp-connection-result':
+      return applyMcpConnectionResult(state, event.actionId, event.status, event.message);
+
     case 'source':
       return withAssistantMessage(state, envelope, event.messageId, (message) => ({
         ...message,
@@ -509,6 +531,23 @@ function applyApprovalResponse(
       ...message,
       parts: message.parts.map((part) =>
         part.type === 'approval' && part.approvalId === approvalId ? { ...part, state: nextState } : part
+      ),
+    })),
+  };
+}
+
+function applyMcpConnectionResult(
+  state: AgentConversationState,
+  actionId: string,
+  status: 'connected' | 'failed',
+  message?: string
+): AgentConversationState {
+  return {
+    ...state,
+    messages: state.messages.map((item) => ({
+      ...item,
+      parts: item.parts.map((part) =>
+        part.type === 'mcp-connection' && part.actionId === actionId ? { ...part, state: status, message } : part
       ),
     })),
   };

--- a/packages/js/src/agent-chat/index.ts
+++ b/packages/js/src/agent-chat/index.ts
@@ -1,20 +1,23 @@
 export { AgentChat } from './agent-chat';
-export { derivePendingApprovals } from './agent-message.types';
+export { derivePendingActions } from './agent-message.types';
 export type {
-  AgentApprovalPart,
   AgentChatChange,
   AgentChatMessagesUpdated,
   AgentConversationStatus,
   AgentConversationTyping,
   AgentEventEnvelope,
   AgentHashFields,
+  AgentMcpConnectionAction,
+  AgentMcpConnectionPart,
   AgentMessage,
+  AgentPendingAction,
+  AgentToolApprovalAction,
   FetchMoreArgs,
   FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
-  RespondToApprovalArgs,
-  RespondToApprovalResult,
+  RespondToActionArgs,
+  RespondToActionResult,
   SendMessageArgs,
   SendMessageResult,
 } from './types';

--- a/packages/js/src/agent-chat/types.ts
+++ b/packages/js/src/agent-chat/types.ts
@@ -1,12 +1,24 @@
 import type { AgentEventEnvelope } from '@novu/agent-event-protocol';
 import type {
-  AgentApprovalPart,
   AgentConversationStatus,
   AgentConversationTyping,
+  AgentMcpConnectionAction,
+  AgentMcpConnectionPart,
   AgentMessage,
+  AgentPendingAction,
+  AgentToolApprovalAction,
 } from './agent-message.types';
 
-export type { AgentApprovalPart, AgentConversationStatus, AgentConversationTyping, AgentEventEnvelope, AgentMessage };
+export type {
+  AgentConversationStatus,
+  AgentConversationTyping,
+  AgentEventEnvelope,
+  AgentMcpConnectionAction,
+  AgentMcpConnectionPart,
+  AgentMessage,
+  AgentPendingAction,
+  AgentToolApprovalAction,
+};
 
 /**
  * HMAC-SHA256(env secret, agentId) hex. Required when the env's `novu-web-chat`
@@ -59,15 +71,15 @@ export type FetchMoreResult = {
   hasMore: boolean;
 };
 
-export type RespondToApprovalArgs = AgentHashFields & {
+export type RespondToActionArgs = AgentHashFields & {
   agentId: string;
-  approvalId: string;
+  actionId: string;
   decision: 'approved' | 'denied';
   conversationId?: string;
   key?: string;
 };
 
-export type RespondToApprovalResult = {
+export type RespondToActionResult = {
   conversationId: string;
 };
 
@@ -84,8 +96,8 @@ export type AgentChatChangeSource =
 export type AgentChatChange = AgentChatChangeSource & {
   /** Messages this fold added. A fold that only changes existing messages adds none. */
   addedMessages: AgentMessage[];
-  /** Approvals that became pending in this fold. One approval is reported one time. */
-  newApprovals: AgentApprovalPart[];
+  /** Actions that became pending in this fold. One action is reported one time. */
+  newActions: AgentPendingAction[];
 };
 
 export type AgentChatMessagesUpdated = {

--- a/packages/js/src/api/agent-chat-service.test.ts
+++ b/packages/js/src/api/agent-chat-service.test.ts
@@ -146,7 +146,7 @@ describe('AgentChatService', () => {
     httpClient.setAuthorizationToken('test-token');
     const service = new AgentChatService({ httpClient });
 
-    const result = await service.respondToApproval({
+    const result = await service.respondToAction({
       agentId: 'agent_1',
       conversationId: 'conv_abcdefghijkl',
       actionId: 'tool-approval:approve:approval_000001',

--- a/packages/js/src/api/agent-chat-service.ts
+++ b/packages/js/src/api/agent-chat-service.ts
@@ -42,14 +42,14 @@ export type AgentChatGetEventsResponse = {
   olderCursor: string | null;
 };
 
-export type AgentChatRespondToApprovalArgs = AgentHashFields & {
+export type AgentChatRespondToActionArgs = AgentHashFields & {
   agentId: string;
   conversationId: string;
   /** Server-minted approve/deny action id echoed from the pending approval part. */
   actionId: string;
 };
 
-export type AgentChatRespondToApprovalResponse = {
+export type AgentChatRespondToActionResponse = {
   identifier: string;
 };
 
@@ -69,7 +69,7 @@ export class AgentChatService {
     });
   }
 
-  async respondToApproval(args: AgentChatRespondToApprovalArgs): Promise<AgentChatRespondToApprovalResponse> {
+  async respondToAction(args: AgentChatRespondToActionArgs): Promise<AgentChatRespondToActionResponse> {
     return this.#postAccept({
       agentId: args.agentId,
       conversationIdentifier: args.conversationId,
@@ -78,7 +78,7 @@ export class AgentChatService {
     });
   }
 
-  async #postAccept<T extends AgentChatSendMessageResponse | AgentChatRespondToApprovalResponse>(
+  async #postAccept<T extends AgentChatSendMessageResponse | AgentChatRespondToActionResponse>(
     body: Record<string, string>
   ): Promise<T> {
     try {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,22 +1,25 @@
 export type * from 'json-logic-js';
 export type {
-  AgentApprovalPart,
   AgentChatChange,
   AgentConversationStatus,
   AgentConversationTyping,
   AgentEventEnvelope,
   AgentHashFields,
+  AgentMcpConnectionAction,
+  AgentMcpConnectionPart,
   AgentMessage,
+  AgentPendingAction,
+  AgentToolApprovalAction,
   FetchMoreArgs,
   FetchMoreResult,
   LoadConversationArgs,
   LoadConversationResult,
-  RespondToApprovalArgs,
-  RespondToApprovalResult,
+  RespondToActionArgs,
+  RespondToActionResult,
   SendMessageArgs,
   SendMessageResult,
 } from './agent-chat';
-export { derivePendingApprovals } from './agent-chat';
+export { derivePendingActions } from './agent-chat';
 export type { AgentChatPlanLimitReason } from './api/agent-chat-service';
 export { AgentChatPlanLimitError } from './api/agent-chat-service';
 export type {

--- a/packages/react/src/hooks/useAgentChat.ts
+++ b/packages/react/src/hooks/useAgentChat.ts
@@ -1,17 +1,17 @@
 import type {
-  AgentApprovalPart,
   AgentChatPlanLimitError,
   AgentConversationStatus,
   AgentConversationTyping,
   AgentEventEnvelope,
   AgentHashFields,
   AgentMessage,
+  AgentPendingAction,
   LoadConversationResult,
   NovuError,
-  RespondToApprovalResult,
+  RespondToActionResult,
   SendMessageResult,
 } from '@novu/js';
-import { derivePendingApprovals } from '@novu/js';
+import { derivePendingActions } from '@novu/js';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useNovu } from './NovuProvider';
@@ -35,11 +35,10 @@ export type UseAgentChatProps = AgentHashFields & {
    */
   onMessage?: (message: AgentMessage) => void;
   /**
-   * Fires once per approval request, including approvals still pending on mount, so a
+   * Fires once per pending action, including actions still pending on mount, so a
    * resumed conversation reports what it is blocked on. Paging backwards is silent.
-   * The run waits until `respondToApproval` answers.
    */
-  onApprovalRequested?: (approval: AgentApprovalPart) => void;
+  onActionRequested?: (action: AgentPendingAction) => void;
   /**
    * Raw envelopes for this conversation, before the derived callbacks for the same fold.
    * A duplicate envelope that the store drops does not fire. Neither does an envelope that
@@ -51,7 +50,7 @@ export type UseAgentChatProps = AgentHashFields & {
 
 export type UseAgentChatResult = {
   messages: AgentMessage[];
-  pendingApprovals: AgentApprovalPart[];
+  pendingActions: AgentPendingAction[];
   conversationId?: string;
   error?: NovuError | AgentChatPlanLimitError;
   /** True until the first history fetch completes. False when there is no `conversationId` prop. */
@@ -71,8 +70,8 @@ export type UseAgentChatResult = {
     data?: SendMessageResult;
     error?: NovuError | AgentChatPlanLimitError;
   }>;
-  respondToApproval: (args: { approvalId: string; decision: 'approved' | 'denied' }) => Promise<{
-    data?: RespondToApprovalResult;
+  respondToAction: (args: { actionId: string; decision: 'approved' | 'denied' }) => Promise<{
+    data?: RespondToActionResult;
     error?: NovuError | AgentChatPlanLimitError;
   }>;
 };
@@ -152,7 +151,7 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
   const [isFetching, setIsFetching] = useState(false);
   const fetchGenerationRef = useRef(0);
 
-  const pendingApprovals = useMemo(() => derivePendingApprovals(messages), [messages]);
+  const pendingActions = useMemo(() => derivePendingActions(messages), [messages]);
 
   const snapshotSetters = useMemo(
     () => ({
@@ -249,10 +248,10 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         setAssignedConversationId(snapshot.conversationId);
       }
 
-      // The store reports each approval once per holder, and a holder outlives a mount.
+      // The store reports each action once per holder, and a holder outlives a mount.
       // Replay from the snapshot so a remount still learns what the run is blocked on.
-      for (const approval of derivePendingApprovals(snapshot.messages)) {
-        propsRef.current.onApprovalRequested?.(approval);
+      for (const action of derivePendingActions(snapshot.messages)) {
+        propsRef.current.onActionRequested?.(action);
       }
     } else if (!conversationIdProp) {
       applyConversationSnapshot(EMPTY_CONVERSATION, snapshotSetters);
@@ -288,8 +287,8 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
         }
       }
 
-      for (const approval of change.newApprovals) {
-        propsRef.current.onApprovalRequested?.(approval);
+      for (const action of change.newActions) {
+        propsRef.current.onActionRequested?.(action);
       }
     });
 
@@ -354,16 +353,16 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
     [novu, agentId, agentHash, sessionKeyRef, conversationIdRef, propsRef]
   );
 
-  const respondToApproval = useCallback(
-    async (args: { approvalId: string; decision: 'approved' | 'denied' }) => {
+  const respondToAction = useCallback(
+    async (args: { actionId: string; decision: 'approved' | 'denied' }) => {
       setError(undefined);
 
-      const response = await novu.agentChat.respondToApproval({
+      const response = await novu.agentChat.respondToAction({
         agentId,
         agentHash,
         key: sessionKeyRef.current,
         conversationId: conversationIdRef.current,
-        approvalId: args.approvalId,
+        actionId: args.actionId,
         decision: args.decision,
       });
 
@@ -379,9 +378,9 @@ export const useAgentChat = (props: UseAgentChatProps): UseAgentChatResult => {
 
   return {
     messages,
-    pendingApprovals,
+    pendingActions,
     sendMessage,
-    respondToApproval,
+    respondToAction,
     conversationId,
     error,
     isLoading,

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -80,7 +80,7 @@ export function useNovu() {
 export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
   return {
     messages: [],
-    pendingApprovals: [],
+    pendingActions: [],
     isLoading: false,
     isFetching: false,
     isRunning: false,
@@ -90,7 +90,7 @@ export function useAgentChat(_: UseAgentChatProps): UseAgentChatResult {
     refetch: () => Promise.resolve(),
     fetchMore: () => Promise.resolve({ data: undefined, error: undefined }),
     sendMessage: () => Promise.resolve({ data: undefined, error: undefined }),
-    respondToApproval: () => Promise.resolve({ data: undefined, error: undefined }),
+    respondToAction: () => Promise.resolve({ data: undefined, error: undefined }),
   };
 }
 


### PR DESCRIPTION
## Summary

- emit durable `mcp-connection-request` and `mcp-connection-result` events for web chat while preserving existing channel cards
- fold connection events into SDK message parts and expose approvals and connections through `pendingActions`
- report OAuth completion to clients and resume the parked run automatically, even if result recording fails

## Research and design

- use connect-specific events because OAuth navigation and completion differ from tool approval decisions
- treat the OAuth callback as the authoritative connection result
- keep the parked run in the managed runtime and resume it after OAuth completion
- keep Slack, WhatsApp, and other channel card delivery unchanged

```mermaid
sequenceDiagram
    participant Runtime
    participant API
    participant Client
    participant OAuth

    Runtime->>API: request_connect tool call
    API->>API: Persist MCP connection request
    API->>Client: mcp-connection-request
    Client->>OAuth: Open authorizeUrl
    OAuth->>API: OAuth callback
    API->>API: Persist MCP connection result
    API->>Client: mcp-connection-result
    API->>Runtime: Resolve parked tool call
    Runtime->>Runtime: Resume original run
```

## Breaking changes

Agent Chat is unreleased, so this change replaces the approval-only API without compatibility aliases:

- `pendingApprovals` → `pendingActions`
- `respondToApproval` → `respondToAction`
- `onApprovalRequested` → `onActionRequested`

## Test plan

- [x] API focused tests: 20 passed
- [x] `@novu/js` focused tests: 69 passed
- [x] DAL activity-view tests: 6 passed
- [x] Full `pnpm build`
- [x] Manual web-chat OAuth flow, refresh hydration, completion, and automatic resume

## Notes

The untracked `playground/agent-chat` application is intentionally excluded. It will land in a separate PR.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds durable MCP connection request/result events for web chat and folds them into the JavaScript and React agent-chat APIs.
- Persists and publishes MCP OAuth connection lifecycle activities.
- Resumes managed runs after successful OAuth even when client-event recording fails.
- Replaces approval-only SDK APIs with generalized pending-action APIs.
- Retains terminal connection results across independently loaded history pages.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/js/src/agent-chat/agent-chat-store.ts | Retains terminal MCP results and reapplies them when connection requests are loaded from another history page, addressing the previously reported pagination issue. |
| apps/api/src/app/agents/mcp/oauth/mcp-oauth-callback/mcp-oauth-callback.usecase.ts | Records web-chat connection outcomes and catches result-recording failures so they no longer replace OAuth responses or prevent successful run resumption. |
| apps/api/src/app/agents/conversation-runtime/conversation/agent-conversation.service.ts | Adds durable, sequenced MCP request/result activity persistence and web-chat publication. |
| packages/js/src/agent-chat/apply-envelope.ts | Folds MCP request and result envelopes into a single connection message part. |
| packages/js/src/agent-chat/agent-message.types.ts | Generalizes pending approvals into typed pending actions that include MCP connections. |
| apps/api/src/app/agents/web-chat/activity-to-events.ts | Maps stored MCP connection activities into the shared client event protocol. |
| libs/dal/src/repositories/conversation-activity/activity-views.ts | Adds MCP connection activities to the client-events and operator-timeline read models. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Runtime
  participant API
  participant Client
  participant OAuth
  Runtime->>API: request_connect
  API->>API: Persist connection request
  API-->>Client: mcp-connection-request
  Client->>OAuth: Open authorization URL
  OAuth->>API: OAuth callback
  API->>API: Persist connection result
  API-->>Client: mcp-connection-result
  API->>Runtime: Resolve parked tool call
  Runtime->>Runtime: Resume original run
```

<sub>Reviews (2): Last reviewed commit: ["fix(api-service,js): handle MCP result e..."](https://github.com/novuhq/novu/commit/e61a0d963c3179e03caf951663966cb762280533) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52540713)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)
- Knowledge Base — [DAL and Data Model](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dal-and-data-model.md)
</details>

<!-- /greptile_comment -->