### PR TITLE
fix(api-service,js): preserve approval history positions fixes NV-8585

### DIFF
--- a/apps/api/src/app/agents/web-chat/activity-to-events.spec.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.spec.ts
@@ -116,4 +116,39 @@ describe('activity-to-events run lifecycle', () => {
       },
     ]);
   });
+
+  it('uses immutable activity ids for approval request messages', () => {
+    const envelopes = mapNewestFirstEventActivities(
+      [
+        activity({
+          type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
+          identifier: 'approval-activity-2',
+          platformMessageId: 'platform-message-2',
+          sequence: 2,
+          toolData: {
+            approvalId: 'approval-2',
+            toolCallId: 'tool-use-2',
+            toolName: 'secondTool',
+          },
+        }),
+        activity({
+          type: ConversationActivityTypeEnum.TOOL_APPROVAL_REQUEST,
+          identifier: 'approval-activity-1',
+          sequence: 1,
+          toolData: {
+            approvalId: 'approval-1',
+            toolCallId: 'tool-use-1',
+            toolName: 'firstTool',
+          },
+        }),
+      ],
+      context
+    );
+
+    expect(
+      envelopes.map((envelope) =>
+        envelope.event.type === 'tool-approval-request' ? envelope.event.messageId : undefined
+      )
+    ).to.deep.equal(['approval-activity-1', 'approval-activity-2']);
+  });
 });

--- a/apps/api/src/app/agents/web-chat/activity-to-events.ts
+++ b/apps/api/src/app/agents/web-chat/activity-to-events.ts
@@ -71,6 +71,7 @@ function mapActivityToEvent(activity: ConversationActivityEntity): AgentEvent | 
 
       return {
         type: 'tool-approval-request',
+        messageId: activity.identifier,
         approvalId: toolData.approvalId,
         toolUseId: toolData.toolCallId,
         toolName: toolData.toolName,

--- a/packages/agent-event-protocol/src/agent-event.types.ts
+++ b/packages/agent-event-protocol/src/agent-event.types.ts
@@ -86,6 +86,8 @@ export type AgentEvent =
   | { type: 'tool-use-result'; toolUseId: string; content: AgentToolResultContent[]; isError?: boolean }
   | ({
       type: 'tool-approval-request';
+      /** Stable assistant message id used to preserve the approval's timeline position during history replay. */
+      messageId?: string;
       /** When true, no companion message carries the approval UI. The consumer should render its default approval card. */
       deliverCard?: boolean;
     } & AgentApprovalRequest)

--- a/packages/js/src/agent-chat/apply-envelope.test.ts
+++ b/packages/js/src/agent-chat/apply-envelope.test.ts
@@ -205,6 +205,38 @@ describe('applyEnvelope', () => {
     expect(approval).toMatchObject({ type: 'approval', approvalId: 'a1', state: 'approved' });
   });
 
+  it('keeps replayed approval requests in their protocol message positions', () => {
+    const state = applyEnvelopes(createInitialAgentConversationState(), [
+      envelope(1, {
+        type: 'tool-approval-request',
+        messageId: 'approval-message-1',
+        approvalId: 'a1',
+        toolUseId: 'tu1',
+        toolName: 'firstTool',
+      }),
+      envelope(2, { type: 'run-finish', outcome: 'paused' }),
+      envelope(3, {
+        type: 'message',
+        role: 'user',
+        messageId: 'user-message-2',
+        content: { markdown: 'Continue' },
+      }),
+      envelope(4, {
+        type: 'tool-approval-request',
+        messageId: 'approval-message-2',
+        approvalId: 'a2',
+        toolUseId: 'tu2',
+        toolName: 'secondTool',
+      }),
+    ]);
+
+    expect(state.messages.map((message) => message.id)).toEqual([
+      'approval-message-1',
+      'user-message-2',
+      'approval-message-2',
+    ]);
+  });
+
   it('folds MCP connection requests and results into one action part', () => {
     const state = applyEnvelopes(createInitialAgentConversationState(), [
       envelope(1, { type: 'message-start', messageId: 'm1' }),

--- a/packages/js/src/agent-chat/apply-envelope.ts
+++ b/packages/js/src/agent-chat/apply-envelope.ts
@@ -131,26 +131,30 @@ function applyEvent(state: AgentConversationState, envelope: AgentEventEnvelope)
         parts: applyToolResult(message.parts, event.toolUseId, event.content, event.isError),
       }));
 
-    case 'tool-approval-request':
-      return clearTyping(
-        withActiveAssistantMessage(state, envelope, (message) => ({
-          ...message,
-          parts: [
-            ...message.parts,
-            {
-              type: 'approval',
-              approvalId: event.approvalId,
-              toolUseId: event.toolUseId,
-              toolName: event.toolName,
-              input: event.input,
-              source: event.source,
-              approveActionId: event.approveActionId,
-              denyActionId: event.denyActionId,
-              state: 'pending',
-            },
-          ],
-        }))
-      );
+    case 'tool-approval-request': {
+      const addApproval = (message: AgentMessage): AgentMessage => ({
+        ...message,
+        parts: [
+          ...message.parts,
+          {
+            type: 'approval',
+            approvalId: event.approvalId,
+            toolUseId: event.toolUseId,
+            toolName: event.toolName,
+            input: event.input,
+            source: event.source,
+            approveActionId: event.approveActionId,
+            denyActionId: event.denyActionId,
+            state: 'pending',
+          },
+        ],
+      });
+      const nextState = event.messageId
+        ? withAssistantMessage(state, envelope, event.messageId, addApproval)
+        : withActiveAssistantMessage(state, envelope, addApproval);
+
+      return clearTyping(nextState);
+    }
 
     case 'tool-approval-response':
       return applyApprovalResponse(state, event.approvalId, event.decision);


### PR DESCRIPTION
## Summary
- add a stable optional message identifier to tool approval request protocol events
- map persisted approvals to immutable activity identifiers for consistent live and history delivery
- preserve each approval card's chronological position during SDK history replay

## Test plan
- [x] `pnpm --filter @novu/js test -- apply-envelope.test.ts --runInBand`
- [x] `pnpm --filter @novu/api-service test -- --grep "uses immutable activity ids for approval request messages"`
- [x] `pnpm build`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR gives persisted tool-approval requests a stable optional protocol message identifier and uses it during SDK folding so approval cards retain their chronological positions across live delivery and history replay.
- Maps approval activity identifiers to protocol `messageId` values.
- Targets identified assistant messages when folding approvals while preserving the legacy active-message fallback.
- Adds API and SDK regression coverage for immutable IDs and replay ordering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

Live and historical approval envelopes use the same required, unique persisted activity identifier, and the SDK preserves backward compatibility for protocol events without that identifier.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/web-chat/activity-to-events.ts | Maps persisted approval requests to stable activity-derived message IDs consistently for live and historical envelopes. |
| packages/agent-event-protocol/src/agent-event.types.ts | Adds a backward-compatible optional message identifier to the tool-approval-request wire event. |
| packages/js/src/agent-chat/apply-envelope.ts | Folds identified approvals into stable assistant messages while retaining active-message behavior for legacy events. |
| apps/api/src/app/agents/web-chat/activity-to-events.spec.ts | Verifies approval history uses immutable activity identifiers rather than mutable platform message IDs. |
| packages/js/src/agent-chat/apply-envelope.test.ts | Verifies multiple replayed approvals retain their positions relative to intervening conversation messages. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant API as API Activity Store
  participant Mapper as Activity Mapper
  participant SDK as JS Envelope Reducer
  participant Timeline as Conversation Timeline
  API->>Mapper: Persisted approval activity (identifier, sequence)
  Mapper->>SDK: "tool-approval-request(messageId = identifier)"
  SDK->>Timeline: Insert/update assistant message by stable ID
  Note over SDK,Timeline: Live and history replay resolve to the same timeline position
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service,js): preserve approval h..."](https://github.com/novuhq/novu/commit/360fc300967769160c32f9f07df30d0f6b53ccad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52564813)</sub>

**Context used:**

- Knowledge Base — [Agents & Conversation Runtime (apps/api/src/app/agents)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/agents-conversation-runtime.md)
- Knowledge Base — [Client SDKs: packages/react, packages/js, packages/react-native, packages/nextjs](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/react-package.md)

<!-- /greptile_comment -->