### PR TITLE
docs(docs): document in-app Agent Chat channel fixes DOC-431

### DIFF
--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -4,7 +4,7 @@ description: "Connect AI agents to Slack, Teams, WhatsApp, Telegram, and email. 
 sidebarTitle: Overview
 ---
 
-Novu Connect is based on the [Agent Communication Infrastructure (ACI)](/agents/get-started/what-is-aci). It ingests channel webhooks, normalizes events, maintains conversation state, and delivers replies so you can run one agent across Slack, Microsoft Teams, WhatsApp, Telegram, and email without rebuilding each integration.
+Novu Connect is based on the [Agent Communication Infrastructure (ACI)](/agents/get-started/what-is-aci). It ingests channel webhooks, normalizes events, maintains conversation state, and delivers replies so you can run one agent across Slack, Microsoft Teams, WhatsApp, Telegram, email, and in-app [Agent Chat](/agents/channels/agent-chat) without rebuilding each integration.
 
 ACI separates two layers:
 
@@ -16,7 +16,7 @@ ACI separates two layers:
 
 ### Inbound conversations
 
-Users message the agent on a connected channel (DM, @mention, or email). Novu loads the conversation history and forwards it to your agent brain with the current turn. Replies go back to the same thread.
+Users message the agent on a connected channel (DM, @mention, email, or in-app Agent Chat). Novu loads the conversation history and forwards it to your agent brain with the current turn. Replies go back to the same thread.
 
 ### Tool approval
 
@@ -70,6 +70,9 @@ Choose how the agent brain runs:
   <Card title="Email" icon="mail" href="/agents/channels/email">
     Threaded HTML, action-link approvals.
   </Card>
+  <Card title="Agent Chat" icon="message-circle" href="/agents/channels/agent-chat">
+    In-app headless hook, typing, tool approval.
+  </Card>
 </Columns>
 
 Platform differences are listed in [Channels overview](/agents/channels/overview).
@@ -103,5 +106,8 @@ Platform differences are listed in [Channels overview](/agents/channels/overview
   </Card>
   <Card href="/agents/conversations" title="Conversation observability" icon="messages-square">
     Inspect live conversations in the dashboard.
+  </Card>
+  <Card href="/agents/channels/agent-chat/quickstart" title="Build the Agent Chat UI" icon="message-circle">
+    Headless `useAgentChat` in your product UI.
   </Card>
 </Columns>

--- a/docs/agents/channels/agent-chat.mdx
+++ b/docs/agents/channels/agent-chat.mdx
@@ -1,0 +1,61 @@
+---
+title: "Agent Chat"
+description: "Connect your agent to in-app Agent Chat: live typing, tool approval, thinking parts, and a headless React hook in your product UI."
+sidebarTitle: Overview
+---
+
+<Note>
+  Agent Chat is in closed beta. Contact us at support@novu.co to get access.
+</Note>
+
+Agent Chat is an ACI channel. The messaging surface is your product UI.
+
+The agent brain, conversation history, tool approval, and dashboard observability match other ACI channels. The client is [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat) from `@novu/react`. You render the messages and the composer.
+
+## Capabilities
+
+| Capability | Support |
+| --- | --- |
+| Full context history | Yes |
+| Threaded replies (one conversation per thread) | Yes |
+| Live typing indicator | Yes |
+| React with eyes on inbound messages | No |
+| Plan card (thinking parts) | Yes |
+| Rich text | Yes (your UI renders message parts) |
+| Tap-to-respond | Yes (tool approval and cards) |
+| Emoji reactions | No |
+| Message edits in place | Yes |
+| Action / MCP tool approval | Yes |
+| MCP connect card | Yes |
+| Resolve conversation | Yes |
+| File parts | Yes |
+| Streaming text parts | Yes (live socket) |
+
+Full matrix: [Channels overview](/agents/channels/overview).
+
+## Examples
+
+### In-app turn
+
+A subscriber sends a message in your UI. Novu loads conversation history, runs the agent brain, and streams the reply over the socket. Typing and thinking parts update while the turn runs.
+
+### Tool approval
+
+A gated tool pauses the turn. `pendingActions` includes a `tool-approval` item. Call `respondToAction` with `approved` or `denied`. The turn resumes after the decision.
+
+## Setup
+
+1. Create an agent and keep it **active**.
+2. In the Novu dashboard, open the agent and add **Agent Chat** as a channel. Novu creates the `novu-agent-chat` integration if it does not exist.
+3. Embed the chat in your app. Follow [Build the UI](/agents/channels/agent-chat/quickstart).
+
+## Related
+
+<Columns cols={2}>
+  <Card href="/agents/channels/agent-chat/quickstart" title="Build the UI" icon="rocket">
+    Install `@novu/react`, wrap `NovuProvider`, and send a message.
+  </Card>
+  <Card href="/platform/sdks/react/hooks/use-agent-chat" title="useAgentChat" icon="code">
+    Hook props, return value, and callbacks.
+  </Card>
+</Columns>

--- a/docs/agents/channels/agent-chat/quickstart.mdx
+++ b/docs/agents/channels/agent-chat/quickstart.mdx
@@ -1,0 +1,498 @@
+---
+title: "Build the Agent Chat UI"
+description: "Install @novu/react, wrap NovuProvider, and use useAgentChat to send, receive, and resume in-app agent conversations."
+sidebarTitle: Build the UI
+---
+
+<Note>
+  Agent Chat is in closed beta. Contact us at support@novu.co to get access.
+</Note>
+
+Build a two-way agent chat in your React app. You supply the UI. Novu supplies conversation state, delivery, and the live socket.
+
+## Prerequisites
+
+Complete [channel setup](/agents/channels/agent-chat#setup) first. Then you need:
+
+- Your **application identifier** from [API Keys](https://dashboard.novu.co/api-keys)
+- A [subscriber](/platform/additional-resources/glossary) id for the signed-in person
+- The public **agent identifier** from the agent page in the dashboard
+
+## Install and wrap NovuProvider
+
+```package-install
+npm install @novu/react
+```
+
+<Note>
+  `@novu/react` requires React 18 or later (`^18.0.0` or `^19.0.0`).
+</Note>
+
+`useAgentChat` reads the Novu client from context. Place `NovuProvider` above the chat.
+
+<Tabs>
+  <Tab title="US">
+```tsx
+import { NovuProvider } from '@novu/react';
+
+export function App() {
+  return (
+    <NovuProvider
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+    >
+      <Chat />
+    </NovuProvider>
+  );
+}
+```
+  </Tab>
+  <Tab title="EU">
+```tsx
+import { NovuProvider } from '@novu/react';
+
+export function App() {
+  return (
+    <NovuProvider
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+      apiUrl="https://eu.api.novu.co"
+      socketUrl="wss://eu.socket.novu.co"
+    >
+      <Chat />
+    </NovuProvider>
+  );
+}
+```
+  </Tab>
+</Tabs>
+
+`NovuProvider` authenticates the subscriber. `useAgentChat` selects which agent to talk to.
+
+<Prompt description="Add Novu Agent Chat to my React app" icon="plug" actions={["copy", "cursor"]}>
+# Add Novu Agent Chat to a React app
+
+Install `@novu/react`. Wrap the app in `NovuProvider`. Call `useAgentChat` and render your own message list and composer. There is no prebuilt `<AgentChat />` component.
+
+Latest docs: https://docs.novu.co/agents/channels/agent-chat/quickstart
+
+## Install
+
+```bash
+npm install @novu/react
+```
+
+## Code
+
+```tsx
+'use client';
+
+import { NovuProvider, useAgentChat } from '@novu/react';
+
+function Chat() {
+  const { messages, sendMessage, isRunning, isLoading, error } = useAgentChat({
+    agentId: 'YOUR_AGENT_IDENTIFIER',
+  });
+
+  return (
+    <div>
+      {error ? <p>{error.message}</p> : null}
+      <ul>
+        {messages.map((message) => (
+          <li key={message.id}>
+            <strong>{message.role}</strong>{' '}
+            {message.parts.map((part, index) =>
+              part.type === 'text' ? <span key={index}>{part.text}</span> : null
+            )}
+          </li>
+        ))}
+      </ul>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          const form = event.currentTarget;
+          const input = form.elements.namedItem('text') as HTMLInputElement;
+          void sendMessage(input.value);
+          form.reset();
+        }}
+      >
+        <input name="text" disabled={isRunning || isLoading} />
+        <button type="submit" disabled={isRunning || isLoading}>
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <NovuProvider
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+    >
+      <Chat />
+    </NovuProvider>
+  );
+}
+```
+
+## Rules
+
+ALWAYS:
+
+- Detect the project's package manager and use it for installation
+- Use `NovuProvider` from `@novu/react` (not a second Novu client)
+- Pass the dashboard agent identifier as `agentId`
+- Disable the composer while `isRunning` or `isLoading` is true
+- Use TypeScript, no comments, no empty props
+
+NEVER:
+
+- Invent a `<AgentChat />` component from `@novu/react`. It does not exist.
+- Use `useChat` from `@ai-sdk/react`. Agent Chat uses `useAgentChat`.
+- Compute HMAC hashes in the browser
+- Hardcode real API keys
+</Prompt>
+
+## Send a message
+
+Omit `conversationId` to start a new chat. The first successful send creates the conversation.
+
+<CodeGroup>
+```tsx title="HTML"
+const { sendMessage, isRunning, isLoading } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+<form
+  onSubmit={(event) => {
+    event.preventDefault();
+    const input = event.currentTarget.elements.namedItem('text') as HTMLInputElement;
+    void sendMessage(input.value).then(({ data }) => {
+      // data.conversationId — store this to resume later
+    });
+    event.currentTarget.reset();
+  }}
+>
+  <input name="text" disabled={isRunning || isLoading} />
+  <button type="submit" disabled={isRunning || isLoading}>
+    Send
+  </button>
+</form>
+```
+
+```tsx title="AI Elements"
+const { sendMessage, isRunning, isLoading } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+<PromptInput
+  onSubmit={async (message) => {
+    if (!message.text.trim() || isRunning || isLoading) {
+      return;
+    }
+
+    const { data } = await sendMessage(message.text);
+    // data.conversationId — store this to resume later
+  }}
+>
+  <PromptInputBody>
+    <PromptInputTextarea disabled={isRunning || isLoading} placeholder="Message" />
+  </PromptInputBody>
+  <PromptInputFooter>
+    <PromptInputSubmit
+      className="ml-auto"
+      disabled={isRunning || isLoading}
+      status={isRunning ? 'streaming' : 'ready'}
+    />
+  </PromptInputFooter>
+</PromptInput>
+```
+</CodeGroup>
+
+If `isRunning` or `isLoading` is true, disable the composer. The agent is still working on the turn.
+
+## Receive and render parts
+
+`messages` is the ordered timeline. Each message has `role` (`user` or `assistant`) and `parts`.
+
+Start with `type === 'text'`. Then handle the other part types as you need them.
+
+| `type` | What to render |
+| --- | --- |
+| `text` | Visible body. `state` is `streaming` or `done`. |
+| `thinking` | Plan text while the agent reasons. |
+| `tool` | Tool call and result. |
+| `approval` | Gated tool. Use `pendingActions` and `respondToAction`. |
+| `mcp-connection` | MCP connect card. Open `authorizeUrl`. |
+| `card` | Structured card payload. |
+| `file` | File attachment metadata. |
+| `source` | Citation (`url` or `document`). |
+
+<CodeGroup>
+```tsx title="HTML"
+const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
+
+{messages.map((message) => (
+  <li key={message.id}>
+    {message.parts.map((part, index) =>
+      part.type === 'text' ? <span key={index}>{part.text}</span> : null
+    )}
+  </li>
+))}
+```
+
+```tsx title="AI Elements"
+const { messages } = useAgentChat({ agentId: 'YOUR_AGENT_IDENTIFIER' });
+
+<Conversation>
+  <ConversationContent>
+    {messages.map((message) => (
+      <Message key={message.id} from={message.role}>
+        <MessageContent>
+          {message.parts.map((part, index) =>
+            part.type === 'text' ? <MessageResponse key={index}>{part.text}</MessageResponse> : null
+          )}
+        </MessageContent>
+      </Message>
+    ))}
+  </ConversationContent>
+  <ConversationScrollButton />
+</Conversation>
+```
+</CodeGroup>
+
+Full field tables: [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat).
+
+## Thinking and running
+
+While the agent turn is in progress, `isRunning` is true. `typing` is present when the agent is typing. Assistant messages can include `thinking` parts before text arrives.
+
+<CodeGroup>
+```tsx title="HTML"
+const { messages, isRunning, typing } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{isRunning ? <p>{typing?.status ?? 'Working…'}</p> : null}
+
+{messages.map((message) =>
+  message.parts.map((part, index) => {
+    if (part.type === 'thinking') {
+      return <em key={index}>{part.text}</em>;
+    }
+
+    if (part.type === 'text') {
+      return <span key={index}>{part.text}</span>;
+    }
+
+    return null;
+  })
+)}
+```
+
+```tsx title="AI Elements"
+const { messages, isRunning, typing } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{isRunning ? <Shimmer>{typing?.status ?? 'Working…'}</Shimmer> : null}
+
+{messages.map((message) => (
+  <Message key={message.id} from={message.role}>
+    <MessageContent>
+      {message.parts.map((part, index) => {
+        if (part.type === 'thinking') {
+          return (
+            <ChainOfThought key={index} defaultOpen={part.state === 'streaming'}>
+              <ChainOfThoughtContent>
+                <ChainOfThoughtStep
+                  label={part.text}
+                  status={part.state === 'streaming' ? 'active' : 'complete'}
+                />
+              </ChainOfThoughtContent>
+            </ChainOfThought>
+          );
+        }
+
+        if (part.type === 'text') {
+          return <MessageResponse key={index}>{part.text}</MessageResponse>;
+        }
+
+        return null;
+      })}
+    </MessageContent>
+  </Message>
+))}
+```
+</CodeGroup>
+
+The first envelope of a turn can create an empty assistant message before any text is folded in. Keep that row in the list. Then fill it as parts arrive.
+
+## Tool approval and MCP connect
+
+`pendingActions` lists waits that block the turn. Do not mix the two action types.
+
+| `action.type` | What to do |
+| --- | --- |
+| `tool-approval` | Call `respondToAction` with `action.id` and `approved` or `denied`. |
+| `mcp-connection` | Open `action.authorizeUrl` in the browser. Do not call `respondToAction`. |
+
+<CodeGroup>
+```tsx title="HTML"
+const { pendingActions, respondToAction } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{pendingActions.map((action) => {
+  if (action.type === 'tool-approval') {
+    return (
+      <button
+        key={action.id}
+        type="button"
+        onClick={() => void respondToAction({ actionId: action.id, decision: 'approved' })}
+      >
+        Approve {action.toolName}
+      </button>
+    );
+  }
+
+  if (action.type === 'mcp-connection') {
+    return (
+      <a key={action.id} href={action.authorizeUrl} target="_blank" rel="noreferrer">
+        Connect {action.displayName}
+      </a>
+    );
+  }
+
+  return null;
+})}
+```
+
+```tsx title="AI Elements"
+const { pendingActions, respondToAction } = useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+});
+
+{pendingActions.map((action) => {
+  if (action.type === 'tool-approval') {
+    return (
+      <Message key={action.id} from="assistant">
+        <MessageContent>
+          <button
+            type="button"
+            onClick={() => void respondToAction({ actionId: action.id, decision: 'approved' })}
+          >
+            Approve {action.toolName}
+          </button>
+        </MessageContent>
+      </Message>
+    );
+  }
+
+  if (action.type === 'mcp-connection') {
+    return (
+      <Message key={action.id} from="assistant">
+        <MessageContent>
+          <a href={action.authorizeUrl} target="_blank" rel="noreferrer">
+            Connect {action.displayName}
+          </a>
+        </MessageContent>
+      </Message>
+    );
+  }
+
+  return null;
+})}
+```
+</CodeGroup>
+
+Pass `action.id` from `pendingActions`. Do not invent approve or deny ids.
+
+## Resume or start another chat
+
+Pass `conversationId` so the hook loads history on mount.
+
+```tsx
+useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  conversationId, // omit to start a new chat
+});
+
+const { data } = await sendMessage(text);
+// persist data.conversationId and pass it back as conversationId
+```
+
+Store the `conversationId` that `sendMessage` returns, or the `conversationId` field on the hook result. On the next visit, pass that id back in.
+
+The hook has no list-conversations API. You store the ids that you want to reopen.
+
+To start another chat, remount the component without `conversationId`, or clear the prop.
+
+## Switch agent
+
+`agentId` selects the agent. If the identifier changes, remount with the new `agentId`.
+
+Omit `conversationId` unless that conversation belongs to the new agent. A conversation id from a different agent does not resume.
+
+## Going to production
+
+HMAC is off by default. Turn it on before you ship. Agent Chat can require two hashes. Each hash has its own dashboard toggle.
+
+| Hash | Toggle | Input | Where you pass it |
+| --- | --- | --- | --- |
+| `subscriberHash` | **Novu In-App** integration | `subscriberId` | `NovuProvider` |
+| `agentHash` | **Agent Chat** integration | agent identifier | `useAgentChat` |
+
+Both hashes use the same secret: the environment API secret from [API Keys](https://dashboard.novu.co/api-keys). Compute them on your server. Do not compute them in the browser.
+
+### subscriberHash
+
+`subscriberHash` authenticates the signed-in subscriber. Without it, another person can guess a `subscriberId` and open that subscriber's session, including Agent Chat.
+
+If **Security HMAC encryption** is on for **Novu In-App**, pass `subscriberHash` to `NovuProvider`. The hash is `HMAC-SHA256(secretKey, subscriberId)` as a lowercase hex string.
+
+Generation recipes (Node.js, Python, and more): [Secure your Inbox with HMAC](/platform/inbox/prepare-for-production#secure-your-inbox-with-hmac-encryption).
+
+### agentHash
+
+`agentHash` authenticates which agent the subscriber can talk to. Without it, a client can send any public agent identifier that is linked to Agent Chat.
+
+If **Security HMAC encryption** is on for **Agent Chat**:
+
+1. Open [Integrations](https://dashboard.novu.co/integrations).
+2. Select the **Agent Chat** integration.
+3. Enable **Security HMAC encryption**.
+4. On your server, compute `HMAC-SHA256(secretKey, agentIdentifier)` as a lowercase hex string.
+5. Pass that value as `agentHash` to `useAgentChat`.
+
+```tsx
+<NovuProvider
+  applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+  subscriber="YOUR_SUBSCRIBER_ID"
+  subscriberHash="YOUR_SUBSCRIBER_HASH"
+>
+  <Chat />
+</NovuProvider>
+```
+
+```tsx
+useAgentChat({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  agentHash: 'YOUR_AGENT_HASH',
+});
+```
+
+If only one toggle is on, pass only that hash. If both toggles are on, pass both hashes.
+
+## Next steps
+
+<Columns cols={2}>
+  <Card href="/platform/sdks/react/hooks/use-agent-chat" title="useAgentChat reference" icon="code">
+    Props, return value, callbacks, and message parts.
+  </Card>
+  <Card href="/agents/channels/agent-chat" title="Channel setup" icon="plug">
+    Link Agent Chat on the agent.
+  </Card>
+</Columns>

--- a/docs/agents/channels/overview.mdx
+++ b/docs/agents/channels/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "Feature support matrix for Novu Connect on Slack, Microsoft Teams, WhatsApp, Telegram, and email."
+description: "Feature support matrix for Novu Connect on Slack, Microsoft Teams, WhatsApp, Telegram, email, and Agent Chat."
 sidebarTitle: Overview
 ---
 
@@ -8,25 +8,25 @@ Novu normalizes inbound events and outbound replies, but each provider exposes a
 
 ## Supported capabilities
 
-| Capability | Slack | Teams | WhatsApp | Telegram | Email |
-| --- | --- | --- | --- | --- | --- |
-| Full context history | Yes | Yes | Yes | Yes | Yes |
-| Threaded replies | Yes | Yes | Yes | Yes | Yes |
-| Live typing indicator | Yes | Yes | Yes | Yes | No |
-| React with eyes on new message | Yes | Yes | Yes | Yes | Yes |
-| Plan card (chain of thought) | Yes (native) | Markdown edit-in-place | No | Markdown edit-in-place | No |
-| Rich text styling | Yes | Yes | Bold / italics | Yes | HTML |
-| Tap-to-respond (buttons) | Yes | Yes | Yes (up to 3) | Yes | Yes (action links) |
-| Emoji reactions | Yes | Yes | Yes | Yes | Gmail only |
-| Message edits in place | Yes | Yes | Yes | Yes | No |
-| Action / tool approval | Yes | Yes | Yes | Yes | Yes |
-| MCP tool approval | Yes | Yes | Yes | Yes | Yes |
-| MCP connect card | Yes | Yes | Yes | Yes | Yes |
-| Resolve conversation | Yes | Yes | Yes | Yes | Yes |
-| Message queueing | Yes | Yes | Yes | Yes | Yes |
-| Outbound file attachments | Yes | Yes | Not yet | Not yet | Not yet |
+| Capability | Slack | Teams | WhatsApp | Telegram | Email | Agent Chat |
+| --- | --- | --- | --- | --- | --- | --- |
+| Full context history | Yes | Yes | Yes | Yes | Yes | Yes |
+| Threaded replies | Yes | Yes | Yes | Yes | Yes | Yes |
+| Live typing indicator | Yes | Yes | Yes | Yes | No | Yes |
+| React with eyes on new message | Yes | Yes | Yes | Yes | Yes | No |
+| Plan card (chain of thought) | Yes (native) | Markdown edit-in-place | No | Markdown edit-in-place | No | Yes (thinking parts) |
+| Rich text styling | Yes | Yes | Bold / italics | Yes | HTML | Yes (your UI) |
+| Tap-to-respond (buttons) | Yes | Yes | Yes (up to 3) | Yes | Yes (action links) | Yes |
+| Emoji reactions | Yes | Yes | Yes | Yes | Gmail only | No |
+| Message edits in place | Yes | Yes | Yes | Yes | No | Yes |
+| Action / tool approval | Yes | Yes | Yes | Yes | Yes | Yes |
+| MCP tool approval | Yes | Yes | Yes | Yes | Yes | Yes |
+| MCP connect card | Yes | Yes | Yes | Yes | Yes | Yes |
+| Resolve conversation | Yes | Yes | Yes | Yes | Yes | Yes |
+| Message queueing | Yes | Yes | Yes | Yes | Yes | Yes |
+| Outbound file attachments | Yes | Yes | Not yet | Not yet | Not yet | Yes (file parts) |
 
-Word-by-word streaming is not supported on any live channel yet.
+Word-by-word streaming is not supported on Slack, Teams, WhatsApp, Telegram, or email. Agent Chat updates text parts over the live socket while the turn runs.
 
 ## Channel pages
 
@@ -45,6 +45,9 @@ Word-by-word streaming is not supported on any live channel yet.
   </Card>
   <Card title="Email" icon="mail" href="/agents/channels/email">
     Threaded HTML, action-link approvals.
+  </Card>
+  <Card title="Agent Chat" icon="message-circle" href="/agents/channels/agent-chat">
+    In-app headless hook, typing, tool approval.
   </Card>
 </Columns>
 

--- a/docs/agents/conversations.mdx
+++ b/docs/agents/conversations.mdx
@@ -38,7 +38,7 @@ Navigate to your agent's detail page to see all conversations, their status, and
 Both managed agents and custom code agents support the same live channels. Capability details (typing, plan cards, buttons, approvals, edits) live in one place:
 
 - [Channels overview](/agents/channels/overview) (full matrix)
-- [Slack](/agents/channels/slack) · [Microsoft Teams](/agents/channels/microsoft-teams) · [WhatsApp](/agents/channels/whatsapp) · [Telegram](/agents/channels/telegram) · [Email](/agents/channels/email)
+- [Slack](/agents/channels/slack) · [Microsoft Teams](/agents/channels/microsoft-teams) · [WhatsApp](/agents/channels/whatsapp) · [Telegram](/agents/channels/telegram) · [Email](/agents/channels/email) · [Agent Chat](/agents/channels/agent-chat)
 
 <Note>
   Platform capabilities vary. For example, typing indicators and message edits are unavailable on email, and outbound file attachments are supported on Slack and Microsoft Teams only today.

--- a/docs/agents/get-started/agents-and-providers.mdx
+++ b/docs/agents/get-started/agents-and-providers.mdx
@@ -7,7 +7,7 @@ description: "How Novu agents and provider connections route messages, resolve i
 
 An agent is the entity you create in Novu when you want to expose agent logic through one or more communication providers.
 
-Each agent has a name, an identifier, and a set of event handlers that define how your application responds to conversation events. An agent can be connected to one or more providers, such as Slack, Microsoft Teams, WhatsApp, or email.
+Each agent has a name, an identifier, and a set of event handlers that define how your application responds to conversation events. An agent can be connected to one or more providers, such as Slack, Microsoft Teams, WhatsApp, email, or in-app Agent Chat.
 
 ## Provider connections
 
@@ -26,6 +26,7 @@ Novu supports the following providers:
 - [WhatsApp](/agents/channels/whatsapp)
 - [Telegram](/agents/channels/telegram)
 - [Email](/agents/channels/email)
+- [Agent Chat](/agents/channels/agent-chat)
 
 While adding a new provider to an agent, Novu will guide you through the setup process for the provider. For what each channel can do (typing, buttons, approvals, edits), see [Channels overview](/agents/channels/overview).
 

--- a/docs/agents/get-started/mental-model.mdx
+++ b/docs/agents/get-started/mental-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mental model"
-description: "Trace how inbound messages flow from Slack, Teams, WhatsApp, or email through Novu's agent communication infrastructure to your agent code and back."
+description: "Trace how inbound messages flow from Slack, Teams, WhatsApp, email, or in-app Agent Chat through Novu's agent communication infrastructure to your agent code and back."
 ---
 
 
@@ -48,7 +48,7 @@ Read more on how to [connect a managed agent](/agents/managed-agent/overview).
 
 A conversation is the stateful thread where communication happens. When a user sends a message from a connected provider, Novu creates a new conversation or loads the existing one for that thread. The conversation includes message history, metadata, participants, status, and platform context needed to process the next interaction.
 
-A conversation can include multiple participants. The agent is one participant in the conversation, but it is not the conversation itself. This distinction matters when you inspect conversations in the dashboard or build agent behavior around conversation state. A Slack thread, email thread, or other provider-specific thread maps to a conversation in Novu automatically.
+A conversation can include multiple participants. The agent is one participant in the conversation, but it is not the conversation itself. This distinction matters when you inspect conversations in the dashboard or build agent behavior around conversation state. A Slack thread, email thread, in-app Agent Chat thread, or other provider-specific thread maps to a conversation in Novu automatically.
 
 ## Participants and subscriber identity
 
@@ -77,6 +77,9 @@ Novu calls your agent brain with the complete context: the message, conversation
   </Card>
   <Card icon="hash" href="/agents/channels/slack" title="Slack">
     Slack capabilities and setup links.
+  </Card>
+  <Card icon="message-circle" href="/agents/channels/agent-chat" title="Agent Chat">
+    Headless chat in your product UI.
   </Card>
   <Card icon="brain" href="/agents/managed-agent/overview" title="Managed agent">
     Connect a managed Claude agent.

--- a/docs/agents/get-started/what-is-aci.mdx
+++ b/docs/agents/get-started/what-is-aci.mdx
@@ -13,6 +13,7 @@ ACI sits between communication channels and your agent logic. Instead of buildin
 * WhatsApp
 * Email
 * Telegram
+* Agent Chat
 * Other supported platforms
 
 The agent brain can be powered by an LLM, custom code, a rules engine, a human-in-the-loop workflow, a managed agent platform, or a combination of systems. ACI does not define the agent’s intelligence. It defines the communication infrastructure around it.
@@ -48,6 +49,7 @@ Communication channels are the places where people interact with the agent:
 * WhatsApp
 * Telegram
 * Email
+* Agent Chat
 * Other supported platforms
 
 When a user sends a message in one of these channels, the message enters the ACI layer.
@@ -75,6 +77,7 @@ Because the agent brain is separate from the channel layer, your agent does not 
 * WhatsApp
 * Email
 * Telegram
+* Agent Chat
 * Other supported channels
 
 ## What ACI handles and what you control
@@ -141,7 +144,7 @@ Follow a connect guide to wire an existing agent (or scaffold a starter) to Slac
     title="Channels overview"
     icon="table"
   >
-  See what Slack, Teams, WhatsApp, Telegram, and email support.
+  See what Slack, Teams, WhatsApp, Telegram, email, and Agent Chat support.
   </Card>
 </Columns>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -330,6 +330,7 @@
                     "pages": [
                       "platform/sdks/react/hooks/novu-provider",
                       "platform/sdks/react/hooks/subscription",
+                      "platform/sdks/react/hooks/use-agent-chat",
                       "platform/sdks/react/hooks/use-counts",
                       "platform/sdks/react/hooks/use-notifications",
                       "platform/sdks/react/hooks/use-novu",
@@ -463,7 +464,12 @@
               "agents/channels/microsoft-teams",
               "agents/channels/whatsapp",
               "agents/channels/telegram",
-              "agents/channels/email"
+              "agents/channels/email",
+              {
+                "group": "Agent Chat",
+                "root": "agents/channels/agent-chat",
+                "pages": ["agents/channels/agent-chat/quickstart"]
+              }
             ],
             "icon": "messages-square"
           },
@@ -1687,6 +1693,21 @@
     {
       "source": "/agents/channels/capabilities",
       "destination": "/agents/channels/overview",
+      "permanent": true
+    },
+    {
+      "source": "/platform/integrations/chat/agent-chat",
+      "destination": "/agents/channels/agent-chat",
+      "permanent": true
+    },
+    {
+      "source": "/agents/agent-chat",
+      "destination": "/agents/channels/agent-chat",
+      "permanent": true
+    },
+    {
+      "source": "/agents/agent-chat/quickstart",
+      "destination": "/agents/channels/agent-chat/quickstart",
       "permanent": true
     },
     {

--- a/docs/platform/inbox.mdx
+++ b/docs/platform/inbox.mdx
@@ -9,6 +9,10 @@ Add real-time in-app notifications to your application with the Novu Inbox compo
 
 The Novu Inbox is a prebuilt, ready-to-use, and fully customizable UI component for delivering real-time in-app notifications. It gives your subscribers a centralized place to view and manage notifications.
 
+<Note>
+  Inbox is one-way notifications. For two-way in-app chat with an agent, see [Agent Chat](/agents/channels/agent-chat).
+</Note>
+
 ![Novu Inbox component showing bell icon, notification list, and preferences panel](/images/inbox/intro-to-inbox.png)
 
 ## What is the composable Inbox architecture?

--- a/docs/platform/sdks/javascript.mdx
+++ b/docs/platform/sdks/javascript.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@novu/js'
-description: "Complete API reference for the @novu/js browser SDK, covering the Novu client, notification streams, preferences, counts, and session management."
+description: "Complete API reference for the @novu/js browser SDK, covering the Novu client, notification streams, preferences, counts, Agent Chat, and session management."
 ---
 
 
@@ -749,6 +749,66 @@ subscription.preferences.map((preference) => {
 ```
 await subscription.delete();
 ```
+
+## Agent Chat
+
+Two-way in-app chat with an agent. Use `novu.agentChat` from `@novu/js`, or the [`useAgentChat`](/platform/sdks/react/hooks/use-agent-chat) hook in React.
+
+Product guide: [Build the Agent Chat UI](/agents/channels/agent-chat/quickstart).
+
+Call `novu.agentChat.subscribe()` while the chat is open so the socket stays connected. Call `unsubscribe()` when the chat unmounts.
+
+### sendMessage
+
+Creates a conversation when `conversationId` is omitted. Later sends must pass the returned id.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `agentId` | `string` | Public agent identifier. |
+| `text` | `string` | User message. |
+| `conversationId` | `string` | Existing conversation to append to. |
+| `agentHash` | `string` | HMAC of `agentId`. Required when Agent Chat HMAC is on. |
+
+```typescript
+novu.agentChat.subscribe();
+
+const { data, error } = await novu.agentChat.sendMessage({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  text: 'Hello',
+});
+
+// data.conversationId, data.messageId
+```
+
+### loadConversation
+
+Loads the newest history page into the local store.
+
+```typescript
+const { data, error } = await novu.agentChat.loadConversation({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  conversationId: 'conv_YOUR_CONVERSATION_ID',
+});
+```
+
+### fetchMore
+
+Loads an older history page when `hasMore` is true.
+
+### respondToAction
+
+Approves or denies a pending tool. Pass the pending action id, not a client-invented id.
+
+```typescript
+await novu.agentChat.respondToAction({
+  agentId: 'YOUR_AGENT_IDENTIFIER',
+  conversationId: 'conv_YOUR_CONVERSATION_ID',
+  actionId: 'YOUR_PENDING_ACTION_ID',
+  decision: 'approved',
+});
+```
+
+Live updates emit `agent_chat.messages.updated` on the Novu event emitter.
 
 ## Types
 

--- a/docs/platform/sdks/react.mdx
+++ b/docs/platform/sdks/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@novu/react"
-description: "API reference for the @novu/react SDK components, including Inbox, Bell, Notifications, Subscription, and hooks for building custom notification experiences."
+description: "API reference for the @novu/react SDK components, including Inbox, Bell, Notifications, Subscription, and hooks for notifications and Agent Chat."
 ---
 
 ## Requirements

--- a/docs/platform/sdks/react/hooks/use-agent-chat.mdx
+++ b/docs/platform/sdks/react/hooks/use-agent-chat.mdx
@@ -1,0 +1,90 @@
+---
+title: "useAgentChat"
+description: "API reference for the useAgentChat hook: conversation state, sendMessage, tool approval, live typing, and history pagination in the Novu React SDK."
+---
+
+<Note>
+  Agent Chat is in closed beta. Contact us at support@novu.co to get access.
+</Note>
+
+The `useAgentChat` hook is the headless client for [Agent Chat](/agents/channels/agent-chat). It loads conversation history, sends messages, streams live turns over the socket, and exposes pending tool approvals.
+
+Use it inside [`NovuProvider`](/platform/sdks/react/hooks/novu-provider). Product guide: [Build the UI](/agents/channels/agent-chat/quickstart).
+
+## Hook parameters
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `agentId` | `string` | Required. Public agent identifier from the dashboard. |
+| `conversationId` | `string` | Resume this conversation and load history on mount. Omit to start a new chat. The first `sendMessage` creates the conversation. |
+| `agentHash` | `string` | HMAC-SHA256 of `agentId` with the environment secret. Required when Security HMAC is on for the Agent Chat integration. |
+| `onSuccess` | `(data: LoadConversationResult) => void` | Fires after a history fetch succeeds. |
+| `onError` | `(error: NovuError \| AgentChatPlanLimitError) => void` | Fires when a load, send, or action response fails. |
+| `onMessage` | `(message: AgentMessage) => void` | Fires once per new message id. History pages are silent. The first envelope of a turn can create an empty assistant message before text arrives. A send that never reaches the server does not fire. The message status becomes `failed` instead. |
+| `onActionRequested` | `(action: AgentPendingAction) => void` | Fires once per pending action, including actions still pending on mount. Paging backwards is silent. |
+| `onEvent` | `(envelope: AgentEventEnvelope) => void` | Raw live envelopes for this conversation. Duplicate envelopes that the store drops do not fire. |
+
+## Return value
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `messages` | `AgentMessage[]` | Folded timeline for the current conversation. |
+| `pendingActions` | `AgentPendingAction[]` | Tool approvals and MCP connect items that are still pending. Derived from `messages`. |
+| `conversationId` | `string \| undefined` | Server conversation id after create or resume. Undefined until the first successful send on a new chat. |
+| `error` | `NovuError \| AgentChatPlanLimitError` | Last error from load, send, or `respondToAction`. |
+| `isLoading` | `boolean` | True until the first history fetch completes. False when there is no `conversationId` prop. |
+| `isFetching` | `boolean` | True while a history request is in flight. |
+| `isRunning` | `boolean` | True while the agent turn is in progress. |
+| `typing` | `AgentConversationTyping \| undefined` | Ephemeral typing indicator. Absent when the agent is not typing. |
+| `status` | `AgentConversationStatus` | `active` or `resolved`. |
+| `hasMore` | `boolean` | True when older history pages are available via `fetchMore`. |
+| `refetch` | `() => Promise<void>` | Reload the newest history page. No-op when there is no conversation id. |
+| `fetchMore` | `() => Promise<{ data?: { messages: AgentMessage[]; hasMore: boolean }; error?: NovuError }>` | Load an older history page. |
+| `sendMessage` | `(text: string) => Promise<{ data?: SendMessageResult; error?: NovuError \| AgentChatPlanLimitError }>` | Send a user message. Creates a conversation when `conversationId` is omitted. |
+| `respondToAction` | `(args: { actionId: string; decision: 'approved' \| 'denied' }) => Promise<{ data?: RespondToActionResult; error?: NovuError \| AgentChatPlanLimitError }>` | Approve or deny a pending `tool-approval`. Pass `action.id` from `pendingActions`. |
+
+## Message type
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Message id. Optimistic local ids are replaced after the server ack. |
+| `role` | `AgentMessageRole` | Sender role (`user` or `assistant`). |
+| `parts` | `AgentMessagePart[]` | Ordered content. See part types below. |
+| `createdAt` | `string` | ISO timestamp. |
+| `status` | `'sending' \| 'sent' \| 'failed'` | Delivery status for the local send. |
+
+### Part types
+
+| `type` | When you see it |
+| --- | --- |
+| `text` | Visible message text. `state` is `streaming` or `done`. |
+| `thinking` | Chain-of-thought / plan text while the agent reasons. |
+| `tool` | Tool call and result. |
+| `approval` | Gated tool waiting on the subscriber. Use `pendingActions` + `respondToAction`. |
+| `mcp-connection` | MCP server connect card. Open `authorizeUrl` in the browser. |
+| `card` | Structured card payload (`card` object). |
+| `file` | File attachment metadata. |
+| `source` | Citation (`url` or `document`). |
+
+## Pending actions
+
+`pendingActions` is derived from pending `approval` and `mcp-connection` parts.
+
+| `type` | What to do |
+| --- | --- |
+| `tool-approval` | Call `respondToAction({ actionId: action.id, decision: 'approved' \| 'denied' })`. |
+| `mcp-connection` | Open `authorizeUrl` in the browser. Do not invent action ids. |
+
+## Plan limit error
+
+`AgentChatPlanLimitError` is thrown (and returned on the hook `error` field) when the organization is over a plan limit. The HTTP status is `402`.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `name` | `'AgentChatPlanLimitError'` | Discriminator. |
+| `reason` | `'agents' \| 'channels' \| 'conversations'` | Which limit blocked the request. |
+| `message` | `string` | Human-readable error. |
+
+## JavaScript SDK
+
+The same client lives on `novu.agentChat` in [`@novu/js`](/platform/sdks/javascript#agent-chat): `sendMessage`, `loadConversation`, `fetchMore`, `respondToAction`, `subscribe`, `unsubscribe`.


### PR DESCRIPTION
## Summary
- Document in-app Agent Chat as a Connect channel: Overview, Build the UI (`useAgentChat`), and hook API reference.
- Add Agent Chat to the channel matrix, ACI/get-started pages, Inbox vs chat callout, and `@novu/js` / `@novu/react` SDK refs.
- Signal closed beta with a support callout (`support@novu.co`); no Beta badges.

Linear: https://linear.app/novu/issue/DOC-431/document-in-app-agent-chat-channel

## Test plan
- [ ] Open `/agents/channels/agent-chat` and `/agents/channels/agent-chat/quickstart` in Mintlify (`cd docs && mint dev`)
- [ ] Confirm sidenav: Channels → Agent Chat → Overview + Build the UI
- [ ] Confirm `/platform/sdks/react/hooks/use-agent-chat` is listed under `@novu/react` Hooks
- [ ] Click through related links from Connect overview, Channels overview, and Inbox
- [ ] Confirm `/agents/agent-chat` and `/platform/integrations/chat/agent-chat` redirect to the channel Overview

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents the closed-beta Agent Chat channel across Connect guides and the JavaScript and React SDK references.

- Adds Agent Chat overview, UI quickstart, capabilities, authentication guidance, and `useAgentChat` reference pages.
- Adds Agent Chat to navigation, channel matrices, SDK references, related guides, and legacy-route redirects.
- The setup guide currently omits the production-environment restriction enforced by the integration-linking API.

<h3>Confidence Score: 4/5</h3>

The production setup limitation should be documented before merging so users are not directed into an endpoint that rejects their environment.

The SDK references and examples align with the current client contracts, but the new channel setup procedure omits a server-enforced production restriction that prevents users from completing the documented step.

**Files Needing Attention:** docs/agents/channels/agent-chat.mdx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/agents/channels/agent-chat.mdx | Adds the channel overview and setup steps, but the setup does not mention that linking the integration is rejected in production environments. |
| docs/agents/channels/agent-chat/quickstart.mdx | Adds a comprehensive React UI guide covering messaging, rendering, actions, conversation resumption, and HMAC configuration. |
| docs/platform/sdks/react/hooks/use-agent-chat.mdx | Adds a hook reference whose documented props, return values, and callback semantics align with the implementation. |
| docs/platform/sdks/javascript.mdx | Documents the public Agent Chat client methods, socket subscription lifecycle, and update event. |
| docs/docs.json | Registers the new pages in navigation and adds redirects from earlier Agent Chat routes. |
| docs/agents/channels/overview.mdx | Extends the channel capability matrix with Agent Chat behavior. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20novuhq%2Fnovu%20PR%20%2312335%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=12335&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Adocs%2Fagents%2Fchannels%2Fagent-chat.mdx%3A49%0A**Production%20integration%20linking%20fails**%0A%0AIf%20users%20perform%20this%20setup%20in%20a%20production%20environment%2C%20the%20dashboard%20calls%20an%20integration-linking%20endpoint%20that%20rejects%20production%20changes%2C%20causing%20step%202%20to%20fail%20with%20a%20forbidden%20response%20without%20explaining%20the%20supported%20provisioning%20path.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=12335&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/agents/channels/agent-chat.mdx:49
**Production integration linking fails**

If users perform this setup in a production environment, the dashboard calls an integration-linking endpoint that rejects production changes, causing step 2 to fail with a forbidden response without explaining the supported provisioning path.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docs): document in-app Agent Chat c..."](https://github.com/novuhq/novu/commit/1fc2b1758e82ae8b3e64ff0164595366b30e8a38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52959899)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->