### PR TITLE
fix(dashboard): use Connect label for Agent Chat provider card (fixes NV-8595) fixes NV-8595

### DIFF
--- a/apps/dashboard/src/components/agents/provider-cards.tsx
+++ b/apps/dashboard/src/components/agents/provider-cards.tsx
@@ -357,7 +357,6 @@ function ProviderCard({
           connected={effectiveConnected}
           connecting={showConnecting}
           inSetup={showInSetup}
-          idleLabel={item.providerId === ChatProviderIdEnum.NovuAgentChat ? 'Try in dashboard' : 'Connect'}
         />
       </div>
     </button>


### PR DESCRIPTION
## Summary
- Agent Chat provider card in the dashboard now shows **Connect** like other channel cards
- Removes the special-case `Try in dashboard` idle label for `NovuAgentChat`

## Test plan
- [ ] Open agent setup / channel selection in dashboard
- [ ] Confirm Agent Chat card shows **Connect** when idle (not connected)
- [ ] Confirm other provider cards still show **Connect** as before
- [ ] Connect Agent Chat and confirm connected state UI is unchanged

fixes NV-8595

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns the Agent Chat provider card’s idle CTA with other provider cards.
- Removes the `NovuAgentChat`-specific `Try in dashboard` label override.
- Uses the existing `Connect` default while leaving connected, connecting, and setup states unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The removed override falls back to the existing `Connect` default, while higher-priority connection and setup states retain their prior rendering behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/components/agents/provider-cards.tsx | Removes the provider-specific idle label override; the existing optional-prop default correctly renders `Connect`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): use Connect label for Ag..."](https://github.com/novuhq/novu/commit/bba9e8ae5b2223990d8f328045a965965074ad4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53303924)</sub>

<!-- /greptile_comment -->