### PR TITLE
fix(api-service): infer chat editorType from body fixes NV-8596

### DIFF
--- a/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
@@ -1186,6 +1186,73 @@ describe('Upsert Workflow #novu-v2', () => {
     });
   });
 
+  describe('chat editorType inference', () => {
+    const mailyBody = JSON.stringify({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello from blocks' }] }],
+    });
+
+    it('sets editorType to block when the chat body is Maily JSON', async () => {
+      const createResponse = await session.testAgent.post('/v2/workflows').send({
+        __source: WorkflowCreationSourceEnum.Editor,
+        name: 'Chat EditorType Block Workflow',
+        workflowId: `chat-editor-type-block-${randomUUID()}`,
+        active: true,
+        steps: [
+          {
+            name: 'Chat Step',
+            type: StepTypeEnum.CHAT,
+            controlValues: { body: mailyBody },
+          },
+        ],
+      });
+
+      expect(createResponse.status).to.equal(201);
+      expect(createResponse.body.data.steps[0].controls.values.editorType).to.equal('block');
+      expect(createResponse.body.data.steps[0].issues?.controls?.editorType).to.equal(undefined);
+    });
+
+    it('sets editorType to text when the chat body is plain text', async () => {
+      const createResponse = await session.testAgent.post('/v2/workflows').send({
+        __source: WorkflowCreationSourceEnum.Editor,
+        name: 'Chat EditorType Text Workflow',
+        workflowId: `chat-editor-type-text-${randomUUID()}`,
+        active: true,
+        steps: [
+          {
+            name: 'Chat Step',
+            type: StepTypeEnum.CHAT,
+            controlValues: { body: 'hello {{payload.foo}}' },
+          },
+        ],
+      });
+
+      expect(createResponse.status).to.equal(201);
+      expect(createResponse.body.data.steps[0].controls.values.editorType).to.equal('text');
+      expect(createResponse.body.data.steps[0].issues?.controls?.editorType).to.equal(undefined);
+    });
+
+    it('does not report editorType enum issues when editorType is empty and body is Maily JSON', async () => {
+      const createResponse = await session.testAgent.post('/v2/workflows').send({
+        __source: WorkflowCreationSourceEnum.Editor,
+        name: 'Chat EditorType Empty Workflow',
+        workflowId: `chat-editor-type-empty-${randomUUID()}`,
+        active: true,
+        steps: [
+          {
+            name: 'Chat Step',
+            type: StepTypeEnum.CHAT,
+            controlValues: { body: mailyBody, editorType: '' },
+          },
+        ],
+      });
+
+      expect(createResponse.status).to.equal(201);
+      expect(createResponse.body.data.steps[0].controls.values.editorType).to.equal('block');
+      expect(createResponse.body.data.steps[0].issues?.controls?.editorType).to.equal(undefined);
+    });
+  });
+
   describe('workflow agent assignment', () => {
     async function createTestAgent(identifier: string, name = identifier) {
       const response = await session.testAgent.post('/v1/agents').send({ name, identifier });

--- a/apps/dashboard/src/components/chat-editor-select.tsx
+++ b/apps/dashboard/src/components/chat-editor-select.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { RiCodeSSlashFill, RiDashboardLine } from 'react-icons/ri';
 import { ConfirmationModal } from '@/components/confirmation-modal';
@@ -27,6 +27,16 @@ export const ChatEditorSelect = ({
   const { control, setValue } = useFormContext();
   const [pendingEditorType, setPendingEditorType] = useState<ChatEditorType | null>(null);
   const body = useWatch({ name: 'body', control });
+  const editorType = useWatch({ name: 'editorType', control });
+
+  useEffect(() => {
+    const resolvedEditorType = deriveChatEditorType(body, editorType, true);
+    if (editorType === resolvedEditorType) {
+      return;
+    }
+
+    setValue('editorType', resolvedEditorType, { shouldDirty: false, shouldValidate: false });
+  }, [body, editorType, setValue]);
 
   return (
     <FormField

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.spec.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/derive-chat-editor-type.spec.ts
@@ -12,8 +12,9 @@ describe('deriveChatEditorType', () => {
     expect(deriveChatEditorType(mailyBody, 'text', true)).toBe('text');
   });
 
-  it('routes Maily JSON to block when editorType is unset', () => {
+  it('routes Maily JSON to block when editorType is unset or invalid', () => {
     expect(deriveChatEditorType(mailyBody, undefined, true)).toBe('block');
+    expect(deriveChatEditorType(mailyBody, '', true)).toBe('block');
   });
 
   it('routes non-empty plain/Liquid bodies to text when editorType is unset', () => {

--- a/apps/dashboard/src/pages/edit-step-template-v2.tsx
+++ b/apps/dashboard/src/pages/edit-step-template-v2.tsx
@@ -1,13 +1,22 @@
-import { ContentIssueEnum, StepResponseDto, StepUpdateDto, WorkflowResponseDto } from '@novu/shared';
+import {
+  ContentIssueEnum,
+  FeatureFlagsKeysEnum,
+  StepResponseDto,
+  StepTypeEnum,
+  StepUpdateDto,
+  WorkflowResponseDto,
+} from '@novu/shared';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { PageMeta } from '@/components/page-meta';
 import { Form } from '@/components/primitives/form/form';
 import { flattenIssues, updateStepInWorkflow } from '@/components/workflow-editor/step-utils';
+import { deriveChatEditorType } from '@/components/workflow-editor/steps/chat/derive-chat-editor-type';
 import { SaveFormContext } from '@/components/workflow-editor/steps/save-form-context';
 import { StepEditorLayout } from '@/components/workflow-editor/steps/step-editor-layout';
 import { UpdateWorkflowFn, useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { useDataRef } from '@/hooks/use-data-ref';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFormAutosave } from '@/hooks/use-form-autosave';
 import { getControlsDefaultValues } from '@/utils/default-values';
 
@@ -40,6 +49,7 @@ type StepTemplateFormProps = {
 };
 
 function StepTemplateForm({ workflow, step, update }: StepTemplateFormProps) {
+  const isChatBlockEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CHAT_BLOCK_EDITOR_ENABLED);
   const form = useForm({
     defaultValues: getControlsDefaultValues(step),
     shouldFocusError: false,
@@ -88,6 +98,11 @@ function StepTemplateForm({ workflow, step, update }: StepTemplateFormProps) {
       const { providerOverrides, ...controlValues } = data as Record<string, unknown> & {
         providerOverrides?: StepUpdateDto['providerOverrides'];
       };
+
+      if (step.type === StepTypeEnum.CHAT && isChatBlockEditorEnabled) {
+        controlValues.editorType = deriveChatEditorType(controlValues.body, controlValues.editorType, true);
+      }
+
       const fp = JSON.stringify({
         v: controlValues,
         po: providerOverrides,

--- a/libs/application-generic/src/dtos/workflow/chat-control.dto.ts
+++ b/libs/application-generic/src/dtos/workflow/chat-control.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsIn, IsOptional, IsString, ValidateIf } from 'class-validator';
 import { SkipControlDto } from './skip.dto';
 
 export class ChatControlDto extends SkipControlDto {
@@ -7,4 +7,15 @@ export class ChatControlDto extends SkipControlDto {
   @IsString()
   @IsOptional()
   body: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Type of editor to use for the body. When omitted, inferred from the body: Maily JSON is "block", otherwise "text".',
+    enum: ['block', 'text'],
+  })
+  @ValidateIf((_, value) => value !== undefined && value !== null && value !== '')
+  @IsIn(['block', 'text'])
+  @IsString()
+  @IsOptional()
+  editorType?: 'block' | 'text';
 }

--- a/libs/application-generic/src/schemas/control/chat-control.schema.ts
+++ b/libs/application-generic/src/schemas/control/chat-control.schema.ts
@@ -8,9 +8,10 @@ export const chatControlZodSchema = z
   .object({
     skip: skipZodSchema,
     body: z.string(),
-    // Optional with no static default so flag-off orgs never persist editorType.
-    // When IS_CHAT_BLOCK_EDITOR_ENABLED is on, the dashboard derives 'block' for
-    // empty/new steps and 'text' for legacy raw bodies.
+    // Optional with no static default so flag-off orgs never persist editorType
+    // for empty steps. When a body is present, upsert/sanitize infers 'block'
+    // from Maily JSON and 'text' from plain/Liquid content — matching email's
+    // persist-a-valid-editorType behavior without forcing a schema default.
     editorType: z.enum(['block', 'text']).optional(),
   })
   .strict();

--- a/libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -26,7 +26,7 @@ import { StepIssuesDto } from '../../dtos/step-issues.dto';
 import { EmailRenderOutput } from '../../dtos/workflow/generate-preview-response.dto';
 import { WorkflowResponseDto } from '../../dtos/workflow/workflow-response.dto';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
-import { EmailControlType } from '../../schemas/control';
+import { ChatControlType, EmailControlType } from '../../schemas/control';
 import { AnalyticsService } from '../../services';
 import {
   computeWorkflowStatus,
@@ -37,6 +37,7 @@ import {
   slugifyOrRandom,
 } from '../../utils';
 import { isStringifiedMailyJSONContent } from '../../utils/maily-utils';
+import { resolveChatEditorType } from '../../utils/resolve-chat-editor-type';
 import { isStepResolverActive } from '../../utils/step-resolver-control-state';
 import { NotificationStep } from '../../value-objects';
 import { SendWebhookMessage } from '../../webhooks';
@@ -523,6 +524,22 @@ export class UpsertWorkflowUseCase {
         } else if (emailControlValues.editorType === 'block' && !isMaily) {
           emailControlValues.body = '';
         }
+      }
+    }
+
+    if (
+      step.template?.type === StepTypeEnum.CHAT &&
+      (command.workflowDto.origin === ResourceOriginEnum.NOVU_CLOUD ||
+        command.workflowDto.origin === ResourceOriginEnum.NOVU_CLOUD_V1) &&
+      !isStepResolverActive(step.template?.stepResolverHash)
+    ) {
+      const chatControlValues = newControlValues as ChatControlType;
+      const resolvedEditorType = resolveChatEditorType(chatControlValues.body, chatControlValues.editorType);
+
+      if (resolvedEditorType) {
+        chatControlValues.editorType = resolvedEditorType;
+      } else {
+        delete chatControlValues.editorType;
       }
     }
 

--- a/libs/application-generic/src/utils/index.ts
+++ b/libs/application-generic/src/utils/index.ts
@@ -36,6 +36,7 @@ export * from './parse-payload-schema';
 export * from './parse-step-variables';
 export * from './payload';
 export * from './provider-overrides';
+export * from './resolve-chat-editor-type';
 export * from './safe-set-path';
 export * from './sanitize-control-values';
 export * from './shorten-environment-name';

--- a/libs/application-generic/src/utils/issues.spec.ts
+++ b/libs/application-generic/src/utils/issues.spec.ts
@@ -1,7 +1,17 @@
 import { JsonSchemaTypeEnum } from '@novu/dal';
 import { ContentIssueEnum, StepTypeEnum } from '@novu/shared';
+import type { PinoLogger } from 'nestjs-pino';
 import { describe, expect, it } from 'vitest';
+import { chatControlSchema } from '../schemas/control';
 import { processControlValuesBySchema } from './issues';
+import { dashboardSanitizeControlValues } from './sanitize-control-values';
+
+const logger = { error: () => {} } as unknown as PinoLogger;
+
+const mailyBody = JSON.stringify({
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+});
 
 describe('processControlValuesBySchema', () => {
   it('maps additionalProperties failures to UNSUPPORTED_PROPERTY for any strict schema', () => {
@@ -27,5 +37,42 @@ describe('processControlValuesBySchema', () => {
         variableName: 'unexpected',
       },
     ]);
+  });
+
+  it('rejects empty-string chat editorType against the control schema', () => {
+    const issues = processControlValuesBySchema({
+      controlSchema: chatControlSchema,
+      controlValues: { body: mailyBody, editorType: '' },
+      stepType: StepTypeEnum.CHAT,
+    });
+
+    expect(issues.controls?.editorType?.[0]?.message).toBe('must be equal to one of the allowed values');
+  });
+
+  it('does not flag editorType after sanitizing a Maily chat body with an empty editorType', () => {
+    const sanitized = dashboardSanitizeControlValues(logger, { body: mailyBody, editorType: '' }, StepTypeEnum.CHAT);
+
+    const issues = processControlValuesBySchema({
+      controlSchema: chatControlSchema,
+      controlValues: sanitized || {},
+      stepType: StepTypeEnum.CHAT,
+    });
+
+    expect(sanitized).toEqual({ body: mailyBody, editorType: 'block' });
+    expect(issues.controls?.editorType).toBeUndefined();
+  });
+
+  it('does not flag editorType for an empty chat step after sanitize', () => {
+    const sanitized = dashboardSanitizeControlValues(logger, { body: '', editorType: '' }, StepTypeEnum.CHAT);
+
+    const issues = processControlValuesBySchema({
+      controlSchema: chatControlSchema,
+      controlValues: sanitized || {},
+      stepType: StepTypeEnum.CHAT,
+    });
+
+    expect(sanitized).not.toHaveProperty('editorType');
+    expect(issues.controls?.editorType).toBeUndefined();
+    expect(issues.controls?.body).toBeDefined();
   });
 });

--- a/libs/application-generic/src/utils/resolve-chat-editor-type.spec.ts
+++ b/libs/application-generic/src/utils/resolve-chat-editor-type.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveChatEditorType } from './resolve-chat-editor-type';
+
+const mailyBody = JSON.stringify({
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+});
+
+describe('resolveChatEditorType', () => {
+  it('prefers an explicit editorType', () => {
+    expect(resolveChatEditorType('{% if true %}x{% endif %}', 'block')).toBe('block');
+    expect(resolveChatEditorType(mailyBody, 'text')).toBe('text');
+  });
+
+  it('maps Maily JSON to block when editorType is unset or invalid', () => {
+    expect(resolveChatEditorType(mailyBody, undefined)).toBe('block');
+    expect(resolveChatEditorType(mailyBody, '')).toBe('block');
+    expect(resolveChatEditorType(mailyBody, 'html')).toBe('block');
+  });
+
+  it('maps non-empty plain/Liquid bodies to text when editorType is unset', () => {
+    expect(resolveChatEditorType('{% if true %}x{% endif %}', undefined)).toBe('text');
+    expect(resolveChatEditorType('hello {{payload.foo}}', '')).toBe('text');
+  });
+
+  it('returns undefined for empty bodies when editorType is unset', () => {
+    expect(resolveChatEditorType('', undefined)).toBeUndefined();
+    expect(resolveChatEditorType(undefined, '')).toBeUndefined();
+  });
+});

--- a/libs/application-generic/src/utils/resolve-chat-editor-type.ts
+++ b/libs/application-generic/src/utils/resolve-chat-editor-type.ts
@@ -1,0 +1,25 @@
+import { isStringifiedMailyJSONContent } from './maily-utils';
+
+export type ChatEditorType = 'block' | 'text';
+
+/**
+ * Resolve a persistable chat `editorType` from control values.
+ * Explicit `block`/`text` always wins. Otherwise Maily JSON bodies map to
+ * `block` and any other non-empty string maps to `text`. Empty/missing bodies
+ * return `undefined` so flag-off orgs do not persist a value.
+ */
+export function resolveChatEditorType(body: unknown, editorType: unknown): ChatEditorType | undefined {
+  if (editorType === 'block' || editorType === 'text') {
+    return editorType;
+  }
+
+  if (typeof body === 'string' && isStringifiedMailyJSONContent(body)) {
+    return 'block';
+  }
+
+  if (typeof body === 'string' && body.length > 0) {
+    return 'text';
+  }
+
+  return undefined;
+}

--- a/libs/application-generic/src/utils/sanitize-control-values.spec.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.spec.ts
@@ -15,7 +15,7 @@ describe('dashboardSanitizeControlValues', () => {
         stepType
       );
 
-      expect(sanitized).toEqual({ body: 'hello', providerOverrides: { slack: { text: 'hi' } } });
+      expect(sanitized).toMatchObject({ body: 'hello', providerOverrides: { slack: { text: 'hi' } } });
     }
   );
 
@@ -31,8 +31,30 @@ describe('dashboardSanitizeControlValues', () => {
     expect(sanitized).toEqual({ body: 'hello', editorType: 'text' });
   });
 
-  it('omits chat editorType when absent', () => {
+  it('infers chat editorType as text from a plain body when editorType is absent', () => {
     const sanitized = dashboardSanitizeControlValues(logger, { body: 'hello' }, StepTypeEnum.CHAT);
+
+    expect(sanitized).toEqual({ body: 'hello', editorType: 'text' });
+  });
+
+  it('infers chat editorType as block from Maily JSON when editorType is unset or invalid', () => {
+    const mailyBody = JSON.stringify({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+    });
+
+    expect(dashboardSanitizeControlValues(logger, { body: mailyBody, editorType: '' }, StepTypeEnum.CHAT)).toEqual({
+      body: mailyBody,
+      editorType: 'block',
+    });
+    expect(dashboardSanitizeControlValues(logger, { body: mailyBody }, StepTypeEnum.CHAT)).toEqual({
+      body: mailyBody,
+      editorType: 'block',
+    });
+  });
+
+  it('omits chat editorType when body and editorType are both empty', () => {
+    const sanitized = dashboardSanitizeControlValues(logger, { body: '', editorType: '' }, StepTypeEnum.CHAT);
 
     expect(sanitized).not.toHaveProperty('editorType');
   });

--- a/libs/application-generic/src/utils/sanitize-control-values.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.ts
@@ -19,6 +19,7 @@ import {
   ToolControlType,
 } from '../schemas/control';
 import { InAppActionType, InAppControlType } from '../schemas/control/in-app-control.schema';
+import { resolveChatEditorType } from './resolve-chat-editor-type';
 
 // Cast input T_Type to trigger Ajv validation errors - possible undefined
 function sanitizeEmptyInput<T_Type>(input: T_Type, defaultValue: T_Type = undefined as unknown as T_Type): T_Type {
@@ -139,10 +140,11 @@ function keepProviderOverrides(
 }
 
 function sanitizeChat(controlValues: WithProviderOverrides<ChatControlType>) {
+  const editorType = resolveChatEditorType(controlValues.body, controlValues.editorType);
   const mappedValues: ChatControlType = {
     body: sanitizeEmptyInput(controlValues.body),
     skip: controlValues.skip,
-    editorType: controlValues.editorType,
+    ...(editorType ? { editorType } : {}),
   };
 
   return keepProviderOverrides(filterNullishValues(mappedValues) as Record<string, unknown>, controlValues);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Fixes [NV-8596](https://linear.app/novu/issue/NV-8596/chat-step-editortype-should-infer-block-vs-text-from-body).

Adding a chat step and filling the rich block editor produced `must be equal to one of the allowed values` on `editorType`. Email always persists a valid `editorType` (schema default `block`). Chat left it as `''` from form string defaults, which AJV rejects against `['block', 'text']`.

Chat now infers and persists `editorType` from the body, matching email's persist-a-valid-value behavior:

- Maily JSON body → `editorType: "block"`
- Plain / Liquid text body → `editorType: "text"`
- Explicit `block` / `text` still wins
- Empty body does not persist an invalid value (the existing "body missing" issue remains)

```mermaid
flowchart TD
  save[Save chat control values]
  explicit{editorType is block or text?}
  maily{Body is Maily JSON?}
  text{Body is non-empty text?}
  persistBlock[Persist editorType block]
  persistText[Persist editorType text]
  omit[Omit editorType]
  save --> explicit
  explicit -->|yes| persistExplicit[Keep explicit editorType]
  explicit -->|no| maily
  maily -->|yes| persistBlock
  maily -->|no| text
  text -->|yes| persistText
  text -->|no| omit
```

### Test plan

- Unit: `resolveChatEditorType`, sanitize inference, AJV issues after sanitize
- E2E: upsert chat step with Maily JSON / plain text / empty `editorType`
- Dashboard: step editor save path writes derived `editorType`; block/text toggle stays in sync

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

`editorType` stays optional with no schema default so flag-off empty chat steps do not persist a value. Inference only runs when a body is present or the client already sent a valid `block`/`text`.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7523dd27-4857-41cc-b273-5ee9a419ab2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7523dd27-4857-41cc-b273-5ee9a419ab2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes chat workflow saves by deriving a valid `editorType` from the body while preserving explicit selections and omitting the field for empty bodies.
- Adds shared server-side chat editor-type resolution and applies it during sanitization and workflow upsert.
- Synchronizes dashboard editor selection and autosave persistence with the inferred type.
- Extends DTO/schema coverage and adds unit and end-to-end tests for block, text, invalid, and empty values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with dashboard, persistence, sanitization, validation, and tests aligned around the same chat editor-type behavior.

Explicit selections remain authoritative, Maily and legacy text bodies are classified consistently across client and server paths, and empty bodies avoid persisting an invalid value.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/application-generic/src/utils/resolve-chat-editor-type.ts | Introduces deterministic resolution that preserves valid explicit values, recognizes Maily JSON, classifies other non-empty strings as text, and omits empty values. |
| libs/application-generic/src/utils/sanitize-control-values.ts | Applies the shared resolver during chat-control sanitization and excludes unresolved editor types. |
| libs/application-generic/src/usecases/upsert-workflow/upsert-workflow.usecase.ts | Normalizes persisted chat editor types for cloud-authored workflows while retaining existing origin and step-resolver boundaries. |
| apps/dashboard/src/components/chat-editor-select.tsx | Keeps the form’s editor selection synchronized with the body-derived editor type without marking initialization as a user edit. |
| apps/dashboard/src/pages/edit-step-template-v2.tsx | Derives the enabled chat editor type before computing the save fingerprint and updating the workflow. |
| libs/application-generic/src/dtos/workflow/chat-control.dto.ts | Documents and validates optional chat editor types while allowing the legacy empty form value to reach normalization. |
| apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts | Covers persisted block and text inference and normalization of an empty editorType through the workflow API. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Save[Save chat controls] --> Explicit{Valid explicit editorType?}
  Explicit -->|Yes| Preserve[Preserve block or text]
  Explicit -->|No| Maily{Body is Maily JSON?}
  Maily -->|Yes| Block[Persist block]
  Maily -->|No| NonEmpty{Body is non-empty text?}
  NonEmpty -->|Yes| Text[Persist text]
  NonEmpty -->|No| Omit[Omit editorType]
  Preserve --> Persist[Upsert controls]
  Block --> Persist
  Text --> Persist
  Omit --> Persist
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): infer chat editorType ..."](https://github.com/novuhq/novu/commit/6379e7b8e835802270296ffc9975c38307fda2cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53313502)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [API App (apps/api)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/api-app.md)
- Knowledge Base — [Dashboard App (apps/dashboard)](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/dashboard-app.md)
- Knowledge Base — [application-generic Library](https://app.greptile.com/novu/-/custom-context/knowledge-base/novuhq/novu/-/docs/application-generic-lib.md)
</details>

<!-- /greptile_comment -->